### PR TITLE
feat(Canvas): Add support for group children

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -135,6 +135,43 @@ describe('CanvasService', () => {
       expect(edges).toEqual([]);
     });
 
+    it('should return nodes and edges for a group with children', () => {
+      const groupVizNode = createVisualizationNode('group', { isGroup: true });
+      const child1VizNode = createVisualizationNode('child1', {});
+      const child2VizNode = createVisualizationNode('child2', {});
+      groupVizNode.addChild(child1VizNode);
+      groupVizNode.addChild(child2VizNode);
+
+      const { nodes, edges } = CanvasService.getFlowDiagram(groupVizNode);
+
+      expect(nodes).toEqual([
+        {
+          ...DEFAULT_NODE_PROPS,
+          id: 'child1-1234',
+          parentNode: 'group-1234',
+          data: { vizNode: child1VizNode },
+        },
+        {
+          ...DEFAULT_NODE_PROPS,
+          id: 'child2-1234',
+          parentNode: 'group-1234',
+          data: { vizNode: child2VizNode },
+        },
+        {
+          children: ['child1-1234', 'child2-1234'],
+          data: { vizNode: groupVizNode },
+          group: true,
+          type: 'group',
+          id: 'Unknown',
+          label: 'Unknown',
+          style: {
+            padding: 60,
+          },
+        },
+      ]);
+      expect(edges).toEqual([]);
+    });
+
     it('should return nodes and edges for a two-nodes VisualizationNode', () => {
       const vizNode = createVisualizationNode('node', {});
       const childNode = createVisualizationNode('child', {});

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -135,9 +135,9 @@ export class CanvasService {
     this.edges = [];
     this.visitedNodes = [];
 
-    const firstChild = vizNode.getChildren()?.[0];
-    if (vizNode.data.isGroup && firstChild) {
-      this.appendNodesAndEdges(firstChild);
+    const children = vizNode.getChildren();
+    if (vizNode.data.isGroup && children) {
+      children.forEach((child) => this.appendNodesAndEdges(child));
       const containerId = vizNode.getBaseEntity()?.getId() ?? 'Unknown';
       const group = this.getContainer(containerId, {
         label: containerId,


### PR DESCRIPTION
### Context
Currently, groups only support a single child.

This is not ideal for the `RouteConfiguration` entity since it could have multiple children.

### Changes
This PR adds support for multiple children in groups.

relates: https://github.com/KaotoIO/kaoto/issues/492