### PR TITLE
feat(Catalog): Add catalog version

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/commands/GenerateCommand.java
@@ -26,8 +26,7 @@ public class GenerateCommand implements Runnable {
                 "Catalog versions: " + configBean.getCatalogVersionSet() + "\n" +
                 "Kamelets version: " + configBean.getKameletsVersion());
 
-        CatalogLibrary library = new CatalogLibrary();
-        library.setName(configBean.getCatalogsName());
+        CatalogLibrary library = new CatalogLibrary(1, configBean.getCatalogsName());
 
         FileUtils.deleteQuietly(configBean.getOutputFolder());
         File outputFolder = createSubFolder(configBean.getOutputFolder());
@@ -47,6 +46,7 @@ public class GenerateCommand implements Runnable {
                             .withKameletsVersion(configBean.getKameletsVersion())
                             .withCamelKCRDsVersion("2.3.1")
                             .withOutputDirectory(catalogDefinitionFolder)
+                            .withVerbose(configBean.isVerbose())
                             .build();
 
                     CatalogDefinition catalogDefinition = catalogGenerator.generate();

--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/model/CatalogLibrary.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/model/CatalogLibrary.java
@@ -21,14 +21,20 @@ import java.util.List;
 public class CatalogLibrary {
     /* Visible for testing */
     public List<CatalogLibraryEntry> definitions = new ArrayList<>();
-    private String name;
+    private final int version;
+    private final String name;
+
+    public CatalogLibrary(int version, String name) {
+        this.version = version;
+        this.name = name;
+    }
+
+    public int getVersion() {
+        return version;
+    }
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public List<CatalogLibraryEntry> getDefinitions() {


### PR DESCRIPTION
### Context
Currently, the Kaoto catalog is not versioned, preventing the project from distinguishing between breaking changes.

This commit adds a version field to tell the UI the catalog format.

fix: https://github.com/KaotoIO/kaoto/issues/2004