### PR TITLE
feat(SourceCode): Preserve modelines

### DIFF
--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -28,6 +28,7 @@ export abstract class CamelKResource implements CamelResource {
   readonly sortFn = createCamelPropertiesSorter(CamelKResource.PARAMETERS_ORDER) as (a: unknown, b: unknown) => number;
   protected resource: CamelKType;
   private metadata?: MetadataEntity;
+  private comments: string[] = [];
 
   constructor(resource?: CamelKType) {
     if (resource) {
@@ -92,5 +93,13 @@ export abstract class CamelKResource implements CamelResource {
   /** Components Catalog related methods */
   getCompatibleComponents(_mode: AddStepMode, _visualEntityData: IVisualizationNodeData): TileFilter | undefined {
     return undefined;
+  }
+
+  setComments(comments: string[]) {
+    this.comments = comments;
+  }
+
+  getComments(): string[] {
+    return this.comments;
   }
 }

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -35,6 +35,8 @@ export interface CamelResource {
   ): TileFilter | undefined;
 
   sortFn?: (a: unknown, b: unknown) => number;
+  setComments(comments: string[]): void;
+  getComments(): string[];
 }
 
 export interface BaseVisualCamelEntityDefinition {

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -186,4 +186,12 @@ describe('CamelRouteResource', () => {
       expect(firstEntity.toJSON()).not.toBeUndefined();
     });
   });
+
+  describe('comments', () => {
+    it('should set and get comments', () => {
+      const resource = new CamelRouteResource();
+      resource.setComments(['a', 'b']);
+      expect(resource.getComments()).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -45,6 +45,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
   ) => number;
   private entities: BaseCamelEntity[] = [];
   private resolvedEntities: BaseVisualCamelEntityDefinition | undefined;
+  private comments: string[] = [];
 
   constructor(json?: unknown) {
     if (!json) return;
@@ -160,6 +161,14 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
     definition?: any,
   ): TileFilter {
     return CamelComponentFilterService.getCamelCompatibleComponents(mode, visualEntityData, definition);
+  }
+
+  setComments(comments: string[]): void {
+    this.comments = comments;
+  }
+
+  getComments(): string[] {
+    return this.comments;
   }
 
   private getEntity(rawItem: unknown): BaseCamelEntity | undefined {

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -98,4 +98,12 @@ describe('KameletResource', () => {
     expect(model.spec.template.beans).toBeUndefined();
     expect(kameletResource.getRouteTemplateBeansEntity()).toBeUndefined();
   });
+
+  describe('comments', () => {
+    it('should set and get comments', () => {
+      const resource = new KameletResource();
+      resource.setComments(['a', 'b']);
+      expect(resource.getComments()).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -53,4 +53,12 @@ describe('PipeResource', () => {
     expect(resource.getEntities().length).toEqual(0);
     expect(resource.toJSON().metadata).toBeUndefined();
   });
+
+  describe('comments', () => {
+    it('should set and get comments', () => {
+      const resource = new PipeResource();
+      resource.setComments(['a', 'b']);
+      expect(resource.getComments()).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/packages/ui/src/stubs/camel-route-yaml-1.1.ts
+++ b/packages/ui/src/stubs/camel-route-yaml-1.1.ts
@@ -9,7 +9,8 @@ export const camelRouteYaml_1_1_original = `
       steps: []
 `;
 
-export const camelRouteYaml_1_1_updated = `- route:
+export const camelRouteYaml_1_1_updated = `
+- route:
     id: route-3376
     from:
       id: from-3505


### PR DESCRIPTION
### Context
Currently, comments are lost when parsing the source code.

### Changes
This commit checks the first lines of the source code and stores the comments up to the first object definition in the YAML code.

fix: https://github.com/KaotoIO/kaoto/issues/937