### PR TITLE
chore(e2e): Add another validation for uploadFixture

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
+++ b/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
@@ -28,6 +28,10 @@ Cypress.Commands.add('uploadFixture', (fixture) => {
   cy.openSourceCode();
   cy.waitForEditorToLoad();
   cy.get('.pf-v5-c-code-editor__main > input').attachFile(fixture);
+
+  cy.get('.pf-v5-c-code-editor').should(($editor) => {
+    expect($editor.find('[data-uri^="inmemory://"]')).to.exist;
+  });
 });
 
 Cypress.Commands.add('editorDeleteLine', (line: number, repeatCount: number) => {


### PR DESCRIPTION
### Context
Currently, there are a few tests that seem to randomly fail:

* branchingStepActions.cy.ts
* branchingStepAddition.cy.ts

This commit adds another validation to ensure the source code has been loaded with the aim of stabilizing them.