### PR TITLE
feat(Canvas): Disable steps

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.scss
@@ -1,12 +1,28 @@
-/* stylelint-disable-next-line selector-class-pattern */
-.custom-node__image {
-  display: flex;
-  flex-flow: column;
-  align-items: center;
-  height: 100%;
-  justify-content: center;
+.custom-node {
+  &__image {
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    height: 100%;
+    justify-content: center;
 
-  img {
-    max-height: 80%;
+    img {
+      max-height: 80%;
+      max-width: 95%;
+    }
   }
+
+  &[data-disabled='true'] &__image {
+    filter: grayscale(100%);
+  }
+
+  &--disabled {
+    --pf-topology__node_decorator--Color: var(--pf-v5-global--BackgroundColor--dark-200);
+  }
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.custom-node__label--disabled {
+  font-style: italic;
+  text-decoration: line-through;
 }

--- a/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/CustomNode.tsx
@@ -1,7 +1,8 @@
 import { Tooltip } from '@patternfly/react-core';
-import { ArrowDownIcon, ArrowUpIcon, CodeBranchIcon, PlusIcon } from '@patternfly/react-icons';
+import { ArrowDownIcon, ArrowUpIcon, BanIcon, CodeBranchIcon, PlusIcon } from '@patternfly/react-icons';
 import {
   ContextMenuSeparator,
+  Decorator,
   DefaultNode,
   ElementModel,
   GraphElement,
@@ -12,6 +13,7 @@ import {
   withContextMenu,
   withSelection,
 } from '@patternfly/react-topology';
+import clsx from 'clsx';
 import { FunctionComponent, ReactElement } from 'react';
 import { AddStepMode } from '../../../models/visualization/base-visual-entity';
 import { CanvasDefaults } from '../Canvas/canvas.defaults';
@@ -20,6 +22,7 @@ import './CustomNode.scss';
 import { ItemAddStep } from './ItemAddStep';
 import { ItemDeleteGroup } from './ItemDeleteGroup';
 import { ItemDeleteStep } from './ItemDeleteStep';
+import { ItemDisableStep } from './ItemDisableStep';
 import { ItemInsertStep } from './ItemInsertStep';
 import { ItemReplaceStep } from './ItemReplaceStep';
 
@@ -31,22 +34,29 @@ const noopFn = () => {};
 const CustomNode: FunctionComponent<CustomNodeProps> = observer(({ element, ...rest }) => {
   const vizNode = element.getData()?.vizNode;
   const label = vizNode?.getNodeLabel();
+  const isDisabled = !!vizNode?.getComponentSchema()?.definition?.disabled;
   const tooltipContent = vizNode?.getTooltipContent();
   const statusDecoratorTooltip = vizNode?.getNodeValidationText();
-  const nodeStatus = !statusDecoratorTooltip ? NodeStatus.default : NodeStatus.warning;
+  const nodeStatus = !statusDecoratorTooltip || isDisabled ? NodeStatus.default : NodeStatus.warning;
 
   return (
     <DefaultNode
       {...rest}
       element={element}
       label={label}
+      labelClassName={clsx('custom-node__label', { 'custom-node__label--disabled': isDisabled })}
       truncateLength={15}
-      showStatusDecorator
+      showStatusDecorator={!isDisabled}
       statusDecoratorTooltip={statusDecoratorTooltip}
       nodeStatus={nodeStatus}
       onStatusDecoratorClick={noopFn}
     >
-      <g data-testid={`custom-node__${vizNode?.id}`} data-nodelabel={label}>
+      <g
+        className="custom-node"
+        data-testid={`custom-node__${vizNode?.id}`}
+        data-nodelabel={label}
+        data-disabled={isDisabled}
+      >
         <foreignObject
           x="0"
           y="0"
@@ -59,6 +69,16 @@ const CustomNode: FunctionComponent<CustomNodeProps> = observer(({ element, ...r
             </div>
           </Tooltip>
         </foreignObject>
+
+        {isDisabled && (
+          <Decorator
+            radius={12}
+            x={CanvasDefaults.DEFAULT_NODE_DIAMETER}
+            y={0}
+            icon={<BanIcon className="custom-node--disabled" />}
+            showBackground
+          />
+        )}
       </g>
     </DefaultNode>
   );
@@ -128,11 +148,18 @@ export const CustomNodeWithSelection: typeof DefaultNode = withSelection()(
       items.push(<ContextMenuSeparator key="context-menu-separator-insert" />);
     }
 
+    if (nodeInteractions.canBeDisabled) {
+      items.push(
+        <ItemDisableStep key="context-menu-item-disable" data-testid="context-menu-item-disable" vizNode={vizNode} />,
+      );
+    }
     if (nodeInteractions.canReplaceStep) {
       items.push(
         <ItemReplaceStep key="context-menu-item-replace" data-testid="context-menu-item-replace" vizNode={vizNode} />,
       );
-      items.push(<ContextMenuSeparator key="context-menu-separator" />);
+    }
+    if (nodeInteractions.canBeDisabled || nodeInteractions.canReplaceStep) {
+      items.push(<ContextMenuSeparator key="context-menu-separator-replace" />);
     }
 
     if (nodeInteractions.canRemoveStep) {

--- a/packages/ui/src/components/Visualization/Custom/ItemDisableStep.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ItemDisableStep.tsx
@@ -1,0 +1,39 @@
+import { BanIcon, CheckIcon } from '@patternfly/react-icons';
+import { ContextMenuItem } from '@patternfly/react-topology';
+import { FunctionComponent, PropsWithChildren, useCallback, useContext } from 'react';
+import { IDataTestID } from '../../../models';
+import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
+import { EntitiesContext } from '../../../providers/entities.provider';
+import { setValue } from '../../../utils/set-value';
+
+interface ItemDisableStepProps extends PropsWithChildren<IDataTestID> {
+  vizNode: IVisualizationNode;
+}
+
+export const ItemDisableStep: FunctionComponent<ItemDisableStepProps> = (props) => {
+  const entitiesContext = useContext(EntitiesContext);
+
+  const isDisabled = !!props.vizNode.getComponentSchema()?.definition?.disabled;
+
+  const onToggleDisableNode = useCallback(() => {
+    const newModel = props.vizNode.getComponentSchema()?.definition || {};
+    setValue(newModel, 'disabled', !isDisabled);
+    props.vizNode.updateModel(newModel);
+
+    entitiesContext?.updateEntitiesFromCamelResource();
+  }, [entitiesContext, isDisabled, props.vizNode]);
+
+  return (
+    <ContextMenuItem onClick={onToggleDisableNode} data-testid={props['data-testid']}>
+      {isDisabled ? (
+        <>
+          <CheckIcon /> Enable
+        </>
+      ) : (
+        <>
+          <BanIcon /> Disable
+        </>
+      )}
+    </ContextMenuItem>
+  );
+};

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -162,4 +162,5 @@ export interface NodeInteraction {
   canReplaceStep: boolean;
   canRemoveStep: boolean;
   canRemoveFlow: boolean;
+  canBeDisabled: boolean;
 }

--- a/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'from' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -14,6 +15,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'intercept' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -26,6 +28,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'interceptFrom' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -38,6 +41,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'interceptSendToEndpoint' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -50,6 +54,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'log' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -62,6 +67,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'onCompletion' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -74,6 +80,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'onException' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -86,6 +93,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'route' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -98,6 +106,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
 
 exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct interaction for the 'to' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
@@ -5,6 +5,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
   path: 'interceptSendToEndpoint'
 }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -17,6 +18,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -29,6 +31,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -41,6 +44,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -53,6 +57,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -65,6 +70,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -77,6 +83,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -89,6 +96,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -101,6 +109,7 @@ exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the cor
 
 exports[`CamelInterceptFromVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
@@ -5,6 +5,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
   path: 'interceptSendToEndpoint'
 }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -17,6 +18,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -29,6 +31,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -41,6 +44,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -53,6 +57,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -65,6 +70,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -77,6 +83,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -89,6 +96,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -101,6 +109,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should retu
 
 exports[`CamelInterceptSendToEndpointVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
@@ -5,6 +5,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
   path: 'interceptSendToEndpoint'
 }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -17,6 +18,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -29,6 +31,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -41,6 +44,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -53,6 +57,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -65,6 +70,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -77,6 +83,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -89,6 +96,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -101,6 +109,7 @@ exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct
 
 exports[`CamelInterceptVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
@@ -5,6 +5,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
   path: 'interceptSendToEndpoint'
 }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -17,6 +18,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -29,6 +31,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -41,6 +44,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -53,6 +57,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -65,6 +70,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 2`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -77,6 +83,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -89,6 +96,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -101,6 +109,7 @@ exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the corr
 
 exports[`CamelOnCompletionVisualEntity getNodeInteraction should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'from' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -14,6 +15,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'intercept' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -26,6 +28,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'interceptFrom' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -38,6 +41,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'interceptSendToEndpoint' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -50,6 +54,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'log' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -62,6 +67,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'onCompletion' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -74,6 +80,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'onException' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": true,
   "canHaveNextStep": false,
   "canHavePreviousStep": false,
@@ -86,6 +93,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'route' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -98,6 +106,7 @@ exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the corre
 
 exports[`CamelOnExceptionVisualEntity getNodeInteraction should return the correct interaction for the 'to' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Pipe getNodeInteraction should return the correct interaction for the '#' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,
@@ -14,6 +15,7 @@ exports[`Pipe getNodeInteraction should return the correct interaction for the '
 
 exports[`Pipe getNodeInteraction should return the correct interaction for the 'sink' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": false,
   "canHavePreviousStep": true,
@@ -26,6 +28,7 @@ exports[`Pipe getNodeInteraction should return the correct interaction for the '
 
 exports[`Pipe getNodeInteraction should return the correct interaction for the 'source' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": false,
@@ -38,6 +41,7 @@ exports[`Pipe getNodeInteraction should return the correct interaction for the '
 
 exports[`Pipe getNodeInteraction should return the correct interaction for the 'steps.1' processor 1`] = `
 {
+  "canBeDisabled": false,
   "canHaveChildren": false,
   "canHaveNextStep": true,
   "canHavePreviousStep": true,

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -193,6 +193,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     );
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -202,6 +203,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
       canReplaceStep,
       canRemoveStep: true,
       canRemoveFlow: data.path === ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -145,6 +145,7 @@ describe('CamelErrorHandlerVisualEntity', () => {
       canRemoveStep: false,
       canReplaceStep: false,
       canRemoveFlow: true,
+      canBeDisabled: false,
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -116,6 +116,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
       canRemoveStep: false,
       canReplaceStep: false,
       canRemoveFlow: true,
+      canBeDisabled: false,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -76,6 +76,7 @@ export class CamelInterceptFromVisualEntity
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -85,6 +86,7 @@ export class CamelInterceptFromVisualEntity
       canReplaceStep,
       canRemoveStep,
       canRemoveFlow: data.path === CamelInterceptFromVisualEntity.ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -88,6 +88,7 @@ export class CamelInterceptSendToEndpointVisualEntity
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -97,6 +98,7 @@ export class CamelInterceptSendToEndpointVisualEntity
       canReplaceStep,
       canRemoveStep,
       canRemoveFlow: data.path === CamelInterceptSendToEndpointVisualEntity.ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -59,6 +59,7 @@ export class CamelInterceptVisualEntity
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -68,6 +69,7 @@ export class CamelInterceptVisualEntity
       canReplaceStep,
       canRemoveStep,
       canRemoveFlow: data.path === CamelInterceptVisualEntity.ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -61,6 +61,7 @@ export class CamelOnCompletionVisualEntity
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -70,6 +71,7 @@ export class CamelOnCompletionVisualEntity
       canReplaceStep,
       canRemoveStep,
       canRemoveFlow: data.path === CamelOnCompletionVisualEntity.ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -61,6 +61,7 @@ export class CamelOnExceptionVisualEntity
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
 
     return {
       canHavePreviousStep,
@@ -70,6 +71,7 @@ export class CamelOnExceptionVisualEntity
       canReplaceStep,
       canRemoveStep,
       canRemoveFlow: data.path === CamelOnExceptionVisualEntity.ROOT_PATH,
+      canBeDisabled,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -137,6 +137,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
       canRemoveStep: false,
       canReplaceStep: false,
       canRemoveFlow: true,
+      canBeDisabled: false,
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -101,6 +101,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualCamelEntity
       canRemoveStep: false,
       canReplaceStep: false,
       canRemoveFlow: true,
+      canBeDisabled: false,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -120,6 +120,7 @@ export class CamelRouteConfigurationVisualEntity
         canRemoveStep: false,
         canReplaceStep: false,
         canRemoveFlow: true,
+        canBeDisabled: false,
       };
     }
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -166,6 +166,7 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
       canReplaceStep: true,
       canRemoveStep: true,
       canRemoveFlow: data.path === ROOT_PATH,
+      canBeDisabled: false,
     };
   }
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -408,4 +408,10 @@ export class CamelComponentSchemaService {
       Object.assign(definition.parameters, parametersFromSyntax);
     }
   }
+
+  static canBeDisabled(processorName: keyof ProcessorDefinition): boolean {
+    const processorDefinition = CamelCatalogService.getComponent(CatalogKind.Pattern, processorName);
+
+    return processorDefinition?.propertiesSchema?.properties?.disabled !== undefined;
+  }
 }

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -32,6 +32,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     canReplaceStep: false,
     canRemoveStep: false,
     canRemoveFlow: false,
+    canBeDisabled: false,
   };
 
   constructor(


### PR DESCRIPTION
## Note
This PR is still a draft because the disabling effect should be more explicit

### Context
Some EIPs provide a `disabled` property to ignore them during the runtime.

### Changes
This commit adds quick access to that property, so users can easily enable/disable nodes in the canvas. In addition to that, the step is grayed out when disabled.

### Screenshots

| Disabled | Enabled |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto/assets/16512618/d5cd6f4c-3bb7-4026-9793-f38440c07f14) | ![image](https://github.com/KaotoIO/kaoto/assets/16512618/70d2fe4a-aeaf-4d3a-8d5e-470af5958fa1) |

fix: https://github.com/KaotoIO/kaoto/issues/758
fix: https://github.com/KaotoIO/kaoto/issues/699