### PR TITLE
Feat(DND): Enable Simple DND

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -12,6 +12,7 @@ import {
   useAnchor,
   useHover,
   useSelection,
+  withDndDrop,
 } from '@patternfly/react-topology';
 import { FunctionComponent, useContext, useRef } from 'react';
 import { AddStepMode, IVisualizationNode, NodeToolbarTrigger } from '../../../../models';
@@ -23,9 +24,10 @@ import { AddStepIcon } from '../Edge/AddStepIcon';
 import { TargetAnchor } from '../target-anchor';
 import './CustomGroupExpanded.scss';
 import { CustomGroupProps } from './Group.models';
+import { customGroupExpandedDropTargetSpec } from '../customComponentUtils';
 
-export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer(
-  ({ element, onContextMenu, onCollapseToggle }) => {
+export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = observer(
+  ({ element, onContextMenu, onCollapseToggle, dndDropRef, droppable }) => {
     if (!isNode(element)) {
       throw new Error('CustomGroupExpanded must be used only on Node elements');
     }
@@ -41,7 +43,7 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer
       CanvasDefaults.HOVER_DELAY_IN,
       CanvasDefaults.HOVER_DELAY_OUT,
     );
-    const boxRef = useRef<Rect>(element.getBounds());
+    const boxRef = useRef<Rect | null>(null);
     const shouldShowToolbar =
       settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
         ? isGHover || isToolbarHover || isSelected
@@ -58,7 +60,9 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer
       return null;
     }
 
-    boxRef.current = element.getBounds();
+    if (!droppable || !boxRef.current) {
+      boxRef.current = element.getBounds();
+    }
     const toolbarWidth = Math.max(CanvasDefaults.STEP_TOOLBAR_WIDTH, boxRef.current.width);
     const toolbarX = boxRef.current.x + (boxRef.current.width - toolbarWidth) / 2;
     const toolbarY = boxRef.current.y - CanvasDefaults.STEP_TOOLBAR_HEIGHT;
@@ -83,6 +87,7 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer
           onContextMenu={onContextMenu}
         >
           <foreignObject
+            ref={dndDropRef}
             data-nodelabel={label}
             x={boxRef.current.x}
             y={boxRef.current.y}
@@ -145,3 +150,5 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer
     );
   },
 );
+
+export const CustomGroupExpanded = withDndDrop(customGroupExpandedDropTargetSpec)(CustomGroupExpandedInner);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -9,6 +9,10 @@
       flex-flow: column nowrap;
       justify-content: space-around;
 
+      &__dropTarget {
+        @include custom.drop-target;
+      }
+
       &__image {
         position: relative;
         display: flex;

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -1,20 +1,32 @@
 import { Icon } from '@patternfly/react-core';
 import { ArrowDownIcon, ArrowRightIcon, BanIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import type { DefaultNode, ElementModel, GraphElement, Node } from '@patternfly/react-topology';
 import {
   AnchorEnd,
+  DefaultNode,
   DEFAULT_LAYER,
+  DragObjectWithType,
+  DragSourceSpec,
+  DragSpecOperationType,
+  EditableDragOperationType,
+  ElementModel,
+  GraphElement,
+  GraphElementProps,
+  isNode,
   LabelBadge,
   Layer,
+  Node,
+  observer,
   Rect,
   TOP_LAYER,
-  WithSelectionProps,
-  isNode,
-  observer,
   useAnchor,
+  useCombineRefs,
   useHover,
+  useDragNode,
   useSelection,
   withContextMenu,
+  withDndDrop,
+  withSelection,
+  useVisualizationController,
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
 import { FunctionComponent, useContext, useRef } from 'react';
@@ -27,146 +39,205 @@ import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { AddStepIcon } from '../Edge/AddStepIcon';
 import { TargetAnchor } from '../target-anchor';
 import './CustomNode.scss';
+import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
+import { customNodeDropTargetSpec } from '../customComponentUtils';
 
 type DefaultNodeProps = Parameters<typeof DefaultNode>[0];
-interface CustomNodeProps extends DefaultNodeProps, WithSelectionProps {
+
+interface CustomNodeProps extends DefaultNodeProps {
   element: GraphElement<ElementModel, CanvasNode['data']>;
   /** Toggle node collapse / expand */
   onCollapseToggle?: () => void;
 }
 
-const CustomNode: FunctionComponent<CustomNodeProps> = observer(({ element, onContextMenu, onCollapseToggle }) => {
-  if (!isNode(element)) {
-    throw new Error('CustomNode must be used only on Node elements');
-  }
+const CustomNode: FunctionComponent<CustomNodeProps> = observer(
+  ({ element, onContextMenu, onCollapseToggle, dndDropRef, hover, droppable, canDrop }) => {
+    if (!isNode(element)) {
+      throw new Error('CustomNode must be used only on Node elements');
+    }
 
-  const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
-  const settingsAdapter = useContext(SettingsContext);
-  const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
-  const isDisabled = !!vizNode?.getComponentSchema()?.definition?.disabled;
-  const tooltipContent = vizNode?.getTooltipContent();
-  const validationText = vizNode?.getNodeValidationText();
-  const doesHaveWarnings = !isDisabled && !!validationText;
-  const [isSelected, onSelect] = useSelection();
-  const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
-  const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
-    CanvasDefaults.HOVER_DELAY_IN,
-    CanvasDefaults.HOVER_DELAY_OUT,
-  );
-  const childCount = element.getAllNodeChildren().length;
-  const boxRef = useRef<Rect>(element.getBounds());
-  const shouldShowToolbar =
-    settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
-      ? isGHover || isToolbarHover || isSelected
-      : isSelected;
-  const shouldShowAddStep =
-    shouldShowToolbar && vizNode?.getNodeInteraction().canHaveNextStep && vizNode.getNextNode() === undefined;
-  const isHorizontal = element.getGraph().getLayout() === LayoutType.DagreHorizontal;
+    const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
+    const entitiesContext = useEntityContext();
+    const controller = useVisualizationController();
+    const settingsAdapter = useContext(SettingsContext);
+    const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
+    const isDisabled = !!vizNode?.getComponentSchema()?.definition?.disabled;
+    const tooltipContent = vizNode?.getTooltipContent();
+    const validationText = vizNode?.getNodeValidationText();
+    const doesHaveWarnings = !isDisabled && !!validationText;
+    const [isSelected, onSelect] = useSelection();
+    const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
+    const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
+      CanvasDefaults.HOVER_DELAY_IN,
+      CanvasDefaults.HOVER_DELAY_OUT,
+    );
+    const childCount = element.getAllNodeChildren().length;
+    const boxRef = useRef<Rect | null>(null);
+    const shouldShowToolbar =
+      settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
+        ? isGHover || isToolbarHover || isSelected
+        : isSelected;
+    const shouldShowAddStep =
+      shouldShowToolbar && vizNode?.getNodeInteraction().canHaveNextStep && vizNode.getNextNode() === undefined;
+    const isHorizontal = element.getGraph().getLayout() === LayoutType.DagreHorizontal;
 
-  useAnchor((element: Node) => {
-    return new TargetAnchor(element);
-  }, AnchorEnd.both);
+    useAnchor((element: Node) => {
+      return new TargetAnchor(element);
+    }, AnchorEnd.both);
 
-  const labelX = (boxRef.current.width - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
-  const toolbarWidth = CanvasDefaults.STEP_TOOLBAR_WIDTH;
-  const toolbarX = (boxRef.current.width - toolbarWidth) / 2;
-  const toolbarY = CanvasDefaults.STEP_TOOLBAR_HEIGHT * -1;
+    const nodeDragSourceSpec: DragSourceSpec<
+      DragObjectWithType,
+      DragSpecOperationType<EditableDragOperationType>,
+      GraphElement,
+      object,
+      GraphElementProps
+    > = {
+      item: { type: '#node#' },
+      begin: () => {
+        const graph = controller.getGraph();
+        // Hide all edges when dragging starts
+        graph.getEdges().forEach((edge) => edge.setVisible(false));
+      },
+      canDrag: () => {
+        if (settingsAdapter.getSettings().experimentalFeatures.enableDragAndDrop) {
+          return element.getData()?.vizNode?.canDragNode();
+        } else {
+          return false;
+        }
+      },
+      end(dropResult, monitor) {
+        const graph = controller.getGraph();
+        // Show all edges after dropping
+        graph.getEdges().forEach((edge) => edge.setVisible(true));
 
-  if (!vizNode) {
-    return null;
-  }
+        if (monitor.didDrop() && dropResult) {
+          const draggedNodePath = element.getData().vizNode.data.path;
+          dropResult.getData()?.vizNode?.moveNodeTo(draggedNodePath);
+          entitiesContext.updateEntitiesFromCamelResource();
+        } else {
+          controller.getGraph().layout();
+        }
+      },
+    };
 
-  return (
-    <Layer id={DEFAULT_LAYER}>
-      <g
-        ref={gHoverRef}
-        className="custom-node"
-        data-testid={`custom-node__${vizNode.id}`}
-        data-nodelabel={label}
-        data-selected={isSelected}
-        data-disabled={isDisabled}
-        data-toolbar-open={shouldShowToolbar}
-        data-warning={doesHaveWarnings}
-        onClick={onSelect}
-        onContextMenu={onContextMenu}
-      >
-        <foreignObject data-nodelabel={label} width={boxRef.current.width} height={boxRef.current.height}>
-          <div className="custom-node__container">
-            <div title={tooltipContent} className="custom-node__container__image">
-              <img alt={tooltipContent} src={vizNode.data.icon} />
+    const [_, dragNodeRef] = useDragNode(nodeDragSourceSpec);
+    const gCombinedRef = useCombineRefs<SVGGElement>(gHoverRef, dragNodeRef);
 
-              {isDisabled && (
-                <Icon className="disabled-step-icon">
-                  <BanIcon />
+    if (!droppable || !boxRef.current) {
+      boxRef.current = element.getBounds();
+    }
+    const labelX = (boxRef.current.width - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
+    const toolbarWidth = CanvasDefaults.STEP_TOOLBAR_WIDTH;
+    const toolbarX = (boxRef.current.width - toolbarWidth) / 2;
+    const toolbarY = CanvasDefaults.STEP_TOOLBAR_HEIGHT * -1;
+
+    if (!vizNode) {
+      return null;
+    }
+
+    return (
+      <Layer id={DEFAULT_LAYER}>
+        <g
+          ref={gCombinedRef}
+          className="custom-node"
+          data-testid={`custom-node__${vizNode.id}`}
+          data-nodelabel={label}
+          data-selected={isSelected}
+          data-disabled={isDisabled}
+          data-toolbar-open={shouldShowToolbar}
+          data-warning={doesHaveWarnings}
+          onClick={onSelect}
+          onContextMenu={onContextMenu}
+        >
+          <foreignObject
+            data-nodelabel={label}
+            width={boxRef.current.width}
+            height={boxRef.current.height}
+            ref={dndDropRef}
+          >
+            <div
+              className={clsx('custom-node__container', {
+                'custom-node__container__dropTarget': canDrop && hover,
+              })}
+            >
+              <div title={tooltipContent} className="custom-node__container__image">
+                <img alt={tooltipContent} src={vizNode.data.icon} />
+
+                {isDisabled && (
+                  <Icon className="disabled-step-icon">
+                    <BanIcon />
+                  </Icon>
+                )}
+              </div>
+            </div>
+          </foreignObject>
+
+          <foreignObject
+            x={labelX}
+            y={boxRef.current.height - 1}
+            width={CanvasDefaults.DEFAULT_LABEL_WIDTH}
+            height={CanvasDefaults.DEFAULT_LABEL_HEIGHT}
+            className="custom-node__label"
+          >
+            <div
+              className={clsx('custom-node__label__text', {
+                'custom-node__label__text__error': doesHaveWarnings,
+              })}
+            >
+              {doesHaveWarnings && (
+                <Icon title={validationText} data-warning={doesHaveWarnings}>
+                  <ExclamationCircleIcon />
                 </Icon>
               )}
+              <span title={label}>{label}</span>
             </div>
-          </div>
-        </foreignObject>
-
-        <foreignObject
-          x={labelX}
-          y={boxRef.current.height - 1}
-          width={CanvasDefaults.DEFAULT_LABEL_WIDTH}
-          height={CanvasDefaults.DEFAULT_LABEL_HEIGHT}
-          className="custom-node__label"
-        >
-          <div
-            className={clsx('custom-node__label__text', {
-              'custom-node__label__text__error': doesHaveWarnings,
-            })}
-          >
-            {doesHaveWarnings && (
-              <Icon title={validationText} data-warning={doesHaveWarnings}>
-                <ExclamationCircleIcon />
-              </Icon>
-            )}
-            <span title={label}>{label}</span>
-          </div>
-        </foreignObject>
-
-        {shouldShowToolbar && (
-          <Layer id={TOP_LAYER}>
-            <foreignObject
-              ref={toolbarHoverRef}
-              className="custom-node__toolbar"
-              x={toolbarX}
-              y={toolbarY}
-              width={toolbarWidth}
-              height={CanvasDefaults.STEP_TOOLBAR_HEIGHT}
-            >
-              <StepToolbar
-                data-testid="step-toolbar"
-                vizNode={vizNode}
-                isCollapsed={element.isCollapsed()}
-                onCollapseToggle={onCollapseToggle}
-              />
-            </foreignObject>
-          </Layer>
-        )}
-
-        {shouldShowAddStep && (
-          <foreignObject
-            x={boxRef.current.width - 8}
-            y={(boxRef.current.height - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2}
-            width={CanvasDefaults.ADD_STEP_ICON_SIZE}
-            height={CanvasDefaults.ADD_STEP_ICON_SIZE}
-          >
-            <AddStepIcon
-              vizNode={vizNode}
-              mode={AddStepMode.AppendStep}
-              title="Add step"
-              data-testid="quick-append-step"
-            >
-              <Icon size="lg">{isHorizontal ? <ArrowRightIcon /> : <ArrowDownIcon />}</Icon>
-            </AddStepIcon>
           </foreignObject>
-        )}
 
-        {childCount && <LabelBadge badge={`${childCount}`} x={0} y={0} />}
-      </g>
-    </Layer>
-  );
-});
+          {!droppable && shouldShowToolbar && (
+            <Layer id={TOP_LAYER}>
+              <foreignObject
+                ref={toolbarHoverRef}
+                className="custom-node__toolbar"
+                x={toolbarX}
+                y={toolbarY}
+                width={toolbarWidth}
+                height={CanvasDefaults.STEP_TOOLBAR_HEIGHT}
+              >
+                <StepToolbar
+                  data-testid="step-toolbar"
+                  vizNode={vizNode}
+                  isCollapsed={element.isCollapsed()}
+                  onCollapseToggle={onCollapseToggle}
+                />
+              </foreignObject>
+            </Layer>
+          )}
 
-export const CustomNodeWithSelection = withContextMenu(NodeContextMenuFn)(CustomNode);
+          {!droppable && shouldShowAddStep && (
+            <foreignObject
+              x={boxRef.current.width - 8}
+              y={(boxRef.current.height - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2}
+              width={CanvasDefaults.ADD_STEP_ICON_SIZE}
+              height={CanvasDefaults.ADD_STEP_ICON_SIZE}
+            >
+              <AddStepIcon
+                vizNode={vizNode}
+                mode={AddStepMode.AppendStep}
+                title="Add step"
+                data-testid="quick-append-step"
+              >
+                <Icon size="lg">{isHorizontal ? <ArrowRightIcon /> : <ArrowDownIcon />}</Icon>
+              </AddStepIcon>
+            </foreignObject>
+          )}
+
+          {childCount && <LabelBadge badge={`${childCount}`} x={0} y={0} />}
+        </g>
+      </Layer>
+    );
+  },
+);
+
+export const CustomNodeWithSelection = withDndDrop(customNodeDropTargetSpec)(
+  withSelection()(withContextMenu(NodeContextMenuFn)(CustomNode)),
+);

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.scss
@@ -9,6 +9,10 @@
       align-items: center;
       justify-content: center;
 
+      &__dropTarget {
+        @include custom.drop-target;
+      }
+
       &__image {
         border: 2px dashed var(--custom-node-BorderColor);
         border-radius: var(--custom-node-BorderRadius);

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
@@ -1,7 +1,16 @@
 import { Icon } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import type { DefaultNode, ElementModel, GraphElement, Node } from '@patternfly/react-topology';
-import { AnchorEnd, DEFAULT_LAYER, Layer, Rect, isNode, observer, useAnchor } from '@patternfly/react-topology';
+import {
+  AnchorEnd,
+  DEFAULT_LAYER,
+  Layer,
+  Rect,
+  isNode,
+  observer,
+  useAnchor,
+  withDndDrop,
+} from '@patternfly/react-topology';
 import { FunctionComponent, useContext, useRef } from 'react';
 import { IVisualizationNode } from '../../../../models';
 import { SettingsContext } from '../../../../providers';
@@ -10,63 +19,78 @@ import { CanvasNode } from '../../Canvas/canvas.models';
 import { useReplaceStep } from '../hooks/replace-step.hook';
 import { TargetAnchor } from '../target-anchor';
 import './PlaceholderNode.scss';
+import clsx from 'clsx';
+import { placeholderNodeDropTargetSpec } from '../customComponentUtils';
 
 type DefaultNodeProps = Parameters<typeof DefaultNode>[0];
-interface CustomNodeProps extends DefaultNodeProps {
+interface PlaceholderNodeInnerProps extends DefaultNodeProps {
   element: GraphElement<ElementModel, CanvasNode['data']>;
 }
 
-export const PlaceholderNode: FunctionComponent<CustomNodeProps> = observer(({ element }) => {
-  if (!isNode(element)) {
-    throw new Error('PlaceholderNode must be used only on Node elements');
-  }
-  const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
-  const settingsAdapter = useContext(SettingsContext);
-  const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
-  const updatedLabel = label === 'placeholder' ? 'Add step' : label;
-  const tooltipContent = 'Click to add a step';
-  const boxRef = useRef<Rect>(element.getBounds());
-  const labelX = (boxRef.current.width - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
+const PlaceholderNodeInner: FunctionComponent<PlaceholderNodeInnerProps> = observer(
+  ({ element, dndDropRef, hover, canDrop }) => {
+    if (!isNode(element)) {
+      throw new Error('PlaceholderNode must be used only on Node elements');
+    }
+    const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
+    const settingsAdapter = useContext(SettingsContext);
+    const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
+    const updatedLabel = label === 'placeholder' ? 'Add step' : label;
+    const tooltipContent = 'Click to add a step';
+    const boxRef = useRef<Rect>(element.getBounds());
+    const labelX = (boxRef.current.width - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
 
-  useAnchor((element: Node) => {
-    return new TargetAnchor(element);
-  }, AnchorEnd.both);
+    useAnchor((element: Node) => {
+      return new TargetAnchor(element);
+    }, AnchorEnd.both);
 
-  if (!vizNode) {
-    return null;
-  }
-  const { onReplaceNode } = useReplaceStep(vizNode);
+    if (!vizNode) {
+      return null;
+    }
+    const { onReplaceNode } = useReplaceStep(vizNode);
 
-  return (
-    <Layer id={DEFAULT_LAYER}>
-      <g
-        className="placeholder-node"
-        data-testid={`placeholder-node__${vizNode.id}`}
-        data-nodelabel={label}
-        onClick={onReplaceNode}
-      >
-        <foreignObject data-nodelabel={label} width={boxRef.current.width} height={boxRef.current.height}>
-          <div className="placeholder-node__container">
-            <div title={tooltipContent} className="placeholder-node__container__image">
-              <Icon size="lg">
-                <PlusCircleIcon />
-              </Icon>
-            </div>
-          </div>
-        </foreignObject>
-
-        <foreignObject
-          x={labelX}
-          y={boxRef.current.height - 1}
-          width={CanvasDefaults.DEFAULT_LABEL_WIDTH}
-          height={CanvasDefaults.DEFAULT_LABEL_HEIGHT}
-          className="placeholder-node__label"
+    return (
+      <Layer id={DEFAULT_LAYER}>
+        <g
+          className="placeholder-node"
+          data-testid={`placeholder-node__${vizNode.id}`}
+          data-nodelabel={label}
+          onClick={onReplaceNode}
         >
-          <div className="placeholder-node__label__text">
-            <span title={updatedLabel}>{updatedLabel}</span>
-          </div>
-        </foreignObject>
-      </g>
-    </Layer>
-  );
-});
+          <foreignObject
+            data-nodelabel={label}
+            width={boxRef.current.width}
+            height={boxRef.current.height}
+            ref={dndDropRef}
+          >
+            <div
+              className={clsx('placeholder-node__container', {
+                'placeholder-node__container__dropTarget': canDrop && hover,
+              })}
+            >
+              <div title={tooltipContent} className="placeholder-node__container__image">
+                <Icon size="lg">
+                  <PlusCircleIcon />
+                </Icon>
+              </div>
+            </div>
+          </foreignObject>
+
+          <foreignObject
+            x={labelX}
+            y={boxRef.current.height - 1}
+            width={CanvasDefaults.DEFAULT_LABEL_WIDTH}
+            height={CanvasDefaults.DEFAULT_LABEL_HEIGHT}
+            className="placeholder-node__label"
+          >
+            <div className="placeholder-node__label__text">
+              <span title={updatedLabel}>{updatedLabel}</span>
+            </div>
+          </foreignObject>
+        </g>
+      </Layer>
+    );
+  },
+);
+
+export const PlaceholderNode = withDndDrop(placeholderNodeDropTargetSpec)(PlaceholderNodeInner);

--- a/packages/ui/src/components/Visualization/Custom/_custom.scss
+++ b/packages/ui/src/components/Visualization/Custom/_custom.scss
@@ -11,6 +11,7 @@
   --custom-node-BorderRadius: 10px;
   --custom-node-hover-BorderColor: var(--pf-v5-global--primary-color--light-100);
   --custom-node-Shadow: var(--pf-v5-global--BoxShadow--md);
+  --custom-node-dropTarget-BorderColor: var(--pf-v5-global--palette--light-green-500);
 
   &[data-selected='true'] {
     --custom-node-BorderColor: var(--pf-v5-global--primary-color--dark-100);
@@ -61,4 +62,9 @@
 
     @content;
   }
+}
+
+@mixin drop-target {
+  border: 3px dashed var(--custom-node-dropTarget-BorderColor);
+  border-radius: 5px;
 }

--- a/packages/ui/src/components/Visualization/Custom/customComponentUtils.ts
+++ b/packages/ui/src/components/Visualization/Custom/customComponentUtils.ts
@@ -1,0 +1,49 @@
+import { DropTargetSpec, GraphElement, GraphElementProps, Node } from '@patternfly/react-topology';
+
+const NODE_DRAG_TYPE = '#node#';
+
+const placeholderNodeDropTargetSpec: DropTargetSpec<GraphElement, unknown, object, GraphElementProps> = {
+  accept: ['#node#'],
+  canDrop: (item) => {
+    const draggedNode = item as Node;
+    // Do not allow group drop yet
+    return !draggedNode.getData().vizNode.data.isGroup;
+  },
+  collect: (monitor) => ({
+    droppable: monitor.isDragging(),
+    hover: monitor.isOver(),
+    canDrop: monitor.canDrop(),
+  }),
+};
+
+const customNodeDropTargetSpec: DropTargetSpec<GraphElement, unknown, object, GraphElementProps> = {
+  accept: ['#node#'],
+  canDrop: (item, _monitor, props) => {
+    const targetNode = props.element;
+    const draggedNode = item as Node;
+
+    // Ensure that the node is not dropped onto itself
+    if (draggedNode !== targetNode) {
+      return targetNode.getData()?.vizNode?.canDropOnNode();
+    }
+
+    return false;
+  },
+  collect: (monitor) => ({
+    droppable: monitor.isDragging(),
+    hover: monitor.isOver(),
+    canDrop: monitor.canDrop(),
+  }),
+};
+
+const customGroupExpandedDropTargetSpec: DropTargetSpec<GraphElement, unknown, object, GraphElementProps> = {
+  accept: ['#node#'],
+  canDrop: () => {
+    return false;
+  },
+  collect: (monitor) => ({
+    droppable: monitor.isDragging(),
+  }),
+};
+
+export { customGroupExpandedDropTargetSpec, customNodeDropTargetSpec, placeholderNodeDropTargetSpec, NODE_DRAG_TYPE };

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -47,6 +47,15 @@ export interface BaseVisualCamelEntity extends BaseCamelEntity {
     targetProperty?: string;
   }) => void;
 
+  /** Check if the node is draggable */
+  canDragNode: (path?: string) => boolean;
+
+  /** Check if the node is droppable */
+  canDropOnNode: (path?: string) => boolean;
+
+  /** Switch steps */
+  moveNodeTo: (options: { draggedNodePath: string; droppedNodePath?: string }) => void;
+
   /** Remove the step at a given path from the underlying Camel entity */
   removeStep: (path?: string) => void;
 
@@ -90,6 +99,12 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
   getNodeTitle(): string;
 
   addBaseEntityStep(definedComponent: DefinedComponent, mode: AddStepMode, targetProperty?: string): void;
+
+  canDragNode(): boolean;
+
+  canDropOnNode(): boolean;
+
+  moveNodeTo(path: string): void;
 
   getNodeInteraction(): NodeInteraction;
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -1,6 +1,6 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { SchemaService } from '../../../components/Form/schema.service';
-import { camelCaseToSpaces, getArrayProperty, getValue, setValue } from '../../../utils';
+import { camelCaseToSpaces, getArrayProperty, getValue, isDefined, setValue } from '../../../utils';
 import { NodeIconResolver, NodeIconType } from '../../../utils/node-icon-resolver';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
@@ -160,6 +160,53 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
       stepsArray.splice(desiredStartIndex, deleteCount, defaultValue);
 
       return;
+    }
+  }
+
+  canDragNode(path?: string) {
+    if (!isDefined(path)) return false;
+
+    return path !== 'route.from' && path !== 'template.from';
+  }
+
+  canDropOnNode(path?: string) {
+    return this.canDragNode(path);
+  }
+
+  /** To Do: combine with addstep()
+   *  Try to re-use insertChildStep()
+   */
+  moveNodeTo(options: { draggedNodePath: string; droppedNodePath?: string }) {
+    if (options.droppedNodePath === undefined) return;
+
+    const pathArray = options.droppedNodePath.split('.');
+    const last = pathArray[pathArray.length - 1];
+    const penultimate = pathArray[pathArray.length - 2];
+
+    const componentPath = options.draggedNodePath.split('.');
+    let stepsArray: ProcessorDefinition[];
+
+    if (!Number.isInteger(Number(last)) && Number.isInteger(Number(penultimate))) {
+      const componentModel = getValue(this.entityDef, componentPath?.slice(0, -1));
+      stepsArray = getArrayProperty(this.entityDef, pathArray.slice(0, -2).join('.'));
+
+      /** Remove the dragged node */
+      this.removeStep(options.draggedNodePath);
+
+      /** Add the dragged node before the drop target */
+      const desiredStartIndex = last === 'placeholder' ? 0 : Number(penultimate);
+      stepsArray.splice(desiredStartIndex, 0, componentModel);
+    }
+
+    if (Number.isInteger(Number(last)) && !Number.isInteger(Number(penultimate))) {
+      const componentModel = getValue(this.entityDef, componentPath);
+      stepsArray = getArrayProperty(this.entityDef, pathArray.slice(0, -1).join('.'));
+
+      /** Remove the dragged node */
+      this.removeStep(options.draggedNodePath);
+
+      /** Add the dragged node before the drop target */
+      stepsArray.splice(Number(last), 0, componentModel);
     }
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -90,6 +90,18 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
     return;
   }
 
+  canDragNode(_path?: string) {
+    return false;
+  }
+
+  canDropOnNode(_path?: string) {
+    return false;
+  }
+
+  moveNodeTo(_options: { draggedNodePath: string; droppedNodePath?: string }) {
+    return;
+  }
+
   removeStep(): void {
     return;
   }

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -73,6 +73,18 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualCamelEntity
     return;
   }
 
+  canDragNode(_path?: string) {
+    return false;
+  }
+
+  canDropOnNode(_path?: string) {
+    return false;
+  }
+
+  moveNodeTo(_options: { draggedNodePath: string; droppedNodePath?: string }) {
+    return;
+  }
+
   removeStep(): void {
     return;
   }

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -9,6 +9,7 @@ import {
   updatePipeFromCustomSchema,
   setValue,
   getValue,
+  isDefined,
 } from '../../../utils';
 import { DefinedComponent } from '../../camel-catalog-index';
 import { EntityType } from '../../camel/entities';
@@ -165,6 +166,29 @@ export class PipeVisualEntity implements BaseVisualCamelEntity {
     } else if (options.mode === AddStepMode.PrependStep) {
       kameletArray.splice(index, 0, step);
     }
+  }
+
+  canDragNode(path?: string) {
+    if (!isDefined(path)) return false;
+
+    return path !== 'source' && path !== 'sink';
+  }
+
+  canDropOnNode(path?: string) {
+    return this.canDragNode(path);
+  }
+
+  moveNodeTo(options: { draggedNodePath: string; droppedNodePath?: string }) {
+    if (options.droppedNodePath === undefined) return;
+
+    const step = getValue(this.pipe.spec!, options.draggedNodePath);
+    const kameletArray = getArrayProperty(this.pipe.spec!, 'steps');
+
+    /** Remove the dragged node */
+    this.removeStep(options.draggedNodePath);
+
+    /** Add the dragged node at the target node index */
+    kameletArray.splice(Number(options.droppedNodePath.split('.').pop()), 0, step);
   }
 
   removeStep(path?: string): void {

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -54,6 +54,18 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     this.getBaseEntity()?.addStep({ definedComponent: definition, mode, data: this.data });
   }
 
+  canDragNode(): boolean {
+    return this.getBaseEntity()?.canDragNode(this.data.path) ?? false;
+  }
+
+  canDropOnNode(): boolean {
+    return this.getBaseEntity()?.canDropOnNode(this.data.path) ?? false;
+  }
+
+  moveNodeTo(path: string): void {
+    this.getBaseEntity()?.moveNodeTo({ draggedNodePath: path, droppedNodePath: this.data.path });
+  }
+
   getNodeInteraction(): NodeInteraction {
     return this.getBaseEntity()?.getNodeInteraction(this.data) ?? this.DISABLED_NODE_INTERACTION;
   }


### PR DESCRIPTION
Fixes #80 partially

Following are the changes coming with this PR:
- Enabled DND of nodes over other nodes.
- Enabled containers drag only when collapsed.
- Added Visual Feedback when DND on nodes.
- Added feature flag for the DND on the settings page.
- Enabled re-arrangement of when/doCatch containers in case of choice/doTry.

Above changes can be tested live [here](https://shivamg640.github.io/kaoto/).

Note:
- We have restricted group drop on placeholder as there are few breaking cases which needs to be handled.
- There is known console error on every successful drag and drop which needs some attention.

