### PR TITLE
Add sidebar width preserve in local storage

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -48,6 +48,10 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
   const [selectedNode, setSelectedNode] = useState<CanvasNode | undefined>(undefined);
   const [nodes, setNodes] = useState<CanvasNode[]>([]);
   const [activeLayout, setActiveLayout] = useLocalStorage(LocalStorageKeys.CanvasLayout, CanvasDefaults.DEFAULT_LAYOUT);
+  const [sidebarWidth, setSidebarWidth] = useLocalStorage(
+    LocalStorageKeys.CanvasSidebarWidth,
+    CanvasDefaults.DEFAULT_SIDEBAR_WIDTH,
+  );
 
   /** Context to interact with the Canvas catalog */
   const catalogModalContext = useContext(CatalogModalContext);
@@ -206,6 +210,10 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
 
   return (
     <TopologyView
+      defaultSideBarSize={sidebarWidth + 'px'}
+      onSideBarResize={(width) => {
+        setSidebarWidth(width);
+      }}
       sideBarResizable
       sideBarOpen={isSidebarOpen}
       sideBar={<CanvasSideBar selectedNode={selectedNode} onClose={handleCloseSideBar} />}

--- a/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
@@ -6,4 +6,5 @@ export class CanvasDefaults {
   static readonly DEFAULT_NODE_SHAPE = NodeShape.rect;
   static readonly DEFAULT_NODE_DIAMETER = 75;
   static readonly DEFAULT_GROUP_PADDING = 50;
+  static readonly DEFAULT_SIDEBAR_WIDTH = 500;
 }

--- a/packages/ui/src/models/local-storage-keys.ts
+++ b/packages/ui/src/models/local-storage-keys.ts
@@ -2,6 +2,7 @@ export const enum LocalStorageKeys {
   SourceCode = 'sourceCode',
   CatalogLayout = 'catalogLayout',
   CanvasLayout = 'canvasLayout',
+  CanvasSidebarWidth = 'canvasSidebarWidth',
   NavigationExpanded = 'navigationExpanded',
   SelectedCatalog = 'selectedCatalog',
   Settings = 'settings',


### PR DESCRIPTION
Store the user specified sidebar width in local storage persisting the width even when switching tabs in the UI.

https://github.com/user-attachments/assets/79e1f796-37c9-4e46-a62e-5d178697fa27

