### PR TITLE
chore(catalog-generator): Lower the required Java version to 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you start contributing, ensure that you have the following installed:
 
 - NodeJS (>v18.x)
 - yarn (>v3.x)
-- Java 21+
+- Java 17+
 
 ### Setting Up the Project
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Have a quick look at our online demo instance:
 ## Requirements
 - NodeJS (v18.x or higher) [+info](https://nodejs.org/en)
 - Yarn (v3.x or higher) [+info](https://yarnpkg.com/getting-started/install)
-- OpenJDK (v21 or higher) [+info](https://developers.redhat.com/products/openjdk/download)
+- OpenJDK (v17 or higher) [+info](https://developers.redhat.com/products/openjdk/download)
 
 _For more information on Vite, check [Vite's documentation](https://vitejs.dev/config/)._
 

--- a/packages/catalog-generator/pom.xml
+++ b/packages/catalog-generator/pom.xml
@@ -11,10 +11,9 @@
   <description>A Camel Catalog generator for Kaoto.</description>
   <url>https://kaoto.io</url>
   <properties>
-    <compiler-plugin.version>3.13.0</compiler-plugin.version>
-    <maven.compiler.release>21</maven.compiler.release>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <version.camel>4.8.0</version.camel>
@@ -23,6 +22,7 @@
     <version.jackson>2.17.2</version.jackson>
     <version.junit>5.11.0</version.junit>
     <version.kubernetes-model>6.13.3</version.kubernetes-model>
+    <version.maven-enforcer-plugin>3.5.0</version.maven-enforcer-plugin>
     <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>
     <version.maven-surefire-plugin>3.5.0</version.maven-surefire-plugin>
   </properties>
@@ -159,6 +159,26 @@
             <classPattern>io.kaoto.camelcatalog.model.*</classPattern>
           </classPatterns>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${version.maven-enforcer-plugin}</version>
+        <executions>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[17,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
@@ -399,15 +399,31 @@ public class CamelCatalogProcessor {
             var entityName = entry.getKey();
             var entitySchema = entry.getValue();
             var entityCatalog = catalogMap.get(entityName);
+
             switch (entityName) {
-                case "beans" -> processBeansParameters(entitySchema, entityCatalog);
-                case "from" -> processFromParameters(entitySchema, entityCatalog);
-                case "route" -> processRouteParameters(entitySchema, entityCatalog);
-                case "routeTemplate" -> processRouteTemplateParameters(entitySchema, entityCatalog);
-                case "templatedRoute" -> processTemplatedRouteParameters(entitySchema, entityCatalog);
-                case "restConfiguration" -> processRestConfigurationParameters(entitySchema, entityCatalog);
-                case "rest" -> processRestParameters(entitySchema, entityCatalog);
-                case null, default -> processEntityParameters(entityName, entitySchema, entityCatalog);
+                case "beans":
+                    processBeansParameters(entitySchema, entityCatalog);
+                    break;
+                case "from":
+                    processFromParameters(entitySchema, entityCatalog);
+                    break;
+                case "route":
+                    processRouteParameters(entitySchema, entityCatalog);
+                    break;
+                case "routeTemplate":
+                    processRouteTemplateParameters(entitySchema, entityCatalog);
+                    break;
+                case "templatedRoute":
+                    processTemplatedRouteParameters(entitySchema, entityCatalog);
+                    break;
+                case "restConfiguration":
+                    processRestConfigurationParameters(entitySchema, entityCatalog);
+                    break;
+                case "rest":
+                    processRestParameters(entitySchema, entityCatalog);
+                    break;
+                default:
+                    processEntityParameters(entityName, entitySchema, entityCatalog);
             }
 
             sortPropertiesAccordingToCamelCatalog(entitySchema, entityCatalog);

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
@@ -59,7 +59,7 @@ class GenerateCommandTest {
         })) {
             generateCommand.run();
 
-            CatalogGeneratorBuilder builder = mockedBuilder.constructed().getFirst();
+            CatalogGeneratorBuilder builder = mockedBuilder.constructed().get(0);
 
             verify(builder, times(1)).withRuntime(CatalogRuntime.Main);
             verify(builder, times(1)).withCamelCatalogVersion("4.8.0");
@@ -99,12 +99,12 @@ class GenerateCommandTest {
         ) {
             generateCommand.run();
 
-            CatalogLibrary library = mockedLibrary.constructed().getFirst();
+            CatalogLibrary library = mockedLibrary.constructed().get(0);
 
             assertEquals(library.getName(), "test-camel-catalog");
             assertEquals(library.getDefinitions().size(), 1);
 
-            CatalogLibraryEntry catalogLibraryEntry = library.getDefinitions().getFirst();
+            CatalogLibraryEntry catalogLibraryEntry = library.getDefinitions().get(0);
             assertEquals(catalogLibraryEntry.name(), "test-camel-catalog");
             assertEquals(catalogLibraryEntry.version(), "4.8.0");
             assertEquals(catalogLibraryEntry.runtime(), "Main");


### PR DESCRIPTION
### Context
Currently, the `catalog-generator` requires Java 21.

While that enables modern syntax, not all users have it installed in their machines, so in order to lower the contribution requirements, we're lowering the required version to be Java 17.

By default, in RHEL 9.0, Java 17 is preinstalled.

Here is an extract of the available Java version per RHEL version

| RHEL Version | Java version | Release date |
| --- | --- | --- |
| RHEL 7 | Java 8  | June 10, 2014 |
| RHEL 8 | Java 11 | May 7, 2019   |
| RHEL 9 :point_left: we're here | Java 17 | May 17, 2022  |

fix: https://github.com/KaotoIO/kaoto/issues/1476