### PR TITLE
feat(exports): Expose models through npm package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,10 @@
       "import": "./lib/esm/public-api.js",
       "require": "./lib/cjs/public-api.js"
     },
+    "./models": {
+      "import": "./lib/esm/models-api.js",
+      "require": "./lib/cjs/models-api.js"
+    },
     "./testing": {
       "import": "./lib/esm/testing-api.js",
       "require": "./lib/cjs/testing-api.js"

--- a/packages/ui/src/models-api.ts
+++ b/packages/ui/src/models-api.ts
@@ -1,0 +1,2 @@
+/** Models components */
+export * from './models';

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -1,5 +1,5 @@
 import set from 'lodash/set';
-import { TileFilter } from '../../public-api';
+import { TileFilter } from '../../components/Catalog/Catalog.models';
 import { IKameletDefinition } from '../kamelets-catalog';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -11,5 +11,6 @@ export * from './kaoto-schema';
 export * from './loading-status';
 export * from './local-storage-keys';
 export * from './react-component';
+export * from './settings';
 export * from './validation';
 export * from './visualization';

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -2,7 +2,7 @@ import { ProcessorDefinition, RouteConfigurationDefinition } from '@kaoto/camel-
 import Ajv, { ValidateFunction } from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
-import { SchemaService } from '../../../public-api';
+import { SchemaService } from '../../../components/Form/schema.service';
 import { NodeIconResolver, NodeIconType, getValue, isDefined, setValue } from '../../../utils';
 import { EntityType } from '../../camel/entities/base-entity';
 import { CatalogKind } from '../../catalog-kind';

--- a/packages/ui/src/providers/schema-bridge.provider.test.tsx
+++ b/packages/ui/src/providers/schema-bridge.provider.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { SchemaBridgeProvider } from './schema-bridge.provider';
 import { KaotoSchemaDefinition } from '../models';
-import { SchemaService } from '../public-api';
+import { SchemaService } from '../components/Form/schema.service';
 
 describe('SchemaBridgeProvider', () => {
   const schema: KaotoSchemaDefinition['schema'] = {

--- a/packages/ui/tsconfig.esm.json
+++ b/packages/ui/tsconfig.esm.json
@@ -28,7 +28,7 @@
       "@testing-library/jest-dom",
     ]
   },
-  "include": ["src/public-api.ts","src/testing-api.ts", "src/global.d.ts"],
+  "include": ["src/public-api.ts", "src/models-api.ts", "src/testing-api.ts", "src/global.d.ts"],
   "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
### Context
Currently, the `models` folder is not exposed through the npm package.

This commit adds a new export to make it available to consumers.