### PR TITLE
feat(Canvas): Add containers for branches

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -112,7 +112,7 @@ Cypress.Commands.add('selectCamelRouteType', (type: string, subType?: string) =>
 
 Cypress.Commands.add('selectRuntimeVersion', (type: string) => {
   cy.hoverOnRuntime(type);
-  cy.get(`[data-testid^="runtime-selector-Camel ${type}"] button.pf-v5-c-menu__item`).click({ force: true });
+  cy.get(`[data-testid^="runtime-selector-Camel ${type}"] button.pf-v5-c-menu__item`).first().click({ force: true });
   cy.waitSchemasLoading();
 
   cy.get('[data-testid="visualization-empty-state"]').should('exist');

--- a/packages/ui/src/components/Visualization/Canvas/CanvasFormTabs.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasFormTabs.test.tsx
@@ -114,7 +114,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const setHeaderNode = rootNode.getChildren()![0].getChildren()![0];
+      const setHeaderNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -179,7 +179,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const marshalNode = rootNode.getChildren()![0].getChildren()![0];
+      const marshalNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -267,7 +267,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const loadBalanceNode = rootNode.getChildren()![0].getChildren()![0];
+      const loadBalanceNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -360,7 +360,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const setHeaderNode = rootNode.getChildren()![0].getChildren()![0];
+      const setHeaderNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -420,7 +420,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const setHeaderNode = rootNode.getChildren()![0].getChildren()![0];
+      const setHeaderNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -485,7 +485,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const marshalNode = rootNode.getChildren()![0].getChildren()![0];
+      const marshalNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -535,7 +535,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const marshalNode = rootNode.getChildren()![0].getChildren()![0];
+      const marshalNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -591,7 +591,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const loadBalanceNode = rootNode.getChildren()![0].getChildren()![0];
+      const loadBalanceNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',
@@ -641,7 +641,7 @@ describe('CanvasFormTabs', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = entity.toVizNode();
-      const loadBalanceNode = rootNode.getChildren()![0].getChildren()![0];
+      const loadBalanceNode = rootNode.getChildren()![1];
       const selectedNode = {
         id: '1',
         type: 'node',

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -684,7 +684,7 @@ exports[`Canvas should render correctly 1`] = `
                           data-layer-id="groups"
                         >
                           <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                             transform="translate(0, 0)"
@@ -692,18 +692,18 @@ exports[`Canvas should render correctly 1`] = `
                             <g>
                               <rect
                                 class="phantom-rect"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               />
                               <foreignobject
                                 class="foreign-object"
                                 data-nodelabel="route-8888"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               >
                                 <div
                                   class="custom-group"
@@ -729,7 +729,7 @@ exports[`Canvas should render correctly 1`] = `
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-1"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-7"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="collapseButton-route-8888"
@@ -757,10 +757,210 @@ exports[`Canvas should render correctly 1`] = `
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-2"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-8"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="contextualMenu-route-8888"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="choice-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="choice"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="choice"
+                                    >
+                                      choice
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-9"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-10"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="otherwise-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="otherwise"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="otherwise"
+                                    >
+                                      otherwise
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-11"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-otherwise"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-12"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-otherwise"
                                         type="button"
                                       >
                                         <svg
@@ -832,16 +1032,16 @@ exports[`Canvas should render correctly 1`] = `
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M37.5 37.5 L-106 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M37.5 37.5 L-120 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(-106, 37.5) rotate(180)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -854,7 +1054,7 @@ exports[`Canvas should render correctly 1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-when-1234"
+                            data-id="amqp-1234-to-amqp-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -887,7 +1087,7 @@ exports[`Canvas should render correctly 1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="when-1234-to-log-1234"
+                            data-id="choice-1234-to-direct-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -898,16 +1098,16 @@ exports[`Canvas should render correctly 1`] = `
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M-120 37.5 L23.5 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M-120 37.5 L37.5 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(23.5, 37.5) rotate(0)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -920,106 +1120,7 @@ exports[`Canvas should render correctly 1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-otherwise-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="otherwise-1234-to-amqp-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="log-1234-to-direct-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                           >
@@ -1041,33 +1142,38 @@ exports[`Canvas should render correctly 1`] = `
                             <g
                               data-id="choice-1234"
                               data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="when-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="log-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="otherwise-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="amqp-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
+                              data-type="group"
+                            >
+                              <g
+                                class="custom-group"
+                              />
+                              <g
+                                data-id="when-1234"
+                                data-kind="node"
+                                data-type="group"
+                              />
+                              <g
+                                data-id="otherwise-1234"
+                                data-kind="node"
+                                data-type="group"
+                              >
+                                <g
+                                  class="custom-group"
+                                />
+                                <g
+                                  data-id="amqp-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                                <g
+                                  data-id="log-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                              </g>
+                            </g>
                             <g
                               data-id="direct-1234"
                               data-kind="node"
@@ -1329,7 +1435,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                           data-layer-id="groups"
                         >
                           <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                             transform="translate(0, 0)"
@@ -1337,18 +1443,18 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             <g>
                               <rect
                                 class="phantom-rect"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               />
                               <foreignobject
                                 class="foreign-object"
                                 data-nodelabel="route-8888"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               >
                                 <div
                                   class="custom-group"
@@ -1374,7 +1480,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-3"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-19"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="collapseButton-route-8888"
@@ -1402,10 +1508,210 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-4"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-20"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="contextualMenu-route-8888"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="choice-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="choice"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="choice"
+                                    >
+                                      choice
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-21"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-22"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="otherwise-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="otherwise"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="otherwise"
+                                    >
+                                      otherwise
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-23"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-otherwise"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-24"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-otherwise"
                                         type="button"
                                       >
                                         <svg
@@ -1477,16 +1783,16 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M37.5 37.5 L-106 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M37.5 37.5 L-120 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(-106, 37.5) rotate(180)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -1499,7 +1805,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-when-1234"
+                            data-id="amqp-1234-to-amqp-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -1532,7 +1838,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="when-1234-to-log-1234"
+                            data-id="choice-1234-to-direct-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -1543,16 +1849,16 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M-120 37.5 L23.5 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M-120 37.5 L37.5 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(23.5, 37.5) rotate(0)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -1565,106 +1871,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-otherwise-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="otherwise-1234-to-amqp-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="log-1234-to-direct-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                           >
@@ -1686,33 +1893,38 @@ exports[`Canvas should render correctly with more routes  1`] = `
                             <g
                               data-id="choice-1234"
                               data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="when-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="log-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="otherwise-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="amqp-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
+                              data-type="group"
+                            >
+                              <g
+                                class="custom-group"
+                              />
+                              <g
+                                data-id="when-1234"
+                                data-kind="node"
+                                data-type="group"
+                              />
+                              <g
+                                data-id="otherwise-1234"
+                                data-kind="node"
+                                data-type="group"
+                              >
+                                <g
+                                  class="custom-group"
+                                />
+                                <g
+                                  data-id="amqp-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                                <g
+                                  data-id="log-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                              </g>
+                            </g>
                             <g
                               data-id="direct-1234"
                               data-kind="node"
@@ -1974,7 +2186,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                           data-layer-id="groups"
                         >
                           <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                             transform="translate(0, 0)"
@@ -1982,18 +2194,18 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             <g>
                               <rect
                                 class="phantom-rect"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               />
                               <foreignobject
                                 class="foreign-object"
                                 data-nodelabel="route-8888"
-                                height="195"
-                                width="195"
-                                x="-60"
-                                y="-60"
+                                height="435"
+                                width="435"
+                                x="-180"
+                                y="-180"
                               >
                                 <div
                                   class="custom-group"
@@ -2019,7 +2231,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-9"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-45"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="collapseButton-route-8888"
@@ -2047,10 +2259,210 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                                       <button
                                         aria-disabled="false"
                                         class="pf-v5-c-button pf-m-control container-controls"
-                                        data-ouia-component-id="OUIA-Generated-Button-control-10"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-46"
                                         data-ouia-component-type="PF5/Button"
                                         data-ouia-safe="true"
                                         data-testid="contextualMenu-route-8888"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="choice-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="choice"
+                                height="315"
+                                width="315"
+                                x="-120"
+                                y="-120"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="choice"
+                                    >
+                                      choice
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-47"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-48"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-choice"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 192 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </foreignobject>
+                            </g>
+                          </g>
+                          <g
+                            data-id="otherwise-1234"
+                            data-kind="node"
+                            data-type="group"
+                            transform="translate(0, 0)"
+                          >
+                            <g>
+                              <rect
+                                class="phantom-rect"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              />
+                              <foreignobject
+                                class="foreign-object"
+                                data-nodelabel="otherwise"
+                                height="195"
+                                width="195"
+                                x="-60"
+                                y="-60"
+                              >
+                                <div
+                                  class="custom-group"
+                                >
+                                  <div
+                                    class="custom-group__title"
+                                  >
+                                    <div
+                                      class="custom-group__title__img-circle"
+                                    >
+                                      <img
+                                        src=""
+                                      />
+                                    </div>
+                                    <span
+                                      title="otherwise"
+                                    >
+                                      otherwise
+                                    </span>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-49"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="collapseButton-otherwise"
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          data-testid="collapse-icon"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M200 288H88c-21.4 0-32.1 25.8-17 41l32.9 31-99.2 99.3c-6.2 6.2-6.2 16.4 0 22.6l25.4 25.4c6.2 6.2 16.4 6.2 22.6 0L152 408l31.1 33c15.1 15.1 40.9 4.4 40.9-17V312c0-13.3-10.7-24-24-24zm112-64h112c21.4 0 32.1-25.9 17-41l-33-31 99.3-99.3c6.2-6.2 6.2-16.4 0-22.6L481.9 4.7c-6.2-6.2-16.4-6.2-22.6 0L360 104l-31.1-33C313.8 55.9 288 66.6 288 88v112c0 13.3 10.7 24 24 24zm96 136l33-31.1c15.1-15.1 4.4-40.9-17-40.9H312c-13.3 0-24 10.7-24 24v112c0 21.4 25.9 32.1 41 17l31-32.9 99.3 99.3c6.2 6.2 16.4 6.2 22.6 0l25.4-25.4c6.2-6.2 6.2-16.4 0-22.6L408 360zM183 71.1L152 104 52.7 4.7c-6.2-6.2-16.4-6.2-22.6 0L4.7 30.1c-6.2 6.2-6.2 16.4 0 22.6L104 152l-33 31.1C55.9 198.2 66.6 224 88 224h112c13.3 0 24-10.7 24-24V88c0-21.3-25.9-32-41-16.9z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
+                                    <div
+                                      style="display: contents;"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        class="pf-v5-c-button pf-m-control container-controls"
+                                        data-ouia-component-id="OUIA-Generated-Button-control-50"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        data-testid="contextualMenu-otherwise"
                                         type="button"
                                       >
                                         <svg
@@ -2122,16 +2534,16 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M37.5 37.5 L-106 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M37.5 37.5 L-120 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(-106, 37.5) rotate(180)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -2144,7 +2556,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-when-1234"
+                            data-id="amqp-1234-to-amqp-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -2177,7 +2589,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             </g>
                           </g>
                           <g
-                            data-id="when-1234-to-log-1234"
+                            data-id="choice-1234-to-direct-1234"
                             data-kind="edge"
                             data-type="edge"
                             style="z-index: 0;"
@@ -2188,16 +2600,16 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             >
                               <path
                                 class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
+                                d="M-120 37.5 L23.5 37.5"
                               />
                               <path
                                 class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
+                                d="M-120 37.5 L37.5 37.5"
                                 style="animation-duration: 0s;"
                               />
                               <g
                                 class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
+                                transform="translate(23.5, 37.5) rotate(0)"
                               >
                                 <polygon
                                   points=" 0,7 0,-7 14,0"
@@ -2210,106 +2622,7 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             </g>
                           </g>
                           <g
-                            data-id="choice-1234-to-otherwise-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="otherwise-1234-to-amqp-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="log-1234-to-direct-1234"
-                            data-kind="edge"
-                            data-type="edge"
-                            style="z-index: 0;"
-                          >
-                            <g
-                              class="pf-topology__edge"
-                              data-test-id="edge-handler"
-                            >
-                              <path
-                                class="pf-topology__edge__background"
-                                d="M37.5 37.5 L0 0"
-                              />
-                              <path
-                                class="pf-topology__edge__link pf-m-solid"
-                                d="M37.5 37.5 L37.5 37.5"
-                                style="animation-duration: 0s;"
-                              />
-                              <g
-                                class="pf-topology-connector-arrow pf-topology__edge"
-                                transform="translate(0, 0) rotate(180)"
-                              >
-                                <polygon
-                                  points=" 0,7 0,-7 14,0"
-                                />
-                                <polygon
-                                  fill-opacity="0"
-                                  stroke-width="0"
-                                />
-                              </g>
-                            </g>
-                          </g>
-                          <g
-                            data-id="route-8888"
+                            data-id="route-8888-1234"
                             data-kind="node"
                             data-type="group"
                           >
@@ -2331,33 +2644,38 @@ exports[`Canvas should render the Catalog button if \`CatalogModalContext\` is p
                             <g
                               data-id="choice-1234"
                               data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="when-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="log-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="otherwise-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
-                            <g
-                              data-id="amqp-1234"
-                              data-kind="node"
-                              data-type="node"
-                              transform="translate(0, 0)"
-                            />
+                              data-type="group"
+                            >
+                              <g
+                                class="custom-group"
+                              />
+                              <g
+                                data-id="when-1234"
+                                data-kind="node"
+                                data-type="group"
+                              />
+                              <g
+                                data-id="otherwise-1234"
+                                data-kind="node"
+                                data-type="group"
+                              >
+                                <g
+                                  class="custom-group"
+                                />
+                                <g
+                                  data-id="amqp-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                                <g
+                                  data-id="log-1234"
+                                  data-kind="node"
+                                  data-type="node"
+                                  transform="translate(0, 0)"
+                                />
+                              </g>
+                            </g>
                             <g
                               data-id="direct-1234"
                               data-kind="node"

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`CanvasForm should render 1`] = `
           >
             <img
               alt="icon"
-              class="form-header__icon-choice-1234"
+              class="form-header__icon-log-1234"
               src=""
             />
             <h2
@@ -69,7 +69,7 @@ exports[`CanvasForm should render 1`] = `
               data-ouia-component-type="PF5/Title"
               data-ouia-safe="true"
             >
-              choice
+              log
             </h2>
           </div>
           <div
@@ -161,7 +161,7 @@ exports[`CanvasForm should render 1`] = `
             >
               <label
                 class="pf-v5-c-form__label"
-                for="uniforms-0000-000e"
+                for="uniforms-0000-000q"
               >
                 <span
                   class="pf-v5-c-form__label-text"
@@ -177,7 +177,7 @@ exports[`CanvasForm should render 1`] = `
                   aria-disabled="false"
                   aria-label="More info for field"
                   class="pf-v5-c-button pf-m-plain field-hint-button"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-11"
                   data-ouia-component-type="PF5/Button"
                   data-ouia-safe="true"
                   data-testid="field-hint-button"
@@ -208,17 +208,17 @@ exports[`CanvasForm should render 1`] = `
                 <input
                   aria-invalid="false"
                   aria-label="uniforms text field"
-                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-5"
                   data-ouia-component-type="PF5/TextInput"
                   data-ouia-safe="true"
                   data-testid="text-field"
                   description="Sets the id of this node"
                   group="common"
-                  id="uniforms-0000-000e"
+                  id="uniforms-0000-000q"
                   label="Id"
                   name="id"
                   type="text"
-                  value=""
+                  value="log-1"
                 />
               </span>
               <div
@@ -249,7 +249,7 @@ exports[`CanvasForm should render 1`] = `
             >
               <label
                 class="pf-v5-c-form__label"
-                for="uniforms-0000-000h"
+                for="uniforms-0000-000t"
               >
                 <span
                   class="pf-v5-c-form__label-text"
@@ -265,7 +265,7 @@ exports[`CanvasForm should render 1`] = `
                   aria-disabled="false"
                   aria-label="More info for field"
                   class="pf-v5-c-button pf-m-plain field-hint-button"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-12"
                   data-ouia-component-type="PF5/Button"
                   data-ouia-safe="true"
                   data-testid="field-hint-button"
@@ -298,11 +298,334 @@ exports[`CanvasForm should render 1`] = `
                   aria-invalid="false"
                   aria-label="description"
                   data-testid="long-text-field"
-                  id="uniforms-0000-000h"
+                  id="uniforms-0000-000t"
                   name="description"
                   rows="1"
                 />
               </span>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-fieldname="message"
+            data-testid="wrapper-field"
+            group="common"
+          >
+            <div
+              class="pf-v5-c-form__group-label"
+            >
+              <label
+                class="pf-v5-c-form__label"
+                for="uniforms-0000-000w"
+              >
+                <span
+                  class="pf-v5-c-form__label-text"
+                >
+                  Message
+                </span>
+                <span
+                  aria-hidden="true"
+                  class="pf-v5-c-form__label-required"
+                >
+                   
+                  *
+                </span>
+              </label>
+               
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <span
+                class="pf-v5-c-form-control"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="uniforms text field"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                  data-ouia-component-type="PF5/TextInput"
+                  data-ouia-safe="true"
+                  data-testid="text-field"
+                  description="Sets the log message (uses simple language)"
+                  group="common"
+                  id="uniforms-0000-000w"
+                  label="Message"
+                  name="message"
+                  type="text"
+                  value="We got a one."
+                />
+              </span>
+              <div
+                class="pf-v5-c-form__helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text__item"
+                  >
+                    <span
+                      class="pf-v5-c-helper-text__item-text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-fieldname="loggingLevel"
+            data-testid="wrapper-field"
+            group="common"
+            options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+          >
+            <div
+              class="pf-v5-c-form__group-label"
+            >
+              <label
+                class="pf-v5-c-form__label"
+                for="uniforms-0000-000z"
+              >
+                <span
+                  class="pf-v5-c-form__label-text"
+                >
+                  Logging Level
+                </span>
+              </label>
+               
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <div
+                class="pf-v5-c-menu-toggle pf-m-full-width pf-m-typeahead"
+              >
+                <div
+                  class="pf-v5-c-text-input-group pf-m-plain"
+                >
+                  <div
+                    autocomplete="off"
+                    class="pf-v5-c-text-input-group__main"
+                    data-testid="create-typeahead-select-input"
+                    id="create-typeahead-select-input"
+                  >
+                    <span
+                      class="pf-v5-c-text-input-group__text"
+                    >
+                      <input
+                        aria-controls="select-create-typeahead-listbox"
+                        aria-expanded="false"
+                        aria-label="Type to filter"
+                        class="pf-v5-c-text-input-group__text-input"
+                        placeholder="Select an option"
+                        role="combobox"
+                        type="text"
+                        value="INFO"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="pf-v5-c-text-input-group__utilities"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="Clear input value"
+                      class="pf-v5-c-button pf-m-plain"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 352 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  aria-expanded="false"
+                  aria-label="Menu toggle"
+                  class="pf-v5-c-menu-toggle__button"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="pf-v5-c-menu-toggle__controls"
+                  >
+                    <span
+                      class="pf-v5-c-menu-toggle__toggle-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-fieldname="logName"
+            data-testid="wrapper-field"
+            group="common"
+          >
+            <div
+              class="pf-v5-c-form__group-label"
+            >
+              <label
+                class="pf-v5-c-form__label"
+                for="uniforms-0000-0012"
+              >
+                <span
+                  class="pf-v5-c-form__label-text"
+                >
+                  Log Name
+                </span>
+              </label>
+               
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <span
+                class="pf-v5-c-form-control"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="uniforms text field"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+                  data-ouia-component-type="PF5/TextInput"
+                  data-ouia-safe="true"
+                  data-testid="text-field"
+                  description="Sets the name of the logger"
+                  group="common"
+                  id="uniforms-0000-0012"
+                  label="Log Name"
+                  name="logName"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <div
+                class="pf-v5-c-form__helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text__item"
+                  >
+                    <span
+                      class="pf-v5-c-helper-text__item-text"
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -373,17 +696,17 @@ exports[`CanvasForm should render 1`] = `
                           <input
                             aria-invalid="false"
                             class="pf-v5-c-check__input"
-                            data-ouia-component-id="OUIA-Generated-Checkbox-3"
+                            data-ouia-component-id="OUIA-Generated-Checkbox-2"
                             data-ouia-component-type="PF5/Checkbox"
                             data-ouia-safe="true"
                             data-testid="bool-field"
-                            id="uniforms-0000-000k"
+                            id="uniforms-0000-0015"
                             name="disabled"
                             type="checkbox"
                           />
                           <label
                             class="pf-v5-c-check__label"
-                            for="uniforms-0000-000k"
+                            for="uniforms-0000-0015"
                           >
                             Disabled
                           </label>
@@ -395,7 +718,7 @@ exports[`CanvasForm should render 1`] = `
                             aria-disabled="false"
                             aria-label="More info for field"
                             class="pf-v5-c-button pf-m-plain field-hint-button"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                            data-ouia-component-id="OUIA-Generated-Button-plain-17"
                             data-ouia-component-type="PF5/Button"
                             data-ouia-safe="true"
                             data-testid="field-hint-button"
@@ -436,80 +759,203 @@ exports[`CanvasForm should render 1`] = `
                   </div>
                   <div
                     class="pf-v5-c-form__group"
+                    data-fieldname="marker"
                     data-testid="wrapper-field"
                     group="advanced"
                   >
                     <div
+                      class="pf-v5-c-form__group-label"
+                    >
+                      <label
+                        class="pf-v5-c-form__label"
+                        for="uniforms-0000-0018"
+                      >
+                        <span
+                          class="pf-v5-c-form__label-text"
+                        >
+                          Marker
+                        </span>
+                      </label>
+                       
+                      <div
+                        style="display: contents;"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="More info for field"
+                          class="pf-v5-c-button pf-m-plain field-hint-button"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          data-testid="field-hint-button"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                          >
+                            <path
+                              d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-c-form__group-control"
+                    >
+                      <span
+                        class="pf-v5-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="uniforms text field"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+                          data-ouia-component-type="PF5/TextInput"
+                          data-ouia-safe="true"
+                          data-testid="text-field"
+                          description="To use slf4j marker"
+                          group="advanced"
+                          id="uniforms-0000-0018"
+                          label="Marker"
+                          name="marker"
+                          type="text"
+                          value=""
+                        />
+                      </span>
+                      <div
+                        class="pf-v5-c-form__helper-text"
+                      >
+                        <div
+                          class="pf-v5-c-helper-text"
+                        >
+                          <div
+                            class="pf-v5-c-helper-text__item"
+                          >
+                            <span
+                              class="pf-v5-c-helper-text__item-text"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-form__group"
+                    data-fieldname="logger"
+                    data-testid="wrapper-field"
+                    group="advanced"
+                  >
+                    <div
+                      class="pf-v5-c-form__group-label"
+                    >
+                      <label
+                        class="pf-v5-c-form__label"
+                        for="uniforms-0000-001b"
+                      >
+                        <span
+                          class="pf-v5-c-form__label-text"
+                        >
+                          Logger
+                        </span>
+                      </label>
+                       
+                      <div
+                        style="display: contents;"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="More info for field"
+                          class="pf-v5-c-button pf-m-plain field-hint-button"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          data-testid="field-hint-button"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                          >
+                            <path
+                              d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div
                       class="pf-v5-c-form__group-control"
                     >
                       <div
-                        style="display: flex; align-items: center;"
+                        class="pf-v5-c-menu-toggle pf-m-full-width pf-m-typeahead"
                       >
-                         
                         <div
-                          class="pf-v5-c-check"
-                        >
-                          <input
-                            aria-invalid="false"
-                            class="pf-v5-c-check__input"
-                            data-ouia-component-id="OUIA-Generated-Checkbox-4"
-                            data-ouia-component-type="PF5/Checkbox"
-                            data-ouia-safe="true"
-                            data-testid="bool-field"
-                            id="uniforms-0000-000n"
-                            name="precondition"
-                            type="checkbox"
-                          />
-                          <label
-                            class="pf-v5-c-check__label"
-                            for="uniforms-0000-000n"
-                          >
-                            Precondition
-                          </label>
-                        </div>
-                        <div
-                          style="display: contents;"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-label="More info for field"
-                            class="pf-v5-c-button pf-m-plain field-hint-button"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            data-testid="field-hint-button"
-                            type="button"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
-                            >
-                              <path
-                                d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
-                              />
-                            </svg>
-                          </button>
-                        </div>
-                        <div
-                          class="pf-v5-c-form__helper-text"
+                          class="pf-v5-c-text-input-group pf-m-plain"
                         >
                           <div
-                            class="pf-v5-c-helper-text"
+                            autocomplete="off"
+                            class="pf-v5-c-text-input-group__main"
+                            id="create-typeahead-select-input"
                           >
-                            <div
-                              class="pf-v5-c-helper-text__item"
+                            <span
+                              class="pf-v5-c-text-input-group__text"
                             >
-                              <span
-                                class="pf-v5-c-helper-text__item-text"
+                              <input
+                                aria-controls="select-create-typeahead-listbox"
+                                aria-expanded="false"
+                                aria-label="Type to filter"
+                                class="pf-v5-c-text-input-group__text-input"
+                                placeholder="Logger bean reference"
+                                role="combobox"
+                                type="text"
+                                value=""
                               />
-                            </div>
+                            </span>
                           </div>
+                          <div
+                            class="pf-v5-c-text-input-group__utilities"
+                          />
                         </div>
+                        <button
+                          aria-expanded="false"
+                          aria-label="Menu toggle"
+                          class="pf-v5-c-menu-toggle__button"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <span
+                            class="pf-v5-c-menu-toggle__controls"
+                          >
+                            <span
+                              class="pf-v5-c-menu-toggle__toggle-icon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -604,7 +1050,7 @@ exports[`CanvasForm should render nothing if no schema and no definition is avai
             <button
               aria-disabled="false"
               class="pf-v5-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-id="OUIA-Generated-Button-plain-21"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"
@@ -801,7 +1247,7 @@ exports[`CanvasForm should render nothing if no schema is available 1`] = `
             <button
               aria-disabled="false"
               class="pf-v5-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/canvas.service.test.ts.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/canvas.service.test.ts.snap
@@ -1,0 +1,481 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a group with children 1`] = `
+[
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {},
+        "id": "child1-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            [Circular],
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {},
+              "id": "child2-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+          ],
+          "data": {
+            "isGroup": true,
+          },
+          "id": "group-1234",
+          "nextNode": undefined,
+          "parentNode": undefined,
+          "previousNode": undefined,
+        },
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "child1-1234",
+    "parentNode": "group-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {},
+        "id": "child2-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {},
+              "id": "child1-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            [Circular],
+          ],
+          "data": {
+            "isGroup": true,
+          },
+          "id": "group-1234",
+          "nextNode": undefined,
+          "parentNode": undefined,
+          "previousNode": undefined,
+        },
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "child2-1234",
+    "parentNode": "group-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "children": [
+      "child1-1234",
+      "child2-1234",
+    ],
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {},
+            "id": "child1-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {},
+            "id": "child2-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+        ],
+        "data": {
+          "isGroup": true,
+        },
+        "id": "group-1234",
+        "nextNode": undefined,
+        "parentNode": undefined,
+        "previousNode": undefined,
+      },
+    },
+    "group": true,
+    "id": "group-1234",
+    "label": "group-1234",
+    "parentNode": undefined,
+    "style": {
+      "padding": 60,
+    },
+    "type": "group",
+  },
+]
+`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a group with children 2`] = `[]`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a multiple nodes VisualizationNode 1`] = `
+[
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {},
+        "id": "node-1234",
+        "nextNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "data": {},
+          "id": "set-header-1234",
+          "nextNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {},
+                    "id": "when-leaf-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {},
+                "id": "when-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [
+                      VisualizationNode {
+                        "DISABLED_NODE_INTERACTION": {
+                          "canBeDisabled": false,
+                          "canHaveChildren": false,
+                          "canHaveNextStep": false,
+                          "canHavePreviousStep": false,
+                          "canHaveSpecialChildren": false,
+                          "canRemoveFlow": false,
+                          "canRemoveStep": false,
+                          "canReplaceStep": false,
+                        },
+                        "data": {},
+                        "id": "log-1234",
+                        "nextNode": undefined,
+                        "parentNode": [Circular],
+                        "previousNode": undefined,
+                      },
+                    ],
+                    "data": {},
+                    "id": "process-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {},
+                "id": "otherwise-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            ],
+            "data": {},
+            "id": "choice-1234",
+            "nextNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {},
+              "id": "direct-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": [Circular],
+            },
+            "parentNode": undefined,
+            "previousNode": [Circular],
+          },
+          "parentNode": undefined,
+          "previousNode": [Circular],
+        },
+        "parentNode": undefined,
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "node-1234",
+    "parentNode": undefined,
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+]
+`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a multiple nodes VisualizationNode 2`] = `
+[
+  {
+    "edgeStyle": "solid",
+    "id": "node-1234-to-set-header-1234",
+    "source": "node-1234",
+    "target": "set-header-1234",
+    "type": "edge",
+  },
+]
+`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a simple VisualizationNode 1`] = `
+[
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {},
+        "id": "node-1234",
+        "nextNode": undefined,
+        "parentNode": undefined,
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "node-1234",
+    "parentNode": undefined,
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+]
+`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a simple VisualizationNode 2`] = `[]`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a two-nodes VisualizationNode 1`] = `
+[
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {},
+            "id": "child-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+        ],
+        "data": {},
+        "id": "node-1234",
+        "nextNode": undefined,
+        "parentNode": undefined,
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "node-1234",
+    "parentNode": undefined,
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+]
+`;
+
+exports[`CanvasService getFlowDiagram should return nodes and edges for a two-nodes VisualizationNode 2`] = `[]`;

--- a/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
@@ -20,7 +20,6 @@ export const enum LayoutType {
 export interface CanvasNode extends NodeModel {
   parentNode?: string;
   data?: {
-    index?: number;
     vizNode?: IVisualizationNode;
   };
 }

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.test.ts
@@ -2,35 +2,21 @@ import {
   BreadthFirstLayout,
   ColaLayout,
   ConcentricLayout,
-  DagreLayout,
   DefaultEdge,
-  EdgeStyle,
   ForceLayout,
   GridLayout,
   ModelKind,
   Visualization,
 } from '@patternfly/react-topology';
 import { createVisualizationNode } from '../../../models/visualization';
+import { BaseVisualCamelEntity } from '../../../models/visualization/base-visual-entity';
 import { CustomGroupWithSelection } from '../Custom';
+import { DagreGroupsExtendedLayout } from '../Custom/Layout/DagreGroupsExtendedLayout';
 import { CanvasDefaults } from './canvas.defaults';
 import { LayoutType } from './canvas.models';
 import { CanvasService } from './canvas.service';
-import { BaseVisualCamelEntity } from '../../../models/visualization/base-visual-entity';
 
 describe('CanvasService', () => {
-  const DEFAULT_NODE_PROPS = {
-    type: 'node',
-    data: undefined,
-    shape: CanvasDefaults.DEFAULT_NODE_SHAPE,
-    width: CanvasDefaults.DEFAULT_NODE_DIAMETER,
-    height: CanvasDefaults.DEFAULT_NODE_DIAMETER,
-  };
-
-  const DEFAULT_EDGE_PROPS = {
-    type: 'edge',
-    edgeStyle: EdgeStyle.solid,
-  };
-
   beforeEach(() => {
     CanvasService.nodes = [];
     CanvasService.edges = [];
@@ -47,12 +33,14 @@ describe('CanvasService', () => {
   it('should allow consumers to create a new controller and register its factories', () => {
     const layoutFactorySpy = jest.spyOn(Visualization.prototype, 'registerLayoutFactory');
     const componentFactorySpy = jest.spyOn(Visualization.prototype, 'registerComponentFactory');
+    const baselineElementFactorySpy = jest.spyOn(Visualization.prototype, 'registerElementFactory');
 
     const controller = CanvasService.createController();
 
     expect(controller).toBeInstanceOf(Visualization);
     expect(layoutFactorySpy).toHaveBeenCalledWith(CanvasService.baselineLayoutFactory);
     expect(componentFactorySpy).toHaveBeenCalledWith(CanvasService.baselineComponentFactory);
+    expect(baselineElementFactorySpy).toHaveBeenCalledWith(CanvasService.baselineElementFactory);
   });
 
   describe('baselineComponentFactory', () => {
@@ -93,7 +81,8 @@ describe('CanvasService', () => {
     [LayoutType.ColaNoForce, ColaLayout],
     [LayoutType.ColaGroups, ColaLayout],
     [LayoutType.Concentric, ConcentricLayout],
-    [LayoutType.DagreVertical, DagreLayout],
+    [LayoutType.DagreVertical, DagreGroupsExtendedLayout],
+    [LayoutType.DagreHorizontal, DagreGroupsExtendedLayout],
     [LayoutType.Force, ForceLayout],
     [LayoutType.Grid, GridLayout],
     ['unknown' as LayoutType, ColaLayout],
@@ -122,15 +111,8 @@ describe('CanvasService', () => {
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
 
-      expect(nodes).toEqual([
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'node-1234',
-          parentNode: undefined,
-          data: { vizNode },
-        },
-      ]);
-      expect(edges).toEqual([]);
+      expect(nodes).toMatchSnapshot();
+      expect(edges).toMatchSnapshot();
     });
 
     it('should return nodes and edges for a group with children', () => {
@@ -142,32 +124,8 @@ describe('CanvasService', () => {
 
       const { nodes, edges } = CanvasService.getFlowDiagram(groupVizNode);
 
-      expect(nodes).toEqual([
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'child1-1234',
-          parentNode: 'group-1234',
-          data: { vizNode: child1VizNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'child2-1234',
-          parentNode: 'group-1234',
-          data: { vizNode: child2VizNode },
-        },
-        {
-          children: ['child1-1234', 'child2-1234'],
-          data: { vizNode: groupVizNode },
-          group: true,
-          type: 'group',
-          id: 'Unknown',
-          label: 'Unknown',
-          style: {
-            padding: 60,
-          },
-        },
-      ]);
-      expect(edges).toEqual([]);
+      expect(nodes).toMatchSnapshot();
+      expect(edges).toMatchSnapshot();
     });
 
     it('should return nodes and edges for a two-nodes VisualizationNode', () => {
@@ -177,28 +135,8 @@ describe('CanvasService', () => {
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
 
-      expect(nodes).toEqual([
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'node-1234',
-          parentNode: undefined,
-          data: { vizNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'child-1234',
-          parentNode: 'node-1234',
-          data: { vizNode: childNode },
-        },
-      ]);
-      expect(edges).toEqual([
-        {
-          id: 'node-1234-to-child-1234',
-          source: 'node-1234',
-          target: 'child-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-      ]);
+      expect(nodes).toMatchSnapshot();
+      expect(edges).toMatchSnapshot();
     });
 
     it('should return nodes and edges for a multiple nodes VisualizationNode', () => {
@@ -232,118 +170,8 @@ describe('CanvasService', () => {
 
       const { nodes, edges } = CanvasService.getFlowDiagram(vizNode);
 
-      expect(nodes).toEqual([
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'node-1234',
-          parentNode: undefined,
-          data: { vizNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'set-header-1234',
-          parentNode: undefined,
-          data: { vizNode: setHeaderNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'choice-1234',
-          parentNode: undefined,
-          data: { vizNode: choiceNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'when-1234',
-          parentNode: 'choice-1234',
-          data: { vizNode: whenNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'when-leaf-1234',
-          parentNode: 'when-1234',
-          data: { vizNode: whenLeafNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'otherwise-1234',
-          parentNode: 'choice-1234',
-          data: { vizNode: otherwiseNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'process-1234',
-          parentNode: 'otherwise-1234',
-          data: { vizNode: processNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'log-1234',
-          parentNode: 'process-1234',
-          data: { vizNode: logNode },
-        },
-        {
-          ...DEFAULT_NODE_PROPS,
-          id: 'direct-1234',
-          parentNode: undefined,
-          data: { vizNode: directNode },
-        },
-      ]);
-      expect(edges).toEqual([
-        {
-          id: 'node-1234-to-set-header-1234',
-          source: 'node-1234',
-          target: 'set-header-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'set-header-1234-to-choice-1234',
-          source: 'set-header-1234',
-          target: 'choice-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'choice-1234-to-when-1234',
-          source: 'choice-1234',
-          target: 'when-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'when-1234-to-when-leaf-1234',
-          source: 'when-1234',
-          target: 'when-leaf-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'choice-1234-to-otherwise-1234',
-          source: 'choice-1234',
-          target: 'otherwise-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'otherwise-1234-to-process-1234',
-          source: 'otherwise-1234',
-          target: 'process-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'process-1234-to-log-1234',
-          source: 'process-1234',
-          target: 'log-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'when-leaf-1234-to-direct-1234',
-          source: 'when-leaf-1234',
-          target: 'direct-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-        {
-          id: 'log-1234-to-direct-1234',
-          source: 'log-1234',
-          target: 'direct-1234',
-          ...DEFAULT_EDGE_PROPS,
-        },
-      ]);
+      expect(nodes).toMatchSnapshot();
+      expect(edges).toMatchSnapshot();
     });
 
     it('should return a group node for a multiple nodes VisualizationNode with a group', () => {

--- a/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.service.ts
@@ -4,21 +4,23 @@ import {
   ColaLayout,
   ComponentFactory,
   ConcentricLayout,
-  DagreLayout,
   DefaultEdge,
   EdgeStyle,
   ForceLayout,
   Graph,
   GraphComponent,
+  GraphElement,
   GridLayout,
   Layout,
-  Model,
+  LEFT_TO_RIGHT,
   ModelKind,
+  TOP_TO_BOTTOM,
   Visualization,
   withPanZoom,
 } from '@patternfly/react-topology';
 import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
-import { CustomGroupWithSelection, CustomNodeWithSelection } from '../Custom';
+import { CustomGroupWithSelection, CustomNodeWithSelection, NoBendpointsEdge } from '../Custom';
+import { DagreGroupsExtendedLayout } from '../Custom/Layout/DagreGroupsExtendedLayout';
 import { CanvasDefaults } from './canvas.defaults';
 import { CanvasEdge, CanvasNode, CanvasNodesAndEdges, LayoutType } from './canvas.models';
 
@@ -32,35 +34,9 @@ export class CanvasService {
 
     newController.registerLayoutFactory(this.baselineLayoutFactory);
     newController.registerComponentFactory(this.baselineComponentFactory);
-
-    const defaultModel: Model = {
-      graph: {
-        id: 'default',
-        type: 'graph',
-      },
-    };
-
-    newController.fromModel(defaultModel, false);
+    newController.registerElementFactory(this.baselineElementFactory);
 
     return newController;
-  }
-
-  static baselineComponentFactory(kind: ModelKind, type: string): ReturnType<ComponentFactory> {
-    switch (type) {
-      case 'group':
-        return CustomGroupWithSelection;
-      default:
-        switch (kind) {
-          case ModelKind.graph:
-            return withPanZoom()(GraphComponent);
-          case ModelKind.node:
-            return CustomNodeWithSelection;
-          case ModelKind.edge:
-            return DefaultEdge;
-          default:
-            return undefined;
-        }
-    }
   }
 
   // ### dagre algo options, uses default value on undefined ###
@@ -103,16 +79,16 @@ export class CanvasService {
       case LayoutType.Concentric:
         return new ConcentricLayout(graph);
       case LayoutType.DagreVertical:
-        return new DagreLayout(graph, {
-          rankdir: 'TB',
+        return new DagreGroupsExtendedLayout(graph, {
+          rankdir: TOP_TO_BOTTOM,
           ranker: 'network-simplex',
           nodesep: 20,
           edgesep: 20,
           ranksep: 0,
         });
       case LayoutType.DagreHorizontal:
-        return new DagreLayout(graph, {
-          rankdir: 'LR',
+        return new DagreGroupsExtendedLayout(graph, {
+          rankdir: LEFT_TO_RIGHT,
           ranker: 'network-simplex',
           nodesep: 20,
           edgesep: 20,
@@ -129,24 +105,39 @@ export class CanvasService {
     }
   }
 
+  static baselineComponentFactory(kind: ModelKind, type: string): ReturnType<ComponentFactory> {
+    switch (type) {
+      case 'group':
+        return CustomGroupWithSelection;
+      default:
+        switch (kind) {
+          case ModelKind.graph:
+            return withPanZoom()(GraphComponent);
+          case ModelKind.node:
+            return CustomNodeWithSelection;
+          case ModelKind.edge:
+            return DefaultEdge;
+          default:
+            return undefined;
+        }
+    }
+  }
+
+  static baselineElementFactory(kind: ModelKind): GraphElement | undefined {
+    switch (kind) {
+      case ModelKind.edge:
+        return new NoBendpointsEdge();
+      default:
+        return undefined;
+    }
+  }
+
   static getFlowDiagram(vizNode: IVisualizationNode): CanvasNodesAndEdges {
     this.nodes = [];
     this.edges = [];
     this.visitedNodes = [];
 
-    const children = vizNode.getChildren();
-    if (vizNode.data.isGroup && children) {
-      children.forEach((child) => this.appendNodesAndEdges(child));
-      const containerId = vizNode.getBaseEntity()?.getId() ?? 'Unknown';
-      const group = this.getContainer(containerId, {
-        label: containerId,
-        children: this.visitedNodes,
-        data: { vizNode },
-      });
-      this.nodes.push(group);
-    } else {
-      this.appendNodesAndEdges(vizNode);
-    }
+    this.appendNodesAndEdges(vizNode);
 
     return { nodes: this.nodes, edges: this.edges };
   }
@@ -157,7 +148,24 @@ export class CanvasService {
       return;
     }
 
-    const node = this.getCanvasNode(vizNodeParam);
+    let node: CanvasNode;
+
+    const children = vizNodeParam.getChildren();
+    if (vizNodeParam.data.isGroup && children) {
+      children.forEach((child) => {
+        this.appendNodesAndEdges(child);
+      });
+
+      const containerId = vizNodeParam.id;
+      node = this.getContainer(containerId, {
+        label: containerId,
+        children: children.map((child) => child.id),
+        parentNode: vizNodeParam.getParentNode()?.id,
+        data: { vizNode: vizNodeParam },
+      });
+    } else {
+      node = this.getCanvasNode(vizNodeParam);
+    }
 
     /** Add node */
     this.nodes.push(node);
@@ -165,20 +173,6 @@ export class CanvasService {
 
     /** Add edges */
     this.edges.push(...this.getEdgesFromVizNode(vizNodeParam));
-
-    /** Traverse the children nodes */
-    const children = vizNodeParam.getChildren();
-    if (children !== undefined) {
-      children.forEach((child) => {
-        this.appendNodesAndEdges(child);
-      });
-    }
-
-    /** Traverse the next node */
-    const nextNode = vizNodeParam.getNextNode();
-    if (nextNode !== undefined) {
-      this.appendNodesAndEdges(nextNode);
-    }
   }
 
   private static getCanvasNode(vizNodeParam: IVisualizationNode): CanvasNode {
@@ -195,28 +189,8 @@ export class CanvasService {
   private static getEdgesFromVizNode(vizNodeParam: IVisualizationNode): CanvasEdge[] {
     const edges: CanvasEdge[] = [];
 
-    /** Connect to previous node if it doesn't have children */
-    if (vizNodeParam.getPreviousNode() !== undefined && vizNodeParam.getPreviousNode()?.getChildren() === undefined) {
-      edges.push(this.getEdge(vizNodeParam.getPreviousNode()!.id, vizNodeParam.id));
-    }
-
-    /** Connect to the parent if it's not a group and there is no previous node */
-    if (
-      vizNodeParam.getParentNode() !== undefined &&
-      !vizNodeParam.getParentNode()?.data.isGroup &&
-      vizNodeParam.getPreviousNode() === undefined
-    ) {
-      edges.push(this.getEdge(vizNodeParam.getParentNode()!.id, vizNodeParam.id));
-    }
-
-    /** Connect to each leaf of the previous node */
-    if (vizNodeParam.getPreviousNode() !== undefined && vizNodeParam.getPreviousNode()?.getChildren() !== undefined) {
-      const leafNodesIds: string[] = [];
-      vizNodeParam.getPreviousNode()!.populateLeafNodesIds(leafNodesIds);
-
-      leafNodesIds.forEach((leafNodeId) => {
-        edges.push(this.getEdge(leafNodeId, vizNodeParam.id));
-      });
+    if (vizNodeParam.getNextNode() !== undefined) {
+      edges.push(this.getEdge(vizNodeParam.id, vizNodeParam.getNextNode()!.id));
     }
 
     return edges;
@@ -224,7 +198,7 @@ export class CanvasService {
 
   private static getContainer(
     id: string,
-    options: { label?: string; children?: string[]; data?: CanvasNode['data'] } = {},
+    options: { label?: string; children?: string[]; parentNode?: string; data?: CanvasNode['data'] } = {},
   ): CanvasNode {
     return {
       id,
@@ -232,6 +206,7 @@ export class CanvasService {
       group: true,
       label: options.label ?? id,
       children: options.children ?? [],
+      parentNode: options.parentNode,
       data: options.data,
       style: {
         padding: CanvasDefaults.DEFAULT_NODE_DIAMETER * 0.8,

--- a/packages/ui/src/components/Visualization/Custom/Group/CollapseButton.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CollapseButton.test.tsx
@@ -17,7 +17,9 @@ describe('CollapseButton', () => {
   });
 
   it('should render the collapse button', () => {
-    const wrapper = render(<CollapseButton element={element} onCollapseChange={onCollapseChange} />);
+    const wrapper = render(
+      <CollapseButton data-testid="collapseButton-test" element={element} onCollapseChange={onCollapseChange} />,
+    );
     const button = wrapper.getByTestId('collapseButton-test');
 
     expect(button).toBeInTheDocument();
@@ -41,7 +43,9 @@ describe('CollapseButton', () => {
   });
 
   it('should call onCollapseChange when the button is clicked', () => {
-    const wrapper = render(<CollapseButton element={element} onCollapseChange={onCollapseChange} />);
+    const wrapper = render(
+      <CollapseButton data-testid="collapseButton-test" element={element} onCollapseChange={onCollapseChange} />,
+    );
     const button = wrapper.getByTestId('collapseButton-test');
 
     act(() => {

--- a/packages/ui/src/components/Visualization/Custom/Group/CollapseButton.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CollapseButton.tsx
@@ -2,15 +2,19 @@ import { Button, Tooltip } from '@patternfly/react-core';
 import { CompressArrowsAltIcon, ExpandArrowsAltIcon } from '@patternfly/react-icons';
 import { CollapsibleGroupProps } from '@patternfly/react-topology';
 import { FunctionComponent, MouseEventHandler } from 'react';
+import { IDataTestID } from '../../../../models';
 import { CustomGroupProps } from './Group.models';
 
-interface CollapseButtonProps {
+interface CollapseButtonProps extends IDataTestID {
   element: CustomGroupProps['element'];
   onCollapseChange?: CollapsibleGroupProps['onCollapseChange'];
 }
 
-export const CollapseButton: FunctionComponent<CollapseButtonProps> = ({ element, onCollapseChange }) => {
-  const id = element.getId();
+export const CollapseButton: FunctionComponent<CollapseButtonProps> = ({
+  element,
+  ['data-testid']: dataTestId,
+  onCollapseChange,
+}) => {
   const onClick: MouseEventHandler<HTMLButtonElement> = (event) => {
     event.stopPropagation();
     onCollapseChange?.(element, !element.isCollapsed());
@@ -18,7 +22,7 @@ export const CollapseButton: FunctionComponent<CollapseButtonProps> = ({ element
 
   return (
     <Tooltip content={element.isCollapsed() ? 'Expand' : 'Collapse'}>
-      <Button className="container-controls" variant="control" onClick={onClick} data-testid={`collapseButton-${id}`}>
+      <Button className="container-controls" variant="control" onClick={onClick} data-testid={dataTestId}>
         {element.isCollapsed() ? (
           <ExpandArrowsAltIcon data-testid="expand-icon" />
         ) : (

--- a/packages/ui/src/components/Visualization/Custom/Group/ContextMenuButton.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/ContextMenuButton.test.tsx
@@ -14,7 +14,7 @@ describe('ContextMenuButton', () => {
   });
 
   it('should render the button', () => {
-    const wrapper = render(<ContextMenuButton element={element} />);
+    const wrapper = render(<ContextMenuButton data-testid="contextualMenu-test" element={element} />);
     const button = wrapper.getByTestId('contextualMenu-test');
 
     expect(button).toBeInTheDocument();
@@ -22,7 +22,7 @@ describe('ContextMenuButton', () => {
   });
 
   it('should open the context menu when the button is clicked', () => {
-    const wrapper = render(<ContextMenuButton element={element} />);
+    const wrapper = render(<ContextMenuButton data-testid="contextualMenu-test" element={element} />);
     const button = wrapper.getByTestId('contextualMenu-test');
 
     act(() => {
@@ -35,7 +35,7 @@ describe('ContextMenuButton', () => {
   });
 
   it('should close the context menu when the button is clicked twice', () => {
-    const wrapper = render(<ContextMenuButton element={element} />);
+    const wrapper = render(<ContextMenuButton data-testid="contextualMenu-test" element={element} />);
     const button = wrapper.getByTestId('contextualMenu-test');
 
     fireEvent.click(button);

--- a/packages/ui/src/components/Visualization/Custom/Group/ContextMenuButton.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/ContextMenuButton.tsx
@@ -2,17 +2,20 @@ import { Button, Tooltip } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { ContextMenu, PointIface } from '@patternfly/react-topology';
 import { FunctionComponent, MouseEventHandler, useRef, useState } from 'react';
+import { IDataTestID } from '../../../../models';
 import { NodeContextMenu } from '../ContextMenu/NodeContextMenu';
 import { CustomGroupProps } from './Group.models';
 
-interface ContextMenuButtonProps {
+interface ContextMenuButtonProps extends IDataTestID {
   element: CustomGroupProps['element'];
 }
 
-export const ContextMenuButton: FunctionComponent<ContextMenuButtonProps> = ({ element }) => {
+export const ContextMenuButton: FunctionComponent<ContextMenuButtonProps> = ({
+  element,
+  ['data-testid']: dataTestId,
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const reference = useRef<PointIface>({ x: 0, y: 0 });
-  const id = element.getId();
 
   const onClick: MouseEventHandler<HTMLButtonElement> & MouseEventHandler<HTMLDivElement> = (event) => {
     event.stopPropagation();
@@ -23,7 +26,7 @@ export const ContextMenuButton: FunctionComponent<ContextMenuButtonProps> = ({ e
   return (
     <>
       <Tooltip content="Contextual menu">
-        <Button className="container-controls" variant="control" onClick={onClick} data-testid={`contextualMenu-${id}`}>
+        <Button className="container-controls" variant="control" onClick={onClick} data-testid={dataTestId}>
           <EllipsisVIcon />
         </Button>
       </Tooltip>

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -113,8 +113,12 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupExpandedProps> = 
                   </div>
                   <span title={label}>{label}</span>
 
-                  <CollapseButton element={element} onCollapseChange={onCollapseChange} />
-                  <ContextMenuButton element={element} />
+                  <CollapseButton
+                    data-testid={`collapseButton-${label}`}
+                    element={element}
+                    onCollapseChange={onCollapseChange}
+                  />
+                  <ContextMenuButton data-testid={`contextualMenu-${label}`} element={element} />
                 </div>
               </div>
             </foreignObject>

--- a/packages/ui/src/components/Visualization/Custom/NoBendingEdge.tsx
+++ b/packages/ui/src/components/Visualization/Custom/NoBendingEdge.tsx
@@ -1,0 +1,7 @@
+import { BaseEdge, Point } from '@patternfly/react-topology';
+
+export class NoBendpointsEdge extends BaseEdge {
+  getBendpoints(): Point[] {
+    return [];
+  }
+}

--- a/packages/ui/src/components/Visualization/Custom/index.ts
+++ b/packages/ui/src/components/Visualization/Custom/index.ts
@@ -1,2 +1,3 @@
 export * from './Group/CustomGroup';
+export * from './NoBendingEdge';
 export * from './Node/CustomNode';

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -236,6 +236,22 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     }
     routeGroupNode.addChild(fromNode);
 
+    fromNode.getChildren()?.forEach((child, index) => {
+      routeGroupNode.addChild(child);
+      if (index === 0) {
+        fromNode.setNextNode(child);
+        child.setPreviousNode(fromNode);
+      }
+
+      const previousChild = fromNode.getChildren()?.[index - 1];
+      if (previousChild) {
+        previousChild.setNextNode(child);
+        child.setPreviousNode(previousChild);
+      }
+    });
+    fromNode.getChildren()?.splice(0);
+    fromNode.data.isGroup = false;
+
     return routeGroupNode;
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -272,21 +272,25 @@ describe('Camel Route', () => {
       /** Since this is the root node, there's no previous step */
       expect(vizNode.getPreviousNode()).toBeUndefined();
       expect(vizNode.getNextNode()).toBeUndefined();
-      expect(vizNode.getChildren()).toHaveLength(1);
+
+      /** from nod eand choice group */
+      expect(vizNode.getChildren()).toHaveLength(2);
+      expect(vizNode.getChildren()?.[0].data.path).toEqual('from');
+      expect(vizNode.getChildren()?.[1].data.path).toEqual('from.steps.0.choice');
 
       /** from */
       expect(fromNode.data.path).toEqual('from');
       expect(fromNode.getNodeLabel()).toEqual('timer');
       /** Since this is the first child node, there's no previous step */
       expect(fromNode.getPreviousNode()).toBeUndefined();
-      expect(fromNode.getNextNode()).toBeUndefined();
-      expect(fromNode.getChildren()).toHaveLength(1);
+      expect(fromNode.getNextNode()).toBeDefined();
+      expect(fromNode.getChildren()).toHaveLength(0);
 
       /** choice */
-      const choiceNode = fromNode.getChildren()?.[0] as IVisualizationNode;
+      const choiceNode = vizNode.getChildren()?.[1] as IVisualizationNode;
       expect(choiceNode.data.path).toEqual('from.steps.0.choice');
       expect(choiceNode.getNodeLabel()).toEqual('choice');
-      expect(choiceNode.getPreviousNode()).toBeUndefined();
+      expect(choiceNode.getPreviousNode()).toBe(fromNode);
       expect(choiceNode.getNextNode()).toBeUndefined();
       expect(choiceNode.getChildren()).toHaveLength(1);
 
@@ -321,21 +325,21 @@ describe('Camel Route', () => {
       /** Since this is the root node, there's no previous step */
       expect(vizNode.getPreviousNode()).toBeUndefined();
       expect(vizNode.getNextNode()).toBeUndefined();
-      expect(vizNode.getChildren()).toHaveLength(1);
+      expect(vizNode.getChildren()).toHaveLength(4);
 
       /** from */
       expect(fromNode.data.path).toEqual('from');
       expect(fromNode.getNodeLabel()).toEqual('timer');
       /** Since this is the first child node, there's no previous step */
       expect(fromNode.getPreviousNode()).toBeUndefined();
-      expect(fromNode.getNextNode()).toBeUndefined();
-      expect(fromNode.getChildren()).toHaveLength(3);
+      expect(fromNode.getNextNode()).toBeDefined();
+      expect(fromNode.getChildren()).toHaveLength(0);
 
       /** setHeader */
-      const setHeaderNode = fromNode.getChildren()?.[0] as IVisualizationNode;
+      const setHeaderNode = vizNode.getChildren()?.[1] as IVisualizationNode;
       expect(setHeaderNode.data.path).toEqual('from.steps.0.set-header');
       expect(setHeaderNode.getNodeLabel()).toEqual('set-header');
-      expect(setHeaderNode.getPreviousNode()).toBeUndefined();
+      expect(setHeaderNode.getPreviousNode()).toBe(fromNode);
       expect(setHeaderNode.getNextNode()).toBeDefined();
       expect(setHeaderNode.getChildren()).toBeUndefined();
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -211,5 +211,24 @@ describe('Pipe', () => {
       expect(sink.getPreviousNode()).toBe(steps0);
       expect(sink.getNextNode()).toBeUndefined();
     });
+
+    it('should include all steps as children of the Pipe group', () => {
+      const vizNode = pipeVisualEntity.toVizNode();
+
+      const sourceNode = vizNode.getChildren()![0];
+      const stepNode = vizNode.getChildren()![1];
+      const sinkNode = vizNode.getChildren()![2];
+
+      expect(vizNode.getChildren()).toHaveLength(3);
+
+      expect(sourceNode.getPreviousNode()).toBeUndefined();
+      expect(sourceNode.getNextNode()).toBe(stepNode);
+
+      expect(stepNode.getPreviousNode()).toBe(sourceNode);
+      expect(stepNode.getNextNode()).toBe(sinkNode);
+
+      expect(sinkNode.getPreviousNode()).toBe(stepNode);
+      expect(sinkNode.getNextNode()).toBeUndefined();
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -221,6 +221,8 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
     /** If there are no steps, we link the `source` and the `sink` together */
 
     pipeGroupNode.addChild(sourceNode);
+    stepNodes.forEach((stepNode) => pipeGroupNode.addChild(stepNode));
+    pipeGroupNode.addChild(sinkNode);
 
     if (stepNodes.length === 0) {
       sourceNode.setNextNode(sinkNode);

--- a/packages/ui/src/models/visualization/flows/support/camel-steps.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-steps.service.ts
@@ -31,9 +31,15 @@ export class CamelStepsService {
       componentLookup.processorName as keyof ProcessorDefinition,
     );
 
+    if (childrenStepsProperties.length > 0) {
+      vizNode.data.isGroup = true;
+    }
+
     childrenStepsProperties.forEach((stepsProperty) => {
       const childrenVizNodes = this.getVizNodesFromChildren(path, stepsProperty, entityDefinition);
-      childrenVizNodes.forEach((childVizNode) => vizNode.addChild(childVizNode));
+      childrenVizNodes.forEach((childVizNode) => {
+        vizNode.addChild(childVizNode);
+      });
     });
 
     return vizNode;

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -180,7 +180,7 @@ describe('VisualizationNode', () => {
       const fromNode = node.getChildren()?.[0];
 
       /** Get set-header node */
-      const setHeaderNode = fromNode!.getChildren()?.[0];
+      const setHeaderNode = node.getChildren()?.[1];
 
       /** Remove set-header node */
       setHeaderNode!.removeChild();
@@ -189,8 +189,10 @@ describe('VisualizationNode', () => {
       node = camelRouteVisualEntityStub.toVizNode();
 
       expect(node.getChildren()?.[0].getNodeLabel()).toEqual('timer');
-      expect(fromNode!.getChildren()?.[0].getNodeLabel()).toEqual('choice-1234');
-      expect(fromNode!.getChildren()).toHaveLength(2);
+      expect(node.getChildren()?.[1].getNodeLabel()).toEqual('choice');
+      expect(node.getChildren()?.[2].getNodeLabel()).toEqual('direct');
+      expect(node.getChildren()).toHaveLength(3);
+      expect(fromNode!.getChildren()).toHaveLength(0);
     });
   });
 

--- a/packages/ui/src/stubs/camel-route-branch.ts
+++ b/packages/ui/src/stubs/camel-route-branch.ts
@@ -1,0 +1,34 @@
+import { parse } from 'yaml';
+
+export const camelRouteBranch = parse(`
+- route:
+    id: route-2768
+    from:
+      id: from-4014
+      uri: timer:template
+      parameters:
+        period: "1000"
+      steps:
+        - choice:
+            id: choice-3431
+            otherwise:
+              id: otherwise-3653
+              steps:
+                - log:
+                    id: log-6808
+                    message: \${body}
+            when:
+              - id: when-4112
+                steps:
+                  - setHeader:
+                      id: setHeader-6078
+                      expression:
+                        simple: {}
+                expression:
+                  simple:
+                    expression: \${header.foo} == 1
+        - to:
+            id: to-3757
+            uri: sql
+            parameters: {}
+`);

--- a/packages/ui/src/tests/__snapshots__/nodes-edges.test.ts.snap
+++ b/packages/ui/src/tests/__snapshots__/nodes-edges.test.ts.snap
@@ -1,0 +1,4626 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nodes and Edges should generate edges for steps with branches 1`] = `
+[
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [],
+        "data": {
+          "componentName": "timer",
+          "icon": "",
+          "isGroup": false,
+          "path": "from",
+          "processorName": "from",
+        },
+        "id": "timer-1234",
+        "nextNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                    "processorName": "setHeader",
+                  },
+                  "id": "setHeader-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.when.0",
+                "processorName": "when",
+              },
+              "id": "when-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.otherwise.steps.0.log",
+                    "processorName": "log",
+                  },
+                  "id": "log-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.otherwise",
+                "processorName": "otherwise",
+              },
+              "id": "otherwise-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice",
+            "processorName": "choice",
+          },
+          "id": "choice-1234",
+          "nextNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": "sql",
+              "icon": "",
+              "path": "from.steps.1.to",
+              "processorName": "to",
+            },
+            "id": "sql-1234",
+            "nextNode": undefined,
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                [Circular],
+                [Circular],
+                [Circular],
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": [Circular],
+          },
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              [Circular],
+              [Circular],
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": [Circular],
+        },
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            [Circular],
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                        "processorName": "setHeader",
+                      },
+                      "id": "setHeader-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.when.0",
+                    "processorName": "when",
+                  },
+                  "id": "when-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.otherwise.steps.0.log",
+                        "processorName": "log",
+                      },
+                      "id": "log-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.otherwise",
+                    "processorName": "otherwise",
+                  },
+                  "id": "otherwise-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice",
+                "processorName": "choice",
+              },
+              "id": "choice-1234",
+              "nextNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+              "parentNode": [Circular],
+              "previousNode": [Circular],
+            },
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {
+                "componentName": "sql",
+                "icon": "",
+                "path": "from.steps.1.to",
+                "processorName": "to",
+              },
+              "id": "sql-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [
+                      VisualizationNode {
+                        "DISABLED_NODE_INTERACTION": {
+                          "canBeDisabled": false,
+                          "canHaveChildren": false,
+                          "canHaveNextStep": false,
+                          "canHavePreviousStep": false,
+                          "canHaveSpecialChildren": false,
+                          "canRemoveFlow": false,
+                          "canRemoveStep": false,
+                          "canReplaceStep": false,
+                        },
+                        "data": {
+                          "componentName": undefined,
+                          "icon": "",
+                          "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                          "processorName": "setHeader",
+                        },
+                        "id": "setHeader-1234",
+                        "nextNode": undefined,
+                        "parentNode": [Circular],
+                        "previousNode": undefined,
+                      },
+                    ],
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "isGroup": true,
+                      "path": "from.steps.0.choice.when.0",
+                      "processorName": "when",
+                    },
+                    "id": "when-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [
+                      VisualizationNode {
+                        "DISABLED_NODE_INTERACTION": {
+                          "canBeDisabled": false,
+                          "canHaveChildren": false,
+                          "canHaveNextStep": false,
+                          "canHavePreviousStep": false,
+                          "canHaveSpecialChildren": false,
+                          "canRemoveFlow": false,
+                          "canRemoveStep": false,
+                          "canReplaceStep": false,
+                        },
+                        "data": {
+                          "componentName": undefined,
+                          "icon": "",
+                          "path": "from.steps.0.choice.otherwise.steps.0.log",
+                          "processorName": "log",
+                        },
+                        "id": "log-1234",
+                        "nextNode": undefined,
+                        "parentNode": [Circular],
+                        "previousNode": undefined,
+                      },
+                    ],
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "isGroup": true,
+                      "path": "from.steps.0.choice.otherwise",
+                      "processorName": "otherwise",
+                    },
+                    "id": "otherwise-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice",
+                  "processorName": "choice",
+                },
+                "id": "choice-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+            },
+          ],
+          "data": {
+            "entity": {
+              "route": {
+                "from": {
+                  "id": "from-4014",
+                  "parameters": {
+                    "period": "1000",
+                  },
+                  "steps": [
+                    {
+                      "choice": {
+                        "id": "choice-3431",
+                        "otherwise": {
+                          "id": "otherwise-3653",
+                          "steps": [
+                            {
+                              "log": {
+                                "id": "log-6808",
+                                "message": "\${body}",
+                              },
+                            },
+                          ],
+                        },
+                        "when": [
+                          {
+                            "expression": {
+                              "simple": {
+                                "expression": "\${header.foo} == 1",
+                              },
+                            },
+                            "id": "when-4112",
+                            "steps": [
+                              {
+                                "setHeader": {
+                                  "expression": {
+                                    "simple": {},
+                                  },
+                                  "id": "setHeader-6078",
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      "to": {
+                        "id": "to-3757",
+                        "parameters": {},
+                        "uri": "sql",
+                      },
+                    },
+                  ],
+                  "uri": "timer:template",
+                },
+                "id": "route-2768",
+              },
+            },
+            "icon": "",
+            "isGroup": true,
+            "path": "#",
+            "processorName": "route",
+          },
+          "id": "route-2768-1234",
+          "nextNode": undefined,
+          "parentNode": undefined,
+          "previousNode": undefined,
+        },
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "timer-1234",
+    "parentNode": "route-2768-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {
+          "componentName": undefined,
+          "icon": "",
+          "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+          "processorName": "setHeader",
+        },
+        "id": "setHeader-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            [Circular],
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice.when.0",
+            "processorName": "when",
+          },
+          "id": "when-1234",
+          "nextNode": undefined,
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              [Circular],
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "path": "from.steps.0.choice.otherwise.steps.0.log",
+                      "processorName": "log",
+                    },
+                    "id": "log-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice.otherwise",
+                  "processorName": "otherwise",
+                },
+                "id": "otherwise-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            ],
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "isGroup": true,
+              "path": "from.steps.0.choice",
+              "processorName": "choice",
+            },
+            "id": "choice-1234",
+            "nextNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {
+                "componentName": "sql",
+                "icon": "",
+                "path": "from.steps.1.to",
+                "processorName": "to",
+              },
+              "id": "sql-1234",
+              "nextNode": undefined,
+              "parentNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [],
+                    "data": {
+                      "componentName": "timer",
+                      "icon": "",
+                      "isGroup": false,
+                      "path": "from",
+                      "processorName": "from",
+                    },
+                    "id": "timer-1234",
+                    "nextNode": [Circular],
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                  [Circular],
+                  [Circular],
+                ],
+                "data": {
+                  "entity": {
+                    "route": {
+                      "from": {
+                        "id": "from-4014",
+                        "parameters": {
+                          "period": "1000",
+                        },
+                        "steps": [
+                          {
+                            "choice": {
+                              "id": "choice-3431",
+                              "otherwise": {
+                                "id": "otherwise-3653",
+                                "steps": [
+                                  {
+                                    "log": {
+                                      "id": "log-6808",
+                                      "message": "\${body}",
+                                    },
+                                  },
+                                ],
+                              },
+                              "when": [
+                                {
+                                  "expression": {
+                                    "simple": {
+                                      "expression": "\${header.foo} == 1",
+                                    },
+                                  },
+                                  "id": "when-4112",
+                                  "steps": [
+                                    {
+                                      "setHeader": {
+                                        "expression": {
+                                          "simple": {},
+                                        },
+                                        "id": "setHeader-6078",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            "to": {
+                              "id": "to-3757",
+                              "parameters": {},
+                              "uri": "sql",
+                            },
+                          },
+                        ],
+                        "uri": "timer:template",
+                      },
+                      "id": "route-2768",
+                    },
+                  },
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "#",
+                  "processorName": "route",
+                },
+                "id": "route-2768-1234",
+                "nextNode": undefined,
+                "parentNode": undefined,
+                "previousNode": undefined,
+              },
+              "previousNode": [Circular],
+            },
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [],
+                  "data": {
+                    "componentName": "timer",
+                    "icon": "",
+                    "isGroup": false,
+                    "path": "from",
+                    "processorName": "from",
+                  },
+                  "id": "timer-1234",
+                  "nextNode": [Circular],
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                [Circular],
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": "sql",
+                    "icon": "",
+                    "path": "from.steps.1.to",
+                    "processorName": "to",
+                  },
+                  "id": "sql-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": [Circular],
+                },
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [],
+              "data": {
+                "componentName": "timer",
+                "icon": "",
+                "isGroup": false,
+                "path": "from",
+                "processorName": "from",
+              },
+              "id": "timer-1234",
+              "nextNode": [Circular],
+              "parentNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  [Circular],
+                  [Circular],
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": "sql",
+                      "icon": "",
+                      "path": "from.steps.1.to",
+                      "processorName": "to",
+                    },
+                    "id": "sql-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": [Circular],
+                  },
+                ],
+                "data": {
+                  "entity": {
+                    "route": {
+                      "from": {
+                        "id": "from-4014",
+                        "parameters": {
+                          "period": "1000",
+                        },
+                        "steps": [
+                          {
+                            "choice": {
+                              "id": "choice-3431",
+                              "otherwise": {
+                                "id": "otherwise-3653",
+                                "steps": [
+                                  {
+                                    "log": {
+                                      "id": "log-6808",
+                                      "message": "\${body}",
+                                    },
+                                  },
+                                ],
+                              },
+                              "when": [
+                                {
+                                  "expression": {
+                                    "simple": {
+                                      "expression": "\${header.foo} == 1",
+                                    },
+                                  },
+                                  "id": "when-4112",
+                                  "steps": [
+                                    {
+                                      "setHeader": {
+                                        "expression": {
+                                          "simple": {},
+                                        },
+                                        "id": "setHeader-6078",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            "to": {
+                              "id": "to-3757",
+                              "parameters": {},
+                              "uri": "sql",
+                            },
+                          },
+                        ],
+                        "uri": "timer:template",
+                      },
+                      "id": "route-2768",
+                    },
+                  },
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "#",
+                  "processorName": "route",
+                },
+                "id": "route-2768-1234",
+                "nextNode": undefined,
+                "parentNode": undefined,
+                "previousNode": undefined,
+              },
+              "previousNode": undefined,
+            },
+          },
+          "previousNode": undefined,
+        },
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "setHeader-1234",
+    "parentNode": "when-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "children": [
+      "setHeader-1234",
+    ],
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+              "processorName": "setHeader",
+            },
+            "id": "setHeader-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+        ],
+        "data": {
+          "componentName": undefined,
+          "icon": "",
+          "isGroup": true,
+          "path": "from.steps.0.choice.when.0",
+          "processorName": "when",
+        },
+        "id": "when-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            [Circular],
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.otherwise.steps.0.log",
+                    "processorName": "log",
+                  },
+                  "id": "log-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.otherwise",
+                "processorName": "otherwise",
+              },
+              "id": "otherwise-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice",
+            "processorName": "choice",
+          },
+          "id": "choice-1234",
+          "nextNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": "sql",
+              "icon": "",
+              "path": "from.steps.1.to",
+              "processorName": "to",
+            },
+            "id": "sql-1234",
+            "nextNode": undefined,
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [],
+                  "data": {
+                    "componentName": "timer",
+                    "icon": "",
+                    "isGroup": false,
+                    "path": "from",
+                    "processorName": "from",
+                  },
+                  "id": "timer-1234",
+                  "nextNode": [Circular],
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                [Circular],
+                [Circular],
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": [Circular],
+          },
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              [Circular],
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [],
+            "data": {
+              "componentName": "timer",
+              "icon": "",
+              "isGroup": false,
+              "path": "from",
+              "processorName": "from",
+            },
+            "id": "timer-1234",
+            "nextNode": [Circular],
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                [Circular],
+                [Circular],
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": "sql",
+                    "icon": "",
+                    "path": "from.steps.1.to",
+                    "processorName": "to",
+                  },
+                  "id": "sql-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": [Circular],
+                },
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": undefined,
+          },
+        },
+        "previousNode": undefined,
+      },
+    },
+    "group": true,
+    "id": "when-1234",
+    "label": "when-1234",
+    "parentNode": "choice-1234",
+    "style": {
+      "padding": 60,
+    },
+    "type": "group",
+  },
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {
+          "componentName": undefined,
+          "icon": "",
+          "path": "from.steps.0.choice.otherwise.steps.0.log",
+          "processorName": "log",
+        },
+        "id": "log-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            [Circular],
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice.otherwise",
+            "processorName": "otherwise",
+          },
+          "id": "otherwise-1234",
+          "nextNode": undefined,
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                      "processorName": "setHeader",
+                    },
+                    "id": "setHeader-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice.when.0",
+                  "processorName": "when",
+                },
+                "id": "when-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              [Circular],
+            ],
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "isGroup": true,
+              "path": "from.steps.0.choice",
+              "processorName": "choice",
+            },
+            "id": "choice-1234",
+            "nextNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {
+                "componentName": "sql",
+                "icon": "",
+                "path": "from.steps.1.to",
+                "processorName": "to",
+              },
+              "id": "sql-1234",
+              "nextNode": undefined,
+              "parentNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [],
+                    "data": {
+                      "componentName": "timer",
+                      "icon": "",
+                      "isGroup": false,
+                      "path": "from",
+                      "processorName": "from",
+                    },
+                    "id": "timer-1234",
+                    "nextNode": [Circular],
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                  [Circular],
+                  [Circular],
+                ],
+                "data": {
+                  "entity": {
+                    "route": {
+                      "from": {
+                        "id": "from-4014",
+                        "parameters": {
+                          "period": "1000",
+                        },
+                        "steps": [
+                          {
+                            "choice": {
+                              "id": "choice-3431",
+                              "otherwise": {
+                                "id": "otherwise-3653",
+                                "steps": [
+                                  {
+                                    "log": {
+                                      "id": "log-6808",
+                                      "message": "\${body}",
+                                    },
+                                  },
+                                ],
+                              },
+                              "when": [
+                                {
+                                  "expression": {
+                                    "simple": {
+                                      "expression": "\${header.foo} == 1",
+                                    },
+                                  },
+                                  "id": "when-4112",
+                                  "steps": [
+                                    {
+                                      "setHeader": {
+                                        "expression": {
+                                          "simple": {},
+                                        },
+                                        "id": "setHeader-6078",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            "to": {
+                              "id": "to-3757",
+                              "parameters": {},
+                              "uri": "sql",
+                            },
+                          },
+                        ],
+                        "uri": "timer:template",
+                      },
+                      "id": "route-2768",
+                    },
+                  },
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "#",
+                  "processorName": "route",
+                },
+                "id": "route-2768-1234",
+                "nextNode": undefined,
+                "parentNode": undefined,
+                "previousNode": undefined,
+              },
+              "previousNode": [Circular],
+            },
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [],
+                  "data": {
+                    "componentName": "timer",
+                    "icon": "",
+                    "isGroup": false,
+                    "path": "from",
+                    "processorName": "from",
+                  },
+                  "id": "timer-1234",
+                  "nextNode": [Circular],
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                [Circular],
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": "sql",
+                    "icon": "",
+                    "path": "from.steps.1.to",
+                    "processorName": "to",
+                  },
+                  "id": "sql-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": [Circular],
+                },
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [],
+              "data": {
+                "componentName": "timer",
+                "icon": "",
+                "isGroup": false,
+                "path": "from",
+                "processorName": "from",
+              },
+              "id": "timer-1234",
+              "nextNode": [Circular],
+              "parentNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  [Circular],
+                  [Circular],
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": "sql",
+                      "icon": "",
+                      "path": "from.steps.1.to",
+                      "processorName": "to",
+                    },
+                    "id": "sql-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": [Circular],
+                  },
+                ],
+                "data": {
+                  "entity": {
+                    "route": {
+                      "from": {
+                        "id": "from-4014",
+                        "parameters": {
+                          "period": "1000",
+                        },
+                        "steps": [
+                          {
+                            "choice": {
+                              "id": "choice-3431",
+                              "otherwise": {
+                                "id": "otherwise-3653",
+                                "steps": [
+                                  {
+                                    "log": {
+                                      "id": "log-6808",
+                                      "message": "\${body}",
+                                    },
+                                  },
+                                ],
+                              },
+                              "when": [
+                                {
+                                  "expression": {
+                                    "simple": {
+                                      "expression": "\${header.foo} == 1",
+                                    },
+                                  },
+                                  "id": "when-4112",
+                                  "steps": [
+                                    {
+                                      "setHeader": {
+                                        "expression": {
+                                          "simple": {},
+                                        },
+                                        "id": "setHeader-6078",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            "to": {
+                              "id": "to-3757",
+                              "parameters": {},
+                              "uri": "sql",
+                            },
+                          },
+                        ],
+                        "uri": "timer:template",
+                      },
+                      "id": "route-2768",
+                    },
+                  },
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "#",
+                  "processorName": "route",
+                },
+                "id": "route-2768-1234",
+                "nextNode": undefined,
+                "parentNode": undefined,
+                "previousNode": undefined,
+              },
+              "previousNode": undefined,
+            },
+          },
+          "previousNode": undefined,
+        },
+        "previousNode": undefined,
+      },
+    },
+    "height": 75,
+    "id": "log-1234",
+    "parentNode": "otherwise-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "children": [
+      "log-1234",
+    ],
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "path": "from.steps.0.choice.otherwise.steps.0.log",
+              "processorName": "log",
+            },
+            "id": "log-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+        ],
+        "data": {
+          "componentName": undefined,
+          "icon": "",
+          "isGroup": true,
+          "path": "from.steps.0.choice.otherwise",
+          "processorName": "otherwise",
+        },
+        "id": "otherwise-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                    "processorName": "setHeader",
+                  },
+                  "id": "setHeader-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.when.0",
+                "processorName": "when",
+              },
+              "id": "when-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            [Circular],
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice",
+            "processorName": "choice",
+          },
+          "id": "choice-1234",
+          "nextNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": "sql",
+              "icon": "",
+              "path": "from.steps.1.to",
+              "processorName": "to",
+            },
+            "id": "sql-1234",
+            "nextNode": undefined,
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [],
+                  "data": {
+                    "componentName": "timer",
+                    "icon": "",
+                    "isGroup": false,
+                    "path": "from",
+                    "processorName": "from",
+                  },
+                  "id": "timer-1234",
+                  "nextNode": [Circular],
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                [Circular],
+                [Circular],
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": [Circular],
+          },
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              [Circular],
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [],
+            "data": {
+              "componentName": "timer",
+              "icon": "",
+              "isGroup": false,
+              "path": "from",
+              "processorName": "from",
+            },
+            "id": "timer-1234",
+            "nextNode": [Circular],
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                [Circular],
+                [Circular],
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": "sql",
+                    "icon": "",
+                    "path": "from.steps.1.to",
+                    "processorName": "to",
+                  },
+                  "id": "sql-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": [Circular],
+                },
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": undefined,
+          },
+        },
+        "previousNode": undefined,
+      },
+    },
+    "group": true,
+    "id": "otherwise-1234",
+    "label": "otherwise-1234",
+    "parentNode": "choice-1234",
+    "style": {
+      "padding": 60,
+    },
+    "type": "group",
+  },
+  {
+    "children": [
+      "when-1234",
+      "otherwise-1234",
+    ],
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                  "processorName": "setHeader",
+                },
+                "id": "setHeader-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            ],
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "isGroup": true,
+              "path": "from.steps.0.choice.when.0",
+              "processorName": "when",
+            },
+            "id": "when-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "path": "from.steps.0.choice.otherwise.steps.0.log",
+                  "processorName": "log",
+                },
+                "id": "log-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            ],
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "isGroup": true,
+              "path": "from.steps.0.choice.otherwise",
+              "processorName": "otherwise",
+            },
+            "id": "otherwise-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+        ],
+        "data": {
+          "componentName": undefined,
+          "icon": "",
+          "isGroup": true,
+          "path": "from.steps.0.choice",
+          "processorName": "choice",
+        },
+        "id": "choice-1234",
+        "nextNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "data": {
+            "componentName": "sql",
+            "icon": "",
+            "path": "from.steps.1.to",
+            "processorName": "to",
+          },
+          "id": "sql-1234",
+          "nextNode": undefined,
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              [Circular],
+              [Circular],
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": [Circular],
+        },
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [],
+              "data": {
+                "componentName": "timer",
+                "icon": "",
+                "isGroup": false,
+                "path": "from",
+                "processorName": "from",
+              },
+              "id": "timer-1234",
+              "nextNode": [Circular],
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            [Circular],
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {
+                "componentName": "sql",
+                "icon": "",
+                "path": "from.steps.1.to",
+                "processorName": "to",
+              },
+              "id": "sql-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": [Circular],
+            },
+          ],
+          "data": {
+            "entity": {
+              "route": {
+                "from": {
+                  "id": "from-4014",
+                  "parameters": {
+                    "period": "1000",
+                  },
+                  "steps": [
+                    {
+                      "choice": {
+                        "id": "choice-3431",
+                        "otherwise": {
+                          "id": "otherwise-3653",
+                          "steps": [
+                            {
+                              "log": {
+                                "id": "log-6808",
+                                "message": "\${body}",
+                              },
+                            },
+                          ],
+                        },
+                        "when": [
+                          {
+                            "expression": {
+                              "simple": {
+                                "expression": "\${header.foo} == 1",
+                              },
+                            },
+                            "id": "when-4112",
+                            "steps": [
+                              {
+                                "setHeader": {
+                                  "expression": {
+                                    "simple": {},
+                                  },
+                                  "id": "setHeader-6078",
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      "to": {
+                        "id": "to-3757",
+                        "parameters": {},
+                        "uri": "sql",
+                      },
+                    },
+                  ],
+                  "uri": "timer:template",
+                },
+                "id": "route-2768",
+              },
+            },
+            "icon": "",
+            "isGroup": true,
+            "path": "#",
+            "processorName": "route",
+          },
+          "id": "route-2768-1234",
+          "nextNode": undefined,
+          "parentNode": undefined,
+          "previousNode": undefined,
+        },
+        "previousNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [],
+          "data": {
+            "componentName": "timer",
+            "icon": "",
+            "isGroup": false,
+            "path": "from",
+            "processorName": "from",
+          },
+          "id": "timer-1234",
+          "nextNode": [Circular],
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              [Circular],
+              [Circular],
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": undefined,
+        },
+      },
+    },
+    "group": true,
+    "id": "choice-1234",
+    "label": "choice-1234",
+    "parentNode": "route-2768-1234",
+    "style": {
+      "padding": 60,
+    },
+    "type": "group",
+  },
+  {
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "data": {
+          "componentName": "sql",
+          "icon": "",
+          "path": "from.steps.1.to",
+          "processorName": "to",
+        },
+        "id": "sql-1234",
+        "nextNode": undefined,
+        "parentNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [],
+              "data": {
+                "componentName": "timer",
+                "icon": "",
+                "isGroup": false,
+                "path": "from",
+                "processorName": "from",
+              },
+              "id": "timer-1234",
+              "nextNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [
+                      VisualizationNode {
+                        "DISABLED_NODE_INTERACTION": {
+                          "canBeDisabled": false,
+                          "canHaveChildren": false,
+                          "canHaveNextStep": false,
+                          "canHavePreviousStep": false,
+                          "canHaveSpecialChildren": false,
+                          "canRemoveFlow": false,
+                          "canRemoveStep": false,
+                          "canReplaceStep": false,
+                        },
+                        "data": {
+                          "componentName": undefined,
+                          "icon": "",
+                          "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                          "processorName": "setHeader",
+                        },
+                        "id": "setHeader-1234",
+                        "nextNode": undefined,
+                        "parentNode": [Circular],
+                        "previousNode": undefined,
+                      },
+                    ],
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "isGroup": true,
+                      "path": "from.steps.0.choice.when.0",
+                      "processorName": "when",
+                    },
+                    "id": "when-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "children": [
+                      VisualizationNode {
+                        "DISABLED_NODE_INTERACTION": {
+                          "canBeDisabled": false,
+                          "canHaveChildren": false,
+                          "canHaveNextStep": false,
+                          "canHavePreviousStep": false,
+                          "canHaveSpecialChildren": false,
+                          "canRemoveFlow": false,
+                          "canRemoveStep": false,
+                          "canReplaceStep": false,
+                        },
+                        "data": {
+                          "componentName": undefined,
+                          "icon": "",
+                          "path": "from.steps.0.choice.otherwise.steps.0.log",
+                          "processorName": "log",
+                        },
+                        "id": "log-1234",
+                        "nextNode": undefined,
+                        "parentNode": [Circular],
+                        "previousNode": undefined,
+                      },
+                    ],
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "isGroup": true,
+                      "path": "from.steps.0.choice.otherwise",
+                      "processorName": "otherwise",
+                    },
+                    "id": "otherwise-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice",
+                  "processorName": "choice",
+                },
+                "id": "choice-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                        "processorName": "setHeader",
+                      },
+                      "id": "setHeader-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.when.0",
+                    "processorName": "when",
+                  },
+                  "id": "when-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.otherwise.steps.0.log",
+                        "processorName": "log",
+                      },
+                      "id": "log-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.otherwise",
+                    "processorName": "otherwise",
+                  },
+                  "id": "otherwise-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice",
+                "processorName": "choice",
+              },
+              "id": "choice-1234",
+              "nextNode": [Circular],
+              "parentNode": [Circular],
+              "previousNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            },
+            [Circular],
+          ],
+          "data": {
+            "entity": {
+              "route": {
+                "from": {
+                  "id": "from-4014",
+                  "parameters": {
+                    "period": "1000",
+                  },
+                  "steps": [
+                    {
+                      "choice": {
+                        "id": "choice-3431",
+                        "otherwise": {
+                          "id": "otherwise-3653",
+                          "steps": [
+                            {
+                              "log": {
+                                "id": "log-6808",
+                                "message": "\${body}",
+                              },
+                            },
+                          ],
+                        },
+                        "when": [
+                          {
+                            "expression": {
+                              "simple": {
+                                "expression": "\${header.foo} == 1",
+                              },
+                            },
+                            "id": "when-4112",
+                            "steps": [
+                              {
+                                "setHeader": {
+                                  "expression": {
+                                    "simple": {},
+                                  },
+                                  "id": "setHeader-6078",
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      "to": {
+                        "id": "to-3757",
+                        "parameters": {},
+                        "uri": "sql",
+                      },
+                    },
+                  ],
+                  "uri": "timer:template",
+                },
+                "id": "route-2768",
+              },
+            },
+            "icon": "",
+            "isGroup": true,
+            "path": "#",
+            "processorName": "route",
+          },
+          "id": "route-2768-1234",
+          "nextNode": undefined,
+          "parentNode": undefined,
+          "previousNode": undefined,
+        },
+        "previousNode": VisualizationNode {
+          "DISABLED_NODE_INTERACTION": {
+            "canBeDisabled": false,
+            "canHaveChildren": false,
+            "canHaveNextStep": false,
+            "canHavePreviousStep": false,
+            "canHaveSpecialChildren": false,
+            "canRemoveFlow": false,
+            "canRemoveStep": false,
+            "canReplaceStep": false,
+          },
+          "children": [
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                    "processorName": "setHeader",
+                  },
+                  "id": "setHeader-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.when.0",
+                "processorName": "when",
+              },
+              "id": "when-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+            VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "path": "from.steps.0.choice.otherwise.steps.0.log",
+                    "processorName": "log",
+                  },
+                  "id": "log-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice.otherwise",
+                "processorName": "otherwise",
+              },
+              "id": "otherwise-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+          ],
+          "data": {
+            "componentName": undefined,
+            "icon": "",
+            "isGroup": true,
+            "path": "from.steps.0.choice",
+            "processorName": "choice",
+          },
+          "id": "choice-1234",
+          "nextNode": [Circular],
+          "parentNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              [Circular],
+              [Circular],
+            ],
+            "data": {
+              "entity": {
+                "route": {
+                  "from": {
+                    "id": "from-4014",
+                    "parameters": {
+                      "period": "1000",
+                    },
+                    "steps": [
+                      {
+                        "choice": {
+                          "id": "choice-3431",
+                          "otherwise": {
+                            "id": "otherwise-3653",
+                            "steps": [
+                              {
+                                "log": {
+                                  "id": "log-6808",
+                                  "message": "\${body}",
+                                },
+                              },
+                            ],
+                          },
+                          "when": [
+                            {
+                              "expression": {
+                                "simple": {
+                                  "expression": "\${header.foo} == 1",
+                                },
+                              },
+                              "id": "when-4112",
+                              "steps": [
+                                {
+                                  "setHeader": {
+                                    "expression": {
+                                      "simple": {},
+                                    },
+                                    "id": "setHeader-6078",
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        "to": {
+                          "id": "to-3757",
+                          "parameters": {},
+                          "uri": "sql",
+                        },
+                      },
+                    ],
+                    "uri": "timer:template",
+                  },
+                  "id": "route-2768",
+                },
+              },
+              "icon": "",
+              "isGroup": true,
+              "path": "#",
+              "processorName": "route",
+            },
+            "id": "route-2768-1234",
+            "nextNode": undefined,
+            "parentNode": undefined,
+            "previousNode": undefined,
+          },
+          "previousNode": VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [],
+            "data": {
+              "componentName": "timer",
+              "icon": "",
+              "isGroup": false,
+              "path": "from",
+              "processorName": "from",
+            },
+            "id": "timer-1234",
+            "nextNode": [Circular],
+            "parentNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                [Circular],
+                [Circular],
+                [Circular],
+              ],
+              "data": {
+                "entity": {
+                  "route": {
+                    "from": {
+                      "id": "from-4014",
+                      "parameters": {
+                        "period": "1000",
+                      },
+                      "steps": [
+                        {
+                          "choice": {
+                            "id": "choice-3431",
+                            "otherwise": {
+                              "id": "otherwise-3653",
+                              "steps": [
+                                {
+                                  "log": {
+                                    "id": "log-6808",
+                                    "message": "\${body}",
+                                  },
+                                },
+                              ],
+                            },
+                            "when": [
+                              {
+                                "expression": {
+                                  "simple": {
+                                    "expression": "\${header.foo} == 1",
+                                  },
+                                },
+                                "id": "when-4112",
+                                "steps": [
+                                  {
+                                    "setHeader": {
+                                      "expression": {
+                                        "simple": {},
+                                      },
+                                      "id": "setHeader-6078",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          "to": {
+                            "id": "to-3757",
+                            "parameters": {},
+                            "uri": "sql",
+                          },
+                        },
+                      ],
+                      "uri": "timer:template",
+                    },
+                    "id": "route-2768",
+                  },
+                },
+                "icon": "",
+                "isGroup": true,
+                "path": "#",
+                "processorName": "route",
+              },
+              "id": "route-2768-1234",
+              "nextNode": undefined,
+              "parentNode": undefined,
+              "previousNode": undefined,
+            },
+            "previousNode": undefined,
+          },
+        },
+      },
+    },
+    "height": 75,
+    "id": "sql-1234",
+    "parentNode": "route-2768-1234",
+    "shape": "rect",
+    "type": "node",
+    "width": 75,
+  },
+  {
+    "children": [
+      "timer-1234",
+      "choice-1234",
+      "sql-1234",
+    ],
+    "data": {
+      "vizNode": VisualizationNode {
+        "DISABLED_NODE_INTERACTION": {
+          "canBeDisabled": false,
+          "canHaveChildren": false,
+          "canHaveNextStep": false,
+          "canHavePreviousStep": false,
+          "canHaveSpecialChildren": false,
+          "canRemoveFlow": false,
+          "canRemoveStep": false,
+          "canReplaceStep": false,
+        },
+        "children": [
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [],
+            "data": {
+              "componentName": "timer",
+              "icon": "",
+              "isGroup": false,
+              "path": "from",
+              "processorName": "from",
+            },
+            "id": "timer-1234",
+            "nextNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                        "processorName": "setHeader",
+                      },
+                      "id": "setHeader-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.when.0",
+                    "processorName": "when",
+                  },
+                  "id": "when-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.otherwise.steps.0.log",
+                        "processorName": "log",
+                      },
+                      "id": "log-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.otherwise",
+                    "processorName": "otherwise",
+                  },
+                  "id": "otherwise-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice",
+                "processorName": "choice",
+              },
+              "id": "choice-1234",
+              "nextNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "data": {
+                  "componentName": "sql",
+                  "icon": "",
+                  "path": "from.steps.1.to",
+                  "processorName": "to",
+                },
+                "id": "sql-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": [Circular],
+              },
+              "parentNode": [Circular],
+              "previousNode": [Circular],
+            },
+            "parentNode": [Circular],
+            "previousNode": undefined,
+          },
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "children": [
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                      "processorName": "setHeader",
+                    },
+                    "id": "setHeader-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice.when.0",
+                  "processorName": "when",
+                },
+                "id": "when-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+              VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [
+                  VisualizationNode {
+                    "DISABLED_NODE_INTERACTION": {
+                      "canBeDisabled": false,
+                      "canHaveChildren": false,
+                      "canHaveNextStep": false,
+                      "canHavePreviousStep": false,
+                      "canHaveSpecialChildren": false,
+                      "canRemoveFlow": false,
+                      "canRemoveStep": false,
+                      "canReplaceStep": false,
+                    },
+                    "data": {
+                      "componentName": undefined,
+                      "icon": "",
+                      "path": "from.steps.0.choice.otherwise.steps.0.log",
+                      "processorName": "log",
+                    },
+                    "id": "log-1234",
+                    "nextNode": undefined,
+                    "parentNode": [Circular],
+                    "previousNode": undefined,
+                  },
+                ],
+                "data": {
+                  "componentName": undefined,
+                  "icon": "",
+                  "isGroup": true,
+                  "path": "from.steps.0.choice.otherwise",
+                  "processorName": "otherwise",
+                },
+                "id": "otherwise-1234",
+                "nextNode": undefined,
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            ],
+            "data": {
+              "componentName": undefined,
+              "icon": "",
+              "isGroup": true,
+              "path": "from.steps.0.choice",
+              "processorName": "choice",
+            },
+            "id": "choice-1234",
+            "nextNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "data": {
+                "componentName": "sql",
+                "icon": "",
+                "path": "from.steps.1.to",
+                "processorName": "to",
+              },
+              "id": "sql-1234",
+              "nextNode": undefined,
+              "parentNode": [Circular],
+              "previousNode": [Circular],
+            },
+            "parentNode": [Circular],
+            "previousNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [],
+              "data": {
+                "componentName": "timer",
+                "icon": "",
+                "isGroup": false,
+                "path": "from",
+                "processorName": "from",
+              },
+              "id": "timer-1234",
+              "nextNode": [Circular],
+              "parentNode": [Circular],
+              "previousNode": undefined,
+            },
+          },
+          VisualizationNode {
+            "DISABLED_NODE_INTERACTION": {
+              "canBeDisabled": false,
+              "canHaveChildren": false,
+              "canHaveNextStep": false,
+              "canHavePreviousStep": false,
+              "canHaveSpecialChildren": false,
+              "canRemoveFlow": false,
+              "canRemoveStep": false,
+              "canReplaceStep": false,
+            },
+            "data": {
+              "componentName": "sql",
+              "icon": "",
+              "path": "from.steps.1.to",
+              "processorName": "to",
+            },
+            "id": "sql-1234",
+            "nextNode": undefined,
+            "parentNode": [Circular],
+            "previousNode": VisualizationNode {
+              "DISABLED_NODE_INTERACTION": {
+                "canBeDisabled": false,
+                "canHaveChildren": false,
+                "canHaveNextStep": false,
+                "canHavePreviousStep": false,
+                "canHaveSpecialChildren": false,
+                "canRemoveFlow": false,
+                "canRemoveStep": false,
+                "canReplaceStep": false,
+              },
+              "children": [
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.when.0.steps.0.setHeader",
+                        "processorName": "setHeader",
+                      },
+                      "id": "setHeader-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.when.0",
+                    "processorName": "when",
+                  },
+                  "id": "when-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+                VisualizationNode {
+                  "DISABLED_NODE_INTERACTION": {
+                    "canBeDisabled": false,
+                    "canHaveChildren": false,
+                    "canHaveNextStep": false,
+                    "canHavePreviousStep": false,
+                    "canHaveSpecialChildren": false,
+                    "canRemoveFlow": false,
+                    "canRemoveStep": false,
+                    "canReplaceStep": false,
+                  },
+                  "children": [
+                    VisualizationNode {
+                      "DISABLED_NODE_INTERACTION": {
+                        "canBeDisabled": false,
+                        "canHaveChildren": false,
+                        "canHaveNextStep": false,
+                        "canHavePreviousStep": false,
+                        "canHaveSpecialChildren": false,
+                        "canRemoveFlow": false,
+                        "canRemoveStep": false,
+                        "canReplaceStep": false,
+                      },
+                      "data": {
+                        "componentName": undefined,
+                        "icon": "",
+                        "path": "from.steps.0.choice.otherwise.steps.0.log",
+                        "processorName": "log",
+                      },
+                      "id": "log-1234",
+                      "nextNode": undefined,
+                      "parentNode": [Circular],
+                      "previousNode": undefined,
+                    },
+                  ],
+                  "data": {
+                    "componentName": undefined,
+                    "icon": "",
+                    "isGroup": true,
+                    "path": "from.steps.0.choice.otherwise",
+                    "processorName": "otherwise",
+                  },
+                  "id": "otherwise-1234",
+                  "nextNode": undefined,
+                  "parentNode": [Circular],
+                  "previousNode": undefined,
+                },
+              ],
+              "data": {
+                "componentName": undefined,
+                "icon": "",
+                "isGroup": true,
+                "path": "from.steps.0.choice",
+                "processorName": "choice",
+              },
+              "id": "choice-1234",
+              "nextNode": [Circular],
+              "parentNode": [Circular],
+              "previousNode": VisualizationNode {
+                "DISABLED_NODE_INTERACTION": {
+                  "canBeDisabled": false,
+                  "canHaveChildren": false,
+                  "canHaveNextStep": false,
+                  "canHavePreviousStep": false,
+                  "canHaveSpecialChildren": false,
+                  "canRemoveFlow": false,
+                  "canRemoveStep": false,
+                  "canReplaceStep": false,
+                },
+                "children": [],
+                "data": {
+                  "componentName": "timer",
+                  "icon": "",
+                  "isGroup": false,
+                  "path": "from",
+                  "processorName": "from",
+                },
+                "id": "timer-1234",
+                "nextNode": [Circular],
+                "parentNode": [Circular],
+                "previousNode": undefined,
+              },
+            },
+          },
+        ],
+        "data": {
+          "entity": {
+            "route": {
+              "from": {
+                "id": "from-4014",
+                "parameters": {
+                  "period": "1000",
+                },
+                "steps": [
+                  {
+                    "choice": {
+                      "id": "choice-3431",
+                      "otherwise": {
+                        "id": "otherwise-3653",
+                        "steps": [
+                          {
+                            "log": {
+                              "id": "log-6808",
+                              "message": "\${body}",
+                            },
+                          },
+                        ],
+                      },
+                      "when": [
+                        {
+                          "expression": {
+                            "simple": {
+                              "expression": "\${header.foo} == 1",
+                            },
+                          },
+                          "id": "when-4112",
+                          "steps": [
+                            {
+                              "setHeader": {
+                                "expression": {
+                                  "simple": {},
+                                },
+                                "id": "setHeader-6078",
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    "to": {
+                      "id": "to-3757",
+                      "parameters": {},
+                      "uri": "sql",
+                    },
+                  },
+                ],
+                "uri": "timer:template",
+              },
+              "id": "route-2768",
+            },
+          },
+          "icon": "",
+          "isGroup": true,
+          "path": "#",
+          "processorName": "route",
+        },
+        "id": "route-2768-1234",
+        "nextNode": undefined,
+        "parentNode": undefined,
+        "previousNode": undefined,
+      },
+    },
+    "group": true,
+    "id": "route-2768-1234",
+    "label": "route-2768-1234",
+    "parentNode": undefined,
+    "style": {
+      "padding": 60,
+    },
+    "type": "group",
+  },
+]
+`;
+
+exports[`Nodes and Edges should generate edges for steps with branches 2`] = `
+[
+  {
+    "edgeStyle": "solid",
+    "id": "timer-1234-to-choice-1234",
+    "source": "timer-1234",
+    "target": "choice-1234",
+    "type": "edge",
+  },
+  {
+    "edgeStyle": "solid",
+    "id": "choice-1234-to-sql-1234",
+    "source": "choice-1234",
+    "target": "sql-1234",
+    "type": "edge",
+  },
+]
+`;

--- a/packages/ui/src/tests/nodes-edges.test.ts
+++ b/packages/ui/src/tests/nodes-edges.test.ts
@@ -1,0 +1,21 @@
+import { CamelRouteResource } from '../models/camel';
+import { CanvasService } from '../components/Visualization/Canvas/canvas.service';
+import { camelRouteBranch } from '../stubs/camel-route-branch';
+
+describe('Nodes and Edges', () => {
+  beforeEach(() => {
+    CanvasService.nodes = [];
+    CanvasService.edges = [];
+  });
+
+  it('should generate edges for steps with branches', () => {
+    const camelResource = new CamelRouteResource(camelRouteBranch);
+    const [camelRoute] = camelResource.getVisualEntities();
+
+    const rootVizNode = camelRoute.toVizNode();
+    const { nodes, edges } = CanvasService.getFlowDiagram(rootVizNode);
+
+    expect(nodes).toMatchSnapshot();
+    expect(edges).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
### Context
Currently, all children are rendered as individual nodes in the Canvas, making it complicated to understand when a step belongs to a parent EIP or if it comes as a next step in the Camel Route.

This commit adds support for rendering EIP branches as containers.

#### [Live instance](https://lordrip.github.io/kaoto/)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8f01f3db-90b4-4d5b-9587-ecf03b457c17) | ![image](https://github.com/user-attachments/assets/1940caba-7d70-4948-adf7-8c057617e40f) |

fix: https://github.com/KaotoIO/kaoto/issues/368