### PR TITLE
chore(viz): Remove unused `populateLeafNodesIds` method

### DIFF
--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -107,8 +107,6 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
 
   removeChild(): void;
 
-  populateLeafNodesIds(ids: string[]): void;
-
   /** Retrieve the node's validation status, relying into the underlying entity */
   getNodeValidationText(): string | undefined;
 }

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -196,43 +196,6 @@ describe('VisualizationNode', () => {
     });
   });
 
-  it('should populate the leaf nodes ids - simple relationship', () => {
-    const child = createVisualizationNode('child', {});
-    node.addChild(child);
-
-    const leafNode = createVisualizationNode('leaf', {});
-    child.addChild(leafNode);
-
-    const ids: string[] = [];
-    node.populateLeafNodesIds(ids);
-
-    expect(ids).toEqual(['leaf-1234']);
-  });
-
-  it('should populate the leaf nodes ids - complex relationship', () => {
-    const choiceNode = createVisualizationNode('choice', {});
-    node.addChild(choiceNode);
-
-    const whenNode = createVisualizationNode('when', {});
-    choiceNode.addChild(whenNode);
-
-    const otherwiseNode = createVisualizationNode('otherwise', {});
-    choiceNode.addChild(otherwiseNode);
-
-    const whenLeafNode = createVisualizationNode('when-leaf', {});
-    whenNode.addChild(whenLeafNode);
-
-    const processNode = createVisualizationNode('process', {});
-    otherwiseNode.addChild(processNode);
-    const logNode = createVisualizationNode('log', {});
-    processNode.addChild(logNode);
-
-    const ids: string[] = [];
-    node.populateLeafNodesIds(ids);
-
-    expect(ids).toEqual(['when-leaf-1234', 'log-1234']);
-  });
-
   describe('getNodeValidationText', () => {
     it('should return undefined when the underlying BaseVisualCamelEntity is not defined', () => {
       node = createVisualizationNode('test', {});

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -115,17 +115,6 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     }
   }
 
-  populateLeafNodesIds(ids: string[]): void {
-    /** If this node doesn't have a next node neither children, it can be considered a leaf node */
-    if (this.nextNode === undefined && this.children === undefined) {
-      ids.push(this.id);
-      return;
-    }
-
-    /** If this node has children, populate the leaf nodes ids of each child */
-    this.children?.forEach((child) => child.populateLeafNodesIds(ids));
-  }
-
   getNodeValidationText(): string | undefined {
     return this.getBaseEntity()?.getNodeValidationText(this.data.path);
   }


### PR DESCRIPTION
### Context
With the introduction of containers for branches (https://github.com/KaotoIO/kaoto/pull/1300), connecting leaf nodes with the previous elements are different.

The use of this method [was removed here](https://github.com/KaotoIO/kaoto/pull/1300/files#diff-3efb01a9b66d3cdfa36a64cf79ca88d897711024f496b0ba1285ba642f82fa3eL215)

fix: https://github.com/KaotoIO/kaoto/issues/368
fix: https://github.com/KaotoIO/kaoto/issues/1329