### PR TITLE
fix(Canvas): Use description for root groups

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
@@ -90,7 +90,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.uploadFixture('flows/kamelet/basic.yaml');
     cy.openDesignPage();
 
-    cy.openRootConfigurationTab('eip-action');
+    cy.openRootConfigurationTab('Produces periodic events about random users!');
 
     cy.selectFormTab('All');
     cy.interactWithConfigInputObject('name', 'test.name');

--- a/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/routeConfiguration.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/routeConfiguration.cy.ts
@@ -3,26 +3,40 @@ describe('Test for root route configuration container', () => {
     cy.openHomePage();
   });
 
+  it('Update routeConfiguration description', () => {
+    cy.selectCamelRouteType('Configuration', 'routeConfiguration');
+
+    // Open routeConfiguration configuration tab, using the first routeConfiguration node
+    cy.get(`g[data-nodelabel^="routeConfiguration-"]`).eq(0).click({ force: true });
+    cy.selectFormTab('All');
+    cy.interactWithConfigInputObject('description', 'routeConfigurationDescription');
+    cy.closeStepConfigurationTab();
+
+    cy.openStepConfigurationTab('routeConfigurationDescription');
+  });
+
   it('Root route configuration', () => {
     cy.selectCamelRouteType('Configuration', 'routeConfiguration');
 
-    cy.openStepConfigurationTab('routeConfiguration');
+    // Open routeConfiguration configuration tab, using the first routeConfiguration node
+    cy.get(`g[data-nodelabel^="routeConfiguration-"]`).eq(0).click({ force: true });
 
     cy.selectFormTab('All');
 
-    cy.interactWithConfigInputObject('description', 'testDescription');
+    cy.interactWithConfigInputObject('description', 'description Label');
     cy.interactWithConfigInputObject('errorHandler.id', 'testErrorHandlerId');
     cy.interactWithConfigInputObject('precondition', 'testPrecondition');
+    cy.closeStepConfigurationTab();
 
     // Insert special node intercept to Route Configuration
-    cy.selectInsertSpecialNode('routeConfiguration');
+    cy.selectInsertSpecialNode('description Label');
     cy.chooseFromCatalog('processor', 'intercept');
 
     cy.openSourceCode();
 
     cy.checkCodeSpanLine('- intercept:');
     cy.checkCodeSpanLine('- routeConfiguration:');
-    cy.checkCodeSpanLine('description: testDescription');
+    cy.checkCodeSpanLine('description: description Label');
     cy.checkCodeSpanLine('errorHandler:');
     cy.checkCodeSpanLine('id: testErrorHandlerId');
     cy.checkCodeSpanLine('precondition: testPrecondition');

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -167,7 +167,7 @@ describe('Canvas', () => {
       await jest.runAllTimersAsync();
     });
 
-    const kamelet = result?.getByText('user-source');
+    const kamelet = result?.getByText('Produces periodic events about random users!');
     if (!kamelet) {
       fail('Kamelet not found');
     }

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -4,6 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../catalog-kind';
+import { NodeLabelType } from '../../settings';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CamelRouteVisualEntity } from './camel-route-visual-entity';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
@@ -22,7 +23,47 @@ describe('AbstractCamelVisualEntity', () => {
   });
 
   beforeEach(() => {
-    abstractVisualEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson.route));
+    abstractVisualEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
+  });
+
+  describe('getNodeLabel', () => {
+    it('should return an empty string if the path is `undefined`', () => {
+      const result = abstractVisualEntity.getNodeLabel(undefined);
+
+      expect(result).toEqual('');
+    });
+
+    it('should return an empty string if the path is empty', () => {
+      const result = abstractVisualEntity.getNodeLabel('');
+
+      expect(result).toEqual('');
+    });
+
+    it('should return the ID as a node label by default', () => {
+      const result = abstractVisualEntity.getNodeLabel('route');
+
+      expect(result).toEqual('route-8888');
+    });
+
+    it('should return the description as a node label', () => {
+      const routeDefinition = cloneDeep(camelRouteJson);
+      routeDefinition.route.description = 'description';
+      abstractVisualEntity = new CamelRouteVisualEntity(routeDefinition);
+
+      const result = abstractVisualEntity.getNodeLabel('route', NodeLabelType.Description);
+
+      expect(result).toEqual('description');
+    });
+
+    it('should return the ID as a node label if description is empty', () => {
+      const routeDefinition = cloneDeep(camelRouteJson);
+      routeDefinition.route.description = '';
+      abstractVisualEntity = new CamelRouteVisualEntity(routeDefinition);
+
+      const result = abstractVisualEntity.getNodeLabel('route', NodeLabelType.Description);
+
+      expect(result).toEqual('route-8888');
+    });
   });
 
   describe('getNodeInteraction', () => {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -36,6 +36,15 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
 
   getNodeLabel(path?: string, labelType?: NodeLabelType): string {
     if (!path) return '';
+    if (path === this.getRootPath()) {
+      const description: string | undefined = getValue(this.entityDef, `${this.getRootPath()}.description`);
+      if (labelType === NodeLabelType.Description && description) {
+        return description;
+      }
+
+      return this.id;
+    }
+
     const componentModel = getValue(this.entityDef, path);
 
     const label = CamelComponentSchemaService.getNodeLabel(

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -48,6 +48,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
   }
 
   getNodeLabel(): string {
+    const id: string | undefined = getValue(this.errorHandlerDef.errorHandler, 'id');
     const deadLetterChannelId: string | undefined = getValue(this.errorHandlerDef.errorHandler, 'deadLetterChannel.id');
     const defaultErrorHandlerId: string | undefined = getValue(
       this.errorHandlerDef.errorHandler,
@@ -70,7 +71,8 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualCamelEntity {
       jtaTransactionErrorHandlerId ??
       noErrorHandlerId ??
       refErrorHandlerId ??
-      springTransactionErrorHandlerId;
+      springTransactionErrorHandlerId ??
+      id;
 
     if (!errorHandlerId?.trim()) errorHandlerId = 'errorHandler';
     return errorHandlerId;

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -222,14 +222,14 @@ describe('Camel Route', () => {
       camelEntity.entityDef.route.description = 'This is a route description';
       const vizNode = camelEntity.toVizNode();
 
-      expect(vizNode.getNodeLabel()).toEqual('This is a route description');
+      expect(vizNode.getNodeLabel(NodeLabelType.Description)).toEqual('This is a route description');
     });
 
     it('should use the default group label if the id is not available', () => {
       camelEntity.entityDef.route.id = undefined;
       const vizNode = camelEntity.toVizNode();
 
-      expect(vizNode.getNodeLabel()).toEqual('route');
+      expect(vizNode.getNodeLabel()).toEqual('route-8888');
     });
 
     it('should use the uri as the node label', () => {

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -6,6 +6,7 @@ import { SourceSchemaType } from '../../camel';
 import { ICamelProcessorDefinition } from '../../camel-processors-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { IKameletDefinition, IKameletMetadata, IKameletSpecProperty } from '../../kamelets-catalog';
+import { NodeLabelType } from '../../settings';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { KameletVisualEntity } from './kamelet-visual-entity';
@@ -83,14 +84,29 @@ describe('KameletVisualEntity', () => {
     expect(kameletVisualEntity.kamelet.metadata.name).toEqual('new-id');
   });
 
-  it('should return the node label when querying the ROOT_PATH', () => {
-    const kamelet = new KameletVisualEntity(kameletDef);
-    expect(kamelet.getNodeLabel(KameletVisualEntity.ROOT_PATH)).toEqual('My Kamelet');
-  });
+  describe('getNodeLabel', () => {
+    it('should return the ID as node label when querying the ROOT_PATH by default', () => {
+      const kamelet = new KameletVisualEntity(kameletDef);
+      expect(kamelet.getNodeLabel(KameletVisualEntity.ROOT_PATH)).toEqual('My Kamelet');
+    });
 
-  it('should return the node label when querying a different path', () => {
-    const kamelet = new KameletVisualEntity(kameletDef);
-    expect(kamelet.getNodeLabel('template.from')).toEqual('timer');
+    it('should return the description as node label when querying the ROOT_PATH', () => {
+      const kamelet = new KameletVisualEntity(kameletDef);
+      expect(kamelet.getNodeLabel(KameletVisualEntity.ROOT_PATH, NodeLabelType.Description)).toEqual(
+        'My Kamelet Description',
+      );
+    });
+
+    it('should fallback to the id as node label when there is no description available', () => {
+      kameletDef.spec.definition.description = undefined;
+      const kamelet = new KameletVisualEntity(kameletDef);
+      expect(kamelet.getNodeLabel(KameletVisualEntity.ROOT_PATH, NodeLabelType.Description)).toEqual('My Kamelet');
+    });
+
+    it('should return the node label when querying a different path', () => {
+      const kamelet = new KameletVisualEntity(kameletDef);
+      expect(kamelet.getNodeLabel('template.from')).toEqual('timer');
+    });
   });
 
   describe('getComponentSchema when querying the ROOT_PATH', () => {

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -40,7 +40,14 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
 
   getNodeLabel(path?: string, labelType?: NodeLabelType): string {
     if (path === this.getRootPath()) {
-      return this.kamelet.metadata.name;
+      const id: string | undefined = this.kamelet.metadata.name;
+      const description: string | undefined = this.kamelet.spec.definition.description;
+
+      if (labelType === NodeLabelType.Description && isDefined(description)) {
+        return description;
+      }
+
+      return id;
     }
 
     return super.getNodeLabel(path, labelType);

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
-import { ROOT_PATH } from '../../../../utils';
 import { ICamelProcessorDefinition } from '../../../camel-processors-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { NodeLabelType } from '../../../settings/settings.model';
@@ -65,7 +64,7 @@ describe('CamelComponentSchemaService', () => {
 
     it('should build the appropriate schema for `route` entity', () => {
       const camelCatalogServiceSpy = jest.spyOn(CamelCatalogService, 'getComponent');
-      const rootPath = ROOT_PATH;
+      const rootPath = 'route';
       const routeDefinition = {
         id: 'route-1234',
         from: {
@@ -282,7 +281,8 @@ describe('CamelComponentSchemaService', () => {
 
   describe('getCamelComponentLookup', () => {
     it.each([
-      [ROOT_PATH, { from: { uri: 'timer' } }, { processorName: 'route' }],
+      ['route', { from: { uri: 'timer' } }, { processorName: 'route' }],
+      ['intercept', { id: 'intercept-8888', steps: [] }, { processorName: 'intercept' }],
       ['from', { uri: 'timer' }, { processorName: 'from', componentName: 'timer' }],
       ['from.steps.0.to', { uri: 'log' }, { processorName: 'to', componentName: 'log' }],
       ['from.steps.1.toD', { uri: 'log' }, { processorName: 'toD', componentName: 'log' }],

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,6 +1,6 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import cloneDeep from 'lodash/cloneDeep';
-import { CamelUriHelper, ParsedParameters, ROOT_PATH, getValue, isDefined } from '../../../../utils';
+import { CamelUriHelper, ParsedParameters, getValue, isDefined } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel-components-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { IKameletDefinition } from '../../../kamelets-catalog';
@@ -43,11 +43,6 @@ export class CamelComponentSchemaService {
     const splitPath = path.split('.');
     const lastPathSegment = splitPath[splitPath.length - 1];
     const pathAsIndex = Number.parseInt(lastPathSegment, 10);
-
-    /** If path is `#` it means the root of the Camel Route */
-    if (path === ROOT_PATH) {
-      return { processorName: 'route' as keyof ProcessorDefinition };
-    }
 
     /**
      * If the last path segment is NaN, it means this is a Camel Processor


### PR DESCRIPTION
### Context
Currently, the root groups use the `id` or the `name` as a label.

### Changes
This commit adds the possibility to use the `description`, if configured, instead.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/04a797b3-1266-4ad0-bbfb-5c43b664cf79) | ![image](https://github.com/user-attachments/assets/0567bc53-c96f-43e7-a0af-f23ed45a9594) |


fix: https://github.com/KaotoIO/kaoto/issues/1581