### PR TITLE
feat(Canvas): Consolidate groups interactions

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/CustomGroup.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomGroup.tsx
@@ -4,11 +4,13 @@ import {
   Layer,
   isNode,
   observer,
-  withSelection,
   withContextMenu,
+  withSelection,
 } from '@patternfly/react-topology';
 import { FunctionComponent } from 'react';
+import { AddStepMode } from '../../../models/visualization/base-visual-entity';
 import { CanvasNode } from '../Canvas/canvas.models';
+import { ItemInsertChildNode } from './ItemInsertChildNode';
 import { ItemRemoveGroup } from './ItemRemoveGroup';
 
 type IDefaultGroup = Parameters<typeof DefaultGroup>[0];
@@ -44,5 +46,10 @@ const CustomGroup: FunctionComponent<ICustomGroup> = observer(({ element, ...res
 });
 
 export const CustomGroupWithSelection = withContextMenu(() => [
+  <ItemInsertChildNode
+    key="context-menu-item-insert-special"
+    data-testid="context-menu-item-insert-special"
+    mode={AddStepMode.InsertSpecialChildStep}
+  />,
   <ItemRemoveGroup key="context-menu-container-remove" data-testid="context-menu-container-remove" />,
 ])(withSelection()(CustomGroup));

--- a/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
@@ -17,6 +17,7 @@ import { ItemAddNode } from './ItemAddNode';
 import { ItemInsertChildNode } from './ItemInsertChildNode';
 import { ItemRemoveNode } from './ItemRemoveNode';
 import { ItemReplaceNode } from './ItemReplaceNode';
+import { ItemRemoveGroup } from './ItemRemoveGroup';
 
 interface CustomNodeProps extends WithSelectionProps {
   element: Node<CanvasNode, CanvasNode['data']>;
@@ -78,4 +79,5 @@ export const CustomNodeWithSelection: typeof DefaultNode = withContextMenu(() =>
   />,
   <ItemReplaceNode key="context-menu-item-replace" data-testid="context-menu-item-replace" />,
   <ItemRemoveNode key="context-menu-item-remove" data-testid="context-menu-item-remove" />,
+  <ItemRemoveGroup key="context-menu-container-remove" data-testid="context-menu-container-remove" />,
 ])(withSelection()(CustomNode) as typeof DefaultNode) as typeof DefaultNode;

--- a/packages/ui/src/components/Visualization/Custom/ItemRemoveGroup.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemRemoveGroup.tsx
@@ -1,6 +1,6 @@
 import { TrashIcon } from '@patternfly/react-icons';
 import { ContextMenuItem, ElementContext, ElementModel, GraphElement } from '@patternfly/react-topology';
-import { FunctionComponent, useCallback, useContext } from 'react';
+import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { IDataTestID } from '../../../models';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import { CanvasNode } from '../Canvas/canvas.models';
@@ -10,15 +10,20 @@ export const ItemRemoveGroup: FunctionComponent<IDataTestID> = (props) => {
   const element: GraphElement<ElementModel, CanvasNode['data']> = useContext(ElementContext);
   const vizNode = element.getData()?.vizNode;
   const flowId = vizNode?.getBaseEntity()?.getId();
+  const shouldRender = useMemo(() => {
+    const nodeInteractions = vizNode?.getNodeInteraction() ?? { canRemoveFlow: false };
+
+    return nodeInteractions.canRemoveFlow;
+  }, [vizNode]);
 
   const onRemoveGroup = useCallback(() => {
     entitiesContext?.camelResource.removeEntity(flowId);
     entitiesContext?.updateEntitiesFromCamelResource();
-  }, [entitiesContext]);
+  }, [entitiesContext, flowId]);
 
-  return (
+  return shouldRender ? (
     <ContextMenuItem onClick={onRemoveGroup} data-testid={props['data-testid']}>
       <TrashIcon /> Delete
     </ContextMenuItem>
-  );
+  ) : null;
 };

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -155,4 +155,5 @@ export interface NodeInteraction {
   canHaveSpecialChildren: boolean;
   canReplaceStep: boolean;
   canRemoveStep: boolean;
+  canRemoveFlow: boolean;
 }

--- a/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'from' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'intercept' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'interceptFrom' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'interceptSendToEndpoint' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'log' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'onCompletion' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'onException' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'route' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'to' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'from' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'intercept' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'interceptFrom' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'interceptSendToEndpoint' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'log' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'onCompletion' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'onException' processor 1`] = `
+{
+  "canHaveChildren": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'route' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'to' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pipe getNodeInteraction should return the correct interaction for the '#' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": true,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`Pipe getNodeInteraction should return the correct interaction for the 'sink' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`Pipe getNodeInteraction should return the correct interaction for the 'source' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": false,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;
+
+exports[`Pipe getNodeInteraction should return the correct interaction for the 'steps.1' processor 1`] = `
+{
+  "canHaveChildren": false,
+  "canHaveNextStep": true,
+  "canHavePreviousStep": true,
+  "canHaveSpecialChildren": false,
+  "canRemoveFlow": false,
+  "canRemoveStep": true,
+  "canReplaceStep": true,
+}
+`;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -1,11 +1,11 @@
 import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
 import cloneDeep from 'lodash/cloneDeep';
 import { camelRouteJson } from '../../../stubs/camel-route';
-import { CamelRouteVisualEntity } from './camel-route-visual-entity';
-import { CamelCatalogService } from './camel-catalog.service';
-import { CatalogKind } from '../../catalog-kind';
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
+import { CatalogKind } from '../../catalog-kind';
+import { CamelCatalogService } from './camel-catalog.service';
+import { CamelRouteVisualEntity } from './camel-route-visual-entity';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('AbstractCamelVisualEntity', () => {
@@ -28,6 +28,35 @@ describe('AbstractCamelVisualEntity', () => {
 
   beforeEach(() => {
     abstractVisualEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson.route));
+  });
+
+  describe('getNodeInteraction', () => {
+    it('should not allow marked processors to have previous/next steps', () => {
+      const result = abstractVisualEntity.getNodeInteraction({ processorName: 'from' });
+      expect(result.canHavePreviousStep).toEqual(false);
+      expect(result.canHaveNextStep).toEqual(false);
+    });
+
+    it('should allow processors to have previous/next steps', () => {
+      const result = abstractVisualEntity.getNodeInteraction({ processorName: 'to' });
+      expect(result.canHavePreviousStep).toEqual(true);
+      expect(result.canHaveNextStep).toEqual(true);
+    });
+
+    it.each([
+      'route',
+      'from',
+      'to',
+      'log',
+      'onException',
+      'onCompletion',
+      'intercept',
+      'interceptFrom',
+      'interceptSendToEndpoint',
+    ])(`should return the correct interaction for the '%s' processor`, (processorName) => {
+      const result = abstractVisualEntity.getNodeInteraction({ processorName });
+      expect(result).toMatchSnapshot();
+    });
   });
 
   describe('getNodeValidationText', () => {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -217,6 +217,7 @@ export abstract class AbstractCamelVisualEntity implements BaseVisualCamelEntity
       canHaveSpecialChildren,
       canReplaceStep: true,
       canRemoveStep: true,
+      canRemoveFlow: data.path === ROOT_PATH,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -59,10 +59,24 @@ describe('CamelErrorHandlerVisualEntity', () => {
     expect(entity.getId()).toEqual(newId);
   });
 
-  it('should return node label', () => {
-    const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+  describe('getNodeLabel', () => {
+    it.each([
+      ['deadLetterChannel', { id: 'deadLetterChannelId' }, 'deadLetterChannelId'],
+      ['defaultErrorHandler', { id: 'defaultErrorHandlerId' }, 'defaultErrorHandlerId'],
+      ['jtaTransactionErrorHandler', { id: 'jtaTransactionErrorHandlerId' }, 'jtaTransactionErrorHandlerId'],
+      ['noErrorHandler', { id: 'noErrorHandlerId' }, 'noErrorHandlerId'],
+      ['refErrorHandler', { id: 'refErrorHandlerId' }, 'refErrorHandlerId'],
+      ['springTransactionErrorHandler', { id: 'springTransactionErrorHandlerId' }, 'springTransactionErrorHandlerId'],
+      ['springTransactionErrorHandler', {}, 'errorHandler'],
+    ])('should return %s label', (errorHandler, definition, label) => {
+      errorHandlerDef.errorHandler = {
+        [errorHandler]: definition,
+      };
 
-    expect(entity.getNodeLabel()).toEqual('errorHandler');
+      const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
+
+      expect(entity.getNodeLabel()).toEqual(label);
+    });
   });
 
   it('should return tooltip content', () => {
@@ -130,6 +144,7 @@ describe('CamelErrorHandlerVisualEntity', () => {
       canHaveSpecialChildren: false,
       canRemoveStep: false,
       canReplaceStep: false,
+      canRemoveFlow: true,
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
@@ -31,4 +31,24 @@ describe('CamelOnExceptionVisualEntity', () => {
       expect(onExceptionDef.onException.id).toEqual(entity.id);
     });
   });
+
+  describe('getNodeInteraction', () => {
+    it.each([
+      'route',
+      'from',
+      'to',
+      'log',
+      'onException',
+      'onCompletion',
+      'intercept',
+      'interceptFrom',
+      'interceptSendToEndpoint',
+    ])(`should return the correct interaction for the '%s' processor`, (processorName) => {
+      const onExceptionDef = { onException: {} as OnException };
+      const entity = new CamelOnExceptionVisualEntity(onExceptionDef);
+
+      const result = entity.getNodeInteraction({ processorName });
+      expect(result).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -225,6 +225,7 @@ export class CamelOnExceptionVisualEntity implements BaseVisualCamelEntity {
       canHaveSpecialChildren,
       canReplaceStep,
       canRemoveStep,
+      canRemoveFlow: data.path === CamelOnExceptionVisualEntity.ROOT_PATH,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -136,6 +136,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
       canHaveSpecialChildren: false,
       canRemoveStep: false,
       canReplaceStep: false,
+      canRemoveFlow: true,
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -100,6 +100,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualCamelEntity
       canHaveSpecialChildren: false,
       canRemoveStep: false,
       canReplaceStep: false,
+      canRemoveFlow: true,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -125,6 +125,16 @@ describe('Pipe', () => {
     });
   });
 
+  describe('getNodeInteraction', () => {
+    it.each(['source', 'sink', 'steps.1', '#'])(
+      `should return the correct interaction for the '%s' processor`,
+      (path) => {
+        const result = pipe.getNodeInteraction({ path });
+        expect(result).toMatchSnapshot();
+      },
+    );
+  });
+
   describe('getNodeValidationText', () => {
     it('should return an `undefined` if the path is `undefined`', () => {
       const result = pipe.getNodeValidationText(undefined);

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { SchemaService } from '../../../components/Form/schema.service';
-import { getArrayProperty, NodeIconResolver } from '../../../utils';
+import { getArrayProperty, NodeIconResolver, ROOT_PATH } from '../../../utils';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
 import { PipeMetadata, PipeSpec, PipeStep } from '../../camel/entities/pipe-overrides';
@@ -165,6 +165,7 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
       canHaveSpecialChildren: false,
       canReplaceStep: true,
       canRemoveStep: true,
+      canRemoveFlow: data.path === ROOT_PATH,
     };
   }
 

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -24,6 +24,15 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   private previousNode: IVisualizationNode | undefined = undefined;
   private nextNode: IVisualizationNode | undefined = undefined;
   private children: IVisualizationNode[] | undefined;
+  private readonly DISABLED_NODE_INTERACTION: NodeInteraction = {
+    canHavePreviousStep: false,
+    canHaveNextStep: false,
+    canHaveChildren: false,
+    canHaveSpecialChildren: false,
+    canReplaceStep: false,
+    canRemoveStep: false,
+    canRemoveFlow: false,
+  };
 
   constructor(
     public readonly id: string,
@@ -47,16 +56,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   }
 
   getNodeInteraction(): NodeInteraction {
-    return (
-      this.getBaseEntity()?.getNodeInteraction(this.data) ?? {
-        canHavePreviousStep: false,
-        canHaveNextStep: false,
-        canHaveChildren: false,
-        canHaveSpecialChildren: false,
-        canReplaceStep: false,
-        canRemoveStep: false,
-      }
-    );
+    return this.getBaseEntity()?.getNodeInteraction(this.data) ?? this.DISABLED_NODE_INTERACTION;
   }
 
   getComponentSchema(): VisualComponentSchema | undefined {


### PR DESCRIPTION
### Context
Currently, expanded and collapsed groups don't have the interactions available, for instance:

* Expanded groups: Only allowed to delete the entire flow
* Collapsed groups: Only allowed to Insert step

This commit consolidates both functionalities where it makes sense, so expanded groups allow the deletion of the flow, and collapsed ones allow to insert step (which expands the group) and the deletion of the entire flow.

### How to test
Use the following route
```yaml
- onException:
    id: onException-2479
- onException:
    id: onException-1968
    steps:
      - to:
          id: to-5255
          uri: activemq
          parameters: {}
```
You should see in both expanded and collapsed groups the `Delete flow` option

relates: https://github.com/KaotoIO/kaoto/issues/492