### PR TITLE
fix(CanvasForm): Provide basic schema for unknown Kamelets

### DIFF
--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -130,5 +130,19 @@ describe('CamelCatalogService', () => {
         definition: (kameletCatalogMap as Record<string, unknown>)['chuck-norris-source'],
       });
     });
+
+    it('should return the kamelet component for unknown kamelets', () => {
+      CamelCatalogService.setCatalogKey(
+        CatalogKind.Kamelet,
+        kameletCatalogMap as unknown as Record<string, IKameletDefinition>,
+      );
+
+      const lookup = CamelCatalogService.getCatalogLookup('kamelet:non-existing-kamelet');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Component,
+        definition: (componentCatalogMap as Record<string, unknown>).kamelet,
+      });
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -79,9 +79,19 @@ export class CamelCatalogService {
     }
 
     if (componentName.startsWith('kamelet:')) {
+      const definition = this.getComponent(CatalogKind.Kamelet, componentName.replace('kamelet:', ''));
+
+      if (definition) {
+        return {
+          catalogKind: CatalogKind.Kamelet,
+          definition,
+        };
+      }
+
+      // If the Kamelet is not found, we fallback to the Kamelet component
       return {
-        catalogKind: CatalogKind.Kamelet,
-        definition: this.getComponent(CatalogKind.Kamelet, componentName.replace('kamelet:', '')),
+        catalogKind: CatalogKind.Component,
+        definition: this.getComponent(CatalogKind.Component, 'kamelet'),
       };
     }
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -393,7 +393,7 @@ describe('CamelComponentSchemaService', () => {
       };
       const actualContent = CamelComponentSchemaService.getTooltipContent(camelElementLookup);
 
-      expect(actualContent).toEqual('kamelet:xyz');
+      expect(actualContent).toEqual('To call Kamelets');
     });
 
     it('should return the processor schema description', () => {

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -29,6 +29,12 @@ describe('CamelUriHelper', () => {
       { syntax: 'log:loggerName', uri: 'log:myLogger', result: { loggerName: 'myLogger' } },
       { syntax: 'log:loggerName', uri: 'log', result: {} },
       { syntax: 'log', uri: 'log:myLogger', result: {} },
+      {
+        syntax: 'kamelet:templateId/routeId',
+        uri: 'kamelet:MyTemplate/MyRouteId',
+        result: { templateId: 'MyTemplate', routeId: 'MyRouteId' },
+      },
+      { syntax: 'kamelet:templateId/routeId', uri: 'kamelet:MyTemplate', result: { templateId: 'MyTemplate' } },
       { syntax: 'as2:apiName/methodName', uri: 'as2', result: {} },
       {
         syntax: 'activemq:destinationType:destinationName',
@@ -142,6 +148,18 @@ describe('CamelUriHelper', () => {
 
   describe('getUriStringFromParameters', () => {
     it.each([
+      {
+        uri: 'kamelet:MyTemplate/MyRouteId',
+        syntax: 'kamelet:templateId/routeId',
+        parameters: { templateId: 'MyTemplate', routeId: 'MyRouteId' },
+        result: { uri: 'kamelet:MyTemplate/MyRouteId', parameters: {} },
+      },
+      {
+        uri: 'kamelet:MyTemplate',
+        syntax: 'kamelet:templateId/routeId',
+        parameters: { templateId: 'MyTemplate' },
+        result: { uri: 'kamelet:MyTemplate', parameters: {} },
+      },
       { uri: 'log', syntax: 'log', parameters: {}, result: { uri: 'log', parameters: {} } },
       {
         uri: 'timer',


### PR DESCRIPTION
### Context
Currently, when using the `kamelet` component, providing an unknown Kamelet to Kaoto, this renders the basic `To` EIP configuration form.

This is not useful since then we can't provide the Kamelet's TemplateId nor RouteId.

| Before | After |
| --- | --- |
| ![image](https://github.com/KaotoIO/kaoto/assets/16512618/5bc86777-bf63-48f9-9d4c-0396c2e89140) | ![image](https://github.com/KaotoIO/kaoto/assets/16512618/94f6abf9-d7bb-4be5-b8df-c9335b100fb1) |

### Changes
The fix is to fallback to the standard `Kamelet` component when passing an unknown Kamelet to Kaoto.

fix: https://github.com/KaotoIO/kaoto/issues/1004