### PR TITLE
feat(BaseEntity): Allow individual entities to omit fields

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.tsx
@@ -5,7 +5,6 @@ import { EntitiesContext } from '../../../providers/entities.provider';
 import { SchemaBridgeProvider } from '../../../providers/schema-bridge.provider';
 import { isDefined, setValue } from '../../../utils';
 import { ErrorBoundary } from '../../ErrorBoundary';
-import { SchemaService } from '../../Form';
 import { CustomAutoForm, CustomAutoFormRef } from '../../Form/CustomAutoForm';
 import { DataFormatEditor } from '../../Form/dataFormat/DataFormatEditor';
 import { LoadBalancerEditor } from '../../Form/loadBalancer/LoadBalancerEditor';
@@ -26,6 +25,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
   const formRef = useRef<CustomAutoFormRef>(null);
   const divRef = useRef<HTMLDivElement>(null);
   const flowIdRef = useRef<string | undefined>(undefined);
+  const omitFields = useRef(props.selectedNode.data?.vizNode?.getBaseEntity()?.getOmitFormFields() || []);
 
   const visualComponentSchema = useMemo(() => {
     const answer = props.selectedNode.data?.vizNode?.getComponentSchema();
@@ -107,7 +107,7 @@ export const CanvasForm: FunctionComponent<CanvasFormProps> = (props) => {
                 model={model}
                 onChange={handleOnChangeIndividualProp}
                 sortFields={false}
-                omitFields={SchemaService.OMIT_FORM_FIELDS}
+                omitFields={omitFields.current}
                 data-testid="autoform"
               />
               <div data-testid="root-form-placeholder" ref={divRef} />

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -26,6 +26,9 @@ export interface BaseVisualCamelEntity extends BaseCamelEntity {
   /** Given a path, get the component type and definition */
   getComponentSchema: (path?: string) => VisualComponentSchema | undefined;
 
+  /** Returnt fields that should be omitted when configuring this entity */
+  getOmitFormFields: () => string[];
+
   /** Given a path, update the model */
   updateModel(path: string | undefined, value: unknown): void;
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-case-declarations */
 import { ProcessorDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { ROOT_PATH, getArrayProperty, getValue, isDefined, setValue } from '../../../utils';
 import { NodeIconResolver } from '../../../utils/node-icon-resolver';
 import { DefinedComponent } from '../../camel-catalog-index';
@@ -61,6 +62,10 @@ export abstract class AbstractCamelVisualEntity implements BaseVisualCamelEntity
     const visualComponentSchema = CamelComponentSchemaService.getVisualComponentSchema(path, componentModel);
 
     return visualComponentSchema;
+  }
+
+  getOmitFormFields(): string[] {
+    return SchemaService.OMIT_FORM_FIELDS;
   }
 
   toJSON() {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -1,5 +1,6 @@
 import { ErrorHandler, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { useSchemasStore } from '../../../store';
 import { isDefined, setValue } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
@@ -65,6 +66,10 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
       schema: schema,
       title: 'Error Handler',
     };
+  }
+
+  getOmitFormFields(): string[] {
+    return SchemaService.OMIT_FORM_FIELDS;
   }
 
   updateModel(path: string | undefined, value: unknown): void {

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -1,5 +1,6 @@
 import { OnException, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { getArrayProperty, getValue, isDefined, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities/base-entity';
@@ -11,12 +12,12 @@ import {
   NodeInteraction,
   VisualComponentSchema,
 } from '../base-visual-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelStepsService } from './support/camel-steps.service';
-import { ModelValidationService } from './support/validators/model-validation.service';
-import { CamelProcessorStepsProperties, CamelRouteVisualEntityData } from './support/camel-component-types';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { CamelComponentDefaultService } from './support/camel-component-default.service';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { CamelProcessorStepsProperties, CamelRouteVisualEntityData } from './support/camel-component-types';
+import { CamelStepsService } from './support/camel-steps.service';
+import { ModelValidationService } from './support/validators/model-validation.service';
 
 export class CamelOnExceptionVisualEntity implements BaseVisualCamelEntity {
   id: string;
@@ -79,6 +80,10 @@ export class CamelOnExceptionVisualEntity implements BaseVisualCamelEntity {
     const visualComponentSchema = CamelComponentSchemaService.getVisualComponentSchema(path, componentModel);
 
     return visualComponentSchema;
+  }
+
+  getOmitFormFields(): string[] {
+    return SchemaService.OMIT_FORM_FIELDS;
   }
 
   updateModel(path: string | undefined, value: unknown): void {

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -2,6 +2,7 @@ import { ProcessorDefinition, RestConfiguration } from '@kaoto-next/camel-catalo
 import Ajv, { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { isDefined, setValue } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
 import { CatalogKind } from '../../catalog-kind';
@@ -75,6 +76,10 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualCamelEntity
       schema: schema?.propertiesSchema || {},
       title: 'Rest Configuration',
     };
+  }
+
+  getOmitFormFields(): string[] {
+    return SchemaService.OMIT_FORM_FIELDS;
   }
 
   updateModel(path: string | undefined, value: unknown): void {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -2,6 +2,7 @@ import { Pipe } from '@kaoto-next/camel-catalog/types';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { getArrayProperty, NodeIconResolver } from '../../../utils';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
@@ -62,6 +63,10 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
     if (!path) return undefined;
     const stepModel = get(this.spec, path) as PipeStep;
     return KameletSchemaService.getVisualComponentSchema(stepModel);
+  }
+
+  getOmitFormFields(): string[] {
+    return SchemaService.OMIT_FORM_FIELDS;
   }
 
   toJSON() {


### PR DESCRIPTION
### Context
Currently, there's a single array to omit form fields, and while this works, in some cases, we could be omitting unintended fields.

### Changes
The solution is to allow for individual Entities to provide their own omit fields list.

relates to: https://github.com/KaotoIO/kaoto/issues/492