### PR TITLE
feat(CanvasToolbar): Add DSL Selector

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/ChangeDSLModal/ChangeDSLModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/ChangeDSLModal/ChangeDSLModal.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ChangeDSLModal } from './ChangeDSLModal';
+
+describe('ChangeDSLModal', () => {
+  it('should be hidden when isOpen is false', () => {
+    const wrapper = render(<ChangeDSLModal isOpen={false} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+
+    expect(wrapper.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+  });
+
+  it('should be visible when isOpen is true', () => {
+    const wrapper = render(<ChangeDSLModal isOpen={true} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+
+    expect(wrapper.queryByTestId('confirmation-modal')).toBeInTheDocument();
+  });
+
+  it('should call onConfirm when confirm button is clicked', () => {
+    const onConfirm = jest.fn();
+    const wrapper = render(<ChangeDSLModal isOpen={true} onConfirm={onConfirm} onCancel={jest.fn()} />);
+
+    fireEvent.click(wrapper.getByTestId('confirmation-modal-confirm'));
+
+    expect(onConfirm).toBeCalled();
+  });
+
+  it('should call onCancel when cancel button is clicked', () => {
+    const onCancel = jest.fn();
+    const wrapper = render(<ChangeDSLModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(wrapper.getByTestId('confirmation-modal-cancel'));
+
+    expect(onCancel).toBeCalled();
+  });
+
+  it('should call onCancel when close button is clicked', () => {
+    const onCancel = jest.fn();
+    const wrapper = render(<ChangeDSLModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(wrapper.getByLabelText('Close'));
+
+    expect(onCancel).toBeCalled();
+  });
+});

--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/ChangeDSLModal/ChangeDSLModal.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/ChangeDSLModal/ChangeDSLModal.tsx
@@ -1,0 +1,34 @@
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+
+interface ChangeDSLModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ChangeDSLModal: FunctionComponent<ChangeDSLModalProps> = (props) => {
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Warning"
+      data-testid="confirmation-modal"
+      titleIconVariant="warning"
+      onClose={props.onCancel}
+      actions={[
+        <Button key="confirm" variant="primary" data-testid="confirmation-modal-confirm" onClick={props.onConfirm}>
+          Confirm
+        </Button>,
+        <Button key="cancel" variant="link" data-testid="confirmation-modal-cancel" onClick={props.onCancel}>
+          Cancel
+        </Button>,
+      ]}
+      isOpen={props.isOpen}
+    >
+      <p>
+        This will remove any existing integration and you will lose your current work. Are you sure you would like to
+        proceed?
+      </p>
+    </Modal>
+  );
+};

--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelector.tsx
@@ -1,0 +1,39 @@
+import { FunctionComponent, PropsWithChildren, useCallback, useContext, useState } from 'react';
+import { SourceSchemaType } from '../../../../models/camel';
+import { FlowTemplateService } from '../../../../models/visualization/flows/support/flow-templates-service';
+import { SourceCodeApiContext } from '../../../../providers';
+import { ChangeDSLModal } from './ChangeDSLModal/ChangeDSLModal';
+import { DSLSelectorToggle } from './DSLSelectorToggle/DSLSelectorToggle';
+
+export const DSLSelector: FunctionComponent<PropsWithChildren> = () => {
+  const sourceCodeContextApi = useContext(SourceCodeApiContext);
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+  const [proposedFlowType, setProposedFlowType] = useState<SourceSchemaType>();
+
+  const checkBeforeAddNewFlow = useCallback((flowType: SourceSchemaType) => {
+    /**
+     * If it is not the same DSL, this operation might result in
+     * removing the existing flows, so then we warn the user first
+     */
+    setProposedFlowType(flowType);
+    setIsConfirmationModalOpen(true);
+  }, []);
+
+  const onConfirm = useCallback(() => {
+    if (proposedFlowType) {
+      sourceCodeContextApi.setCodeAndNotify(FlowTemplateService.getFlowYamlTemplate(proposedFlowType));
+      setIsConfirmationModalOpen(false);
+    }
+  }, [proposedFlowType, sourceCodeContextApi]);
+
+  const onCancel = useCallback(() => {
+    setIsConfirmationModalOpen(false);
+  }, []);
+
+  return (
+    <>
+      <DSLSelectorToggle onSelect={checkBeforeAddNewFlow} />
+      <ChangeDSLModal isOpen={isConfirmationModalOpen} onConfirm={onConfirm} onCancel={onCancel} />
+    </>
+  );
+};

--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelectorToggle/DSLSelectorToggle.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelectorToggle/DSLSelectorToggle.test.tsx
@@ -1,0 +1,177 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { FunctionComponent } from 'react';
+import { EntitiesContextResult } from '../../../../../hooks';
+import { KaotoSchemaDefinition } from '../../../../../models';
+import { SourceSchemaType, sourceSchemaConfig } from '../../../../../models/camel';
+import { EntitiesContext } from '../../../../../providers/entities.provider';
+import { DSLSelectorToggle } from './DSLSelectorToggle';
+
+const config = sourceSchemaConfig;
+config.config[SourceSchemaType.Pipe].schema = {
+  name: 'Pipe',
+  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+config.config[SourceSchemaType.Kamelet].schema = {
+  name: 'Kamelet',
+  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+config.config[SourceSchemaType.Route].schema = {
+  name: 'route',
+  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
+} as KaotoSchemaDefinition;
+
+describe('DSLSelectorToggle.tsx', () => {
+  let onSelect: () => void;
+  beforeEach(() => {
+    onSelect = jest.fn();
+  });
+
+  const DSLSelectorWithContext: FunctionComponent<{ currentSchemaType?: SourceSchemaType }> = (props) => {
+    const currentSchemaType = props.currentSchemaType ?? SourceSchemaType.Route;
+    return (
+      <EntitiesContext.Provider key={Date.now()} value={{ currentSchemaType } as unknown as EntitiesContextResult}>
+        <DSLSelectorToggle onSelect={onSelect} />
+      </EntitiesContext.Provider>
+    );
+  };
+
+  it('component renders', () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+    const toggle = wrapper.queryByTestId('dsl-list-dropdown');
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it('should call onSelect when clicking on the MenuToggleAction', async () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+
+    /** Click on toggle */
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    const element = await wrapper.findByText('Pipe');
+    act(() => {
+      fireEvent.click(element);
+    });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalled();
+    });
+  });
+
+  it('should disable the MenuToggleAction if the DSL is already selected', async () => {
+    const wrapper = render(<DSLSelectorWithContext currentSchemaType={SourceSchemaType.Route} />);
+
+    /** Click on toggle */
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    const element = await wrapper.findByText('Camel Route');
+    // act(() => {
+    //   fireEvent.click(element);
+    // });
+
+    waitFor(() => {
+      expect(element).toBeDisabled();
+    });
+  });
+
+  it('should toggle list of DSLs', async () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+
+    /** Click on toggle */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByText('Pipe');
+    expect(element).toBeInTheDocument();
+
+    /** Close Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    waitFor(() => {
+      expect(element).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show selected value', async () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Camel Route');
+      fireEvent.click(element);
+    });
+
+    /** Open Select again */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByRole('option', { selected: true });
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveTextContent('Camel Route');
+  });
+
+  it('should have selected DSL if provided', async () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Pipe');
+    });
+  });
+
+  it('should close Select when pressing ESC', async () => {
+    const wrapper = render(<DSLSelectorWithContext />);
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = await wrapper.findByRole('listbox');
+
+    expect(menu).toBeInTheDocument();
+
+    /** Press Escape key to close the menu */
+    act(() => {
+      fireEvent.focus(menu);
+      fireEvent.keyDown(menu, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    waitFor(() => {
+      /** The close panel is an async process */
+      expect(menu).not.toBeInTheDocument();
+    });
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Camel Route');
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelectorToggle/DSLSelectorToggle.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/DSLSelector/DSLSelectorToggle/DSLSelectorToggle.tsx
@@ -1,0 +1,82 @@
+import { MenuToggle, Select, SelectList, SelectOption } from '@patternfly/react-core';
+import { FunctionComponent, MouseEvent, RefObject, useCallback, useContext, useRef, useState } from 'react';
+import { ISourceSchema, SourceSchemaType, sourceSchemaConfig } from '../../../../../models/camel';
+import { EntitiesContext } from '../../../../../providers/entities.provider';
+
+interface ISourceTypeSelector {
+  onSelect?: (value: SourceSchemaType) => void;
+}
+
+export const DSLSelectorToggle: FunctionComponent<ISourceTypeSelector> = (props) => {
+  const { currentSchemaType } = useContext(EntitiesContext)!;
+  const currentFlowType: ISourceSchema = sourceSchemaConfig.config[currentSchemaType];
+  const [isOpen, setIsOpen] = useState(false);
+  const dslEntriesRef = useRef<Partial<Record<SourceSchemaType, ISourceSchema>>>({
+    [SourceSchemaType.Route]: sourceSchemaConfig.config[SourceSchemaType.Route],
+    [SourceSchemaType.Kamelet]: sourceSchemaConfig.config[SourceSchemaType.Kamelet],
+    [SourceSchemaType.Pipe]: sourceSchemaConfig.config[SourceSchemaType.Pipe],
+  });
+
+  const onSelect = useCallback(
+    (_event: MouseEvent | undefined, flowType: string | number | undefined) => {
+      if (!flowType) {
+        return;
+      }
+      const dsl = sourceSchemaConfig.config[flowType as SourceSchemaType];
+
+      setIsOpen(false);
+      if (dsl !== undefined) {
+        props.onSelect?.(flowType as SourceSchemaType);
+      }
+    },
+    [props],
+  );
+
+  const toggle = (toggleRef: RefObject<HTMLButtonElement>) => (
+    <MenuToggle
+      data-testid="dsl-list-dropdown"
+      ref={toggleRef}
+      onClick={() => {
+        setIsOpen(!isOpen);
+      }}
+      isExpanded={isOpen}
+    >
+      {sourceSchemaConfig.config[currentSchemaType].name}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id="dsl-list-select"
+      isOpen={isOpen}
+      selected={currentSchemaType}
+      onSelect={onSelect}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+      style={{ width: '20rem' }}
+    >
+      <SelectList>
+        {Object.entries(dslEntriesRef.current).map(([sourceType, sourceSchema], index) => {
+          const isOptionDisabled = sourceSchema.name === currentFlowType.name;
+
+          return (
+            <SelectOption
+              key={`dsl-${sourceSchema.schema?.name ?? index}`}
+              data-testid={`dsl-${sourceSchema.schema?.name}`}
+              itemId={sourceType}
+              description={
+                <span className="pf-v5-u-text-break-word" style={{ wordBreak: 'keep-all' }}>
+                  {sourceSchemaConfig.config[sourceType as SourceSchemaType].description}
+                </span>
+              }
+              isDisabled={isOptionDisabled}
+            >
+              {sourceSchema.name}
+              {isOptionDisabled && ' (current DSL)'}
+            </SelectOption>
+          );
+        })}
+      </SelectList>
+    </Select>
+  );
+};

--- a/packages/ui/src/models/camel/source-schema-config.ts
+++ b/packages/ui/src/models/camel/source-schema-config.ts
@@ -6,6 +6,7 @@ export interface ISourceSchema {
   schema: KaotoSchemaDefinition | undefined;
   name: string;
   multipleRoute: boolean;
+  description?: string;
 }
 
 interface IEntitySchemaConfig {
@@ -22,26 +23,35 @@ class SourceSchemaConfig {
       name: 'Camel Route',
       schema: undefined,
       multipleRoute: true,
+      description:
+        'Defines an executable integration flow by declaring a source (starter) and followed by a sequence of actions (or steps). Actions can include data manipulations, EIPs (integration patterns) and internal or external calls.',
     },
     [SourceSchemaType.Kamelet]: {
       name: 'Kamelet',
       schema: undefined,
       multipleRoute: false,
+      description:
+        'Defines a reusable Camel route as a building block. Kamelets can not be executed on their own, they are used as sources, actions or sinks in Camel Routes or Pipes.',
     },
     [SourceSchemaType.Pipe]: {
       name: 'Pipe',
       schema: undefined,
       multipleRoute: false,
+      description:
+        'Defines a sequence of concatenated Kamelets to form start to finish integration flows. Pipes are a more abstract level of defining integration flows, by chosing and configuring Kamelets.',
     },
     [SourceSchemaType.KameletBinding]: {
       name: 'Kamelet Binding',
       schema: undefined,
       multipleRoute: false,
+      description:
+        'Defines a sequence of concatenated Kamelets to form start to finish integration flows. Pipes are a more abstract level of defining integration flows, by chosing and configuring Kamelets.',
     },
     [SourceSchemaType.Integration]: {
       name: 'Integration',
       schema: undefined,
       multipleRoute: true,
+      description: 'An integration defines a Camel route in a CRD file.',
     },
   };
 


### PR DESCRIPTION
### Context
In order to create new entities, a DSL Slector component needs to be added.

### Changes
This commit adds said component divided into 3 sections:

1. `ChangeDSLModal`: A modal to warn the user whenever the DSL is being changed since the existing integration will be removed
2. `DSLSelectorToggle`: The DSL Button itself
3. `DSLSelector`: The main entry point for the DSL Selector, this component is in charge of combining both `DSLSelectorToggle` and the `ChangeDSLModal` components

### Screenshots
#### DSLSelectorToggle
![image](https://github.com/KaotoIO/kaoto/assets/16512618/db9f1508-0738-4c0f-8793-d9fea164d7b7)

#### ChangeDSLModal
![image](https://github.com/KaotoIO/kaoto/assets/16512618/f87ecb7a-2846-4cbb-b4c4-3ad4adcffff3)


relates: https://github.com/KaotoIO/kaoto/issues/1030