### PR TITLE
fix: Added CustomLongTextField and using it for 'Expression', 'Sasl Jaas Config' fields

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
@@ -53,16 +53,16 @@ describe('Test for camel route root containers configuration', () => {
       .find('.pf-topology__node__label__background')
       .click();
 
-    cy.get(`input[name="description"]`).clear().type('test.description');
+    cy.get(`textarea[name="description"]`).clear().type('test.description');
     cy.get(`input[name="group"]`).clear().type('test.group');
-    cy.get(`input[name="inputType.description"]`).clear().type('test.inputType.description');
+    cy.get(`textarea[name="inputType.description"]`).clear().type('test.inputType.description');
     cy.get(`input[name="inputType.id"]`).clear().type('test.inputType.id');
     cy.get(`input[name="inputType.urn"]`).clear().type('test.inputType.urn');
     cy.get(`input[name="inputType.validate"]`).check();
     cy.get(`input[name="logMask"]`).check();
     cy.get(`input[name="messageHistory"]`).check();
     cy.get(`input[name="nodePrefixId"]`).clear().type('test.nodePrefixId');
-    cy.get(`input[name="outputType.description"]`).clear().type('test.outputType.description');
+    cy.get(`textarea[name="outputType.description"]`).clear().type('test.outputType.description');
     cy.get(`input[name="outputType.id"]`).clear().type('test.outputType.id');
     cy.get(`input[name="outputType.urn"]`).clear().type('test.outputType.urn');
     cy.get(`input[name="outputType.validate"]`).check();

--- a/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/rootOnException.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/rootOnException.cy.ts
@@ -34,7 +34,7 @@ describe('Test for root containers', () => {
       .find('.pf-topology__node__label__background')
       .click();
 
-    cy.get(`input[name="description"]`).clear().type('testDescription');
+    cy.get(`textarea[name="description"]`).clear().type('testDescription');
     cy.get(`input[name="onExceptionOccurredRef"]`).clear().type('testOnExceptionOccurredRef');
     cy.get(`input[name="onRedeliveryRef"]`).clear().type('testOnRedeliveryRef');
     cy.get(`input[name="redeliveryPolicy.id"]`).clear().type('testRedeliveryPolicyId');

--- a/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/loadBalancerConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/loadBalancerConfig.cy.ts
@@ -19,7 +19,7 @@ describe('Tests for sidebar loadBalancer step configuration', () => {
       .type('roundRobinId');
 
     cy.get(`input[name="id"]`).eq(1).clear().type('testId');
-    cy.get(`input[name="description"]`).clear().type('loadBalancerDescription');
+    cy.get(`textarea[name="description"]`).clear().type('loadBalancerDescription');
     cy.get(`input[name="inheritErrorHandler"]`).check();
     cy.closeStepConfigurationTab();
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "lint:style:fix": "yarn lint:style --fix"
   },
   "dependencies": {
-    "@kaoto-next/uniforms-patternfly": "^0.6.8",
+    "@kaoto-next/uniforms-patternfly": "^0.6.10",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/notifications": "0.32.0",
     "@patternfly/patternfly": "5.2.1",

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -1,4 +1,4 @@
-import { BoolField, DateField, ListField, LongTextField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
+import { BoolField, DateField, ListField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
 import { createAutoField } from 'uniforms';
 import { getValue } from '../../utils';
 import { OneOfField } from './OneOf/OneOfField';
@@ -9,7 +9,11 @@ import { TypeaheadField } from './customField/TypeaheadField';
 import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 import { ExpressionField } from './expression/ExpressionField';
 import { PropertiesField } from './properties/PropertiesField';
+import { CustomLongTextField } from './customField/CustomLongTextField';
 import { PasswordField } from './customField/PasswordField';
+
+// Name of the properties that should load CustomLongTextField
+const CustomLongTextProps = ['Expression', 'Description'];
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly
@@ -59,8 +63,8 @@ export const CustomAutoField = createAutoField((props) => {
       /* catalog preprocessor put 'string' as a type and the javaType as a schema $comment */
       if (comment?.startsWith('class:')) {
         return BeanReferenceField;
-      } else if (title === 'Expression') {
-        return LongTextField;
+      } else if (CustomLongTextProps.includes(title)) {
+        return CustomLongTextField;
       }
       return TextField;
   }

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.scss
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.scss
@@ -1,0 +1,5 @@
+.custom-long-test-field {
+  textarea {
+    padding: 6px 8px 0;
+  }
+}

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.test.tsx
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { AutoField } from '@kaoto-next/uniforms-patternfly';
+import { AutoForm } from 'uniforms';
+import { CustomAutoFieldDetector } from '../CustomAutoField';
+import { SchemaService } from '../schema.service';
+import { CustomNestField } from './CustomNestField';
+
+describe('CustomLongTextField', () => {
+  const mockSchema = {
+    title: 'Test',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      parameters: {
+        type: 'object',
+        title: 'Endpoint Properties',
+        description: 'Endpoint properties description',
+        properties: {
+          expression: {
+            title: 'Expression',
+            group: 'common',
+            description: 'expression for queryInputStream',
+            type: 'string',
+          },
+          timerName: {
+            title: 'Timer Name',
+            group: 'common',
+            description: 'The name of the timer',
+            type: 'string',
+          },
+          pattern: {
+            title: 'Pattern',
+            group: 'advanced',
+            description:
+              'Allows you to specify a custom Date pattern to use for setting the time option using URI syntax.',
+            type: 'string',
+          },
+          saslJaasConfig: {
+            title: 'Sasl Jaas Config',
+            group: 'security',
+            description: 'Expose the kafka sasl.jaas.config parameter',
+            type: 'string',
+          },
+        },
+      },
+    },
+  };
+
+  const schemaService = new SchemaService();
+  const schemaBridge = schemaService.getSchemaBridge(mockSchema);
+
+  it('should render the component', () => {
+    render(
+      <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+        <AutoForm schema={schemaBridge!}>
+          <CustomNestField name="parameters" />
+        </AutoForm>
+      </AutoField.componentDetectorContext.Provider>,
+    );
+    const inputExpressionElement = screen
+      .getAllByRole('textbox')
+      .filter((textbox) => textbox.getAttribute('data-testid') === 'long-text-field');
+    expect(inputExpressionElement).toHaveLength(1);
+
+    const securityProperties = screen.getByRole('button', { name: 'Security properties' });
+    expect(securityProperties).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
@@ -1,0 +1,11 @@
+import { LongTextField } from '@kaoto-next/uniforms-patternfly';
+import { FunctionComponent, RefObject } from 'react';
+import './CustomLongTextField.scss';
+
+type LongTextFieldProps = Parameters<typeof LongTextField>[0] & { ref: RefObject<HTMLTextAreaElement> };
+
+export const CustomLongTextField: FunctionComponent<LongTextFieldProps> = (props) => {
+  return (
+    <LongTextField className="custom-long-test-field" {...props} inputRef={props.ref} rows={1} autoResize={true} />
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -203,7 +203,7 @@ describe('CanvasForm', () => {
       </EntitiesProvider>,
     );
 
-    const idField = screen.getAllByLabelText('Description', { selector: 'input' })[0];
+    const idField = screen.getAllByLabelText('Description', { selector: 'textarea' })[0];
     act(() => {
       fireEvent.change(idField, { target: { value: '' } });
     });

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`CanvasForm should render 1`] = `
                 <input
                   aria-invalid="false"
                   aria-label="uniforms text field"
-                  data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
                   data-ouia-component-type="PF5/TextInput"
                   data-ouia-safe="true"
                   data-testid="text-field"
@@ -162,7 +162,7 @@ exports[`CanvasForm should render 1`] = `
             </div>
           </div>
           <div
-            class="pf-v5-c-form__group"
+            class="pf-v5-c-form__group custom-long-test-field"
             data-fieldname="description"
             data-testid="wrapper-field"
           >
@@ -213,38 +213,18 @@ exports[`CanvasForm should render 1`] = `
               class="pf-v5-c-form__group-control"
             >
               <span
-                class="pf-v5-c-form-control"
+                class="pf-v5-c-form-control pf-m-resize-vertical"
+                style="height: 6px;"
               >
-                <input
+                <textarea
                   aria-invalid="false"
-                  aria-label="uniforms text field"
-                  data-ouia-component-id="OUIA-Generated-TextInputBase-4"
-                  data-ouia-component-type="PF5/TextInput"
-                  data-ouia-safe="true"
-                  data-testid="text-field"
-                  description="Sets the description of this node"
+                  aria-label="description"
+                  data-testid="long-text-field"
                   id="uniforms-0000-000h"
-                  label="Description"
                   name="description"
-                  type="text"
-                  value=""
+                  rows="1"
                 />
               </span>
-              <div
-                class="pf-v5-c-form__helper-text"
-              >
-                <div
-                  class="pf-v5-c-helper-text"
-                >
-                  <div
-                    class="pf-v5-c-helper-text__item"
-                  >
-                    <span
-                      class="pf-v5-c-helper-text__item-text"
-                    />
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
           <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,16 +2382,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto-next/uniforms-patternfly@npm:^0.6.8":
-  version: 0.6.8
-  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.8"
+"@kaoto-next/uniforms-patternfly@npm:^0.6.10":
+  version: 0.6.10
+  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.10"
   dependencies:
     invariant: ^2.2.4
     lodash: ^4.17.21
     react: ^18.2.0
     react-dom: ^18.2.0
     uniforms: 4.0.0-alpha.5
-  checksum: 882aa818eba9af30b73fd54a7f0b5c17871feda34e53b6fedb098662fc8f4206387fa2dccc077d9a8437133d90a1ab5e80349c3db6e7dc540abedf609cb5371f
+  checksum: 3d8565d4ce5a9eaa4a6c6128bc7c8a93d6f473c73713279971054ec2fda816e5c8a0d3871717caef31c61c3ef71b6855a9030836ff6dae46459cb3fd8ed4ec43
   languageName: node
   linkType: hard
 
@@ -2465,7 +2465,7 @@ __metadata:
     "@babel/preset-env": ^7.21.5
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
-    "@kaoto-next/uniforms-patternfly": ^0.6.8
+    "@kaoto-next/uniforms-patternfly": ^0.6.10
     "@kaoto/camel-catalog": "workspace:*"
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0


### PR DESCRIPTION
Fixes #1043 
However there are some issues with this new CustomLongTextField listed Following:

The new field is interacting with the CSS of CustomNestField's ExpandableSection. Hence it doesn't load correctly for Kafka's Sasl Jaas Config:
![image](https://github.com/KaotoIO/kaoto/assets/73224329/99cfef91-533b-48dd-9000-f4b29de47aea)
Note that once the field is click and you start adding some text, the field automatically corrects. Also the field loads correctly if we load the ExpandableSection as Expanded by adding the isExpanded attribute always.