### PR TITLE
fix(Build): Fix Windows build

### DIFF
--- a/packages/catalog-generator/scripts/json-schema-to-typescript.mts
+++ b/packages/catalog-generator/scripts/json-schema-to-typescript.mts
@@ -69,6 +69,13 @@ async function main() {
   }
 
   const indexDefinitionFileName = catalogLibraryIndex.definitions[0].fileName;
+
+  /**
+   * In windows, path starting with C:\ are not supported
+   * We need to add file:// to the path to make it work
+   * [pathToFileURL](https://nodejs.org/api/url.html#url_url_pathtofileurl_path)
+   * Related issue: https://github.com/nodejs/node/issues/31710
+   */
   const indexFileUri = pathToFileURL(`./dist/camel-catalog/${indexDefinitionFileName}`).toString();
   const indexDefinitionContent: CatalogDefinition = (await import(indexFileUri, { assert: { type: 'json' } })).default;
 
@@ -77,17 +84,9 @@ async function main() {
       return;
     }
 
-    const baseFolder = indexDefinitionFileName.substring(0, indexDefinitionFileName.lastIndexOf('/'));
-    const schemaFile = resolve(`./dist/camel-catalog/${baseFolder}/${schema.file}`);
-
-    /**
-     * In windows, path starting with C:\ are not supported
-     * We need to add file:// to the path to make it work
-     * [pathToFileURL](https://nodejs.org/api/url.html#url_url_pathtofileurl_path)
-     * Related issue: https://github.com/nodejs/node/issues/31710
-     */
-    const schemaFileUri = pathToFileURL(schemaFile).toString();
-    const schemaContent = (await import(schemaFileUri, { assert: { type: 'json' } })).default;
+    const baseFolder = indexFileUri.substring(0, indexFileUri.lastIndexOf('/'));
+    const schemaFile = `${baseFolder}/${schema.file}`;
+    const schemaContent = (await import(schemaFile, { assert: { type: 'json' } })).default;
 
     addTitleToDefinitions(schemaContent);
 


### PR DESCRIPTION
### Context
Currently, building Kaoto on Windows is broken due to a problem resolving the base path of the catalog related to the folder separator.

### Changes
The fix is to use the `pathToFileURL` function at all times when resolving paths, so the folder and file paths gets properly resolved.

![image](https://github.com/user-attachments/assets/a36e91f4-6882-4cc0-ba9b-ff63885a4e30)


fix: https://github.com/KaotoIO/kaoto/issues/1592
