### PR TITLE
chore: Cleanup create new resource functionality

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -22,7 +22,6 @@ describe('ItemReplaceStep', () => {
     currentSchemaType: camelResource.getType(),
     updateSourceCodeFromEntities: jest.fn(),
     updateEntitiesFromCamelResource: jest.fn(),
-    setCurrentSchemaType: jest.fn(),
   };
 
   const mockReplaceModalContext = {

--- a/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
+++ b/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
@@ -62,7 +62,7 @@ export const RouteVisualization: React.FC<{
   }, [eventNotifier, codeChange]);
 
   useEffect(() => {
-    eventNotifier.next('code:updated', code);
+    eventNotifier.next('code:updated', { code });
   }, [code, eventNotifier]);
 
   return (

--- a/packages/ui/src/hooks/entities.test.tsx
+++ b/packages/ui/src/hooks/entities.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { CamelResource, SourceSchemaType } from '../models/camel';
+import { CamelResource } from '../models/camel';
 import { CamelRouteVisualEntity } from '../models/visualization/flows';
 import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
 import { camelRouteYaml_1_1_original, camelRouteYaml_1_1_updated } from '../stubs/camel-route-yaml-1.1';
@@ -36,7 +36,7 @@ describe('useEntities', () => {
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      eventNotifier.next('code:updated', camelRouteYaml);
+      eventNotifier.next('code:updated', { code: camelRouteYaml });
     });
 
     expect(result.current.entities).toEqual([]);
@@ -48,7 +48,7 @@ describe('useEntities', () => {
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      eventNotifier.next('code:updated', camelRouteYaml_1_1_original);
+      eventNotifier.next('code:updated', { code: camelRouteYaml_1_1_original });
     });
 
     act(() => {
@@ -131,37 +131,6 @@ describe('useEntities', () => {
     );
   });
 
-  it('should recreate the Camel Resource when the schema is updated', () => {
-    let firstCamelResource: CamelResource;
-    let secondCamelResource: CamelResource;
-
-    const { result } = renderHook(() => useEntities());
-
-    act(() => {
-      firstCamelResource = result.current.camelResource;
-      result.current.setCurrentSchemaType(SourceSchemaType.Route);
-    });
-
-    act(() => {
-      secondCamelResource = result.current.camelResource;
-      expect(firstCamelResource).not.toBe(secondCamelResource);
-    });
-  });
-
-  it('should notify subscribers when the schema is updated', () => {
-    const notifierSpy = jest.spyOn(eventNotifier, 'next');
-    const { result } = renderHook(() => useEntities());
-
-    act(() => {
-      result.current.setCurrentSchemaType(SourceSchemaType.Route);
-    });
-
-    expect(notifierSpy).toHaveBeenCalledWith(
-      'entities:updated',
-      `[]
-`,
-    );
-  });
   it(`should store code's comments`, () => {
     const code = `# This is a comment
       # An indented comment
@@ -184,7 +153,7 @@ describe('useEntities', () => {
     const { result } = renderHook(() => useEntities());
 
     act(() => {
-      eventNotifier.next('code:updated', code);
+      eventNotifier.next('code:updated', { code });
     });
 
     expect(result.current.camelResource.toString()).toContain(

--- a/packages/ui/src/hooks/entities.ts
+++ b/packages/ui/src/hooks/entities.ts
@@ -29,11 +29,6 @@ export interface EntitiesContextResult {
    * just the entities
    */
   updateEntitiesFromCamelResource: () => void;
-
-  /**
-   * Sets the current schema type and recreates the CamelResource
-   */
-  setCurrentSchemaType: (entity: SourceSchemaType) => void;
 }
 
 export const useEntities = (): EntitiesContextResult => {
@@ -46,8 +41,8 @@ export const useEntities = (): EntitiesContextResult => {
    * Subscribe to the `code:updated` event to recreate the CamelResource
    */
   useLayoutEffect(() => {
-    return eventNotifier.subscribe('code:updated', (code) => {
-      const camelResource = CamelResourceFactory.createCamelResource(code);
+    return eventNotifier.subscribe('code:updated', ({ code, path }) => {
+      const camelResource = CamelResourceFactory.createCamelResource(code, { path });
       const entities = camelResource.getEntities();
       const visualEntities = camelResource.getVisualEntities();
 
@@ -74,31 +69,15 @@ export const useEntities = (): EntitiesContextResult => {
     updateSourceCodeFromEntities();
   }, [camelResource, updateSourceCodeFromEntities]);
 
-  const setCurrentSchemaType = useCallback(
-    (type: SourceSchemaType) => {
-      setCamelResource(CamelResourceFactory.createCamelResource(type));
-      updateEntitiesFromCamelResource();
-    },
-    [updateEntitiesFromCamelResource],
-  );
-
   return useMemo(
     () => ({
       entities,
       visualEntities,
       currentSchemaType: camelResource?.getType(),
       camelResource,
-      setCurrentSchemaType,
       updateEntitiesFromCamelResource,
       updateSourceCodeFromEntities,
     }),
-    [
-      entities,
-      visualEntities,
-      camelResource,
-      setCurrentSchemaType,
-      updateEntitiesFromCamelResource,
-      updateSourceCodeFromEntities,
-    ],
+    [entities, visualEntities, camelResource, updateEntitiesFromCamelResource, updateSourceCodeFromEntities],
   );
 };

--- a/packages/ui/src/layout/Shell.tsx
+++ b/packages/ui/src/layout/Shell.tsx
@@ -36,7 +36,7 @@ export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
     const unSubscribeFromEntities = eventNotifier.subscribe('entities:updated', (code) => {
       localStorage.setItem(LocalStorageKeys.SourceCode, code);
     });
-    const unSubscribeFromCode = eventNotifier.subscribe('code:updated', (code) => {
+    const unSubscribeFromCode = eventNotifier.subscribe('code:updated', ({ code }) => {
       localStorage.setItem(LocalStorageKeys.SourceCode, code);
     });
 

--- a/packages/ui/src/models/camel/camel-resource-factory.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.ts
@@ -1,10 +1,10 @@
-import { SourceSchemaType } from './source-schema-type';
-import { CamelResource } from './camel-resource';
-import { CamelResourceSerializer, XmlCamelResourceSerializer, YamlCamelResourceSerializer } from '../../serializers';
-import { CamelRouteResource } from './camel-route-resource';
-import { CamelKResourceFactory } from './camel-k-resource-factory';
 import { CamelYamlDsl, Integration, KameletBinding, Pipe } from '@kaoto/camel-catalog/types';
+import { CamelResourceSerializer, XmlCamelResourceSerializer, YamlCamelResourceSerializer } from '../../serializers';
 import { IKameletDefinition } from '../kamelets-catalog';
+import { CamelKResourceFactory } from './camel-k-resource-factory';
+import { CamelResource } from './camel-resource';
+import { CamelRouteResource } from './camel-route-resource';
+import { getResourceTypeFromPath } from './source-schema-type';
 
 export class CamelResourceFactory {
   /**
@@ -15,7 +15,9 @@ export class CamelResourceFactory {
    * @param type
    * @param source
    */
-  static createCamelResource(source?: string, type?: SourceSchemaType): CamelResource {
+  static createCamelResource(source?: string, options: Partial<{ path: string }> = {}): CamelResource {
+    const pathResourceType = getResourceTypeFromPath(options.path);
+
     const serializer: CamelResourceSerializer = XmlCamelResourceSerializer.isApplicable(source)
       ? new XmlCamelResourceSerializer()
       : new YamlCamelResourceSerializer();
@@ -23,7 +25,7 @@ export class CamelResourceFactory {
     const parsedCode = typeof source === 'string' ? serializer.parse(source) : source;
     const resource = CamelKResourceFactory.getCamelKResource(
       parsedCode as Integration | KameletBinding | Pipe | IKameletDefinition,
-      type,
+      pathResourceType,
     );
 
     if (resource) return resource;

--- a/packages/ui/src/models/camel/camel-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-resource.test.ts
@@ -15,36 +15,45 @@ describe('CamelResourceFactory.createCamelResource', () => {
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty CamelRouteResource if no args is specified', () => {
-    const resource = CamelResourceFactory.createCamelResource(undefined, SourceSchemaType.Route);
+  it('should create an empty CamelRouteResource if a camel.yaml path is specified', () => {
+    const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.yaml' });
+    expect(resource.getType()).toEqual(SourceSchemaType.Route);
+    expect(resource.getEntities()).toEqual([]);
+    expect(resource.getVisualEntities()).toEqual([]);
+  });
+
+  it('should create an empty CamelRouteResource if a camel.xml path is specified', () => {
+    const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.xml' });
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
   it('should create an empty IntegrationResource if no args is specified', () => {
-    const resource = CamelResourceFactory.createCamelResource(undefined, SourceSchemaType.Integration);
+    const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chat.integration.yaml' });
     expect(resource.getType()).toEqual(SourceSchemaType.Integration);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
   it('should create an empty KameletResource if no args is specified', () => {
-    const resource = CamelResourceFactory.createCamelResource(undefined, SourceSchemaType.Kamelet);
+    const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chuck-norris-source.kamelet.yaml' });
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toMatchSnapshot();
   });
 
   it('should create an empty CameletBindingResource if no args is specified', () => {
-    const resource = CamelResourceFactory.createCamelResource(undefined, SourceSchemaType.KameletBinding);
+    const resource = CamelResourceFactory.createCamelResource(undefined, {
+      path: 'webhook-binding.kamelet-binding.yaml',
+    });
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
   });
 
   it('should create an empty PipeResource if no args is specified', () => {
-    const resource = CamelResourceFactory.createCamelResource(undefined, SourceSchemaType.Pipe);
+    const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'webhook.pipe.yaml' });
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);

--- a/packages/ui/src/models/camel/source-schema-type.test.ts
+++ b/packages/ui/src/models/camel/source-schema-type.test.ts
@@ -1,0 +1,18 @@
+import { getResourceTypeFromPath, SourceSchemaType } from './source-schema-type';
+
+describe('getResourceTypeFromPath', () => {
+  const cases: [string, SourceSchemaType][] = [
+    ['my.integration.yaml', SourceSchemaType.Integration],
+    ['my.kamelet-binding.yaml', SourceSchemaType.KameletBinding],
+    ['my.kamelet.yaml', SourceSchemaType.Kamelet],
+    ['my.pipe.yaml', SourceSchemaType.Pipe],
+    ['my.camel.xml', SourceSchemaType.Route],
+    ['my.yaml', SourceSchemaType.Route],
+    ['my.json', SourceSchemaType.Route],
+    ['my.txt', SourceSchemaType.Route],
+  ];
+
+  it.each(cases)('should return %s for %s', (path, expected) => {
+    expect(getResourceTypeFromPath(path)).toEqual(expected);
+  });
+});

--- a/packages/ui/src/models/camel/source-schema-type.ts
+++ b/packages/ui/src/models/camel/source-schema-type.ts
@@ -1,7 +1,23 @@
 export enum SourceSchemaType {
   Route = 'Route',
   Integration = 'Integration',
-  Kamelet = 'Kamelet',
   KameletBinding = 'KameletBinding',
+  Kamelet = 'Kamelet',
   Pipe = 'Pipe',
 }
+
+export const getResourceTypeFromPath = (path?: string): SourceSchemaType | undefined => {
+  if (path?.includes('.integration')) {
+    return SourceSchemaType.Integration;
+  } else if (path?.includes('.kamelet-binding')) {
+    return SourceSchemaType.KameletBinding;
+  } else if (path?.includes('.kamelet')) {
+    return SourceSchemaType.Kamelet;
+  } else if (path?.includes('.pipe')) {
+    return SourceSchemaType.Pipe;
+  } else if (path?.endsWith('.xml')) {
+    return SourceSchemaType.Route;
+  }
+
+  return SourceSchemaType.Route;
+};

--- a/packages/ui/src/multiplying-architecture/KaotoBridge.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoBridge.tsx
@@ -147,7 +147,7 @@ export const KaotoBridge = forwardRef<EditorApi, PropsWithChildren<KaotoBridgePr
      * It sets the originalContent to the received value.
      */
     const setContent = useCallback(
-      (_path: string, content: string) => {
+      (path: string, content: string) => {
         /**
          * If the new content is the same as the current one, we don't need to update the Editor,
          * as it will regenerate the Camel Resource, hence disconnecting the configuration form (if open).
@@ -166,7 +166,7 @@ export const KaotoBridge = forwardRef<EditorApi, PropsWithChildren<KaotoBridgePr
          */
         if (sourceCodeRef.current === content) return;
 
-        sourceCodeApiContext.setCodeAndNotify(content);
+        sourceCodeApiContext.setCodeAndNotify(content, path);
         sourceCodeRef.current = content;
       },
       [sourceCodeApiContext],
@@ -181,7 +181,7 @@ export const KaotoBridge = forwardRef<EditorApi, PropsWithChildren<KaotoBridgePr
         sourceCodeRef.current = newContent;
       });
 
-      const unsubscribeFromSourceCode = eventNotifier.subscribe('code:updated', (newContent: string) => {
+      const unsubscribeFromSourceCode = eventNotifier.subscribe('code:updated', ({ code: newContent }) => {
         /** Ignore the first change, from an empty string to the file content  */
         if (sourceCodeRef.current !== '') {
           onNewEdit(newContent);

--- a/packages/ui/src/providers/source-code.provider.test.tsx
+++ b/packages/ui/src/providers/source-code.provider.test.tsx
@@ -49,7 +49,7 @@ describe('SourceCodeProvider', () => {
       );
     });
 
-    expect(notifierSpy).toHaveBeenCalledWith('code:updated', camelRouteYaml);
+    expect(notifierSpy).toHaveBeenCalledWith('code:updated', { code: camelRouteYaml, path: undefined });
   });
 });
 

--- a/packages/ui/src/providers/source-code.provider.tsx
+++ b/packages/ui/src/providers/source-code.provider.tsx
@@ -11,7 +11,7 @@ import { EventNotifier } from '../utils';
 
 interface ISourceCodeApi {
   /** Set the Source Code and notify subscribers */
-  setCodeAndNotify: (sourceCode: string) => void;
+  setCodeAndNotify: (sourceCode: string, path?: string) => void;
 }
 
 export const SourceCodeContext = createContext<string>('');
@@ -28,9 +28,9 @@ export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) 
   }, [eventNotifier]);
 
   const setCodeAndNotify = useCallback(
-    (code: string) => {
+    (code: string, path?: string) => {
       setSourceCode(code);
-      eventNotifier.next('code:updated', code);
+      eventNotifier.next('code:updated', { code, path });
     },
     [eventNotifier],
   );

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -13,7 +13,6 @@ interface TestProviderWrapperProps extends PropsWithChildren {
 
 interface TestProvidersWrapperResult {
   Provider: FunctionComponent<PropsWithChildren>;
-  setCurrentSchemaTypeSpy: EntitiesContextResult['setCurrentSchemaType'];
   updateEntitiesFromCamelResourceSpy: EntitiesContextResult['updateEntitiesFromCamelResource'];
   updateSourceCodeFromEntitiesSpy: EntitiesContextResult['updateSourceCodeFromEntities'];
 }
@@ -21,7 +20,6 @@ interface TestProvidersWrapperResult {
 export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): TestProvidersWrapperResult => {
   const camelResource = props.camelResource ?? new CamelRouteResource([camelRouteJson]);
   const currentSchemaType = camelResource.getType();
-  const setCurrentSchemaTypeSpy = jest.fn();
   const updateEntitiesFromCamelResourceSpy = jest.fn();
   const updateSourceCodeFromEntitiesSpy = jest.fn();
 
@@ -41,7 +39,6 @@ export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): Test
           entities: camelResource.getEntities(),
           visualEntities: camelResource.getVisualEntities(),
           currentSchemaType,
-          setCurrentSchemaType: setCurrentSchemaTypeSpy,
           updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
           updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
         } as unknown as EntitiesContextResult
@@ -51,5 +48,5 @@ export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): Test
     </EntitiesContext.Provider>
   );
 
-  return { Provider, setCurrentSchemaTypeSpy, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy };
+  return { Provider, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy };
 };

--- a/packages/ui/src/utils/event-notifier.test.ts
+++ b/packages/ui/src/utils/event-notifier.test.ts
@@ -6,9 +6,9 @@ describe('EventNotifier', () => {
     const listener = jest.fn();
 
     eventNotifier.subscribe('code:updated', listener);
-    eventNotifier.next('code:updated', 'my source code');
+    eventNotifier.next('code:updated', { code: 'my source code' });
 
-    expect(listener).toHaveBeenCalledWith('my source code');
+    expect(listener).toHaveBeenCalledWith({ code: 'my source code' });
   });
 
   it('should unsubscribe', () => {
@@ -17,7 +17,7 @@ describe('EventNotifier', () => {
 
     const unsubscribe = eventNotifier.subscribe('code:updated', listener);
     unsubscribe();
-    eventNotifier.next('code:updated', 'payload');
+    eventNotifier.next('code:updated', { code: 'payload' });
 
     expect(listener).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/utils/event-notifier.ts
+++ b/packages/ui/src/utils/event-notifier.ts
@@ -1,5 +1,5 @@
 interface Events {
-  'code:updated': string;
+  'code:updated': { code: string; path?: string };
   'entities:updated': string;
 }
 


### PR DESCRIPTION
### Context
In relation to https://github.com/KaotoIO/kaoto/pull/2009, we need to add the filename to the source code API to be able to create the appropriate resource with the right serializer.

### Changes
* Remove `setCurrentSchemaType` API which wasn't used
* Add an optional `path` property to the `setCodeAndNotify` API
* Remove unnecessary methods
 