### PR TITLE
fix(CanvasForm): Expression field shows `[object Object]`

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -55,7 +55,7 @@ describe('CamelComponentDefaultService', () => {
       expect(setHeaderDefault.setHeader).toBeDefined();
       expect((setHeaderDefault.setHeader!.id as string).startsWith('setHeader-')).toBeTruthy();
       expect(setHeaderDefault.setHeader!.name).toBeUndefined();
-      expect((setHeaderDefault.setHeader!.expression as any).simple.expression).toEqual({});
+      expect((setHeaderDefault.setHeader!.expression as any).simple).toEqual({});
     });
 
     it('should return the default value for a setProperty processor', () => {
@@ -66,7 +66,7 @@ describe('CamelComponentDefaultService', () => {
       expect(setPropertyDefault.setProperty).toBeDefined();
       expect((setPropertyDefault.setProperty!.id as string).startsWith('setProperty-')).toBeTruthy();
       expect(setPropertyDefault.setProperty!.name).toBeUndefined();
-      expect((setPropertyDefault.setProperty!.expression as any).simple.expression).toEqual({});
+      expect((setPropertyDefault.setProperty!.expression as any).simple).toEqual({});
     });
 
     it('should return the default value for a setVariable processor', () => {
@@ -77,7 +77,7 @@ describe('CamelComponentDefaultService', () => {
       expect(setVariableDefault.setVariable).toBeDefined();
       expect((setVariableDefault.setVariable!.id as string).startsWith('setVariable-')).toBeTruthy();
       expect(setVariableDefault.setVariable!.name).toBeUndefined();
-      expect((setVariableDefault.setVariable!.expression as any).simple.expression).toEqual({});
+      expect((setVariableDefault.setVariable!.expression as any).simple).toEqual({});
     });
 
     it('should return the default value for a setBody processor', () => {
@@ -87,7 +87,7 @@ describe('CamelComponentDefaultService', () => {
       } as DefinedComponent);
       expect(setBodyDefault.setBody).toBeDefined();
       expect((setBodyDefault.setBody!.id as string).startsWith('setBody-')).toBeTruthy();
-      expect((setBodyDefault.setBody!.expression as any).simple.expression).toEqual({});
+      expect((setBodyDefault.setBody!.expression as any).simple).toEqual({});
     });
 
     it('should return the default value for a filter processor', () => {
@@ -97,7 +97,7 @@ describe('CamelComponentDefaultService', () => {
       } as DefinedComponent);
       expect(filterDefault.filter).toBeDefined();
       expect((filterDefault.filter!.id as string).startsWith('filter-')).toBeTruthy();
-      expect((filterDefault.filter!.expression as any).simple.expression).toEqual({});
+      expect((filterDefault.filter!.expression as any).simple).toEqual({});
       expect(filterDefault.filter!.steps).toBeUndefined();
     });
   });

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -132,9 +132,9 @@ export class CamelComponentDefaultService {
         ${processorName}:
           id: ${getCamelRandomId(processorName)}
           expression:
-            simple:
-              expression: {}
+            simple: {}
         `);
+
       default:
         return {
           [processorName]: {


### PR DESCRIPTION
### Context
When a new expression-aware step is generated, the expression property is created as follows:

```yaml
        setHeader:
          id: setHeader-1234
          expression:
            simple:
              expression: {}
```

Notice the `expression: {}` bit which causes for the expression TextField to render `[object Object]`

### Changes
Replace the autogenerated step with an empty `simple: {}`, so there's the feedback that a property is left to be configured. In the future, there will be the same feedback in the Canvas as well. https://github.com/KaotoIO/kaoto/issues/705

```yaml
        setHeader:
          id: setHeader-1234
          expression:
            simple: {}
```

### Note
This comes from this PR https://github.com/KaotoIO/kaoto/pull/1068, in which I suggested using `expression: {}` for the newly created step.

fix: https://github.com/KaotoIO/kaoto/issues/1076