### PR TITLE
fix(Build): Run Kaoto in Windows

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
@@ -53,7 +53,6 @@ public class GenerateCommand implements Runnable {
                     File indexFile = catalogDefinitionFolder.toPath().resolve(catalogDefinition.getFileName()).toFile();
                     String relateIndexFile = outputFolder.toPath().relativize(indexFile.toPath()).toString().replace(File.separator, "/");
 
-                    System.out.println(relateIndexFile);
 
                     catalogDefinition.setFileName(relateIndexFile);
 

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
@@ -51,9 +51,11 @@ public class GenerateCommand implements Runnable {
 
                     CatalogDefinition catalogDefinition = catalogGenerator.generate();
                     File indexFile = catalogDefinitionFolder.toPath().resolve(catalogDefinition.getFileName()).toFile();
-                    File relateIndexFile = outputFolder.toPath().relativize(indexFile.toPath()).toFile();
+                    String relateIndexFile = outputFolder.toPath().relativize(indexFile.toPath()).toString().replace(File.separator, "/");
 
-                    catalogDefinition.setFileName(relateIndexFile.toString());
+                    System.out.println(relateIndexFile);
+
+                    catalogDefinition.setFileName(relateIndexFile);
 
                     library.addDefinition(catalogDefinition);
                 });

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCommandTest.java
@@ -85,7 +85,8 @@ class GenerateCommandTest {
             File expectedFolder = new File(tempDir, "camel-main/4.8.0");
             verify(builder, times(1)).withOutputDirectory(expectedFolder);
 
-            String expectedFile = Path.of("camel-main", "4.8.0", "index.json").toString();
+            /* This path will be used to relatively load the subsequent files, it always needs to use `/` */
+            String expectedFile = "camel-main/4.8.0/index.json";
             assertEquals(catalogDefinition.getFileName(), expectedFile);
         }
     }
@@ -126,7 +127,8 @@ class GenerateCommandTest {
             assertEquals(catalogLibraryEntry.version(), "4.8.0");
             assertEquals(catalogLibraryEntry.runtime(), "Main");
 
-            String expectedFile = Path.of("camel-main", "4.8.0", "index.json").toString();
+            /* This path will be used to relatively load the subsequent files, it always needs to use `/` */
+            String expectedFile = "camel-main/4.8.0/index.json";
             assertEquals(catalogLibraryEntry.fileName(), expectedFile);
         }
     }

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import react from '@vitejs/plugin-react';
 import { dirname, relative } from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig, normalizePath } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import packageJson from './package.json';
 import { getCamelCatalogFiles } from './scripts/get-camel-catalog-files';
@@ -19,11 +19,12 @@ export default defineConfig(async () => {
       react(),
       viteStaticCopy({
         targets: camelCatalogFiles.map((file) => {
+          const normalizedFile = normalizePath(file);
           const relativePath = relative(basePath, file);
-          const dest = './camel-catalog/' + dirname(relativePath);
+          const dest = normalizePath('./camel-catalog/' + dirname(relativePath));
 
           return {
-            src: file,
+            src: normalizedFile,
             dest,
             transform: (content, filename) => {
               return JSON.stringify(JSON.parse(content));


### PR DESCRIPTION
### Context
Currently, dev mode is broken in Windows since the `vite.config.js` file is not copying the catalog files properly. In addition to that, the file paths are generated using the underlying OS path separator.

### Changes
The fix is to use the `normalizePath` function from `vite`, so it uses a Linux-like path to copy the files. From the Catalog generator part, it forces the use of the `/` as a path separator so it loads properly in the browser.

fix: https://github.com/KaotoIO/kaoto/issues/1654