### PR TITLE
feat(Form): Clean current schema after switching to another schema

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.tsx
@@ -1,7 +1,7 @@
 import { Form } from '@patternfly/react-core';
-import { FunctionComponent, useCallback } from 'react';
+import { FunctionComponent, useCallback, useState } from 'react';
 import { KaotoSchemaDefinition } from '../../../../models';
-import { isDefined, ROOT_PATH } from '../../../../utils';
+import { isDefined, ROOT_PATH, setValue } from '../../../../utils';
 import { AutoField } from './fields/AutoField';
 import { FormComponentFactoryProvider } from './providers/FormComponentFactoryProvider';
 import { ModelContextProvider } from './providers/ModelProvider';
@@ -16,10 +16,22 @@ interface FormProps {
 }
 
 export const KaotoForm: FunctionComponent<FormProps> = ({ schema, onChange, model, omitFields = [] }) => {
+  const [formModel, setFormModel] = useState<unknown>(model);
+
   const onPropertyChange = useCallback(
     (propName: string, value: unknown) => {
       console.log('KaotoForm.onPropertyChange', propName, value);
+
       onChange(propName, value);
+      setFormModel((prevModel: unknown) => {
+        if (typeof prevModel !== 'object') {
+          return value;
+        }
+
+        const newModel = { ...prevModel };
+        setValue(newModel, propName, value);
+        return newModel;
+      });
     },
     [onChange],
   );
@@ -32,7 +44,7 @@ export const KaotoForm: FunctionComponent<FormProps> = ({ schema, onChange, mode
     <FormComponentFactoryProvider>
       <SchemaDefinitionsProvider schema={schema} omitFields={omitFields}>
         <SchemaProvider schema={schema}>
-          <ModelContextProvider model={model} onPropertyChange={onPropertyChange}>
+          <ModelContextProvider model={formModel} onPropertyChange={onPropertyChange}>
             <Form>
               <AutoField propName={ROOT_PATH} />
             </Form>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
@@ -1,16 +1,14 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { safeGetValue } from '../../../../../utils';
 import { ModelContext } from '../providers/ModelProvider';
 
 export const useFieldValue = <T = unknown>(propertyPath: string) => {
   const { model, onPropertyChange } = useContext(ModelContext);
   const propertyName = propertyPath.replace('#.', '');
-  const modelValue = safeGetValue(model, propertyName) as T | undefined;
-  const [value, setValue] = useState<T | undefined>(modelValue);
+  const value = safeGetValue(model, propertyName) as T | undefined;
 
   const onChange = (value: T) => {
     onPropertyChange(propertyName, value);
-    setValue(value);
   };
 
   return {


### PR DESCRIPTION
### Context
This PR adds an `useState` in the `KaotoForm` component so it can be rerendered when a property changes, this refreshes the values of every field, allowing the `OneOf` field to always have up-to-date data.

In addition to that, the `OneOf` component introduces a `onSchemaChange` callback that remove the properties from the selected schema before switching to a new one.

### Notes
part of #1939 