### PR TITLE
Feat/parse expression fields

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EIPGenerator.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EIPGenerator.java
@@ -91,6 +91,7 @@ public class EIPGenerator implements Generator {
         camelCatalogSchemaEnhancer.fillRequiredPropertiesIfNeeded(Kind.model, processorName, processorJSONSchema);
         camelCatalogSchemaEnhancer.sortPropertiesAccordingToCatalog(processorName, processorJSONSchema);
         camelCatalogSchemaEnhancer.fillPropertiesInformation(processorName, processorJSONSchema);
+        camelCatalogSchemaEnhancer.fillExpressionFormatInOneOf(processorJSONSchema);
 
         if (processorJSONSchema.has("definitions")) {
             iterateOverDefinitions(processorJSONSchema.withObject("definitions"), (model, node) -> {
@@ -101,6 +102,7 @@ public class EIPGenerator implements Generator {
                 camelCatalogSchemaEnhancer.fillRequiredPropertiesIfNeeded(model, node);
                 camelCatalogSchemaEnhancer.sortPropertiesAccordingToCatalog(model, node);
                 camelCatalogSchemaEnhancer.fillPropertiesInformation(model, node);
+                camelCatalogSchemaEnhancer.fillExpressionFormatInOneOf(node);
             });
         }
     }

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EntityGenerator.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EntityGenerator.java
@@ -92,6 +92,7 @@ public class EntityGenerator implements Generator {
                 camelCatalogSchemaEnhancer.fillRequiredPropertiesIfNeeded(model, node);
                 camelCatalogSchemaEnhancer.sortPropertiesAccordingToCatalog(model, node);
                 camelCatalogSchemaEnhancer.fillPropertiesInformation(model, node);
+                camelCatalogSchemaEnhancer.fillExpressionFormatInOneOf(node);
             });
         }
     }

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EIPGeneratorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EIPGeneratorTest.java
@@ -240,17 +240,60 @@ class EIPGeneratorTest {
         var definitions = processorsMap.get("setHeader").withObject("propertiesSchema").withObject("definitions");
         assertTrue(definitions.has("org.apache.camel.model.language.ConstantExpression"));
         assertTrue(definitions.withObject("org.apache.camel.model.language.ConstantExpression").has("properties"));
-        List<String> sortedPropertiesListConstant = definitions.get("org.apache.camel.model.language.ConstantExpression")
-                .withObject("properties").properties().stream().map(Map.Entry::getKey).toList();
+        List<String> sortedPropertiesListConstant =
+                definitions.get("org.apache.camel.model.language.ConstantExpression")
+                        .withObject("properties").properties().stream().map(Map.Entry::getKey).toList();
 
         assertEquals(List.of("id", "expression", "resultType", "trim"), sortedPropertiesListConstant);
 
         assertTrue(definitions.has("org.apache.camel.model.language.DatasonnetExpression"));
         assertTrue(definitions.withObject("org.apache.camel.model.language.DatasonnetExpression").has("properties"));
-        List<String> sortedPropertiesListSimple = definitions.get("org.apache.camel.model.language.DatasonnetExpression")
-                .withObject("properties").properties().stream().map(Map.Entry::getKey).toList();
+        List<String> sortedPropertiesListSimple =
+                definitions.get("org.apache.camel.model.language.DatasonnetExpression")
+                        .withObject("properties").properties().stream().map(Map.Entry::getKey).toList();
 
         assertEquals(List.of("id", "expression", "bodyMediaType", "outputMediaType", "source", "resultType", "trim"),
                 sortedPropertiesListSimple);
+    }
+
+    @Test
+    void shouldSetExpressionPropertyFormatToExpressionProperty() {
+        var processorsMap = eipGenerator.generate();
+
+        var correlationExpressionPropertyNode =
+                processorsMap.get("aggregate").withObject("propertiesSchema").withObject("properties")
+                        .withObject("correlationExpression");
+
+        assertTrue(correlationExpressionPropertyNode.has("format"));
+    }
+
+    @Test
+    void shouldSetExpressionFormatToOneOfExpression() {
+        var processorsMap = eipGenerator.generate();
+
+        var oneOfArray = processorsMap.get("setHeader").withObject("propertiesSchema").withArray("anyOf").get(0);
+
+        assertTrue(oneOfArray.has("format"));
+    }
+
+    @Test
+    void shouldSetExpressionFormatToPropertyExpressionDefinition() {
+        var processorsMap = eipGenerator.generate();
+
+        var oneOfNode= processorsMap.get("saga").withObject("propertiesSchema").withObject("definitions")
+                .withObject("org.apache.camel.model.PropertyExpressionDefinition").withArray("anyOf").get(0);
+
+        assertTrue(oneOfNode.has("format"));
+    }
+
+    @Test
+    void shouldSetExpressionFormatToPropertyExpression() {
+        var processorsMap = eipGenerator.generate();
+
+        var correlationExpressionNode =
+                processorsMap.get("aggregate").withObject("propertiesSchema").withObject("properties")
+                        .withObject("correlationExpression");
+
+        assertTrue(correlationExpressionNode.has("format"));
     }
 }

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EntityGeneratorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EntityGeneratorTest.java
@@ -228,4 +228,25 @@ class EntityGeneratorTest {
         assertEquals(List.of("id", "expression", "bodyMediaType", "outputMediaType", "source", "resultType", "trim"),
                 sortedPropertiesListSimple);
     }
+
+    @Test
+    void shouldSetExpressionFormatToOneOfExpressionForOnCompletion() {
+        var entitiesMap = entityGenerator.generate();
+
+        var oneOfArray = entitiesMap.get("onCompletion").withObject("propertiesSchema").withObject("definitions")
+                .withObject("org.apache.camel.model.WhenDefinition").withArray("anyOf").get(0);
+
+        assertTrue(oneOfArray.has("format"));
+    }
+
+    @Test
+    void shouldSetExpressionFormatToOneOfExpressionForOnException() {
+        var entitiesMap = entityGenerator.generate();
+
+        var oneOfArray = entitiesMap.get("onException").withObject("propertiesSchema").withObject("definitions")
+                .withObject("org.apache.camel.model.WhenDefinition").withArray("anyOf").get(0);
+
+        assertTrue(oneOfArray.has("format"));
+    }
+
 }

--- a/packages/ui/src/components/Form/schema.service.ts
+++ b/packages/ui/src/components/Form/schema.service.ts
@@ -6,17 +6,7 @@ import { SchemaBridge } from './schema-bridge';
 
 export class SchemaService {
   static readonly DROPDOWN_PLACEHOLDER = 'Select an option...';
-  static readonly OMIT_FORM_FIELDS = [
-    'from',
-    'outputs',
-    'steps',
-    'onWhen',
-    'when',
-    'otherwise',
-    'doCatch',
-    'doFinally',
-    'uri',
-  ];
+  static readonly OMIT_FORM_FIELDS = ['from', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally', 'uri'];
   private readonly ajv: Ajv;
   private readonly FILTER_DOM_PROPS = ['$comment', 'additionalProperties'];
 

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.scss
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.scss
@@ -1,4 +1,7 @@
 .kaoto-form {
+  --pf-v6-c-form__field-group-body--PaddingBlockStart: 0;
+  --pf-v6-c-form__field-group-header--PaddingBlockEnd: 0;
+
   &__label {
     --pf-v6-c-form__label--FontSize: --pf-t--global--font--size--body--md;
     --pf-v6-c-form__label-required--FontSize: --pf-t--global--font--size--body--lg;

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayField.tsx
@@ -43,9 +43,8 @@ export const ArrayField: FunctionComponent<FieldProps> = ({ propName }) => {
 
   return (
     <ArrayFieldWrapper
-      propName={propName}
       type="array"
-      title={schema.title}
+      title={schema.title ?? propName}
       description={schema.description}
       defaultValue={schema.default}
       actions={

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayFieldWrapper.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayFieldWrapper.tsx
@@ -8,29 +8,27 @@ import {
   Popover,
 } from '@patternfly/react-core';
 import { FunctionComponent, PropsWithChildren, ReactNode, useMemo } from 'react';
-import { FieldProps } from '../../typings';
 
-interface FieldWrapperProps extends FieldProps {
-  type: 'array' | 'object';
-  title?: string;
+interface FieldWrapperProps {
+  type: 'array' | 'object' | 'expression';
+  title: string;
   description?: string;
   defaultValue?: unknown;
   actions?: ReactNode;
 }
 
 export const ArrayFieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps>> = ({
-  propName,
   type,
-  title: propsTitle,
+  title,
   description,
   defaultValue,
   actions,
   children,
 }) => {
-  const title = propsTitle ?? propName;
   const id = `${title}-popover`;
 
   const cardActions: CardHeaderActionsObject = useMemo(() => ({ actions, hasNoOffset: false }), [actions]);
+  const shouldRenderChildren = Array.isArray(children) ? children.length > 0 : !!children;
 
   return (
     <Card>
@@ -54,7 +52,7 @@ export const ArrayFieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapper
         </CardTitle>
       </CardHeader>
 
-      {children && <CardBody className="pf-v6-c-form kaoto-form__label">{children}</CardBody>}
+      {shouldRenderChildren && <CardBody className="pf-v6-c-form kaoto-form__label">{children}</CardBody>}
     </Card>
   );
 };

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
@@ -1,20 +1,36 @@
-import { FunctionComponent, useContext } from 'react';
+import { FunctionComponent, useContext, useMemo } from 'react';
 import { ROOT_PATH, setValue } from '../../../../../../utils';
 import { useFieldValue } from '../../hooks/field-value';
 import { ModelContextProvider } from '../../providers/ModelProvider';
-import { SchemaContext } from '../../providers/SchemaProvider';
+import { SchemaContext, SchemaProvider } from '../../providers/SchemaProvider';
 import { FieldProps } from '../../typings';
 import { FieldWrapper } from '../FieldWrapper';
-import { AnyOfField } from '../ObjectField/AnyOfField';
 import { ExpressionService } from './expression.service';
 import { ExpressionFieldInner } from './ExpressionFieldInner';
 
+/**
+ * ExpressionField component.
+ *
+ * This component is reponsible for parsing the different expression models and rendering the ExpressionField.
+ * There are two types of expression fields:
+ * - Root expression field: Like the one in setHeader, resequencer, etc.
+ * - Property expression field: Like the one in aggregate.correlationExpression, etc.
+ *
+ * For the root expressions, the components path is like follows:
+ * - ObjectField -> AnyOfField -> FormComponentFactoryProvider -> ExpressionField
+ * this brings `oneOf` fields to the root level.
+ *
+ * For the property expressions, the components path is like follows:
+ * - ObjectField -> property resolution -> FormComponentFactoryProvider -> ExpressionField
+ * this brings an entire schema with a `anyOf` array where the languages are specified.
+ */
 export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
 
   const isRootExpression = schema.format === 'expression';
   const parsedModel = ExpressionService.parseExpressionModel(originalModel);
+  const expressionsSchema = useMemo(() => ExpressionService.getExpressionsSchema(schema), [schema]);
 
   const onExpressionChange = (propName: string, model: unknown) => {
     const localValue = parsedModel ?? {};
@@ -25,9 +41,9 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
   if (isRootExpression) {
     return (
       <ModelContextProvider model={parsedModel} onPropertyChange={onExpressionChange}>
-        {Array.isArray(schema.oneOf) && (
-          <ExpressionFieldInner propName={ROOT_PATH} required={required} schemas={schema.oneOf} />
-        )}
+        <SchemaProvider schema={expressionsSchema}>
+          <ExpressionFieldInner propName={ROOT_PATH} required={required} />
+        </SchemaProvider>
       </ModelContextProvider>
     );
   }
@@ -42,8 +58,9 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
       defaultValue={schema.default?.toString()}
     >
       <ModelContextProvider model={parsedModel} onPropertyChange={onExpressionChange}>
-        {/* AnyOf field */}
-        {Array.isArray(schema.anyOf) && <AnyOfField propName={ROOT_PATH} anyOf={schema.anyOf} />}
+        <SchemaProvider schema={expressionsSchema}>
+          <ExpressionFieldInner propName={ROOT_PATH} required={required} />
+        </SchemaProvider>
       </ModelContextProvider>
     </FieldWrapper>
   );

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import { ROOT_PATH, setValue } from '../../../../../../utils';
 import { useFieldValue } from '../../hooks/field-value';
 import { ModelContextProvider } from '../../providers/ModelProvider';
@@ -7,38 +7,30 @@ import { FieldProps } from '../../typings';
 import { FieldWrapper } from '../FieldWrapper';
 import { AnyOfField } from '../ObjectField/AnyOfField';
 import { ExpressionService } from './expression.service';
+import { ExpressionFieldInner } from './ExpressionFieldInner';
 
 export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
 
   const isRootExpression = schema.format === 'expression';
-  const parsedModel = isRootExpression
-    ? ExpressionService.parseStepExpressionModel(originalModel)
-    : ExpressionService.parsePropertyExpressionModel(originalModel);
+  const parsedModel = ExpressionService.parseExpressionModel(originalModel);
 
-  const onExpressionChange = useCallback(
-    (propName: string, model: unknown) => {
-      const localValue = originalModel ?? {};
-      setValue(localValue, propName, model);
-      onChange(localValue);
-    },
-    [onChange, originalModel],
-  );
+  const onExpressionChange = (propName: string, model: unknown) => {
+    const localValue = parsedModel ?? {};
+    setValue(localValue, propName, model);
+    onChange(localValue);
+  };
 
-  const expressionAnyOfSchemas = useMemo(() => {
-    /** This is usually when a property it's a expression, like `aggregate.correlationExpression` */
-    if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-      return schema.anyOf;
-    }
-
-    /** This is usually when an EIP or an Entity has a root expression, like `setHeader`, `resequence` or `onCompletion` */
-    if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
-      return [{ oneOf: schema.oneOf }];
-    }
-
-    return undefined;
-  }, [schema.anyOf, schema.oneOf]);
+  if (isRootExpression) {
+    return (
+      <ModelContextProvider model={parsedModel} onPropertyChange={onExpressionChange}>
+        {Array.isArray(schema.oneOf) && (
+          <ExpressionFieldInner propName={ROOT_PATH} required={required} schemas={schema.oneOf} />
+        )}
+      </ModelContextProvider>
+    );
+  }
 
   return (
     <FieldWrapper
@@ -51,7 +43,7 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
     >
       <ModelContextProvider model={parsedModel} onPropertyChange={onExpressionChange}>
         {/* AnyOf field */}
-        {Array.isArray(expressionAnyOfSchemas) && <AnyOfField propName={ROOT_PATH} anyOf={expressionAnyOfSchemas} />}
+        {Array.isArray(schema.anyOf) && <AnyOfField propName={ROOT_PATH} anyOf={schema.anyOf} />}
       </ModelContextProvider>
     </FieldWrapper>
   );

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionField.tsx
@@ -1,0 +1,58 @@
+import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+import { ROOT_PATH, setValue } from '../../../../../../utils';
+import { useFieldValue } from '../../hooks/field-value';
+import { ModelContextProvider } from '../../providers/ModelProvider';
+import { SchemaContext } from '../../providers/SchemaProvider';
+import { FieldProps } from '../../typings';
+import { FieldWrapper } from '../FieldWrapper';
+import { AnyOfField } from '../ObjectField/AnyOfField';
+import { ExpressionService } from './expression.service';
+
+export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, required }) => {
+  const { schema } = useContext(SchemaContext);
+  const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
+
+  const isRootExpression = schema.format === 'expression';
+  const parsedModel = isRootExpression
+    ? ExpressionService.parseStepExpressionModel(originalModel)
+    : ExpressionService.parsePropertyExpressionModel(originalModel);
+
+  const onExpressionChange = useCallback(
+    (propName: string, model: unknown) => {
+      const localValue = originalModel ?? {};
+      setValue(localValue, propName, model);
+      onChange(localValue);
+    },
+    [onChange, originalModel],
+  );
+
+  const expressionAnyOfSchemas = useMemo(() => {
+    /** This is usually when a property it's a expression, like `aggregate.correlationExpression` */
+    if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+      return schema.anyOf;
+    }
+
+    /** This is usually when an EIP or an Entity has a root expression, like `setHeader`, `resequence` or `onCompletion` */
+    if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+      return [{ oneOf: schema.oneOf }];
+    }
+
+    return undefined;
+  }, [schema.anyOf, schema.oneOf]);
+
+  return (
+    <FieldWrapper
+      propName={propName}
+      required={required}
+      title={schema.title}
+      type="expression"
+      description={schema.description}
+      defaultValue={schema.default?.toString()}
+    >
+      <ModelContextProvider model={parsedModel} onPropertyChange={onExpressionChange}>
+        {/* AnyOf field */}
+        {Array.isArray(expressionAnyOfSchemas) && <AnyOfField propName={ROOT_PATH} anyOf={expressionAnyOfSchemas} />}
+      </ModelContextProvider>
+    </FieldWrapper>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionFieldInner.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/ExpressionFieldInner.tsx
@@ -1,0 +1,19 @@
+import { FunctionComponent } from 'react';
+import { KaotoSchemaDefinition } from '../../../../../../models';
+import { SchemaProvider } from '../../providers/SchemaProvider';
+import { FieldProps } from '../../typings';
+import { AutoField } from '../AutoField';
+
+interface ExpressionFieldInner extends FieldProps {
+  schemas: KaotoSchemaDefinition['schema'][];
+}
+
+export const ExpressionFieldInner: FunctionComponent<ExpressionFieldInner> = ({ propName, required, schemas }) => {
+  const [rootExpressionSchema] = schemas;
+
+  return (
+    <SchemaProvider schema={rootExpressionSchema}>
+      <AutoField propName={propName} required={required} />
+    </SchemaProvider>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.test.ts
@@ -1,0 +1,121 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { CamelCatalogService, CatalogKind } from '../../../../../../models';
+import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { ExpressionService } from './expression.service';
+
+describe('ExpressionService', () => {
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    const languageCatalog = catalogsMap.languageCatalog;
+    CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
+  });
+
+  const stepExpressionArray: [Record<string, unknown>, Record<string, unknown>][] = [
+    [
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: {
+            expression: '${body}',
+            trim: true,
+          },
+        },
+      },
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: {
+            expression: '${body}',
+            trim: true,
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: '${body}',
+        },
+      },
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: {
+            expression: '${body}',
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: 'MY_HEADER',
+        simple: {
+          id: 'simple',
+          expression: '${body}',
+        },
+      },
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: {
+            id: 'simple',
+            expression: '${body}',
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: 'MY_HEADER',
+        simple: '${body}',
+      },
+      {
+        name: 'MY_HEADER',
+        expression: {
+          simple: {
+            expression: '${body}',
+          },
+        },
+      },
+    ],
+  ];
+
+  it.each(stepExpressionArray)('should parse %s', (parentModel, expected) => {
+    const result = ExpressionService.parseStepExpressionModel(parentModel);
+
+    expect(result).toEqual(expected);
+  });
+
+  const propertyExpressionArray: [Record<string, unknown>, Record<string, unknown>][] = [
+    [
+      {
+        simple: {
+          expression: '${body}',
+          trim: true,
+        },
+      },
+      {
+        simple: {
+          expression: '${body}',
+          trim: true,
+        },
+      },
+    ],
+    [
+      { simple: '${body}' },
+      {
+        simple: {
+          expression: '${body}',
+        },
+      },
+    ],
+  ];
+
+  it.each(propertyExpressionArray)('should parse expressionProperty %s', (parentModel, expected) => {
+    const result = ExpressionService.parsePropertyExpressionModel(parentModel);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.test.ts
@@ -11,7 +11,7 @@ describe('ExpressionService', () => {
     CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
   });
 
-  const stepExpressionArray: [Record<string, unknown>, Record<string, unknown>][] = [
+  const expressionsArray: [Record<string, unknown>, Record<string, unknown>][] = [
     [
       {
         name: 'MY_HEADER',
@@ -24,11 +24,9 @@ describe('ExpressionService', () => {
       },
       {
         name: 'MY_HEADER',
-        expression: {
-          simple: {
-            expression: '${body}',
-            trim: true,
-          },
+        simple: {
+          expression: '${body}',
+          trim: true,
         },
       },
     ],
@@ -41,10 +39,8 @@ describe('ExpressionService', () => {
       },
       {
         name: 'MY_HEADER',
-        expression: {
-          simple: {
-            expression: '${body}',
-          },
+        simple: {
+          expression: '${body}',
         },
       },
     ],
@@ -58,11 +54,9 @@ describe('ExpressionService', () => {
       },
       {
         name: 'MY_HEADER',
-        expression: {
-          simple: {
-            id: 'simple',
-            expression: '${body}',
-          },
+        simple: {
+          id: 'simple',
+          expression: '${body}',
         },
       },
     ],
@@ -73,22 +67,11 @@ describe('ExpressionService', () => {
       },
       {
         name: 'MY_HEADER',
-        expression: {
-          simple: {
-            expression: '${body}',
-          },
+        simple: {
+          expression: '${body}',
         },
       },
     ],
-  ];
-
-  it.each(stepExpressionArray)('should parse %s', (parentModel, expected) => {
-    const result = ExpressionService.parseStepExpressionModel(parentModel);
-
-    expect(result).toEqual(expected);
-  });
-
-  const propertyExpressionArray: [Record<string, unknown>, Record<string, unknown>][] = [
     [
       {
         simple: {
@@ -113,8 +96,8 @@ describe('ExpressionService', () => {
     ],
   ];
 
-  it.each(propertyExpressionArray)('should parse expressionProperty %s', (parentModel, expected) => {
-    const result = ExpressionService.parsePropertyExpressionModel(parentModel);
+  it.each(expressionsArray)('should parse %s', (parentModel, expected) => {
+    const result = ExpressionService.parseExpressionModel(parentModel);
 
     expect(result).toEqual(expected);
   });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.ts
@@ -1,0 +1,110 @@
+import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
+import { CamelCatalogService } from '../../../../../../models';
+import { isDefined } from '../../../../../../utils';
+
+type StepExpression = { expression: ExpressionDefinition; [key: string]: unknown };
+
+export class ExpressionService {
+  /**
+   * Parse the expression model from the parent step model object. Since expression has several dialects,
+   * this method tries to read all possibility and merge into a single representation. Camel expression has
+   * following 4 dialects, where the 2nd and 4th doesn't allow to configure additional properties:
+   * <ul>
+   *   <li>---
+   * ```yaml
+   * - setBody:
+   *     expression:
+   *       simple:
+   *         expression: ${body}
+   *         trim: true
+   * ```
+   * </li>
+   * <li>---
+   * ```yaml
+   * - setBody:
+   *     expression:
+   *       simple: ${body}
+   * ```
+   * </li>
+   * <li>---
+   * ```yaml
+   * - setBody:
+   *     simple:
+   *       expression: ${body}
+   *       trim: true
+   * ```
+   * </li>
+   * <li>---
+   * ```yaml
+   * - setBody:
+   *     simple: ${body}
+   * ```
+   * </li>
+   * </ul>
+   * @param parentModel The parent step model object which has expression as its parameter. For example `setBody` contents.
+   * */
+  static parseStepExpressionModel(parentModel?: Record<string, unknown>): StepExpression | undefined {
+    if (!isDefined(parentModel)) {
+      return undefined;
+    }
+
+    if (parentModel.expression && Object.keys(parentModel.expression).length > 0) {
+      const [languageModelName] = Object.keys(parentModel.expression);
+      const parsedModel = this.parseLanguageModel(parentModel.expression as Record<string, unknown>, languageModelName);
+
+      return { ...parentModel, expression: parsedModel };
+    }
+
+    const languageNames = this.getLanguageNames();
+    return Object.entries(parentModel).reduce((acc, [key, value]) => {
+      if (languageNames.includes(key)) {
+        acc['expression'] = this.parseLanguageModel({ [key]: value }, key);
+        return acc;
+      }
+
+      return { ...acc, [key]: value };
+    }, {} as StepExpression);
+  }
+
+  /**
+   * Parse the property expression model from the parent parameter model object.
+   * @param parentModel The parent parameter model object which is an expression type. For example `completionPredicate` parameter contents of `aggregate` EIP.
+   */
+  static parsePropertyExpressionModel(parentModel?: Record<string, unknown>): ExpressionDefinition | undefined {
+    const rootExpression = this.parseStepExpressionModel(parentModel);
+
+    if (!isDefined(rootExpression)) {
+      return undefined;
+    }
+
+    return rootExpression.expression;
+  }
+
+  private static getLanguageNames(): string[] {
+    const languageCatalogMap = CamelCatalogService.getLanguageMap();
+
+    if (Object.keys(languageCatalogMap).length === 0) {
+      throw new Error('Language catalog is not initialized');
+    }
+
+    return Object.values(languageCatalogMap).map((lang) => lang.model.name);
+  }
+
+  /**
+   * Parse the language model object. i.e `{ simple: '${body}' }` into `{ simple: { expression: '${body}' } }`
+   *
+   * @param model The language model object. i.e `{ simple: '${body}' }`
+   * @param langName The language name. i.e `simple`
+   * @returns The parsed language model object. i.e `{ simple: { expression: '${body}' } }`
+   */
+  private static parseLanguageModel(model: Record<string, unknown>, langName: string): ExpressionDefinition {
+    const lang = model[langName];
+
+    if (typeof lang === 'object') {
+      return model as ExpressionDefinition;
+    } else {
+      // expression could be even a number
+      return { [langName]: { expression: lang } } as ExpressionDefinition;
+    }
+  }
+}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ExpressionField/expression.service.ts
@@ -1,8 +1,26 @@
 import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
-import { CamelCatalogService } from '../../../../../../models';
+import { CamelCatalogService, KaotoSchemaDefinition } from '../../../../../../models';
 import { isDefined } from '../../../../../../utils';
 
 export class ExpressionService {
+  static getExpressionsSchema(schema: KaotoSchemaDefinition['schema']): KaotoSchemaDefinition['schema'] {
+    /**
+     * Expressions are stored in a oneOf array bigger than 3 elements.
+     * Otherwise, it might be a nested structure of anyOf / oneOf.
+     */
+    if (Array.isArray(schema.oneOf) && schema.oneOf.length > 3) {
+      return schema;
+    }
+
+    if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+      return this.getExpressionsSchema(schema.anyOf[0]);
+    } else if (Array.isArray(schema.oneOf)) {
+      return this.getExpressionsSchema(schema.oneOf[0]);
+    }
+
+    return {};
+  }
+
   /**
    * Parse the expression model from the parent step model object or from a expression property.
    * Since expression has several dialects, this method tries to read all possibility and merge into

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ObjectField/ObjectField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ObjectField/ObjectField.tsx
@@ -38,7 +38,6 @@ export const ObjectField: FunctionComponent<FieldProps> = ({ propName, onRemove:
 
   return (
     <ArrayFieldWrapper
-      propName={propName}
       type="object"
       title={schema.title}
       description={schema.description}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/OneOfField/OneOfField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/OneOfField/OneOfField.tsx
@@ -1,54 +1,15 @@
-import { FunctionComponent, useContext, useMemo, useState } from 'react';
-import { isDefined } from '../../../../../../utils';
-import { getAppliedSchemaIndexV2 } from '../../../../../../utils/get-applied-schema-index';
-import { getOneOfSchemaListV2, OneOfSchemas } from '../../../../../../utils/get-oneof-schema-list';
-import { useFieldValue } from '../../hooks/field-value';
-import { SchemaContext, SchemaProvider } from '../../providers/SchemaProvider';
+import { FunctionComponent } from 'react';
+import { useOneOfField } from '../../hooks/one-of-field';
+import { SchemaProvider } from '../../providers/SchemaProvider';
 import { FieldProps } from '../../typings';
 import { AutoField } from '../AutoField';
 import { SchemaList } from './SchemaList';
-import { CanvasFormTabsContext } from '../../../../../../providers/canvas-form-tabs.provider';
 
 export const OneOfField: FunctionComponent<FieldProps> = ({ propName }) => {
-  const { selectedTab } = useContext(CanvasFormTabsContext);
-  const { schema, definitions } = useContext(SchemaContext);
-  const { value, onChange } = useFieldValue<Record<string, unknown>>(propName);
+  const { selectedOneOfSchema, oneOfSchemas, onSchemaChange, shouldRender } = useOneOfField(propName);
 
-  const oneOfSchemas: OneOfSchemas[] = useMemo(
-    () => getOneOfSchemaListV2(schema.oneOf ?? [], definitions),
-    [definitions, schema.oneOf],
-  );
-
-  const appliedSchemaIndex = getAppliedSchemaIndexV2(value, oneOfSchemas, definitions);
-  const presetSchema = appliedSchemaIndex === -1 ? undefined : oneOfSchemas[appliedSchemaIndex];
-  const [selectedOneOfSchema, setSelectedOneOfSchema] = useState<OneOfSchemas | undefined>(presetSchema);
-
-  const onSchemaChange = (schema?: OneOfSchemas) => {
-    if (schema?.name === selectedOneOfSchema?.name) {
-      return;
-    }
-
-    if (typeof value === 'object' && isDefined(selectedOneOfSchema?.schema.properties)) {
-      const newValue = { ...value };
-      Object.keys(selectedOneOfSchema.schema.properties).forEach((prop) => {
-        delete (newValue as Record<string, unknown>)[prop];
-      });
-      onChange(newValue);
-    }
-
-    setSelectedOneOfSchema(schema);
-  };
-
-  if (selectedTab === 'Modified') {
-    const selectedOneOfSchemaProperty = selectedOneOfSchema?.schema.properties;
-    if (selectedOneOfSchemaProperty) {
-      const hasModelDefined = Object.keys(selectedOneOfSchemaProperty).some(
-        (propName) => isDefined(value) && isDefined(value[propName]),
-      );
-      if (!hasModelDefined) {
-        return null;
-      }
-    }
+  if (!shouldRender) {
+    return null;
   }
 
   return (

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/OneOfField/SchemaList.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/OneOfField/SchemaList.tsx
@@ -12,6 +12,8 @@ interface SchemaList extends FieldProps {
   selectedSchema: OneOfSchemas | undefined;
   schemas: OneOfSchemas[];
   onChange: (schema: OneOfSchemas | undefined) => void;
+  onCleanInput?: () => void;
+  placeholder?: string;
 }
 
 export const SchemaList: FunctionComponent<PropsWithChildren<SchemaList>> = ({
@@ -19,6 +21,8 @@ export const SchemaList: FunctionComponent<PropsWithChildren<SchemaList>> = ({
   selectedSchema,
   schemas,
   onChange,
+  onCleanInput,
+  placeholder,
   children,
 }) => {
   const items: TypeaheadItem<KaotoSchemaDefinition['schema']>[] = useMemo(
@@ -53,9 +57,17 @@ export const SchemaList: FunctionComponent<PropsWithChildren<SchemaList>> = ({
 
   return (
     <>
-      <FormGroup isStack hasNoPaddingTop label={`OneOf ${propName}`} fieldId={propName} role="group">
-        {useTypeahead && <Typeahead selectedItem={selectedItem} items={items} id={propName} onChange={onItemChange} />}
-        {!useTypeahead && (
+      <FormGroup isStack hasNoPaddingTop fieldId={propName} role="group">
+        {useTypeahead ? (
+          <Typeahead
+            selectedItem={selectedItem}
+            items={items}
+            id={propName}
+            placeholder={placeholder}
+            onChange={onItemChange}
+            onCleanInput={onCleanInput}
+          />
+        ) : (
           <SimpleSelector selectedItem={selectedItem} items={items} id={propName} onChange={onItemChange} />
         )}
       </FormGroup>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/one-of-field.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/one-of-field.ts
@@ -1,0 +1,58 @@
+import { useContext, useMemo, useState } from 'react';
+import { CanvasFormTabsContext } from '../../../../../providers';
+import { isDefined } from '../../../../../utils';
+import { getAppliedSchemaIndexV2 } from '../../../../../utils/get-applied-schema-index';
+import { OneOfSchemas, getOneOfSchemaListV2 } from '../../../../../utils/get-oneof-schema-list';
+import { SchemaContext } from '../providers/SchemaProvider';
+import { useFieldValue } from './field-value';
+
+export const useOneOfField = (propName: string) => {
+  const { selectedTab } = useContext(CanvasFormTabsContext);
+  const { schema, definitions } = useContext(SchemaContext);
+  const { value, onChange } = useFieldValue<Record<string, unknown>>(propName);
+
+  const oneOfSchemas: OneOfSchemas[] = useMemo(
+    () => getOneOfSchemaListV2(schema.oneOf ?? [], definitions),
+    [definitions, schema.oneOf],
+  );
+
+  const appliedSchemaIndex = getAppliedSchemaIndexV2(value, oneOfSchemas, definitions);
+  const presetSchema = appliedSchemaIndex === -1 ? undefined : oneOfSchemas[appliedSchemaIndex];
+  const [selectedOneOfSchema, setSelectedOneOfSchema] = useState<OneOfSchemas | undefined>(presetSchema);
+
+  const onSchemaChange = (schema?: OneOfSchemas) => {
+    if (schema?.name === selectedOneOfSchema?.name) {
+      return;
+    }
+
+    if (typeof value === 'object' && isDefined(selectedOneOfSchema?.schema.properties)) {
+      const newValue = { ...value };
+      Object.keys(selectedOneOfSchema.schema.properties).forEach((prop) => {
+        delete (newValue as Record<string, unknown>)[prop];
+      });
+      onChange(newValue);
+    }
+
+    setSelectedOneOfSchema(schema);
+  };
+
+  let shouldRender = true;
+  if (selectedTab === 'Modified') {
+    const selectedOneOfSchemaProperty = selectedOneOfSchema?.schema.properties;
+    if (selectedOneOfSchemaProperty) {
+      const hasModelDefined = Object.keys(selectedOneOfSchemaProperty).some(
+        (propName) => isDefined(value) && isDefined(value[propName]),
+      );
+      if (!hasModelDefined) {
+        shouldRender = false;
+      }
+    }
+  }
+
+  return {
+    selectedOneOfSchema,
+    oneOfSchemas,
+    onSchemaChange,
+    shouldRender,
+  };
+};

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/providers/FormComponentFactoryProvider.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/providers/FormComponentFactoryProvider.test.tsx
@@ -4,6 +4,7 @@ import { KaotoSchemaDefinition } from '../../../../../models';
 import { ArrayField } from '../fields/ArrayField/ArrayField';
 import { BooleanField } from '../fields/BooleanField';
 import { DisabledField } from '../fields/DisabledField';
+import { ExpressionField } from '../fields/ExpressionField/ExpressionField';
 import { ObjectField } from '../fields/ObjectField/ObjectField';
 import { OneOfField } from '../fields/OneOfField/OneOfField';
 import { PasswordField } from '../fields/PasswordField';
@@ -29,6 +30,8 @@ describe('FormComponentFactoryProvider', () => {
     [{ type: 'boolean' }, BooleanField],
     [{ type: 'object', properties: { name: { type: 'string' } } }, ObjectField],
     [{ type: 'object', properties: {} }, PropertiesField],
+    [{ format: 'expression' }, ExpressionField],
+    [{ format: 'expressionField' }, ExpressionField],
     [{ type: 'array' }, ArrayField],
     [{ oneOf: [] }, OneOfField],
     [{}, DisabledField],

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/providers/FormComponentFactoryProvider.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/providers/FormComponentFactoryProvider.tsx
@@ -4,6 +4,7 @@ import { ArrayField } from '../fields/ArrayField/ArrayField';
 import { BooleanField } from '../fields/BooleanField';
 import { DisabledField } from '../fields/DisabledField';
 import { EnumField } from '../fields/EnumField';
+import { ExpressionField } from '../fields/ExpressionField/ExpressionField';
 import { ObjectField } from '../fields/ObjectField/ObjectField';
 import { OneOfField } from '../fields/OneOfField/OneOfField';
 import { PasswordField } from '../fields/PasswordField';
@@ -36,6 +37,8 @@ export const FormComponentFactoryProvider: FunctionComponent<PropsWithChildren> 
       return PropertiesField;
     } else if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
       return BeanField;
+    } else if (schema.format === 'expression' || schema.format === 'expressionProperty') {
+      return ExpressionField;
     }
 
     switch (schema.type) {

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/typings.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/typings.ts
@@ -1,5 +1,10 @@
 export interface FieldProps {
+  /** Property name, e.g. #.correlationExpression */
   propName: string;
+
+  /** Whether the field is required */
   required?: boolean;
+
+  /** Callback to signal what to do when the user remove the value */
   onRemove?: (propName: string) => void;
 }

--- a/packages/ui/src/components/typeahead/Typeahead.tsx
+++ b/packages/ui/src/components/typeahead/Typeahead.tsx
@@ -27,6 +27,11 @@ import { TypeaheadProps } from './Typeahead.types';
 const createNewValue = 'create-new';
 const createNewWithNameValue = 'create-new-with-name';
 
+const DEFAULT_POPPER_PROPS = {
+  position: 'end',
+  preventOverflow: true,
+} as const;
+
 export const Typeahead: FunctionComponent<TypeaheadProps> = ({
   selectedItem,
   items: itemsProps,
@@ -55,7 +60,7 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
       localArray.unshift({ name: selectedItem.name, value: selectedItem.value });
     }
     return localArray;
-  }, [itemsProps, selectedItem, onCreate, createNewValue]);
+  }, [itemsProps, onCreate, onCreatePrefix, selectedItem?.name, selectedItem?.value]);
 
   useEffect(() => {
     if (selectedItem?.name) {
@@ -161,6 +166,7 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
       selected={selectedItem?.name}
       onSelect={onItemChanged}
       toggle={toggle}
+      popperProps={DEFAULT_POPPER_PROPS}
     >
       <SelectList>
         {filteredItems.map((item) => (

--- a/packages/ui/src/utils/set-value.test.ts
+++ b/packages/ui/src/utils/set-value.test.ts
@@ -32,10 +32,10 @@ describe('setValue', () => {
     expect(obj).toEqual({ a: { b: { c: 2 } } });
   });
 
-  it('should combine the properties of the value at the root path', () => {
+  it('should remove the properties of the source object that are not in the value object at the root path', () => {
     const obj = { a: { b: { c: 1 } } };
     setValue(obj, ROOT_PATH, { d: 2 });
-    expect(obj).toEqual({ a: { b: { c: 1 } }, d: 2 });
+    expect(obj).toEqual({ d: 2 });
   });
 
   it('should remove all properties when assigning `undefined` to the root path', () => {

--- a/packages/ui/src/utils/set-value.ts
+++ b/packages/ui/src/utils/set-value.ts
@@ -10,6 +10,15 @@ export const setValue = (obj: any, path: string | string[], value: any): void =>
 
   if (path === ROOT_PATH) {
     if (isDefined(value)) {
+      const rootObject = Object.keys(obj);
+      const valueObject = Object.keys(value);
+
+      rootObject.forEach((key) => {
+        if (!valueObject.includes(key)) {
+          delete obj[key];
+        }
+      });
+
       Object.assign(obj, value);
     } else {
       Object.keys(obj).forEach((key) => delete obj[key]);


### PR DESCRIPTION
### Context
This PR adds a specialized `ExpressionField`, based on the premise that `onOf` schemas will be decorated with `format: expression`.

### Notes
There are 3 expression types:
* Root expression (`ExpressionDefinition`): Used for EIPs like `setHeader` or `setBody`
* Property expression (`ExpressionSubElementDefinition`): Used for properties like `aggregate.correlationExpression`
* Combined expression (`PropertyExpressionDefinition`): Used for array items having expressions, like `saga.options`.

part of https://github.com/KaotoIO/kaoto/pull/1939