### PR TITLE
Fix loading of Red Hat artifacts for catalog

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CatalogGenerator.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generator/CatalogGenerator.java
@@ -58,12 +58,12 @@ public class CatalogGenerator {
 
     public CatalogDefinition generate() {
         camelCatalogVersionLoader.loadKameletBoundaries();
+        camelCatalogVersionLoader.loadCamelCatalog(camelCatalogVersion);
         camelCatalogVersionLoader.loadKamelets(kameletsVersion);
         camelCatalogVersionLoader.loadKubernetesSchema();
         camelCatalogVersionLoader.loadCamelKCRDs(camelKCRDsVersion);
         camelCatalogVersionLoader.loadLocalSchemas();
         camelCatalogVersionLoader.loadCamelYamlDsl(camelCatalogVersion);
-        camelCatalogVersionLoader.loadCamelCatalog(camelCatalogVersion);
 
         var catalogDefinition = new CatalogDefinition();
         var yamlDslSchemaProcessor = processCamelSchema(catalogDefinition);

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/maven/CamelCatalogVersionLoader.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/maven/CamelCatalogVersionLoader.java
@@ -131,6 +131,7 @@ public class CamelCatalogVersionLoader {
         ClassLoader classLoader = kaotoVersionManager.getClassLoader();
         URL resourceURL = classLoader.getResource(Constants.CAMEL_YAML_DSL_ARTIFACT);
         if (resourceURL == null) {
+        	LOGGER.log(Level.SEVERE, "No " + Constants.CAMEL_YAML_DSL_ARTIFACT + " file found in the classpath");
             return false;
         }
 

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCatalogWithRedHatVersionTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCatalogWithRedHatVersionTest.java
@@ -1,0 +1,49 @@
+package io.kaoto.camelcatalog.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kaoto.camelcatalog.beans.ConfigBean;
+import io.kaoto.camelcatalog.model.CatalogCliArgument;
+import io.kaoto.camelcatalog.model.CatalogDefinition;
+import io.kaoto.camelcatalog.model.CatalogRuntime;
+
+class GenerateCatalogWithRedHatVersionTest {
+	
+    @TempDir
+    File tempDir;
+
+	@Test
+	void testOK() throws Exception {
+        CatalogDefinition catalogDefinition = new CatalogDefinition();
+        catalogDefinition.setFileName("index.json");
+        catalogDefinition.setName("test-camel-catalog");
+        catalogDefinition.setVersion("4.4.0.redhat-00045");
+        catalogDefinition.setRuntime(CatalogRuntime.Main);
+
+        CatalogCliArgument catalogCliArg = new CatalogCliArgument();
+        catalogCliArg.setRuntime(CatalogRuntime.Main);
+        catalogCliArg.setCatalogVersion("4.4.0.redhat-00045");
+
+        ConfigBean configBean = new ConfigBean();
+        configBean.setOutputFolder(tempDir.toString());
+        configBean.setCatalogsName("test-camel-catalog");
+        configBean.addCatalogVersion(catalogCliArg);
+        configBean.setKameletsVersion("1.0.0");
+
+        GenerateCommand generateCommand = new GenerateCommand(configBean);
+        
+        generateCommand.run();
+        
+        assertTrue(new File(tempDir, "camel-main/4.4.0.redhat-00045").exists(), "The folder for the catalog wasn't created");
+        assertEquals(34, new File(tempDir, "camel-main/4.4.0.redhat-00045").listFiles().length, "The folder for the catalog doesn't contain the correct number of files");
+	}
+	
+}


### PR DESCRIPTION
the test is passing locally for me despite i checked settings.xml to not have the red hat maven repoitory and remove the org.apache/camel folder from my .m2 so maybe another specific part is failing?

relates to https://github.com/KaotoIO/kaoto/issues/1597