### PR TITLE
fix(1100): Use '${body}' as default for Log's EIP message

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -37,6 +37,16 @@ describe('CamelComponentDefaultService', () => {
       expect(doTryDefault.doTry?.doCatch?.[0].exception).toHaveLength(1);
     });
 
+    it('should return the default value for a log processor', () => {
+      const logDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
+        type: 'processor',
+        name: 'log',
+      } as DefinedComponent) as any;
+      expect(logDefault.log).toBeDefined();
+      expect((logDefault.log.id as string).startsWith('log-')).toBeTruthy();
+      expect(logDefault.log.message).toEqual('${body}');
+    });
+
     it('should return the default value for a doCatch processor', () => {
       const doCatchDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
         type: 'processor',

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -115,6 +115,13 @@ export class CamelComponentDefaultService {
                 message: "\${body}"
         `);
 
+      case 'log':
+        return parse(`
+        log:
+          id: ${getCamelRandomId('log')}
+          message: "\${body}"
+        `);
+
       case 'doCatch':
         return parse(`
           id: ${getCamelRandomId('doCatch')}


### PR DESCRIPTION
Fixes #1100 