### PR TITLE
fix(e2e): fix beansConfig.cy failing with the "properties" expandable…

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/metadata.ts
+++ b/packages/ui-tests/cypress/support/next-commands/metadata.ts
@@ -12,11 +12,13 @@ Cypress.Commands.add('switchWrappedSection', (sectionName: string, wrapped: bool
   cy.get(`[data-testid="expandable-section-${sectionName}"]`)
     .should('be.visible')
     .within(() => {
-      cy.get('.pf-v6-c-expandable-section__toggle').each(($button) => {
-        if ($button.attr('aria-expanded') === String(wrapped)) {
-          cy.wrap($button).click();
-          cy.wrap($button).should('have.attr', 'aria-expanded', String(!wrapped));
-        }
+      cy.get('.pf-v6-c-expandable-section__toggle').within(() => {
+        cy.get('button').each(($button) => {
+          if ($button.attr('aria-expanded') === String(wrapped)) {
+            cy.wrap($button).click();
+            cy.wrap($button).should('have.attr', 'aria-expanded', String(!wrapped));
+          }
+        });
       });
     });
 });


### PR DESCRIPTION
… section not expanded due to the added "div" before the toggle button