### PR TITLE
chore(Canvas): Remove Route name restriction

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/multiflow/multiFlowDesigner.cy.ts
@@ -42,10 +42,7 @@ describe('Test for Multi route actions from the canvas', () => {
     cy.get('.pf-v5-c-helper-text__item-text').should('have.text', 'Name must be unique');
     cy.get('[data-testid="goto-btn-route-1234--text-input"]').dblclick();
     cy.get('[data-testid="goto-btn-route-1234--text-input"]').clear().type('test 2');
-    cy.get('.pf-v5-c-helper-text__item-text').should(
-      'have.text',
-      'Name should only contain lowercase letters, numbers, and dashes',
-    );
+    cy.get('.pf-v5-c-helper-text__item-text').should('have.text', '');
     cy.get('[data-testid="goto-btn-route-1234--text-input"]').dblclick();
     cy.get('[data-testid="goto-btn-route-1234--text-input"]').clear().type('test3');
     cy.get('[data-testid="goto-btn-route-1234--save"]').click();

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
@@ -37,29 +37,4 @@ describe('routeIdValidator', () => {
     expect(result.status).toEqual(ValidationStatus.Error);
     expect(result.errMessages).toEqual(['Name must be unique']);
   });
-
-  it('should return an error if the name is not a valid URI', () => {
-    const resource = new CamelRouteResource(camelRouteJson);
-    const visualEntities = resource.getVisualEntities();
-    jest.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
-
-    const result = RouteIdValidator.validateUniqueName('The amazing Route', visualEntities);
-
-    expect(result.status).toEqual(ValidationStatus.Error);
-    expect(result.errMessages).toEqual(['Name should only contain lowercase letters, numbers, and dashes']);
-  });
-
-  it('should return an error if the name is not unique neither a valid URI', () => {
-    const resource = new CamelRouteResource(camelRouteJson);
-    const visualEntities = resource.getVisualEntities();
-    jest.spyOn(visualEntities[0], 'getId').mockReturnValue('The amazing Route');
-
-    const result = RouteIdValidator.validateUniqueName('The amazing Route', visualEntities);
-
-    expect(result.status).toEqual(ValidationStatus.Error);
-    expect(result.errMessages).toEqual([
-      'Name should only contain lowercase letters, numbers, and dashes',
-      'Name must be unique',
-    ]);
-  });
 });

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.ts
@@ -20,18 +20,13 @@ export class RouteIdValidator {
     const errMessages = [];
     const flowsIds = visualEntities.map((flow) => flow.getId());
 
-    const isValidURI = RouteIdValidator.isNameValidCheck(flowName);
-    if (!isValidURI) {
-      errMessages.push('Name should only contain lowercase letters, numbers, and dashes');
-    }
-
     const isUnique = !flowsIds.includes(flowName);
     if (!isUnique) {
       errMessages.push('Name must be unique');
     }
 
     return {
-      status: isValidURI && isUnique ? ValidationStatus.Success : ValidationStatus.Error,
+      status: isUnique ? ValidationStatus.Success : ValidationStatus.Error,
       errMessages,
     };
   }


### PR DESCRIPTION
### Context
Currently, the route name validator is too strict, whereas Camel JBang accepts route names as:
* `AnotherRoute`
* `My Route`
* `#$%^&$%^`

This PR disable that validation section.
![image](https://github.com/KaotoIO/kaoto/assets/16512618/19b9905e-76d3-4b97-b894-9092c946b555)

While keeping the unique ID validation
![image](https://github.com/KaotoIO/kaoto/assets/16512618/67e16dea-2358-4ec0-9935-6691939c5e3e)

fix: https://github.com/KaotoIO/kaoto/issues/968