### PR TITLE
fix: Added CustomLongTextField and using it for 'Expression', 'Sasl Jaas Config' fields

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "lint:style:fix": "yarn lint:style --fix"
   },
   "dependencies": {
-    "@kaoto-next/uniforms-patternfly": "^0.6.8",
+    "@kaoto-next/uniforms-patternfly": "^0.6.10",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/notifications": "0.32.0",
     "@patternfly/patternfly": "5.2.1",

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -1,4 +1,4 @@
-import { BoolField, DateField, ListField, LongTextField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
+import { BoolField, DateField, ListField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
 import { createAutoField } from 'uniforms';
 import { getValue } from '../../utils';
 import { OneOfField } from './OneOf/OneOfField';
@@ -9,6 +9,10 @@ import { TypeaheadField } from './customField/TypeaheadField';
 import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 import { ExpressionField } from './expression/ExpressionField';
 import { PropertiesField } from './properties/PropertiesField';
+import { CustomLongTextField } from './customField/CustomLongTextField';
+
+// Name of the properties that should load CustomLongTextField
+const CustomLongTextProps = ['Expression', 'Sasl Jaas Config'];
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly
@@ -53,8 +57,8 @@ export const CustomAutoField = createAutoField((props) => {
       /* catalog preprocessor put 'string' as a type and the javaType as a schema $comment */
       if (comment?.startsWith('class:')) {
         return BeanReferenceField;
-      } else if (title === 'Expression') {
-        return LongTextField;
+      } else if (CustomLongTextProps.includes(title)) {
+        return CustomLongTextField;
       }
       return TextField;
   }

--- a/packages/ui/src/components/Form/CustomAutoForm.tsx
+++ b/packages/ui/src/components/Form/CustomAutoForm.tsx
@@ -65,9 +65,9 @@ export const CustomAutoForm = forwardRef<CustomAutoFormRef, CustomAutoFormProps>
             <AutoField
               key={field}
               name={field}
-              inputRef={(node: HTMLElement) => {
-                fieldsRefs.current[index] = node;
-              }}
+              // inputRef={(node: HTMLElement) => {
+              //   fieldsRefs.current[index] = node;
+              // }}
             />
           ))
         ) : (

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.scss
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.scss
@@ -1,0 +1,5 @@
+.custom-long-test-field {
+  textarea {
+    padding: 6px 8px 0;
+  }
+}

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
@@ -1,0 +1,9 @@
+import { HTMLFieldProps } from 'uniforms';
+import { LongTextField } from '@kaoto-next/uniforms-patternfly';
+import './CustomLongTextField.scss';
+
+export type CustomLongTextFieldProps = HTMLFieldProps<string, HTMLDivElement>;
+
+export const CustomLongTextField = (props: CustomLongTextFieldProps) => {
+  return <LongTextField className="custom-long-test-field" {...props} rows={1} autoResize={true} />;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@ __metadata:
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
     "@kaoto-next/camel-catalog": "workspace:*"
-    "@kaoto-next/uniforms-patternfly": ^0.6.8
+    "@kaoto-next/uniforms-patternfly": ^0.6.10
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0
     "@patternfly/patternfly": 5.2.1
@@ -2531,16 +2531,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaoto-next/uniforms-patternfly@npm:^0.6.8":
-  version: 0.6.8
-  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.8"
+"@kaoto-next/uniforms-patternfly@npm:^0.6.10":
+  version: 0.6.10
+  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.10"
   dependencies:
     invariant: ^2.2.4
     lodash: ^4.17.21
     react: ^18.2.0
     react-dom: ^18.2.0
     uniforms: 4.0.0-alpha.5
-  checksum: 882aa818eba9af30b73fd54a7f0b5c17871feda34e53b6fedb098662fc8f4206387fa2dccc077d9a8437133d90a1ab5e80349c3db6e7dc540abedf609cb5371f
+  checksum: 3d8565d4ce5a9eaa4a6c6128bc7c8a93d6f473c73713279971054ec2fda816e5c8a0d3871717caef31c61c3ef71b6855a9030836ff6dae46459cb3fd8ed4ec43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1043 

However there are some issues with this new CustomLongTextField listed Following:

1. The new field is interacting with the CSS of `CustomNestField's` `ExpandableSection`. Hence it doesn't load correctly for Kafka's `Sasl Jaas Config`:
![image](https://github.com/KaotoIO/kaoto/assets/73224329/d133d09c-3042-4ad8-983d-264341ca6f1f)
Note that once the field is click and you start adding some text, the field automatically corrects. Also the field loads correctly if  we load the ExpandableSection as Expanded by adding the `isExpanded` attribute always.

2. The field is unable to load the form as soon as you choose any language for the `Expression` to configure a `setBody`.