### PR TITLE
Feat/pick settings from multiplying architecture at init

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -13,11 +13,9 @@ import { SourceCodeProvider } from '../providers/source-code.provider';
 import { KaotoBridge } from './KaotoBridge';
 import { KaotoEditor } from './KaotoEditor';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
-import { CatalogSchemaLoader } from '../utils';
 
 export class KaotoEditorApp implements Editor {
   private readonly editorRef: RefObject<EditorApi>;
-  private readonly catalogUrl: string;
   af_isReact = true;
   af_componentId = 'kaoto-editor';
   af_componentTitle = 'Kaoto Editor';
@@ -25,9 +23,9 @@ export class KaotoEditorApp implements Editor {
   constructor(
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<KaotoEditorChannelApi>,
     private readonly initArgs: EditorInitArgs,
+    private readonly catalogUrl: string,
   ) {
     this.editorRef = createRef<EditorApi>();
-    this.catalogUrl = `${this.initArgs.resourcesPathPrefix}${CatalogSchemaLoader.DEFAULT_CATALOG_PATH.replace('.', '')}`;
   }
 
   async getElementPosition() {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
@@ -6,12 +6,20 @@ import {
   KogitoEditorEnvelopeContextType,
 } from '@kie-tools-core/editor/dist/api';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
+import { CatalogSchemaLoader, isDefined } from '../utils';
 
 export class KaotoEditorFactory implements EditorFactory<Editor, KaotoEditorChannelApi> {
-  public createEditor(
+  public async createEditor(
     envelopeContext: KogitoEditorEnvelopeContextType<KaotoEditorChannelApi>,
     initArgs: EditorInitArgs,
   ): Promise<Editor> {
-    return Promise.resolve(new KaotoEditorApp(envelopeContext, initArgs));
+    let catalogUrl;
+    const catalogUrlFromChannelApi = await envelopeContext.channelApi.requests.getCatalogURL();
+    if (isDefined(catalogUrlFromChannelApi)) {
+      catalogUrl = catalogUrlFromChannelApi;
+    } else {
+      catalogUrl = `${initArgs.resourcesPathPrefix}${CatalogSchemaLoader.DEFAULT_CATALOG_PATH.replace('.', '')}`;
+    }
+    return Promise.resolve(new KaotoEditorApp(envelopeContext, initArgs, catalogUrl));
   }
 }


### PR DESCRIPTION
currently error in console.log:

```
react-dom.development.js:16227 Uncaught (in promise) Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
    at Object.throwInvalidHookError (react-dom.development.js:16227:1)
    at useContext (react.development.js:1618:1)
    at KaotoEditorApp.tsx:30:41

```

![image](https://github.com/KaotoIO/kaoto/assets/1105127/5840be64-673f-4f48-9100-9902088765c6)
