### PR TITLE
fix(Canvas): Avoid removing `from`

### DIFF
--- a/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
@@ -8,7 +8,7 @@ exports[`AbstractCamelVisualEntity getNodeInteraction should return the correct 
   "canHavePreviousStep": false,
   "canHaveSpecialChildren": false,
   "canRemoveFlow": false,
-  "canRemoveStep": true,
+  "canRemoveStep": false,
   "canReplaceStep": true,
 }
 `;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -182,18 +182,15 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
-    );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
-    );
-    const canReplaceStep = CamelComponentSchemaService.canReplaceStep(
-      (data as CamelRouteVisualEntityData).processorName,
-    );
+    const processorName = (data as CamelRouteVisualEntityData).processorName;
+    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(processorName);
+    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(processorName);
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canReplaceStep = CamelComponentSchemaService.canReplaceStep(processorName);
+    const canRemoveStep = processorName !== ('from' as keyof ProcessorDefinition);
+    const canRemoveFlow = data.path === ROOT_PATH;
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(processorName);
 
     return {
       canHavePreviousStep,
@@ -201,8 +198,8 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
       canHaveChildren,
       canHaveSpecialChildren,
       canReplaceStep,
-      canRemoveStep: true,
-      canRemoveFlow: data.path === ROOT_PATH,
+      canRemoveStep,
+      canRemoveFlow,
       canBeDisabled,
     };
   }


### PR DESCRIPTION
Since we're handling `from` deletion differently to avoid losing its children, we shouldn't allow user to delete it but rather replace it.

This commit hides the delete option for the `from` node.