### PR TITLE
feat(catalog): Display `Provided by` information

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -44,6 +44,18 @@ describe('camelComponentToTile', () => {
     expect(tile.version).toEqual('4.0.0');
   });
 
+  it('should populate the provider', () => {
+    const componentDef = {
+      component: {
+        provider: 'my-provider',
+      },
+    } as ICamelComponentDefinition;
+
+    const tile = camelComponentToTile(componentDef);
+
+    expect(tile.provider).toEqual('my-provider');
+  });
+
   it('should populate tags with `consumerOnly` and `producerOnly` when applicable', () => {
     const componentDef = {
       component: {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -2,7 +2,7 @@ import { ITile } from '../components/Catalog/Catalog.models';
 import { CatalogKind, ICamelComponentDefinition, ICamelProcessorDefinition, IKameletDefinition } from '../models';
 
 export const camelComponentToTile = (componentDef: ICamelComponentDefinition): ITile => {
-  const { name, title, description, supportLevel, label, version } = componentDef.component;
+  const { name, title, description, supportLevel, label, provider, version } = componentDef.component;
   const headerTags: string[] = ['Component'];
   const tags: string[] = [];
 
@@ -28,6 +28,7 @@ export const camelComponentToTile = (componentDef: ICamelComponentDefinition): I
     description,
     headerTags,
     tags,
+    provider,
     version,
     rawObject: componentDef,
   };

--- a/packages/ui/src/components/Catalog/Catalog.models.ts
+++ b/packages/ui/src/components/Catalog/Catalog.models.ts
@@ -6,6 +6,7 @@ export interface ITile {
   headerTags?: string[];
   tags: string[];
   version?: string;
+  provider?: string;
   /** @deprecated Please relay on name property instead */
   rawObject?: unknown;
 }

--- a/packages/ui/src/components/Catalog/CatalogFilter.tsx
+++ b/packages/ui/src/components/Catalog/CatalogFilter.tsx
@@ -15,11 +15,14 @@ import { FunctionComponent, useEffect, useRef } from 'react';
 import { CatalogLayout } from './Catalog.models';
 import './CatalogFilter.scss';
 import { CatalogLayoutIcon } from './CatalogLayoutIcon';
+import { ProviderFilter } from './ProviderFilter/ProviderFilter';
 
 interface CatalogFilterProps {
   className?: string;
   searchTerm: string;
   groups: { name: string; count: number }[];
+  providers: string[];
+  selectedProviders: string[];
   tags: string[];
   tagsOverflowIndex: number;
   layouts: CatalogLayout[];
@@ -30,6 +33,7 @@ interface CatalogFilterProps {
   setActiveGroups: (groups: string[]) => void;
   setActiveLayout: (layout: CatalogLayout) => void;
   setFilterTags: (tags: string[]) => void;
+  onSelectProvider: (provider: string) => void;
 }
 
 export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
@@ -76,6 +80,14 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
           />
         </FormGroup>
 
+        <FormGroup className="filter-bar__provider" label="Provider" fieldId="provider">
+          <ProviderFilter
+            providers={props.providers}
+            selectedProviders={props.selectedProviders}
+            onSelectProvider={props.onSelectProvider}
+          />
+        </FormGroup>
+
         <FormGroup label="Type" fieldId="element-type">
           <ToggleGroup aria-label="Select element type">
             {props.groups.map((tileGroup) => (
@@ -98,7 +110,7 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
         <FormGroup label="Layout" fieldId="layout">
           <ToggleGroup aria-label="Change layout">
             {props.layouts.map((key) => (
-              <Tooltip aria-label="Layout toggle Tooltip" content={<p>Display elements with a {key} view</p>}>
+              <Tooltip key={key} aria-label="Layout toggle Tooltip" content={<p>Display elements with a {key} view</p>}>
                 <ToggleGroupItem
                   icon={<CatalogLayoutIcon key={key} layout={key} />}
                   key={key}

--- a/packages/ui/src/components/Catalog/DataListItem.scss
+++ b/packages/ui/src/components/Catalog/DataListItem.scss
@@ -38,6 +38,6 @@
     text-align: right;
     padding: 0 10px;
     font-weight: bold;
-    background-color: var(--pf-v5-global--palette--black-150);
+    background-color: var(--pf-v5-global--palette--blue-50);
   }
 }

--- a/packages/ui/src/components/Catalog/DataListItem.scss
+++ b/packages/ui/src/components/Catalog/DataListItem.scss
@@ -31,4 +31,13 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
   }
+
+  &__provider {
+    display: block;
+    font-size: var(--pf-v5-c-card__body--FontSize);
+    text-align: right;
+    padding: 0 10px;
+    font-weight: bold;
+    background-color: var(--pf-v5-global--palette--black-150);
+  }
 }

--- a/packages/ui/src/components/Catalog/DataListItem.tsx
+++ b/packages/ui/src/components/Catalog/DataListItem.tsx
@@ -32,6 +32,11 @@ const descriptionElementOrder = {
   md: '3',
 };
 
+const providerElementOrder = {
+  default: '4',
+  md: '4',
+};
+
 export const CatalogDataListItem: FunctionComponent<ICatalogDataListItemProps> = (props) => {
   return (
     <DataListItem
@@ -75,8 +80,13 @@ export const CatalogDataListItem: FunctionComponent<ICatalogDataListItemProps> =
                     <CatalogTagsPanel tags={props.tile.tags} onTagClick={props.onTagClick} />
                   </div>
                 </GridItem>
-                <GridItem span={12} order={descriptionElementOrder}>
+                <GridItem sm={12} md={11} order={descriptionElementOrder}>
                   <span className="catalog-data-list-item__description">{props.tile.description}</span>
+                </GridItem>
+                <GridItem sm={12} md={1} order={providerElementOrder}>
+                  <span className="catalog-data-list-item__provider" data-provider={props.tile.provider}>
+                    {props.tile.provider}
+                  </span>
                 </GridItem>
               </Grid>
             </DataListCell>,

--- a/packages/ui/src/components/Catalog/ProviderFilter/ProviderFilter.scss
+++ b/packages/ui/src/components/Catalog/ProviderFilter/ProviderFilter.scss
@@ -1,0 +1,7 @@
+[data-testid='provider-filter-toggle'] {
+  width: 200px;
+}
+
+[data-testid='providers-select-item-undefined'] {
+  font-style: italic;
+}

--- a/packages/ui/src/components/Catalog/ProviderFilter/ProviderFilter.tsx
+++ b/packages/ui/src/components/Catalog/ProviderFilter/ProviderFilter.tsx
@@ -1,0 +1,81 @@
+import { Badge, Menu, MenuContent, MenuItem, MenuList, MenuToggle, Popper } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useCallback, useRef, useState } from 'react';
+import './ProviderFilter.scss';
+
+interface ProviderFilterProps {
+  providers: string[];
+  selectedProviders: string[];
+  onSelectProvider: (provider: string) => void;
+}
+
+export const ProviderFilter: FunctionComponent<ProviderFilterProps> = ({
+  providers,
+  selectedProviders,
+  onSelectProvider,
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onSelect = useCallback(
+    (_event: unknown, itemId: string | number | undefined) => {
+      if (typeof itemId === 'undefined') {
+        return;
+      }
+
+      const itemStr = itemId.toString();
+      onSelectProvider(itemStr);
+    },
+    [onSelectProvider],
+  );
+
+  const toggle = (
+    <MenuToggle
+      data-testid="provider-filter-toggle"
+      ref={toggleRef}
+      onClick={() => {
+        setIsOpen(!isOpen);
+      }}
+      isExpanded={isOpen}
+      icon={<FilterIcon />}
+      {...(selectedProviders.length > 0 && { badge: <Badge isRead>{selectedProviders.length}</Badge> })}
+    >
+      Provided by
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} id="providers-select-menu" onSelect={onSelect} selected={selectedProviders}>
+      <MenuContent>
+        <MenuList>
+          {providers.map((provider) => (
+            <MenuItem
+              key={provider}
+              itemId={provider}
+              data-testid={`providers-select-item-${provider}`}
+              hasCheckbox
+              isSelected={selectedProviders.includes(provider)}
+            >
+              {provider}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        triggerRef={toggleRef}
+        popper={menu}
+        popperRef={menuRef}
+        appendTo={containerRef.current || undefined}
+        isVisible={isOpen}
+      />
+    </div>
+  );
+};

--- a/packages/ui/src/components/Catalog/Tile.scss
+++ b/packages/ui/src/components/Catalog/Tile.scss
@@ -44,6 +44,6 @@
     text-align: right;
     padding: 0 10px;
     font-weight: bold;
-    background-color: var(--pf-v5-global--palette--black-150);
+    background-color: var(--pf-v5-global--palette--blue-50);
   }
 }

--- a/packages/ui/src/components/Catalog/Tile.scss
+++ b/packages/ui/src/components/Catalog/Tile.scss
@@ -38,4 +38,12 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  &__provider {
+    font-size: var(--pf-v5-c-card__body--FontSize);
+    text-align: right;
+    padding: 0 10px;
+    font-weight: bold;
+    background-color: var(--pf-v5-global--palette--black-150);
+  }
 }

--- a/packages/ui/src/components/Catalog/Tile.tsx
+++ b/packages/ui/src/components/Catalog/Tile.tsx
@@ -59,6 +59,12 @@ export const Tile: FunctionComponent<PropsWithChildren<TileProps>> = (props) => 
       <CardFooter>
         <CatalogTagsPanel tags={props.tile.tags} onTagClick={props.onTagClick} />
       </CardFooter>
+
+      {props.tile.provider && (
+        <p className="tile__provider" data-provider={props.tile.provider}>
+          Provided by {props.tile.provider}
+        </p>
+      )}
     </Card>
   );
 };

--- a/packages/ui/src/components/Catalog/__snapshots__/DataListItem.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/DataListItem.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`DataListItem renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="pf-v5-l-grid__item pf-m-12-col"
+            class="pf-v5-l-grid__item pf-m-12-col-on-sm pf-m-11-col-on-md"
             style="--pf-v5-l-grid--item--Order: 2; --pf-v5-l-grid--item--Order-on-md: 3;"
           >
             <span
@@ -171,6 +171,14 @@ exports[`DataListItem renders correctly 1`] = `
             >
               tile-description
             </span>
+          </div>
+          <div
+            class="pf-v5-l-grid__item pf-m-12-col-on-sm pf-m-1-col-on-md"
+            style="--pf-v5-l-grid--item--Order: 4; --pf-v5-l-grid--item--Order-on-md: 4;"
+          >
+            <span
+              class="catalog-data-list-item__provider"
+            />
           </div>
         </div>
       </div>

--- a/packages/ui/src/components/Catalog/filter-tiles.test.ts
+++ b/packages/ui/src/components/Catalog/filter-tiles.test.ts
@@ -25,6 +25,7 @@ describe('filterTiles', () => {
       description: 'Schedule a task to run at a specific time.',
       tags: ['scheduling'],
       type: CatalogKind.Component,
+      provider: 'Red Hat',
     },
     hazelcast: {
       name: 'hazelcast',
@@ -72,6 +73,28 @@ describe('filterTiles', () => {
       [CatalogKind.Component]: [tilesMap.activemq],
       [CatalogKind.Pattern]: [tilesMap.setBody, tilesMap.split],
       [CatalogKind.Kamelet]: [tilesMap.slackSource],
+    });
+  });
+
+  it('should filter tiles by provider', () => {
+    const options = { selectedProviders: ['Red Hat'] };
+    const result = filterTiles(tiles, options);
+
+    expect(result).toEqual({
+      [CatalogKind.Component]: [tilesMap.cron],
+      [CatalogKind.Pattern]: [],
+      [CatalogKind.Kamelet]: [],
+    });
+  });
+
+  it('should return tiles without provider when community is selected', () => {
+    const options = { selectedProviders: ['Community'] };
+    const result = filterTiles(tiles, options);
+
+    expect(result).toEqual({
+      [CatalogKind.Component]: [tilesMap.activemq, tilesMap.cometd, tilesMap.hazelcast],
+      [CatalogKind.Pattern]: [tilesMap.setBody, tilesMap.split],
+      [CatalogKind.Kamelet]: [tilesMap.beerSource, tilesMap.slackSource],
     });
   });
 

--- a/packages/ui/src/components/Catalog/filter-tiles.ts
+++ b/packages/ui/src/components/Catalog/filter-tiles.ts
@@ -5,9 +5,9 @@ const checkThatArrayContainsAllTags = (tileTags: string[], searchTags: string[])
 
 export const filterTiles = (
   tiles: ITile[],
-  options?: { searchTerm?: string; searchTags?: string[] },
+  options?: { searchTerm?: string; searchTags?: string[]; selectedProviders?: string[] },
 ): Record<string, ITile[]> => {
-  const { searchTerm = '', searchTags = [] } = options ?? {};
+  const { searchTerm = '', searchTags = [], selectedProviders = [] } = options ?? {};
   const searchTermLowercase = searchTerm.toLowerCase();
 
   return tiles.reduce(
@@ -15,9 +15,19 @@ export const filterTiles = (
       /** Filter by selected tags */
       const doesTagsMatches = searchTags.length ? checkThatArrayContainsAllTags(tile.tags, searchTags) : true;
 
+      /** Filter by providers */
+      let doesProviderMatch = true;
+      if (selectedProviders.length) {
+        doesProviderMatch =
+          tile.provider === undefined
+            ? selectedProviders.includes('Community')
+            : selectedProviders.includes(tile.provider);
+      }
+
       /** Determine whether the tile should be included in the filtered list */
       const shouldInclude =
         doesTagsMatches &&
+        doesProviderMatch &&
         (!searchTermLowercase ||
           tile.name.toLowerCase().includes(searchTermLowercase) ||
           tile.title.toLowerCase().includes(searchTermLowercase) ||

--- a/packages/ui/src/models/camel-components-catalog.ts
+++ b/packages/ui/src/models/camel-components-catalog.ts
@@ -33,6 +33,7 @@ export interface ICamelComponent {
   consumerOnly?: boolean;
   producerOnly?: boolean;
   lenientProperties?: boolean;
+  provider?: string;
 }
 
 // these interfaces don't contain all properties which are save in the component json object. If you need some new, add it here


### PR DESCRIPTION
### Context
When generating a catalog, there are Camel components that are provided by a specific build while others are simply upstream.

This commit displays that information in the catalog, to make it easier to distinguish them.

### Screenshot
![image](https://github.com/KaotoIO/kaoto/assets/16512618/574e3fcb-8ffe-4de5-a9f0-67351676e506)

fix: https://github.com/KaotoIO/kaoto/issues/1109