### PR TITLE
fix(Resources): onException should be created at the top

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -8,6 +8,7 @@ import { CamelComponentFilterService } from '../visualization/flows/support/came
 import { BeansEntity } from '../visualization/metadata/beansEntity';
 import { createCamelResource } from './camel-resource';
 import { CamelRouteResource } from './camel-route-resource';
+import { EntityType } from './entities';
 import { SourceSchemaType } from './source-schema-type';
 
 describe('CamelRouteResource', () => {
@@ -55,6 +56,33 @@ describe('CamelRouteResource', () => {
       const id = resource.addNewEntity();
 
       expect(resource.getVisualEntities()).toHaveLength(1);
+      expect(resource.getVisualEntities()[0].id).toEqual(id);
+    });
+
+    it('should add new entities at the end of the list and return its ID', () => {
+      const resource = new CamelRouteResource();
+      resource.addNewEntity();
+      const id = resource.addNewEntity(EntityType.Route);
+
+      expect(resource.getVisualEntities()).toHaveLength(2);
+      expect(resource.getVisualEntities()[1].id).toEqual(id);
+    });
+
+    it('should add OnException entity at the beginning of the list and return its ID', () => {
+      const resource = new CamelRouteResource();
+      resource.addNewEntity();
+      const id = resource.addNewEntity(EntityType.OnException);
+
+      expect(resource.getVisualEntities()).toHaveLength(2);
+      expect(resource.getVisualEntities()[0].id).toEqual(id);
+    });
+
+    it('should add ErrorHandler entity at the beginning of the list and return its ID', () => {
+      const resource = new CamelRouteResource();
+      resource.addNewEntity();
+      const id = resource.addNewEntity(EntityType.ErrorHandler);
+
+      expect(resource.getVisualEntities()).toHaveLength(2);
       expect(resource.getVisualEntities()[0].id).toEqual(id);
     });
   });

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -39,6 +39,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
       { type: EntityType.RestConfiguration, group: 'Rest', Entity: CamelRestConfigurationVisualEntity },
     ];
   static readonly PARAMETERS_ORDER = ['id', 'description', 'uri', 'parameters', 'steps'];
+  private static readonly ERROR_RELATED_ENTITIES = [EntityType.OnException, EntityType.ErrorHandler];
   readonly sortFn = createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (
     a: unknown,
     b: unknown,
@@ -93,7 +94,13 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
       const supportedEntity = CamelRouteResource.SUPPORTED_ENTITIES.find(({ type }) => type === entityType);
       if (supportedEntity) {
         const entity = new supportedEntity.Entity();
-        this.entities.push(entity);
+
+        /** Error related entities should be added at the beginning of the list */
+        if (CamelRouteResource.ERROR_RELATED_ENTITIES.includes(entityType)) {
+          this.entities.unshift(entity);
+        } else {
+          this.entities.push(entity);
+        }
         return entity.id;
       }
     }


### PR DESCRIPTION
### Context
When adding an `onException` to the Canvas, it's created at the end of the YAML, but it should be created at the beginning instead.

fix: https://github.com/KaotoIO/kaoto/issues/1577