### PR TITLE
feat(Canvas): Add new entities to the Canvas

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
@@ -5,11 +5,11 @@ describe('Test for Multi route actions from the canvas', () => {
 
   it('User changes route type in the canvas', () => {
     cy.switchIntegrationType('Kamelet');
-    cy.get('[data-testid="toolbar-current-dsl"]').contains('Kamelet');
+    cy.get('[data-testid="dsl-list-dropdown"]').contains('Kamelet');
     cy.switchIntegrationType('camelYamlDsl');
-    cy.get('[data-testid="toolbar-current-dsl"]').contains('Camel Route');
+    cy.get('[data-testid="dsl-list-dropdown"]').contains('Camel Route');
     cy.switchIntegrationType('Pipe');
-    cy.get('[data-testid="toolbar-current-dsl"]').contains('Pipe');
+    cy.get('[data-testid="dsl-list-dropdown"]').contains('Pipe');
   });
 
   it('User shows and hides a route', () => {
@@ -55,8 +55,7 @@ describe('Test for Multi route actions from the canvas', () => {
     cy.checkCodeSpanLine('id: route-1234', 0);
   });
 
-  // Blocked ATM by https://github.com/KaotoIO/kaoto/issues/301
-  it.skip('User deletes routes in the canvas till there are no routes', () => {
+  it('User deletes routes in the canvas till there are no routes', () => {
     cy.openDesignPage();
     cy.addNewRoute();
     cy.addNewRoute();
@@ -67,13 +66,17 @@ describe('Test for Multi route actions from the canvas', () => {
     cy.deleteRoute(0);
     cy.deleteRoute(0);
     cy.deleteRoute(0);
-    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
-    cy.get('[data-testid="flows-list-empty-state"]').should('have.length', 1);
-    cy.get('[data-testid="flows-list-route-count"]').should('have.text', '0/0');
 
-    cy.get('[data-testid="flows-list-empty-state"]').within(() => {
-      cy.get('h4.pf-c-title').should('have.text', "There's no routes to show");
+    cy.toggleFlowsList();
+
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
+
+    cy.get('[data-testid="flows-list-route-count"]').should('have.text', '0/0');
+    cy.get('#flows-list-select').within(() => {
+      cy.get('h4.pf-v5-c-empty-state__title-text').should('have.text', "There's no routes to show");
     });
+
+    cy.get('[data-testid="visualization-empty-state"]').should('be.visible');
   });
 
   const testData = ['Pipe', 'Kamelet'];
@@ -83,7 +86,7 @@ describe('Test for Multi route actions from the canvas', () => {
       cy.switchIntegrationType(data);
       cy.get('[data-testid="dsl-list-dropdown"]').click({ force: true });
       cy.get('.pf-v5-c-menu__item-text').contains(data).closest('button').should('be.disabled');
-      cy.get('[data-testid="dsl-list-btn"]').should('be.disabled');
+      cy.get('[data-testid="new-entity-list-dropdown"]').should('not.exist');
 
       cy.get('[data-testid="flows-list-route-count"]').should('have.text', '1/1');
     });
@@ -92,6 +95,7 @@ describe('Test for Multi route actions from the canvas', () => {
   it('User creates multiple CamelRoute type routes in canvas', () => {
     // Camel Route is set as default type - simply add new routes
     cy.deleteRoute(0);
+    cy.addNewRoute();
     cy.addNewRoute();
     cy.addNewRoute();
 

--- a/packages/ui-tests/cypress/support/next-commands/default.ts
+++ b/packages/ui-tests/cypress/support/next-commands/default.ts
@@ -64,7 +64,8 @@ Cypress.Commands.add('switchIntegrationType', (type: string) => {
 });
 
 Cypress.Commands.add('addNewRoute', () => {
-  cy.get('[data-testid="dsl-list-btn"]').click();
+  cy.get('[data-testid="new-entity-list-dropdown"]').click();
+  cy.get('[data-testid="new-entity-route"]').click();
 });
 
 Cypress.Commands.add('toggleRouteVisibility', (index) => {

--- a/packages/ui-tests/stories/canvas/Canvas.stories.tsx
+++ b/packages/ui-tests/stories/canvas/Canvas.stories.tsx
@@ -39,8 +39,8 @@ const emptyCamelRouteJson = {
   },
 };
 
-const camelRouteEntity = new CamelRouteVisualEntity(complexRouteMock.route);
-const emptyCamelRouteEntity = new CamelRouteVisualEntity(emptyCamelRouteJson.route);
+const camelRouteEntity = new CamelRouteVisualEntity(complexRouteMock);
+const emptyCamelRouteEntity = new CamelRouteVisualEntity(emptyCamelRouteJson);
 const pipeEntity = new PipeVisualEntity(pipeJson.spec!);
 const kameletEntity = new KameletVisualEntity(kameletJson);
 const emptyPipeEntity = new PipeVisualEntity(emptyPipeJson.spec!);

--- a/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
@@ -56,7 +56,7 @@ const selectedNode: CanvasNode = {
           },
         } as VisualComponentSchema;
       },
-      getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+      getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson),
     } as IVisualizationNode,
   },
 };
@@ -79,7 +79,7 @@ const unknownSelectedNode: CanvasNode = {
           definition: null,
         } as VisualComponentSchema;
       },
-      getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+      getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson),
     } as IVisualizationNode,
   },
 };

--- a/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
@@ -3,30 +3,36 @@ import {
   CatalogSchemaLoader,
   CatalogTilesProvider,
   ContextToolbar,
-  EntitiesContext,
+  EntitiesProvider,
   SchemasLoaderProvider,
-  SourceCodeContext,
+  SourceCodeApiContext,
+  SourceCodeProvider,
   VisibleFlowsProvider,
+  camelRouteYaml,
+  kameletYaml,
+  pipeYaml,
 } from '@kaoto/kaoto/testing';
 import { Divider, Toolbar, ToolbarContent, ToolbarGroup } from '@patternfly/react-core';
 import { Meta, StoryFn } from '@storybook/react';
-import camelRouteMock from '../../cypress/fixtures/camelRouteMock.json';
+import { useContext } from 'react';
 
-const EntitiesContextDecorator = (Story: StoryFn) => (
-  <SourceCodeContext.Provider value={{ sourceCode: '', setCodeAndNotify: () => {} }}>
-    <EntitiesContext.Provider value={camelRouteMock}>
-      <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-        <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-          <CatalogTilesProvider>
-            <VisibleFlowsProvider>
-              <Story />
-            </VisibleFlowsProvider>
-          </CatalogTilesProvider>
-        </CatalogLoaderProvider>
-      </SchemasLoaderProvider>
-    </EntitiesContext.Provider>
-  </SourceCodeContext.Provider>
-);
+const EntitiesContextDecorator = (Story: StoryFn) => {
+  return (
+    <SourceCodeProvider>
+      <EntitiesProvider>
+        <SchemasLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+          <CatalogLoaderProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+            <CatalogTilesProvider>
+              <VisibleFlowsProvider>
+                <Story />
+              </VisibleFlowsProvider>
+            </CatalogTilesProvider>
+          </CatalogLoaderProvider>
+        </SchemasLoaderProvider>
+      </EntitiesProvider>
+    </SourceCodeProvider>
+  );
+};
 
 export default {
   title: 'Canvas/ContextToolbar',
@@ -37,7 +43,10 @@ export default {
   },
 } as Meta<typeof ContextToolbar>;
 
-const Template: StoryFn<typeof ContextToolbar> = () => {
+const Template: StoryFn<{ sourceCode: string }> = (props: { sourceCode: string }) => {
+  const sourceCodeApi = useContext(SourceCodeApiContext);
+  sourceCodeApi.setCodeAndNotify(props.sourceCode);
+
   return (
     <Toolbar>
       <ToolbarContent>
@@ -49,4 +58,23 @@ const Template: StoryFn<typeof ContextToolbar> = () => {
     </Toolbar>
   );
 };
+
 export const Default = Template.bind({});
+Default.args = {
+  sourceCode: camelRouteYaml,
+};
+
+export const Kamelet = Template.bind({});
+Kamelet.args = {
+  sourceCode: kameletYaml,
+};
+
+export const Pipe = Template.bind({});
+Pipe.args = {
+  sourceCode: pipeYaml,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  sourceCode: '',
+};

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -2,26 +2,26 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { CamelRouteResource, KameletResource } from '../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../models/visualization/flows';
-import { EntitiesContext } from '../../../providers';
 import { CatalogModalContext } from '../../../providers/catalog-modal.provider';
-import { VisibleFLowsContextResult, VisibleFlowsContext } from '../../../providers/visible-flows.provider';
+import { VisibleFLowsContextResult } from '../../../providers/visible-flows.provider';
 import { TestProvidersWrapper } from '../../../stubs';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { kameletJson } from '../../../stubs/kamelet-route';
 import { Canvas } from './Canvas';
 
 describe('Canvas', () => {
-  const entity = new CamelRouteVisualEntity(camelRouteJson.route);
+  const entity = new CamelRouteVisualEntity(camelRouteJson);
   const entity2 = { ...entity, id: 'route-9999' } as CamelRouteVisualEntity;
 
   it('should render correctly', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { visibleFlows: { ['route-8888']: true } } as unknown as VisibleFLowsContextResult,
+    });
     const result = render(
-      <TestProvidersWrapper
-        visibleFlows={{ visibleFlows: { ['route-8888']: true } } as unknown as VisibleFLowsContextResult}
-      >
+      <Provider>
         <Canvas entities={[entity]} />
-      </TestProvidersWrapper>,
+      </Provider>,
     );
 
     await waitFor(async () => expect(result.container.querySelector('#fit-to-screen')).toBeInTheDocument());
@@ -29,14 +29,15 @@ describe('Canvas', () => {
   });
 
   it('should render correctly with more routes ', async () => {
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: {
+        visibleFlows: { ['route-8888']: true, ['route-9999']: false },
+      } as unknown as VisibleFLowsContextResult,
+    });
     const result = render(
-      <TestProvidersWrapper
-        visibleFlows={
-          { visibleFlows: { ['route-8888']: true, ['route-9999']: false } } as unknown as VisibleFLowsContextResult
-        }
-      >
+      <Provider>
         <Canvas entities={[entity, entity2]} />
-      </TestProvidersWrapper>,
+      </Provider>,
     );
 
     await waitFor(async () => expect(result.container.querySelector('#fit-to-screen')).toBeInTheDocument());
@@ -45,34 +46,23 @@ describe('Canvas', () => {
 
   it('should be able to delete the routes', async () => {
     const camelResource = new CamelRouteResource(camelRouteJson);
-    const routeEntity = camelResource.getVisualEntities();
+    const routeEntities = camelResource.getVisualEntities();
     const removeSpy = jest.spyOn(camelResource, 'removeEntity');
-    const setCurrentSchemaTypeSpy = jest.fn();
-    const updateEntitiesFromCamelResourceSpy = jest.fn();
-    const updateSourceCodeFromEntitiesSpy = jest.fn();
 
-    render(
-      <EntitiesContext.Provider
-        value={{
-          camelResource,
-          entities: camelResource.getEntities(),
-          visualEntities: camelResource.getVisualEntities(),
-          currentSchemaType: camelResource.getType(),
-          setCurrentSchemaType: setCurrentSchemaTypeSpy,
-          updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
-          updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
-        }}
-      >
-        <VisibleFlowsContext.Provider
-          value={{ visibleFlows: { ['route-8888']: true } } as unknown as VisibleFLowsContextResult}
-        >
-          <Canvas entities={routeEntity} />
-        </VisibleFlowsContext.Provider>
-      </EntitiesContext.Provider>,
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        visibleFlows: { ['route-8888']: true },
+      } as unknown as VisibleFLowsContextResult,
+    });
+    const wrapper = render(
+      <Provider>
+        <Canvas entities={routeEntities} />
+      </Provider>,
     );
 
     // Right click anywhere on the container label
-    const route = screen.getByText('route-8888');
+    const route = wrapper.getByText('route-8888');
     await act(async () => {
       fireEvent.contextMenu(route);
     });
@@ -92,34 +82,24 @@ describe('Canvas', () => {
 
   it('should be able to delete the kamelets', async () => {
     const kameletResource = new KameletResource(kameletJson);
-    const kameletEntity = kameletResource.getVisualEntities();
+    const kameletEntities = kameletResource.getVisualEntities();
     const removeSpy = jest.spyOn(kameletResource, 'removeEntity');
-    const setCurrentSchemaTypeSpy = jest.fn();
-    const updateEntitiesFromCamelResourceSpy = jest.fn();
-    const updateSourceCodeFromEntitiesSpy = jest.fn();
 
-    render(
-      <EntitiesContext.Provider
-        value={{
-          camelResource: kameletResource,
-          entities: kameletResource.getEntities(),
-          visualEntities: kameletResource.getVisualEntities(),
-          currentSchemaType: kameletResource.getType(),
-          setCurrentSchemaType: setCurrentSchemaTypeSpy,
-          updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
-          updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
-        }}
-      >
-        <VisibleFlowsContext.Provider
-          value={{ visibleFlows: { ['user-source']: true } } as unknown as VisibleFLowsContextResult}
-        >
-          <Canvas entities={kameletEntity} />
-        </VisibleFlowsContext.Provider>
-      </EntitiesContext.Provider>,
+    const { Provider } = TestProvidersWrapper({
+      camelResource: kameletResource,
+      visibleFlowsContext: {
+        visibleFlows: { ['user-source']: true },
+      } as unknown as VisibleFLowsContextResult,
+    });
+
+    const wrapper = render(
+      <Provider>
+        <Canvas entities={kameletEntities} />
+      </Provider>,
     );
 
     // Right click anywhere on the container label
-    const kamelet = screen.getByText('user-source');
+    const kamelet = wrapper.getByText('user-source');
     // const route = document.querySelectorAll('.pf-topology__group');
     await act(async () => {
       fireEvent.contextMenu(kamelet);
@@ -138,13 +118,14 @@ describe('Canvas', () => {
   });
 
   it('should render the Catalog button if `CatalogModalContext` is provided', async () => {
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { visibleFlows: { ['route-8888']: true } } as unknown as VisibleFLowsContextResult,
+    });
     const result = render(
       <CatalogModalContext.Provider value={{ getNewComponent: jest.fn(), setIsModalOpen: jest.fn() }}>
-        <TestProvidersWrapper
-          visibleFlows={{ visibleFlows: { ['route-8888']: true } } as unknown as VisibleFLowsContextResult}
-        >
+        <Provider>
           <Canvas entities={[entity]} />
-        </TestProvidersWrapper>
+        </Provider>
       </CatalogModalContext.Provider>,
     );
 
@@ -156,10 +137,13 @@ describe('Canvas', () => {
 
   describe('Empty state', () => {
     it('should render empty state when there is no visual entity', async () => {
+      const { Provider } = TestProvidersWrapper({
+        visibleFlowsContext: { visibleFlows: {} } as unknown as VisibleFLowsContextResult,
+      });
       const result = render(
-        <TestProvidersWrapper visibleFlows={{ visibleFlows: {} } as unknown as VisibleFLowsContextResult}>
+        <Provider>
           <Canvas entities={[]} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
 
       await waitFor(async () => expect(result.getByTestId('visualization-empty-state')).toBeInTheDocument());
@@ -167,12 +151,13 @@ describe('Canvas', () => {
     });
 
     it('should render empty state when there is no visible flows', async () => {
+      const { Provider } = TestProvidersWrapper({
+        visibleFlowsContext: { visibleFlows: { ['route-8888']: false } } as unknown as VisibleFLowsContextResult,
+      });
       const result = render(
-        <TestProvidersWrapper
-          visibleFlows={{ visibleFlows: { ['route-8888']: false } } as unknown as VisibleFLowsContextResult}
-        >
+        <Provider>
           <Canvas entities={[entity]} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
 
       await waitFor(async () => expect(result.getByTestId('visualization-empty-state')).toBeInTheDocument());

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -84,7 +84,7 @@ describe('CanvasForm', () => {
   });
 
   beforeEach(() => {
-    camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson.route);
+    camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson);
     const { nodes } = CanvasService.getFlowDiagram(camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[2]; // choice
   });
@@ -112,7 +112,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => undefined,
-          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson),
         } as unknown as IVisualizationNode,
       },
     };
@@ -141,7 +141,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson),
         } as unknown as IVisualizationNode,
       },
     };
@@ -172,7 +172,7 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson),
         } as unknown as IVisualizationNode,
       },
     };

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -3,29 +3,39 @@ import { FunctionComponent, useContext } from 'react';
 import { sourceSchemaConfig } from '../../../models/camel';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import './ContextToolbar.scss';
+import { DSLSelector } from './DSLSelector/DSLSelector';
 import { FlowClipboard } from './FlowClipboard/FlowClipboard';
 import { FlowExportImage } from './FlowExportImage/FlowExportImage';
-import { NewFlow } from '../EmptyState/FlowType/NewFlow';
 import { FlowsMenu } from './Flows/FlowsMenu';
+import { NewEntity } from './NewEntity/NewEntity';
 
 export const ContextToolbar: FunctionComponent = () => {
   const { currentSchemaType } = useContext(EntitiesContext)!;
+  const isMultipleRoutes = sourceSchemaConfig.config[currentSchemaType].multipleRoute;
 
-  return [
-    <ToolbarItem className="current-dsl-tag" key="toolbar-current-dsl">
-      <span data-testid="toolbar-current-dsl">{sourceSchemaConfig.config[currentSchemaType].name || 'None'}</span>
+  const toolbarItems: JSX.Element[] = [
+    <ToolbarItem key="toolbar-dsl-selector">
+      <DSLSelector />
     </ToolbarItem>,
     <ToolbarItem key="toolbar-flows-list">
       <FlowsMenu />
     </ToolbarItem>,
-    <ToolbarItem key="toolbar-new-route">
-      <NewFlow />
-    </ToolbarItem>,
+  ];
+
+  if (isMultipleRoutes) {
+    toolbarItems.push(
+      <ToolbarItem key="toolbar-new-route">
+        <NewEntity />
+      </ToolbarItem>,
+    );
+  }
+
+  return toolbarItems.concat([
     <ToolbarItem key="toolbar-clipboard">
       <FlowClipboard />
     </ToolbarItem>,
     <ToolbarItem key={'toolbar-export-image'}>
       <FlowExportImage />
     </ToolbarItem>,
-  ];
+  ]);
 };

--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelector.test.tsx
@@ -1,9 +1,7 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { EntitiesContextResult } from '../../../../hooks';
 import { KaotoSchemaDefinition } from '../../../../models';
 import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
-import { EntitiesContext } from '../../../../providers/entities.provider';
-import { SourceCodeApiContext } from '../../../../providers/source-code.provider';
+import { TestProvidersWrapper } from '../../../../stubs';
 import { DSLSelector } from './DSLSelector';
 
 describe('DSLSelector.tsx', () => {
@@ -25,28 +23,14 @@ describe('DSLSelector.tsx', () => {
     schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
   } as KaotoSchemaDefinition;
 
-  const renderWithContext = () => {
-    return render(
-      <SourceCodeApiContext.Provider
-        value={{
-          setCodeAndNotify: jest.fn(),
-        }}
-      >
-        <EntitiesContext.Provider
-          value={
-            {
-              currentSchemaType: SourceSchemaType.Integration,
-            } as unknown as EntitiesContextResult
-          }
-        >
-          <DSLSelector />
-        </EntitiesContext.Provider>
-      </SourceCodeApiContext.Provider>,
-    );
-  };
-
   it('should render all of the types', async () => {
-    const wrapper = renderWithContext();
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <DSLSelector />
+      </Provider>,
+    );
+
     const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
@@ -61,7 +45,13 @@ describe('DSLSelector.tsx', () => {
   });
 
   it('should warn the user when adding a different type of flow', async () => {
-    const wrapper = renderWithContext();
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <DSLSelector />
+      </Provider>,
+    );
+
     const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
@@ -1,36 +1,26 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { EntitiesContextResult } from '../../../../hooks';
-import { SourceSchemaType } from '../../../../models/camel';
-import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
-import { IVisibleFlows } from '../../../../models/visualization/flows/support/flows-visibility';
-import { EntitiesContext } from '../../../../providers/entities.provider';
-import { VisibleFLowsContextResult, VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
+import { CamelResource, CamelRouteResource } from '../../../../models/camel';
+import { EntityType } from '../../../../models/camel/entities';
+import { VisibleFLowsContextResult } from '../../../../providers/visible-flows.provider';
+import { TestProvidersWrapper } from '../../../../stubs';
 import { FlowsMenu } from './FlowsMenu';
 
-const FlowsMenuWithContext: React.FunctionComponent<{
-  visibleFlows?: IVisibleFlows;
-}> = ({ visibleFlows }) => {
-  const visFlows = { ['entity1']: true, ['entity2']: false };
-
-  const entContextValue = {
-    currentSchemaType: SourceSchemaType.Integration,
-    visualEntities: [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity],
-  } as unknown as EntitiesContextResult;
-
-  return (
-    <EntitiesContext.Provider value={entContextValue as unknown as EntitiesContextResult}>
-      <VisibleFlowsContext.Provider
-        value={{ visibleFlows: visibleFlows ?? visFlows } as unknown as VisibleFLowsContextResult}
-      >
-        <FlowsMenu />
-      </VisibleFlowsContext.Provider>
-    </EntitiesContext.Provider>
-  );
-};
-
 describe('FlowsMenu.tsx', () => {
+  let camelResource: CamelResource;
+  beforeEach(async () => {
+    camelResource = new CamelRouteResource();
+    camelResource.addNewEntity(EntityType.Route);
+    camelResource.addNewEntity(EntityType.RouteConfiguration);
+  });
+
   it('should open the flows list when clicking the dropdown', async () => {
-    const wrapper = render(<FlowsMenuWithContext />);
+    const { Provider } = TestProvidersWrapper({ camelResource });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
+
     const dropdown = await wrapper.findByTestId('flows-list-dropdown');
 
     /** Open List */
@@ -46,7 +36,13 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should open the flows list when clicking the action button', async () => {
-    const wrapper = render(<FlowsMenuWithContext />);
+    const { Provider } = TestProvidersWrapper({ camelResource });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
+
     const dropdown = await wrapper.findByTestId('flows-list-btn');
 
     /** Open List */
@@ -62,7 +58,13 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should close the flows list when pressing ESC', async () => {
-    const wrapper = render(<FlowsMenuWithContext />);
+    const { Provider } = TestProvidersWrapper({ camelResource });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
+
     const dropdown = await wrapper.findByTestId('flows-list-btn');
 
     /** Open List */
@@ -84,28 +86,71 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should render the route id when a single route is visible', async () => {
-    const wrapper = render(<FlowsMenuWithContext />);
+    const singleFlowCamelResource = new CamelRouteResource();
+    singleFlowCamelResource.addNewEntity(EntityType.Route);
+
+    const { Provider } = TestProvidersWrapper({
+      camelResource: singleFlowCamelResource,
+      visibleFlowsContext: { visibleFlows: { ['route-1234']: true } } as unknown as VisibleFLowsContextResult,
+    });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
+
     const routeId = await wrapper.findByTestId('flows-list-route-id');
 
-    expect(routeId).toHaveTextContent('entity1');
+    expect(routeId).toHaveTextContent('route-1234');
   });
 
   it('should NOT render the route id but "Routes" when there is no flow visible', async () => {
-    const wrapper = render(<FlowsMenuWithContext visibleFlows={{ ['entity1']: false, ['entity2']: false }} />);
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },
+      } as unknown as VisibleFLowsContextResult,
+    });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
     const routeId = await wrapper.findByTestId('flows-list-route-id');
 
     expect(routeId).toHaveTextContent('Routes');
   });
 
   it('should NOT render the route id but "Routes" when there is more than 1 flow visible', async () => {
-    const wrapper = render(<FlowsMenuWithContext visibleFlows={{ ['entity1']: true, ['entity2']: true }} />);
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },
+      } as unknown as VisibleFLowsContextResult,
+    });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
     const routeId = await wrapper.findByTestId('flows-list-route-id');
 
     expect(routeId).toHaveTextContent('Routes');
   });
 
   it('should render the visible routes count', async () => {
-    const wrapper = render(<FlowsMenuWithContext visibleFlows={{ ['entity1']: true, ['entity2']: true }} />);
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },
+      } as unknown as VisibleFLowsContextResult,
+    });
+    const wrapper = render(
+      <Provider>
+        <FlowsMenu />
+      </Provider>,
+    );
+
     const routeCount = await wrapper.findByTestId('flows-list-route-count');
     expect(routeCount).toHaveTextContent('2/2');
   });

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -1,0 +1,128 @@
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition, KaotoSchemaDefinition } from '../../../../models';
+import { SourceSchemaType, sourceSchemaConfig } from '../../../../models/camel';
+import { TestProvidersWrapper } from '../../../../stubs';
+import { NewEntity } from './NewEntity';
+
+const config = sourceSchemaConfig;
+config.config[SourceSchemaType.Pipe].schema = {
+  name: 'Pipe',
+  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+config.config[SourceSchemaType.Kamelet].schema = {
+  name: 'Kamelet',
+  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+config.config[SourceSchemaType.Route].schema = {
+  name: 'route',
+  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+
+describe('NewEntity', () => {
+  beforeEach(async () => {
+    const entitiesCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    delete (entitiesCatalog as any).default;
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Entity,
+      entitiesCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+    );
+  });
+
+  it('component renders', () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <NewEntity />
+      </Provider>,
+    );
+
+    const toggle = wrapper.queryByTestId('new-entity-list-dropdown');
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it('should call `updateEntitiesFromCamelResource` when selecting an item', async () => {
+    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <NewEntity />
+      </Provider>,
+    );
+
+    /** Click on toggle */
+    const toggle = await wrapper.findByTestId('new-entity-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    const element = await wrapper.findAllByRole('menuitem');
+    act(() => {
+      fireEvent.click(element[0]);
+    });
+
+    await waitFor(async () => {
+      expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('should toggle list of DSLs', async () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <NewEntity />
+      </Provider>,
+    );
+
+    const toggle = await wrapper.findByTestId('new-entity-list-dropdown');
+
+    /** Click on toggle */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByText('Route');
+    expect(element).toBeInTheDocument();
+
+    /** Close Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    await waitFor(async () => {
+      expect(element).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close Select when pressing ESC', async () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <NewEntity />
+      </Provider>,
+    );
+
+    const toggle = await wrapper.findByTestId('new-entity-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = await wrapper.findByRole('menu');
+
+    expect(menu).toBeInTheDocument();
+
+    /** Press Escape key to close the menu */
+    act(() => {
+      fireEvent.focus(menu);
+      fireEvent.keyDown(menu, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    await waitFor(async () => {
+      /** The close panel is an async process */
+      expect(menu).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
@@ -1,0 +1,107 @@
+import { Menu, MenuContainer, MenuContent, MenuItem, MenuList, MenuToggle } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent, ReactElement, useCallback, useContext, useRef, useState } from 'react';
+import { BaseVisualCamelEntityDefinition } from '../../../../models/camel/camel-resource';
+import { EntityType } from '../../../../models/camel/entities';
+import { EntitiesContext } from '../../../../providers/entities.provider';
+import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
+
+export const NewEntity: FunctionComponent = () => {
+  const { camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
+  const visibleFlowsContext = useContext(VisibleFlowsContext)!;
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const groupedEntities = useRef<BaseVisualCamelEntityDefinition>(camelResource.getCanvasEntityList());
+
+  const onSelect = useCallback(
+    (_event: unknown, entityType: string | number | undefined) => {
+      if (!entityType) {
+        return;
+      }
+
+      /**
+       * If it's the same DSL as we have in the existing Flows list,
+       * we don't need to do anything special, just add a new flow if
+       * supported
+       */
+      const newId = camelResource.addNewEntity(entityType as EntityType);
+      visibleFlowsContext.visualFlowsApi.hideAllFlows();
+      visibleFlowsContext.visualFlowsApi.setVisibleFlows([newId]);
+      updateEntitiesFromCamelResource();
+      setIsOpen(false);
+    },
+    [camelResource, updateEntitiesFromCamelResource, visibleFlowsContext.visualFlowsApi],
+  );
+
+  const getMenuItem = useCallback(
+    (
+      entity:
+        | { title: string; description?: string; name: EntityType }
+        | { title: string; description?: string; key: string },
+      flyoutMenu?: ReactElement,
+    ) => {
+      const name = 'name' in entity ? entity.name : entity.key;
+      return (
+        <MenuItem
+          key={`new-entity-${name}`}
+          data-testid={`new-entity-${name}`}
+          itemId={name}
+          description={
+            <span className="pf-v5-u-text-break-word" style={{ wordBreak: 'keep-all' }}>
+              {entity.description}
+            </span>
+          }
+          flyoutMenu={flyoutMenu}
+        >
+          {entity.title}
+        </MenuItem>
+      );
+    },
+    [],
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      menu={
+        // TODO: Workaround for flyout menu being scrollable and packed within the toolbar
+        <Menu ref={menuRef} style={{ overflowY: 'unset' }} containsFlyout onSelect={onSelect}>
+          <MenuContent>
+            <MenuList>
+              {groupedEntities.current.common.map((entityDef) => getMenuItem(entityDef))}
+
+              {Object.entries(groupedEntities.current.groups).map(([group, entities]) => {
+                const flyoutMenu = (
+                  <Menu onSelect={onSelect}>
+                    <MenuContent>
+                      <MenuList>{entities.map((entityDef) => getMenuItem(entityDef))}</MenuList>
+                    </MenuContent>
+                  </Menu>
+                );
+
+                return getMenuItem({ key: group, title: group }, flyoutMenu);
+              })}
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      }
+      menuRef={menuRef}
+      toggle={
+        <MenuToggle
+          data-testid="new-entity-list-dropdown"
+          ref={toggleRef}
+          onClick={() => {
+            setIsOpen(!isOpen);
+          }}
+          isExpanded={isOpen}
+        >
+          <PlusIcon />
+          <span className="pf-v5-u-m-sm">New</span>
+        </MenuToggle>
+      }
+      toggleRef={toggleRef}
+    />
+  );
+};

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
@@ -52,7 +52,7 @@ describe('NewFlow.tsx', () => {
 
   const visualEntities = [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity];
 
-  test('should render all of the types', async () => {
+  it('should render all of the types', async () => {
     const wrapper = renderWithContext();
     const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
@@ -67,7 +67,7 @@ describe('NewFlow.tsx', () => {
     }
   });
 
-  test('should warn the user when adding a different type of flow', async () => {
+  it('should warn the user when adding a different type of flow', async () => {
     const wrapper = renderWithContext();
     const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 

--- a/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
@@ -5,10 +5,11 @@ import { VisualizationEmptyState } from './VisualizationEmptyState';
 describe('VisualizationEmptyState.tsx', () => {
   describe('when there are no routes', () => {
     it('should render the CubesIcon whenever there are no routes', () => {
+      const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <TestProvidersWrapper>
+        <Provider>
           <VisualizationEmptyState entitiesNumber={0} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
 
       const icon = wrapper.getByTestId('cubes-icon');
@@ -17,10 +18,11 @@ describe('VisualizationEmptyState.tsx', () => {
     });
 
     it('should state that there are no routes', () => {
+      const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <TestProvidersWrapper>
+        <Provider>
           <VisualizationEmptyState entitiesNumber={0} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
 
       const noRoutesTitle = wrapper.getByText('There are no routes defined');
@@ -33,10 +35,11 @@ describe('VisualizationEmptyState.tsx', () => {
 
   describe('when there are routes but they are not visible', () => {
     it('should render the EyeSlashIcon whenever there are no routes', () => {
+      const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <TestProvidersWrapper>
+        <Provider>
           <VisualizationEmptyState entitiesNumber={1} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
       const icon = wrapper.getByTestId('eye-slash-icon');
 
@@ -44,10 +47,11 @@ describe('VisualizationEmptyState.tsx', () => {
     });
 
     it('should state that there are no visible routes', () => {
+      const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <TestProvidersWrapper>
+        <Provider>
           <VisualizationEmptyState entitiesNumber={1} />
-        </TestProvidersWrapper>,
+        </Provider>,
       );
       const noRoutesTitle = wrapper.getByText('There are no visible routes');
       const noRoutesSuggestion = wrapper.getByText('You can toggle the visibility of a route by using Routes list');

--- a/packages/ui/src/hooks/entities.test.tsx
+++ b/packages/ui/src/hooks/entities.test.tsx
@@ -40,7 +40,7 @@ describe('useEntities', () => {
     });
 
     expect(result.current.entities).toEqual([]);
-    expect(result.current.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson.route)]);
+    expect(result.current.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson)]);
   });
 
   it('should serialize using YAML 1.1', () => {

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -4,13 +4,13 @@ import {
   Pipe as PipeType,
 } from '@kaoto/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
+import { createCamelPropertiesSorter } from '../../utils';
 import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { MetadataEntity } from '../visualization/metadata';
-import { CamelResource } from './camel-resource';
+import { BaseVisualCamelEntityDefinition, CamelResource } from './camel-resource';
 import { BaseCamelEntity } from './entities';
 import { SourceSchemaType } from './source-schema-type';
-import { createCamelPropertiesSorter } from '../../utils';
 
 export type CamelKType = IntegrationType | IKameletDefinition | KameletBindingType | PipeType;
 
@@ -39,6 +39,13 @@ export abstract class CamelKResource implements CamelResource {
       };
     }
     this.metadata = this.resource.metadata && new MetadataEntity(this.resource);
+  }
+
+  getCanvasEntityList(): BaseVisualCamelEntityDefinition {
+    return {
+      common: [],
+      groups: {},
+    };
   }
 
   removeEntity(_id?: string) {}

--- a/packages/ui/src/models/camel/camel-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-resource.test.ts
@@ -69,8 +69,7 @@ describe('createCamelResource', () => {
     expect(resource.getVisualEntities().length).toEqual(2);
   });
 
-  // TODO
-  it.skip('should create a Kamelet', () => {
+  it('should create a Kamelet', () => {
     const resource = createCamelResource(kameletJson);
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     expect(resource.getVisualEntities().length).toEqual(1);

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -7,23 +7,24 @@ import { TileFilter } from '../../components/Catalog';
 import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { BeansEntity } from '../visualization/metadata';
+import { RouteTemplateBeansEntity } from '../visualization/metadata/routeTemplateBeansEntity';
 import { CamelRouteResource } from './camel-route-resource';
-import { BaseCamelEntity } from './entities';
+import { BaseCamelEntity, EntityType } from './entities';
 import { IntegrationResource } from './integration-resource';
 import { KameletBindingResource } from './kamelet-binding-resource';
 import { KameletResource } from './kamelet-resource';
 import { PipeResource } from './pipe-resource';
 import { SourceSchemaType } from './source-schema-type';
-import { RouteTemplateBeansEntity } from '../visualization/metadata/routeTemplateBeansEntity';
 
 export interface CamelResource {
   getVisualEntities(): BaseVisualCamelEntity[];
   getEntities(): BaseCamelEntity[];
-  addNewEntity(entity?: unknown): string;
+  addNewEntity(entityType?: EntityType): string;
   removeEntity(id?: string): void;
   supportsMultipleVisualEntities(): boolean;
   toJSON(): unknown;
   getType(): SourceSchemaType;
+  getCanvasEntityList(): BaseVisualCamelEntityDefinition;
 
   /** Components Catalog related methods */
   getCompatibleComponents(
@@ -34,6 +35,17 @@ export interface CamelResource {
   ): TileFilter | undefined;
 
   sortFn?: (a: unknown, b: unknown) => number;
+}
+
+export interface BaseVisualCamelEntityDefinition {
+  common: BaseVisualCamelEntityDefinitionItem[];
+  groups: Record<string, BaseVisualCamelEntityDefinitionItem[]>;
+}
+
+export interface BaseVisualCamelEntityDefinitionItem {
+  name: EntityType;
+  title: string;
+  description: string;
 }
 
 export interface BeansAwareResource {

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -137,13 +137,13 @@ describe('CamelRouteResource', () => {
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
 
-    it('should create a new entity after deleting them all', () => {
+    it('should NOT create a new entity after deleting them all', () => {
       const resource = new CamelRouteResource(camelRouteJson);
       const camelRouteEntity = resource.getVisualEntities()[0];
 
       resource.removeEntity(camelRouteEntity.id);
 
-      expect(resource.getVisualEntities()).toHaveLength(1);
+      expect(resource.getVisualEntities()).toHaveLength(0);
     });
   });
 

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -53,6 +53,12 @@ export interface BaseVisualCamelEntity extends BaseCamelEntity {
   toVizNode: () => IVisualizationNode;
 }
 
+export interface BaseVisualCamelEntityConstructor {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): BaseVisualCamelEntity;
+  isApplicable: (entity: unknown) => boolean;
+}
+
 /**
  * IVisualizationNode
  *

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -84,7 +84,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
       expect(entity.getComponentSchema().definition).toEqual(restConfigurationDef.restConfiguration);
     });
 
-    it.skip('should return schema from store', () => {
+    it('should return schema from store', () => {
       const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
 
       expect(entity.getComponentSchema().schema).toEqual(restConfigurationSchema);

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -13,7 +13,7 @@ describe('Camel Route', () => {
   let camelEntity: CamelRouteVisualEntity;
 
   beforeEach(() => {
-    camelEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson.route));
+    camelEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
   });
 
   describe('isCamelRoute', () => {
@@ -250,9 +250,11 @@ describe('Camel Route', () => {
 
     it('should populate the viz node chain with simple steps', () => {
       const vizNode = new CamelRouteVisualEntity({
-        id: 'route-1234',
-        from: { uri: 'timer', steps: [{ choice: { when: [{ steps: [{ log: { message: 'We got a one.' } }] }] } }] },
-      } as unknown as RouteDefinition).toVizNode();
+        route: {
+          id: 'route-1234',
+          from: { uri: 'timer', steps: [{ choice: { when: [{ steps: [{ log: { message: 'We got a one.' } }] }] } }] },
+        },
+      }).toVizNode();
       const fromNode = vizNode.getChildren()![0];
 
       /** Given a structure of

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -118,7 +118,7 @@ export class VisualFlowsApi {
   }
 
   setVisibleFlows(flows: string[]) {
-    this.dispatch({ type: 'setVisibleFlows', flows: flows });
+    this.dispatch({ type: 'setVisibleFlows', flows });
   }
 
   clearFlows() {
@@ -126,7 +126,7 @@ export class VisualFlowsApi {
   }
 
   initVisibleFlows(visibleFlows: IVisibleFlows) {
-    this.dispatch({ type: 'initVisibleFlows', visibleFlows: visibleFlows });
+    this.dispatch({ type: 'initVisibleFlows', visibleFlows });
   }
 
   renameFlow(flowId: string, newName: string) {

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -173,7 +173,7 @@ describe('VisualizationNode', () => {
     });
 
     it('should delegate to the BaseVisualCamelEntity to remove the underlying child', () => {
-      const camelRouteVisualEntityStub = new CamelRouteVisualEntity(camelRouteJson.route);
+      const camelRouteVisualEntityStub = new CamelRouteVisualEntity(camelRouteJson);
 
       node = camelRouteVisualEntityStub.toVizNode();
       const fromNode = node.getChildren()?.[0];

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -1,16 +1,54 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { EntitiesProvider, VisibleFLowsContextResult, VisibleFlowsContext } from '../providers';
+import { EntitiesContextResult } from '../hooks';
+import { CamelResource } from '../models/camel/camel-resource';
+import { CamelRouteResource } from '../models/camel/camel-route-resource';
+import { VisualFlowsApi } from '../models/visualization/flows/support/flows-visibility';
+import { EntitiesContext, VisibleFLowsContextResult, VisibleFlowsContext } from '../providers';
+import { camelRouteJson } from './camel-route';
 
-interface ITestProviderWrapper extends PropsWithChildren {
-  visibleFlows?: VisibleFLowsContextResult;
+interface TestProviderWrapperProps extends PropsWithChildren {
+  camelResource?: CamelResource;
+  visibleFlowsContext?: VisibleFLowsContextResult;
 }
 
-export const TestProvidersWrapper: FunctionComponent<ITestProviderWrapper> = (props) => {
-  const visibleFlows = props.visibleFlows || ({ visibleFlows: {} } as unknown as VisibleFLowsContextResult);
+interface TestProvidersWrapperResult {
+  Provider: FunctionComponent<PropsWithChildren>;
+  setCurrentSchemaTypeSpy: EntitiesContextResult['setCurrentSchemaType'];
+  updateEntitiesFromCamelResourceSpy: EntitiesContextResult['updateEntitiesFromCamelResource'];
+  updateSourceCodeFromEntitiesSpy: EntitiesContextResult['updateSourceCodeFromEntities'];
+}
 
-  return (
-    <EntitiesProvider>
-      <VisibleFlowsContext.Provider value={visibleFlows}>{props.children}</VisibleFlowsContext.Provider>
-    </EntitiesProvider>
+export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): TestProvidersWrapperResult => {
+  const camelResource = props.camelResource ?? new CamelRouteResource(camelRouteJson);
+  const currentSchemaType = camelResource.getType();
+  const setCurrentSchemaTypeSpy = jest.fn();
+  const updateEntitiesFromCamelResourceSpy = jest.fn();
+  const updateSourceCodeFromEntitiesSpy = jest.fn();
+
+  const dispatchSpy = jest.fn();
+  const visibleFlowsContext: VisibleFLowsContextResult = {
+    visibleFlows: props.visibleFlowsContext?.visibleFlows ?? {},
+    visualFlowsApi: props.visibleFlowsContext?.visualFlowsApi ?? new VisualFlowsApi(dispatchSpy),
+  };
+
+  const Provider: FunctionComponent<PropsWithChildren> = (props) => (
+    <EntitiesContext.Provider
+      key={Date.now()}
+      value={
+        {
+          camelResource,
+          entities: camelResource.getEntities(),
+          visualEntities: camelResource.getVisualEntities(),
+          currentSchemaType,
+          setCurrentSchemaType: setCurrentSchemaTypeSpy,
+          updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
+          updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
+        } as unknown as EntitiesContextResult
+      }
+    >
+      <VisibleFlowsContext.Provider value={visibleFlowsContext}>{props.children}</VisibleFlowsContext.Provider>
+    </EntitiesContext.Provider>
   );
+
+  return { Provider, setCurrentSchemaTypeSpy, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy };
 };

--- a/packages/ui/src/stubs/camel-route.ts
+++ b/packages/ui/src/stubs/camel-route.ts
@@ -101,4 +101,4 @@ export const camelRouteJson = {
   },
 };
 
-export const camelRoute = new CamelRouteVisualEntity(camelRouteJson.route);
+export const camelRoute = new CamelRouteVisualEntity(camelRouteJson);


### PR DESCRIPTION
### Context
Currently, setting the current DSL and creating a new entity are tied together in a single step in the NewFlow component.

This commit split that functionality into two separate buttons:
1. DSL Selector: Meant to choose the current DSL and therefore determine which type of entities can be added to the Canvas

2. NewEntity: This is for adding new entities, supported by the current DSL, or said differently, allowing to add entities from the current CamelResource registry.

### Notes
The existing functionality from the CanvasEmptyState is preserved for now.

In addition to that, when removing all routes, a new route won't be created by default.

### Screenshots
#### DSL Selector
![image](https://github.com/KaotoIO/kaoto/assets/16512618/437a3fc4-923f-4f43-be87-c268890ae456)

#### New entity
![image](https://github.com/KaotoIO/kaoto/assets/16512618/a038d621-529d-4d81-ba6f-bb5ba1bcfa87)

#### Toolbar with Camel Route DSL
![image](https://github.com/KaotoIO/kaoto/assets/16512618/2c03dd99-8adc-4276-aed2-f19b1991429d)

#### Toolbar with Kamelet DSL
![image](https://github.com/KaotoIO/kaoto/assets/16512618/ac420e6e-c2f8-4c53-a801-95863729eb4d)

#### Toolbar with Pipe
![image](https://github.com/KaotoIO/kaoto/assets/16512618/efbda09a-032c-4bb5-9a58-c40354087eff)

fix: https://github.com/KaotoIO/kaoto/issues/1030