### PR TITLE
fix(CanvasForm): Remove double scrollbar

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.scss
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.scss
@@ -1,9 +1,11 @@
-.pf-topology-resizable-side-bar {
+// Fix for: https://github.com/KaotoIO/kaoto/issues/1944
+#topology-resize-panel {
+  --pf-v6-c-drawer__panel--PaddingBlockStart: 0;
+  --pf-v6-c-drawer__panel--PaddingBlockEnd: 0;
+}
+
+.canvas-sidebar {
   width: calc(100% - 10px);
   position: absolute;
   height: 100%;
-}
-/* stylelint-disable-next-line selector-class-pattern */
-.pf-v6-c-drawer__splitter pf-m-vertical {
-  border: none;
 }

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
@@ -21,7 +21,7 @@ export const CanvasSideBar: FunctionComponent<CanvasSideBarProps> = (props) => {
      * We cannot use the onClose property since the button has 'position: absolute'
      * and doesn't take into account the sidebar children.
      */
-    <TopologySideBar resizable>
+    <TopologySideBar resizable className="canvas-sidebar">
       <ErrorBoundary key={props.selectedNode.id} fallback={<p>Something did not work as expected</p>}>
         <FilteredFieldProvider>
           <CanvasForm selectedNode={props.selectedNode} onClose={props.onClose} />

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CanvasSideBar displays selected node information 1`] = `
 <DocumentFragment>
   <div
-    class="pf-topology-resizable-side-bar"
+    class="pf-topology-resizable-side-bar canvas-sidebar"
     role="dialog"
   >
     <div


### PR DESCRIPTION
### Context
After upgrading to Patternfly v6, the `Card` component has `padding-block-start` and `padding-block-end` CSS properties set to `0.5rem` and that's generating an additional scrollbar in the form.

### Changes
The fix is to set those properties to 0 for the Form scope.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/bfb8a8a7-0ca2-474e-85ca-47646e476da3) | ![image](https://github.com/user-attachments/assets/140c5188-1239-452c-8a76-f42e68b6765c) |


fix: https://github.com/KaotoIO/kaoto/issues/1944