### PR TITLE
chore(vite): Normalize SCSS node_modules imports

### DIFF
--- a/packages/ui-tests/.storybook/main.ts
+++ b/packages/ui-tests/.storybook/main.ts
@@ -1,6 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import packageJson from '../../../package.json';
 
 /**
@@ -57,8 +57,10 @@ const config: StorybookConfig = {
       resolve: {
         alias: [
           {
-            find: /~(.*)/,
-            replacement: '$1',
+            find: /^~.+/,
+            replacement: (val) => {
+              return val.replace(/^~/, '');
+            },
           },
         ],
       },


### PR DESCRIPTION
### Context
After forwarding `DragDrop.scss`, we need to instruct `vite` to import files starting with `~` from the `node_modules` folder.

### Changes
This commit normalizes the required configuration to do so.

Comes from: https://github.com/KaotoIO/kaoto/pull/1927
Relates: https://github.com/KaotoIO/kaoto/pull/1927/files#r1924952467