### PR TITLE
Fix: Moved Kamelet and Pipe Configuration schema generation into Entities Generator

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EntityGenerator.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EntityGenerator.java
@@ -81,15 +81,18 @@ public class EntityGenerator implements Generator {
         });
 
         // Add ObjectMeta Schema
-        var ObjectMetaJSON = k8sSchemaReader.getObjectMetaJSONSchema();
-        camelCatalogSchemaEnhancer.fillSchemaInformation(ObjectMetaJSON);
-        EntityMap.put("ObjectMeta", ObjectMetaJSON);
+        var objectMetaJSON = k8sSchemaReader.getObjectMetaJSONSchema();
+        camelCatalogSchemaEnhancer.fillSchemaInformation(objectMetaJSON);
+        ObjectNode objectMetaSchema = jsonMapper.createObjectNode();
+        objectMetaSchema.set("propertiesSchema", objectMetaJSON);
+        EntityMap.put("ObjectMeta", objectMetaSchema);
 
         // Add custom schemas
         for (var localSchemaEntry : localSchemas.entrySet()) {
             try {
-                var schema = (ObjectNode) jsonMapper.readTree(localSchemaEntry.getValue());
                 var name = localSchemaEntry.getKey();
+                ObjectNode schema = jsonMapper.createObjectNode();
+                schema.set("propertiesSchema", jsonMapper.readTree(localSchemaEntry.getValue()));
                 EntityMap.put(name, schema);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Local Schema definition not found");

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCatalogWithRedHatVersionTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/commands/GenerateCatalogWithRedHatVersionTest.java
@@ -16,7 +16,7 @@ import io.kaoto.camelcatalog.model.CatalogDefinition;
 import io.kaoto.camelcatalog.model.CatalogRuntime;
 
 class GenerateCatalogWithRedHatVersionTest {
-	
+
     @TempDir
     File tempDir;
 
@@ -43,7 +43,7 @@ class GenerateCatalogWithRedHatVersionTest {
         generateCommand.run();
         
         assertTrue(new File(tempDir, "camel-main/4.4.0.redhat-00045").exists(), "The folder for the catalog wasn't created");
-        assertEquals(34, new File(tempDir, "camel-main/4.4.0.redhat-00045").listFiles().length, "The folder for the catalog doesn't contain the correct number of files");
+        assertEquals(31, new File(tempDir, "camel-main/4.4.0.redhat-00045").listFiles().length, "The folder for the catalog doesn't contain the correct number of files");
 	}
 	
 }

--- a/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
@@ -1,0 +1,58 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { EntitiesContext } from '../../providers/entities.provider';
+import { PipeResource } from '../../models/camel';
+import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
+import { CatalogKind } from '../../models/catalog-kind';
+import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { MetadataPage } from './MetadataPage';
+
+const camelResource = new PipeResource();
+const mockEntitiesContext = {
+  camelResource,
+  entities: camelResource.getEntities(),
+  visualEntities: camelResource.getVisualEntities(),
+  currentSchemaType: camelResource.getType(),
+  updateSourceCodeFromEntities: jest.fn(),
+  updateEntitiesFromCamelResource: jest.fn(),
+};
+
+describe('MetadataPage', () => {
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+  });
+
+  it('renders "Not applicable" when the resource type is not supported', () => {
+    const { container } = render(<MetadataPage />);
+
+    expect(container).toMatchSnapshot();
+    expect(screen.getByText('Not applicable')).toBeInTheDocument();
+  });
+
+  it('renders the KaotoForm when the resource type is supported', () => {
+    const { container } = render(
+      <EntitiesContext.Provider value={mockEntitiesContext}>
+        <MetadataPage />
+      </EntitiesContext.Provider>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('calls updateSourceCodeFromEntities when the model changes', () => {
+    render(
+      <EntitiesContext.Provider value={mockEntitiesContext}>
+        <MetadataPage />
+      </EntitiesContext.Provider>,
+    );
+
+    const addButton = screen.getAllByRole('button', { name: 'Add a new property' });
+    act(() => {
+      fireEvent.click(addButton[0]);
+    });
+
+    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -13,7 +13,7 @@ export const MetadataPage: FunctionComponent = () => {
   const formTabsValue: CanvasFormTabsContextResult = useMemo(() => ({ selectedTab: 'All', onTabChange: () => {} }), []);
   const entitiesContext = useContext(EntitiesContext);
   const camelkResource = entitiesContext?.camelResource as CamelKResource;
-  const metadataSchema = CamelCatalogService.getComponent(CatalogKind.Entity, 'ObjectMeta') ?? {};
+  const metadataSchema = CamelCatalogService.getComponent(CatalogKind.Entity, 'ObjectMeta')?.propertiesSchema || {};
 
   const isSupported = useMemo(() => {
     return camelkResource && camelkResource.getType() in CamelKResourceKinds;

--- a/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
+++ b/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
@@ -1,0 +1,1781 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetadataPage renders "Not applicable" when the resource type is not supported 1`] = `
+<div>
+  <div
+    class="pf-v6-c-content"
+    data-ouia-component-id="OUIA-Generated-Content-1"
+    data-ouia-component-type="PF6/Content"
+    data-ouia-safe="true"
+    data-pf-content="true"
+  >
+    Not applicable
+  </div>
+</div>
+`;
+
+exports[`MetadataPage renders the KaotoForm when the resource type is supported 1`] = `
+<div>
+  <form
+    class="pf-v6-c-form kaoto-form kaoto-form__label"
+    data-testid="metadata-form"
+    novalidate=""
+  >
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.annotations__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.annotations"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            annotations
+             
+            <span
+              class="pf-v6-c-badge pf-m-unread"
+              title="0 properties"
+            >
+              0
+            </span>
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for [object Object] field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Key
+          </div>
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Value
+          </div>
+          <div
+            class="pf-v6-l-split__item"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Add a new property"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.annotations__add"
+              title="Add a new property"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <hr
+          class="pf-v6-c-content--hr"
+          data-ouia-component-id="OUIA-Generated-Content-2"
+          data-ouia-component-type="PF6/Content"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        />
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.creationTimestamp__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.creationTimestamp"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            creationTimestamp
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for creationTimestamp field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.creationTimestamp-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.creationTimestamp"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.creationTimestamp"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear creationTimestamp field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.creationTimestamp__clear"
+              title="Clear creationTimestamp field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.deletionGracePeriodSeconds__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.deletionGracePeriodSeconds"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            deletionGracePeriodSeconds
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for deletionGracePeriodSeconds field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.deletionGracePeriodSeconds-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.deletionGracePeriodSeconds"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.deletionGracePeriodSeconds"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear deletionGracePeriodSeconds field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.deletionGracePeriodSeconds__clear"
+              title="Clear deletionGracePeriodSeconds field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.deletionTimestamp__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.deletionTimestamp"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            deletionTimestamp
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for deletionTimestamp field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.deletionTimestamp-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.deletionTimestamp"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.deletionTimestamp"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear deletionTimestamp field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.deletionTimestamp__clear"
+              title="Clear deletionTimestamp field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-1"
+      data-ouia-component-type="PF6/Card"
+      data-ouia-safe="true"
+      data-testid="#.finalizers__field-wrapper"
+      id=""
+    >
+      <div
+        class="pf-v6-c-card__header"
+      >
+        <div
+          class="pf-v6-c-card__actions"
+        >
+          <button
+            aria-disabled="false"
+            aria-label="Add new item"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-9"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#.finalizers__add"
+            title="Add new item"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="pf-v6-c-card__header-main"
+        >
+          <div
+            class="pf-v6-c-card__title"
+          >
+            <div
+              class="pf-v6-c-card__title-text"
+            >
+              finalizers
+               
+              <div
+                style="display: contents;"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="More info for finalizers field"
+                  class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  role="button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.generateName__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.generateName"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            generateName
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for generateName field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.generateName-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.generateName"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.generateName"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear generateName field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-12"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.generateName__clear"
+              title="Clear generateName field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.generation__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.generation"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            generation
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for generation field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-13"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.generation-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.generation"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.generation"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear generation field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-14"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.generation__clear"
+              title="Clear generation field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.labels__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.labels"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            labels
+             
+            <span
+              class="pf-v6-c-badge pf-m-unread"
+              title="0 properties"
+            >
+              0
+            </span>
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for [object Object] field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-15"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Key
+          </div>
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Value
+          </div>
+          <div
+            class="pf-v6-l-split__item"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Add a new property"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-16"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.labels__add"
+              title="Add a new property"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <hr
+          class="pf-v6-c-content--hr"
+          data-ouia-component-id="OUIA-Generated-Content-3"
+          data-ouia-component-type="PF6/Content"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        />
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-2"
+      data-ouia-component-type="PF6/Card"
+      data-ouia-safe="true"
+      data-testid="#.managedFields__field-wrapper"
+      id=""
+    >
+      <div
+        class="pf-v6-c-card__header"
+      >
+        <div
+          class="pf-v6-c-card__actions"
+        >
+          <button
+            aria-disabled="false"
+            aria-label="Add new item"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-17"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#.managedFields__add"
+            title="Add new item"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="pf-v6-c-card__header-main"
+        >
+          <div
+            class="pf-v6-c-card__title"
+          >
+            <div
+              class="pf-v6-c-card__title-text"
+            >
+              managedFields
+               
+              <div
+                style="display: contents;"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="More info for managedFields field"
+                  class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  role="button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.name__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.name"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            name
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for name field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.name-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.name"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.name"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear name field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.name__clear"
+              title="Clear name field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.namespace__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.namespace"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            namespace
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for namespace field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-21"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.namespace-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.namespace"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.namespace"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear namespace field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-22"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.namespace__clear"
+              title="Clear namespace field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-3"
+      data-ouia-component-type="PF6/Card"
+      data-ouia-safe="true"
+      data-testid="#.ownerReferences__field-wrapper"
+      id=""
+    >
+      <div
+        class="pf-v6-c-card__header"
+      >
+        <div
+          class="pf-v6-c-card__actions"
+        >
+          <button
+            aria-disabled="false"
+            aria-label="Add new item"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-23"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#.ownerReferences__add"
+            title="Add new item"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="pf-v6-c-card__header-main"
+        >
+          <div
+            class="pf-v6-c-card__title"
+          >
+            <div
+              class="pf-v6-c-card__title-text"
+            >
+              ownerReferences
+               
+              <div
+                style="display: contents;"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="More info for ownerReferences field"
+                  class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  role="button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.resourceVersion__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.resourceVersion"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            resourceVersion
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for resourceVersion field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-25"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.resourceVersion-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.resourceVersion"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.resourceVersion"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear resourceVersion field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-26"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.resourceVersion__clear"
+              title="Clear resourceVersion field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.selfLink__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.selfLink"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            selfLink
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for selfLink field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-27"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.selfLink-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.selfLink"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.selfLink"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear selfLink field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-28"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.selfLink__clear"
+              title="Clear selfLink field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.uid__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.uid"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            uid
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for uid field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-29"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-c-text-input-group"
+        >
+          <div
+            aria-describedby="#.uid-popover"
+            class="pf-v6-c-text-input-group__main pf-m-icon kaoto-form__string-field"
+            id="#.uid"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                name="#.uid"
+                role="textbox"
+                type="text"
+                value=""
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear uid field"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-30"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.uid__clear"
+              title="Clear uid field"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div
+    class="pf-v6-c-card kaoto-form kaoto-form__empty"
+    data-ouia-component-id="OUIA-Generated-Card-4"
+    data-ouia-component-type="PF6/Card"
+    data-ouia-safe="true"
+    data-testid="no-field-found"
+    id=""
+  >
+    <div
+      class="pf-v6-c-card__body"
+    >
+      <div
+        class="pf-v6-c-alert pf-m-info"
+        data-ouia-component-id="OUIA-Generated-Alert-info-1"
+        data-ouia-component-type="PF6/Alert"
+        data-ouia-safe="true"
+      >
+        <div
+          class="pf-v6-c-alert__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+            />
+          </svg>
+        </div>
+        <h4
+          class="pf-v6-c-alert__title"
+        >
+          <span
+            class="pf-v6-screen-reader"
+          >
+            Info alert:
+          </span>
+          No All fields found
+        </h4>
+        <div
+          class="pf-v6-c-alert__description"
+        >
+          No field found matching this criteria. Please switch to the
+           
+          <button
+            aria-disabled="false"
+            class="pf-v6-c-button pf-m-link pf-m-inline"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            id="All"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__text"
+            >
+              <b>
+                All
+              </b>
+            </span>
+          </button>
+           
+          tab.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
@@ -1,0 +1,65 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PipeErrorHandlerPage } from './PipeErrorHandlerPage';
+import { EntitiesContext } from '../../providers/entities.provider';
+import { PipeResource } from '../../models/camel';
+import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
+import { CatalogKind } from '../../models/catalog-kind';
+import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+
+const camelResource = new PipeResource();
+const mockEntitiesContext = {
+  camelResource,
+  entities: camelResource.getEntities(),
+  visualEntities: camelResource.getVisualEntities(),
+  currentSchemaType: camelResource.getType(),
+  updateSourceCodeFromEntities: jest.fn(),
+  updateEntitiesFromCamelResource: jest.fn(),
+};
+
+describe('PipeErrorHandlerPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+  });
+
+  it('renders "Not applicable" when the resource type is not supported', () => {
+    const { container } = render(<PipeErrorHandlerPage />);
+
+    expect(container).toMatchSnapshot();
+    expect(screen.getByText('Not applicable')).toBeInTheDocument();
+  });
+
+  it('renders the KaotoForm when the resource type is supported', () => {
+    const { container } = render(
+      <EntitiesContext.Provider value={mockEntitiesContext}>
+        <PipeErrorHandlerPage />
+      </EntitiesContext.Provider>,
+    );
+
+    expect(container).toMatchSnapshot();
+    expect(screen.getByRole('button', { name: 'No Pipe ErrorHandler' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Log Pipe ErrorHandler' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'No Pipe ErrorHandler' })).toBeInTheDocument();
+  });
+
+  it('calls updateSourceCodeFromEntities when the model changes', () => {
+    render(
+      <EntitiesContext.Provider value={mockEntitiesContext}>
+        <PipeErrorHandlerPage />
+      </EntitiesContext.Provider>,
+    );
+
+    const addButton = screen.getByRole('button', { name: 'Add a new property' });
+    act(() => {
+      fireEvent.click(addButton);
+    });
+
+    expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -1,4 +1,3 @@
-import { PipeErrorHandler as PipeErrorHandlerType } from '@kaoto/camel-catalog/types';
 import { Content } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
 import { KaotoForm, KaotoFormProps } from '../../components/Visualization/Canvas/FormV2/KaotoForm';
@@ -14,8 +13,8 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);
   const pipeResource = entitiesContext?.camelResource as PipeResource;
 
-  const errorHandlerSchema = (CamelCatalogService.getComponent(CatalogKind.Entity, 'PipeErrorHandler') ??
-    {}) as KaotoSchemaDefinition['schema'];
+  const errorHandlerSchema = (CamelCatalogService.getComponent(CatalogKind.Entity, 'PipeErrorHandler')
+    ?.propertiesSchema || {}) as KaotoSchemaDefinition['schema'];
 
   if (Array.isArray(errorHandlerSchema.oneOf) && !Array.isArray(errorHandlerSchema.anyOf)) {
     errorHandlerSchema.anyOf = [{ oneOf: errorHandlerSchema.oneOf }];
@@ -32,7 +31,7 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
   }, [pipeResource]);
 
   const onChangeModel = useCallback(
-    (model: PipeErrorHandlerType) => {
+    (model: Record<string, unknown>) => {
       if (Object.keys(model).length > 0) {
         let entity = pipeResource.getErrorHandlerEntity();
         if (!entity) {

--- a/packages/ui/src/pages/PipeErrorHandler/__snapshots__/PipeErrorHandlerPage.test.tsx.snap
+++ b/packages/ui/src/pages/PipeErrorHandler/__snapshots__/PipeErrorHandlerPage.test.tsx.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PipeErrorHandlerPage renders "Not applicable" when the resource type is not supported 1`] = `
+<div>
+  <div
+    class="pf-v6-c-content"
+    data-ouia-component-id="OUIA-Generated-Content-1"
+    data-ouia-component-type="PF6/Content"
+    data-ouia-safe="true"
+    data-pf-content="true"
+  >
+    Not applicable
+  </div>
+</div>
+`;
+
+exports[`PipeErrorHandlerPage renders the KaotoForm when the resource type is supported 1`] = `
+<div>
+  <form
+    class="pf-v6-c-form kaoto-form kaoto-form__label"
+    data-testid="pipe-error-handler-form"
+    novalidate=""
+  >
+    <div
+      aria-labelledby="#-legend"
+      class="pf-v6-c-form__group"
+      role="group"
+    >
+      <div
+        class="pf-v6-c-form__group-control pf-m-stack"
+      >
+        <div
+          aria-label="# oneof list"
+          class="pf-v6-c-toggle-group"
+          data-testid="#__oneof-list"
+          id="#"
+          role="group"
+        >
+          <div
+            class="pf-v6-c-toggle-group__item"
+          >
+            <button
+              aria-pressed="true"
+              class="pf-v6-c-toggle-group__button pf-m-selected"
+              id="No Pipe ErrorHandler"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-toggle-group__text"
+              >
+                No Pipe ErrorHandler
+              </span>
+            </button>
+          </div>
+          <div
+            class="pf-v6-c-toggle-group__item"
+          >
+            <button
+              aria-pressed="false"
+              class="pf-v6-c-toggle-group__button"
+              id="Log Pipe ErrorHandler"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-toggle-group__text"
+              >
+                Log Pipe ErrorHandler
+              </span>
+            </button>
+          </div>
+          <div
+            class="pf-v6-c-toggle-group__item"
+          >
+            <button
+              aria-pressed="false"
+              class="pf-v6-c-toggle-group__button"
+              id="Sink Pipe ErrorHandler"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-toggle-group__text"
+              >
+                Sink Pipe ErrorHandler
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-form__group"
+      data-testid="#.none__field-wrapper"
+    >
+      <div
+        class="pf-v6-c-form__group-label"
+      >
+        <label
+          class="pf-v6-c-form__label"
+          for="#.none"
+        >
+          <span
+            class="pf-v6-c-form__label-text"
+          >
+            none
+             
+            <span
+              class="pf-v6-c-badge pf-m-unread"
+              title="0 properties"
+            >
+              0
+            </span>
+          </span>
+          <span
+            aria-hidden="true"
+            class="pf-v6-c-form__label-required"
+          >
+             
+            *
+          </span>
+        </label>
+          
+        <span
+          class="pf-v6-c-form__group-label-help"
+        >
+          <div
+            style="display: contents;"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="More info for [object Object] field"
+              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              role="button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        class="pf-v6-c-form__group-control"
+      >
+        <div
+          class="pf-v6-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Key
+          </div>
+          <div
+            class="pf-v6-l-split__item pf-m-fill"
+          >
+            Value
+          </div>
+          <div
+            class="pf-v6-l-split__item"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Add a new property"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.none__add"
+              title="Add a new property"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <hr
+          class="pf-v6-c-content--hr"
+          data-ouia-component-id="OUIA-Generated-Content-2"
+          data-ouia-component-type="PF6/Content"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        />
+      </div>
+    </div>
+  </form>
+  <div
+    class="pf-v6-c-card kaoto-form kaoto-form__empty"
+    data-ouia-component-id="OUIA-Generated-Card-1"
+    data-ouia-component-type="PF6/Card"
+    data-ouia-safe="true"
+    data-testid="no-field-found"
+    id=""
+  >
+    <div
+      class="pf-v6-c-card__body"
+    >
+      <div
+        class="pf-v6-c-alert pf-m-info"
+        data-ouia-component-id="OUIA-Generated-Alert-info-1"
+        data-ouia-component-type="PF6/Alert"
+        data-ouia-safe="true"
+      >
+        <div
+          class="pf-v6-c-alert__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+            />
+          </svg>
+        </div>
+        <h4
+          class="pf-v6-c-alert__title"
+        >
+          <span
+            class="pf-v6-screen-reader"
+          >
+            Info alert:
+          </span>
+          No All fields found
+        </h4>
+        <div
+          class="pf-v6-c-alert__description"
+        >
+          No field found matching this criteria. Please switch to the
+           
+          <button
+            aria-disabled="false"
+            class="pf-v6-c-button pf-m-link pf-m-inline"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            id="All"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__text"
+            >
+              <b>
+                All
+              </b>
+            </span>
+          </button>
+           
+          tab.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Fixes #2072 partially.

This PR brings the following 2 changes in:
- Using the Kamelet and Pipe Config code inside of the Entities Generator for loading the forms.
- Added **propertiesSchema** to **objectMeta** and **PipeErrorHandler** to mentain the similar structure in the entities Catalog