### PR TITLE
fix(Catalog): Ignore missing `model` properties

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CamelCatalogProcessor.java
@@ -482,7 +482,8 @@ public class CamelCatalogProcessor {
             throws Exception {
         var catalogOp = entityCatalog.getOptions().stream().filter(op -> op.getName().equals(propertyName)).findFirst();
         if (catalogOp.isEmpty()) {
-            throw new Exception(String.format("Option '%s' not found for '%s'", propertyName, entityCatalog.getName()));
+            LOGGER.warning(String.format("Option '%s' not found for '%s'", propertyName, entityCatalog.getName()));
+            return;
         }
         var catalogOption = catalogOp.get();
         if (catalogOption.getDisplayName() != null)


### PR DESCRIPTION
### Context
In the following Camel versions, a new `errorHandler` property was added to the `RouteDefinition` to allow different `errorHandlers` per route.

* 4.4.x
* 4.5.0

The issue with that is the `errorHandler` property is present in the YAML schema but not in the `RouteDefinition` model, making the generation fail.

### Workaround 
As a workaround, this commit ignores the missing properties from the model, but is present in the YAML DSL.

The result of this is the `errorHandler` property missing in the configuration form but present in the YAML DSL.