### PR TITLE
fix(Form): Use property name as title if title is not present

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.scss
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.scss
@@ -2,6 +2,8 @@
   &__label {
     --pf-v6-c-form__label--FontSize: --pf-t--global--font--size--body--md;
     --pf-v6-c-form__label-required--FontSize: --pf-t--global--font--size--body--lg;
+
+    text-transform: capitalize;
   }
 
   /* stylelint-disable-next-line selector-class-pattern */

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/EnumField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/EnumField.tsx
@@ -5,10 +5,14 @@ import { useFieldValue } from '../hooks/field-value';
 import { SchemaContext } from '../providers/SchemaProvider';
 import { FieldProps } from '../typings';
 import { FieldWrapper } from './FieldWrapper';
+import { isDefined } from '../../../../../utils';
 
 export const EnumField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
   const { value = '', onChange } = useFieldValue<string | undefined>(propName);
+  if (!isDefined(schema)) {
+    throw new Error(`StringField: schema is not defined for ${propName}`);
+  }
 
   const items: TypeaheadItem<string>[] = useMemo(
     () =>
@@ -47,10 +51,6 @@ export const EnumField: FunctionComponent<FieldProps> = ({ propName, required })
   const onCleanInput = useCallback(() => {
     onChange(undefined);
   }, [onChange]);
-
-  if (!schema) {
-    return <div>EnumField - Schema not defined</div>;
-  }
 
   return (
     <FieldWrapper

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.tsx
@@ -19,18 +19,19 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
   children,
 }) => {
   const id = `${propName}-popover`;
+  const label = title ?? propName.split('.').pop();
 
   return (
     <FormGroup
       fieldId={propName}
-      label={title ?? propName}
+      label={label}
       isRequired={required}
       labelHelp={
         <Popover
           id={id}
           headerContent={
-            <p>
-              {title} {`<${type}>`}
+            <p className="kaoto-form__label">
+              {label} {`<${type}>`}
             </p>
           }
           bodyContent={<p>{description}</p>}
@@ -38,7 +39,7 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
           triggerAction="hover"
           withFocusTrap={false}
         >
-          <FormGroupLabelHelp aria-label={`More info for ${title} field`} />
+          <FormGroupLabelHelp aria-label={`More info for ${label} field`} />
         </Popover>
       }
     >

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
@@ -11,7 +11,11 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
   const { schema } = useContext(SchemaContext);
   const [passwordHidden, setPasswordHidden] = useState<boolean>(true);
   const { value = '', onChange } = useFieldValue<string>(propName);
-  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${propName} field`;
+  const lastPropName = propName.split('.').pop();
+  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
+  if (!isDefined(schema)) {
+    throw new Error(`PasswordField: schema is not defined for ${propName}`);
+  }
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
@@ -26,10 +30,6 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
   };
-
-  if (!schema) {
-    return <div>PasswordField - Schema not defined</div>;
-  }
 
   const id = `${propName}-popover`;
 

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PropertiesField/PropertiesField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PropertiesField/PropertiesField.tsx
@@ -11,6 +11,7 @@ export const PropertiesField: FunctionComponent<FieldProps> = ({ propName, requi
   const { value, onChange } = useFieldValue<KeyValueType | undefined>(propName);
 
   const items = Object.entries(value ?? {});
+  const title = schema.title ?? propName.split('.').pop();
 
   return (
     <FieldWrapper
@@ -18,7 +19,7 @@ export const PropertiesField: FunctionComponent<FieldProps> = ({ propName, requi
       required={required}
       title={
         <>
-          {schema.title} <Badge title={`${items.length} properties`}>{items.length}</Badge>
+          {title} <Badge title={`${items.length} properties`}>{items.length}</Badge>
         </>
       }
       type="object"

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
@@ -10,7 +10,11 @@ import { FieldWrapper } from './FieldWrapper';
 export const StringField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
   const { value = '', onChange } = useFieldValue<string>(propName);
-  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${propName} field`;
+  const lastPropName = propName.split('.').pop();
+  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
+  if (!isDefined(schema)) {
+    throw new Error(`StringField: schema is not defined for ${propName}`);
+  }
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
@@ -25,10 +29,6 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
   };
-
-  if (!schema) {
-    return <div>StringField - Schema not defined</div>;
-  }
 
   const id = `${propName}-popover`;
 

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/TextAreaField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/TextAreaField.tsx
@@ -10,8 +10,12 @@ import { FieldWrapper } from './FieldWrapper';
 export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
   const { value = '', onChange } = useFieldValue<string>(propName);
-  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${propName} field`;
+  const lastPropName = propName.split('.').pop();
+  const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
   const rows = Math.max(value.split('\n').length, 2);
+  if (!isDefined(schema)) {
+    throw new Error(`TextAreaField: schema is not defined for ${propName}`);
+  }
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
@@ -26,10 +30,6 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
   };
-
-  if (!schema) {
-    return <div>TextAreaField - Schema not defined</div>;
-  }
 
   const id = `${propName}-popover`;
 


### PR DESCRIPTION
### Context
This PR uses the propertyName as the title when the title is not present in the schema.

Part of https://github.com/KaotoIO/kaoto/pull/1939