### PR TITLE
fix(Document Export): Fix multiline property value in the table

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/MarkdownComponentMapping.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/MarkdownComponentMapping.tsx
@@ -58,7 +58,9 @@ export const markdownComponentMapping: Components = {
   ),
   td: ({ children }) => (
     <Td hasLeftBorder hasRightBorder modifier="breakWord">
-      {children}
+      <pre>
+        <code>{children}</code>
+      </pre>
     </Td>
   ),
 };

--- a/packages/ui/src/services/documentation.service.test.ts
+++ b/packages/ui/src/services/documentation.service.test.ts
@@ -16,6 +16,7 @@ import { restOperationsYaml } from '../stubs/rest-operations';
 import { routeConfigurationFullYaml } from '../stubs/route-configuration-full';
 import { EventNotifier } from '../utils';
 import { DocumentationService } from './documentation.service';
+import { kameletWithMultilineXmlPropYaml } from '../stubs/kamelet-with-multiline-xml-prop';
 
 describe('DocumentationService', () => {
   let eventNotifier: EventNotifier;
@@ -167,6 +168,14 @@ describe('DocumentationService', () => {
       expect(markdown).toContain('# Dependencies');
       expect(markdown).toContain('## Metadata : Labels');
       expect(markdown).toContain('## Metadata : Annotations');
+    });
+
+    it('should generate markdown for kamelet with multiline property and XML', () => {
+      const documentationEntities = createDocumentationEntitiesFromYaml(kameletWithMultilineXmlPropYaml);
+      const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
+
+      expect(markdown).toContain('<strong>sample</strong>');
+      expect(markdown).toContain('foo&#10;<Some>aaa</Some>&#10;bbb');
     });
 
     it('should generate aws-cloudtail-source kamelet markdown', () => {

--- a/packages/ui/src/services/documentation.service.ts
+++ b/packages/ui/src/services/documentation.service.ts
@@ -78,7 +78,7 @@ export class DocumentationService {
     const rows: TableRow[] = parsedTable.data.reduce((acc, rowData) => {
       const row: TableRow = {};
       for (let colIndex = 0; colIndex < parsedTable.headers.length; colIndex++) {
-        row[parsedTable.headers[colIndex]] = rowData[colIndex];
+        row[parsedTable.headers[colIndex]] = DocumentationService.escapeValue(rowData[colIndex]);
       }
       acc.push(row);
       return acc;
@@ -94,6 +94,11 @@ export class DocumentationService {
         },
         {},
       );
+  }
+
+  private static escapeValue(value: string | number): string {
+    if (!value || typeof value !== 'string') return value as string;
+    return value.replace(/{(\r\n)|\r|\n/g, '&#10;');
   }
 
   private static parseEntity(documentationEntity: DocumentationEntity): ParsedTable[] | ParsedTable | undefined {

--- a/packages/ui/src/stubs/kamelet-with-multiline-xml-prop.ts
+++ b/packages/ui/src/stubs/kamelet-with-multiline-xml-prop.ts
@@ -1,0 +1,52 @@
+export const kameletWithMultilineXmlPropYaml = `
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  annotations:
+    camel.apache.org/catalog.version: main-SNAPSHOT
+    camel.apache.org/kamelet.group: Users
+    camel.apache.org/kamelet.icon: data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K
+    camel.apache.org/kamelet.support.level: Stable
+    camel.apache.org/provider: Apache Software Foundation
+  labels:
+    camel.apache.org/kamelet.type: source
+  name: kamelet-6703
+spec:
+  definition:
+    description: <strong>sample</strong>
+    properties:
+      period:
+        default: 5000
+        title: Period
+        type: integer
+    title: kamelet-6703
+    type: object
+  dependencies:
+    - camel:timer
+    - camel:http
+    - camel:kamelet
+  template:
+    from:
+      steps:
+        - to:
+            description: <strong>sample</strong>
+            parameters:
+              httpUri: random-data-api.com/api/v2/users
+            uri: https
+        - setBody:
+            id: setBody-1975
+            simple:
+              expression: |-
+                foo
+                <Some>aaa</Some>
+                bbb
+        - to: kamelet:sink
+      id: from-2961
+      parameters:
+        period: "{{period}}"
+        timerName: user
+      uri: timer
+  types:
+    out:
+      mediaType: application/json
+`;


### PR DESCRIPTION
Fixes: #2096

It replaces the line breaks to `&#10;` and also put `<pre><code>` when the markdown is rendered in the preview through the component mapper. On the other hand it preserves the XML tags as-is in the markdown source code for download to keep property value polution minimal. The markdown renderer would have to disable HTML to render XML tags in the property value.

#### Preview
![Screenshot From 2025-03-18 09-46-17](https://github.com/user-attachments/assets/0a75c913-a962-45a9-848a-74e75057b56e)

#### Markdown source
```md
# Diagram

![Diagram](route-export.png)
# Steps

| Step ID      | Step    | URI          | Parameter Name    | Value                            |
| ------------ | ------- | ------------ | ----------------- | -------------------------------- |
| from-2961    | from    | timer        | period            | {{period}}                       |
|              |         |              | timerName         | user                             |
|              | to      | https        | description       | <strong>sample</strong>          |
|              |         |              | httpUri           | random-data-api.com/api/v2/users |
| setBody-1975 | setBody |              | simple.expression | foo&#10;<Some>aaa</Some>&#10;bbb |
|              | to      | kamelet:sink |                   |                                  |


# Definition

<strong>sample</strong>
| Property Name | Meta Property Name | Value                   |
| ------------- | ------------------ | ----------------------- |

...(snip)...
```