### PR TITLE
fix(catalog-generator): Fix Windows tests

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/Util.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/Util.java
@@ -19,8 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.commons.io.FilenameUtils;
-
 public class Util {
     public static String generateHash(byte[] content) throws Exception {
         if (content == null)
@@ -44,8 +42,7 @@ public class Util {
 
         // Resolve the relative path
         Path absolutePath = currentDirectory.resolve(folder);
-        String normalizedfolder = FilenameUtils.separatorsToUnix(absolutePath.toString());
 
-        return normalizedfolder;
+        return absolutePath.toString();
     }
 }

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandOptionsTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandOptionsTest.java
@@ -41,7 +41,7 @@ public class GenerateCommandOptionsTest {
         generateCommandOptions.configure(args);
         String outputDir = Util.getNormalizedFolder("outputDir");
 
-        assertEquals(outputDir, configBean.getOutputFolder().toString());
+        assertEquals(outputDir, configBean.getOutputFolder().toPath().toString());
         assertEquals("catalogName", configBean.getCatalogsName());
         assertEquals("kameletsVersion", configBean.getKameletsVersion());
     }

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -84,7 +85,8 @@ class GenerateCommandTest {
             File expectedFolder = new File(tempDir, "camel-main/4.8.0");
             verify(builder, times(1)).withOutputDirectory(expectedFolder);
 
-            assertEquals(catalogDefinition.getFileName(), "camel-main/4.8.0/index.json");
+            String expectedFile = Path.of("camel-main", "4.8.0", "index.json").toString();
+            assertEquals(catalogDefinition.getFileName(), expectedFile);
         }
     }
 
@@ -123,7 +125,9 @@ class GenerateCommandTest {
             assertEquals(catalogLibraryEntry.name(), "test-camel-catalog");
             assertEquals(catalogLibraryEntry.version(), "4.8.0");
             assertEquals(catalogLibraryEntry.runtime(), "Main");
-            assertEquals(catalogLibraryEntry.fileName(), "camel-main/4.8.0/index.json");
+
+            String expectedFile = Path.of("camel-main", "4.8.0", "index.json").toString();
+            assertEquals(catalogLibraryEntry.fileName(), expectedFile);
         }
     }
 }


### PR DESCRIPTION
### Context
Currently, the `catalog-generator` tests are failing in Microsoft Windows due to the file separator.

This PR fixes it by using the underlying OS file separator instead.