### PR TITLE
fix(440): Sort language/dataformat properties with catalog index order

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
@@ -22,6 +22,7 @@ import io.kaoto.camelcatalog.model.CatalogRuntime;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.tooling.model.ComponentModel;
 import org.apache.camel.tooling.model.EipModel;
+import org.apache.camel.tooling.model.EipModel.EipOptionModel;
 import org.apache.camel.tooling.model.JsonMapper;
 import org.apache.camel.tooling.model.Kind;
 
@@ -200,11 +201,24 @@ public class CamelCatalogProcessor {
      * @throws Exception
      */
     public String getDataFormatCatalog() throws Exception {
+        var catalogMap = new LinkedHashMap<String, EipModel>();
+        for (var name : camelCatalog.findDataFormatNames()) {
+            var modelCatalog = camelCatalog.dataFormatModel(name);
+            catalogMap.put(modelCatalog.getName(), camelCatalog.eipModel(name));
+        }
         var answer = jsonMapper.createObjectNode();
         var dataFormatSchemaMap = schemaProcessor.getDataFormats();
         for (var entry : dataFormatSchemaMap.entrySet()) {
             var dataFormatName = entry.getKey();
             var dataFormatSchema = entry.getValue();
+            EipModel eipModel = catalogMap.get(dataFormatName);
+            List<EipOptionModel> eipModelOptions = Arrays.asList();
+            if (eipModel != null) {
+                eipModelOptions = eipModel.getOptions();
+            }
+
+            sortPropertiesAccordingToCamelCatalog(dataFormatSchema, eipModelOptions); 
+
             var dataFormatCatalog = (EipModel) camelCatalog.model(Kind.eip, dataFormatName);
             if (dataFormatCatalog == null) {
                 throw new Exception("DataFormat " + dataFormatName + " is not found in Camel model catalog.");
@@ -230,9 +244,22 @@ public class CamelCatalogProcessor {
     public String getLanguageCatalog() throws Exception {
         var answer = jsonMapper.createObjectNode();
         var languageSchemaMap = schemaProcessor.getLanguages();
+        var catalogMap = new LinkedHashMap<String, EipModel>();
+        for (var name : camelCatalog.findLanguageNames()) {
+            var modelCatalog = camelCatalog.languageModel(name);
+            catalogMap.put(modelCatalog.getName(), camelCatalog.eipModel(name));
+        }
         for (var entry : languageSchemaMap.entrySet()) {
             var languageName = entry.getKey();
             var languageSchema = entry.getValue();
+            EipModel eipModel = catalogMap.get(languageName);
+            List<EipOptionModel> eipModelOptions = Arrays.asList();
+            if (eipModel != null) {
+                eipModelOptions = eipModel.getOptions();
+            }
+
+            sortPropertiesAccordingToCamelCatalog(languageSchema, eipModelOptions); 
+
             var languageCatalog = (EipModel) camelCatalog.model(Kind.eip, languageName);
             if (languageCatalog == null) {
                 throw new Exception("Language " + languageName + " is not found in Camel model catalog.");
@@ -426,7 +453,7 @@ public class CamelCatalogProcessor {
                     processEntityParameters(entityName, entitySchema, entityCatalog);
             }
 
-            sortPropertiesAccordingToCamelCatalog(entitySchema, entityCatalog);
+            sortPropertiesAccordingToCamelCatalog(entitySchema, entityCatalog.getOptions());
 
             var json = JsonMapper.asJsonObject(entityCatalog).toJson();
             var catalogTree = (ObjectNode) jsonMapper.readTree(json);
@@ -624,11 +651,11 @@ public class CamelCatalogProcessor {
         }
     }
 
-    private void sortPropertiesAccordingToCamelCatalog(ObjectNode entitySchema, EipModel entityCatalog) {
+    private void sortPropertiesAccordingToCamelCatalog(ObjectNode entitySchema, List<EipOptionModel> entityCatalogOptions) {
         var sortedSchemaProperties = jsonMapper.createObjectNode();
         var camelYamlDslProperties = entitySchema.withObject("/properties").properties().stream().map(Map.Entry::getKey)
                 .sorted(
-                        new CamelYamlDSLKeysComparator(entityCatalog.getOptions()))
+                        new CamelYamlDSLKeysComparator(entityCatalogOptions))
                 .toList();
 
         for (var propertyName : camelYamlDslProperties) {


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/440

Expression:

| Before | After |
|--------|--------|
| ![Screenshot from 2024-10-02 12-45-33](https://github.com/user-attachments/assets/9b2514b5-f921-405a-885a-3d8ecb678681) | ![Screenshot from 2024-10-02 12-46-18](https://github.com/user-attachments/assets/d492408d-c962-466e-bab2-dc40e09c5dc9) | 
| ![image](https://github.com/user-attachments/assets/159b6ebc-9b5b-4e8f-a79a-3a30908b0416) | ![image](https://github.com/user-attachments/assets/75c39b48-3f7c-4766-8101-5b08bb9a0977) | 



Dataformat:
| Before | After |
|--------|--------|
| ![Screenshot from 2024-10-02 12-49-38](https://github.com/user-attachments/assets/0bda8165-3107-4e7b-9fef-e17983c3ac79) | ![Screenshot from 2024-10-02 12-50-02](https://github.com/user-attachments/assets/35b6813c-8b26-4b5f-9054-579b5a883e4d) | 


