### PR TITLE
fix(CanvasForm): Improvements over the `ParametersField` component

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/propertiesFilter.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/propertiesFilter.cy.ts
@@ -113,7 +113,7 @@ describe('Tests for side panel step filtering', () => {
 
     cy.selectFormTab('Required');
 
-    cy.get('.pf-v5-c-alert__title').should('contain', 'No Required Field Found');
+    cy.get('.pf-v5-c-alert__title').should('contain', 'No Required fields found');
   });
 
   it('Side panel to retain user specified fields filter', () => {

--- a/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasSideBar.stories.tsx
@@ -1,5 +1,6 @@
 import {
   CamelRouteVisualEntity,
+  CanvasFormTabsContext,
   CanvasNode,
   CanvasSideBar,
   IVisualizationNode,
@@ -99,9 +100,16 @@ const Template: StoryFn<typeof CanvasSideBar> = (args) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleClose = () => setIsModalOpen(!isModalOpen);
   return (
-    <VisibleFlowsProvider>
-      <CanvasSideBar {...args} onClose={handleClose} />
-    </VisibleFlowsProvider>
+    <CanvasFormTabsContext.Provider
+      value={{
+        selectedTab: 'All',
+        onTabChange: () => {},
+      }}
+    >
+      <VisibleFlowsProvider>
+        <CanvasSideBar {...args} onClose={handleClose} />
+      </VisibleFlowsProvider>
+    </CanvasFormTabsContext.Provider>
   );
 };
 

--- a/packages/ui/src/components/Form/CustomAutoFields.test.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.test.tsx
@@ -1,0 +1,40 @@
+import { act, render } from '@testing-library/react';
+import { KaotoSchemaDefinition } from '../../models';
+import { CanvasFormTabsProvider } from '../../providers';
+import { UniformsWrapper } from '../../stubs/TestUniformsWrapper';
+import { TimerComponentSchema } from '../../stubs/timer.component.schema';
+import { CustomAutoFields } from './CustomAutoFields';
+
+describe('CustomAutoFields', () => {
+  it('renders `AutoFields` for common fields', () => {
+    let wrapper: ReturnType<typeof render> | undefined;
+
+    act(() => {
+      wrapper = render(
+        <CanvasFormTabsProvider>
+          <UniformsWrapper model={{}} schema={TimerComponentSchema as KaotoSchemaDefinition['schema']}>
+            <CustomAutoFields />
+          </UniformsWrapper>
+        </CanvasFormTabsProvider>,
+      );
+    });
+
+    expect(wrapper?.asFragment()).toMatchSnapshot();
+  });
+
+  it('render `NoFieldFound` when there are no fields', () => {
+    let wrapper: ReturnType<typeof render> | undefined;
+
+    act(() => {
+      wrapper = render(
+        <CanvasFormTabsProvider>
+          <UniformsWrapper model={{}} schema={{ type: 'object' } as KaotoSchemaDefinition['schema']}>
+            <CustomAutoFields />
+          </UniformsWrapper>
+        </CanvasFormTabsProvider>,
+      );
+    });
+
+    expect(wrapper?.asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/components/Form/CustomAutoFields.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.tsx
@@ -27,7 +27,7 @@ export function CustomAutoFields({
   const { schema } = useForm();
   const rootField = schema.getField('');
   const { filteredFieldText, isGroupExpanded } = useContext(FilteredFieldContext);
-  const { selectedTab } = useContext(CanvasFormTabsContext);
+  const canvasFormTabsContext = useContext(CanvasFormTabsContext);
 
   /** Special handling for oneOf schemas */
   if (Array.isArray((rootField as KaotoSchemaDefinition['schema']).oneOf)) {
@@ -45,7 +45,7 @@ export function CustomAutoFields({
   const propertiesArray = getFieldGroups(actualFieldsSchema);
 
   if (
-    selectedTab !== 'All' &&
+    canvasFormTabsContext?.selectedTab !== 'All' &&
     propertiesArray.common.length === 0 &&
     Object.keys(propertiesArray.groups).length === 0
   ) {

--- a/packages/ui/src/components/Form/NoFieldFound.test.tsx
+++ b/packages/ui/src/components/Form/NoFieldFound.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CanvasFormTabsContext, CanvasFormTabsContextResult } from '../../providers';
+import { NoFieldFound } from './NoFieldFound';
+
+describe('NoFieldFound Component', () => {
+  it('should render null if canvasFormTabsContext is not provided', () => {
+    const { container } = render(<NoFieldFound />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render the alert with the correct tab name', () => {
+    const mockContextValue: CanvasFormTabsContextResult = {
+      selectedTab: 'Required',
+      onTabChange: jest.fn(),
+    };
+
+    render(
+      <CanvasFormTabsContext.Provider value={mockContextValue}>
+        <NoFieldFound />
+      </CanvasFormTabsContext.Provider>,
+    );
+
+    expect(screen.getByTestId('no-field-found')).toBeInTheDocument();
+    expect(screen.getByText('No Required fields found')).toBeInTheDocument();
+  });
+
+  it('should call onTabChange when the button is clicked', () => {
+    const mockContextValue: CanvasFormTabsContextResult = {
+      selectedTab: 'Required',
+      onTabChange: jest.fn(),
+    };
+
+    render(
+      <CanvasFormTabsContext.Provider value={mockContextValue}>
+        <NoFieldFound />
+      </CanvasFormTabsContext.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: /All/i });
+    fireEvent.click(button);
+
+    expect(mockContextValue.onTabChange).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Form/NoFieldFound.tsx
+++ b/packages/ui/src/components/Form/NoFieldFound.tsx
@@ -3,13 +3,18 @@ import { FunctionComponent, useContext } from 'react';
 import { CanvasFormTabsContext } from '../../providers';
 
 export const NoFieldFound: FunctionComponent = () => {
-  const { selectedTab, onTabChange } = useContext(CanvasFormTabsContext);
+  const canvasFormTabsContext = useContext(CanvasFormTabsContext);
+
+  if (!canvasFormTabsContext) {
+    return null;
+  }
+
   return (
-    <Card>
+    <Card data-testid="no-field-found">
       <CardBody>
-        <Alert variant="info" title={`No ${selectedTab} Field Found`}>
+        <Alert variant="info" title={`No ${canvasFormTabsContext.selectedTab} fields found`}>
           No field found matching this criteria. Please switch to the{' '}
-          <Button id="All" onClick={(e) => onTabChange(e, true)} variant="link" isInline>
+          <Button id="All" onClick={canvasFormTabsContext.onTabChange} variant="link" isInline>
             <b>All</b>
           </Button>{' '}
           tab.

--- a/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
@@ -1,8 +1,6 @@
-import { AutoForm } from '@kaoto-next/uniforms-patternfly';
 import { act, fireEvent, render } from '@testing-library/react';
-import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { KaotoSchemaDefinition } from '../../../models/kaoto-schema';
-import { SchemaBridgeContext } from '../../../providers/schema-bridge.provider';
+import { UniformsWrapper } from '../../../stubs/TestUniformsWrapper';
 import { SchemaService } from '../schema.service';
 import { OneOfField } from './OneOfField';
 
@@ -88,28 +86,3 @@ describe('OneOfField', () => {
     expect(nameField).toHaveValue('');
   });
 });
-
-const UniformsWrapper: FunctionComponent<
-  PropsWithChildren<{
-    model: Record<string, unknown>;
-    schema: KaotoSchemaDefinition['schema'];
-  }>
-> = (props) => {
-  const schemaBridge = new SchemaService().getSchemaBridge(props.schema);
-  const divRef = useRef<HTMLDivElement>(null);
-  const [, setLastRenderTimestamp] = useState<number>(-1);
-
-  useEffect(() => {
-    /** Force re-render to update the divRef */
-    setLastRenderTimestamp(Date.now());
-  }, []);
-
-  return (
-    <SchemaBridgeContext.Provider value={{ schemaBridge, parentRef: divRef }}>
-      <AutoForm model={props.model} schema={schemaBridge}>
-        {props.children}
-      </AutoForm>
-      <div ref={divRef} />
-    </SchemaBridgeContext.Provider>
-  );
-};

--- a/packages/ui/src/components/Form/__snapshots__/CustomAutoFields.test.tsx.snap
+++ b/packages/ui/src/components/Form/__snapshots__/CustomAutoFields.test.tsx.snap
@@ -1,0 +1,1582 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomAutoFields render \`NoFieldFound\` when there are no fields 1`] = `
+<DocumentFragment>
+  <form
+    class="pf-v5-c-form"
+    data-testid="base-form"
+    novalidate=""
+  >
+    <div
+      class="pf-v5-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-4"
+      data-ouia-component-type="PF5/Card"
+      data-ouia-safe="true"
+      data-testid="no-field-found"
+      id=""
+    >
+      <div
+        class="pf-v5-c-card__body"
+      >
+        <div
+          class="pf-v5-c-alert pf-m-info"
+          data-ouia-component-id="OUIA-Generated-Alert-info-1"
+          data-ouia-component-type="PF5/Alert"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-v5-c-alert__icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v5-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+              />
+            </svg>
+          </div>
+          <h4
+            class="pf-v5-c-alert__title"
+          >
+            <span
+              class="pf-v5-screen-reader"
+            >
+              Info alert:
+            </span>
+            No Required fields found
+          </h4>
+          <div
+            class="pf-v5-c-alert__description"
+          >
+            No field found matching this criteria. Please switch to the 
+            <button
+              aria-disabled="false"
+              class="pf-v5-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-1"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              id="All"
+              type="button"
+            >
+              <b>
+                All
+              </b>
+            </button>
+             tab.
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div />
+</DocumentFragment>
+`;
+
+exports[`CustomAutoFields renders \`AutoFields\` for common fields 1`] = `
+<DocumentFragment>
+  <form
+    class="pf-v5-c-form"
+    data-testid="base-form"
+    novalidate=""
+  >
+    <div>
+      <div
+        class="pf-v5-c-form__group"
+        data-fieldname="timerName"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="uniforms-0000-0001"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Timer Name
+            </span>
+            <span
+              aria-hidden="true"
+              class="pf-v5-c-form__label-required"
+            >
+               *
+            </span>
+          </label>
+           
+          <div
+            style="display: contents;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="More info for field"
+              class="pf-v5-c-button pf-m-plain field-hint-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              data-testid="field-hint-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <span
+            class="pf-v5-c-form-control"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="uniforms text field"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+              data-ouia-component-type="PF5/TextInput"
+              data-ouia-safe="true"
+              data-testid="text-field"
+              description="The name of the timer"
+              group="consumer"
+              id="uniforms-0000-0001"
+              label="Timer Name"
+              name="timerName"
+              type="text"
+              value=""
+            />
+          </span>
+          <div
+            class="pf-v5-c-form__helper-text"
+          >
+            <div
+              class="pf-v5-c-helper-text"
+            >
+              <div
+                class="pf-v5-c-helper-text__item"
+              >
+                <span
+                  class="pf-v5-c-helper-text__item-text"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-form__group"
+        data-fieldname="delay"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="uniforms-0000-0003"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Delay
+            </span>
+          </label>
+           
+          <div
+            style="display: contents;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="More info for field"
+              class="pf-v5-c-button pf-m-plain field-hint-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              data-testid="field-hint-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <span
+            class="pf-v5-c-form-control"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="uniforms text field"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+              data-ouia-component-type="PF5/TextInput"
+              data-ouia-safe="true"
+              data-testid="text-field"
+              description="The number of milliseconds to wait before the first event is generated. Should not be used in conjunction with the time option. The default value is 1000."
+              group="consumer"
+              id="uniforms-0000-0003"
+              label="Delay"
+              name="delay"
+              type="text"
+              value="1000"
+            />
+          </span>
+          <div
+            class="pf-v5-c-form__helper-text"
+          >
+            <div
+              class="pf-v5-c-helper-text"
+            >
+              <div
+                class="pf-v5-c-helper-text__item"
+              >
+                <span
+                  class="pf-v5-c-helper-text__item-text"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-form__group"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <div
+            style="display: flex; align-items: center;"
+          >
+             
+            <div
+              class="pf-v5-c-check"
+            >
+              <input
+                aria-invalid="false"
+                class="pf-v5-c-check__input"
+                data-ouia-component-id="OUIA-Generated-Checkbox-1"
+                data-ouia-component-type="PF5/Checkbox"
+                data-ouia-safe="true"
+                data-testid="bool-field"
+                id="uniforms-0000-0005"
+                name="fixedRate"
+                type="checkbox"
+              />
+              <label
+                class="pf-v5-c-check__label"
+                for="uniforms-0000-0005"
+              >
+                Fixed Rate
+              </label>
+            </div>
+            <div
+              style="display: contents;"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="More info for field"
+                class="pf-v5-c-button pf-m-plain field-hint-button"
+                data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                data-ouia-component-type="PF5/Button"
+                data-ouia-safe="true"
+                data-testid="field-hint-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v5-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="pf-v5-c-form__helper-text"
+            >
+              <div
+                class="pf-v5-c-helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text__item"
+                >
+                  <span
+                    class="pf-v5-c-helper-text__item-text"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-form__group"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <div
+            style="display: flex; align-items: center;"
+          >
+             
+            <div
+              class="pf-v5-c-check"
+            >
+              <input
+                aria-invalid="false"
+                class="pf-v5-c-check__input"
+                data-ouia-component-id="OUIA-Generated-Checkbox-2"
+                data-ouia-component-type="PF5/Checkbox"
+                data-ouia-safe="true"
+                data-testid="bool-field"
+                id="uniforms-0000-0007"
+                name="includeMetadata"
+                type="checkbox"
+              />
+              <label
+                class="pf-v5-c-check__label"
+                for="uniforms-0000-0007"
+              >
+                Include Metadata
+              </label>
+            </div>
+            <div
+              style="display: contents;"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="More info for field"
+                class="pf-v5-c-button pf-m-plain field-hint-button"
+                data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                data-ouia-component-type="PF5/Button"
+                data-ouia-safe="true"
+                data-testid="field-hint-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v5-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="pf-v5-c-form__helper-text"
+            >
+              <div
+                class="pf-v5-c-helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text__item"
+                >
+                  <span
+                    class="pf-v5-c-helper-text__item-text"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-form__group"
+        data-fieldname="period"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="uniforms-0000-0009"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Period
+            </span>
+          </label>
+           
+          <div
+            style="display: contents;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="More info for field"
+              class="pf-v5-c-button pf-m-plain field-hint-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              data-testid="field-hint-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <span
+            class="pf-v5-c-form-control"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="uniforms text field"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+              data-ouia-component-type="PF5/TextInput"
+              data-ouia-safe="true"
+              data-testid="text-field"
+              description="Generate periodic events every period. Must be zero or positive value. The default value is 1000."
+              group="consumer"
+              id="uniforms-0000-0009"
+              label="Period"
+              name="period"
+              type="text"
+              value="1000"
+            />
+          </span>
+          <div
+            class="pf-v5-c-form__helper-text"
+          >
+            <div
+              class="pf-v5-c-helper-text"
+            >
+              <div
+                class="pf-v5-c-helper-text__item"
+              >
+                <span
+                  class="pf-v5-c-helper-text__item-text"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-form__group"
+        data-fieldname="repeatCount"
+        data-testid="wrapper-field"
+        group="consumer"
+      >
+        <div
+          class="pf-v5-c-form__group-label"
+        >
+          <label
+            class="pf-v5-c-form__label"
+            for="uniforms-0000-000b"
+          >
+            <span
+              class="pf-v5-c-form__label-text"
+            >
+              Repeat Count
+            </span>
+          </label>
+           
+          <div
+            style="display: contents;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="More info for field"
+              class="pf-v5-c-button pf-m-plain field-hint-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              data-testid="field-hint-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-form__group-control"
+        >
+          <span
+            class="pf-v5-c-form-control"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="uniforms num field"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+              data-ouia-component-type="PF5/TextInput"
+              data-ouia-safe="true"
+              data-testid="num-field"
+              id="uniforms-0000-000b"
+              name="repeatCount"
+              step="1"
+              type="number"
+              value=""
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-expandable-section"
+      >
+        <button
+          aria-controls="expandable-section-content"
+          aria-expanded="false"
+          class="pf-v5-c-expandable-section__toggle"
+          id="expandable-section-toggle"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-expandable-section__toggle-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v5-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
+          </span>
+          <span
+            class="pf-v5-c-expandable-section__toggle-text"
+          >
+            Processor consumer (advanced) properties
+          </span>
+        </button>
+        <div
+          aria-labelledby="expandable-section-toggle"
+          class="pf-v5-c-expandable-section__content"
+          hidden=""
+          id="expandable-section-content"
+          role="region"
+        >
+          <div
+            class="pf-v5-c-card pf-m-flat nest-field-card"
+            data-ouia-component-id="OUIA-Generated-Card-1"
+            data-ouia-component-type="PF5/Card"
+            data-ouia-safe="true"
+            id=""
+          >
+            <div
+              class="pf-v5-c-card__body nest-field-card-body"
+            >
+              <div
+                class="pf-v5-c-form__group"
+                data-testid="wrapper-field"
+                group="consumer (advanced)"
+              >
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <div
+                    style="display: flex; align-items: center;"
+                  >
+                     
+                    <div
+                      class="pf-v5-c-check"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="pf-v5-c-check__input"
+                        data-ouia-component-id="OUIA-Generated-Checkbox-3"
+                        data-ouia-component-type="PF5/Checkbox"
+                        data-ouia-safe="true"
+                        data-testid="bool-field"
+                        id="uniforms-0000-000d"
+                        name="bridgeErrorHandler"
+                        type="checkbox"
+                      />
+                      <label
+                        class="pf-v5-c-check__label"
+                        for="uniforms-0000-000d"
+                      >
+                        Bridge Error Handler
+                      </label>
+                    </div>
+                    <div
+                      style="display: contents;"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="More info for field"
+                        class="pf-v5-c-button pf-m-plain field-hint-button"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        data-testid="field-hint-button"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 1024 1024"
+                          width="1em"
+                        >
+                          <path
+                            d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v5-c-form__helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text"
+                      >
+                        <div
+                          class="pf-v5-c-helper-text__item"
+                        >
+                          <span
+                            class="pf-v5-c-helper-text__item-text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="exceptionHandler"
+                data-testid="wrapper-field"
+                group="consumer (advanced)"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000f"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Exception Handler
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <span
+                    class="pf-v5-c-form-control"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="uniforms text field"
+                      data-ouia-component-id="OUIA-Generated-TextInputBase-5"
+                      data-ouia-component-type="PF5/TextInput"
+                      data-ouia-safe="true"
+                      data-testid="text-field"
+                      description="To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored."
+                      group="consumer (advanced)"
+                      id="uniforms-0000-000f"
+                      label="Exception Handler"
+                      name="exceptionHandler"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <div
+                    class="pf-v5-c-form__helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text__item"
+                      >
+                        <span
+                          class="pf-v5-c-helper-text__item-text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="exchangePattern"
+                data-testid="wrapper-field"
+                group="consumer (advanced)"
+                options="[object Object],[object Object]"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000h"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Exchange Pattern
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <div
+                    data-testid="select-inputs-field"
+                    id="uniforms-0000-000h"
+                  >
+                    <span
+                      class="pf-v5-c-form-control"
+                    >
+                      <select
+                        aria-invalid="false"
+                        data-ouia-component-id="OUIA-Generated-FormSelect-default-1"
+                        data-ouia-component-type="PF5/FormSelect"
+                        data-ouia-safe="true"
+                        id="uniforms-0000-000h"
+                        name="exchangePattern"
+                        role="listbox"
+                      >
+                        <option
+                          class=""
+                          value="InOnly"
+                        >
+                          InOnly
+                        </option>
+                        <option
+                          class=""
+                          value="InOut"
+                        >
+                          InOut
+                        </option>
+                      </select>
+                      <span
+                        class="pf-v5-c-form-control__utilities"
+                      >
+                        <span
+                          class="pf-v5-c-form-control__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-expandable-section"
+      >
+        <button
+          aria-controls="expandable-section-content"
+          aria-expanded="false"
+          class="pf-v5-c-expandable-section__toggle"
+          id="expandable-section-toggle"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-expandable-section__toggle-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v5-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
+          </span>
+          <span
+            class="pf-v5-c-expandable-section__toggle-text"
+          >
+            Processor advanced properties
+          </span>
+        </button>
+        <div
+          aria-labelledby="expandable-section-toggle"
+          class="pf-v5-c-expandable-section__content"
+          hidden=""
+          id="expandable-section-content"
+          role="region"
+        >
+          <div
+            class="pf-v5-c-card pf-m-flat nest-field-card"
+            data-ouia-component-id="OUIA-Generated-Card-2"
+            data-ouia-component-type="PF5/Card"
+            data-ouia-safe="true"
+            id=""
+          >
+            <div
+              class="pf-v5-c-card__body nest-field-card-body"
+            >
+              <div
+                class="pf-v5-c-form__group"
+                data-testid="wrapper-field"
+                group="advanced"
+              >
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <div
+                    style="display: flex; align-items: center;"
+                  >
+                     
+                    <div
+                      class="pf-v5-c-check"
+                    >
+                      <input
+                        aria-invalid="false"
+                        checked=""
+                        class="pf-v5-c-check__input"
+                        data-ouia-component-id="OUIA-Generated-Checkbox-4"
+                        data-ouia-component-type="PF5/Checkbox"
+                        data-ouia-safe="true"
+                        data-testid="bool-field"
+                        id="uniforms-0000-000j"
+                        name="daemon"
+                        type="checkbox"
+                      />
+                      <label
+                        class="pf-v5-c-check__label"
+                        for="uniforms-0000-000j"
+                      >
+                        Daemon
+                      </label>
+                    </div>
+                    <div
+                      style="display: contents;"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="More info for field"
+                        class="pf-v5-c-button pf-m-plain field-hint-button"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        data-testid="field-hint-button"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 1024 1024"
+                          width="1em"
+                        >
+                          <path
+                            d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v5-c-form__helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text"
+                      >
+                        <div
+                          class="pf-v5-c-helper-text__item"
+                        >
+                          <span
+                            class="pf-v5-c-helper-text__item-text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="pattern"
+                data-testid="wrapper-field"
+                group="advanced"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000l"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Pattern
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <span
+                    class="pf-v5-c-form-control"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="uniforms text field"
+                      data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                      data-ouia-component-type="PF5/TextInput"
+                      data-ouia-safe="true"
+                      data-testid="text-field"
+                      description="Allows you to specify a custom Date pattern to use for setting the time option using URI syntax."
+                      group="advanced"
+                      id="uniforms-0000-000l"
+                      label="Pattern"
+                      name="pattern"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <div
+                    class="pf-v5-c-form__helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text__item"
+                      >
+                        <span
+                          class="pf-v5-c-helper-text__item-text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-testid="wrapper-field"
+                group="advanced"
+              >
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <div
+                    style="display: flex; align-items: center;"
+                  >
+                     
+                    <div
+                      class="pf-v5-c-check"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="pf-v5-c-check__input"
+                        data-ouia-component-id="OUIA-Generated-Checkbox-5"
+                        data-ouia-component-type="PF5/Checkbox"
+                        data-ouia-safe="true"
+                        data-testid="bool-field"
+                        id="uniforms-0000-000n"
+                        name="synchronous"
+                        type="checkbox"
+                      />
+                      <label
+                        class="pf-v5-c-check__label"
+                        for="uniforms-0000-000n"
+                      >
+                        Synchronous
+                      </label>
+                    </div>
+                    <div
+                      style="display: contents;"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="More info for field"
+                        class="pf-v5-c-button pf-m-plain field-hint-button"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        data-testid="field-hint-button"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 1024 1024"
+                          width="1em"
+                        >
+                          <path
+                            d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v5-c-form__helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text"
+                      >
+                        <div
+                          class="pf-v5-c-helper-text__item"
+                        >
+                          <span
+                            class="pf-v5-c-helper-text__item-text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="time"
+                data-testid="wrapper-field"
+                group="advanced"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000p"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Time
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <span
+                    class="pf-v5-c-form-control"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="uniforms text field"
+                      data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+                      data-ouia-component-type="PF5/TextInput"
+                      data-ouia-safe="true"
+                      data-testid="text-field"
+                      description="A java.util.Date the first event should be generated. If using the URI, the pattern expected is: yyyy-MM-dd HH:mm:ss or yyyy-MM-dd'T'HH:mm:ss."
+                      group="advanced"
+                      id="uniforms-0000-000p"
+                      label="Time"
+                      name="time"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <div
+                    class="pf-v5-c-form__helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text__item"
+                      >
+                        <span
+                          class="pf-v5-c-helper-text__item-text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="timer"
+                data-testid="wrapper-field"
+                group="advanced"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000r"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Timer
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <span
+                    class="pf-v5-c-form-control"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="uniforms text field"
+                      data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+                      data-ouia-component-type="PF5/TextInput"
+                      data-ouia-safe="true"
+                      data-testid="text-field"
+                      description="To use a custom Timer"
+                      group="advanced"
+                      id="uniforms-0000-000r"
+                      label="Timer"
+                      name="timer"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <div
+                    class="pf-v5-c-form__helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text"
+                    >
+                      <div
+                        class="pf-v5-c-helper-text__item"
+                      >
+                        <span
+                          class="pf-v5-c-helper-text__item-text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-expandable-section"
+      >
+        <button
+          aria-controls="expandable-section-content"
+          aria-expanded="false"
+          class="pf-v5-c-expandable-section__toggle"
+          id="expandable-section-toggle"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-expandable-section__toggle-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v5-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
+          </span>
+          <span
+            class="pf-v5-c-expandable-section__toggle-text"
+          >
+            Processor scheduler properties
+          </span>
+        </button>
+        <div
+          aria-labelledby="expandable-section-toggle"
+          class="pf-v5-c-expandable-section__content"
+          hidden=""
+          id="expandable-section-content"
+          role="region"
+        >
+          <div
+            class="pf-v5-c-card pf-m-flat nest-field-card"
+            data-ouia-component-id="OUIA-Generated-Card-3"
+            data-ouia-component-type="PF5/Card"
+            data-ouia-safe="true"
+            id=""
+          >
+            <div
+              class="pf-v5-c-card__body nest-field-card-body"
+            >
+              <div
+                class="pf-v5-c-form__group"
+                data-fieldname="runLoggingLevel"
+                data-testid="wrapper-field"
+                group="scheduler"
+                options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+              >
+                <div
+                  class="pf-v5-c-form__group-label"
+                >
+                  <label
+                    class="pf-v5-c-form__label"
+                    for="uniforms-0000-000t"
+                  >
+                    <span
+                      class="pf-v5-c-form__label-text"
+                    >
+                      Run Logging Level
+                    </span>
+                  </label>
+                   
+                  <div
+                    style="display: contents;"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="More info for field"
+                      class="pf-v5-c-button pf-m-plain field-hint-button"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      data-testid="field-hint-button"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 1024 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-form__group-control"
+                >
+                  <div
+                    data-testid="select-inputs-field"
+                    id="uniforms-0000-000t"
+                  >
+                    <span
+                      class="pf-v5-c-form-control"
+                    >
+                      <select
+                        aria-invalid="false"
+                        data-ouia-component-id="OUIA-Generated-FormSelect-default-2"
+                        data-ouia-component-type="PF5/FormSelect"
+                        data-ouia-safe="true"
+                        id="uniforms-0000-000t"
+                        name="runLoggingLevel"
+                        role="listbox"
+                      >
+                        <option
+                          class=""
+                          value="TRACE"
+                        >
+                          TRACE
+                        </option>
+                        <option
+                          class=""
+                          value="DEBUG"
+                        >
+                          DEBUG
+                        </option>
+                        <option
+                          class=""
+                          value="INFO"
+                        >
+                          INFO
+                        </option>
+                        <option
+                          class=""
+                          value="WARN"
+                        >
+                          WARN
+                        </option>
+                        <option
+                          class=""
+                          value="ERROR"
+                        >
+                          ERROR
+                        </option>
+                        <option
+                          class=""
+                          value="OFF"
+                        >
+                          OFF
+                        </option>
+                      </select>
+                      <span
+                        class="pf-v5-c-form-control__utilities"
+                      >
+                        <span
+                          class="pf-v5-c-form-control__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div />
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/Form/properties/AddPropertyButtons.tsx
+++ b/packages/ui/src/components/Form/properties/AddPropertyButtons.tsx
@@ -2,10 +2,11 @@ import { Button, Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { FolderPlusIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 type AddPropertyPopoverProps = {
-  showLabel?: boolean;
   path: string[];
-  disabled?: boolean;
   createPlaceholder: (isObject: boolean) => void;
+  canAddObjectProperties?: boolean;
+  showLabel?: boolean;
+  disabled?: boolean;
 };
 
 /**
@@ -14,10 +15,11 @@ type AddPropertyPopoverProps = {
  * @constructor
  */
 export function AddPropertyButtons({
-  showLabel = false,
   path,
-  disabled = false,
   createPlaceholder,
+  canAddObjectProperties = true,
+  showLabel = false,
+  disabled = false,
 }: AddPropertyPopoverProps) {
   return (
     <Split>
@@ -34,19 +36,22 @@ export function AddPropertyButtons({
           </Button>
         </Tooltip>
       </SplitItem>
-      <SplitItem>
-        <Tooltip content="Add object property">
-          <Button
-            data-testid={`properties-add-object-property-${path.join('-')}-btn`}
-            variant={'link'}
-            icon={<FolderPlusIcon />}
-            isDisabled={disabled}
-            onClick={() => createPlaceholder(true)}
-          >
-            {showLabel && 'Add object property'}
-          </Button>
-        </Tooltip>
-      </SplitItem>
+
+      {canAddObjectProperties && (
+        <SplitItem>
+          <Tooltip content="Add object property">
+            <Button
+              data-testid={`properties-add-object-property-${path.join('-')}-btn`}
+              variant={'link'}
+              icon={<FolderPlusIcon />}
+              isDisabled={disabled}
+              onClick={() => createPlaceholder(true)}
+            >
+              {showLabel && 'Add object property'}
+            </Button>
+          </Tooltip>
+        </SplitItem>
+      )}
     </Split>
   );
 }

--- a/packages/ui/src/components/Form/properties/PropertiesField.scss
+++ b/packages/ui/src/components/Form/properties/PropertiesField.scss
@@ -1,0 +1,19 @@
+$root-element: 'properties-field';
+
+.#{$root-element} {
+  .#{$root-element} &__head,
+  .#{$root-element} &__body {
+    .#{$root-element}__row__value {
+      max-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      --pf-v5-c-table--cell--PaddingLeft: 0 !important;
+    }
+
+    .#{$root-element}__row__action[data-column-type='action'] {
+      --pf-v5-c-table--cell--PaddingRight: 0 !important;
+    }
+  }
+}

--- a/packages/ui/src/components/Form/properties/PropertiesFieldEmptyState.tsx
+++ b/packages/ui/src/components/Form/properties/PropertiesFieldEmptyState.tsx
@@ -1,0 +1,30 @@
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import { AddPropertyButtons } from './AddPropertyButtons';
+
+interface IPropertiesFieldEmptyState {
+  name: string;
+  disabled: boolean;
+  canAddObjectProperties: boolean;
+  createPlaceholder: (isObject: boolean) => void;
+}
+
+export const PropertiesFieldEmptyState: FunctionComponent<IPropertiesFieldEmptyState> = ({
+  name,
+  disabled,
+  canAddObjectProperties,
+  createPlaceholder,
+}) => {
+  return (
+    <EmptyState>
+      <EmptyStateBody>No {name}</EmptyStateBody>
+      <AddPropertyButtons
+        showLabel
+        path={[]}
+        disabled={disabled}
+        canAddObjectProperties={canAddObjectProperties}
+        createPlaceholder={createPlaceholder}
+      />
+    </EmptyState>
+  );
+};

--- a/packages/ui/src/components/Form/properties/PropertyRow.scss
+++ b/packages/ui/src/components/Form/properties/PropertyRow.scss
@@ -1,7 +1,0 @@
-/* stylelint-disable-next-line selector-class-pattern */
-td.property-row__value {
-  max-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}

--- a/packages/ui/src/components/Form/properties/PropertyRow.tsx
+++ b/packages/ui/src/components/Form/properties/PropertyRow.tsx
@@ -2,7 +2,6 @@ import { Button, HelperText, HelperTextItem, Split, SplitItem, TextInput, Toolti
 import { CheckIcon, PencilAltIcon, TimesIcon, TrashIcon } from '@patternfly/react-icons';
 import { Td, TdProps, TreeRowWrapper } from '@patternfly/react-table';
 import { FormEvent, useState } from 'react';
-import './PropertyRow.scss';
 import { AddPropertyButtons } from './AddPropertyButtons';
 
 type PropertyRowProps = {
@@ -97,7 +96,12 @@ export function PropertyRow({
 
   return (
     <TreeRowWrapper key={getKey()} row={{ props: treeRow!.props }}>
-      <Td className="property-row__value" dataLabel="NAME" treeRow={treeRow}>
+      <Td
+        data-testid={`${getKey()}-name-label`}
+        className="properties-field__row__value"
+        dataLabel="NAME"
+        treeRow={treeRow}
+      >
         {isEditing ? (
           <>
             <TextInput
@@ -118,33 +122,29 @@ export function PropertyRow({
             )}
           </>
         ) : (
-          <div data-testid={`${getKey()}-name-label`}>{nodeName}</div>
+          <>{nodeName}</>
         )}
       </Td>
-      <Td className="property-row__value" dataLabel="VALUE">
-        {(() => {
-          if (isObject && !isEditing) {
-            return <AddPropertyButtons path={path} createPlaceholder={createPlaceholder} />;
-          } else if (!isObject && isEditing) {
-            return (
-              <TextInput
-                aria-label={`${getKey()}-value`}
-                data-testid={`${getKey()}-value-input`}
-                name={`properties-input-${getKey()}-value`}
-                type="text"
-                value={userInputValue}
-                onKeyDown={(event) => event.stopPropagation()}
-                onChange={(event, value) => handleUserInputValue(value, event)}
-              />
-            );
-          } else if (!isObject && !isEditing) {
-            return <span data-testid={`${getKey()}-value-label`}>{nodeValue}</span>;
-          } else {
-            return <></>;
-          }
-        })()}
+
+      <Td data-testid={`${getKey()}-value-label`} className="properties-field__row__value" dataLabel="VALUE">
+        {isObject && !isEditing && <AddPropertyButtons path={path} createPlaceholder={createPlaceholder} />}
+
+        {!isObject && isEditing && (
+          <TextInput
+            aria-label={`${getKey()}-value`}
+            data-testid={`${getKey()}-value-input`}
+            name={`properties-input-${getKey()}-value`}
+            type="text"
+            value={userInputValue}
+            onKeyDown={(event) => event.stopPropagation()}
+            onChange={(event, value) => handleUserInputValue(value, event)}
+          />
+        )}
+
+        {!isObject && !isEditing && <>{nodeValue}</>}
       </Td>
-      <Td isActionCell>
+
+      <Td isActionCell className="properties-field__row__action" data-column-type="action">
         <Split>
           {isEditing
             ? [

--- a/packages/ui/src/components/Form/properties/PropetiesField.test.tsx
+++ b/packages/ui/src/components/Form/properties/PropetiesField.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import { KaotoSchemaDefinition } from '../../../models';
+import { UniformsWrapper } from '../../../stubs/TestUniformsWrapper';
+import { PropertiesField } from './PropertiesField';
+
+describe('PropertiesField Component', () => {
+  const parametersSchema: KaotoSchemaDefinition['schema'] = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    properties: {
+      parameters: {
+        title: 'Parameters',
+        group: 'consumer',
+        description: 'List of Tool parameters in the form of parameter.=',
+        type: 'object',
+        deprecated: false,
+      },
+    },
+  };
+
+  it('renders without crashing', () => {
+    const wrapper = render(
+      <UniformsWrapper model={{}} schema={parametersSchema}>
+        <PropertiesField name="parameters" />
+      </UniformsWrapper>,
+    );
+
+    const propertiesFieldElement = wrapper.getByTestId('expandable-section-parameters');
+    expect(propertiesFieldElement).toBeInTheDocument();
+  });
+
+  it('displays the correct label', () => {
+    const label = 'Test Label';
+    const wrapper = render(
+      <UniformsWrapper model={{}} schema={parametersSchema}>
+        <PropertiesField name="parameters" label={label} />
+      </UniformsWrapper>,
+    );
+    const labelElement = wrapper.getByText(label);
+    expect(labelElement).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Form/properties/properties-field.models.ts
+++ b/packages/ui/src/components/Form/properties/properties-field.models.ts
@@ -1,0 +1,11 @@
+import { HTMLFieldProps } from 'uniforms';
+
+export interface PlaceholderState {
+  isObject: boolean;
+  parentNodeId: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface IPropertiesField extends HTMLFieldProps<any, HTMLDivElement> {
+  [key: string]: unknown;
+}

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 import { CamelRouteResource } from '../../../models/camel';
 import { EntityType } from '../../../models/camel/entities';
+import { CanvasFormTabsProvider } from '../../../providers';
 import { TestProvidersWrapper } from '../../../stubs/TestProvidersWrapper';
 import { CanvasNode } from './canvas.models';
 import { CanvasSideBar } from './CanvasSideBar';
@@ -20,7 +21,11 @@ describe('CanvasSideBar', () => {
   });
 
   it('does not render anything if there is no selectedNode', () => {
-    const wrapper = render(<CanvasSideBar selectedNode={undefined} onClose={() => {}} />);
+    const wrapper = render(
+      <CanvasFormTabsProvider>
+        <CanvasSideBar selectedNode={undefined} onClose={() => {}} />
+      </CanvasFormTabsProvider>,
+    );
 
     expect(wrapper.container).toBeEmptyDOMElement();
   });
@@ -28,7 +33,9 @@ describe('CanvasSideBar', () => {
   it('displays selected node information', () => {
     const wrapper = render(
       <Provider>
-        <CanvasSideBar selectedNode={selectedNode} onClose={() => {}} />
+        <CanvasFormTabsProvider>
+          <CanvasSideBar selectedNode={selectedNode} onClose={() => {}} />
+        </CanvasFormTabsProvider>
       </Provider>,
     );
 
@@ -40,7 +47,9 @@ describe('CanvasSideBar', () => {
 
     const wrapper = render(
       <Provider>
-        <CanvasSideBar selectedNode={selectedNode} onClose={onCloseSpy} />
+        <CanvasFormTabsProvider>
+          <CanvasSideBar selectedNode={selectedNode} onClose={onCloseSpy} />
+        </CanvasFormTabsProvider>
       </Provider>,
     );
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -65,7 +65,9 @@ describe('CanvasForm', () => {
     const { container } = render(
       <EntitiesProvider>
         <VisibleFlowsProvider>
-          <CanvasForm selectedNode={selectedNode} />
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
         </VisibleFlowsProvider>
       </EntitiesProvider>,
     );
@@ -94,7 +96,9 @@ describe('CanvasForm', () => {
     const { container } = render(
       <EntitiesContext.Provider value={null}>
         <VisibleFlowsProvider>
-          <CanvasForm selectedNode={selectedNode} />
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
         </VisibleFlowsProvider>
       </EntitiesContext.Provider>,
     );
@@ -128,7 +132,9 @@ describe('CanvasForm', () => {
     const { container } = render(
       <EntitiesContext.Provider value={null}>
         <VisibleFlowsProvider>
-          <CanvasForm selectedNode={selectedNode} />
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
         </VisibleFlowsProvider>
       </EntitiesContext.Provider>,
     );
@@ -255,7 +261,9 @@ describe('CanvasForm', () => {
     render(
       <EntitiesProvider>
         <VisibleFlowsContext.Provider value={{ visibleFlows: { [flowId]: true }, visualFlowsApi }}>
-          <CanvasForm selectedNode={selectedNode} />
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
         </VisibleFlowsContext.Provider>
       </EntitiesProvider>,
     );

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.tsx
@@ -16,7 +16,7 @@ interface CanvasFormTabsProps {
 
 export const CanvasFormBody: FunctionComponent<CanvasFormTabsProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
-  const { selectedTab } = useContext(CanvasFormTabsContext);
+  const { selectedTab } = useContext(CanvasFormTabsContext) ?? { selectedTab: 'Required' };
   const divRef = useRef<HTMLDivElement>(null);
   const formRef = useRef<CustomAutoFormRef>(null);
   const omitFields = useRef(props.selectedNode.data?.vizNode?.getOmitFormFields() || []);

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.test.tsx
@@ -1,9 +1,14 @@
 import { render } from '@testing-library/react';
+import { CanvasFormTabsProvider } from '../../../../providers';
 import { CanvasFormHeader } from './CanvasFormHeader';
 
 describe('CanvasFormHeader', () => {
   it('renders correctly', () => {
-    const { asFragment } = render(<CanvasFormHeader nodeId="nodeId" nodeIcon="nodeIcon" title="title" />);
+    const { asFragment } = render(
+      <CanvasFormTabsProvider>
+        <CanvasFormHeader nodeId="nodeId" nodeIcon="nodeIcon" title="title" />
+      </CanvasFormTabsProvider>,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.tsx
@@ -24,7 +24,7 @@ interface CanvasFormHeaderProps {
 
 export const CanvasFormHeader: FunctionComponent<CanvasFormHeaderProps> = (props) => {
   const { filteredFieldText, onFilterChange } = useContext(FilteredFieldContext);
-  const { selectedTab, onTabChange } = useContext(CanvasFormTabsContext);
+  const canvasFormTabsContext = useContext(CanvasFormTabsContext);
 
   return (
     <>
@@ -40,19 +40,21 @@ export const CanvasFormHeader: FunctionComponent<CanvasFormHeaderProps> = (props
         </GridItem>
       </Grid>
 
-      <ToggleGroup aria-label="Single selectable form tabs" className="form-tabs">
-        {Object.entries(FormTabsModes).map(([mode, tooltip]) => (
-          <Tooltip key={mode} content={tooltip}>
-            <ToggleGroupItem
-              key={mode}
-              text={mode}
-              buttonId={mode}
-              isSelected={selectedTab === mode}
-              onChange={onTabChange}
-            />
-          </Tooltip>
-        ))}
-      </ToggleGroup>
+      {canvasFormTabsContext && (
+        <ToggleGroup aria-label="Single selectable form tabs" className="form-tabs">
+          {Object.entries(FormTabsModes).map(([mode, tooltip]) => (
+            <Tooltip key={mode} content={tooltip}>
+              <ToggleGroupItem
+                key={mode}
+                text={mode}
+                buttonId={mode}
+                isSelected={canvasFormTabsContext.selectedTab === mode}
+                onChange={canvasFormTabsContext.onTabChange}
+              />
+            </Tooltip>
+          ))}
+        </ToggleGroup>
+      )}
 
       <SearchInput
         className="filter-fields"

--- a/packages/ui/src/providers/canvas-form-tabs.provider.test.tsx
+++ b/packages/ui/src/providers/canvas-form-tabs.provider.test.tsx
@@ -5,7 +5,7 @@ import { CanvasFormTabsContext, CanvasFormTabsProvider } from './canvas-form-tab
 describe('CanvasFormTabsProvider', () => {
   it('should provide default selectedTab value', () => {
     const TestComponent: FunctionComponent = () => {
-      const { selectedTab } = useContext(CanvasFormTabsContext);
+      const { selectedTab } = useContext(CanvasFormTabsContext)!;
       return <div data-testid="selected-tab">{selectedTab}</div>;
     };
 
@@ -21,17 +21,17 @@ describe('CanvasFormTabsProvider', () => {
 
   it('should update selectedTab on tab change', () => {
     const TestComponent: FunctionComponent = () => {
-      const { selectedTab, onTabChange } = useContext(CanvasFormTabsContext);
+      const { selectedTab, onTabChange } = useContext(CanvasFormTabsContext)!;
       return (
         <div>
           <div data-testid="selected-tab">{selectedTab}</div>
-          <button id="Required" onClick={(e) => onTabChange(e, true)} data-testid="required-tab">
+          <button id="Required" onClick={onTabChange} data-testid="required-tab">
             Required Tab
           </button>
-          <button id="All" onClick={(e) => onTabChange(e, true)} data-testid="all-fields-tab">
+          <button id="All" onClick={onTabChange} data-testid="all-fields-tab">
             All Fields Tab
           </button>
-          <button id="Modified" onClick={(e) => onTabChange(e, true)} data-testid="user-modified-tab">
+          <button id="Modified" onClick={onTabChange} data-testid="user-modified-tab">
             User Modified Tab
           </button>
         </div>

--- a/packages/ui/src/providers/canvas-form-tabs.provider.tsx
+++ b/packages/ui/src/providers/canvas-form-tabs.provider.tsx
@@ -4,15 +4,9 @@ import { FormTabsModes } from '../components/Visualization/Canvas/Form/canvasfor
 
 export interface CanvasFormTabsContextResult {
   selectedTab: keyof typeof FormTabsModes;
-  onTabChange: (
-    event: MouseEvent | React.MouseEvent<any, MouseEvent> | React.KeyboardEvent<Element>,
-    _isSelected: boolean,
-  ) => void;
+  onTabChange: (event: MouseEvent | React.MouseEvent<any, MouseEvent> | React.KeyboardEvent<Element>) => void;
 }
-export const CanvasFormTabsContext = createContext<CanvasFormTabsContextResult>({
-  selectedTab: 'Required',
-  onTabChange: () => {},
-});
+export const CanvasFormTabsContext = createContext<CanvasFormTabsContextResult | undefined>(undefined);
 
 /**
  * Used for fetching and injecting the selected tab information from the canvas form

--- a/packages/ui/src/stubs/TestUniformsWrapper.tsx
+++ b/packages/ui/src/stubs/TestUniformsWrapper.tsx
@@ -1,0 +1,30 @@
+import { AutoForm } from '@kaoto-next/uniforms-patternfly';
+import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { SchemaService } from '../components/Form/schema.service';
+import { KaotoSchemaDefinition } from '../models/kaoto-schema';
+import { SchemaBridgeContext } from '../providers/schema-bridge.provider';
+
+export const UniformsWrapper: FunctionComponent<
+  PropsWithChildren<{
+    model: Record<string, unknown>;
+    schema: KaotoSchemaDefinition['schema'];
+  }>
+> = (props) => {
+  const schemaBridge = new SchemaService().getSchemaBridge(props.schema);
+  const divRef = useRef<HTMLDivElement>(null);
+  const [, setLastRenderTimestamp] = useState<number>(-1);
+
+  useEffect(() => {
+    /** Force re-render to update the divRef */
+    setLastRenderTimestamp(Date.now());
+  }, []);
+
+  return (
+    <SchemaBridgeContext.Provider value={{ schemaBridge, parentRef: divRef }}>
+      <AutoForm model={props.model} schema={schemaBridge}>
+        {props.children}
+      </AutoForm>
+      <div ref={divRef} />
+    </SchemaBridgeContext.Provider>
+  );
+};

--- a/packages/ui/src/stubs/timer.component.schema.ts
+++ b/packages/ui/src/stubs/timer.component.schema.ts
@@ -1,0 +1,133 @@
+export const TimerComponentSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    timerName: {
+      title: 'Timer Name',
+      group: 'consumer',
+      description: 'The name of the timer',
+      type: 'string',
+      deprecated: false,
+    },
+    delay: {
+      title: 'Delay',
+      group: 'consumer',
+      description:
+        'The number of milliseconds to wait before the first event is generated. Should not be used in conjunction with the time option. The default value is 1000.',
+      format: 'duration',
+      type: 'string',
+      deprecated: false,
+      default: '1000',
+    },
+    fixedRate: {
+      title: 'Fixed Rate',
+      group: 'consumer',
+      description: 'Events take place at approximately regular intervals, separated by the specified period.',
+      type: 'boolean',
+      deprecated: false,
+      default: false,
+    },
+    includeMetadata: {
+      title: 'Include Metadata',
+      group: 'consumer',
+      description: 'Whether to include metadata in the exchange such as fired time, timer name, timer count etc.',
+      type: 'boolean',
+      deprecated: false,
+      default: false,
+    },
+    period: {
+      title: 'Period',
+      group: 'consumer',
+      description: 'Generate periodic events every period. Must be zero or positive value. The default value is 1000.',
+      format: 'duration',
+      type: 'string',
+      deprecated: false,
+      default: '1000',
+    },
+    repeatCount: {
+      title: 'Repeat Count',
+      group: 'consumer',
+      description:
+        'Specifies a maximum limit for the number of fires. Therefore, if you set it to 1, the timer will only fire once. If you set it to 5, it will only fire five times. A value of zero or negative means fire forever.',
+      type: 'integer',
+      deprecated: false,
+    },
+    bridgeErrorHandler: {
+      title: 'Bridge Error Handler',
+      group: 'consumer (advanced)',
+      description:
+        'Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions (if possible) occurred while the Camel consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. Important: This is only possible if the 3rd party component allows Camel to be alerted if an exception was thrown. Some components handle this internally only, and therefore bridgeErrorHandler is not possible. In other situations we may improve the Camel component to hook into the 3rd party component and make this possible for future releases. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored.',
+      type: 'boolean',
+      deprecated: false,
+      default: false,
+    },
+    exceptionHandler: {
+      title: 'Exception Handler',
+      group: 'consumer (advanced)',
+      description:
+        'To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored.',
+      type: 'string',
+      deprecated: false,
+      $comment: 'class:org.apache.camel.spi.ExceptionHandler',
+    },
+    exchangePattern: {
+      title: 'Exchange Pattern',
+      group: 'consumer (advanced)',
+      description: 'Sets the exchange pattern when the consumer creates an exchange.',
+      type: 'string',
+      deprecated: false,
+      enum: ['InOnly', 'InOut'],
+    },
+    daemon: {
+      title: 'Daemon',
+      group: 'advanced',
+      description:
+        'Specifies whether the thread associated with the timer endpoint runs as a daemon. The default value is true.',
+      type: 'boolean',
+      deprecated: false,
+      default: true,
+    },
+    pattern: {
+      title: 'Pattern',
+      group: 'advanced',
+      description: 'Allows you to specify a custom Date pattern to use for setting the time option using URI syntax.',
+      type: 'string',
+      deprecated: false,
+    },
+    synchronous: {
+      title: 'Synchronous',
+      group: 'advanced',
+      description: 'Sets whether synchronous processing should be strictly used',
+      type: 'boolean',
+      deprecated: false,
+      default: false,
+    },
+    time: {
+      title: 'Time',
+      group: 'advanced',
+      description:
+        "A java.util.Date the first event should be generated. If using the URI, the pattern expected is: yyyy-MM-dd HH:mm:ss or yyyy-MM-dd'T'HH:mm:ss.",
+      type: 'string',
+      deprecated: false,
+    },
+    timer: {
+      title: 'Timer',
+      group: 'advanced',
+      description: 'To use a custom Timer',
+      type: 'string',
+      deprecated: false,
+      $comment: 'class:java.util.Timer',
+    },
+    runLoggingLevel: {
+      title: 'Run Logging Level',
+      group: 'scheduler',
+      description:
+        'The consumer logs a start/complete log line when it polls. This option allows you to configure the logging level for that.',
+      type: 'string',
+      deprecated: false,
+      default: 'TRACE',
+      enum: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF'],
+    },
+  },
+  required: ['timerName'],
+};

--- a/packages/ui/src/utils/get-field-groups.test.ts
+++ b/packages/ui/src/utils/get-field-groups.test.ts
@@ -1,3 +1,4 @@
+import { TimerComponentSchema } from '../stubs/timer.component.schema';
 import { getFieldGroups } from './get-field-groups';
 
 describe('useFieldGroups', () => {
@@ -81,135 +82,7 @@ describe('useFieldGroups', () => {
     expect(propertiesArray).toEqual(expectedOutputValue);
   });
 
-  it('should get a object with common array and groups object containing differnt groups array', () => {
-    inputValue = {
-      timerName: {
-        title: 'Timer Name',
-        group: 'consumer',
-        description: 'The name of the timer',
-        type: 'string',
-        deprecated: false,
-      },
-      delay: {
-        title: 'Delay',
-        group: 'consumer',
-        description: 'Delay before first event is triggered.',
-        format: 'duration',
-        type: 'string',
-        deprecated: false,
-        default: '1000',
-      },
-      fixedRate: {
-        title: 'Fixed Rate',
-        group: 'consumer',
-        description: 'Events take place at approximately regular intervals, separated by the specified period.',
-        type: 'boolean',
-        deprecated: false,
-        default: false,
-      },
-      includeMetadata: {
-        title: 'Include Metadata',
-        group: 'consumer',
-        description: 'Whether to include metadata in the exchange such as fired time, timer name, timer count etc.',
-        type: 'boolean',
-        deprecated: false,
-        default: false,
-      },
-      period: {
-        title: 'Period',
-        group: 'consumer',
-        description: 'If greater than 0, generate periodic events every period.',
-        format: 'duration',
-        type: 'string',
-        deprecated: false,
-        default: '1000',
-      },
-      repeatCount: {
-        title: 'Repeat Count',
-        group: 'consumer',
-        description:
-          'Specifies a maximum limit of number of fires. So if you set it to 1, the timer will only fire once. If you set it to 5, it will only fire five times. A value of zero or negative means fire forever.',
-        type: 'integer',
-        deprecated: false,
-      },
-      bridgeErrorHandler: {
-        title: 'Bridge Error Handler',
-        group: 'consumer (advanced)',
-        description:
-          'Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions (if possible) occurred while the Camel consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. Important: This is only possible if the 3rd party component allows Camel to be alerted if an exception was thrown. Some components handle this internally only, and therefore bridgeErrorHandler is not possible. In other situations we may improve the Camel component to hook into the 3rd party component and make this possible for future releases. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored.',
-        type: 'boolean',
-        deprecated: false,
-        default: false,
-      },
-      exceptionHandler: {
-        title: 'Exception Handler',
-        group: 'consumer (advanced)',
-        description:
-          'To let the consumer use a custom ExceptionHandler. Notice if the option bridgeErrorHandler is enabled then this option is not in use. By default the consumer will deal with exceptions, that will be logged at WARN or ERROR level and ignored.',
-        type: 'string',
-        deprecated: false,
-        $comment: 'class:org.apache.camel.spi.ExceptionHandler',
-      },
-      exchangePattern: {
-        title: 'Exchange Pattern',
-        group: 'consumer (advanced)',
-        description: 'Sets the exchange pattern when the consumer creates an exchange.',
-        type: 'string',
-        deprecated: false,
-        enum: ['InOnly', 'InOut'],
-      },
-      daemon: {
-        title: 'Daemon',
-        group: 'advanced',
-        description:
-          'Specifies whether or not the thread associated with the timer endpoint runs as a daemon. The default value is true.',
-        type: 'boolean',
-        deprecated: false,
-        default: true,
-      },
-      pattern: {
-        title: 'Pattern',
-        group: 'advanced',
-        description: 'Allows you to specify a custom Date pattern to use for setting the time option using URI syntax.',
-        type: 'string',
-        deprecated: false,
-      },
-      synchronous: {
-        title: 'Synchronous',
-        group: 'advanced',
-        description: 'Sets whether synchronous processing should be strictly used',
-        type: 'boolean',
-        deprecated: false,
-        default: false,
-      },
-      time: {
-        title: 'Time',
-        group: 'advanced',
-        description:
-          "A java.util.Date the first event should be generated. If using the URI, the pattern expected is: yyyy-MM-dd HH:mm:ss or yyyy-MM-dd'T'HH:mm:ss.",
-        type: 'string',
-        deprecated: false,
-      },
-      timer: {
-        title: 'Timer',
-        group: 'advanced',
-        description: 'To use a custom Timer',
-        type: 'string',
-        deprecated: false,
-        $comment: 'class:java.util.Timer',
-      },
-      runLoggingLevel: {
-        title: 'Run Logging Level',
-        group: 'scheduler',
-        description:
-          'The consumer logs a start/complete log line when it polls. This option allows you to configure the logging level for that.',
-        type: 'string',
-        deprecated: false,
-        default: 'TRACE',
-        enum: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF'],
-      },
-    };
-
+  it('should get a object with common array and groups object containing different groups array', () => {
     const expectedOutputValue = {
       common: ['timerName', 'delay', 'fixedRate', 'includeMetadata', 'period', 'repeatCount'],
       groups: {
@@ -218,11 +91,11 @@ describe('useFieldGroups', () => {
         scheduler: ['runLoggingLevel'],
       },
     };
-    const propertiesArray = getFieldGroups(inputValue);
+    const propertiesArray = getFieldGroups(TimerComponentSchema.properties);
     expect(propertiesArray).toEqual(expectedOutputValue);
   });
 
-  it('should get a object with empty common array and emplty groups object', () => {
+  it('should get a object with empty common array and empty groups object', () => {
     inputValue = {};
 
     const expectedOutputValue = {

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './get-value';
 export * from './init-visible-flows';
 export * from './is-defined';
 export * from './is-enum-type';
+export * from './join-path';
 export * from './node-icon-resolver';
 export * from './resolve-ref-if-needed';
 export * from './set-value';

--- a/packages/ui/src/utils/join-path.test.ts
+++ b/packages/ui/src/utils/join-path.test.ts
@@ -1,0 +1,28 @@
+import { getJoinPath } from './join-path';
+
+describe('getJoinPath', () => {
+  it('should return a joined string with hyphens for a valid array of strings', () => {
+    const result = getJoinPath(['home', 'user', 'documents']);
+    expect(result).toBe('home-user-documents');
+  });
+
+  it('should return an empty string if the array is empty', () => {
+    const result = getJoinPath([]);
+    expect(result).toBe('');
+  });
+
+  it('should handle an array with one element correctly', () => {
+    const result = getJoinPath(['single']);
+    expect(result).toBe('single');
+  });
+
+  it('should handle an array with multiple elements correctly', () => {
+    const result = getJoinPath(['a', 'b', 'c']);
+    expect(result).toBe('a-b-c');
+  });
+
+  it('should handle an array with empty strings correctly', () => {
+    const result = getJoinPath(['a', '', 'c']);
+    expect(result).toBe('a--c');
+  });
+});

--- a/packages/ui/src/utils/join-path.ts
+++ b/packages/ui/src/utils/join-path.ts
@@ -1,0 +1,7 @@
+export const getJoinPath = (path: string[]) => {
+  if (!Array.isArray(path)) {
+    return '';
+  }
+
+  return path.join('-');
+};


### PR DESCRIPTION
### Context
This handles styling topics around the `PropertiesField`.

### Improvements
* When the PropertiesField contains properties, the expandable section is expanded by default
* Reduced the left and right padding
* Changes the containing `Td` so it can limit the overflow
* Add a few missing tests

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b3c03f22-94cc-4ccc-8cf3-60685fc2fcba) | ![image](https://github.com/user-attachments/assets/7ebaf553-d13f-467c-a18d-b5e58c0a4d34) |
| ![image](https://github.com/user-attachments/assets/0ea9429a-2d40-46e3-9a99-2bf7a41f89f1) | ![image](https://github.com/user-attachments/assets/19057a25-3732-451e-94a0-7770dad22bc9) |

fix: https://github.com/KaotoIO/kaoto/issues/1473