### PR TITLE
feat(ConfigForm): Add support for oneOf fields

### DIFF
--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessorTest.java
@@ -30,7 +30,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CamelCatalogProcessorTest {
+class CamelCatalogProcessorTest {
     private static final List<String> ALLOWED_ENUM_TYPES = List.of("integer", "number", "string");
     private final CamelCatalogProcessor processor;
     private final ObjectNode componentCatalog;
@@ -41,7 +41,7 @@ public class CamelCatalogProcessorTest {
     private final ObjectNode entityCatalog;
     private final ObjectNode loadBalancerCatalog;
 
-    public CamelCatalogProcessorTest() throws Exception {
+    CamelCatalogProcessorTest() throws Exception {
         CamelCatalog catalog = new DefaultCamelCatalog();
         ObjectMapper jsonMapper = new ObjectMapper();
         var is = YamlRoutesBuilderLoader.class.getClassLoader().getResourceAsStream("schema/camelYamlDsl.json");
@@ -60,7 +60,7 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testProcessCatalog() throws Exception {
+    void testProcessCatalog() throws Exception {
         var catalogMap = processor.processCatalog();
         assertEquals(processor.getComponentCatalog(), catalogMap.get("components"));
         assertEquals(processor.getDataFormatCatalog(), catalogMap.get("dataformats"));
@@ -72,7 +72,7 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testGetComponentCatalog() throws Exception {
+    void testGetComponentCatalog() throws Exception {
         assertTrue(componentCatalog.size() > 300);
         var directModel = componentCatalog
                 .withObject("/direct")
@@ -123,7 +123,7 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testComponentEnumParameter() throws Exception {
+    void testComponentEnumParameter() throws Exception {
         checkEnumParameters(componentCatalog);
     }
 
@@ -154,7 +154,7 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testGetDataFormatCatalog() throws Exception {
+    void testGetDataFormatCatalog() throws Exception {
         var customModel = dataFormatCatalog
                 .withObject("/custom")
                 .withObject("/model");
@@ -173,12 +173,12 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testDataFormatEnumParameter() throws Exception {
+    void testDataFormatEnumParameter() throws Exception {
         checkEnumParameters(dataFormatCatalog);
     }
 
     @Test
-    public void testGetLanguageCatalog() throws Exception {
+    void testGetLanguageCatalog() throws Exception {
         assertFalse(languageCatalog.has("file"));
         var customModel = languageCatalog
                 .withObject("/language")
@@ -198,12 +198,12 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testLanguageEnumParameter() throws Exception {
+    void testLanguageEnumParameter() throws Exception {
         checkEnumParameters(languageCatalog);
     }
 
     @Test
-    public void testGetModelCatalog() throws Exception {
+    void testGetModelCatalog() throws Exception {
         assertTrue(modelCatalog.size() > 200);
         var aggregateModel = modelCatalog
                 .withObject("/aggregate")
@@ -213,12 +213,12 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testModelEnumParameter() throws Exception {
+    void testModelEnumParameter() throws Exception {
         checkEnumParameters(modelCatalog);
     }
 
     @Test
-    public void testGetPatternCatalog() throws Exception {
+    void testGetPatternCatalog() throws Exception {
         assertTrue(processorCatalog.size() > 65 && processorCatalog.size() < 80);
         var choiceModel = processorCatalog.withObject("/choice").withObject("/model");
         assertEquals("choice", choiceModel.get("name").asText());
@@ -235,17 +235,18 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testRouteConfigurationCatalog() throws Exception {
-        List.of("intercept", "interceptFrom", "interceptSendToEndpoint", "onCompletion", "onException").forEach(name -> assertTrue(entityCatalog.has(name), name));
+    void testRouteConfigurationCatalog() throws Exception {
+        List.of("intercept", "interceptFrom", "interceptSendToEndpoint", "onCompletion", "onException")
+                .forEach(name -> assertTrue(entityCatalog.has(name), name));
     }
 
     @Test
-    public void testPatternEnumParameter() throws Exception {
+    void testPatternEnumParameter() throws Exception {
         checkEnumParameters(processorCatalog);
     }
 
     @Test
-    public void testGetEntityCatalog() throws Exception {
+    void testGetEntityCatalog() throws Exception {
         List.of(
                 "bean",
                 "beans",
@@ -262,8 +263,7 @@ public class CamelCatalogProcessorTest {
                 "templatedRoute",
                 "restConfiguration",
                 "rest",
-                "routeTemplateBean"
-        ).forEach(name -> assertTrue(entityCatalog.has(name), name));
+                "routeTemplateBean").forEach(name -> assertTrue(entityCatalog.has(name), name));
         var bean = entityCatalog.withObject("/bean");
         var beanScriptLanguage = bean.withObject("/propertiesSchema")
                 .withObject("/properties")
@@ -284,12 +284,12 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testEntityEnumParameter() throws Exception {
+    void testEntityEnumParameter() throws Exception {
         checkEnumParameters(entityCatalog);
     }
 
     @Test
-    public void testGetLoadBalancerCatalog() throws Exception {
+    void testGetLoadBalancerCatalog() throws Exception {
         assertFalse(loadBalancerCatalog.isEmpty());
         var failoverModel = loadBalancerCatalog.withObject("/failoverLoadBalancer/model");
         assertEquals("failoverLoadBalancer", failoverModel.get("name").asText());
@@ -309,7 +309,7 @@ public class CamelCatalogProcessorTest {
     }
 
     @Test
-    public void testLoadBalancerEnumParameter() throws Exception {
+    void testLoadBalancerEnumParameter() throws Exception {
         checkEnumParameters(loadBalancerCatalog);
     }
 }

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/CamelYamlDSLKeysComparatorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/CamelYamlDSLKeysComparatorTest.java
@@ -26,16 +26,16 @@ import org.apache.camel.tooling.model.Kind;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class CamelYamlDSLKeysComparatorTest {
+class CamelYamlDSLKeysComparatorTest {
     private DefaultCamelCatalog api;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         this.api = new DefaultCamelCatalog();
     }
 
     @Test
-    public void sort_keys_using_the_catalog_index() throws Exception {
+    void sort_keys_using_the_catalog_index() throws Exception {
         var aggregateCatalogModel = (EipModel) api.model(Kind.eip, "aggregate");
 
         List<String> aggregateKeysFromCamelYAMLDsl = List.of("aggregateController", "aggregationRepository",

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/K8sSchemaProcessorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/K8sSchemaProcessorTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class K8sSchemaProcessorTest {
+class K8sSchemaProcessorTest {
     private static final String[] K8S_DEFINITIONS =
             new String[] {
                     "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
@@ -32,14 +32,14 @@ public class K8sSchemaProcessorTest {
     private final ObjectMapper jsonMapper;
     private final K8sSchemaProcessor processor;
 
-    public K8sSchemaProcessorTest() throws Exception {
+    K8sSchemaProcessorTest() throws Exception {
         jsonMapper = new ObjectMapper();
         var openapiSpec = (ObjectNode) jsonMapper.readTree(getClass().getClassLoader().getResourceAsStream("kubernetes-api-v1-openapi.json"));
         processor = new K8sSchemaProcessor(jsonMapper, openapiSpec);
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         var schemaMap = processor.processK8sDefinitions(List.of(K8S_DEFINITIONS));
         var objectMeta = (ObjectNode) jsonMapper.readTree(schemaMap.get("ObjectMeta"));
         assertTrue(objectMeta.withObject("/properties").has("annotations"));

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/KameletProcessorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/KameletProcessorTest.java
@@ -29,8 +29,8 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class KameletProcessorTest {
-    private static final List<String> ALLOWED_ENUM_TYPES = List.of("integer", "number", "string" );
+class KameletProcessorTest {
+    private static final List<String> ALLOWED_ENUM_TYPES = List.of("integer", "number", "string");
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());;
 
     private ObjectNode processKamelet(String name) throws Exception {
@@ -59,7 +59,7 @@ public class KameletProcessorTest {
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         var beerSource = processKamelet("beer-source");
         assertTrue(beerSource.has("propertiesSchema"));
         var periodProp = beerSource.withObject("/propertiesSchema")
@@ -92,7 +92,7 @@ public class KameletProcessorTest {
     }
 
     @Test
-    public void testEnumParameters() throws Exception {
+    void testEnumParameters() throws Exception {
         for (var kamelet : getAllKameletFiles().values()) {
             var schema = kamelet.withObject("/propertiesSchema");
             var title = schema.get("title");

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/UtilTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generator/UtilTest.java
@@ -25,11 +25,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UtilTest {
+class UtilTest {
     private final List<String> testFiles = List.of("testfile1.txt", "testfile2.txt");
 
     @Test
-    public void testGenerateHash() throws Exception {
+    void testGenerateHash() throws Exception {
         var fileHashMap = new HashMap<String, String>();
         for (var file : testFiles) {
             var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
@@ -51,7 +51,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testGenerateHashFromPath() throws Exception {
+    void testGenerateHashFromPath() throws Exception {
         var url = Thread.currentThread().getContextClassLoader().getResource(testFiles.get(0));
         if (url == null) throw new Exception("no test file available");
         var testFilePath = Path.of(url.toURI());
@@ -65,7 +65,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testGenerateHashFromString() throws Exception {
+    void testGenerateHashFromString() throws Exception {
         var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(testFiles.get(0));
         if (is == null) throw new Exception("no test file available");
         var testFileString = new String(is.readAllBytes());
@@ -79,7 +79,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testMessageDigestHash() throws Exception {
+    void testMessageDigestHash() throws Exception {
         try (var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(testFiles.get(0))) {
             if (is == null) throw new Exception("no test file available");
             var digest = MessageDigest.getInstance("MD5");

--- a/packages/catalog-generator/src/test/resources/camel-4.9.0-tokenizer-schema.json
+++ b/packages/catalog-generator/src/test/resources/camel-4.9.0-tokenizer-schema.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "properties": {
+      "tokenizer": {
+        "title": "Specialized tokenizer for AI applications",
+        "description": "Represents a Camel tokenizer for AI.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "Sets the description of this node"
+          },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "description": "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Sets the id of this node"
+          },
+          "langChain4jCharacterTokenizer": {},
+          "langChain4jLineTokenizer": {},
+          "langChain4jParagraphTokenizer": {},
+          "langChain4jSentenceTokenizer": {},
+          "langChain4jWordTokenizer": {}
+        },
+        "anyOf": [
+          {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "langChain4jCharacterTokenizer"
+                ],
+                "properties": {
+                  "langChain4jCharacterTokenizer": {
+                    "$ref": "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jCharacterTokenizerDefinition"
+                  }
+                }
+              },
+              {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "langChain4jCharacterTokenizer"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "langChain4jLineTokenizer"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "langChain4jParagraphTokenizer"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "langChain4jSentenceTokenizer"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "langChain4jWordTokenizer"
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "langChain4jLineTokenizer"
+                ],
+                "properties": {
+                  "langChain4jLineTokenizer": {
+                    "$ref": "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jTokenizerDefinition"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "langChain4jParagraphTokenizer"
+                ],
+                "properties": {
+                  "langChain4jParagraphTokenizer": {
+                    "$ref": "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jParagraphTokenizerDefinition"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "langChain4jSentenceTokenizer"
+                ],
+                "properties": {
+                  "langChain4jSentenceTokenizer": {
+                    "$ref": "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jSentenceTokenizerDefinition"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "langChain4jWordTokenizer"
+                ],
+                "properties": {
+                  "langChain4jWordTokenizer": {
+                    "$ref": "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jWordTokenizerDefinition"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "definitions": {
+      "org.apache.camel.model.tokenizer.LangChain4jCharacterTokenizerDefinition": {
+        "title": "LangChain4J Tokenizer with character splitter",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The id of this node"
+          },
+          "maxOverlap": {
+            "type": "number",
+            "title": "Max Overlap",
+            "description": "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens": {
+            "type": "number",
+            "title": "Max Tokens",
+            "description": "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "title": "Tokenizer Type",
+            "description": "Sets the tokenizer type",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jLineTokenizerDefinition": {
+        "title": "LangChain4J Tokenizer with line splitter",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The id of this node"
+          },
+          "maxOverlap": {
+            "type": "number",
+            "title": "Max Overlap",
+            "description": "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens": {
+            "type": "number",
+            "title": "Max Tokens",
+            "description": "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "title": "Tokenizer Type",
+            "description": "Sets the tokenizer type",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jParagraphTokenizerDefinition": {
+        "title": "LangChain4J Tokenizer with paragraph splitter",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The id of this node"
+          },
+          "maxOverlap": {
+            "type": "number",
+            "title": "Max Overlap",
+            "description": "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens": {
+            "type": "number",
+            "title": "Max Tokens",
+            "description": "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "title": "Tokenizer Type",
+            "description": "Sets the tokenizer type",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jSentenceTokenizerDefinition": {
+        "title": "LangChain4J Tokenizer with sentence splitter",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The id of this node"
+          },
+          "maxOverlap": {
+            "type": "number",
+            "title": "Max Overlap",
+            "description": "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens": {
+            "type": "number",
+            "title": "Max Tokens",
+            "description": "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "title": "Tokenizer Type",
+            "description": "Sets the tokenizer type",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jTokenizerDefinition": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "maxOverlap": {
+            "type": "number"
+          },
+          "maxTokens": {
+            "type": "number"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jWordTokenizerDefinition": {
+        "title": "LangChain4J Tokenizer with word splitter",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The id of this node"
+          },
+          "maxOverlap": {
+            "type": "number",
+            "title": "Max Overlap",
+            "description": "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens": {
+            "type": "number",
+            "title": "Max Tokens",
+            "description": "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType": {
+            "type": "string",
+            "title": "Tokenizer Type",
+            "description": "Sets the tokenizer type",
+            "enum": [
+              "OPEN_AI",
+              "AZURE",
+              "QWEN"
+            ]
+          }
+        },
+        "required": [
+          "maxOverlap",
+          "maxTokens"
+        ]
+      }
+    }
+  }
+}

--- a/packages/ui/src/components/Form/CustomAutoField.test.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.test.tsx
@@ -11,45 +11,11 @@ jest.mock('uniforms', () => {
 import { BoolField, DateField, ListField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
 import { AutoFieldProps } from 'uniforms';
 import { CustomAutoField } from './CustomAutoField';
-import { OneOfField } from './OneOf/OneOfField';
 import { CustomNestField } from './customField/CustomNestField';
 import { DisabledField } from './customField/DisabledField';
 import { TypeaheadField } from './customField/TypeaheadField';
 
 describe('CustomAutoField', () => {
-  it('should return `OneOfField` if `props.oneOf` is an array with a length > 0', () => {
-    const props: AutoFieldProps = {
-      oneOf: [{ type: 'string' }],
-      name: 'test',
-    };
-
-    const result = CustomAutoField(props);
-
-    expect(result).toBe(OneOfField);
-  });
-
-  it('should NOT return `OneOfField` if `props.oneOf` is an empty array', () => {
-    const props: AutoFieldProps = {
-      oneOf: [],
-      name: 'test',
-    };
-
-    const result = CustomAutoField(props);
-
-    expect(result).not.toBe(OneOfField);
-  });
-
-  it('should NOT return `OneOfField` if `props.oneOf` is not an array', () => {
-    const props: AutoFieldProps = {
-      oneOf: undefined,
-      name: 'test',
-    };
-
-    const result = CustomAutoField(props);
-
-    expect(result).not.toBe(OneOfField);
-  });
-
   it('should return `RadioField` if `props.options` & `props.checkboxes` are defined and `props.fieldType` is not `Array`', () => {
     const props: AutoFieldProps = {
       options: [],

--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -1,16 +1,15 @@
 import { BoolField, DateField, ListField, RadioField, TextField } from '@kaoto-next/uniforms-patternfly';
 import { createAutoField } from 'uniforms';
 import { getValue } from '../../utils';
-import { OneOfField } from './OneOf/OneOfField';
 import { BeanReferenceField } from './bean/BeanReferenceField';
+import { CustomLongTextField } from './customField/CustomLongTextField';
 import { CustomNestField } from './customField/CustomNestField';
 import { DisabledField } from './customField/DisabledField';
+import { PasswordField } from './customField/PasswordField';
 import { TypeaheadField } from './customField/TypeaheadField';
 import { ExpressionAwareNestField } from './expression/ExpressionAwareNestField';
 import { ExpressionField } from './expression/ExpressionField';
 import { PropertiesField } from './properties/PropertiesField';
-import { CustomLongTextField } from './customField/CustomLongTextField';
-import { PasswordField } from './customField/PasswordField';
 
 // Name of the properties that should load CustomLongTextField
 const CustomLongTextProps = ['Expression', 'Description', 'Query'];
@@ -20,10 +19,6 @@ const CustomLongTextProps = ['Expression', 'Description', 'Query'];
  * In case a field is not supported, it will render a DisabledField
  */
 export const CustomAutoField = createAutoField((props) => {
-  if (Array.isArray(props.oneOf) && props.oneOf.length > 0) {
-    return OneOfField;
-  }
-
   if (props.options) {
     return props.checkboxes && props.fieldType !== Array ? RadioField : TypeaheadField;
   }

--- a/packages/ui/src/components/Form/CustomAutoFields.test.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.test.tsx
@@ -37,4 +37,54 @@ describe('CustomAutoFields', () => {
 
     expect(wrapper?.asFragment()).toMatchSnapshot();
   });
+
+  it('should render the "oneOf" selector when needed', () => {
+    const mockSchema: KaotoSchemaDefinition['schema'] = {
+      title: 'Test',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: {
+          title: 'ID',
+          type: 'string',
+        },
+      },
+      oneOf: [
+        {
+          title: 'One',
+          type: 'object',
+          properties: {
+            timerName: {
+              title: 'Timer Name',
+              description: 'The name of the timer',
+              type: 'string',
+            },
+          },
+        },
+        {
+          title: 'Two',
+          type: 'object',
+          properties: {
+            pattern: {
+              title: 'Pattern',
+              description:
+                'Allows you to specify a custom Date pattern to use for setting the time option using URI syntax.',
+              type: 'string',
+            },
+          },
+        },
+      ],
+    };
+
+    const wrapper = render(
+      <CanvasFormTabsProvider>
+        <UniformsWrapper model={{}} schema={mockSchema}>
+          <CustomAutoFields />
+        </UniformsWrapper>
+      </CanvasFormTabsProvider>,
+    );
+
+    const oneOfToggle = wrapper.queryByTestId('-oneof-toggle');
+    expect(oneOfToggle).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/Form/CustomAutoFields.tsx
+++ b/packages/ui/src/components/Form/CustomAutoFields.tsx
@@ -1,14 +1,14 @@
 import { AutoField } from '@kaoto-next/uniforms-patternfly';
+import { Card, CardBody } from '@patternfly/react-core';
 import { ComponentType, createElement, useContext } from 'react';
 import { useForm } from 'uniforms';
-import { KaotoSchemaDefinition } from '../../models';
-import { Card, CardBody } from '@patternfly/react-core';
-import { getFieldGroups } from '../../utils';
-import { CatalogKind } from '../../models';
+import { CatalogKind, KaotoSchemaDefinition } from '../../models';
 import { CanvasFormTabsContext, FilteredFieldContext } from '../../providers';
+import { getFieldGroups } from '../../utils';
 import './CustomAutoFields.scss';
 import { CustomExpandableSection } from './customField/CustomExpandableSection';
 import { NoFieldFound } from './NoFieldFound';
+import { OneOfField } from './OneOf/OneOfField';
 
 export type AutoFieldsProps = {
   autoField?: ComponentType<{ name: string }>;
@@ -28,11 +28,7 @@ export function CustomAutoFields({
   const rootField = schema.getField('');
   const { filteredFieldText, isGroupExpanded } = useContext(FilteredFieldContext);
   const canvasFormTabsContext = useContext(CanvasFormTabsContext);
-
-  /** Special handling for oneOf schemas */
-  if (Array.isArray((rootField as KaotoSchemaDefinition['schema']).oneOf)) {
-    return createElement(element, props, [createElement(autoField!, { key: '', name: '' })]);
-  }
+  const oneOf = (rootField as KaotoSchemaDefinition['schema']).oneOf;
 
   const cleanQueryTerm = filteredFieldText.replace(/\s/g, '').toLowerCase();
   const actualFields = (fields ?? schema.getSubfields()).filter(
@@ -78,6 +74,9 @@ export function CustomAutoFields({
           </Card>
         </CustomExpandableSection>
       ))}
+
+      {/* Special handling for oneOf schemas */}
+      {Array.isArray(oneOf) && <OneOfField name="" fields={fields} oneOf={oneOf} {...props} />}
     </>,
   );
 }

--- a/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfField.test.tsx
@@ -20,7 +20,7 @@ describe('OneOfField', () => {
   };
 
   it('should render', () => {
-    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf!} />, {
       wrapper: (props) => (
         <UniformsWrapper model={{}} schema={oneOfSchema}>
           {props.children}
@@ -32,7 +32,7 @@ describe('OneOfField', () => {
   });
 
   it('should render correctly', () => {
-    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf!} />, {
       wrapper: (props) => (
         <UniformsWrapper model={{}} schema={oneOfSchema}>
           {props.children}
@@ -45,7 +45,7 @@ describe('OneOfField', () => {
   });
 
   it('should render the appropriate schema when given a matching model', () => {
-    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf!} />, {
       wrapper: (props) => (
         <UniformsWrapper model={{ name: 'John Doe' }} schema={oneOfSchema}>
           {props.children}
@@ -60,7 +60,7 @@ describe('OneOfField', () => {
   });
 
   it('should render a new selected schema', async () => {
-    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf} />, {
+    const wrapper = render(<OneOfField name="" oneOf={oneOfSchema.oneOf!} />, {
       wrapper: (props) => (
         <UniformsWrapper model={{}} schema={oneOfSchema}>
           {props.children}

--- a/packages/ui/src/components/Form/OneOf/OneOfField.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfField.tsx
@@ -1,6 +1,6 @@
-import { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { GuaranteedProps, connectField } from 'uniforms';
+import { HTMLFieldProps, connectField } from 'uniforms';
 import { useAppliedSchema, useSchemaBridgeContext } from '../../../hooks';
 import { KaotoSchemaDefinition } from '../../../models';
 import { SchemaBridgeProvider } from '../../../providers/schema-bridge.provider';
@@ -10,9 +10,16 @@ import { CustomAutoForm, CustomAutoFormRef } from '../CustomAutoForm';
 import { SchemaService } from '../schema.service';
 import { OneOfSchemaList } from './OneOfSchemaList';
 
-interface OneOfComponentProps extends GuaranteedProps<unknown> {
-  oneOf: KaotoSchemaDefinition['schema'][];
-}
+type OneOfComponentProps = HTMLFieldProps<
+  object,
+  HTMLDivElement,
+  {
+    properties?: Record<string, unknown>;
+    helperText?: string;
+    itemProps?: object;
+    oneOf: KaotoSchemaDefinition['schema'][];
+  }
+>;
 
 const applyDefinitionsToSchema = (
   schema?: KaotoSchemaDefinition['schema'],
@@ -27,7 +34,7 @@ const applyDefinitionsToSchema = (
   });
 };
 
-const OneOfComponent: FunctionComponent<OneOfComponentProps> = ({ name: propsName, oneOf, onChange }) => {
+export const OneOfField = connectField(({ name: propsName, oneOf, onChange }: OneOfComponentProps) => {
   const formRef = useRef<CustomAutoFormRef>(null);
   const divRef = useRef<HTMLDivElement>(null);
 
@@ -106,6 +113,4 @@ const OneOfComponent: FunctionComponent<OneOfComponentProps> = ({ name: propsNam
       )}
     </OneOfSchemaList>
   );
-};
-
-export const OneOfField = connectField(OneOfComponent as unknown as Parameters<typeof connectField>[0]);
+});

--- a/packages/ui/src/components/Form/OneOf/OneOfSchemaList.scss
+++ b/packages/ui/src/components/Form/OneOf/OneOfSchemaList.scss
@@ -1,0 +1,3 @@
+.oneof-toggle {
+  margin-bottom: 1rem;
+}

--- a/packages/ui/src/components/Form/OneOf/OneOfSchemaList.tsx
+++ b/packages/ui/src/components/Form/OneOf/OneOfSchemaList.tsx
@@ -1,7 +1,4 @@
 import {
-  Card,
-  CardBody,
-  CardTitle,
   Dropdown,
   DropdownItem,
   DropdownList,
@@ -15,6 +12,7 @@ import { FunctionComponent, PropsWithChildren, Ref, useCallback, useEffect, useS
 import { OneOfSchemas } from '../../../utils/get-oneof-schema-list';
 import { isDefined } from '../../../utils/is-defined';
 import { SchemaService } from '../schema.service';
+import './OneOfSchemaList.scss';
 
 interface OneOfComponentProps extends PropsWithChildren {
   name: string;
@@ -50,6 +48,7 @@ export const OneOfSchemaList: FunctionComponent<OneOfComponentProps> = ({
       <MenuToggle
         id={`${name}-oneof-toggle`}
         data-testid={`${name}-oneof-toggle`}
+        className="oneof-toggle"
         ref={toggleRef}
         onClick={onToggleClick}
         isFullWidth
@@ -76,36 +75,34 @@ export const OneOfSchemaList: FunctionComponent<OneOfComponentProps> = ({
   }
 
   return (
-    <Card>
-      <CardTitle>
-        <Dropdown
-          id={`${name}-oneof-select`}
-          data-testid={`${name}-oneof-select`}
-          isOpen={isOpen}
-          selected={selectedSchemaName}
-          onSelect={onSelect}
-          onOpenChange={setIsOpen}
-          toggle={toggle}
-          isScrollable
-        >
-          <DropdownList data-testid={`${name}-oneof-select-dropdownlist`}>
-            {oneOfSchemas.map((schemaDef) => {
-              return (
-                <DropdownItem
-                  data-testid={`${name}-oneof-select-dropdownlist-${schemaDef.name}`}
-                  key={schemaDef.name}
-                  value={schemaDef.name}
-                  description={schemaDef.description}
-                >
-                  {schemaDef.name}
-                </DropdownItem>
-              );
-            })}
-          </DropdownList>
-        </Dropdown>
-      </CardTitle>
+    <>
+      <Dropdown
+        id={`${name}-oneof-select`}
+        data-testid={`${name}-oneof-select`}
+        isOpen={isOpen}
+        selected={selectedSchemaName}
+        onSelect={onSelect}
+        onOpenChange={setIsOpen}
+        toggle={toggle}
+        isScrollable
+      >
+        <DropdownList data-testid={`${name}-oneof-select-dropdownlist`}>
+          {oneOfSchemas.map((schemaDef) => {
+            return (
+              <DropdownItem
+                data-testid={`${name}-oneof-select-dropdownlist-${schemaDef.name}`}
+                key={schemaDef.name}
+                value={schemaDef.name}
+                description={schemaDef.description}
+              >
+                {schemaDef.name}
+              </DropdownItem>
+            );
+          })}
+        </DropdownList>
+      </Dropdown>
 
-      <CardBody>{children}</CardBody>
-    </Card>
+      {children}
+    </>
   );
 };

--- a/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfField.test.tsx.snap
+++ b/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfField.test.tsx.snap
@@ -7,74 +7,55 @@ exports[`OneOfField should render 1`] = `
     data-testid="base-form"
     novalidate=""
   >
-    <div
-      class="pf-v5-c-card"
-      data-ouia-component-id="OUIA-Generated-Card-1"
-      data-ouia-component-type="PF5/Card"
+    <button
+      aria-expanded="false"
+      class="pf-v5-c-menu-toggle pf-m-full-width oneof-toggle"
+      data-ouia-component-id="OUIA-Generated-MenuToggle-1"
+      data-ouia-component-type="PF5/MenuToggle"
       data-ouia-safe="true"
-      id=""
+      data-testid="-oneof-toggle"
+      id="-oneof-toggle"
+      type="button"
     >
-      <div
-        class="pf-v5-c-card__title"
+      <span
+        class="pf-v5-c-menu-toggle__text"
       >
         <div
-          class="pf-v5-c-card__title-text"
+          class="pf-v5-c-content"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v5-c-menu-toggle pf-m-full-width"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-1"
-            data-ouia-component-type="PF5/MenuToggle"
+          <small
+            class=""
+            data-ouia-component-id="OUIA-Generated-Text-1"
+            data-ouia-component-type="PF5/Text"
             data-ouia-safe="true"
-            data-testid="-oneof-toggle"
-            id="-oneof-toggle"
-            type="button"
+            data-pf-content="true"
           >
-            <span
-              class="pf-v5-c-menu-toggle__text"
-            >
-              <div
-                class="pf-v5-c-content"
-              >
-                <small
-                  class=""
-                  data-ouia-component-id="OUIA-Generated-Text-1"
-                  data-ouia-component-type="PF5/Text"
-                  data-ouia-safe="true"
-                  data-pf-content="true"
-                >
-                  Select an option...
-                </small>
-              </div>
-            </span>
-            <span
-              class="pf-v5-c-menu-toggle__controls"
-            >
-              <span
-                class="pf-v5-c-menu-toggle__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v5-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
+            Select an option...
+          </small>
         </div>
-      </div>
-      <div
-        class="pf-v5-c-card__body"
-      />
-    </div>
+      </span>
+      <span
+        class="pf-v5-c-menu-toggle__controls"
+      >
+        <span
+          class="pf-v5-c-menu-toggle__toggle-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v5-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
   </form>
   <div />
 </DocumentFragment>

--- a/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfSchemaList.test.tsx.snap
+++ b/packages/ui/src/components/Form/OneOf/__snapshots__/OneOfSchemaList.test.tsx.snap
@@ -2,73 +2,54 @@
 
 exports[`OneOfSchemaList should render 1`] = `
 <DocumentFragment>
-  <div
-    class="pf-v5-c-card"
-    data-ouia-component-id="OUIA-Generated-Card-1"
-    data-ouia-component-type="PF5/Card"
+  <button
+    aria-expanded="false"
+    class="pf-v5-c-menu-toggle pf-m-full-width oneof-toggle"
+    data-ouia-component-id="OUIA-Generated-MenuToggle-1"
+    data-ouia-component-type="PF5/MenuToggle"
     data-ouia-safe="true"
-    id=""
+    data-testid="-oneof-toggle"
+    id="-oneof-toggle"
+    type="button"
   >
-    <div
-      class="pf-v5-c-card__title"
+    <span
+      class="pf-v5-c-menu-toggle__text"
     >
       <div
-        class="pf-v5-c-card__title-text"
+        class="pf-v5-c-content"
       >
-        <button
-          aria-expanded="false"
-          class="pf-v5-c-menu-toggle pf-m-full-width"
-          data-ouia-component-id="OUIA-Generated-MenuToggle-1"
-          data-ouia-component-type="PF5/MenuToggle"
+        <small
+          class=""
+          data-ouia-component-id="OUIA-Generated-Text-1"
+          data-ouia-component-type="PF5/Text"
           data-ouia-safe="true"
-          data-testid="-oneof-toggle"
-          id="-oneof-toggle"
-          type="button"
+          data-pf-content="true"
         >
-          <span
-            class="pf-v5-c-menu-toggle__text"
-          >
-            <div
-              class="pf-v5-c-content"
-            >
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-1"
-                data-ouia-component-type="PF5/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                Select an option...
-              </small>
-            </div>
-          </span>
-          <span
-            class="pf-v5-c-menu-toggle__controls"
-          >
-            <span
-              class="pf-v5-c-menu-toggle__toggle-icon"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 320 512"
-                width="1em"
-              >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                />
-              </svg>
-            </span>
-          </span>
-        </button>
+          Select an option...
+        </small>
       </div>
-    </div>
-    <div
-      class="pf-v5-c-card__body"
-    />
-  </div>
+    </span>
+    <span
+      class="pf-v5-c-menu-toggle__controls"
+    >
+      <span
+        class="pf-v5-c-menu-toggle__toggle-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="pf-v5-svg"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
+      </span>
+    </span>
+  </button>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/Form/customField/CustomNestField.test.tsx
+++ b/packages/ui/src/components/Form/customField/CustomNestField.test.tsx
@@ -82,33 +82,31 @@ describe('CustomNestField', () => {
       .filter((textbox) => textbox.getAttribute('label') === 'Pattern');
     expect(inputPatternElement).toHaveLength(1);
   });
-});
 
-describe('CustomNestField', () => {
-  const mockSchema = {
-    title: 'Test',
-    type: 'object',
-    additionalProperties: false,
-    properties: {
-      parameters: {
-        type: 'object',
-        title: 'Endpoint Properties',
-        description: 'Endpoint properties description',
-        properties: {
-          timerName: {
-            title: 'Timer Name',
-            description: 'The name of the timer',
-            type: 'string',
+  it('should not render the advanced properties button if no advanced properties are provided', () => {
+    const mockSchema = {
+      title: 'Test',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        parameters: {
+          type: 'object',
+          title: 'Endpoint Properties',
+          description: 'Endpoint properties description',
+          properties: {
+            timerName: {
+              title: 'Timer Name',
+              description: 'The name of the timer',
+              type: 'string',
+            },
           },
         },
       },
-    },
-  };
+    };
 
-  const schemaService = new SchemaService();
-  const schemaBridge = schemaService.getSchemaBridge(mockSchema);
+    const schemaService = new SchemaService();
+    const schemaBridge = schemaService.getSchemaBridge(mockSchema);
 
-  it('should not render the advanced properties button if no advanced properties are provided', () => {
     render(
       <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
         <AutoForm schema={schemaBridge!}>

--- a/packages/ui/src/components/Form/customField/CustomNestField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomNestField.tsx
@@ -20,16 +20,20 @@
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { useContext } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
+import { FilteredFieldContext } from '../../../providers';
 import { getFieldGroups } from '../../../utils';
 import { CustomAutoField } from '../CustomAutoField';
-import './CustomNestField.scss';
-import { FilteredFieldContext } from '../../../providers';
 import { CustomExpandableSection } from './CustomExpandableSection';
+import './CustomNestField.scss';
 
 export type CustomNestFieldProps = HTMLFieldProps<
   object,
   HTMLDivElement,
-  { properties?: Record<string, unknown>; helperText?: string; itemProps?: object }
+  {
+    properties?: Record<string, unknown>;
+    helperText?: string;
+    itemProps?: object;
+  }
 >;
 
 export const CustomNestField = connectField(
@@ -56,7 +60,7 @@ export const CustomNestField = connectField(
     if (propertiesArray.common.length === 0 && Object.keys(propertiesArray.groups).length === 0) return null;
 
     return (
-      <Card isFlat className="custom-nest-field" data-testid={'nest-field'} {...filterDOMProps(props)}>
+      <Card isFlat className="custom-nest-field" data-testid="nest-field" {...filterDOMProps(props)}>
         <CardHeader>
           <CardTitle>{label}</CardTitle>
         </CardHeader>


### PR DESCRIPTION
### Context
Currently, we have partial support for the `oneOf` schemas.

This commit cleans up the generated schemas, by removing the `not` definition from `oneOf` and also removing the empty properties like:

```
{
  property: { }
}
```

Test the changes live: https://lordrip.github.io/kaoto/

```yaml
- errorHandler: {}
```

fix: https://github.com/KaotoIO/kaoto/issues/1550
fix: https://github.com/KaotoIO/kaoto/issues/948