### PR TITLE
fix(vscode): Provide fallback for VSCode catalog

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
@@ -13,13 +13,12 @@ export class KaotoEditorFactory implements EditorFactory<Editor, KaotoEditorChan
     envelopeContext: KogitoEditorEnvelopeContextType<KaotoEditorChannelApi>,
     initArgs: EditorInitArgs,
   ): Promise<Editor> {
-    let catalogUrl;
-    const catalogUrlFromChannelApi = await envelopeContext.channelApi.requests.getCatalogURL();
-    if (isDefined(catalogUrlFromChannelApi)) {
-      catalogUrl = catalogUrlFromChannelApi;
-    } else {
+    let catalogUrl = await envelopeContext.channelApi.requests.getCatalogURL();
+
+    if (!isDefined(catalogUrl) || catalogUrl === '') {
       catalogUrl = `${initArgs.resourcesPathPrefix}${CatalogSchemaLoader.DEFAULT_CATALOG_PATH.replace('.', '')}`;
     }
+
     return Promise.resolve(new KaotoEditorApp(envelopeContext, initArgs, catalogUrl));
   }
 }


### PR DESCRIPTION
### Context
The lifecycle of a VSCode setting is as follows:

1. It starts with `null`
2. When the user updates it, it stores that value
3. When the user clears it, the value gets to be an empty string '""'

In case the `catalogUrl` is an empty string, we provide a fallback to use the embedded catalog.

fix: https://github.com/KaotoIO/kaoto/issues/1109
relates: https://github.com/KaotoIO/kaoto/issues/1204