### PR TITLE
fix(catalog-generator): Use Label or Group for the EIP parameters grouping

### DIFF
--- a/packages/catalog-generator/pom.xml
+++ b/packages/catalog-generator/pom.xml
@@ -39,11 +39,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-yaml-dsl</artifactId>
-      <version>${version.camel}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-catalog-maven</artifactId>
       <version>${version.camel}</version>
     </dependency>
@@ -81,6 +76,12 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-yaml-dsl</artifactId>
+      <version>${version.camel}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
@@ -373,7 +373,13 @@ public class CamelCatalogProcessor {
                     required.add(propertyName);
                 }
 
-                propertySchema.put("group", catalogOp.getGroup());
+                /* In Apache Camel previous to 4.5.0, the displayName is stored in the label property */
+                if (catalogOp.getLabel() != null) {
+                    propertySchema.put("group", catalogOp.getLabel());
+                } else if (catalogOp.getGroup() != null) {
+                    propertySchema.put("group", catalogOp.getGroup());
+                }
+
                 sortedSchemaProperties.set(propertyName, propertySchema);
             }
 


### PR DESCRIPTION
### Context
Starting from Camel 4.5.0, the `label` property from EIP was renamed to `group`.

This PR handles that change and uses whatever is available at the moment of creating the catalog. In addition to that, it changed the scope of the `camel-yaml-dsl` dependency because it was forcing the catalog generator to use the latest YAML DSL schema, failing to generate older catalog versions.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c551119b-e3fb-42c8-be29-533d963e70de) | ![image](https://github.com/user-attachments/assets/8e4ed582-4f67-48cf-9905-5295bf7ea0ec) |


fix: https://github.com/KaotoIO/kaoto/issues/1381