### PR TITLE
chore: Add kaoto examples link

### DIFF
--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -98,6 +98,14 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
                   &nbsp;<span className="pf-u-mr-lg">Help</span>
                 </DropdownItem>
               </a>
+              <a href="https://github.com/KaotoIO/kaoto-examples" target="_blank" rel="noreferrer">
+                <DropdownItem key="feedback">
+                  <Icon isInline>
+                    <GithubIcon />
+                  </Icon>
+                  &nbsp;<span className="pf-u-mr-lg">Examples</span>
+                </DropdownItem>
+              </a>
               <a href="https://github.com/KaotoIO/kaoto/issues/new/choose" target="_blank" rel="noreferrer">
                 <DropdownItem key="feedback">
                   <Icon isInline>


### PR DESCRIPTION
### Context
Adding the link to the kaoto-examples repository
![image](https://github.com/user-attachments/assets/74359ab1-747e-4665-be6b-8e74398519b3)
