### PR TITLE
chore(Settings): Add experimental features

### DIFF
--- a/packages/ui/src/assets/settingsSchema.json
+++ b/packages/ui/src/assets/settingsSchema.json
@@ -24,6 +24,20 @@
       "default": "onHover",
       "type": "string",
       "enum": ["onHover", "onSelection"]
+    },
+    "experimentalFeatures": {
+      "title": "Experimental features",
+      "description": "Enable / disable experimental features",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enableDragAndDrop": {
+          "title": "Enable Drag & Drop",
+          "description": "Control whether to enable drag and drop feature",
+          "type": "boolean",
+          "default": false
+        }
+      }
     }
   }
 }

--- a/packages/ui/src/components/Form/CustomAutoForm.scss
+++ b/packages/ui/src/components/Form/CustomAutoForm.scss
@@ -1,0 +1,5 @@
+/* stylelint-disable-next-line selector-class-pattern */
+form.pf-v5-c-form > div:not(.pf-v5-c-form__group) {
+  display: grid;
+  gap: var(--pf-v5-c-form--GridGap);
+}

--- a/packages/ui/src/components/Form/CustomAutoForm.tsx
+++ b/packages/ui/src/components/Form/CustomAutoForm.tsx
@@ -4,6 +4,7 @@ import { useSchemaBridgeContext } from '../../hooks';
 import { IDataTestID } from '../../models';
 import { CustomAutoFieldDetector } from './CustomAutoField';
 import { CustomAutoFields } from './CustomAutoFields';
+import './CustomAutoForm.scss';
 
 interface CustomAutoFormProps extends IDataTestID {
   model: unknown;

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -378,6 +378,117 @@ exports[`SettingsForm should render 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="pf-v5-c-card pf-m-flat custom-nest-field"
+      data-ouia-component-id="OUIA-Generated-Card-2"
+      data-ouia-component-type="PF5/Card"
+      data-ouia-safe="true"
+      data-testid="nest-field"
+      description="Enable / disable experimental features"
+      id="uniforms-0000-000b"
+      properties="[object Object]"
+    >
+      <div
+        class="pf-v5-c-card__header"
+      >
+        <div
+          class="pf-v5-c-card__header-main"
+        >
+          <div
+            class="pf-v5-c-card__title"
+          >
+            <div
+              class="pf-v5-c-card__title-text"
+              id="uniforms-0000-000b-title"
+            >
+              Experimental features
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-c-card__body"
+      >
+        <div
+          class="pf-v5-c-form__group"
+          data-testid="wrapper-field"
+        >
+          <div
+            class="pf-v5-c-form__group-control"
+          >
+            <div
+              style="display: flex; align-items: center;"
+            >
+               
+              <div
+                class="pf-v5-c-check"
+              >
+                <input
+                  aria-invalid="false"
+                  class="pf-v5-c-check__input"
+                  data-ouia-component-id="OUIA-Generated-Checkbox-1"
+                  data-ouia-component-type="PF5/Checkbox"
+                  data-ouia-safe="true"
+                  data-testid="bool-field"
+                  id="uniforms-0000-000d"
+                  name="experimentalFeatures.enableDragAndDrop"
+                  type="checkbox"
+                />
+                <label
+                  class="pf-v5-c-check__label"
+                  for="uniforms-0000-000d"
+                >
+                  Enable Drag & Drop
+                </label>
+              </div>
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="pf-v5-c-form__helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text__item"
+                  >
+                    <span
+                      class="pf-v5-c-helper-text__item-text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </form>
 `;

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -15,6 +15,9 @@ describe('LocalStorageSettingsAdapter', () => {
       catalogUrl: 'http://example.com',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
+      experimentalFeatures: {
+        enableDragAndDrop: true,
+      },
     };
 
     adapter.saveSettings(newSettings);
@@ -38,6 +41,9 @@ describe('LocalStorageSettingsAdapter', () => {
       catalogUrl: 'http://example.com',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
+      experimentalFeatures: {
+        enableDragAndDrop: true,
+      },
     };
 
     adapter.saveSettings(newSettings);

--- a/packages/ui/src/models/settings/settings.model.ts
+++ b/packages/ui/src/models/settings/settings.model.ts
@@ -12,6 +12,9 @@ export interface ISettingsModel {
   catalogUrl: string;
   nodeLabel: NodeLabelType;
   nodeToolbarTrigger: NodeToolbarTrigger;
+  experimentalFeatures: {
+    enableDragAndDrop: boolean;
+  };
 }
 
 export interface AbstractSettingsAdapter {
@@ -23,6 +26,9 @@ export class SettingsModel implements ISettingsModel {
   catalogUrl: string = '';
   nodeLabel: NodeLabelType = NodeLabelType.Description;
   nodeToolbarTrigger: NodeToolbarTrigger = NodeToolbarTrigger.onHover;
+  experimentalFeatures = {
+    enableDragAndDrop: false,
+  };
 
   constructor(options: Partial<ISettingsModel> = {}) {
     Object.assign(this, options);

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -16,6 +16,9 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: 'catalog-url',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const envelopeContext = {
@@ -41,6 +44,9 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: 'catalog-url',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const getVSCodeKaotoSettingsSpy = jest.fn().mockResolvedValue(settingsModel);
@@ -91,11 +97,17 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: '',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
     const expectedSettings: ISettingsModel = {
       catalogUrl: 'path-prefix/camel-catalog/index.json',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const getVSCodeKaotoSettingsSpy = jest.fn().mockResolvedValue(settingsModel);

--- a/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`SettingsProvider should render 1`] = `
 <p
   data-testid="settings"
 >
-  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover"}
+  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","experimentalFeatures":{"enableDragAndDrop":false}}
 </p>
 `;


### PR DESCRIPTION
### Context
Currently, there's no mechanism to enable experimental features.

### Changes
This PR adds a new `experimentalFeatures` section to include long-running features that still are in the experimental phase.

### Screenshot
![image](https://github.com/user-attachments/assets/5f37fafb-de8e-4c00-8c32-8a10f161cf59)

### Notes
relates: https://github.com/KaotoIO/kaoto/issues/80
prerequisite of: https://github.com/KaotoIO/kaoto/pull/1620