### PR TITLE
chore: Avoid double Maven build

### DIFF
--- a/packages/catalog-generator/package.json
+++ b/packages/catalog-generator/package.json
@@ -17,9 +17,9 @@
     "./*.json": "./dist/camel-catalog/*.json"
   },
   "scripts": {
-    "build": "yarn clean && yarn build:mvn && yarn build:default:catalog && yarn build:ts",
-    "build:mvn": "./mvnw clean install --no-transfer-progress",
-    "build:default:catalog": "./mvnw package; java -jar ./target/catalog-generator-0.0.1-SNAPSHOT.jar -o ./dist/camel-catalog -n \"Default Kaoto catalog\"",
+    "build": "yarn clean && yarn build:default:catalog && yarn build:ts",
+    "build:mvn": "./mvnw clean package --no-transfer-progress",
+    "build:default:catalog": "yarn run build:mvn; java -jar ./target/catalog-generator-0.0.1-SNAPSHOT.jar -o ./dist/camel-catalog -n \"Default Kaoto catalog\"",
     "build:ts": "node --loader ts-node/esm ./scripts/json-schema-to-typescript.mts",
     "lint": "yarn eslint \"scripts/**/*.{mts,ts}\"",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
- keep a separate `build:mvn` for ease of read
- currently there is no integration test and no need to install locally the generated artifact, so using `package` phase only (and not install or verify)
- the impact of the change is that there will be `mvn clean` called also when calling directly `yarn run build:default:catalog`, which I think is acceptable
- it is saving ~30 seconds of build time on CI