### PR TITLE
fix(1207): filtering string with empty space

### DIFF
--- a/packages/ui/src/components/Form/CustomAutoFields.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.tsx
@@ -32,10 +32,9 @@ export function CustomAutoFields({
     return createElement(element, props, [createElement(autoField!, { key: '', name: '' })]);
   }
 
+  const cleanQueryTerm = filteredFieldText.replace(/\s/g, '').toLowerCase();
   const actualFields = (fields ?? schema.getSubfields()).filter(
-    (field) =>
-      !omitFields!.includes(field) &&
-      (field === 'parameters' || field.toLowerCase().includes(filteredFieldText.toLowerCase())),
+    (field) => !omitFields!.includes(field) && (field === 'parameters' || field.toLowerCase().includes(cleanQueryTerm)),
   );
   const actualFieldsSchema = actualFields.reduce((acc: { [name: string]: unknown }, name) => {
     acc[name] = schema.getField(name);

--- a/packages/ui/src/components/Form/customField/CustomNestField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomNestField.tsx
@@ -46,8 +46,9 @@ export const CustomNestField = connectField(
     ...props
   }: CustomNestFieldProps) => {
     const { filteredFieldText, isGroupExpanded } = useContext(FilteredFieldContext);
+    const cleanQueryTerm = filteredFieldText.replace(/\s/g, '').toLowerCase();
     const filteredProperties = Object.entries(props.properties ?? {}).filter((field) =>
-      field[0].toLowerCase().includes(filteredFieldText.toLowerCase()),
+      field[0].toLowerCase().includes(cleanQueryTerm),
     );
     const actualProperties = Object.fromEntries(filteredProperties);
     const propertiesArray = getFieldGroups(actualProperties);


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/1207

make the filter ignore empty spaces, to facilitate filtering both on spaced and unspaced strings

https://github.com/user-attachments/assets/7075dbbc-6308-4501-b4f9-a8c04be6de7f

