### PR TITLE
fix(OnCompletion): Add OnCompletion at the beginning of the route

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -97,6 +97,15 @@ describe('CamelRouteResource', () => {
       expect(resource.getVisualEntities()).toHaveLength(2);
       expect(resource.getVisualEntities()[0].id).toEqual(id);
     });
+
+    it('should add OnCompletion entity at the beginning of the list and return its ID', () => {
+      const resource = new CamelRouteResource();
+      resource.addNewEntity();
+      const id = resource.addNewEntity(EntityType.OnCompletion);
+
+      expect(resource.getVisualEntities()).toHaveLength(2);
+      expect(resource.getVisualEntities()[0].id).toEqual(id);
+    });
   });
 
   it('should return the right type', () => {

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -43,7 +43,11 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
       { type: EntityType.Rest, group: 'Rest', Entity: CamelRestVisualEntity },
     ];
   static readonly PARAMETERS_ORDER = ['id', 'description', 'uri', 'parameters', 'steps'];
-  private static readonly ERROR_RELATED_ENTITIES = [EntityType.OnException, EntityType.ErrorHandler];
+  private static readonly ENTITIES_ORDER_PRIORITY = [
+    EntityType.OnException,
+    EntityType.ErrorHandler,
+    EntityType.OnCompletion,
+  ];
   readonly sortFn = createCamelPropertiesSorter(CamelRouteResource.PARAMETERS_ORDER) as (
     a: unknown,
     b: unknown,
@@ -112,7 +116,7 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
         const entity = new supportedEntity.Entity();
 
         /** Error related entities should be added at the beginning of the list */
-        if (CamelRouteResource.ERROR_RELATED_ENTITIES.includes(entityType)) {
+        if (CamelRouteResource.ENTITIES_ORDER_PRIORITY.includes(entityType)) {
           this.entities.unshift(entity);
         } else {
           this.entities.push(entity);


### PR DESCRIPTION
### Context
OnCompletion entities should be placed before existing camel routes; otherwise, it will fail at runtime.

fix: https://github.com/KaotoIO/kaoto/issues/2008