### PR TITLE
fix(beans-xml-serializer): flatten bean object properties

### DIFF
--- a/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
@@ -54,4 +54,66 @@ describe('BeanXmlParser', () => {
     expect(bean).toBeDefined();
     testSerializer(expected, bean!);
   });
+
+  it('parse bean properties properly', () => {
+    const bean = {
+      name: 'beanFromProps',
+      type: 'com.acme.MyBean',
+      builderClass: 'com.acme.MyBeanBuilder',
+      builderMethod: 'createMyBean',
+      properties: { field1: 'f1_p', field2: { nested1: 'p2', nested2: { nested3: 'value' } } },
+    };
+
+    const result = BeansXmlSerializer.serialize(bean, doc);
+    const expected = `<bean name="beanFromProps" 
+      type="com.acme.MyBean" builderClass="com.acme.MyBeanBuilder" builderMethod="createMyBean">
+  <properties>
+    <property key="field1" value="f1_p"/>
+    <property key="field2.nested1" value="p2"/>
+    <property key="field2.nested2.nested3" value="value"/>
+  </properties>
+</bean>`;
+    expect(result).toBeDefined();
+    testSerializer(expected, result!);
+  });
+
+  it('handle undefined constructors properly', () => {
+    const constructors = {
+      '0': 'true',
+      '1': undefined,
+      '2': 'Hello World',
+    };
+
+    // with undefined for constructors I went with the empty string instead of omit the element to keep the index
+    const expected = `<constructors>
+  <constructor index="0" value="true"/>
+  <constructor index="1" value=""/>
+  <constructor index="2" value="Hello World"/>
+</constructors>`;
+
+    const result = BeansXmlSerializer.serializeConstructors(constructors, doc);
+    expect(result).toBeDefined();
+    testSerializer(expected, result);
+  });
+
+  it('handles undefined  values properly', () => {
+    const properties = {
+      field1: 'value',
+      field2: undefined,
+      field3: {
+        nested1: 'valid',
+        nested2: undefined,
+      },
+    };
+
+    const result = BeansXmlSerializer.serializeProperties(properties, doc);
+    const expected = `
+  <properties>
+    <property key="field1" value="value"/>
+   <property key="field3.nested1" value="valid"/>
+ </properties>`;
+
+    expect(result).toBeDefined();
+    testSerializer(expected, result!);
+  });
 });


### PR DESCRIPTION
fix #2086
When object property in the bean tab is defined, bean-xml serializer will convert it as follows :
```typescript
 properties: {
    a: value,
    nested:{ 
         b:value,
         c: { c1: value}
    }
}
```

to: 
```xml
<properties>
  <property key="a" value="value"/>
  <property key="nested.b" value="value"/>
  <property key="nested.c.c1" value="value"/>
</properties>
```