### PR TITLE
chore(VSCode): Avoid loading JSON Schemas for VS Code

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -97,7 +97,7 @@ export const KaotoEditor = () => {
                 <>
                   <TabTitleIcon>
                     <Icon>
-                      <img src={bean} />
+                      <img src={bean} alt="Camel beans icon" />
                     </Icon>
                   </TabTitleIcon>
                   <TabTitleText>Beans</TabTitleText>

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -15,7 +15,6 @@ import { AbstractSettingsAdapter } from '../models/settings';
 import { CatalogLoaderProvider } from '../providers/catalog.provider';
 import { EntitiesProvider } from '../providers/entities.provider';
 import { RuntimeProvider } from '../providers/runtime.provider';
-import { SchemasLoaderProvider } from '../providers/schemas.provider';
 import { SettingsProvider } from '../providers/settings.provider';
 import { SourceCodeProvider } from '../providers/source-code.provider';
 import { EditService } from './EditService';
@@ -146,32 +145,30 @@ export class KaotoEditorApp implements Editor {
   af_componentRoot() {
     return (
       <RuntimeProvider catalogUrl={this.settingsAdapter.getSettings().catalogUrl}>
-        <SchemasLoaderProvider>
-          <CatalogLoaderProvider>
-            <SourceCodeProvider>
-              <EntitiesProvider fileExtension={this.initArgs.fileExtension}>
-                <SettingsProvider adapter={this.settingsAdapter}>
-                  <KaotoBridge
-                    ref={this.editorRef}
-                    channelType={this.initArgs.channel}
-                    onReady={this.sendReady}
-                    onNewEdit={this.sendNewEdit}
-                    setNotifications={this.sendNotifications}
-                    onStateControlCommandUpdate={this.sendStateControlCommand}
-                    getMetadata={this.getMetadata}
-                    setMetadata={this.setMetadata}
-                    getResourceContent={this.getResourceContent}
-                    saveResourceContent={this.saveResourceContent}
-                    deleteResource={this.deleteResource}
-                    askUserForFileSelection={this.askUserForFileSelection}
-                  >
-                    <RouterProvider router={kaotoEditorRouter} />
-                  </KaotoBridge>
-                </SettingsProvider>
-              </EntitiesProvider>
-            </SourceCodeProvider>
-          </CatalogLoaderProvider>
-        </SchemasLoaderProvider>
+        <CatalogLoaderProvider>
+          <SourceCodeProvider>
+            <EntitiesProvider fileExtension={this.initArgs.fileExtension}>
+              <SettingsProvider adapter={this.settingsAdapter}>
+                <KaotoBridge
+                  ref={this.editorRef}
+                  channelType={this.initArgs.channel}
+                  onReady={this.sendReady}
+                  onNewEdit={this.sendNewEdit}
+                  setNotifications={this.sendNotifications}
+                  onStateControlCommandUpdate={this.sendStateControlCommand}
+                  getMetadata={this.getMetadata}
+                  setMetadata={this.setMetadata}
+                  getResourceContent={this.getResourceContent}
+                  saveResourceContent={this.saveResourceContent}
+                  deleteResource={this.deleteResource}
+                  askUserForFileSelection={this.askUserForFileSelection}
+                >
+                  <RouterProvider router={kaotoEditorRouter} />
+                </KaotoBridge>
+              </SettingsProvider>
+            </EntitiesProvider>
+          </SourceCodeProvider>
+        </CatalogLoaderProvider>
       </RuntimeProvider>
     );
   }


### PR DESCRIPTION
### Context
After merging https://github.com/KaotoIO/kaoto/pull/2081, we're no longer generating schemas for the `Form` component but for the `SourceCodeEditor` component used in the web version.

### Changes
With this in mind, we no longer need to load said schemas in VS Code, as the `SourceCodeEditor` component is not used there.