### PR TITLE
feat(build): Rename `@kaoto-next` scope to `@kaoto`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,16 +7,15 @@ body:
       value: |
         Thank you for reporting an issue :pray:.
 
-        - This issue tracker is for reporting bugs found in [Kaoto UI](https://github.com/KaotoIO/kaoto-next)
+        - This issue tracker is for reporting bugs found in [Kaoto UI](https://github.com/KaotoIO/kaoto)
         - If you have a question about how to achieve something and are struggling, please post a question
-        inside of Kaoto's [Discussions](https://github.com/KaotoIO/kaoto-next/discussions)
+        inside of Kaoto's [Discussions](https://github.com/KaotoIO/kaoto/discussions)
         - If it's an issue about the website please go to the [kaoto.io website repo](https://github.com/KaotoIO/kaoto.io)
-        - If it's an issue about the backend or API, please go to [that repo](https://github.com/KaotoIO/kaoto-backend)
 
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
-         - [Kaoto's Open Issues](https://github.com/KaotoIO/kaoto-next/issues?q=is%3Aissue+sort%3Aupdated-desc+position)
-         - [Kaoto's Closed Issues](https://github.com/KaotoIO/kaoto-next/issues?q=is%3Aissue+sort%3Aupdated-desc+position+is%3Aclosed)
-         - [Kaoto Discussions](https://github.com/KaotoIO/kaoto-next/discussions)
+         - [Kaoto's Open Issues](https://github.com/KaotoIO/kaoto/issues?q=is%3Aissue+sort%3Aupdated-desc+position)
+         - [Kaoto's Closed Issues](https://github.com/KaotoIO/kaoto/issues?q=is%3Aissue+sort%3Aupdated-desc+position+is%3Aclosed)
+         - [Kaoto Discussions](https://github.com/KaotoIO/kaoto/discussions)
 
         The more information you fill in, the better the community can help you.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🤔 Questions & Discussions
-    url: https://github.com/KaotoIO/kaoto-next/discussions
+    url: https://github.com/KaotoIO/kaoto/discussions
     about: Please ask and answer questions here.

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@kaoto-next'
+          scope: '@kaoto'
           cache: 'yarn'
 
       - uses: actions/setup-java@v4
@@ -34,16 +34,16 @@ jobs:
 
       # Lint style files
       - name: 💅 Run stylelint
-        run: yarn workspace @kaoto-next/ui run lint:style
+        run: yarn workspace @kaoto/kaoto run lint:style
 
       # Run tests
       - name: 🧪 Run tests
         run: yarn workspaces foreach --verbose --topological-dev run test
 
-      # Build packages excluding @kaoto-next/camel-catalog since it was build during installing dependencies
+      # Build packages excluding @kaoto/camel-catalog since it was build during installing dependencies
       - name: Build packages
-        run: yarn workspaces foreach --verbose --topological-dev --exclude @kaoto-next/camel-catalog run build
+        run: yarn workspaces foreach --verbose --topological-dev --exclude @kaoto/camel-catalog run build
 
       # Build lib
-      - name: Build @kaoto-next/ui package in lib mode
-        run: yarn workspace @kaoto-next/ui run build:lib
+      - name: Build @kaoto/kaoto package in lib mode
+        run: yarn workspace @kaoto/kaoto run build:lib

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,7 +20,7 @@ on:
 # List of jobs
 jobs:
   chromatic-deployment:
-    if: github.repository == 'KaotoIO/kaoto-next' && github.actor != 'renovate[bot]' && !github.event.pull_request.draft
+    if: github.repository == 'KaotoIO/kaoto' && github.actor != 'renovate[bot]' && !github.event.pull_request.draft
     # Operating System
     runs-on: ubuntu-latest
     # Job steps
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@kaoto-next'
+          scope: '@kaoto'
           cache: 'yarn'
 
       - uses: actions/setup-java@v4
@@ -47,9 +47,9 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      # 👇 Builds the kaoto-next/ui in library mode
+      # 👇 Builds the kaoto/ui in library mode
       - name: Build ui library
-        run: yarn workspace @kaoto-next/ui run build:lib
+        run: yarn workspace @kaoto/kaoto run build:lib
 
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-          scope: "@kaoto-next"
+          scope: "@kaoto"
           cache: "yarn"
 
       - name: "🛰️ Setup Java"
@@ -41,10 +41,10 @@ jobs:
       - name: "🔧 Install dependencies"
         run: yarn
 
-      # Build packages excluding @kaoto-next/camel-catalog since it was build during installing dependencies
+      # Build packages excluding @kaoto/camel-catalog since it was build during installing dependencies
       - name: "🔧 Build packages"
         run: |
-          yarn workspaces foreach --verbose --topological-dev --exclude @kaoto-next/camel-catalog run build
+          yarn workspaces foreach --verbose --topological-dev --exclude @kaoto/camel-catalog run build
 
       - name: "🔧 Tar UI Dist"
         shell: bash
@@ -82,7 +82,7 @@ jobs:
           mkdir -p packages/ui/dist
           tar -xzf "${{ runner.temp }}/kaoto-ui.tgz" -C packages/ui/dist
 
-      - name: "📤 Upload artifact @kaoto-next/ui web application"
+      - name: "📤 Upload artifact @kaoto/kaoto web application"
         uses: actions/upload-pages-artifact@v3
         with:
           path: "packages/ui/dist"
@@ -92,7 +92,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   deploy-images:
-    if: github.repository == 'KaotoIO/kaoto-next'
+    if: github.repository == 'KaotoIO/kaoto'
     runs-on: ubuntu-latest
     needs:
       - build-distribution

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,13 +43,13 @@ jobs:
       # Install dependencies
       - run: yarn install --immutable
 
-      # Build packages excluding @kaoto-next/camel-catalog since it was build during installing dependencies
+      # Build packages excluding @kaoto/camel-catalog since it was build during installing dependencies
       - name: Build packages
-        run: yarn workspaces foreach --verbose --topological-dev --exclude @kaoto-next/camel-catalog run build
+        run: yarn workspaces foreach --verbose --topological-dev --exclude @kaoto/camel-catalog run build
 
       # Build lib
-      - name: Build @kaoto-next/ui package in lib mode
-        run: yarn workspace @kaoto-next/ui run build:lib
+      - name: Build @kaoto/kaoto package in lib mode
+        run: yarn workspace @kaoto/kaoto run build:lib
 
       - name: 💾 Save build folder
         uses: actions/upload-artifact@v4
@@ -100,7 +100,7 @@ jobs:
           browser: firefox
           # we have already installed all dependencies above
           # install: false
-          start: yarn workspace @kaoto-next/ui run preview
+          start: yarn workspace @kaoto/kaoto run preview
           config: baseUrl=http://localhost:4173
           working-directory: packages/ui-tests
           wait-on: 'http://localhost:4173'
@@ -159,7 +159,7 @@ jobs:
           browser: chrome
           # we have already installed all dependencies above
           # install: false
-          start: yarn workspace @kaoto-next/ui run preview
+          start: yarn workspace @kaoto/kaoto run preview
           config: baseUrl=http://localhost:4173
           working-directory: packages/ui-tests
           wait-on: 'http://localhost:4173'
@@ -218,7 +218,7 @@ jobs:
           browser: edge
           # we have already installed all dependencies above
           # install: false
-          start: yarn workspace @kaoto-next/ui run preview
+          start: yarn workspace @kaoto/kaoto run preview
           config: baseUrl=http://localhost:4173
           working-directory: packages/ui-tests
           wait-on: 'http://localhost:4173'

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@kaoto-next'
+          scope: '@kaoto'
           cache: 'yarn'
 
       - uses: actions/setup-java@v4
@@ -65,8 +65,8 @@ jobs:
         run: yarn
 
       # Build lib
-      - name: Build @kaoto-next/ui package in lib mode
-        run: yarn workspace @kaoto-next/ui run build:lib
+      - name: Build @kaoto/kaoto package in lib mode
+        run: yarn workspace @kaoto/kaoto run build:lib
 
       # Version and publish
       - name: 'Version and publish'
@@ -91,7 +91,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@kaoto-next'
+          scope: '@kaoto'
           cache: 'yarn'
 
       - uses: actions/setup-java@v4
@@ -105,7 +105,7 @@ jobs:
 
       - name: "🔧 Build packages"
         run: |
-          yarn workspaces foreach --verbose --topological-dev --exclude @kaoto-next/camel-catalog run build
+          yarn workspaces foreach --verbose --topological-dev --exclude @kaoto/camel-catalog run build
 
       - name: "🛰️ Login to Container Registry"
         uses: docker/login-action@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Kaoto-Next
+# Contributing to Kaoto
 
-Thank you for considering contributing to Kaoto-next! Community contributions are essential for the project's success, and we welcome bug fixes, documentation improvements, feature additions, and more.
+Thank you for considering contributing to Kaoto! Community contributions are essential for the project's success, and we welcome bug fixes, documentation improvements, feature additions, and more.
 
 ## Getting Started
 
@@ -18,7 +18,7 @@ Before you start contributing, ensure that you have the following installed:
    - Fork the project to your GitHub account by clicking the 'Fork' button on the project's GitHub page.
 
 2. **Clone Your Fork**:
-   - Clone your fork using `git clone https://github.com/YOUR_USERNAME/kaoto-next.git`.
+   - Clone your fork using `git clone https://github.com/YOUR_USERNAME/kaoto.git`.
 
 3. **Install Dependencies**:
    - Navigate to the cloned folder and run `yarn install` to install all necessary dependencies.
@@ -30,7 +30,7 @@ Before you start contributing, ensure that you have the following installed:
 
 ### Find or Create an Issue
 
-- Look for existing issues on the [GitHub Issues page](https://github.com/KaotoIO/kaoto-next/issues).
+- Look for existing issues on the [GitHub Issues page](https://github.com/KaotoIO/kaoto/issues).
 - If you want to work on something new, feel free to create a new issue and discuss it with the team.
 
 ### Create a Feature Branch
@@ -49,7 +49,7 @@ Before you start contributing, ensure that you have the following installed:
 
 ### Submit a Pull Request (PR)
 
-- Create a pull request from your fork to the main Kaoto-next repository.
+- Create a pull request from your fork to the main Kaoto repository.
 - Provide a detailed description of your changes, referencing any related issues.
 - Await feedback or approval from the maintainers.
 
@@ -71,7 +71,7 @@ Before you start contributing, ensure that you have the following installed:
 
 ---
 
-Your contributions make Kaoto-next better, and we sincerely appreciate your support and collaboration. Happy coding!
+Your contributions make Kaoto better, and we sincerely appreciate your support and collaboration. Happy coding!
 
 ## Questions or Need Help?
 
@@ -79,4 +79,4 @@ If you have any questions or need assistance, feel free to create an issue on Gi
 
 ---
 
-Your contributions make Kaoto-next better, and we sincerely appreciate your support and collaboration. Happy coding!
+Your contributions make Kaoto better, and we sincerely appreciate your support and collaboration. Happy coding!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kaoto-next
+# kaoto
 The next version of the UI for the Kaoto project.
 
 https://kaotoio.github.io/kaoto/
@@ -8,7 +8,7 @@ https://kaotoio.github.io/kaoto/
 - [Getting Started](#getting-started)
   - [Clone the Repository](#clone-the-repository)
   - [Install Dependencies](#install-dependencies)
-- [Running kaoto-next with Docker](#running-kaoto-next-with-docker)
+- [Running kaoto with Docker](#running-kaoto-with-docker)
 - [Development](#development)
   - [Web Application](#web-application)
     - [Run](#run)
@@ -30,23 +30,23 @@ _For more information on Vite, check [Vite's documentation](https://vitejs.dev/c
 First, clone the repository to your local machine.
 
 ```sh
-git clone https://github.com/KaotoIO/kaoto-next
+git clone https://github.com/KaotoIO/kaoto
 ```
 ### Install Dependencies
 
 Navigate to the cloned directory and install the necessary packages.
 
 ```sh
-cd kaoto-next
+cd kaoto
 yarn install
 ```
-_Note: By default, `@kaoto-next/camel-catalog` will also be built using the `mvn` wrapper._
+_Note: By default, `@kaoto/camel-catalog` will also be built using the `mvn` wrapper._
 
-## Running kaoto-next with Docker
+## Running kaoto with Docker
 For trial purposes, there is a docker image that can be run locally:
 
 ```sh
-docker run --rm -p 8080:8080 --name kaoto-next quay.io/kaotoio/kaoto-app:main
+docker run --rm -p 8080:8080 --name kaoto quay.io/kaotoio/kaoto-app:main
 ```
 
 ## Development
@@ -54,26 +54,26 @@ docker run --rm -p 8080:8080 --name kaoto-next quay.io/kaotoio/kaoto-app:main
 #### Run
 To start the development server, execute the following command:
 ```sh
-yarn workspace @kaoto-next/ui run start
+yarn workspace @kaoto/kaoto run start
 ```
 The application will be accessible at `http://localhost:5173` by default.
 
 #### Build
 To build the web application, execute:
 ```sh
-yarn workspace @kaoto-next/ui run build
+yarn workspace @kaoto/kaoto run build
 ```
 
 ### Public Components
 To build the public components, execute:
 ```sh
-yarn workspace @kaoto-next/ui run build:lib
+yarn workspace @kaoto/kaoto run build:lib
 ```
 
 ## Camel Catalog and Supporting Schemas
 To build the Camel Catalog and the supporting schemas, run:
 ```sh
-yarn workspace @kaoto-next/camel-catalog run build
+yarn workspace @kaoto/camel-catalog run build
 ```
 _Optional: You can update the Camel version in the `pom.xml` file and then run the build command again._
 
@@ -84,9 +84,9 @@ To view the storybook stories, go to [Chromatic](https://main--64ef22df8bb709ffa
 To run Storybook locally:
 ``` bash
 # first build the ui library
-yarn workspace @kaoto-next/ui build:lib
+yarn workspace @kaoto/kaoto build:lib
 
 # run the storybook
-yarn workspace @kaoto-next/ui-tests storybook
+yarn workspace @kaoto/kaoto-tests storybook
 ```
-To publish to Chromatic: `yarn workspace @kaoto-next/ui-tests chromatic`
+To publish to Chromatic: `yarn workspace @kaoto/kaoto-tests chromatic`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# kaoto-next
+# kaoto
 The next version of the UI for the Kaoto project.
 
 ## How to do a release

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "kaoto-next",
+  "name": "kaoto",
   "version": "2.0.0-dev",
   "description": "Next version of the UI of the Kaoto project",
-  "repository": "https://github.com/KaotoIO/kaoto-next",
+  "repository": "https://github.com/KaotoIO/kaoto",
   "author": "The Kaoto Team",
   "license": "Apache License v2.0",
   "workspaces": [
@@ -25,7 +25,7 @@
     "typescript": "5.4.5"
   },
   "scripts": {
-    "postinstall": "yarn workspace @kaoto-next/camel-catalog run build",
+    "postinstall": "yarn workspace @kaoto/camel-catalog run build",
     "version": "lerna version",
     "publish": "lerna publish from-package"
   },

--- a/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessor.java
+++ b/packages/camel-catalog/kaoto-camel-catalog-maven-plugin/src/main/java/io/kaoto/camelcatalog/CamelYamlDslSchemaProcessor.java
@@ -149,7 +149,7 @@ public class CamelYamlDslSchemaProcessor {
     /**
      * Extract single OneOf definition from AnyOf definition and put it into the root definitions.
      * It's a workaround for the current Camel YAML DSL JSON schema, where some AnyOf definition
-     * contains only one OneOf definition. This can be removed once https://github.com/KaotoIO/kaoto-next/issues/948
+     * contains only one OneOf definition. This can be removed once https://github.com/KaotoIO/kaoto/issues/948
      * is resolved.
      * This is done mostly for the errorHandler definition, f.i.
      * ```

--- a/packages/camel-catalog/package.json
+++ b/packages/camel-catalog/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@kaoto-next/camel-catalog",
+  "name": "@kaoto/camel-catalog",
   "version": "2.0.0-dev",
   "type": "commonjs",
   "description": "Camel Catalog and schemas for Kaoto",
-  "repository": "https://github.com/KaotoIO/kaoto-next",
+  "repository": "https://github.com/KaotoIO/kaoto",
   "repositoryDirectory": "packages/camel-catalog",
   "author": "The Kaoto Team",
   "license": "Apache License v2.0",

--- a/packages/ui-tests/README.md
+++ b/packages/ui-tests/README.md
@@ -5,15 +5,15 @@
 Running the tests from the root folder
 
 ```bash
-yarn workspace @kaoto-next/ui-tests e2e
+yarn workspace @kaoto/kaoto-tests e2e
 ```
 
 Running the tests in headless mode
 
 ```bash
-yarn workspace @kaoto-next/ui-tests run e2e:headless
+yarn workspace @kaoto/kaoto-tests run e2e:headless
 
 # with a specific browser
 # options: chrome, chromium, edge, electron, firefox
-yarn workspace @kaoto-next/ui-tests run e2e:headless --browser firefox
+yarn workspace @kaoto/kaoto-tests run e2e:headless --browser firefox
 ```

--- a/packages/ui-tests/cypress/e2e/codeEditor/malformedFlows.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/malformedFlows.cy.ts
@@ -3,7 +3,7 @@ describe('Test for Multi route actions from the code editor', () => {
     cy.openHomePage();
   });
 
-  // blocked ATM by https://github.com/KaotoIO/kaoto-next/issues/575
+  // blocked ATM by https://github.com/KaotoIO/kaoto/issues/575
   it.skip('User creates a flow with missing route ID', () => {
     cy.openSourceCode();
     cy.uploadFixture('flows/malformed/camelRoute/missingId.yaml');
@@ -23,7 +23,7 @@ describe('Test for Multi route actions from the code editor', () => {
     cy.compareFileWithMonacoEditor('flows/malformed/missingIdRoute.yaml');
   });
 
-  // blocked ATM by https://github.com/KaotoIO/kaoto-next/issues/683
+  // blocked ATM by https://github.com/KaotoIO/kaoto/issues/683
   it.skip('User creates kameletBinding with missing kind definition', () => {
     cy.openSourceCode();
     cy.uploadFixture('flows/malformed/kamelet/missingKind.yaml');
@@ -45,7 +45,7 @@ describe('Test for Multi route actions from the code editor', () => {
     cy.openStepConfigurationTab('id');
     cy.get('[data-ouia-component-id^="OUIA-Generated-Title"]').should('have.text', 'id');
     cy.closeStepConfigurationTab();
-    // Related issue to provide more info https://github.com/KaotoIO/kaoto-next/issues/309
+    // Related issue to provide more info https://github.com/KaotoIO/kaoto/issues/309
     // verify the route wasn't removed and left for the user to repair
     cy.openSourceCode();
     cy.compareFileWithMonacoEditor('flows/malformed/camelRoute/unknownNode.yaml');

--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepRemoval.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepRemoval.cy.ts
@@ -62,7 +62,7 @@ describe('Tests for Design page', () => {
     cy.removeNodeByName('log');
     cy.get('.pf-topology-side-bar').should('not.be.visible');
 
-    // Blocked by https://github.com/KaotoIO/kaoto-next/issues/527
+    // Blocked by https://github.com/KaotoIO/kaoto/issues/527
     // cy.openStepConfigurationTab('timer');
     // cy.get('.pf-topology-side-bar').should('be.visible');
     // cy.removeNodeByName('setHeader');

--- a/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
@@ -55,7 +55,7 @@ describe('Test for Multi route actions from the canvas', () => {
     cy.checkCodeSpanLine('id: route-1234', 0);
   });
 
-  // Blocked ATM by https://github.com/KaotoIO/kaoto-next/issues/301
+  // Blocked ATM by https://github.com/KaotoIO/kaoto/issues/301
   it.skip('User deletes routes in the canvas till there are no routes', () => {
     cy.openDesignPage();
     cy.addNewRoute();

--- a/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
@@ -30,7 +30,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.checkNodeExist('log', 1);
   });
 
-  // Blocked by: https://github.com/KaotoIO/kaoto-next/issues/860
+  // Blocked by: https://github.com/KaotoIO/kaoto/issues/860
   it.skip('Canvas route wrap and unwrap, toggle visibility', () => {
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
     cy.openDesignPage();

--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/routeBeanConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/routeBeanConf.cy.ts
@@ -80,7 +80,7 @@ describe('Test for node bean reference and configuration support', () => {
     });
   });
 
-  // blocked by https://github.com/KaotoIO/kaoto-next/issues/558
+  // blocked by https://github.com/KaotoIO/kaoto/issues/558
   it.skip('Beans - delete bean using the bean editor', () => {
     cy.uploadFixture('flows/camelRoute/sqlBeans.yaml');
     cy.openDesignPage();

--- a/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
@@ -39,7 +39,7 @@ describe('Tests for sidebar dataformat configuration', () => {
     cy.checkCodeSpanLine('unmarshalType: com.fasterxml.jackson.databind.JsonNode', 1);
     cy.checkCodeSpanLine('schemaResolver: "#bean:{{schemaResolver}}"', 1);
 
-    // Blocked by https://github.com/KaotoIO/kaoto-next/issues/489
+    // Blocked by https://github.com/KaotoIO/kaoto/issues/489
     // cy.checkCodeSpanLine('camel:jackson-avro', 1);
   });
 });

--- a/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/expressionStepConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/expressionStepConfig.cy.ts
@@ -22,7 +22,7 @@ describe('Tests for sidebar expression configuration', () => {
     cy.checkCodeSpanLine('resultType: java.lang.String', 1);
   });
 
-  //reproducer for https://github.com/KaotoIO/kaoto-next/issues/518
+  //reproducer for https://github.com/KaotoIO/kaoto/issues/518
   it('Design - name attribute was sometimes lost after expression configuration', () => {
     cy.uploadFixture('flows/camelRoute/basic.yaml');
     cy.openDesignPage();
@@ -71,7 +71,7 @@ describe('Tests for sidebar expression configuration', () => {
     cy.checkCodeSpanLine('expression: .name', 1);
   });
 
-  // Blocked by: https://github.com/KaotoIO/kaoto-next/issues/904
+  // Blocked by: https://github.com/KaotoIO/kaoto/issues/904
   it.skip('Design - expression configuration with switching type', () => {
     cy.uploadFixture('flows/camelRoute/basic.yaml');
     cy.openDesignPage();

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@kaoto-next/ui-tests",
+  "name": "@kaoto/kaoto-tests",
   "private": true,
   "version": "2.0.0-dev",
   "type": "module",
   "description": "Kaoto UI tests and storybook",
-  "repository": "https://github.com/KaotoIO/kaoto-next",
+  "repository": "https://github.com/KaotoIO/kaoto",
   "repositoryDirectory": "packages/ui-tests",
   "author": {
     "name": "The Kaoto Team"
@@ -22,7 +22,7 @@
     "chromatic": "chromatic --build-script-name 'build:storybook' --exit-zero-on-changes --project-token=chpt_7a4940aa65b14ab"
   },
   "devDependencies": {
-    "@kaoto-next/ui": "workspace:*",
+    "@kaoto/kaoto": "workspace:*",
     "@storybook/addon-essentials": "^7.2.3",
     "@storybook/addon-interactions": "^7.2.3",
     "@storybook/addon-links": "^7.2.3",

--- a/packages/ui-tests/stories/canvas/Canvas.stories.tsx
+++ b/packages/ui-tests/stories/canvas/Canvas.stories.tsx
@@ -13,7 +13,7 @@ import {
   VisibleFlowsContext,
   kameletJson,
   pipeJson,
-} from '@kaoto-next/ui/testing';
+} from '@kaoto/kaoto/testing';
 import { Meta, StoryFn } from '@storybook/react';
 import complexRouteMock from '../../cypress/fixtures/complexRouteMock.json';
 

--- a/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
@@ -8,7 +8,7 @@ import {
   VisibleFlowsProvider,
   VisualComponentSchema,
   camelRouteJson,
-} from '@kaoto-next/ui/testing';
+} from '@kaoto/kaoto/testing';
 import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 

--- a/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
@@ -7,7 +7,7 @@ import {
   SchemasLoaderProvider,
   SourceCodeContext,
   VisibleFlowsProvider,
-} from '@kaoto-next/ui/testing';
+} from '@kaoto/kaoto/testing';
 import { Divider, Toolbar, ToolbarContent, ToolbarGroup } from '@patternfly/react-core';
 import { Meta, StoryFn } from '@storybook/react';
 import camelRouteMock from '../../cypress/fixtures/camelRouteMock.json';

--- a/packages/ui-tests/stories/canvas/InlineEdit.stories.tsx
+++ b/packages/ui-tests/stories/canvas/InlineEdit.stories.tsx
@@ -1,4 +1,4 @@
-import { InlineEdit } from '@kaoto-next/ui';
+import { InlineEdit } from '@kaoto/kaoto';
 import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';

--- a/packages/ui-tests/stories/canvas/NewBeanModal.stories.tsx
+++ b/packages/ui-tests/stories/canvas/NewBeanModal.stories.tsx
@@ -1,10 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react';
-import {
-  CatalogLoaderProvider,
-  CatalogSchemaLoader,
-  SchemasLoaderProvider,
-  NewBeanModal,
-} from '@kaoto-next/ui/testing';
+import { CatalogLoaderProvider, CatalogSchemaLoader, SchemasLoaderProvider, NewBeanModal } from '@kaoto/kaoto/testing';
 
 export default {
   title: 'Canvas/NewBeanModal',

--- a/packages/ui-tests/stories/catalog/Catalog.stories.tsx
+++ b/packages/ui-tests/stories/catalog/Catalog.stories.tsx
@@ -1,4 +1,4 @@
-import { Catalog, ITile } from '@kaoto-next/ui';
+import { Catalog, ITile } from '@kaoto/kaoto';
 import { Meta, StoryFn } from '@storybook/react';
 import catalog from '../../cypress/fixtures/catalog-slim.json';
 

--- a/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
+++ b/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
@@ -1,4 +1,4 @@
-import { ITile, PropertiesModal } from '@kaoto-next/ui';
+import { ITile, PropertiesModal } from '@kaoto/kaoto';
 import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import aggregate from '../../cypress/fixtures/aggregate.json';

--- a/packages/ui-tests/stories/metadataEditor/BeanEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/BeanEditor.stories.tsx
@@ -1,4 +1,4 @@
-import { MetadataEditor } from '@kaoto-next/ui';
+import { MetadataEditor } from '@kaoto/kaoto';
 import { Meta, StoryFn } from '@storybook/react';
 
 import mockSchema from '../../cypress/fixtures/metadata/beansSchema.json';

--- a/packages/ui-tests/stories/metadataEditor/DataformatEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/DataformatEditor.stories.tsx
@@ -1,4 +1,4 @@
-import { DataFormatEditor, MetadataEditor } from '@kaoto-next/ui';
+import { DataFormatEditor, MetadataEditor } from '@kaoto/kaoto';
 import {
   CatalogLoaderProvider,
   CatalogSchemaLoader,
@@ -6,7 +6,7 @@ import {
   KaotoSchemaDefinition,
   SchemasLoaderProvider,
   VisualComponentSchema,
-} from '@kaoto-next/ui/testing';
+} from '@kaoto/kaoto/testing';
 import { Meta, StoryFn } from '@storybook/react';
 import { CanvasNode } from './../canvas.models';
 

--- a/packages/ui-tests/stories/metadataEditor/ErrorHandler.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/ErrorHandler.stories.tsx
@@ -1,4 +1,4 @@
-import { MetadataEditor } from '@kaoto-next/ui';
+import { MetadataEditor } from '@kaoto/kaoto';
 import { Meta, StoryFn } from '@storybook/react';
 
 import errorHandler from '../../cypress/fixtures/metadata/errorHandlerSchema.json';

--- a/packages/ui-tests/stories/metadataEditor/ExpressionEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/ExpressionEditor.stories.tsx
@@ -1,4 +1,4 @@
-import { MetadataEditor, StepExpressionEditor } from '@kaoto-next/ui';
+import { MetadataEditor, StepExpressionEditor } from '@kaoto/kaoto';
 import {
   CatalogLoaderProvider,
   CatalogSchemaLoader,
@@ -6,7 +6,7 @@ import {
   KaotoSchemaDefinition,
   SchemasLoaderProvider,
   VisualComponentSchema,
-} from '@kaoto-next/ui/testing';
+} from '@kaoto/kaoto/testing';
 import { Meta, StoryFn } from '@storybook/react';
 import { CanvasNode } from './../canvas.models';
 

--- a/packages/ui-tests/stories/metadataEditor/MetadataEditor.stories.tsx
+++ b/packages/ui-tests/stories/metadataEditor/MetadataEditor.stories.tsx
@@ -1,4 +1,4 @@
-import { MetadataEditor } from '@kaoto-next/ui';
+import { MetadataEditor } from '@kaoto/kaoto';
 import { Meta, StoryFn } from '@storybook/react';
 
 import mockSchema from '../../cypress/fixtures/metadata/metadataSchema.json';

--- a/packages/ui-tests/stories/navigation/Navigation.stories.tsx
+++ b/packages/ui-tests/stories/navigation/Navigation.stories.tsx
@@ -1,4 +1,4 @@
-import { Navigation, Shell, SourceCodeProvider } from '@kaoto-next/ui/testing';
+import { Navigation, Shell, SourceCodeProvider } from '@kaoto/kaoto/testing';
 import { StoryFn } from '@storybook/react';
 import { withRouter, reactRouterOutlet, reactRouterParameters } from 'storybook-addon-react-router-v6';
 

--- a/packages/ui/.lintstagedrc.json
+++ b/packages/ui/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.ts": "yarn workspace @kaoto-next/ui run eslint \"src/**/*.ts\"",
-  "*.tsx": "yarn workspace @kaoto-next/ui run eslint \"src/**/*.tsx\"",
-  "*.scss": "yarn workspace @kaoto-next/ui run lint:style"
+  "*.ts": "yarn workspace @kaoto/kaoto run eslint \"src/**/*.ts\"",
+  "*.tsx": "yarn workspace @kaoto/kaoto run eslint \"src/**/*.tsx\"",
+  "*.scss": "yarn workspace @kaoto/kaoto run lint:style"
 }

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kaoto-next</title>
+    <title>Kaoto</title>
   </head>
   <body>
     <script type="module">

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@kaoto-next/ui",
+  "name": "@kaoto/kaoto",
   "version": "2.0.0-dev",
   "type": "module",
   "description": "Kaoto UI",
-  "repository": "https://github.com/KaotoIO/kaoto-next",
+  "repository": "https://github.com/KaotoIO/kaoto",
   "repositoryDirectory": "packages/ui",
   "author": "The Kaoto Team",
   "publishConfig": {
@@ -38,7 +38,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "yarn eslint \"src/**/*.{ts,tsx}\"",
-    "lint:fix": "yarn lint:code --fix",
+    "lint:fix": "yarn lint --fix",
     "lint:style": "yarn stylelint \"src/**/*.{css,scss}\"",
     "lint:style:fix": "yarn lint:style --fix"
   },
@@ -82,7 +82,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
-    "@kaoto-next/camel-catalog": "workspace:*",
+    "@kaoto/camel-catalog": "workspace:*",
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/packages/ui/scripts/get-camel-catalog-files.js
+++ b/packages/ui/scripts/get-camel-catalog-files.js
@@ -15,13 +15,13 @@ export const getCamelCatalogFiles = () => {
   let camelCatalogPath = '';
 
   try {
-    const camelCatalogIndexJsonPath = require.resolve('@kaoto-next/camel-catalog/index.json');
+    const camelCatalogIndexJsonPath = require.resolve('@kaoto/camel-catalog/index.json');
     camelCatalogPath = normalizePath(dirname(camelCatalogIndexJsonPath));
   } catch (error) {
-    throw new Error(`Could not find '@kaoto-next/camel-catalog' \n\n ${error}`);
+    throw new Error(`Could not find '@kaoto/camel-catalog' \n\n ${error}`);
   }
 
-  console.info(`Found '@kaoto-next/camel-catalog' in ${camelCatalogPath}`, '\n');
+  console.info(`Found '@kaoto/camel-catalog' in ${camelCatalogPath}`, '\n');
 
   try {
     if (readdirSync(camelCatalogPath).length === 0) {
@@ -31,8 +31,8 @@ export const getCamelCatalogFiles = () => {
     const message = [
       `The '${camelCatalogPath}' folder is empty.`,
       'No files found in the Camel Catalog directory.',
-      'Please run `yarn workspace @kaoto-next/camel-catalog run build`',
-      'or `yarn build` in the `@kaoto-next/camel-catalog` package',
+      'Please run `yarn workspace @kaoto/camel-catalog run build`',
+      'or `yarn build` in the `@kaoto/camel-catalog` package',
     ];
 
     throw new Error(message.join('\n\n'));

--- a/packages/ui/src/components/Form/bean/BeanReferenceField.test.tsx
+++ b/packages/ui/src/components/Form/bean/BeanReferenceField.test.tsx
@@ -9,12 +9,12 @@ import { CustomAutoFieldDetector } from '../CustomAutoField';
 import { SchemaService } from '../schema.service';
 import { BeanReferenceField } from './BeanReferenceField';
 import { BeansAwareResource, CamelRouteResource } from '../../../models/camel';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition } from '../../../models';
 
 describe('BeanReferenceField', () => {
   beforeAll(async () => {
-    const entitiesCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const entitiesCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (entitiesCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/bean/BeanReferenceField.tsx
+++ b/packages/ui/src/components/Form/bean/BeanReferenceField.tsx
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { wrapField } from '@kaoto-next/uniforms-patternfly';
-import { RegistryBeanDefinition, RouteTemplateBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { RegistryBeanDefinition, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
 import { NewBeanModal } from './NewBeanModal';
 import { BeansEntityHandler } from '../../../models/visualization/metadata/beans-entity-handler';
 

--- a/packages/ui/src/components/Form/bean/NewBeanModal.test.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.test.tsx
@@ -1,14 +1,14 @@
 import { NewBeanModal } from './NewBeanModal';
 import { fireEvent, render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { act } from 'react-dom/test-utils';
 
 describe('NewBeanModal', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let beanSchema: any;
   beforeAll(async () => {
-    const entitiesCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const entitiesCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     beanSchema = entitiesCatalog.bean.propertiesSchema;
   });
 

--- a/packages/ui/src/components/Form/bean/NewBeanModal.tsx
+++ b/packages/ui/src/components/Form/bean/NewBeanModal.tsx
@@ -1,4 +1,4 @@
-import { RegistryBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { RegistryBeanDefinition } from '@kaoto/camel-catalog/types';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { KaotoSchemaDefinition } from '../../../models';

--- a/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
+++ b/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { CatalogKind, ICamelDataformatDefinition, KaotoSchemaDefinition } from '../../../models';
@@ -13,7 +13,7 @@ describe('DataFormatEditor', () => {
   let dataformatCatalog: Record<string, ICamelDataformatDefinition>;
   beforeAll(async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    dataformatCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
+    dataformatCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (dataformatCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/dataFormat/dataformat.service.test.ts
+++ b/packages/ui/src/components/Form/dataFormat/dataformat.service.test.ts
@@ -1,11 +1,11 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CatalogKind, ICamelDataformatDefinition, ICamelLanguageDefinition } from '../../../models';
 import { CamelCatalogService } from '../../../models/visualization/flows';
 import { DataFormatService } from './dataformat.service';
 
 describe('DataFormatService', () => {
   beforeAll(async () => {
-    const dataformatCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
+    const dataformatCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (dataformatCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/dataFormat/dataformat.service.ts
+++ b/packages/ui/src/components/Form/dataFormat/dataformat.service.ts
@@ -11,7 +11,7 @@ export class DataFormatService {
 
   /**
    * Get the DataFormat schema from the DataFormat catalog. DataFormat catalog has its properties schema in itself,
-   * which is combined in @kaoto-next/camel-catalog.
+   * which is combined in @kaoto/camel-catalog.
    * @param dataFormatCatalog The {@link ICamelDataformatDefinition} object represents the DataFormat to get the schema.
    */
   static getDataFormatSchema(dataFormatCatalog?: ICamelDataformatDefinition) {

--- a/packages/ui/src/components/Form/expression/ExpressionAwareNestField.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionAwareNestField.test.tsx
@@ -1,5 +1,5 @@
 import { SchemaService } from '../schema.service';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
 import { AutoField } from '@kaoto-next/uniforms-patternfly';
 import { AutoForm } from 'uniforms';
@@ -33,7 +33,7 @@ describe('ExpressionAwareNestField', () => {
   const schemaBridge = schemaService.getSchemaBridge(mockSchema);
 
   beforeAll(async () => {
-    const languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    const languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/expression/ExpressionEditor.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionEditor.test.tsx
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
@@ -12,7 +12,7 @@ describe('ExpressionEditor', () => {
 
   let languageCatalog: Record<string, ICamelLanguageDefinition>;
   beforeAll(async () => {
-    languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Language,

--- a/packages/ui/src/components/Form/expression/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionField.test.tsx
@@ -5,7 +5,7 @@ import { AutoField } from '@kaoto-next/uniforms-patternfly';
 import { AutoForm } from 'uniforms';
 import { CustomAutoFieldDetector } from '../CustomAutoField';
 import { act } from 'react-dom/test-utils';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
 
 const mockSchema = {
@@ -26,7 +26,7 @@ const schemaBridge = schemaService.getSchemaBridge(mockSchema);
 const mockOnChange = jest.fn();
 
 beforeAll(async () => {
-  const languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+  const languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
   /* eslint-disable  @typescript-eslint/no-explicit-any */
   delete (languageCatalog as any).default;
   CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
+++ b/packages/ui/src/components/Form/expression/ExpressionModalLauncher.test.tsx
@@ -1,14 +1,14 @@
 import { ExpressionModalLauncher } from './ExpressionModalLauncher';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CamelCatalogService, CatalogKind, ICamelLanguageDefinition } from '../../../models';
 import { ExpressionService } from './expression.service';
 
 describe('ExpressionModalLauncher', () => {
   let languageCatalog: Record<string, ICamelLanguageDefinition>;
   beforeAll(async () => {
-    languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/expression/expression.service.test.ts
+++ b/packages/ui/src/components/Form/expression/expression.service.test.ts
@@ -1,11 +1,11 @@
 import { ExpressionService } from './expression.service';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CatalogKind, ICamelLanguageDefinition } from '../../../models';
 import { CamelCatalogService } from '../../../models/visualization/flows';
 
 describe('ExpressionService', () => {
   beforeAll(async () => {
-    const languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    const languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/expression/expression.service.ts
+++ b/packages/ui/src/components/Form/expression/expression.service.ts
@@ -12,7 +12,7 @@ export class ExpressionService {
 
   /**
    * Get the language schema from the language catalog. Language catalog has its properties schema in itself,
-   * which is combined in @kaoto-next/camel-catalog.
+   * which is combined in @kaoto/camel-catalog.
    * @param languageCatalog The {@link ICamelLanguageDefinition} object represents the language to get the schema.
    */
   static getLanguageSchema(languageCatalog: ICamelLanguageDefinition) {

--- a/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.test.tsx
+++ b/packages/ui/src/components/Form/loadBalancer/LoadBalancerEditor.test.tsx
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { CatalogKind, ICamelLoadBalancerDefinition, KaotoSchemaDefinition } from '../../../models';
@@ -12,7 +12,7 @@ describe('LoadBalancerEditor', () => {
   let mockNode: CanvasNode;
   let loadbalancerCatalog: Record<string, ICamelLoadBalancerDefinition>;
   beforeAll(async () => {
-    loadbalancerCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
+    loadbalancerCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (loadbalancerCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.test.ts
+++ b/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.test.ts
@@ -1,11 +1,11 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { CatalogKind, ICamelLoadBalancerDefinition } from '../../../models';
 import { CamelCatalogService } from '../../../models/visualization/flows';
 import { LoadBalancerService } from './loadbalancer.service';
 
 describe('LoadBalancerService', () => {
   beforeAll(async () => {
-    const loadbalancerCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
+    const loadbalancerCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (loadbalancerCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.ts
+++ b/packages/ui/src/components/Form/loadBalancer/loadbalancer.service.ts
@@ -11,7 +11,7 @@ export class LoadBalancerService {
 
   /**
    * Get the LoadBalancer schema from the LoadBalancer catalog. LoadBalancer catalog has its properties schema in itself,
-   * which is combined in @kaoto-next/camel-catalog.
+   * which is combined in @kaoto/camel-catalog.
    * @param loadBalancerCatalog The {@link ICamelLoadBalancerDefinition} object represents the LoadBalancer to get the schema.
    */
   static getLoadBalancerSchema(loadBalancerCatalog?: ICamelLoadBalancerDefinition) {

--- a/packages/ui/src/components/Form/stepExpression/StepExpressionEditor.test.tsx
+++ b/packages/ui/src/components/Form/stepExpression/StepExpressionEditor.test.tsx
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { CatalogKind, ICamelLanguageDefinition, KaotoSchemaDefinition } from '../../../models';
@@ -13,7 +13,7 @@ describe('StepExpressionEditor', () => {
   let mockNode: CanvasNode;
   let languageCatalog: Record<string, ICamelLanguageDefinition>;
   beforeAll(async () => {
-    languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (languageCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/components/MetadataEditor/PipeErrorHandlerEditor.test.tsx
+++ b/packages/ui/src/components/MetadataEditor/PipeErrorHandlerEditor.test.tsx
@@ -1,13 +1,13 @@
 import { PipeErrorHandlerEditor } from './PipeErrorHandlerEditor';
 import { within } from '@testing-library/dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { act } from 'react-dom/test-utils';
 
 describe('PipeErrorHandlerEditor', () => {
   let pipeErrorHandlerSchema: Record<string, unknown>;
   beforeAll(async () => {
-    pipeErrorHandlerSchema = await import('@kaoto-next/camel-catalog/' + catalogIndex.schemas.PipeErrorHandler.file);
+    pipeErrorHandlerSchema = await import('@kaoto/camel-catalog/' + catalogIndex.schemas.PipeErrorHandler.file);
   });
   it('should render', () => {
     const model = {

--- a/packages/ui/src/components/MetadataEditor/PipeErrorHandlerEditor.tsx
+++ b/packages/ui/src/components/MetadataEditor/PipeErrorHandlerEditor.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, PropsWithChildren, Ref, useCallback, useEffect, useMemo, useState } from 'react';
-import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto-next/camel-catalog/types';
+import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto/camel-catalog/types';
 import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import { MetadataEditor } from './MetadataEditor';
 

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -1,5 +1,5 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
-import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 import { AutoField, AutoFields } from '@kaoto-next/uniforms-patternfly';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
@@ -37,21 +37,21 @@ describe('CanvasForm', () => {
   const schemaService = new SchemaService();
 
   beforeAll(async () => {
-    componentCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
+    componentCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file);
     delete componentCatalogMap.default;
-    const modelCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.models.file);
+    const modelCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.models.file);
     delete modelCatalog.default;
-    patternCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
+    patternCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.patterns.file);
     delete patternCatalogMap.default;
-    kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    kameletCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
     delete kameletCatalogMap.default;
-    const languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    const languageCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
     delete languageCatalog.default;
-    const dataformatCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
+    const dataformatCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
     delete dataformatCatalog.default;
-    const loadbalancerCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
+    const loadbalancerCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
     delete loadbalancerCatalog.default;
-    const entitiesCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const entitiesCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     delete entitiesCatalog.default;
     CamelCatalogService.setCatalogKey(
       CatalogKind.Component,

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip, TooltipProps } from '@patternfly/react-core';
 import { ImageIcon } from '@patternfly/react-icons';
 import { toPng } from 'html-to-image';
-import { Exception } from '@kaoto-next/camel-catalog/types';
+import { Exception } from '@kaoto/camel-catalog/types';
 
 export const defaultTooltipText = 'Export as image';
 

--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -101,7 +101,7 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
                   &nbsp;<span className="pf-u-mr-lg">Help</span>
                 </DropdownItem>
               </a>
-              <a href="https://github.com/KaotoIO/kaoto-next/issues/new/choose" target="_blank">
+              <a href="https://github.com/KaotoIO/kaoto/issues/new/choose" target="_blank">
                 <DropdownItem key="feedback">
                   <Icon isInline>
                     <GithubIcon />

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -2,7 +2,7 @@ import {
   Integration as IntegrationType,
   KameletBinding as KameletBindingType,
   Pipe as PipeType,
-} from '@kaoto-next/camel-catalog/types';
+} from '@kaoto/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
 import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -2,7 +2,7 @@ import {
   Integration as IntegrationType,
   KameletBinding as KameletBindingType,
   Pipe as PipeType,
-} from '@kaoto-next/camel-catalog/types';
+} from '@kaoto/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
 import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode, BaseVisualCamelEntity, IVisualizationNodeData } from '../visualization/base-visual-entity';

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -1,4 +1,4 @@
-import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 import { TileFilter } from '../../components/Catalog';
 import { createCamelPropertiesSorter, isDefined } from '../../utils';
 import { AddStepMode } from '../visualization/base-visual-entity';

--- a/packages/ui/src/models/camel/entities/kamelet-binding-overrides.ts
+++ b/packages/ui/src/models/camel/entities/kamelet-binding-overrides.ts
@@ -1,4 +1,4 @@
-import { KameletBinding } from '@kaoto-next/camel-catalog/types';
+import { KameletBinding } from '@kaoto/camel-catalog/types';
 
 export type KameletBindingSpec = NonNullable<KameletBinding['spec']>;
 export type KameletBindingSource = NonNullable<KameletBinding['spec']>['source'];

--- a/packages/ui/src/models/camel/entities/pipe-overrides.ts
+++ b/packages/ui/src/models/camel/entities/pipe-overrides.ts
@@ -1,4 +1,4 @@
-import { Pipe } from '@kaoto-next/camel-catalog/types';
+import { Pipe } from '@kaoto/camel-catalog/types';
 
 export type PipeSpec = NonNullable<Pipe['spec']>;
 export type PipeMetadata = NonNullable<Pipe['metadata']>;

--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -1,6 +1,6 @@
 import { BaseCamelEntity } from './entities';
 import { BaseVisualCamelEntity } from '../visualization/base-visual-entity';
-import { Integration as IntegrationType } from '@kaoto-next/camel-catalog/types';
+import { Integration as IntegrationType } from '@kaoto/camel-catalog/types';
 import { SourceSchemaType } from './source-schema-type';
 import { CamelKResource } from './camel-k-resource';
 

--- a/packages/ui/src/models/camel/kamelet-binding-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.ts
@@ -1,7 +1,7 @@
 import { SourceSchemaType } from './source-schema-type';
 import { PipeVisualEntity } from '../visualization/flows';
 import { PipeResource } from './pipe-resource';
-import { KameletBinding as KameletBindingType } from '@kaoto-next/camel-catalog/types';
+import { KameletBinding as KameletBindingType } from '@kaoto/camel-catalog/types';
 
 /**
  * @deprecated KameletBinding was renamed to Pipe in Camel K 2.0. While KameletBinding is still supported,

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -1,4 +1,4 @@
-import { Pipe as PipeType } from '@kaoto-next/camel-catalog/types';
+import { Pipe as PipeType } from '@kaoto/camel-catalog/types';
 import { ITile, TileFilter } from '../../components/Catalog/Catalog.models';
 import { CatalogKind } from '../catalog-kind';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';

--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -1,4 +1,4 @@
-import { FromDefinition, Kamelet, ObjectMeta, RouteTemplateBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { FromDefinition, Kamelet, ObjectMeta, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
 import { SourceSchemaType } from './camel/source-schema-type';
 import { KaotoSchemaDefinition } from './kaoto-schema';
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import cloneDeep from 'lodash/cloneDeep';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
@@ -13,10 +13,10 @@ describe('AbstractCamelVisualEntity', () => {
 
   beforeAll(async () => {
     const componentCatalogMap: Record<string, ICamelComponentDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file
     );
     const modelsCatalogMap: Record<string, ICamelProcessorDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.models.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.models.file
     );
     CamelCatalogService.setCatalogKey(CatalogKind.Component, componentCatalogMap);
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, modelsCatalogMap);

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { SchemaService } from '../../../components/Form/schema.service';
 import { ROOT_PATH, getArrayProperty, getValue, setValue } from '../../../utils';
 import { NodeIconResolver } from '../../../utils/node-icon-resolver';

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { ICamelComponentDefinition } from '../../camel-components-catalog';
 import { ICamelLanguageDefinition } from '../../camel-languages-catalog';
 import { CatalogKind } from '../../catalog-kind';
@@ -12,11 +12,11 @@ describe('CamelCatalogService', () => {
   let loadbalancersMap: Record<string, unknown>;
   let kameletCatalogMap: Record<string, unknown>;
   beforeEach(async () => {
-    componentCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
-    dataformatsCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
-    languagesCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
-    loadbalancersMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
-    kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    componentCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file);
+    dataformatsCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
+    languagesCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.languages.file);
+    loadbalancersMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
+    kameletCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
     CamelCatalogService.setCatalogKey(
       CatalogKind.Component,
       componentCatalogMap as unknown as Record<string, ICamelComponentDefinition>,

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -1,4 +1,4 @@
-import { ErrorHandlerBuilderDeserializer, NoErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { ErrorHandlerBuilderDeserializer, NoErrorHandler } from '@kaoto/camel-catalog/types';
 import { useSchemasStore } from '../../../store';
 import { errorHandlerSchema } from '../../../stubs/error-handler';
 import { EntityType } from '../../camel/entities';

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -1,4 +1,4 @@
-import { ErrorHandlerBuilderDeserializer, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ErrorHandlerBuilderDeserializer, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { SchemaService } from '../../../components/Form/schema.service';
 import { useSchemasStore } from '../../../store';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -1,4 +1,4 @@
-import { InterceptFrom, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { InterceptFrom, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -1,4 +1,4 @@
-import { InterceptSendToEndpoint, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { InterceptSendToEndpoint, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -1,4 +1,4 @@
-import { Intercept, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { Intercept, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -1,4 +1,4 @@
-import { OnCompletion } from '@kaoto-next/camel-catalog/types';
+import { OnCompletion } from '@kaoto/camel-catalog/types';
 import { IVisualizationNodeData } from '../base-visual-entity';
 import { CamelOnCompletionVisualEntity } from './camel-on-completion-visual-entity';
 import { ModelValidationService } from './support/validators/model-validation.service';

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -1,4 +1,4 @@
-import { OnCompletion, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { OnCompletion, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
@@ -1,5 +1,5 @@
 import { CamelOnExceptionVisualEntity } from './camel-on-exception-visual-entity';
-import { OnException } from '@kaoto-next/camel-catalog/types';
+import { OnException } from '@kaoto/camel-catalog/types';
 
 describe('CamelOnExceptionVisualEntity', () => {
   const ONEXCEPTION_ID_REGEXP = /^onException-[a-zA-Z0-9]{4}$/;

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -1,4 +1,4 @@
-import { OnException, ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { OnException, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -1,5 +1,5 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
-import { RestConfiguration } from '@kaoto-next/camel-catalog/types';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
+import { RestConfiguration } from '@kaoto/camel-catalog/types';
 import { restConfigurationSchema, restConfigurationStub } from '../../../stubs/rest-configuration';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 import { EntityType } from '../../camel/entities';
@@ -12,7 +12,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
   let restConfigurationDef: { restConfiguration: RestConfiguration };
 
   beforeAll(async () => {
-    const entityCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const entityCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     CamelCatalogService.setCatalogKey(
       CatalogKind.Entity,
       entityCatalogMap as unknown as Record<string, ICamelProcessorDefinition>,

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RestConfiguration } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition, RestConfiguration } from '@kaoto/camel-catalog/types';
 import Ajv, { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteConfigurationDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition, RouteConfigurationDefinition } from '@kaoto/camel-catalog/types';
 import Ajv, { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
 import cloneDeep from 'lodash/cloneDeep';
 import { camelFromJson } from '../../../stubs/camel-from';
 import { camelRouteJson } from '../../../stubs/camel-route';

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -1,4 +1,4 @@
-import { FromDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { FromDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { isDefined, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel-catalog-index';

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -6,7 +6,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { KameletVisualEntity } from './kamelet-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CatalogKind } from '../../catalog-kind';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 
 describe('KameletVisualEntity', () => {
@@ -85,7 +85,7 @@ describe('KameletVisualEntity', () => {
   describe('getComponentSchema when querying the ROOT_PATH', () => {
     let entityCatalogMap: Record<string, unknown>;
     beforeEach(async () => {
-      entityCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+      entityCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
       CamelCatalogService.setCatalogKey(
         CatalogKind.Entity,
         entityCatalogMap as unknown as Record<string, ICamelProcessorDefinition>,

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,4 +1,4 @@
-import { RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import {
   ROOT_PATH,

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -1,5 +1,5 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
-import { Pipe } from '@kaoto-next/camel-catalog/types';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
+import { Pipe } from '@kaoto/camel-catalog/types';
 import cloneDeep from 'lodash/cloneDeep';
 import { pipeJson } from '../../../stubs/pipe';
 import { EntityType } from '../../camel/entities';
@@ -18,7 +18,7 @@ describe('Pipe', () => {
   beforeEach(async () => {
     pipeCR = cloneDeep(pipeJson);
     pipe = new PipeVisualEntity(pipeCR.spec!);
-    kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    kameletCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
     CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, kameletCatalogMap as Record<string, IKameletDefinition>);
   });
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -1,4 +1,4 @@
-import { Pipe } from '@kaoto-next/camel-catalog/types';
+import { Pipe } from '@kaoto/camel-catalog/types';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -1,6 +1,6 @@
 import { CamelComponentDefaultService } from './camel-component-default.service';
 import { DefinedComponent } from '../../../camel-catalog-index';
-import { DoCatch } from '@kaoto-next/camel-catalog/types';
+import { DoCatch } from '@kaoto/camel-catalog/types';
 
 describe('CamelComponentDefaultService', () => {
   describe('getDefaultNodeDefinitionValue', () => {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { parse } from 'yaml';
 import { getCamelRandomId } from '../../../../camel-utils/camel-random-id';
 import { DefinedComponent } from '../../../camel-catalog-index';

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import {
   componentCronTile,
   componentKubernetesSecretsTile,

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -1,5 +1,5 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { CamelUriHelper, ROOT_PATH } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel-components-catalog';
 import { ICamelProcessorDefinition } from '../../../camel-processors-catalog';
@@ -14,11 +14,11 @@ describe('CamelComponentSchemaService', () => {
   let modelCatalogMap = {} as Record<string, ICamelProcessorDefinition>;
 
   beforeAll(async () => {
-    const componentCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
-    modelCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.models.file);
-    const patternCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
-    const kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
-    const entityCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const componentCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file);
+    modelCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.models.file);
+    const patternCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.patterns.file);
+    const kameletCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    const entityCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     CamelCatalogService.setCatalogKey(
       CatalogKind.Component,
       componentCatalogMap as unknown as Record<string, ICamelComponentDefinition>,

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import cloneDeep from 'lodash/cloneDeep';
 import { CamelUriHelper, ParsedParameters, ROOT_PATH, isDefined } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel-components-catalog';

--- a/packages/ui/src/models/visualization/flows/support/camel-component-types.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-types.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { IVisualizationNodeData } from '../../base-visual-entity';
 
 export interface ICamelElementLookupResult {

--- a/packages/ui/src/models/visualization/flows/support/camel-steps.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-steps.service.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto-next/camel-catalog/types';
+import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { ICamelElementLookupResult } from './camel-component-types';
 import { CamelStepsService } from './camel-steps.service';
 

--- a/packages/ui/src/models/visualization/flows/support/camel-steps.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-steps.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { DoCatch, ProcessorDefinition, When1 } from '@kaoto-next/camel-catalog/types';
+import { DoCatch, ProcessorDefinition, When1 } from '@kaoto/camel-catalog/types';
 import { getValue } from '../../../../utils';
 import { NodeIconResolver } from '../../../../utils/node-icon-resolver';
 import { IVisualizationNode } from '../../base-visual-entity';

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
@@ -2,12 +2,12 @@ import cloneDeep from 'lodash/cloneDeep';
 import { CatalogKind } from '../../../catalog-kind';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { KameletSchemaService } from './kamelet-schema.service';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 
 describe('KameletSchemaService', () => {
   let kameletCatalogMap: Record<string, unknown>;
   beforeEach(async () => {
-    kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    kameletCatalogMap = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
     CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       'beer-source': (kameletCatalogMap as any)['beer-source'],

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { IKameletDefinition } from '../../../../kamelets-catalog';
 import { ICamelComponentDefinition } from '../../../../camel-components-catalog';
 import { ICamelProcessorDefinition } from '../../../../camel-processors-catalog';
@@ -34,16 +34,16 @@ describe('ModelValidationService', () => {
 
   beforeAll(async () => {
     const componentCatalogMap: Record<string, ICamelComponentDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file
     );
     const modelCatalogMap: Record<string, ICamelProcessorDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.models.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.models.file
     );
     const patternCatalogMap: Record<string, ICamelProcessorDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.patterns.file
     );
     const kameletsCatalogMap: Record<string, IKameletDefinition> = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file
     );
     CamelCatalogService.setCatalogKey(CatalogKind.Component, componentCatalogMap);
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, modelCatalogMap);

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -1,4 +1,4 @@
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import cloneDeep from 'lodash/cloneDeep';
 import * as routeStub from '../../../stubs/camel-route';
 import * as kameletStub from '../../../stubs/kamelet-route';
@@ -11,7 +11,7 @@ import { BeansEntityHandler } from './beans-entity-handler';
 
 describe('BeansEntityHandler', () => {
   beforeAll(async () => {
-    const entitiesCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    const entitiesCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.entities.file);
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     delete (entitiesCatalog as any).default;
     CamelCatalogService.setCatalogKey(

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -1,8 +1,4 @@
-import {
-  BeansDeserializer,
-  RegistryBeanDefinition,
-  RouteTemplateBeanDefinition,
-} from '@kaoto-next/camel-catalog/types';
+import { BeansDeserializer, RegistryBeanDefinition, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
 import { BeansAwareResource, CamelResource, RouteTemplateBeansAwareResource } from '../../camel';
 import { EntityType } from '../../camel/entities';
 import { CatalogKind } from '../../catalog-kind';

--- a/packages/ui/src/models/visualization/metadata/beansEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/beansEntity.ts
@@ -1,4 +1,4 @@
-import { BeansDeserializer } from '@kaoto-next/camel-catalog/types';
+import { BeansDeserializer } from '@kaoto/camel-catalog/types';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType, BaseCamelEntity } from '../../camel/entities';
 import { isDefined } from '../../../utils';

--- a/packages/ui/src/models/visualization/metadata/metadataEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/metadataEntity.ts
@@ -1,4 +1,4 @@
-import { ObjectMeta as MetadataModel } from '@kaoto-next/camel-catalog/types';
+import { ObjectMeta as MetadataModel } from '@kaoto/camel-catalog/types';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType, BaseCamelEntity } from '../../camel/entities';
 

--- a/packages/ui/src/models/visualization/metadata/routeTemplateBeansEntity.ts
+++ b/packages/ui/src/models/visualization/metadata/routeTemplateBeansEntity.ts
@@ -1,4 +1,4 @@
-import { RouteTemplateBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
 import { v4 as uuidv4 } from 'uuid';
 import { EntityType, BaseCamelEntity } from '../../camel/entities';
 

--- a/packages/ui/src/pages/Beans/BeansPage.tsx
+++ b/packages/ui/src/pages/Beans/BeansPage.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { EntitiesContext } from '../../providers/entities.provider';
 import { MetadataEditor } from '../../components/MetadataEditor';
 import { BeansEntityHandler } from '../../models/visualization/metadata/beans-entity-handler';
-import { BeansDeserializer, RouteTemplateBeanDefinition } from '@kaoto-next/camel-catalog/types';
+import { BeansDeserializer, RouteTemplateBeanDefinition } from '@kaoto/camel-catalog/types';
 
 export const BeansPage: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { MetadataEditor } from '../../components/MetadataEditor';
 import { useSchemasStore } from '../../store';
 import { EntitiesContext } from '../../providers/entities.provider';
-import { ObjectMeta } from '@kaoto-next/camel-catalog/types';
+import { ObjectMeta } from '@kaoto/camel-catalog/types';
 import { CamelKResource, CamelKResourceKinds } from '../../models/camel/camel-k-resource';
 
 export const MetadataPage: FunctionComponent = () => {

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -1,7 +1,7 @@
 import { TextContent } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { EntitiesContext } from '../../providers/entities.provider';
-import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto-next/camel-catalog/types';
+import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto/camel-catalog/types';
 import { PipeResource, SourceSchemaType } from '../../models/camel';
 import { useSchemasStore } from '../../store';
 import { PipeErrorHandlerEditor } from '../../components/MetadataEditor/PipeErrorHandlerEditor';

--- a/packages/ui/src/providers/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/providers/catalog-tiles.provider.test.tsx
@@ -1,8 +1,8 @@
-//import componentsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-components.json';
-//import patternsCatalog from '@kaoto-next/camel-catalog/camel-catalog-aggregate-patterns.json';
-//import kameletsBoundariesCatalog from '@kaoto-next/camel-catalog/kamelet-boundaries.json';
-//import kameletsCatalog from '@kaoto-next/camel-catalog/kamelets-aggregate.json';
-import * as catalogIndex from '@kaoto-next/camel-catalog/index.json';
+//import componentsCatalog from '@kaoto/camel-catalog/camel-catalog-aggregate-components.json';
+//import patternsCatalog from '@kaoto/camel-catalog/camel-catalog-aggregate-patterns.json';
+//import kameletsBoundariesCatalog from '@kaoto/camel-catalog/kamelet-boundaries.json';
+//import kameletsCatalog from '@kaoto/camel-catalog/kamelets-aggregate.json';
+import * as catalogIndex from '@kaoto/camel-catalog/index.json';
 import { act, render, screen } from '@testing-library/react';
 import { camelComponentToTile, camelProcessorToTile, kameletToTile } from '../camel-utils';
 import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition, IKameletDefinition } from '../models';
@@ -24,11 +24,11 @@ describe('CatalogTilesProvider', () => {
   let getCatalogByKeySpy: jest.SpyInstance;
 
   beforeEach(async () => {
-    const componentsCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
-    const patternsCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
-    const kameletsCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    const componentsCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.components.file);
+    const patternsCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.patterns.file);
+    const kameletsCatalog = await import('@kaoto/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
     const kameletsBoundariesCatalog = await import(
-      '@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kameletBoundaries.file
+      '@kaoto/camel-catalog/' + catalogIndex.catalogs.kameletBoundaries.file
     );
 
     getCatalogByKeySpy = jest.spyOn(CamelCatalogService, 'getCatalogByKey');

--- a/packages/ui/src/providers/catalog.provider.test.tsx
+++ b/packages/ui/src/providers/catalog.provider.test.tsx
@@ -1,4 +1,4 @@
-import catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import catalogIndex from '@kaoto/camel-catalog/index.json';
 import { act, render, screen } from '@testing-library/react';
 import { CamelCatalogService, CatalogKind } from '../models';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';

--- a/packages/ui/src/providers/schemas.provider.test.tsx
+++ b/packages/ui/src/providers/schemas.provider.test.tsx
@@ -1,4 +1,4 @@
-import catalogIndex from '@kaoto-next/camel-catalog/index.json';
+import catalogIndex from '@kaoto/camel-catalog/index.json';
 import { act, render, screen } from '@testing-library/react';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
 import { SchemasLoaderProvider } from './schemas.provider';

--- a/packages/ui/src/router/links.models.ts
+++ b/packages/ui/src/router/links.models.ts
@@ -9,5 +9,5 @@ export const enum Links {
 }
 
 export const enum ExternalLinks {
-  GitHub = 'https://github.com/KaotoIO/kaoto-next',
+  GitHub = 'https://github.com/KaotoIO/kaoto',
 }

--- a/packages/ui/src/stubs/camel-from.ts
+++ b/packages/ui/src/stubs/camel-from.ts
@@ -1,4 +1,4 @@
-import { FromDefinition } from '@kaoto-next/camel-catalog/types';
+import { FromDefinition } from '@kaoto/camel-catalog/types';
 import { CamelRouteVisualEntity } from '../models/visualization/flows';
 
 /**

--- a/packages/ui/src/stubs/pipe.ts
+++ b/packages/ui/src/stubs/pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe } from '@kaoto-next/camel-catalog/types';
+import { Pipe } from '@kaoto/camel-catalog/types';
 
 export const pipeYaml = `
 apiVersion: camel.apache.org/v1

--- a/packages/ui/src/stubs/rest-configuration.ts
+++ b/packages/ui/src/stubs/rest-configuration.ts
@@ -1,4 +1,4 @@
-import { RestConfiguration } from '@kaoto-next/camel-catalog/types';
+import { RestConfiguration } from '@kaoto/camel-catalog/types';
 import { KaotoSchemaDefinition } from '../models';
 
 export const restConfigurationStub: { restConfiguration: RestConfiguration } = {

--- a/packages/ui/src/utils/get-applied-schema-index.test.ts
+++ b/packages/ui/src/utils/get-applied-schema-index.test.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { ErrorHandler } from '@kaoto/camel-catalog/types';
 import { getAppliedSchemaIndex } from './get-applied-schema-index';
 import { errorHandlerSchema } from '../stubs/error-handler';
 

--- a/packages/ui/src/utils/weight-schema-properties.test.ts
+++ b/packages/ui/src/utils/weight-schema-properties.test.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler } from '@kaoto-next/camel-catalog/types';
+import { ErrorHandler } from '@kaoto/camel-catalog/types';
 import { errorHandlerSchema } from '../stubs/error-handler';
 import { weightSchemaProperties } from './weight-schema-properties';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,9 +2382,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto-next/camel-catalog@workspace:*, @kaoto-next/camel-catalog@workspace:packages/camel-catalog":
+"@kaoto-next/uniforms-patternfly@npm:^0.6.8":
+  version: 0.6.8
+  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.8"
+  dependencies:
+    invariant: ^2.2.4
+    lodash: ^4.17.21
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    uniforms: 4.0.0-alpha.5
+  checksum: 882aa818eba9af30b73fd54a7f0b5c17871feda34e53b6fedb098662fc8f4206387fa2dccc077d9a8437133d90a1ab5e80349c3db6e7dc540abedf609cb5371f
+  languageName: node
+  linkType: hard
+
+"@kaoto/camel-catalog@workspace:*, @kaoto/camel-catalog@workspace:packages/camel-catalog":
   version: 0.0.0-use.local
-  resolution: "@kaoto-next/camel-catalog@workspace:packages/camel-catalog"
+  resolution: "@kaoto/camel-catalog@workspace:packages/camel-catalog"
   dependencies:
     "@types/node": ^20.0.0
     eslint: ^8.45.0
@@ -2399,11 +2412,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaoto-next/ui-tests@workspace:packages/ui-tests":
+"@kaoto/kaoto-tests@workspace:packages/ui-tests":
   version: 0.0.0-use.local
-  resolution: "@kaoto-next/ui-tests@workspace:packages/ui-tests"
+  resolution: "@kaoto/kaoto-tests@workspace:packages/ui-tests"
   dependencies:
-    "@kaoto-next/ui": "workspace:*"
+    "@kaoto/kaoto": "workspace:*"
     "@storybook/addon-essentials": ^7.2.3
     "@storybook/addon-interactions": ^7.2.3
     "@storybook/addon-links": ^7.2.3
@@ -2444,16 +2457,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaoto-next/ui@workspace:*, @kaoto-next/ui@workspace:packages/ui":
+"@kaoto/kaoto@workspace:*, @kaoto/kaoto@workspace:packages/ui":
   version: 0.0.0-use.local
-  resolution: "@kaoto-next/ui@workspace:packages/ui"
+  resolution: "@kaoto/kaoto@workspace:packages/ui"
   dependencies:
     "@babel/core": ^7.23.2
     "@babel/preset-env": ^7.21.5
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
-    "@kaoto-next/camel-catalog": "workspace:*"
     "@kaoto-next/uniforms-patternfly": ^0.6.8
+    "@kaoto/camel-catalog": "workspace:*"
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0
     "@patternfly/patternfly": 5.2.1
@@ -2530,19 +2543,6 @@ __metadata:
     zustand: ^4.3.9
   languageName: unknown
   linkType: soft
-
-"@kaoto-next/uniforms-patternfly@npm:^0.6.8":
-  version: 0.6.8
-  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.8"
-  dependencies:
-    invariant: ^2.2.4
-    lodash: ^4.17.21
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    uniforms: 4.0.0-alpha.5
-  checksum: 882aa818eba9af30b73fd54a7f0b5c17871feda34e53b6fedb098662fc8f4206387fa2dccc077d9a8437133d90a1ab5e80349c3db6e7dc540abedf609cb5371f
-  languageName: node
-  linkType: hard
 
 "@kie-tools-core/backend@npm:0.32.0":
   version: 0.32.0
@@ -13580,9 +13580,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kaoto-next@workspace:.":
+"kaoto@workspace:.":
   version: 0.0.0-use.local
-  resolution: "kaoto-next@workspace:."
+  resolution: "kaoto@workspace:."
   dependencies:
     "@lerna-lite/cli": ^3.0.0
     "@lerna-lite/publish": ^3.0.0


### PR DESCRIPTION
### Context
With the upcoming 2.0 GA release, we need to use the official package name and leave `@kaoto-next` for experimental topics.

fix: https://github.com/KaotoIO/kaoto/issues/1009