### PR TITLE
fix(settings): Move settings link to the kebab menu

### DIFF
--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -79,5 +79,4 @@ const navElements: NavElements = [
   { title: 'Metadata', to: Links.Metadata },
   { title: 'Pipe ErrorHandler', to: Links.PipeErrorHandler },
   { title: 'Catalog', to: Links.Catalog },
-  { title: 'Settings', to: Links.Settings },
 ];

--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -16,6 +16,7 @@ import {
 import { EllipsisVIcon, ExternalLinkAltIcon, GithubIcon } from '@patternfly/react-icons';
 import { BarsIcon } from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import React, { FunctionComponent, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import logo from '../assets/logo-kaoto.png';
 import { useComponentLink } from '../hooks/ComponentLink';
 import { Links } from '../router/links.models';
@@ -110,9 +111,11 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
                 </DropdownItem>
               </a>
               <Divider component="li" key="separator1" />
-              <DropdownItem id="settings" key="settings" isDisabled>
-                Settings
-              </DropdownItem>
+              <Link data-testid="settings-link" to={Links.Settings}>
+                <DropdownItem id="settings" key="settings">
+                  Settings
+                </DropdownItem>
+              </Link>
               <Divider component="li" key="separator2" />
               <DropdownItem
                 id="about"


### PR DESCRIPTION
### Context
There is a disabled settings page option in the top bar kebab menu.

This commit removes the existing settings navigation link and places it under the existing kebab menu.

![image](https://github.com/KaotoIO/kaoto/assets/16512618/9cb41471-48d2-4007-8bf0-dacb004d0ba8)

fix: https://github.com/KaotoIO/kaoto/issues/1224