### PR TITLE
chore(Entities): Add default constructor parameter

### DIFF
--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -17,7 +17,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
   id: string;
   readonly type = EntityType.ErrorHandler;
 
-  constructor(public errorHandlerDef: { errorHandler: ErrorHandlerBuilderDeserializer }) {
+  constructor(public errorHandlerDef: { errorHandler: ErrorHandlerBuilderDeserializer } = { errorHandler: {} }) {
     const id = getCamelRandomId('errorHandler');
     this.id = id;
   }

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -23,7 +23,7 @@ export class CamelInterceptFromVisualEntity
   readonly type = EntityType.InterceptFrom;
   static readonly ROOT_PATH = 'interceptFrom';
 
-  constructor(interceptFromRaw: { interceptFrom: InterceptFrom }) {
+  constructor(interceptFromRaw: { interceptFrom: InterceptFrom } = { interceptFrom: {} }) {
     let interceptFromDef: { interceptFrom: Exclude<InterceptFrom, string> };
     if (typeof interceptFromRaw.interceptFrom === 'string') {
       interceptFromDef = {

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -23,7 +23,9 @@ export class CamelInterceptSendToEndpointVisualEntity
   readonly type = EntityType.InterceptSendToEndpoint;
   static readonly ROOT_PATH = 'interceptSendToEndpoint';
 
-  constructor(interceptSendToEndpointRaw: { interceptSendToEndpoint: InterceptSendToEndpoint }) {
+  constructor(
+    interceptSendToEndpointRaw: { interceptSendToEndpoint: InterceptSendToEndpoint } = { interceptSendToEndpoint: {} },
+  ) {
     let interceptSendToEndpointDef: { interceptSendToEndpoint: Exclude<InterceptSendToEndpoint, string> };
     if (typeof interceptSendToEndpointRaw.interceptSendToEndpoint === 'string') {
       interceptSendToEndpointDef = {

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -22,7 +22,7 @@ export class CamelInterceptVisualEntity
   readonly type = EntityType.Intercept;
   static readonly ROOT_PATH = 'intercept';
 
-  constructor(public interceptDef: { intercept: Intercept }) {
+  constructor(public interceptDef: { intercept: Intercept } = { intercept: {} }) {
     super(interceptDef);
     const id = interceptDef.intercept.id ?? getCamelRandomId(CamelInterceptVisualEntity.ROOT_PATH);
     this.id = id;

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -22,7 +22,7 @@ export class CamelOnCompletionVisualEntity
   readonly type = EntityType.OnCompletion;
   static readonly ROOT_PATH = 'onCompletion';
 
-  constructor(public onCompletionDef: { onCompletion: OnCompletion }) {
+  constructor(public onCompletionDef: { onCompletion: OnCompletion } = { onCompletion: {} }) {
     super(onCompletionDef);
     const id = onCompletionDef.onCompletion.id ?? getCamelRandomId(CamelOnCompletionVisualEntity.ROOT_PATH);
     this.id = id;

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -22,7 +22,7 @@ export class CamelOnExceptionVisualEntity
   readonly type = EntityType.OnException;
   private static readonly ROOT_PATH = 'onException';
 
-  constructor(public onExceptionDef: { onException: OnException }) {
+  constructor(public onExceptionDef: { onException: OnException } = { onException: {} }) {
     super(onExceptionDef);
     const id = onExceptionDef.onException.id ?? getCamelRandomId(CamelOnExceptionVisualEntity.ROOT_PATH);
     this.id = id;

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -21,7 +21,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualCamelEntity
   readonly type = EntityType.RestConfiguration;
   private schemaValidator: ValidateFunction<RestConfiguration> | undefined;
 
-  constructor(public restConfigurationDef: { restConfiguration: RestConfiguration }) {
+  constructor(public restConfigurationDef: { restConfiguration: RestConfiguration } = { restConfiguration: {} }) {
     const id = getCamelRandomId('restConfiguration');
     this.id = id;
   }

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -37,7 +37,9 @@ export class CamelRouteConfigurationVisualEntity
     'onCompletion',
   ];
 
-  constructor(public routeConfigurationDef: { routeConfiguration: RouteConfigurationDefinition }) {
+  constructor(
+    public routeConfigurationDef: { routeConfiguration: RouteConfigurationDefinition } = { routeConfiguration: {} },
+  ) {
     super(routeConfigurationDef);
     const id =
       routeConfigurationDef.routeConfiguration.id ?? getCamelRandomId(CamelRouteConfigurationVisualEntity.ROOT_PATH);


### PR DESCRIPTION
### Context
In order to simplify the construction of new entities, we need to provide a default parameter to the constructor, so the entities can be created on its own.

Related entities:
* ErrorHandler
* Intercept
* InterceptFrom
* InterceptSendToEndpoint
* OnCompletion
* OnException
* RestConfiguration
* RouteConfiguration

relates: https://github.com/KaotoIO/kaoto/issues/1030