### PR TITLE
feat(Catalog): Include RHBAC in the catalogs

### DIFF
--- a/packages/catalog-generator/package.json
+++ b/packages/catalog-generator/package.json
@@ -13,13 +13,15 @@
     ".": "./dist",
     "./index.json": "./dist/camel-catalog/index.json",
     "./types": "./dist/types/index.ts",
+    "./catalog-index.d.ts": "./dist/types/catalog-index.d.ts",
     "./package.json": "./package.json",
     "./*.json": "./dist/camel-catalog/*.json"
   },
   "scripts": {
     "build": "yarn clean && yarn build:default:catalog && yarn build:ts",
     "build:mvn": "./mvnw clean package --no-transfer-progress",
-    "build:default:catalog": "yarn run build:mvn; java -jar ./target/catalog-generator-0.0.1-SNAPSHOT.jar -o ./dist/camel-catalog -n \"Default Kaoto catalog\"",
+    "build:catalog": "node ./scripts/build-catalogs.mjs",
+    "build:default:catalog": "yarn run build:mvn; yarn run build:catalog",
     "build:ts": "node --loader ts-node/esm ./scripts/json-schema-to-typescript.mts",
     "lint": "yarn eslint \"scripts/**/*.{mts,ts}\"",
     "lint:fix": "yarn lint --fix",

--- a/packages/catalog-generator/scripts/build-catalogs.mjs
+++ b/packages/catalog-generator/scripts/build-catalogs.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env ts-node
+// @ts-check
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+import { resolve } from 'path';
+import { existsSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * @type {Record<import('../dist/types').CatalogRuntime, string[]>}
+ **/
+const CATALOGS = {
+  Main: ['4.8.1', '4.4.4', '4.4.0.redhat-00046'],
+  Quarkus: ['3.16.0', '3.8.3', '3.8.0.redhat-00014'],
+  SpringBoot: ['4.8.1', '4.4.4', '4.4.0.redhat-00039'],
+};
+const KAMELETS_VERSION = '4.8.1';
+
+const generateCatalogs = () => {
+  let camelCatalogPath = '';
+  try {
+    const camelCatalogIndexJsonPath = require.resolve('@kaoto/camel-catalog/catalog-index.d.ts');
+    camelCatalogPath = dirname(camelCatalogIndexJsonPath);
+  } catch (error) {
+    throw new Error(`Could not find '@kaoto/camel-catalog' \n\n ${error}`);
+  } finally {
+    if (camelCatalogPath) console.log(`Found '@kaoto/camel-catalog' in ${camelCatalogPath}`, '\n');
+  }
+
+  const binary = resolve(camelCatalogPath, '../../target/catalog-generator-0.0.1-SNAPSHOT.jar');
+  if (!existsSync(binary)) {
+    throw new Error(`Could not find the catalog-generator JAR at ${binary}`);
+  }
+
+  const destinationFolder = resolve(camelCatalogPath, '../../dist/camel-catalog');
+  const args = [
+    '-jar',
+    binary,
+    '-o',
+    destinationFolder,
+    '-n',
+    'Default Kaoto catalog',
+    '-k',
+    KAMELETS_VERSION,
+    ...getVersionArguments(),
+  ];
+
+  spawn('java', args, {
+    stdio: 'inherit',
+  });
+};
+
+const getVersionArguments = () => {
+  /** @type string[] */
+  const starter = [];
+
+  return Object.entries(CATALOGS).reduce((acc, [runtime, versions]) => {
+    const flag = runtime.slice(0, 1).toLowerCase();
+
+    versions.forEach((version) => {
+      acc.push(`-${flag}`);
+      acc.push(version);
+    });
+
+    return acc;
+  }, starter);
+};
+
+generateCatalogs();


### PR DESCRIPTION
### Context
Currently, only the latest Camel version is available in the catalog.

### Changes
This commit includes RHBAC versions in the Kaoto catalog.

fix: https://github.com/KaotoIO/kaoto/issues/1392