### PR TITLE
fix(1390): Pipe contextual menu broken buttons removed

### DIFF
--- a/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/pipe-visual-entity.test.ts.snap
@@ -4,12 +4,12 @@ exports[`Pipe getNodeInteraction should return the correct interaction for the '
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
-  "canHaveNextStep": true,
-  "canHavePreviousStep": true,
+  "canHaveNextStep": false,
+  "canHavePreviousStep": false,
   "canHaveSpecialChildren": false,
   "canRemoveFlow": true,
-  "canRemoveStep": true,
-  "canReplaceStep": true,
+  "canRemoveStep": false,
+  "canReplaceStep": false,
 }
 `;
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -188,13 +188,13 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     return {
       /** Pipe cannot have a Kamelet before the source property */
-      canHavePreviousStep: data.path !== 'source',
+      canHavePreviousStep: data.path !== ROOT_PATH && data.path !== 'source',
       /** Pipe cannot have a Kamelet after the sink property */
-      canHaveNextStep: data.path !== 'sink',
+      canHaveNextStep: data.path !== ROOT_PATH && data.path !== 'sink',
       canHaveChildren: false,
       canHaveSpecialChildren: false,
-      canReplaceStep: true,
-      canRemoveStep: true,
+      canReplaceStep: data.path !== ROOT_PATH,
+      canRemoveStep: data.path !== ROOT_PATH,
       canRemoveFlow: data.path === ROOT_PATH,
       canBeDisabled: false,
     };


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/1390

removed the unnecessary context buttons:
![Screenshot from 2024-09-05 11-38-51](https://github.com/user-attachments/assets/566107b6-3d84-448b-81a3-15c9bf17ebae)
