### PR TITLE
fix(CircuitBreaker): Add onFallback support

### DIFF
--- a/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.test.ts
@@ -1,0 +1,67 @@
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RootNodeMapper } from '../root-node-mapper';
+import { CircuitBreakerNodeMapper } from './circuit-breaker-node-mapper';
+import { OnFallbackNodeMapper } from './on-fallback-node-mapper';
+import { noopNodeMapper } from './testing/noop-node-mapper';
+
+describe('CircuitBreakerNodeMapper', () => {
+  let mapper: CircuitBreakerNodeMapper;
+  let routeDefinition: RouteDefinition;
+  const path = 'from.steps.0.circuitBreaker';
+
+  beforeEach(() => {
+    const rootNodeMapper = new RootNodeMapper();
+    const onFallbackNodeMapper = new OnFallbackNodeMapper(rootNodeMapper);
+    rootNodeMapper.registerDefaultMapper(mapper);
+    rootNodeMapper.registerMapper('onFallback', onFallbackNodeMapper);
+    rootNodeMapper.registerMapper('log', noopNodeMapper);
+
+    mapper = new CircuitBreakerNodeMapper(rootNodeMapper);
+
+    routeDefinition = {
+      from: {
+        uri: 'timer',
+        parameters: {
+          timerName: 'timerName',
+        },
+        steps: [
+          {
+            circuitBreaker: {
+              steps: [{ log: 'step log' }],
+              onFallback: {
+                steps: [{ log: 'onFallback log' }],
+              },
+            },
+          },
+        ],
+      },
+    };
+  });
+
+  it('should return children', () => {
+    const vizNode = mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+
+    expect(vizNode.getChildren()).toHaveLength(2);
+  });
+
+  it('should return step nodes as children', () => {
+    const vizNode = mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+
+    expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.circuitBreaker.steps.0.log');
+  });
+
+  it('should return an `onFallback` node if defined', () => {
+    const vizNode = mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+
+    expect(vizNode.getChildren()?.[1].data.path).toBe('from.steps.0.circuitBreaker.onFallback');
+  });
+
+  it('should not return an `onFallback` node if not defined', () => {
+    routeDefinition.from.steps[0].circuitBreaker!.onFallback = undefined;
+
+    const vizNode = mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+
+    expect(vizNode.getChildren()).toHaveLength(1);
+    expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.circuitBreaker.steps.0.log');
+  });
+});

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
@@ -1,0 +1,37 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { NodeIconResolver, NodeIconType } from '../../../../../utils/node-icon-resolver';
+import { IVisualizationNode } from '../../../base-visual-entity';
+import { createVisualizationNode } from '../../../visualization-node';
+import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
+import { BaseNodeMapper } from './base-node-mapper';
+
+export class CircuitBreakerNodeMapper extends BaseNodeMapper {
+  getVizNodeFromProcessor(
+    path: string,
+    _componentLookup: ICamelElementLookupResult,
+    entityDefinition: unknown,
+  ): IVisualizationNode {
+    const processorName: keyof ProcessorDefinition = 'circuitBreaker';
+
+    const data: CamelRouteVisualEntityData = {
+      path,
+      icon: NodeIconResolver.getIcon(processorName, NodeIconType.EIP),
+      processorName,
+      isGroup: true,
+    };
+
+    const vizNode = createVisualizationNode(path, data);
+
+    const children = this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
+    children.forEach((child) => {
+      vizNode.addChild(child);
+    });
+
+    const onFallbackNode = this.getChildrenFromSingleClause(`${path}.onFallback`, entityDefinition);
+    if (onFallbackNode.length > 0) {
+      vizNode.addChild(onFallbackNode[0]);
+    }
+
+    return vizNode;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.test.ts
@@ -1,0 +1,42 @@
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RootNodeMapper } from '../root-node-mapper';
+import { OnFallbackNodeMapper } from './on-fallback-node-mapper';
+import { noopNodeMapper } from './testing/noop-node-mapper';
+
+describe('OnFallbackNodeMapper', () => {
+  let mapper: OnFallbackNodeMapper;
+  let routeDefinition: RouteDefinition;
+  const path = 'from.steps.0.choice.onFallback';
+
+  beforeEach(() => {
+    const rootNodeMapper = new RootNodeMapper();
+    rootNodeMapper.registerDefaultMapper(mapper);
+    rootNodeMapper.registerMapper('log', noopNodeMapper);
+
+    mapper = new OnFallbackNodeMapper(rootNodeMapper);
+
+    routeDefinition = {
+      from: {
+        uri: 'timer',
+        parameters: {
+          timerName: 'timerName',
+        },
+        steps: [
+          {
+            circuitBreaker: {
+              onFallback: {
+                steps: [{ log: 'logName' }],
+              },
+            },
+          },
+        ],
+      },
+    };
+  });
+
+  it('should return children', () => {
+    const vizNode = mapper.getVizNodeFromProcessor(path, { processorName: 'onFallback' }, routeDefinition);
+
+    expect(vizNode.getChildren()).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
@@ -1,0 +1,32 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { NodeIconResolver, NodeIconType } from '../../../../../utils/node-icon-resolver';
+import { IVisualizationNode } from '../../../base-visual-entity';
+import { createVisualizationNode } from '../../../visualization-node';
+import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
+import { BaseNodeMapper } from './base-node-mapper';
+
+export class OnFallbackNodeMapper extends BaseNodeMapper {
+  getVizNodeFromProcessor(
+    path: string,
+    _componentLookup: ICamelElementLookupResult,
+    entityDefinition: unknown,
+  ): IVisualizationNode {
+    const processorName: keyof ProcessorDefinition = 'onFallback';
+
+    const data: CamelRouteVisualEntityData = {
+      path,
+      icon: NodeIconResolver.getIcon(processorName, NodeIconType.EIP),
+      processorName,
+      isGroup: true,
+    };
+
+    const vizNode = createVisualizationNode(path, data);
+
+    const children = this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
+    children.forEach((child) => {
+      vizNode.addChild(child);
+    });
+
+    return vizNode;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/testing/noop-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/testing/noop-node-mapper.ts
@@ -1,8 +1,9 @@
 import { createVisualizationNode } from '../../../../visualization-node';
+import { ICamelElementLookupResult } from '../../../support/camel-component-types';
 import { INodeMapper } from '../../node-mapper';
 
 export const noopNodeMapper: INodeMapper = {
-  getVizNodeFromProcessor: () => {
-    return createVisualizationNode('noop', {});
+  getVizNodeFromProcessor: (path: string, componentLookup: ICamelElementLookupResult, entityDefinition: unknown) => {
+    return createVisualizationNode('noop', { path, componentLookup, entityDefinition });
   },
 };

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
@@ -1,7 +1,9 @@
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { BaseNodeMapper } from './mappers/base-node-mapper';
 import { ChoiceNodeMapper } from './mappers/choice-node-mapper';
+import { CircuitBreakerNodeMapper } from './mappers/circuit-breaker-node-mapper';
 import { DataMapperNodeMapper } from './mappers/datamapper-node-mapper';
+import { OnFallbackNodeMapper } from './mappers/on-fallback-node-mapper';
 import { OtherwiseNodeMapper } from './mappers/otherwise-node-mapper';
 import { StepNodeMapper } from './mappers/step-node-mapper';
 import { WhenNodeMapper } from './mappers/when-node-mapper';
@@ -16,6 +18,8 @@ describe('NodeMapperService', () => {
     NodeMapperService.getVizNode('path', { processorName: 'log' }, {});
 
     expect(registerDefaultMapperSpy).toHaveBeenCalledWith(expect.any(BaseNodeMapper));
+    expect(registerMapperSpy).toHaveBeenCalledWith('circuitBreaker', expect.any(CircuitBreakerNodeMapper));
+    expect(registerMapperSpy).toHaveBeenCalledWith('onFallback', expect.any(OnFallbackNodeMapper));
     expect(registerMapperSpy).toHaveBeenCalledWith('choice', expect.any(ChoiceNodeMapper));
     expect(registerMapperSpy).toHaveBeenCalledWith('when', expect.any(WhenNodeMapper));
     expect(registerMapperSpy).toHaveBeenCalledWith('otherwise', expect.any(OtherwiseNodeMapper));

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.ts
@@ -3,12 +3,14 @@ import { IVisualizationNode } from '../../base-visual-entity';
 import { ICamelElementLookupResult } from '../support/camel-component-types';
 import { BaseNodeMapper } from './mappers/base-node-mapper';
 import { ChoiceNodeMapper } from './mappers/choice-node-mapper';
+import { CircuitBreakerNodeMapper } from './mappers/circuit-breaker-node-mapper';
 import { DataMapperNodeMapper } from './mappers/datamapper-node-mapper';
+import { LoadBalanceNodeMapper } from './mappers/loadbalance-node-mapper';
+import { MulticastNodeMapper } from './mappers/multicast-node-mapper';
+import { OnFallbackNodeMapper } from './mappers/on-fallback-node-mapper';
 import { OtherwiseNodeMapper } from './mappers/otherwise-node-mapper';
 import { StepNodeMapper } from './mappers/step-node-mapper';
 import { WhenNodeMapper } from './mappers/when-node-mapper';
-import { MulticastNodeMapper } from './mappers/multicast-node-mapper';
-import { LoadBalanceNodeMapper } from './mappers/loadbalance-node-mapper';
 import { INodeMapper } from './node-mapper';
 import { RootNodeMapper } from './root-node-mapper';
 
@@ -34,6 +36,8 @@ export class NodeMapperService {
   private static initializeRootNodeMapper() {
     this.rootNodeMapper = new RootNodeMapper();
     this.rootNodeMapper.registerDefaultMapper(new BaseNodeMapper(this.rootNodeMapper));
+    this.rootNodeMapper.registerMapper('circuitBreaker', new CircuitBreakerNodeMapper(this.rootNodeMapper));
+    this.rootNodeMapper.registerMapper('onFallback', new OnFallbackNodeMapper(this.rootNodeMapper));
     this.rootNodeMapper.registerMapper('choice', new ChoiceNodeMapper(this.rootNodeMapper));
     this.rootNodeMapper.registerMapper('when', new WhenNodeMapper(this.rootNodeMapper));
     this.rootNodeMapper.registerMapper('otherwise', new OtherwiseNodeMapper(this.rootNodeMapper));

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -4,6 +4,17 @@ import { DoCatch } from '@kaoto/camel-catalog/types';
 
 describe('CamelComponentDefaultService', () => {
   describe('getDefaultNodeDefinitionValue', () => {
+    it('should return the default circuitBreaker clause', () => {
+      /* eslint-disable  @typescript-eslint/no-explicit-any */
+      const circuitBreakerDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
+        type: 'processor',
+        name: 'circuitBreaker',
+      } as DefinedComponent) as any;
+      expect(circuitBreakerDefault).toBeDefined();
+      expect(circuitBreakerDefault.circuitBreaker.steps).toEqual([]);
+      expect(circuitBreakerDefault.circuitBreaker.onFallback.steps[0].log).toBeDefined();
+    });
+
     it('should return the default choice clause', () => {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       const choiceDefault = CamelComponentDefaultService.getDefaultNodeDefinitionValue({

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -77,6 +77,19 @@ export class CamelComponentDefaultService {
 
   private static getDefaultValueFromProcessor(processorName: keyof ProcessorDefinition): ProcessorDefinition {
     switch (processorName) {
+      case 'circuitBreaker':
+        return parse(`
+        circuitBreaker:
+          id: ${getCamelRandomId('circuitBreaker')}
+          steps: []
+          onFallback:
+            id: ${getCamelRandomId('onFallback')}
+            steps:
+            - log:
+                id: ${getCamelRandomId('log')}
+                message: "\${body}"
+        `);
+
       case 'choice':
         return parse(`
         choice:

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
@@ -8,7 +8,9 @@ import {
   kameletSinkTile,
   kameletSourceTile,
   kameletStringTemplateActionTile,
+  processorCircuitBreakerTile,
   processorInterceptTile,
+  processorOnFallbackTile,
   processorOtherwiseTile,
   processorTile,
   processorWhenTile,
@@ -40,37 +42,70 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);
     });
 
-    it('should offer applicable processors when requesting special children', () => {
-      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
-        AddStepMode.InsertSpecialChildStep,
-        {
-          path: 'route.from.steps.0.choice',
-          processorName: 'choice',
-          label: 'Choice',
-        },
-        {},
-      );
+    describe('circuitBreaker', () => {
+      it('should offer applicable processors when requesting special children', () => {
+        const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+          AddStepMode.InsertSpecialChildStep,
+          {
+            path: 'route.from.steps.0.circuitBreaker',
+            processorName: 'circuitBreaker',
+            label: 'Circuit Breaker',
+          },
+          {},
+        );
 
-      expect(tiles.filter(filterFn)).toEqual([processorWhenTile, processorOtherwiseTile]);
+        expect(tiles.filter(filterFn)).toEqual([processorOnFallbackTile]);
+      });
+
+      it('should NOT offer already defined processors when requesting special children', () => {
+        const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+          AddStepMode.InsertSpecialChildStep,
+          {
+            path: 'route.from.steps.0.circuitBreaker',
+            processorName: 'circuitBreaker',
+            label: 'Circuit Breaker',
+          },
+          { onFallback: {} },
+        );
+
+        expect(tiles.filter(filterFn)).toEqual([]);
+      });
     });
 
-    it('should NOT offer already defined processors when requesting special children', () => {
-      const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
-        AddStepMode.InsertSpecialChildStep,
-        {
-          path: 'route.from.steps.0.choice',
-          processorName: 'choice',
-          label: 'Choice',
-        },
-        { otherwise: {} },
-      );
+    describe('choice', () => {
+      it('should offer applicable processors when requesting special children', () => {
+        const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+          AddStepMode.InsertSpecialChildStep,
+          {
+            path: 'route.from.steps.0.choice',
+            processorName: 'choice',
+            label: 'Choice',
+          },
+          {},
+        );
 
-      expect(tiles.filter(filterFn)).toEqual([processorWhenTile]);
+        expect(tiles.filter(filterFn)).toEqual([processorWhenTile, processorOtherwiseTile]);
+      });
+
+      it('should NOT offer already defined processors when requesting special children', () => {
+        const filterFn = CamelComponentFilterService.getCamelCompatibleComponents(
+          AddStepMode.InsertSpecialChildStep,
+          {
+            path: 'route.from.steps.0.choice',
+            processorName: 'choice',
+            label: 'Choice',
+          },
+          { otherwise: {} },
+        );
+
+        expect(tiles.filter(filterFn)).toEqual([processorWhenTile]);
+      });
     });
 
     it('should offer applicable processors when requesting routeConfiguration special children', () => {
@@ -98,6 +133,7 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);
@@ -114,6 +150,7 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);
@@ -148,6 +185,7 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);
@@ -193,6 +231,7 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);
@@ -210,6 +249,7 @@ describe('CamelComponentFilterService', () => {
         kameletStringTemplateActionTile,
         kameletSSHSinkTile,
         processorTile,
+        processorCircuitBreakerTile,
         componentSlackTile,
         componentKubernetesSecretsTile,
       ]);

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
@@ -6,6 +6,7 @@ import { CamelRouteVisualEntityData } from './camel-component-types';
 export class CamelComponentFilterService {
   static readonly REST_DSL_METHODS = ['delete', 'get', 'head', 'patch', 'post', 'put'];
   private static readonly SPECIAL_PROCESSORS = [
+    'onFallback',
     'when',
     'otherwise',
     'doCatch',
@@ -21,6 +22,7 @@ export class CamelComponentFilterService {
    * specialChildren is a map of processor names and their special children.
    */
   static readonly SPECIAL_PROCESSORS_PARENTS_MAP = {
+    circuitBreaker: ['onFallback'],
     choice: ['when', 'otherwise'],
     doTry: ['doCatch', 'doFinally'],
     routeConfiguration: ['intercept', 'interceptFrom', 'interceptSendToEndpoint', 'onException', 'onCompletion'],
@@ -59,6 +61,9 @@ export class CamelComponentFilterService {
         this.SPECIAL_PROCESSORS_PARENTS_MAP[processorName as keyof typeof this.SPECIAL_PROCESSORS_PARENTS_MAP];
       /** If an `otherwise` or a `doFinally` already exists, we shouldn't offer it in the catalog */
       const definitionKeys = Object.keys(definition ?? {});
+      if (processorName === 'circuitBreaker' && definitionKeys.includes('onFallback')) {
+        childrenLookup = childrenLookup.filter((child) => child !== 'onFallback');
+      }
       if (processorName === 'choice' && definitionKeys.includes('otherwise')) {
         childrenLookup = childrenLookup.filter((child) => child !== 'otherwise');
       }

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -558,6 +558,13 @@ describe('CamelComponentSchemaService', () => {
       ['doCatch', [{ name: 'steps', type: 'branch' }]],
       ['doFinally', [{ name: 'steps', type: 'branch' }]],
       ['aggregate', [{ name: 'steps', type: 'branch' }]],
+      [
+        'circuitBreaker',
+        [
+          { name: 'steps', type: 'branch' },
+          { name: 'onFallback', type: 'single-clause' },
+        ],
+      ],
       ['onFallback', [{ name: 'steps', type: 'branch' }]],
       ['saga', [{ name: 'steps', type: 'branch' }]],
       [

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -176,7 +176,6 @@ export class CamelComponentSchemaService {
       /** doTry */ case 'doCatch':
       /** doTry */ case 'doFinally':
       case 'aggregate':
-      case 'circuitBreaker':
       case 'filter':
       case 'loadBalance':
       case 'loop':
@@ -195,6 +194,12 @@ export class CamelComponentSchemaService {
       case /** routeConfiguration */ 'onException' as keyof ProcessorDefinition:
       case /** routeConfiguration */ 'onCompletion' as keyof ProcessorDefinition:
         return [{ name: 'steps', type: 'branch' }];
+
+      case 'circuitBreaker':
+        return [
+          { name: 'steps', type: 'branch' },
+          { name: 'onFallback', type: 'single-clause' },
+        ];
 
       case 'choice':
         return [

--- a/packages/ui/src/stubs/tiles.ts
+++ b/packages/ui/src/stubs/tiles.ts
@@ -36,6 +36,20 @@ export const kameletSSHSinkTile: ITile = {
   tags: ['sink'],
 };
 
+export const processorCircuitBreakerTile: ITile = {
+  type: CatalogKind.Processor,
+  name: 'circuitBreaker',
+  title: 'Circuit Breaker',
+  tags: ['eip', 'routing', 'error'],
+};
+
+export const processorOnFallbackTile: ITile = {
+  type: CatalogKind.Processor,
+  name: 'onFallback',
+  title: 'On Fallback',
+  tags: ['eip', 'routing', 'error'],
+};
+
 export const processorTile: ITile = {
   type: CatalogKind.Processor,
   name: 'choice',
@@ -92,6 +106,8 @@ export const tiles: ITile[] = [
   kameletStringTemplateActionTile,
   kameletSSHSinkTile,
   processorTile,
+  processorCircuitBreakerTile,
+  processorOnFallbackTile,
   processorWhenTile,
   processorOtherwiseTile,
   processorInterceptTile,


### PR DESCRIPTION
### Context
Currently, `onFallback` is offered as a regular EIP, instead, it should be offered as part of the `CircuitBreaker` EIP.

fix: https://github.com/KaotoIO/kaoto/issues/1935