### PR TITLE
feat(CanvasForm): Transformed single line TextField into TextArea

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "lint:style:fix": "yarn lint:style --fix"
   },
   "dependencies": {
-    "@kaoto-next/uniforms-patternfly": "^0.6.8",
+    "@kaoto-next/uniforms-patternfly": "^0.6.10",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/notifications": "0.32.0",
     "@patternfly/patternfly": "5.2.1",

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -9,6 +9,7 @@ import { TypeaheadField } from './customField/TypeaheadField';
 import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 import { ExpressionField } from './expression/ExpressionField';
 import { PropertiesField } from './properties/PropertiesField';
+import { CustomLongTextField } from './customField/CustomLongTextField';
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly
@@ -56,7 +57,7 @@ export const CustomAutoField = createAutoField((props) => {
       } else if (title === 'Expression') {
         return LongTextField;
       }
-      return TextField;
+      return CustomLongTextField;
   }
 
   return DisabledField;

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -54,9 +54,9 @@ export const CustomAutoField = createAutoField((props) => {
       /* catalog preprocessor put 'string' as a type and the javaType as a schema $comment */
       if (comment?.startsWith('class:')) {
         return BeanReferenceField;
-      } else if (title === 'Expression') {
-        return LongTextField;
-      }
+      // } else if (title === 'Expression') {
+      //   return LongTextField;
+      // }
       return CustomLongTextField;
   }
 

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.scss
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.scss
@@ -1,0 +1,5 @@
+.custom-long-test-field {
+  textarea {
+    padding: 6px 8px 0;
+  }
+}

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
@@ -1,0 +1,9 @@
+import { HTMLFieldProps } from 'uniforms';
+import { LongTextField } from '@kaoto-next/uniforms-patternfly';
+import './CustomLongTextField.scss';
+
+export type CustomLongTextFieldProps = HTMLFieldProps<string, HTMLDivElement>;
+
+export const CustomLongTextField = (props: CustomLongTextFieldProps) => {
+  return <LongTextField className="custom-long-test-field" {...props} rows={1} autoResize={true} />;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@ __metadata:
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
     "@kaoto-next/camel-catalog": "workspace:*"
-    "@kaoto-next/uniforms-patternfly": ^0.6.8
+    "@kaoto-next/uniforms-patternfly": ^0.6.10
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0
     "@patternfly/patternfly": 5.2.1
@@ -2531,16 +2531,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaoto-next/uniforms-patternfly@npm:^0.6.8":
-  version: 0.6.8
-  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.8"
+"@kaoto-next/uniforms-patternfly@npm:^0.6.10":
+  version: 0.6.10
+  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.10"
   dependencies:
     invariant: ^2.2.4
     lodash: ^4.17.21
     react: ^18.2.0
     react-dom: ^18.2.0
     uniforms: 4.0.0-alpha.5
-  checksum: 882aa818eba9af30b73fd54a7f0b5c17871feda34e53b6fedb098662fc8f4206387fa2dccc077d9a8437133d90a1ab5e80349c3db6e7dc540abedf609cb5371f
+  checksum: 3d8565d4ce5a9eaa4a6c6128bc7c8a93d6f473c73713279971054ec2fda816e5c8a0d3871717caef31c61c3ef71b6855a9030836ff6dae46459cb3fd8ed4ec43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1021
The Text field looks like this with the latest change:
![Screenshot from 2024-04-25 03-26-31](https://github.com/KaotoIO/kaoto/assets/73224329/2c9af9d2-3070-46cb-bcf6-93c6ba5b7cb4)


