### PR TITLE
Reduce Maven download log

### DIFF
--- a/packages/catalog-generator/package.json
+++ b/packages/catalog-generator/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "yarn clean && yarn build:mvn && yarn build:default:catalog && yarn build:ts",
-    "build:mvn": "./mvnw clean install verify",
+    "build:mvn": "./mvnw clean install --no-transfer-progress",
     "build:default:catalog": "./mvnw package; java -jar ./target/catalog-generator-0.0.1-SNAPSHOT.jar -o ./dist/camel-catalog -n \"Default Kaoto catalog\"",
     "build:ts": "node --loader ts-node/esm ./scripts/json-schema-to-typescript.mts",
     "lint": "yarn eslint \"scripts/**/*.{mts,ts}\"",


### PR DESCRIPTION
On CI, the log cannot be correctly displayed and parsed in the GitHub default UI due to the large amount of it, mainly due to the download transfer progress of Maven components. Consequently, using `--no-transfer-progress` on the first Maven build to reduce the amount of logs.

Also updated Maven lifecycle phase, removed the verify phase as it is included in the install phase. See
https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#a-build-lifecycle-is-made-up-of-phases for reference