### PR TITLE
fix(991): Removing useMemo() from the code

### DIFF
--- a/packages/ui/src/components/Form/CustomAutoFields.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.tsx
@@ -1,5 +1,5 @@
 import { AutoField } from '@kaoto-next/uniforms-patternfly';
-import { ComponentType, createElement, useMemo } from 'react';
+import { ComponentType, createElement } from 'react';
 import { useForm } from 'uniforms';
 import { KaotoSchemaDefinition } from '../../models';
 import { Card, CardBody, ExpandableSection, capitalize } from '@patternfly/react-core';
@@ -24,19 +24,17 @@ export function CustomAutoFields({
   const { schema } = useForm();
   const rootField = schema.getField('');
 
+  /** Special handling for oneOf schemas */
+  if (Array.isArray((rootField as KaotoSchemaDefinition['schema']).oneOf)) {
+    return createElement(element, props, [createElement(autoField!, { key: '', name: '' })]);
+  }
+
   const actualFields = (fields ?? schema.getSubfields()).filter((field) => !omitFields!.includes(field));
   const actualFieldsSchema = actualFields.reduce((acc: { [name: string]: unknown }, name) => {
     acc[name] = schema.getField(name);
     return acc;
   }, {});
-  const propertiesArray = useMemo(() => {
-    return getFieldGroups(actualFieldsSchema);
-  }, [actualFieldsSchema]);
-
-  /** Special handling for oneOf schemas */
-  if (Array.isArray((rootField as KaotoSchemaDefinition['schema']).oneOf)) {
-    return createElement(element, props, [createElement(autoField!, { key: '', name: '' })]);
-  }
+  const propertiesArray = getFieldGroups(actualFieldsSchema);
 
   return createElement(
     element,
@@ -48,10 +46,10 @@ export function CustomAutoFields({
 
       {Object.entries(propertiesArray.groups).map(([groupName, groupFields]) => (
         <ExpandableSection
-          key={`${groupName}-section-toggle`}
+          key={`processor-${groupName}-section-toggle`}
           toggleText={capitalize(`${CatalogKind.Processor} ${groupName} properties`)}
-          toggleId="expandable-section-toggle"
-          contentId="expandable-section-content"
+          toggleId={`processor-${groupName}-expandable-section-toggle`}
+          contentId="processor-expandable-section-content"
         >
           <Card className="nest-field-card">
             <CardBody className="nest-field-card-body">

--- a/packages/ui/src/components/Form/customField/CustomNestField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomNestField.tsx
@@ -18,7 +18,6 @@
  */
 
 import { Card, CardBody, CardHeader, CardTitle, ExpandableSection, capitalize } from '@patternfly/react-core';
-import { useMemo } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 import { getFieldGroups } from '../../../utils';
 import { CustomAutoField } from '../CustomAutoField';
@@ -43,9 +42,7 @@ export const CustomNestField = connectField(
     disabled,
     ...props
   }: CustomNestFieldProps) => {
-    const propertiesArray = useMemo(() => {
-      return getFieldGroups(props.properties ?? {});
-    }, [props.properties]);
+    const propertiesArray = getFieldGroups(props.properties ?? {});
 
     return (
       <Card className="custom-nest-field" data-testid={'nest-field'} {...filterDOMProps(props)}>
@@ -64,7 +61,7 @@ export const CustomNestField = connectField(
             <ExpandableSection
               key={`${groupName}-section-toggle`}
               toggleText={capitalize(`${groupName} properties`)}
-              toggleId="expandable-section-toggle"
+              toggleId={`${groupName}-expandable-section-toggle`}
               contentId="expandable-section-content"
             >
               <CardBody>

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -234,9 +234,9 @@ exports[`CanvasForm should render 1`] = `
             class="pf-v5-c-expandable-section"
           >
             <button
-              aria-controls="expandable-section-content"
+              aria-controls="processor-expandable-section-content"
               class="pf-v5-c-expandable-section__toggle"
-              id="expandable-section-toggle"
+              id="processor-advanced-expandable-section-toggle"
               type="button"
             >
               <span
@@ -263,10 +263,10 @@ exports[`CanvasForm should render 1`] = `
               </span>
             </button>
             <div
-              aria-labelledby="expandable-section-toggle"
+              aria-labelledby="processor-advanced-expandable-section-toggle"
               class="pf-v5-c-expandable-section__content"
               hidden=""
-              id="expandable-section-content"
+              id="processor-expandable-section-content"
               role="region"
             >
               <div


### PR DESCRIPTION
### Description
This PR is related to a previous [PR](https://github.com/KaotoIO/kaoto/pull/1141), where I added the following two changes:
1. Removed the useMemo() calls as I found out that it is unnecessarily used and the underlying code is getting executed all the time the component is re-executed as we inject an object as it dependency. I might be incorrect on this so please let me know if we need a discussion over this.
2. Modified the id to make it unique for all the groups in the expandable section.

