### PR TITLE
fix(Form): Update Beans list after creation

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/BeanField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/BeanField.tsx
@@ -5,7 +5,7 @@ import { EntitiesContext } from '../../../../../providers';
 import { getSerializedModel } from '../../../../../utils';
 import { extractGroup } from '../../../../../utils/get-tagged-field-from-string';
 import { NewBeanModal } from '../../../../Form';
-import { CREATE_NEW_WITH_NAME_VALUE, Typeahead } from '../../../../typeahead/Typeahead';
+import { CREATE_NEW_ITEM, Typeahead } from '../../../../typeahead/Typeahead';
 import { TypeaheadItem } from '../../../../typeahead/Typeahead.types';
 import { useFieldValue } from '../hooks/field-value';
 import { SchemaContext } from '../providers/SchemaProvider';
@@ -26,19 +26,18 @@ export const BeanField: FunctionComponent<FieldProps> = ({ propName, required })
   }, [beansHandler]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>(beanReference);
-  const beansEntity = useMemo(() => {
-    return beansHandler.getBeansEntity();
-  }, [beansHandler]);
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
   const items = useMemo(() => {
     return (
-      beansEntity?.parent.beans.map((item) => ({
+      beansHandler.getAllBeansNameAndType().map((item) => ({
         name: item.name ? (beansHandler.getReferenceFromName(item.name) ?? '') : '',
         description: String(item.type),
         value: String(item.name),
       })) ?? []
     );
-  }, [beansEntity?.parent.beans, beansHandler]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [beansHandler, lastUpdated]);
 
   const selectedItem = useMemo(() => {
     if (!value) {
@@ -64,11 +63,13 @@ export const BeanField: FunctionComponent<FieldProps> = ({ propName, required })
 
   const onCleanInput = useCallback(() => {
     onChange(undefined);
+    setLastUpdated(Date.now());
+    setIsOpen(false);
   }, [onChange]);
 
   const onSelect = useCallback((value: string | undefined, filterValue: string | undefined) => {
     if (value) {
-      if (value === CREATE_NEW_WITH_NAME_VALUE) {
+      if (value === CREATE_NEW_ITEM) {
         setInputValue(filterValue ?? '');
       } else {
         setInputValue('');
@@ -86,6 +87,7 @@ export const BeanField: FunctionComponent<FieldProps> = ({ propName, required })
       setIsOpen(false);
       onChange(beanRef ?? '');
       setInputValue(beanRef as string);
+      setLastUpdated(Date.now());
     },
     [beansHandler, onChange],
   );

--- a/packages/ui/src/components/typeahead/Typeahead.test.tsx
+++ b/packages/ui/src/components/typeahead/Typeahead.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { Typeahead } from './Typeahead';
+import { CREATE_NEW_ITEM, Typeahead } from './Typeahead';
 import { TypeaheadProps } from './Typeahead.types';
 
 const mockItems = [
@@ -105,5 +105,34 @@ describe('Typeahead', () => {
     fireEvent.click(clearButton);
 
     expect(defaultProps.onCleanInput).toHaveBeenCalled();
+  });
+
+  it('should allow users to create a new item if the onCreate callback is set', async () => {
+    render(<Typeahead {...defaultProps} onCreate={jest.fn()} onCreatePrefix="multiverse" />);
+
+    const input = screen.getByPlaceholderText('Select or write an option');
+    await act(async () => {
+      fireEvent.click(input);
+    });
+
+    expect(screen.getByText('Create new multiverse')).toBeInTheDocument();
+  });
+
+  it('should allow users to create a new item if the onCreate callback is set and there is a value', async () => {
+    render(<Typeahead {...defaultProps} onCreate={jest.fn()} onCreatePrefix="brick" />);
+
+    const input = screen.getByPlaceholderText('Select or write an option');
+    await act(async () => {
+      fireEvent.click(input);
+    });
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'in the wall' } });
+    });
+
+    const createNewElement = screen.getByLabelText(`option ${CREATE_NEW_ITEM.toLocaleLowerCase()}`);
+
+    expect(createNewElement).toBeInTheDocument();
+    expect(createNewElement).toHaveTextContent("Create new brick 'in the wall'");
   });
 });

--- a/packages/ui/src/components/typeahead/Typeahead.tsx
+++ b/packages/ui/src/components/typeahead/Typeahead.tsx
@@ -24,8 +24,7 @@ import {
 import { isDefined } from '../../utils';
 import { TypeaheadProps } from './Typeahead.types';
 
-export const CREATE_NEW_VALUE = 'create-new';
-export const CREATE_NEW_WITH_NAME_VALUE = 'create-new-with-name';
+export const CREATE_NEW_ITEM = 'create-new-with-name';
 
 const DEFAULT_POPPER_PROPS = {
   position: 'end',
@@ -51,11 +50,8 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
   const selectedOptionRef = useRef<HTMLSelectElement>(null);
 
   const items = useMemo(() => {
-    const localArray = itemsProps.slice();
-    if (isDefined(onCreate)) {
-      localArray.push({ name: `Create new ${onCreatePrefix}`, description: '', value: CREATE_NEW_VALUE });
-    }
     const isValueInArray = isDefined(itemsProps.find((item) => item.name === selectedItem?.name));
+    const localArray = itemsProps.slice();
     if (isValueInArray) {
       return localArray;
     }
@@ -63,7 +59,7 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
       localArray.unshift({ name: selectedItem.name, value: selectedItem.value });
     }
     return localArray;
-  }, [itemsProps, onCreate, onCreatePrefix, selectedItem?.name, selectedItem?.value]);
+  }, [itemsProps, selectedItem?.name, selectedItem?.value]);
 
   useEffect(() => {
     if (selectedItem?.name) {
@@ -73,7 +69,7 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
 
   const onItemChanged = useCallback(
     (_event: unknown, name: string | number | undefined) => {
-      if (name === CREATE_NEW_VALUE || name === CREATE_NEW_WITH_NAME_VALUE) {
+      if (name === CREATE_NEW_ITEM) {
         onCreate?.(name, inputValue);
         setIsOpen(false);
         return;
@@ -208,16 +204,13 @@ export const Typeahead: FunctionComponent<TypeaheadProps> = ({
           </SelectOption>
         ))}
 
-        {filteredItems.length === 0 && onCreate && (
-          <SelectOption
-            value={CREATE_NEW_WITH_NAME_VALUE}
-            aria-label={`option ${CREATE_NEW_WITH_NAME_VALUE.toLocaleLowerCase()}`}
-          >
-            Create new {onCreatePrefix} &quot;{inputValue}&quot;
+        {filteredItems.length === 0 && <SelectOption isDisabled>No items found</SelectOption>}
+
+        {onCreate && (
+          <SelectOption value={CREATE_NEW_ITEM} aria-label={`option ${CREATE_NEW_ITEM.toLocaleLowerCase()}`}>
+            Create new {onCreatePrefix} {inputValue ? `'${inputValue}'` : ''}
           </SelectOption>
         )}
-
-        {filteredItems.length === 0 && !onCreate && <SelectOption isDisabled>No items found</SelectOption>}
       </SelectList>
     </Select>
   );


### PR DESCRIPTION
### Context
When creating a new bean from the `BeanField`, the list is not updated, making it complicated for picking it up when expanding the list.

### Changes
This commit updates the list after the bean creation.

fix: https://github.com/KaotoIO/kaoto/issues/2037