### PR TITLE
fix(Canvas): Avoid recreating the VisibleFlows object

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
@@ -81,6 +81,14 @@ describe('VisualFlowsApi', () => {
     });
 
     describe('initVisibleFlows', () => {
+      it('should not create a new state if all flows already exists', () => {
+        const initialState = { flowId1: true, flowId2: false };
+        action = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };
+        const newState = VisibleFlowsReducer(initialState, action);
+
+        expect(newState).toBe(initialState);
+      });
+
       it('should keep existing visibility', () => {
         const initialState = { flowId1: false, flowId2: true };
         action = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -1,13 +1,4 @@
-import {
-  FunctionComponent,
-  PropsWithChildren,
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-} from 'react';
+import { FunctionComponent, PropsWithChildren, createContext, useContext, useEffect, useMemo, useReducer } from 'react';
 import {
   IVisibleFlows,
   VisibleFlowsReducer,
@@ -24,7 +15,6 @@ export interface VisibleFLowsContextResult {
 export const VisibleFlowsContext = createContext<VisibleFLowsContextResult | undefined>(undefined);
 
 export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props) => {
-  const isMountingRef = useRef(true);
   const entitiesContext = useContext(EntitiesContext);
   const visualEntitiesIds = useMemo(
     () => entitiesContext?.visualEntities.map((entity) => entity.id) ?? [],
@@ -37,10 +27,7 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
   }, [dispatch]);
 
   useEffect(() => {
-    if (!isMountingRef.current) {
-      visualFlowsApi.initVisibleFlows(visualEntitiesIds);
-    }
-    isMountingRef.current = false;
+    visualFlowsApi.initVisibleFlows(visualEntitiesIds);
   }, [visualEntitiesIds, visualFlowsApi]);
 
   const value = useMemo(() => {


### PR DESCRIPTION
### Context
When an entity is updated, for instance, by adding a new component, the VisibleFlows object gets recreated, causing some 'useEffects' to be triggered twice.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/d7bfd68c-e559-4399-8520-b0bf8e14ccde) | ![image](https://github.com/user-attachments/assets/c9bf7e2b-36c7-466e-82e8-bde06ca81dcc) |
