### PR TITLE
chore: Update quarkus versions

### DIFF
--- a/packages/catalog-generator/scripts/build-catalogs.mjs
+++ b/packages/catalog-generator/scripts/build-catalogs.mjs
@@ -15,13 +15,34 @@ const require = createRequire(import.meta.url);
 const CATALOGS = {
   // https://repo1.maven.org/maven2/org/apache/camel/camel-catalog/
   // https://maven.repository.redhat.com/ga/org/apache/camel/camel-catalog/
-  Main: ['4.9.0', '4.8.2', '4.4.4', '4.4.0.redhat-00046', '4.8.0.redhat-00017'],
+  Main: [
+    //
+    '4.9.0',
+    '4.8.2',
+    '4.4.4',
+    '4.8.0.redhat-00017',
+    '4.4.0.redhat-00046',
+  ],
   // https://repo1.maven.org/maven2/org/apache/camel/quarkus/camel-quarkus-catalog/
   // https://maven.repository.redhat.com/ga/org/apache/camel/quarkus/camel-quarkus-catalog/
-  Quarkus: ['3.16.0', '3.8.4', '3.8.0.redhat-00018', '3.15.0.redhat-00007'],
+  Quarkus: [
+    //
+    '3.17.0', // Camel 4.9.0
+    '3.15.1', // Camel 4.8.1
+    '3.8.4', // Camel 4.4.4
+    '3.15.0.redhat-00007', // Camel 4.8.0.redhat-00015
+    '3.8.0.redhat-00018', // Camel 4.4.0.redhat-00046
+  ],
   // https://repo1.maven.org/maven2/org/apache/camel/springboot/camel-catalog-provider-springboot/
   // https://maven.repository.redhat.com/ga/org/apache/camel/springboot/camel-catalog-provider-springboot/
-  SpringBoot: ['4.9.0', '4.8.2', '4.4.4', '4.4.0.redhat-00039', '4.8.0.redhat-00022'],
+  SpringBoot: [
+    //
+    '4.9.0',
+    '4.8.2',
+    '4.4.4',
+    '4.8.0.redhat-00022',
+    '4.4.0.redhat-00039',
+  ],
 };
 // https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/
 const KAMELETS_VERSION = '4.9.0';


### PR DESCRIPTION
### Changes
1. Separate each version into its own line, so we avoid conflicts whenever versions are updated in separate PRs
2. Align Quarkus versions to the "Last version, latest 2 LTS versions" approach
3. Add comments about what underlying Camel version is embedded in the Quarkus version

### Notes
Output of the `camel version list --fresh --runtime=quarkus` command
```bash
$ camel version list --fresh --runtime=quarkus

 CAMEL VERSION   QUARKUS    JDK   KIND     RELEASED     SUPPORTED UNTIL 
     ...   
     4.4.2        3.8.2    17,21  LTS         May 2024    February 2025 
     4.4.3        3.8.3    17,21  LTS        July 2024    February 2025 
     4.4.4        3.8.4    17,21  LTS    November 2024    February 2025 
     4.5.0       3.10.0    17,21            April 2024                  
     4.6.0       3.11.0    17,21              May 2024                  
     4.6.0       3.12.0    17,21             June 2024                  
     4.7.0       3.13.0    17,21             July 2024                  
     4.7.0       3.14.0    17,21           August 2024                  
     4.8.0       3.15.0    17,21  LTS   September 2024   September 2025 
     4.8.1       3.15.1    17,21  LTS    November 2024   September 2025 
     4.8.1       3.16.0    17,21          October 2024                  
     4.9.0       3.17.0                                                 
```