### PR TITLE
feat(RouteConfiguration): Add support for RouteConfiguration entity

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -4,8 +4,13 @@ import { createCamelPropertiesSorter, isDefined } from '../../utils';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity, isCamelFrom, isCamelRoute } from '../visualization/flows';
 import { CamelErrorHandlerVisualEntity } from '../visualization/flows/camel-error-handler-visual-entity';
+import { CamelInterceptFromVisualEntity } from '../visualization/flows/camel-intercept-from-visual-entity';
+import { CamelInterceptSendToEndpointVisualEntity } from '../visualization/flows/camel-intercept-send-to-endpoint-visual-entity';
+import { CamelInterceptVisualEntity } from '../visualization/flows/camel-intercept-visual-entity';
+import { CamelOnCompletionVisualEntity } from '../visualization/flows/camel-on-completion-visual-entity';
 import { CamelOnExceptionVisualEntity } from '../visualization/flows/camel-on-exception-visual-entity';
 import { CamelRestConfigurationVisualEntity } from '../visualization/flows/camel-rest-configuration-visual-entity';
+import { CamelRouteConfigurationVisualEntity } from '../visualization/flows/camel-route-configuration-visual-entity';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
 import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
@@ -18,8 +23,13 @@ import { SourceSchemaType } from './source-schema-type';
 export class CamelRouteResource implements CamelResource, BeansAwareResource {
   static readonly SUPPORTED_ENTITIES = [
     CamelOnExceptionVisualEntity,
+    CamelOnCompletionVisualEntity,
     CamelErrorHandlerVisualEntity,
     CamelRestConfigurationVisualEntity,
+    CamelRouteConfigurationVisualEntity,
+    CamelInterceptVisualEntity,
+    CamelInterceptFromVisualEntity,
+    CamelInterceptSendToEndpointVisualEntity,
   ] as const;
   static readonly PARAMETERS_ORDER = ['id', 'description', 'uri', 'parameters', 'steps'];
   readonly sortFn = createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (

--- a/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
@@ -20,7 +20,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
   "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canReplaceStep": false,
 }
 `;
 
@@ -32,7 +32,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
   "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canReplaceStep": false,
 }
 `;
 
@@ -44,7 +44,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
   "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canReplaceStep": false,
 }
 `;
 
@@ -68,7 +68,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
   "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canReplaceStep": false,
 }
 `;
 
@@ -80,7 +80,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
   "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canReplaceStep": false,
 }
 `;
 

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{
+  processorName: 'interceptSendToEndpoint',
+  path: 'interceptSendToEndpoint'
+}' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptFromVisualEntity should serialize the entity 1`] = `
+{
+  "interceptFrom": {
+    "id": "interceptFrom-1234",
+    "uri": "direct:a-reference",
+  },
+}
+`;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{
+  processorName: 'interceptSendToEndpoint',
+  path: 'interceptSendToEndpoint'
+}' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptSendToEndpointVisualEntity should serialize the entity 1`] = `
+{
+  "interceptSendToEndpoint": {
+    "id": "interceptSendToEndpoint-1234",
+    "uri": "direct:a-reference",
+  },
+}
+`;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{
+  processorName: 'interceptSendToEndpoint',
+  path: 'interceptSendToEndpoint'
+}' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelInterceptVisualEntity should serialize the entity 1`] = `
+{
+  "intercept": {
+    "disabled": false,
+    "id": "intercept-1234",
+  },
+}
+`;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{
+  processorName: 'interceptSendToEndpoint',
+  path: 'interceptSendToEndpoint'
+}' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 2`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnCompletionVisualEntity should serialize the entity 1`] = `
+{
+  "onCompletion": {
+    "id": "onCompletion-1234",
+    "mode": "AfterConsumer",
+  },
+}
+`;

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -1,12 +1,12 @@
-import { ErrorHandler, NoErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { ErrorHandlerBuilderDeserializer, NoErrorHandler } from '@kaoto-next/camel-catalog/types';
 import { useSchemasStore } from '../../../store';
 import { errorHandlerSchema } from '../../../stubs/error-handler';
-import { CamelErrorHandlerVisualEntity } from './camel-error-handler-visual-entity';
 import { EntityType } from '../../camel/entities';
+import { CamelErrorHandlerVisualEntity } from './camel-error-handler-visual-entity';
 
 describe('CamelErrorHandlerVisualEntity', () => {
   const ERROR_HANDLER_ID_REGEXP = /^errorHandler-[a-zA-Z0-9]{4}$/;
-  let errorHandlerDef: { errorHandler: ErrorHandler };
+  let errorHandlerDef: { errorHandler: ErrorHandlerBuilderDeserializer };
 
   beforeAll(() => {
     useSchemasStore.getState().setSchema('errorHandler', {

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -1,0 +1,110 @@
+import { IVisualizationNodeData } from '../base-visual-entity';
+import { CamelInterceptFromVisualEntity } from './camel-intercept-from-visual-entity';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+describe('CamelInterceptFromVisualEntity', () => {
+  describe('constructor', () => {
+    it('should allow to create an instance out of the string definition', () => {
+      const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({ interceptFrom: 'a-reference' });
+
+      expect(interceptFromVisualEntity.getId()).toBeDefined();
+    });
+
+    it('should allow to create an instance out of the object definition', () => {
+      const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+        interceptFrom: { id: 'a-reference', uri: 'direct:a-reference' },
+      });
+
+      expect(interceptFromVisualEntity.getId()).toEqual('a-reference');
+    });
+
+    it('should allow to create an instance out of the object definition without id', () => {
+      const interceptFromRaw = {
+        interceptFrom: { id: undefined, uri: 'direct:a-reference' },
+      };
+      const interceptFromVisualEntity = new CamelInterceptFromVisualEntity(interceptFromRaw);
+
+      expect(interceptFromVisualEntity.getId()).toBeDefined();
+      expect(interceptFromRaw.interceptFrom.id).toEqual(interceptFromVisualEntity.getId());
+    });
+  });
+
+  describe('isApplicable', () => {
+    it.each([
+      [{ from: { id: 'from-1234', steps: [] } }, false],
+      [{ onCompletion: { id: 'onCompletionId' } }, false],
+      [{ onException: { id: 'onExceptionId' } }, false],
+      [{ intercept: { id: 'interceptId' } }, false],
+      [{ interceptFrom: { id: 'interceptFromId' } }, true],
+      [{ interceptSendToEndpoint: { id: 'interceptSendToEndpointId' } }, false],
+    ])('should return %s for %s', (definition, result) => {
+      expect(CamelInterceptFromVisualEntity.isApplicable(definition)).toEqual(result);
+    });
+  });
+
+  it('should return the id', () => {
+    const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+      interceptFrom: { id: 'id', uri: 'direct:a-reference' },
+    });
+    expect(interceptFromVisualEntity.getId()).toEqual('id');
+  });
+
+  it('should set the id', () => {
+    const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({ interceptFrom: 'a-reference' });
+    interceptFromVisualEntity.setId('new-id');
+    expect(interceptFromVisualEntity.getId()).toEqual('new-id');
+    expect(interceptFromVisualEntity.interceptFromDef.interceptFrom.id).toEqual('new-id');
+  });
+
+  describe('getNodeInteraction', () => {
+    it.each([
+      { processorName: 'route', path: 'route' },
+      { processorName: 'from', path: 'from' },
+      { processorName: 'to', path: 'to' },
+      { processorName: 'log', path: 'log' },
+      { processorName: 'onException', path: 'onException' },
+      { processorName: 'onCompletion', path: 'onCompletion' },
+      { processorName: 'intercept', path: 'intercept' },
+      { processorName: 'interceptFrom', path: 'interceptFrom' },
+      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
+    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+        interceptFrom: { id: 'id', uri: 'direct:a-reference' },
+      });
+
+      const result = interceptFromVisualEntity.getNodeInteraction(data as IVisualizationNodeData);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('should delegate the validation text to the ModelValidationService', () => {
+    const validateNodeStatusSpy = jest.spyOn(ModelValidationService, 'validateNodeStatus');
+
+    const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+      interceptFrom: { id: 'id', uri: 'direct:a-reference' },
+    });
+    interceptFromVisualEntity.getNodeValidationText('a-path');
+
+    expect(validateNodeStatusSpy).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('should return the vizualization node', () => {
+    const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+      interceptFrom: { id: 'id', uri: 'direct:a-reference' },
+    });
+    const vizNode = interceptFromVisualEntity.toVizNode();
+
+    expect(vizNode.data.processorName).toBe(CamelInterceptFromVisualEntity.ROOT_PATH);
+    expect(vizNode.data.entity).toBe(interceptFromVisualEntity);
+    expect(vizNode.data.isGroup).toBeTruthy();
+  });
+
+  it('should serialize the entity', () => {
+    const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
+      interceptFrom: { id: undefined, uri: 'direct:a-reference' },
+    });
+    const result = interceptFromVisualEntity.toJSON();
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -1,0 +1,117 @@
+import { InterceptFrom, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { isDefined } from '../../../utils';
+import { EntityType } from '../../camel/entities/base-entity';
+import {
+  BaseVisualCamelEntity,
+  IVisualizationNode,
+  IVisualizationNodeData,
+  NodeInteraction,
+} from '../base-visual-entity';
+import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { CamelRouteVisualEntityData } from './support/camel-component-types';
+import { CamelStepsService } from './support/camel-steps.service';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+export class CamelInterceptFromVisualEntity
+  extends AbstractCamelVisualEntity<{ interceptFrom: InterceptFrom }>
+  implements BaseVisualCamelEntity
+{
+  id: string;
+  interceptFromDef: { interceptFrom: Exclude<InterceptFrom, string> };
+  readonly type = EntityType.InterceptFrom;
+  static readonly ROOT_PATH = 'interceptFrom';
+
+  constructor(interceptFromRaw: { interceptFrom: InterceptFrom }) {
+    let interceptFromDef: { interceptFrom: Exclude<InterceptFrom, string> };
+    if (typeof interceptFromRaw.interceptFrom === 'string') {
+      interceptFromDef = {
+        interceptFrom: {
+          uri: interceptFromRaw.interceptFrom,
+        },
+      };
+    } else {
+      interceptFromDef = { interceptFrom: interceptFromRaw.interceptFrom };
+    }
+
+    super(interceptFromDef);
+    this.interceptFromDef = interceptFromDef;
+    const id = interceptFromDef.interceptFrom.id ?? getCamelRandomId(CamelInterceptFromVisualEntity.ROOT_PATH);
+    this.id = id;
+    this.interceptFromDef.interceptFrom.id = id;
+  }
+
+  static isApplicable(interceptFromDef: unknown): interceptFromDef is { interceptFrom: InterceptFrom } {
+    if (!isDefined(interceptFromDef) || Array.isArray(interceptFromDef) || typeof interceptFromDef !== 'object') {
+      return false;
+    }
+
+    const objectKeys = Object.keys(interceptFromDef!);
+
+    return (
+      objectKeys.length === 1 &&
+      this.ROOT_PATH in interceptFromDef! &&
+      (typeof interceptFromDef.interceptFrom === 'object' || typeof interceptFromDef.interceptFrom === 'string')
+    );
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  setId(id: string): void {
+    this.id = id;
+    this.interceptFromDef.interceptFrom.id = id;
+  }
+
+  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
+    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+    );
+    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+      (data as CamelRouteVisualEntityData).processorName,
+    );
+    const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
+    const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
+    const canReplaceStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
+    const canRemoveStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
+
+    return {
+      canHavePreviousStep,
+      canHaveNextStep: canHavePreviousStep,
+      canHaveChildren,
+      canHaveSpecialChildren,
+      canReplaceStep,
+      canRemoveStep,
+      canRemoveFlow: data.path === CamelInterceptFromVisualEntity.ROOT_PATH,
+    };
+  }
+
+  getNodeValidationText(path?: string | undefined): string | undefined {
+    const componentVisualSchema = this.getComponentSchema(path);
+    if (!componentVisualSchema) return undefined;
+
+    return ModelValidationService.validateNodeStatus(componentVisualSchema);
+  }
+
+  toVizNode(): IVisualizationNode<IVisualizationNodeData> {
+    const interceptFromGroupNode = CamelStepsService.getVizNodeFromProcessor(
+      CamelInterceptFromVisualEntity.ROOT_PATH,
+      { processorName: CamelInterceptFromVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      this.interceptFromDef,
+    );
+    interceptFromGroupNode.data.entity = this;
+    interceptFromGroupNode.data.isGroup = true;
+
+    return interceptFromGroupNode;
+  }
+
+  toJSON(): { interceptFrom: InterceptFrom } {
+    return { interceptFrom: this.interceptFromDef.interceptFrom };
+  }
+
+  protected getRootUri(): string | undefined {
+    return undefined;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -1,0 +1,110 @@
+import { IVisualizationNodeData } from '../base-visual-entity';
+import { CamelInterceptSendToEndpointVisualEntity } from './camel-intercept-send-to-endpoint-visual-entity';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+describe('CamelInterceptSendToEndpointVisualEntity', () => {
+  describe('constructor', () => {
+    it('should allow to create an instance out of the object definition', () => {
+      const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+        interceptSendToEndpoint: { id: 'a-reference', uri: 'direct:a-reference' },
+      });
+
+      expect(interceptSendToEndpointVisualEntity.getId()).toEqual('a-reference');
+    });
+
+    it('should allow to create an instance out of the object definition without id', () => {
+      const interceptSendToEndpointRaw = {
+        interceptSendToEndpoint: { id: undefined, uri: 'direct:a-reference' },
+      };
+      const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity(
+        interceptSendToEndpointRaw,
+      );
+
+      expect(interceptSendToEndpointVisualEntity.getId()).toBeDefined();
+      expect(interceptSendToEndpointRaw.interceptSendToEndpoint.id).toEqual(
+        interceptSendToEndpointVisualEntity.getId(),
+      );
+    });
+  });
+
+  describe('isApplicable', () => {
+    it.each([
+      [{ from: { id: 'from-1234', steps: [] } }, false],
+      [{ onCompletion: { id: 'onCompletionId' } }, false],
+      [{ onException: { id: 'onExceptionId' } }, false],
+      [{ intercept: { id: 'interceptId' } }, false],
+      [{ interceptFrom: { id: 'interceptFromId' } }, false],
+      [{ interceptSendToEndpoint: { id: 'interceptSendToEndpointId' } }, true],
+    ])('should return %s for %s', (definition, result) => {
+      expect(CamelInterceptSendToEndpointVisualEntity.isApplicable(definition)).toEqual(result);
+    });
+  });
+
+  it('should return the id', () => {
+    const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+      interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
+    });
+    expect(interceptSendToEndpointVisualEntity.getId()).toEqual('id');
+  });
+
+  it('should set the id', () => {
+    const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+      interceptSendToEndpoint: 'a-reference',
+    });
+    interceptSendToEndpointVisualEntity.setId('new-id');
+    expect(interceptSendToEndpointVisualEntity.getId()).toEqual('new-id');
+    expect(interceptSendToEndpointVisualEntity.interceptSendToEndpointDef.interceptSendToEndpoint.id).toEqual('new-id');
+  });
+
+  describe('getNodeInteraction', () => {
+    it.each([
+      { processorName: 'route', path: 'route' },
+      { processorName: 'from', path: 'from' },
+      { processorName: 'to', path: 'to' },
+      { processorName: 'log', path: 'log' },
+      { processorName: 'onException', path: 'onException' },
+      { processorName: 'onCompletion', path: 'onCompletion' },
+      { processorName: 'intercept', path: 'intercept' },
+      { processorName: 'interceptFrom', path: 'interceptFrom' },
+      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
+    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+        interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
+      });
+
+      const result = interceptSendToEndpointVisualEntity.getNodeInteraction(data as IVisualizationNodeData);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('should delegate the validation text to the ModelValidationService', () => {
+    const validateNodeStatusSpy = jest.spyOn(ModelValidationService, 'validateNodeStatus');
+
+    const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+      interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
+    });
+    interceptSendToEndpointVisualEntity.getNodeValidationText('a-path');
+
+    expect(validateNodeStatusSpy).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('should return the vizualization node', () => {
+    const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+      interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
+    });
+    const vizNode = interceptSendToEndpointVisualEntity.toVizNode();
+
+    expect(vizNode.data.processorName).toBe(CamelInterceptSendToEndpointVisualEntity.ROOT_PATH);
+    expect(vizNode.data.entity).toBe(interceptSendToEndpointVisualEntity);
+    expect(vizNode.data.isGroup).toBeTruthy();
+  });
+
+  it('should serialize the entity', () => {
+    const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
+      interceptSendToEndpoint: { id: undefined, uri: 'direct:a-reference' },
+    });
+    const result = interceptSendToEndpointVisualEntity.toJSON();
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -1,0 +1,127 @@
+import { InterceptSendToEndpoint, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { isDefined } from '../../../utils';
+import { EntityType } from '../../camel/entities/base-entity';
+import {
+  BaseVisualCamelEntity,
+  IVisualizationNode,
+  IVisualizationNodeData,
+  NodeInteraction,
+} from '../base-visual-entity';
+import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { CamelRouteVisualEntityData } from './support/camel-component-types';
+import { CamelStepsService } from './support/camel-steps.service';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+export class CamelInterceptSendToEndpointVisualEntity
+  extends AbstractCamelVisualEntity<{ interceptSendToEndpoint: InterceptSendToEndpoint }>
+  implements BaseVisualCamelEntity
+{
+  id: string;
+  interceptSendToEndpointDef: { interceptSendToEndpoint: Exclude<InterceptSendToEndpoint, string> };
+  readonly type = EntityType.InterceptSendToEndpoint;
+  static readonly ROOT_PATH = 'interceptSendToEndpoint';
+
+  constructor(interceptSendToEndpointRaw: { interceptSendToEndpoint: InterceptSendToEndpoint }) {
+    let interceptSendToEndpointDef: { interceptSendToEndpoint: Exclude<InterceptSendToEndpoint, string> };
+    if (typeof interceptSendToEndpointRaw.interceptSendToEndpoint === 'string') {
+      interceptSendToEndpointDef = {
+        interceptSendToEndpoint: {
+          id: getCamelRandomId(CamelInterceptSendToEndpointVisualEntity.ROOT_PATH),
+          uri: interceptSendToEndpointRaw.interceptSendToEndpoint,
+        },
+      };
+    } else {
+      interceptSendToEndpointDef = { interceptSendToEndpoint: interceptSendToEndpointRaw.interceptSendToEndpoint };
+    }
+
+    super(interceptSendToEndpointDef);
+    this.interceptSendToEndpointDef = interceptSendToEndpointDef;
+    const id =
+      interceptSendToEndpointDef.interceptSendToEndpoint.id ??
+      getCamelRandomId(CamelInterceptSendToEndpointVisualEntity.ROOT_PATH);
+    this.id = id;
+    this.interceptSendToEndpointDef.interceptSendToEndpoint.id = id;
+  }
+
+  static isApplicable(
+    interceptSendToEndpointDef: unknown,
+  ): interceptSendToEndpointDef is { interceptSendToEndpoint: InterceptSendToEndpoint } {
+    if (
+      !isDefined(interceptSendToEndpointDef) ||
+      Array.isArray(interceptSendToEndpointDef) ||
+      typeof interceptSendToEndpointDef !== 'object'
+    ) {
+      return false;
+    }
+
+    const objectKeys = Object.keys(interceptSendToEndpointDef!);
+
+    return (
+      objectKeys.length === 1 &&
+      this.ROOT_PATH in interceptSendToEndpointDef! &&
+      (typeof interceptSendToEndpointDef.interceptSendToEndpoint === 'object' ||
+        typeof interceptSendToEndpointDef.interceptSendToEndpoint === 'string')
+    );
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  setId(id: string): void {
+    this.id = id;
+    this.interceptSendToEndpointDef.interceptSendToEndpoint.id = id;
+  }
+
+  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
+    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+    );
+    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+      (data as CamelRouteVisualEntityData).processorName,
+    );
+    const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
+    const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
+    const canReplaceStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
+    const canRemoveStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
+
+    return {
+      canHavePreviousStep,
+      canHaveNextStep: canHavePreviousStep,
+      canHaveChildren,
+      canHaveSpecialChildren,
+      canReplaceStep,
+      canRemoveStep,
+      canRemoveFlow: data.path === CamelInterceptSendToEndpointVisualEntity.ROOT_PATH,
+    };
+  }
+
+  getNodeValidationText(path?: string | undefined): string | undefined {
+    const componentVisualSchema = this.getComponentSchema(path);
+    if (!componentVisualSchema) return undefined;
+
+    return ModelValidationService.validateNodeStatus(componentVisualSchema);
+  }
+
+  toVizNode(): IVisualizationNode<IVisualizationNodeData> {
+    const interceptSendToEndpointGroupNode = CamelStepsService.getVizNodeFromProcessor(
+      CamelInterceptSendToEndpointVisualEntity.ROOT_PATH,
+      { processorName: CamelInterceptSendToEndpointVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      this.interceptSendToEndpointDef,
+    );
+    interceptSendToEndpointGroupNode.data.entity = this;
+    interceptSendToEndpointGroupNode.data.isGroup = true;
+
+    return interceptSendToEndpointGroupNode;
+  }
+
+  toJSON(): { interceptSendToEndpoint: InterceptSendToEndpoint } {
+    return { interceptSendToEndpoint: this.interceptSendToEndpointDef.interceptSendToEndpoint };
+  }
+
+  protected getRootUri(): string | undefined {
+    return undefined;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -1,0 +1,104 @@
+import { IVisualizationNodeData } from '../base-visual-entity';
+import { CamelInterceptVisualEntity } from './camel-intercept-visual-entity';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+describe('CamelInterceptVisualEntity', () => {
+  describe('constructor', () => {
+    it('should allow to create an instance out of the object definition', () => {
+      const interceptVisualEntity = new CamelInterceptVisualEntity({
+        intercept: { id: 'a-reference', disabled: false },
+      });
+
+      expect(interceptVisualEntity.getId()).toEqual('a-reference');
+    });
+
+    it('should allow to create an instance out of the object definition without id', () => {
+      const interceptRaw = {
+        intercept: { id: undefined, uri: 'direct:a-reference' },
+      };
+      const interceptVisualEntity = new CamelInterceptVisualEntity(interceptRaw);
+
+      expect(interceptVisualEntity.getId()).toBeDefined();
+      expect(interceptRaw.intercept.id).toEqual(interceptVisualEntity.getId());
+    });
+  });
+
+  describe('isApplicable', () => {
+    it.each([
+      [{ from: { id: 'from-1234', steps: [] } }, false],
+      [{ onCompletion: { id: 'onCompletionId' } }, false],
+      [{ onException: { id: 'onExceptionId' } }, false],
+      [{ intercept: { id: 'interceptId' } }, true],
+      [{ interceptFrom: { id: 'interceptFromId' } }, false],
+      [{ interceptSendToEndpoint: { id: 'interceptSendToEndpointId' } }, false],
+    ])('should return %s for %s', (definition, result) => {
+      expect(CamelInterceptVisualEntity.isApplicable(definition)).toEqual(result);
+    });
+  });
+
+  it('should return the id', () => {
+    const interceptVisualEntity = new CamelInterceptVisualEntity({
+      intercept: { id: 'id', disabled: false },
+    });
+    expect(interceptVisualEntity.getId()).toEqual('id');
+  });
+
+  it('should set the id', () => {
+    const interceptVisualEntity = new CamelInterceptVisualEntity({ intercept: { id: 'a-reference', disabled: false } });
+    interceptVisualEntity.setId('new-id');
+    expect(interceptVisualEntity.getId()).toEqual('new-id');
+    expect(interceptVisualEntity.interceptDef.intercept.id).toEqual('new-id');
+  });
+
+  describe('getNodeInteraction', () => {
+    it.each([
+      { processorName: 'route', path: 'route' },
+      { processorName: 'from', path: 'from' },
+      { processorName: 'to', path: 'to' },
+      { processorName: 'log', path: 'log' },
+      { processorName: 'onException', path: 'onException' },
+      { processorName: 'onCompletion', path: 'onCompletion' },
+      { processorName: 'intercept', path: 'intercept' },
+      { processorName: 'interceptFrom', path: 'interceptFrom' },
+      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
+    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      const interceptVisualEntity = new CamelInterceptVisualEntity({
+        intercept: { id: 'id', disabled: false },
+      });
+
+      const result = interceptVisualEntity.getNodeInteraction(data as IVisualizationNodeData);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('should delegate the validation text to the ModelValidationService', () => {
+    const validateNodeStatusSpy = jest.spyOn(ModelValidationService, 'validateNodeStatus');
+
+    const interceptVisualEntity = new CamelInterceptVisualEntity({
+      intercept: { id: 'id', disabled: false },
+    });
+    interceptVisualEntity.getNodeValidationText('a-path');
+
+    expect(validateNodeStatusSpy).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('should return the vizualization node', () => {
+    const interceptVisualEntity = new CamelInterceptVisualEntity({
+      intercept: { id: 'id', disabled: false },
+    });
+    const vizNode = interceptVisualEntity.toVizNode();
+
+    expect(vizNode.data.processorName).toBe(CamelInterceptVisualEntity.ROOT_PATH);
+    expect(vizNode.data.entity).toBe(interceptVisualEntity);
+    expect(vizNode.data.isGroup).toBeTruthy();
+  });
+
+  it('should serialize the entity', () => {
+    const interceptVisualEntity = new CamelInterceptVisualEntity({
+      intercept: { id: undefined, disabled: false },
+    });
+    const result = interceptVisualEntity.toJSON();
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -1,4 +1,4 @@
-import { OnException, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { Intercept, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
@@ -14,31 +14,29 @@ import { CamelRouteVisualEntityData } from './support/camel-component-types';
 import { CamelStepsService } from './support/camel-steps.service';
 import { ModelValidationService } from './support/validators/model-validation.service';
 
-export class CamelOnExceptionVisualEntity
-  extends AbstractCamelVisualEntity<{ onException: OnException }>
+export class CamelInterceptVisualEntity
+  extends AbstractCamelVisualEntity<{ intercept: Intercept }>
   implements BaseVisualCamelEntity
 {
   id: string;
-  readonly type = EntityType.OnException;
-  private static readonly ROOT_PATH = 'onException';
+  readonly type = EntityType.Intercept;
+  static readonly ROOT_PATH = 'intercept';
 
-  constructor(public onExceptionDef: { onException: OnException }) {
-    super(onExceptionDef);
-    const id = onExceptionDef.onException.id ?? getCamelRandomId(CamelOnExceptionVisualEntity.ROOT_PATH);
+  constructor(public interceptDef: { intercept: Intercept }) {
+    super(interceptDef);
+    const id = interceptDef.intercept.id ?? getCamelRandomId(CamelInterceptVisualEntity.ROOT_PATH);
     this.id = id;
-    this.onExceptionDef.onException.id = id;
+    this.interceptDef.intercept.id = id;
   }
 
-  static isApplicable(onExceptionDef: unknown): onExceptionDef is { onException: OnException } {
-    if (!isDefined(onExceptionDef) || Array.isArray(onExceptionDef) || typeof onExceptionDef !== 'object') {
+  static isApplicable(interceptDef: unknown): interceptDef is { intercept: Intercept } {
+    if (!isDefined(interceptDef) || Array.isArray(interceptDef) || typeof interceptDef !== 'object') {
       return false;
     }
 
-    const objectKeys = Object.keys(onExceptionDef!);
+    const objectKeys = Object.keys(interceptDef!);
 
-    return (
-      objectKeys.length === 1 && this.ROOT_PATH in onExceptionDef! && typeof onExceptionDef.onException === 'object'
-    );
+    return objectKeys.length === 1 && this.ROOT_PATH in interceptDef! && typeof interceptDef.intercept === 'object';
   }
 
   getId(): string {
@@ -47,7 +45,7 @@ export class CamelOnExceptionVisualEntity
 
   setId(id: string): void {
     this.id = id;
-    this.onExceptionDef.onException.id = id;
+    this.interceptDef.intercept.id = id;
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
@@ -59,8 +57,8 @@ export class CamelOnExceptionVisualEntity
     );
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
-    const canReplaceStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
-    const canRemoveStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
+    const canReplaceStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
+    const canRemoveStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
 
     return {
       canHavePreviousStep,
@@ -69,7 +67,7 @@ export class CamelOnExceptionVisualEntity
       canHaveSpecialChildren,
       canReplaceStep,
       canRemoveStep,
-      canRemoveFlow: data.path === CamelOnExceptionVisualEntity.ROOT_PATH,
+      canRemoveFlow: data.path === CamelInterceptVisualEntity.ROOT_PATH,
     };
   }
 
@@ -81,19 +79,19 @@ export class CamelOnExceptionVisualEntity
   }
 
   toVizNode(): IVisualizationNode<IVisualizationNodeData> {
-    const onExceptionGroupNode = CamelStepsService.getVizNodeFromProcessor(
-      CamelOnExceptionVisualEntity.ROOT_PATH,
-      { processorName: CamelOnExceptionVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
-      this.onExceptionDef,
+    const interceptGroupNode = CamelStepsService.getVizNodeFromProcessor(
+      CamelInterceptVisualEntity.ROOT_PATH,
+      { processorName: CamelInterceptVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      this.interceptDef,
     );
-    onExceptionGroupNode.data.entity = this;
-    onExceptionGroupNode.data.isGroup = true;
+    interceptGroupNode.data.entity = this;
+    interceptGroupNode.data.isGroup = true;
 
-    return onExceptionGroupNode;
+    return interceptGroupNode;
   }
 
-  toJSON(): { onException: OnException } {
-    return { onException: this.onExceptionDef.onException };
+  toJSON(): { intercept: Intercept } {
+    return { intercept: this.interceptDef.intercept };
   }
 
   protected getRootUri(): string | undefined {

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -1,0 +1,107 @@
+import { OnCompletion } from '@kaoto-next/camel-catalog/types';
+import { IVisualizationNodeData } from '../base-visual-entity';
+import { CamelOnCompletionVisualEntity } from './camel-on-completion-visual-entity';
+import { ModelValidationService } from './support/validators/model-validation.service';
+
+describe('CamelOnCompletionVisualEntity', () => {
+  describe('constructor', () => {
+    it('should allow to create an instance out of the object definition', () => {
+      const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+        onCompletion: { id: 'a-reference', mode: 'AfterConsumer' },
+      });
+
+      expect(onCompletionVisualEntity.getId()).toEqual('a-reference');
+    });
+
+    it('should allow to create an instance out of the object definition without id', () => {
+      const onCompletionRaw: { onCompletion: OnCompletion } = {
+        onCompletion: { id: undefined, mode: 'AfterConsumer' },
+      };
+      const onCompletionVisualEntity = new CamelOnCompletionVisualEntity(onCompletionRaw);
+
+      expect(onCompletionVisualEntity.getId()).toBeDefined();
+      expect(onCompletionRaw.onCompletion.id).toEqual(onCompletionVisualEntity.getId());
+    });
+  });
+
+  describe('isApplicable', () => {
+    it.each([
+      [{ from: { id: 'from-1234', steps: [] } }, false],
+      [{ onCompletion: { id: 'onCompletionId' } }, true],
+      [{ onException: { id: 'onExceptionId' } }, false],
+      [{ intercept: { id: 'interceptId' } }, false],
+      [{ interceptFrom: { id: 'interceptFromId' } }, false],
+      [{ interceptSendToEndpoint: { id: 'interceptSendToEndpointId' } }, false],
+    ])('should return %s for %s', (definition, result) => {
+      expect(CamelOnCompletionVisualEntity.isApplicable(definition)).toEqual(result);
+    });
+  });
+
+  it('should return the id', () => {
+    const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+      onCompletion: { id: 'id', mode: 'AfterConsumer' },
+    });
+    expect(onCompletionVisualEntity.getId()).toEqual('id');
+  });
+
+  it('should set the id', () => {
+    const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+      onCompletion: { id: 'id', mode: 'AfterConsumer' },
+    });
+    onCompletionVisualEntity.setId('new-id');
+    expect(onCompletionVisualEntity.getId()).toEqual('new-id');
+    expect(onCompletionVisualEntity.onCompletionDef.onCompletion.id).toEqual('new-id');
+  });
+
+  describe('getNodeInteraction', () => {
+    it.each([
+      { processorName: 'route', path: 'route' },
+      { processorName: 'from', path: 'from' },
+      { processorName: 'to', path: 'to' },
+      { processorName: 'log', path: 'log' },
+      { processorName: 'onException', path: 'onException' },
+      { processorName: 'onCompletion', path: 'onCompletion' },
+      { processorName: 'intercept', path: 'intercept' },
+      { processorName: 'onCompletion', path: 'onCompletion' },
+      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
+    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+        onCompletion: { id: 'id', mode: 'AfterConsumer' },
+      });
+
+      const result = onCompletionVisualEntity.getNodeInteraction(data as IVisualizationNodeData);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('should delegate the validation text to the ModelValidationService', () => {
+    const validateNodeStatusSpy = jest.spyOn(ModelValidationService, 'validateNodeStatus');
+
+    const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+      onCompletion: { id: 'id', mode: 'AfterConsumer' },
+    });
+    onCompletionVisualEntity.getNodeValidationText('a-path');
+
+    expect(validateNodeStatusSpy).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('should return the vizualization node', () => {
+    const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+      onCompletion: { id: 'id', mode: 'AfterConsumer' },
+    });
+    const vizNode = onCompletionVisualEntity.toVizNode();
+
+    expect(vizNode.data.processorName).toBe(CamelOnCompletionVisualEntity.ROOT_PATH);
+    expect(vizNode.data.entity).toBe(onCompletionVisualEntity);
+    expect(vizNode.data.isGroup).toBeTruthy();
+  });
+
+  it('should serialize the entity', () => {
+    const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
+      onCompletion: { id: undefined, mode: 'AfterConsumer' },
+    });
+    const result = onCompletionVisualEntity.toJSON();
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -1,4 +1,4 @@
-import { OnException, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { OnCompletion, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
@@ -14,30 +14,30 @@ import { CamelRouteVisualEntityData } from './support/camel-component-types';
 import { CamelStepsService } from './support/camel-steps.service';
 import { ModelValidationService } from './support/validators/model-validation.service';
 
-export class CamelOnExceptionVisualEntity
-  extends AbstractCamelVisualEntity<{ onException: OnException }>
+export class CamelOnCompletionVisualEntity
+  extends AbstractCamelVisualEntity<{ onCompletion: OnCompletion }>
   implements BaseVisualCamelEntity
 {
   id: string;
-  readonly type = EntityType.OnException;
-  private static readonly ROOT_PATH = 'onException';
+  readonly type = EntityType.OnCompletion;
+  static readonly ROOT_PATH = 'onCompletion';
 
-  constructor(public onExceptionDef: { onException: OnException }) {
-    super(onExceptionDef);
-    const id = onExceptionDef.onException.id ?? getCamelRandomId(CamelOnExceptionVisualEntity.ROOT_PATH);
+  constructor(public onCompletionDef: { onCompletion: OnCompletion }) {
+    super(onCompletionDef);
+    const id = onCompletionDef.onCompletion.id ?? getCamelRandomId(CamelOnCompletionVisualEntity.ROOT_PATH);
     this.id = id;
-    this.onExceptionDef.onException.id = id;
+    this.onCompletionDef.onCompletion.id = id;
   }
 
-  static isApplicable(onExceptionDef: unknown): onExceptionDef is { onException: OnException } {
-    if (!isDefined(onExceptionDef) || Array.isArray(onExceptionDef) || typeof onExceptionDef !== 'object') {
+  static isApplicable(onCompletionDef: unknown): onCompletionDef is { onCompletion: OnCompletion } {
+    if (!isDefined(onCompletionDef) || Array.isArray(onCompletionDef) || typeof onCompletionDef !== 'object') {
       return false;
     }
 
-    const objectKeys = Object.keys(onExceptionDef!);
+    const objectKeys = Object.keys(onCompletionDef!);
 
     return (
-      objectKeys.length === 1 && this.ROOT_PATH in onExceptionDef! && typeof onExceptionDef.onException === 'object'
+      objectKeys.length === 1 && this.ROOT_PATH in onCompletionDef! && typeof onCompletionDef.onCompletion === 'object'
     );
   }
 
@@ -47,7 +47,7 @@ export class CamelOnExceptionVisualEntity
 
   setId(id: string): void {
     this.id = id;
-    this.onExceptionDef.onException.id = id;
+    this.onCompletionDef.onCompletion.id = id;
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
@@ -59,8 +59,8 @@ export class CamelOnExceptionVisualEntity
     );
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
-    const canReplaceStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
-    const canRemoveStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
+    const canReplaceStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
+    const canRemoveStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
 
     return {
       canHavePreviousStep,
@@ -69,7 +69,7 @@ export class CamelOnExceptionVisualEntity
       canHaveSpecialChildren,
       canReplaceStep,
       canRemoveStep,
-      canRemoveFlow: data.path === CamelOnExceptionVisualEntity.ROOT_PATH,
+      canRemoveFlow: data.path === CamelOnCompletionVisualEntity.ROOT_PATH,
     };
   }
 
@@ -81,19 +81,19 @@ export class CamelOnExceptionVisualEntity
   }
 
   toVizNode(): IVisualizationNode<IVisualizationNodeData> {
-    const onExceptionGroupNode = CamelStepsService.getVizNodeFromProcessor(
-      CamelOnExceptionVisualEntity.ROOT_PATH,
-      { processorName: CamelOnExceptionVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
-      this.onExceptionDef,
+    const onCompletionGroupNode = CamelStepsService.getVizNodeFromProcessor(
+      CamelOnCompletionVisualEntity.ROOT_PATH,
+      { processorName: CamelOnCompletionVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      this.onCompletionDef,
     );
-    onExceptionGroupNode.data.entity = this;
-    onExceptionGroupNode.data.isGroup = true;
+    onCompletionGroupNode.data.entity = this;
+    onCompletionGroupNode.data.isGroup = true;
 
-    return onExceptionGroupNode;
+    return onCompletionGroupNode;
   }
 
-  toJSON(): { onException: OnException } {
-    return { onException: this.onExceptionDef.onException };
+  toJSON(): { onCompletion: OnCompletion } {
+    return { onCompletion: this.onCompletionDef.onCompletion };
   }
 
   protected getRootUri(): string | undefined {

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -1,0 +1,201 @@
+import { ProcessorDefinition, RouteConfigurationDefinition } from '@kaoto-next/camel-catalog/types';
+import Ajv, { ValidateFunction } from 'ajv-draft-04';
+import addFormats from 'ajv-formats';
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { SchemaService } from '../../../public-api';
+import { NodeIconResolver, getValue, isDefined, setValue } from '../../../utils';
+import { EntityType } from '../../camel/entities/base-entity';
+import { CatalogKind } from '../../catalog-kind';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import {
+  BaseVisualCamelEntity,
+  IVisualizationNode,
+  IVisualizationNodeData,
+  NodeInteraction,
+  VisualComponentSchema,
+} from '../base-visual-entity';
+import { createVisualizationNode } from '../visualization-node';
+import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { CamelCatalogService } from './camel-catalog.service';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { CamelStepsService } from './support/camel-steps.service';
+
+export class CamelRouteConfigurationVisualEntity
+  extends AbstractCamelVisualEntity<{ routeConfiguration: RouteConfigurationDefinition }>
+  implements BaseVisualCamelEntity
+{
+  id: string;
+  readonly type = EntityType.RouteConfiguration;
+  private static readonly ROOT_PATH = 'routeConfiguration';
+  private schemaValidator: ValidateFunction<RouteConfigurationDefinition> | undefined;
+  private readonly OMIT_FORM_FIELDS = [
+    ...SchemaService.OMIT_FORM_FIELDS,
+    'intercept',
+    'interceptFrom',
+    'interceptSendToEndpoint',
+    'onException',
+    'onCompletion',
+  ];
+
+  constructor(public routeConfigurationDef: { routeConfiguration: RouteConfigurationDefinition }) {
+    super(routeConfigurationDef);
+    const id =
+      routeConfigurationDef.routeConfiguration.id ?? getCamelRandomId(CamelRouteConfigurationVisualEntity.ROOT_PATH);
+    this.id = id;
+    this.routeConfigurationDef.routeConfiguration.id = id;
+  }
+
+  static isApplicable(
+    routeConfigurationDef: unknown,
+  ): routeConfigurationDef is { routeConfiguration: RouteConfigurationDefinition } {
+    if (
+      !isDefined(routeConfigurationDef) ||
+      Array.isArray(routeConfigurationDef) ||
+      typeof routeConfigurationDef !== 'object'
+    ) {
+      return false;
+    }
+
+    const objectKeys = Object.keys(routeConfigurationDef!);
+
+    return (
+      objectKeys.length === 1 &&
+      this.ROOT_PATH in routeConfigurationDef! &&
+      typeof routeConfigurationDef.routeConfiguration === 'object'
+    );
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  setId(id: string): void {
+    this.id = id;
+  }
+
+  getTooltipContent(path?: string): string {
+    if (path === CamelRouteConfigurationVisualEntity.ROOT_PATH) {
+      return 'routeConfiguration';
+    }
+
+    return super.getTooltipContent(path);
+  }
+
+  getComponentSchema(path?: string | undefined): VisualComponentSchema | undefined {
+    if (path === CamelRouteConfigurationVisualEntity.ROOT_PATH) {
+      const schema = CamelCatalogService.getComponent(CatalogKind.Entity, 'routeConfiguration');
+      return {
+        title: 'Route Configuration',
+        schema: schema?.propertiesSchema || {},
+        definition: Object.assign({}, this.routeConfigurationDef.routeConfiguration),
+      };
+    }
+
+    return super.getComponentSchema(path);
+  }
+
+  getOmitFormFields(): string[] {
+    return this.OMIT_FORM_FIELDS;
+  }
+
+  updateModel(path: string | undefined, value: unknown): void {
+    if (!path) return;
+
+    setValue(this.routeConfigurationDef, path, value);
+
+    if (!isDefined(this.routeConfigurationDef.routeConfiguration)) {
+      this.routeConfigurationDef.routeConfiguration = {};
+    }
+  }
+
+  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
+    if (data.path === CamelRouteConfigurationVisualEntity.ROOT_PATH) {
+      return {
+        canHavePreviousStep: false,
+        canHaveNextStep: false,
+        canHaveChildren: false,
+        canHaveSpecialChildren: true,
+        canRemoveStep: false,
+        canReplaceStep: false,
+        canRemoveFlow: true,
+      };
+    }
+
+    return super.getNodeInteraction(data);
+  }
+
+  getNodeValidationText(): string | undefined {
+    const componentVisualSchema = this.getComponentSchema();
+    if (!componentVisualSchema) return undefined;
+
+    if (!this.schemaValidator) {
+      this.schemaValidator = this.getValidatorFunction(componentVisualSchema.schema);
+    }
+
+    this.schemaValidator?.({ ...this.routeConfigurationDef.routeConfiguration });
+
+    return this.schemaValidator?.errors?.map((error) => `'${error.instancePath}' ${error.message}`).join(',\n');
+  }
+
+  toVizNode(): IVisualizationNode {
+    const routeConfigurationGroupNode = createVisualizationNode(this.id, {
+      path: CamelRouteConfigurationVisualEntity.ROOT_PATH,
+      entity: this,
+      isGroup: true,
+      icon: NodeIconResolver.getIcon(this.type),
+      processorName: CamelRouteConfigurationVisualEntity.ROOT_PATH,
+    });
+
+    CamelComponentSchemaService.getProcessorStepsProperties(
+      CamelRouteConfigurationVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+    ).forEach((stepsProperty) => {
+      const childEntities = getValue(this.routeConfigurationDef.routeConfiguration, stepsProperty.name, []);
+      if (!Array.isArray(childEntities)) return;
+
+      childEntities.forEach((childEntity, index) => {
+        const childNode = CamelStepsService.getVizNodeFromProcessor(
+          `${CamelRouteConfigurationVisualEntity.ROOT_PATH}.${stepsProperty.name}.${index}.${
+            Object.keys(childEntity)[0]
+          }`,
+          {
+            processorName: stepsProperty.name as keyof ProcessorDefinition,
+          },
+          this.routeConfigurationDef,
+        );
+
+        routeConfigurationGroupNode.addChild(childNode);
+      });
+    });
+
+    return routeConfigurationGroupNode;
+  }
+
+  toJSON(): { routeConfiguration: RouteConfigurationDefinition } {
+    return { routeConfiguration: this.routeConfigurationDef.routeConfiguration };
+  }
+
+  protected getRootUri(): string | undefined {
+    return undefined;
+  }
+
+  private getValidatorFunction(
+    schema: KaotoSchemaDefinition['schema'],
+  ): ValidateFunction<RouteConfigurationDefinition> | undefined {
+    return undefined;
+    const ajv = new Ajv({
+      strict: false,
+      allErrors: true,
+      useDefaults: 'empty',
+    });
+    addFormats(ajv);
+
+    let schemaValidator: ValidateFunction<RouteConfigurationDefinition> | undefined;
+    try {
+      schemaValidator = ajv.compile<RouteConfigurationDefinition>(schema);
+    } catch (error) {
+      console.error('Could not compile schema', error);
+    }
+
+    return schemaValidator;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -1,8 +1,11 @@
 import { FromDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
-import { isDefined } from '../../../utils';
+import { isDefined, setValue } from '../../../utils';
+import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
+import { AddStepMode, IVisualizationNodeData } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { CamelComponentDefaultService } from './support/camel-component-default.service';
 
 /** Very basic check to determine whether this object is a Camel Route */
 export const isCamelRoute = (rawEntity: unknown): rawEntity is { route: RouteDefinition } => {
@@ -33,7 +36,7 @@ export const isCamelFrom = (rawEntity: unknown): rawEntity is { from: FromDefini
   return isFromHolder && isValidUriField;
 };
 
-export class CamelRouteVisualEntity extends AbstractCamelVisualEntity {
+export class CamelRouteVisualEntity extends AbstractCamelVisualEntity<RouteDefinition> {
   id: string;
   readonly type = EntityType.Route;
 
@@ -47,6 +50,45 @@ export class CamelRouteVisualEntity extends AbstractCamelVisualEntity {
   setId(routeId: string): void {
     this.id = routeId;
     this.route.id = this.id;
+  }
+
+  toJSON(): { route: RouteDefinition } {
+    return { route: this.route };
+  }
+
+  addStep(options: {
+    definedComponent: DefinedComponent;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    targetProperty?: string | undefined;
+  }): void {
+    /** Replace the root `from` step */
+    if (options.mode === AddStepMode.ReplaceStep && options.data.path === 'from' && isDefined(this.route.from)) {
+      const fromValue = CamelComponentDefaultService.getDefaultFromDefinitionValue(options.definedComponent);
+      Object.assign(this.route.from, fromValue);
+      return;
+    }
+
+    super.addStep(options);
+  }
+
+  removeStep(path?: string): void {
+    if (!path) return;
+    /**
+     * If there's only one path segment, it means the target is the `from` property of the route
+     * therefore we replace it with an empty object
+     */
+    if (path === 'from') {
+      setValue(this.route, 'from.uri', '');
+      return;
+    }
+
+    super.removeStep(path);
+  }
+
+  updateModel(path: string | undefined, value: unknown): void {
+    super.updateModel(path, value);
+    if (isDefined(this.route.id)) this.id = this.route.id;
   }
 
   protected getRootUri(): string | undefined {


### PR DESCRIPTION
### Context
This commit adds support for the `RouteConfiguration` entity.

In detail, the following entities were added:
* intercept
* interceptFrom
* interceptSendToEndpoint
* onCompletion

Also the nested version of said entities were added


fix: https://github.com/KaotoIO/kaoto/issues/492