### PR TITLE
fix: Add PasswordField to mask input value of the field with `format:…

### DIFF
--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -9,6 +9,7 @@ import { TypeaheadField } from './customField/TypeaheadField';
 import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 import { ExpressionField } from './expression/ExpressionField';
 import { PropertiesField } from './properties/PropertiesField';
+import { PasswordField } from './customField/PasswordField';
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly
@@ -36,6 +37,11 @@ export const CustomAutoField = createAutoField((props) => {
   } else if (props.fieldType === Object && (props.field as any)?.type === 'object' && comment === 'expression') {
     // The property which supports inlined expression such as `/setHeaders/headers[n]
     return ExpressionAwareNestField;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((props.field as any)?.format === 'password') {
+    return PasswordField;
   }
 
   switch (props.fieldType) {

--- a/packages/ui/src/components/Form/CustomAutoForm.tsx
+++ b/packages/ui/src/components/Form/CustomAutoForm.tsx
@@ -50,6 +50,7 @@ export const CustomAutoForm = forwardRef<CustomAutoFormRef, CustomAutoFormProps>
   return (
     <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
       <AutoForm
+        autoComplete="new-password"
         ref={formRef}
         schema={schemaBridge}
         model={props.model}

--- a/packages/ui/src/components/Form/customField/PasswordField.test.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.test.tsx
@@ -1,0 +1,52 @@
+import { AutoField } from '@kaoto-next/uniforms-patternfly';
+import { CustomAutoFieldDetector } from '../CustomAutoField';
+import { AutoForm } from 'uniforms';
+import { PasswordField } from './PasswordField';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { SchemaService } from '../schema.service';
+
+describe('PasswordField', () => {
+  const mockSchema = {
+    title: 'Test',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      secret: {
+        title: 'Secret',
+        group: 'secret',
+        format: 'password',
+        description: 'The secret',
+        type: 'string',
+      },
+    },
+  };
+  const mockOnChange = jest.fn();
+  const schemaService = new SchemaService();
+  const schemaBridge = schemaService.getSchemaBridge(mockSchema);
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('should render the component', async () => {
+    render(
+      <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+        <AutoForm schema={schemaBridge!}>
+          <PasswordField name="secret" />
+        </AutoForm>
+      </AutoField.componentDetectorContext.Provider>,
+    );
+    let input = screen.getByTestId('password-field');
+    expect(input).toBeInTheDocument();
+    expect(input.getAttribute('type')).toEqual('password');
+    await act(async () => {
+      fireEvent.input(input, { target: { value: 'passwd' } });
+    });
+    const toggle = screen.getByTestId('password-show-hide-button');
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    input = screen.getByTestId('password-field');
+    expect(input.getAttribute('type')).toEqual('text');
+  });
+});

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -40,7 +40,9 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
           name={props.name}
           isDisabled={props.disabled}
           validated={props.error ? 'error' : 'default'}
-          onChange={(_event, value) => onChange(value)}
+          onChange={(_event, value) => {
+            onChange(value);
+          }
           placeholder={props.placeholder}
           ref={props.inputRef}
           type={passwordHidden ? 'password' : 'text'}

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -59,7 +59,9 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
         <Button
           data-testid={'password-show-hide-button'}
           variant="control"
-          onClick={() => setPasswordHidden(!passwordHidden)}
+          onClick={() => {
+            setPasswordHidden(!passwordHidden);
+          }
           aria-label={passwordHidden ? 'Show' : 'Hide'}
         >
           {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -1,0 +1,72 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { connectField, filterDOMProps } from 'uniforms';
+import {
+  Button,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  TextInput,
+  TextInputProps,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+import { wrapField } from '@kaoto-next/uniforms-patternfly';
+import { Ref, useState } from 'react';
+
+type PasswordFieldProps = {
+  id: string;
+  decimal?: boolean;
+  inputRef?: Ref<HTMLInputElement>;
+  onChange: (value?: string) => void;
+  value?: string;
+  disabled?: boolean;
+  error?: boolean;
+  errorMessage?: string;
+  helperText?: string;
+  field?: { format: string };
+} & Omit<TextInputProps, 'isDisabled'>;
+
+const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
+  const [passwordHidden, setPasswordHidden] = useState<boolean>(true);
+
+  return wrapField(
+    props,
+    <InputGroup>
+      <InputGroupItem isFill>
+        <TextInput
+          aria-label={'uniforms text field'}
+          data-testid={'password-field'}
+          name={props.name}
+          isDisabled={props.disabled}
+          validated={props.error ? 'error' : 'default'}
+          onChange={(_event, value) => onChange(value)}
+          placeholder={props.placeholder}
+          ref={props.inputRef}
+          type={passwordHidden ? 'password' : 'text'}
+          value={props.value}
+          {...filterDOMProps(props)}
+        />
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem icon={props.error && <ExclamationCircleIcon />} variant={props.error ? 'error' : 'default'}>
+              {!props.error ? props.helperText : props.errorMessage}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </InputGroupItem>
+      <InputGroupItem>
+        <Button
+          data-testid={'password-show-hide-button'}
+          variant="control"
+          onClick={() => setPasswordHidden(!passwordHidden)}
+          aria-label={passwordHidden ? 'Show' : 'Hide'}
+        >
+          {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+        </Button>
+      </InputGroupItem>
+    </InputGroup>,
+  );
+};
+
+export const PasswordField = connectField(PasswordFieldComponent);

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -35,8 +35,8 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
     <InputGroup>
       <InputGroupItem isFill>
         <TextInput
-          aria-label={'uniforms text field'}
-          data-testid={'password-field'}
+          aria-label="uniforms text field"
+          data-testid="password-field"
           name={props.name}
           isDisabled={props.disabled}
           validated={props.error ? 'error' : 'default'}

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -35,6 +35,7 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
     <InputGroup>
       <InputGroupItem isFill>
         <TextInput
+          autoComplete="new-password"
           aria-label="uniforms text field"
           data-testid="password-field"
           name={props.name}

--- a/packages/ui/src/components/Form/customField/PasswordField.tsx
+++ b/packages/ui/src/components/Form/customField/PasswordField.tsx
@@ -42,7 +42,7 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
           validated={props.error ? 'error' : 'default'}
           onChange={(_event, value) => {
             onChange(value);
-          }
+          }}
           placeholder={props.placeholder}
           ref={props.inputRef}
           type={passwordHidden ? 'password' : 'text'}
@@ -63,7 +63,7 @@ const PasswordFieldComponent = ({ onChange, ...props }: PasswordFieldProps) => {
           variant="control"
           onClick={() => {
             setPasswordHidden(!passwordHidden);
-          }
+          }}
           aria-label={passwordHidden ? 'Show' : 'Hide'}
         >
           {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`CanvasForm should render 1`] = `
       class="pf-v5-c-card__body canvas-form__body"
     >
       <form
+        autocomplete="new-password"
         class="pf-v5-c-form"
         data-testid="autoform"
         novalidate=""


### PR DESCRIPTION
… password`

Fixes: #285
Fixes: #503

![Screenshot from 2024-05-02 21-14-45](https://github.com/KaotoIO/kaoto/assets/265462/a7b4e0d9-d09d-437e-bff4-809c1ca61f8b)
![Screenshot from 2024-05-02 21-17-34](https://github.com/KaotoIO/kaoto/assets/265462/d2ca9e02-6537-4ca6-9eb7-6d54e830455c)
