### PR TITLE
Fix(Catalog): Restrict group information for empty EIP properties

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/CamelCatalogSchemaEnhancer.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/CamelCatalogSchemaEnhancer.java
@@ -139,6 +139,10 @@ public class CamelCatalogSchemaEnhancer {
 
         modelNode.withObject("properties").fields().forEachRemaining(entry -> {
             String propertyName = entry.getKey();
+            ObjectNode propertyNode = (ObjectNode) entry.getValue();
+            if (propertyNode.isEmpty()) {
+                return;
+            }
 
             Optional<EipModel.EipOptionModel> modelOption =
                     modelOptions.stream().filter(option -> option.getName().equals(propertyName)).findFirst();
@@ -152,7 +156,6 @@ public class CamelCatalogSchemaEnhancer {
                 return;
             }
 
-            ObjectNode propertyNode = (ObjectNode) entry.getValue();
             if (propertyNode.has("$comment")) {
                 propertyNode.put("$comment", propertyNode.get("$comment").asText() + "|group:" + group);
             } else {

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/CamelCatalogSchemaEnhancerTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/CamelCatalogSchemaEnhancerTest.java
@@ -114,20 +114,22 @@ class CamelCatalogSchemaEnhancerTest {
 
     @Test
     void shouldFillGroupInformationForModel() {
-        var choiceNode = camelYamlDslSchema
+        var setHeaderNode = camelYamlDslSchema
                 .withObject("items")
                 .withObject("definitions")
-                .withObject("org.apache.camel.model.ChoiceDefinition");
+                .withObject("org.apache.camel.model.SetHeaderDefinition");
 
-        camelCatalogSchemaEnhancer.fillGroupInformation("choice", choiceNode);
+        camelCatalogSchemaEnhancer.fillGroupInformation("setHeader", setHeaderNode);
 
-        var idPropertyNode = choiceNode.withObject("properties").withObject("id");
-        var preconditionPropertyNode = choiceNode.withObject("properties").withObject("precondition");
+        var expressionPropertyNode = setHeaderNode.withObject("properties").withObject("expression");
+        var idPropertyNode = setHeaderNode.withObject("properties").withObject("id");
+        var disabledPropertyNode = setHeaderNode.withObject("properties").withObject("disabled");
 
+        assertFalse(expressionPropertyNode.has("$comment"));
         assertTrue(idPropertyNode.has("$comment"));
-        assertTrue(preconditionPropertyNode.has("$comment"));
+        assertTrue(disabledPropertyNode.has("$comment"));
         assertEquals("group:common", idPropertyNode.get("$comment").asText());
-        assertEquals("group:advanced", preconditionPropertyNode.get("$comment").asText());
+        assertEquals("group:advanced", disabledPropertyNode.get("$comment").asText());
     }
 
     @Test


### PR DESCRIPTION
Now, We don't see any "Expression" field in the form:
![image](https://github.com/user-attachments/assets/e5077688-ad24-4a44-a037-389075780fa2)
