### PR TITLE
feat(Canvas): Use hover styles upon open toolbar

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               data-grouplabel="route-8888"
                               data-selected="false"
                               data-testid="custom-group__route-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="route-8888"
@@ -121,6 +122,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               data-grouplabel="choice"
                               data-selected="false"
                               data-testid="custom-group__choice-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="choice"
@@ -161,6 +163,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               data-grouplabel="otherwise"
                               data-selected="false"
                               data-testid="custom-group__otherwise-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="otherwise"
@@ -810,6 +813,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               data-grouplabel="route-8888"
                               data-selected="false"
                               data-testid="custom-group__route-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="route-8888"
@@ -850,6 +854,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               data-grouplabel="choice"
                               data-selected="false"
                               data-testid="custom-group__choice-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="choice"
@@ -890,6 +895,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               data-grouplabel="otherwise"
                               data-selected="false"
                               data-testid="custom-group__otherwise-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="otherwise"
@@ -2351,6 +2357,7 @@ exports[`Canvas should render correctly 1`] = `
                               data-grouplabel="route-8888"
                               data-selected="false"
                               data-testid="custom-group__route-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="route-8888"
@@ -2391,6 +2398,7 @@ exports[`Canvas should render correctly 1`] = `
                               data-grouplabel="choice"
                               data-selected="false"
                               data-testid="custom-group__choice-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="choice"
@@ -2431,6 +2439,7 @@ exports[`Canvas should render correctly 1`] = `
                               data-grouplabel="otherwise"
                               data-selected="false"
                               data-testid="custom-group__otherwise-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="otherwise"
@@ -3080,6 +3089,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                               data-grouplabel="route-8888"
                               data-selected="false"
                               data-testid="custom-group__route-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="route-8888"
@@ -3120,6 +3130,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                               data-grouplabel="choice"
                               data-selected="false"
                               data-testid="custom-group__choice-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="choice"
@@ -3160,6 +3171,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                               data-grouplabel="otherwise"
                               data-selected="false"
                               data-testid="custom-group__otherwise-1234"
+                              data-toolbar-open="false"
                             >
                               <foreignobject
                                 data-nodelabel="otherwise"

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
@@ -41,6 +41,7 @@
       }
 
       &:hover,
+      [data-toolbar-open='true'] &,
       [data-selected='true'] & {
         border-color: var(--custom-node-hover-BorderColor);
         box-shadow: var(--custom-node-Shadow);

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -64,6 +64,7 @@ export const CustomGroupExpanded: FunctionComponent<CustomGroupProps> = observer
           data-grouplabel={label}
           data-selected={isSelected}
           data-disabled={isDisabled}
+          data-toolbar-open={shouldShowToolbar}
           onClick={onSelect}
           onContextMenu={onContextMenu}
         >

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -28,6 +28,7 @@
       }
 
       &:hover &__image,
+      [data-toolbar-open='true'] & &__image,
       [data-selected='true'] & &__image {
         border-color: var(--custom-node-hover-BorderColor);
         box-shadow: var(--custom-node-Shadow);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -79,6 +79,7 @@ const CustomNode: FunctionComponent<CustomNodeProps> = observer(({ element, onCo
         data-nodelabel={label}
         data-selected={isSelected}
         data-disabled={isDisabled}
+        data-toolbar-open={shouldShowToolbar}
         data-warning={doesHaveWarnings}
         onClick={onSelect}
         onContextMenu={onContextMenu}


### PR DESCRIPTION
### Context
Currently, when opening the step toolbar upon hovering over a node or a group, the hover style is lost when hovering over the toolbar.

### Changes
This commit retains the hover styling when the toolbar is open.

| Before |After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3d2af327-de1e-43bc-abbb-3b3fe2b7ee9d) | ![image](https://github.com/user-attachments/assets/fe397c26-2b1f-49f9-8fac-405d36e6835e) |
