### PR TITLE
chore: Remove  since is not needed

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,6 @@
     "lint:style:fix": "yarn lint:style --fix"
   },
   "dependencies": {
-    "@dagrejs/dagre": "1.1.3",
     "@kaoto-next/uniforms-patternfly": "^0.6.15",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/notifications": "0.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,15 +1685,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dagrejs/dagre@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@dagrejs/dagre@npm:1.1.3"
-  dependencies:
-    "@dagrejs/graphlib": 2.2.2
-  checksum: f9bb8e00aaa5342887974068e0c534cdc65b444ee3a9fbfebe546b5129c478b67c7772f1470ecfeedeba7d2d5894d3355714fed56a937dddc3c4aa0c3f170901
-  languageName: node
-  linkType: hard
-
 "@dagrejs/graphlib@npm:2.2.2":
   version: 2.2.2
   resolution: "@dagrejs/graphlib@npm:2.2.2"
@@ -2606,7 +2597,6 @@ __metadata:
     "@babel/preset-env": ^7.21.5
     "@babel/preset-react": ^7.18.6
     "@babel/preset-typescript": ^7.21.5
-    "@dagrejs/dagre": 1.1.3
     "@kaoto-next/uniforms-patternfly": ^0.6.15
     "@kaoto/camel-catalog": "workspace:*"
     "@kie-tools-core/editor": 0.32.0


### PR DESCRIPTION
After upgrading [`@patternfly/react-topology`](https://github.com/KaotoIO/kaoto/pull/1302), calculating the layout inside of Kaoto is not needed anymore, so `@dagre/dagrejs` is also not needed.

relates: https://github.com/patternfly/react-topology/issues/230