### PR TITLE
fix(e2e): Remove usage of `#processor-advanced-expandable-section-toggle`

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/interceptSendToEndpoint.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/interceptSendToEndpoint.cy.ts
@@ -14,7 +14,7 @@ describe('Test for interceptSendToEndpoint configuration container', () => {
     cy.interactWithConfigInputObject('description', 'testDescription');
     cy.interactWithConfigInputObject('skipSendToOriginalEndpoint', 'testSkipSendToOriginalEndpoint');
 
-    cy.get('#processor-advanced-expandable-section-toggle').click();
+    cy.contains('button', 'Processor advanced properties').click();
     cy.interactWithConfigInputObject('afterUri', 'testAfterUri');
 
     cy.openSourceCode();

--- a/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/onCompletion.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/onCompletion.cy.ts
@@ -15,7 +15,7 @@ describe('Test for onCompletion configuration container', () => {
     cy.interactWithConfigInputObject('onCompleteOnly');
     cy.interactWithConfigInputObject('onFailureOnly');
 
-    cy.get('#processor-advanced-expandable-section-toggle').click();
+    cy.contains('button', 'Processor advanced properties').click();
     cy.selectInTypeaheadField('mode', 'BeforeConsumer');
     cy.interactWithConfigInputObject('parallelProcessing');
     cy.interactWithConfigInputObject('useOriginalMessage');


### PR DESCRIPTION
### Context
The `interceptSendToEndpoint` and `onCompletion` entities have expandable sections, making the e2e to fail.

relates to: https://github.com/KaotoIO/kaoto/pull/1195