### PR TITLE
fix(SourceCode): Fix doCatch serialization

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -1,5 +1,6 @@
 import { CamelComponentDefaultService } from './camel-component-default.service';
 import { DefinedComponent } from '../../../camel-catalog-index';
+import { DoCatch } from '@kaoto-next/camel-catalog/types';
 
 describe('CamelComponentDefaultService', () => {
   describe('getDefaultNodeDefinitionValue', () => {
@@ -23,6 +24,27 @@ describe('CamelComponentDefaultService', () => {
       expect(whenDefault).toBeDefined();
       expect(whenDefault.expression.simple.expression).toEqual('${header.foo} == 1');
       expect(whenDefault.steps[0].log).toBeDefined();
+    });
+
+    it('should return the default value for a doTry processor', () => {
+      const doTryDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
+        type: 'processor',
+        name: 'doTry',
+      } as DefinedComponent);
+      expect(doTryDefault).toBeDefined();
+      expect(doTryDefault.doTry?.doCatch).toHaveLength(1);
+      expect(doTryDefault.doTry?.doCatch?.[0].steps).toHaveLength(0);
+      expect(doTryDefault.doTry?.doCatch?.[0].exception).toHaveLength(1);
+    });
+
+    it('should return the default value for a doCatch processor', () => {
+      const doCatchDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
+        type: 'processor',
+        name: 'doCatch',
+      } as DefinedComponent) as DoCatch;
+      expect(doCatchDefault).toBeDefined();
+      expect(doCatchDefault.id).toBeDefined();
+      expect(doCatchDefault.exception).toHaveLength(1);
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -103,6 +103,8 @@ export class CamelComponentDefaultService {
           id: ${getCamelRandomId('doTry')}
           doCatch:
             - id: ${getCamelRandomId('doCatch')}
+              exception:
+                - java.lang.NullPointerException
               steps: []
           doFinally:
             id: ${getCamelRandomId('doFinally')}
@@ -111,6 +113,14 @@ export class CamelComponentDefaultService {
             - log:
                 id: ${getCamelRandomId('log')}
                 message: "\${body}"
+        `);
+
+      case 'doCatch':
+        return parse(`
+          id: ${getCamelRandomId('doCatch')}
+          exception:
+            - java.lang.NullPointerException
+          steps: []
         `);
 
       default:


### PR DESCRIPTION
### Context
Currently, there's no handling when adding a new `doCatch` element to a `doTry` processor, leading to create a wrong structure.

The fix is to handle this situation so a proper `doCatch` is created at the right position with the correct structure.

fix: https://github.com/KaotoIO/kaoto/issues/1025