### PR TITLE
fix(CatalogGenerator): Ignore 'enum' property for multiValue param

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
@@ -174,7 +174,7 @@ public class CamelCatalogProcessor {
                 }
             }
 
-            if (property.has("enum")) {
+            if (property.has("enum") && !property.has("multiValue")) {
                 property.withArray("/enum")
                         .forEach(e -> propertySchema.withArray("/enum").add(e));
                 if (!propertySchema.has("type") || "object".equals(propertySchema.get("type").asText())) {


### PR DESCRIPTION
In Camel 4.8.0, there's an enum property over a multiValue parameter, making the configuration form to render a selector instead of a metadata editor.