### PR TITLE
feat: Update default Camel Quarkus catalog version from 3.14.0 to 3.15.0

### DIFF
--- a/packages/catalog-generator/pom.xml
+++ b/packages/catalog-generator/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <version.camel>4.8.0</version.camel>
-    <version.camel.quarkus>3.14.0</version.camel.quarkus>
+    <version.camel.quarkus>3.15.0</version.camel.quarkus>
     <version.camel-kamelets>4.8.0</version.camel-kamelets>
     <version.jackson>2.17.2</version.jackson>
     <version.junit>5.11.1</version.junit>


### PR DESCRIPTION
this is the version aligned with Camel 4.8.0