### PR TITLE
fix(xml-serializer): Recognise also steps and expressions defined by string

### DIFF
--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CamelCatalogService, CatalogKind } from '../../../models';
 
-import { describe } from 'node:test';
 import { BeansXmlParser } from './beans-xml-parser';
 
 export const getElementFromXml = (xml: string): Element => {

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
@@ -50,6 +50,22 @@ describe('BeanXmlParser', () => {
     });
   });
 
+  it('parse bean constructors without index defined', () => {
+    const beansElement = getElementFromXml(`
+        <bean>
+        <constructors>
+            <constructor value="true"/>
+            <constructor value="Hello World"/>
+        </constructors>
+        </bean>`);
+
+    const result = BeansXmlParser.parseBeanConstructors(beansElement);
+    expect(result).toEqual({
+      '0': 'true',
+      '1': 'Hello World',
+    });
+  });
+
   it('parse Properties correctly ', () => {
     const beanProperties = getElementFromXml(`<bean> <properties>
             <property key="field1" value="f1_p" />

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
@@ -50,12 +50,12 @@ export class BeansXmlParser {
 
     if (!constructorsElement) return undefined;
 
-    Array.from(constructorsElement.children).forEach((constructorElement) => {
+    Array.from(constructorsElement.children).forEach((constructorElement, index) => {
       const constructorIndex = constructorElement.getAttribute('index');
       const constructorValue = constructorElement.getAttribute('value');
 
-      if (constructorIndex && constructorValue) {
-        constructors = { ...constructors, [constructorIndex]: constructorValue };
+      if (constructorValue) {
+        constructors = { ...constructors, [constructorIndex ?? index]: constructorValue };
       }
     });
 

--- a/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/parsers/expression-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use RouteXmlParser. file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { collectNamespaces, extractAttributesFromXmlElement } from '../utils/xml-utils';
 import { CamelCatalogService, CatalogKind, ICamelProcessorProperty } from '../../../models';
 import { ExpressionDefinition } from '@kaoto/camel-catalog/types';

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { RouteXmlParser } from './route-xml-parser';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CamelCatalogService, CatalogKind } from '../../../models';
 import { KaotoXmlParser } from '../kaoto-xml-parser';
-import { describe } from 'node:test';
 
 export const getElementFromXml = (xml: string): Element => {
   const parser = new DOMParser();

--- a/packages/ui/src/serializers/xml/parsers/route-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/route-xml-parser.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use RouteXmlParser. file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   FromDefinition,
   ProcessorDefinition,

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { describe } from 'node:test';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { StepParser } from './step-parser';
 import { getElementFromXml } from './route-xml-parser.test';

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use RouteXmlParser. file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
@@ -1,5 +1,20 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { describe } from 'node:test';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { CamelCatalogService, CatalogKind } from '../../../models';

--- a/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CamelCatalogService, CatalogKind } from '../../../models';
 import { ElementType, StepXmlSerializer } from './step-xml-serializer';
 import { BeanFactory } from '@kaoto/camel-catalog/types';

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,17 @@ describe('ExpressionSerialisation tests', () => {
         simple: { expression: 'a=b' },
       },
     };
+    const expected = `<when><simple>a=b</simple></when>`;
+    const element = doc.createElement('when');
+    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    testSerializer(expected, element);
+  });
+
+  it('serialize simple expression with text definition', () => {
+    const entity = {
+      simple: 'a=b',
+    };
+
     const expected = `<when><simple>a=b</simple></when>`;
     const element = doc.createElement('when');
     ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
@@ -15,7 +15,6 @@
  */
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { describe } from 'node:test';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { CamelCatalogService, CatalogKind } from '../../../models';

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025a Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use RouteXmlParser. file except in compliance with the License.
@@ -61,14 +61,15 @@ export class ExpressionXmlSerializer {
 
   static createExpressionElement(
     expressionType: string,
-    expressionObject: Expression,
+    expressionObject: Expression | string,
     doc: Document,
     routeParent?: Element,
   ): Element {
     const expressionElement = doc.createElement(expressionType);
     const properties = CamelCatalogService.getComponent(CatalogKind.Processor, expressionType)?.properties;
 
-    expressionElement.textContent = expressionObject.expression;
+    expressionElement.textContent =
+      typeof expressionObject === 'string' ? expressionObject : expressionObject.expression;
 
     for (const [key, value] of Object.entries(expressionObject)) {
       if (key === 'expression') continue;

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025a Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use RouteXmlParser. file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { KaotoXmlSerializer } from './kaoto-xml-serializer';
 import { EntityType } from '../../../models/camel/entities';

--- a/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { describe } from 'node:test';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { CamelCatalogService, CatalogKind } from '../../../models';

--- a/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/serializers/serializer-test-utils.ts
+++ b/packages/ui/src/serializers/xml/serializers/serializer-test-utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -15,53 +15,53 @@
  */
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { describe } from 'node:test';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { CamelCatalogService, CatalogKind } from '../../../models';
 
 import {
   aggregateXml,
+  choiceXml,
   circuitBreakerXml,
+  deadLetterChannelXml,
+  doTryXml,
+  dynamicRouterXml,
+  enrichXml,
   filterXml,
   loadBalanceXml,
   loopXml,
   multicastXml,
   pipelineXml,
+  recipientListXml,
   resequenceXml,
+  routingSlipXml,
   sagaXml,
   splitXml,
-  choiceXml,
-  doTryXml,
-  deadLetterChannelXml,
-  enrichXml,
-  dynamicRouterXml,
-  recipientListXml,
-  routingSlipXml,
   throttleXml,
 } from '../../../stubs/eip-xml-snippets';
 import {
   aggregateEntity,
+  choiceEntity,
   circuitBreakerEntity,
+  deadLetterChannelEntity,
+  doTryEntity,
+  dynamicRouterEntity,
+  enrichEntity,
   filterEntity,
   loadBalanceEntity,
   loopEntity,
   multicastEntity,
   pipelineEntity,
+  recipientListEntity,
   resequenceEntity,
+  routingSlipEntity,
   sagaEntity,
   splitEntity,
-  choiceEntity,
-  doTryEntity,
-  deadLetterChannelEntity,
-  enrichEntity,
-  dynamicRouterEntity,
-  recipientListEntity,
-  routingSlipEntity,
   throttleEntity,
 } from '../../../stubs/eip-entity-snippets';
-import { StepXmlSerializer } from './step-xml-serializer';
+import { ElementType, StepXmlSerializer } from './step-xml-serializer';
 import { XmlFormatter } from '../utils/xml-formatter';
+import { getDocument } from './serializer-test-utils';
 
 export const normalizeLineEndings = (str: string): string => {
   return str
@@ -69,44 +69,132 @@ export const normalizeLineEndings = (str: string): string => {
     .replace(/\s+/g, ' ')
     .trim();
 };
-describe('Serialize EIP elements', () => {
+
+describe('step-xml-serializer tests', () => {
   let domParser: DOMParser;
   let xmlSerializer: XMLSerializer;
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
     domParser = new DOMParser();
     xmlSerializer = new XMLSerializer();
   });
 
-  const testCases = [
-    { name: 'aggregate', xml: aggregateXml, entity: aggregateEntity },
-    { name: 'circuitBreaker', xml: circuitBreakerXml, entity: circuitBreakerEntity },
-    { name: 'filter', xml: filterXml, entity: filterEntity },
-    { name: 'loadBalance', xml: loadBalanceXml, entity: loadBalanceEntity },
-    { name: 'loop', xml: loopXml, entity: loopEntity },
-    { name: 'multicast', xml: multicastXml, entity: multicastEntity },
-    { name: 'pipeline', xml: pipelineXml, entity: pipelineEntity },
-    { name: 'resequence', xml: resequenceXml, entity: resequenceEntity },
-    { name: 'saga', xml: sagaXml, entity: sagaEntity },
-    { name: 'split', xml: splitXml, entity: splitEntity },
-    { name: 'choice', xml: choiceXml, entity: choiceEntity },
-    { name: 'doTry', xml: doTryXml, entity: doTryEntity },
-    { name: 'errorHandler', xml: deadLetterChannelXml, entity: deadLetterChannelEntity },
-    { name: 'enrich', xml: enrichXml, entity: enrichEntity },
-    { name: 'dynamicRouter', xml: dynamicRouterXml, entity: dynamicRouterEntity },
-    { name: 'recipientList', xml: recipientListXml, entity: recipientListEntity },
-    { name: 'routingSlip', xml: routingSlipXml, entity: routingSlipEntity },
-    { name: 'throttle', xml: throttleXml, entity: throttleEntity },
-  ];
+  describe('serialize steps with string definitions', () => {
+    const testCases = [
+      { name: 'to', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
+      { name: 'toD', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
+      { name: 'log', stepString: 'message', attributeName: 'message' },
+      { name: 'customLoadBalancer', stepString: 'ref', attributeName: 'ref' },
+      { name: 'setExchangePattern', stepString: 'a*=b', attributeName: 'pattern' },
+      { name: 'routeBuilder', stepString: 'customBuilder', attributeName: 'ref' },
+      { name: 'removeVariable', stepString: 'variable', attributeName: 'name' },
+      { name: 'removeProperty', stepString: 'variable', attributeName: 'name' },
+      { name: 'removeProperties', stepString: 'a*', attributeName: 'pattern' },
+      { name: 'removeHeaders', stepString: 'a*', attributeName: 'pattern' },
+      { name: 'removeHeader', stepString: 'header', attributeName: 'name' },
+      { name: 'convertBodyTo', stepString: 'string', attributeName: 'type' },
+    ];
 
-  it.each(testCases)('Parse $name', ({ name, xml, entity }) => {
-    const document = domParser.parseFromString('', 'application/xml');
-    const result = StepXmlSerializer.serialize(name, entity, document);
-    const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
-    const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
-    const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
-    expect(resultString).toEqual(expectedString);
+    it.each(testCases)('serializes $name with string definition', ({ name, stepString, attributeName }) => {
+      const step = stepString as unknown as ElementType;
+
+      const result = StepXmlSerializer.serialize(name, step, getDocument());
+      console.log(result.children);
+      expect(result.tagName).toBe(name);
+      expect(result.getAttribute(attributeName)).toBe(stepString);
+    });
+  });
+
+  describe('Basic serialization', () => {
+    it('serializes a to step with URI', () => {
+      const toStep = {
+        uri: 'file:output',
+        parameters: {
+          fileName: 'output.txt',
+          directoryName: 'output',
+          fileExist: 'Append',
+        },
+      };
+
+      const result = StepXmlSerializer.serialize('to', toStep, getDocument());
+      expect(result.tagName).toBe('to');
+      expect(result.getAttribute('uri')).toBe('file:output?fileName=output.txt&fileExist=Append');
+    });
+
+    it('serializes a step with attributes', () => {
+      const logStep = {
+        message: 'Hello World',
+        logName: 'testLogger',
+      };
+
+      const result = StepXmlSerializer.serialize('log', logStep, getDocument());
+      expect(result.tagName).toBe('log');
+      expect(result.getAttribute('message')).toBe('Hello World');
+      expect(result.getAttribute('logName')).toBe('testLogger');
+    });
+
+    it('serializes a step with nested elements', () => {
+      const parentStep = {
+        steps: [{ to: { uri: 'direct:first' } }, { to: { uri: 'direct:second' } }],
+      };
+
+      const result = StepXmlSerializer.serialize('route', parentStep, getDocument());
+      expect(result.tagName).toBe('route');
+      expect(result.children.length).toBe(2);
+      expect(result.children[0].tagName).toBe('to');
+      expect(result.children[0].getAttribute('uri')).toBe('direct:first');
+      expect(result.children[1].tagName).toBe('to');
+      expect(result.children[1].getAttribute('uri')).toBe('direct:second');
+    });
+
+    it('creates URI from component parameters correctly', () => {
+      const fileStep = {
+        uri: 'file:data',
+        parameters: {
+          noop: true,
+          recursive: true,
+          delete: false,
+        },
+      };
+
+      const result = StepXmlSerializer.serialize('from', fileStep, getDocument());
+      expect(result.tagName).toBe('from');
+      expect(result.getAttribute('uri')).toBe('file:data?noop=true&recursive=true&delete=false');
+    });
+  });
+
+  describe('Serialize EIP elements', () => {
+    const testCases = [
+      { name: 'aggregate', xml: aggregateXml, entity: aggregateEntity },
+      { name: 'circuitBreaker', xml: circuitBreakerXml, entity: circuitBreakerEntity },
+      { name: 'filter', xml: filterXml, entity: filterEntity },
+      { name: 'loadBalance', xml: loadBalanceXml, entity: loadBalanceEntity },
+      { name: 'loop', xml: loopXml, entity: loopEntity },
+      { name: 'multicast', xml: multicastXml, entity: multicastEntity },
+      { name: 'pipeline', xml: pipelineXml, entity: pipelineEntity },
+      { name: 'resequence', xml: resequenceXml, entity: resequenceEntity },
+      { name: 'saga', xml: sagaXml, entity: sagaEntity },
+      { name: 'split', xml: splitXml, entity: splitEntity },
+      { name: 'choice', xml: choiceXml, entity: choiceEntity },
+      { name: 'doTry', xml: doTryXml, entity: doTryEntity },
+      { name: 'errorHandler', xml: deadLetterChannelXml, entity: deadLetterChannelEntity },
+      { name: 'enrich', xml: enrichXml, entity: enrichEntity },
+      { name: 'dynamicRouter', xml: dynamicRouterXml, entity: dynamicRouterEntity },
+      { name: 'recipientList', xml: recipientListXml, entity: recipientListEntity },
+      { name: 'routingSlip', xml: routingSlipXml, entity: routingSlipEntity },
+      { name: 'throttle', xml: throttleXml, entity: throttleEntity },
+    ];
+
+    it.each(testCases)('Parse $name', ({ name, xml, entity }) => {
+      const document = domParser.parseFromString('', 'application/xml');
+      const result = StepXmlSerializer.serialize(name, entity, document);
+      const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
+      const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
+      const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
+      expect(resultString).toEqual(expectedString);
+    });
   });
 });

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use RouteXmlParser. file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -38,7 +38,7 @@ export class StepXmlSerializer {
           break;
 
         case 'attribute':
-          this.serializeAttribute(element, key, processor, processor[key]);
+          this.serializeAttribute(element, key, processor, props, processor[key]);
           break;
 
         case 'expression':
@@ -62,6 +62,7 @@ export class StepXmlSerializer {
       camelElement = camelElement[elementName] as ElementType;
     }
     const routeParent = elementName === 'route' ? element : parent;
+
     const properties = CamelCatalogService.getComponent(
       CatalogKind.Processor,
       PROCESSOR_NAMES.get(elementName) ?? elementName,
@@ -229,13 +230,19 @@ export class StepXmlSerializer {
   private static serializeAttribute(
     element: Element,
     key: string,
-    processor: ElementType,
+    processor: ElementType | string,
+    props: ICamelProcessorProperty,
     attributeValue: unknown,
   ): void {
-    if (attributeValue) {
-      const value = key === 'uri' ? this.createUriFromParameters(processor) : (attributeValue as string);
-      element.setAttribute(key, value);
+    if (typeof processor === 'string') {
+      if (props.required) element.setAttribute(key, processor);
+      return;
     }
+
+    if (!attributeValue) return;
+
+    const value = key === 'uri' ? this.createUriFromParameters(processor) : String(attributeValue);
+    element.setAttribute(key, value);
   }
 
   static decorateDoTry(doTry: DoTry, doTryElement: Element, doc: Document): Element {

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use RouteXmlParser. file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/ui/src/serializers/xml/xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/xml-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Changes:

-  - closes #2084 => implement the recognition of the steps and expressions defined only by string not only as a object, for example:

``` yaml 
 steps:
  - setBody:
      constant: Initial message
  - to: log:info?showAll=true&multiline=true&logMask=true
```  
  

- removing incorrect imports in some tests
-  fixed parsing beans constructors when index is not defined: fixes #1998
-  licenses updated

