### PR TITLE
fix: exclude whenSkipSendToEndpoint from EIP names in EIPGenerator

### DIFF
--- a/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EIPGenerator.java
+++ b/packages/catalog-generator/src/main/java/io/kaoto/camelcatalog/generators/EIPGenerator.java
@@ -126,7 +126,9 @@ public class EIPGenerator implements Generator {
 
         while (eipsIterator.hasNext()) {
             var entry = eipsIterator.next();
-            eipNames.add(entry.getKey());
+            if (!"whenSkipSendToEndpoint".equals(entry.getKey())) {
+                eipNames.add(entry.getKey());
+            }
         }
 
         eipNames.add("when");

--- a/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EIPGeneratorTest.java
+++ b/packages/catalog-generator/src/test/java/io/kaoto/camelcatalog/generators/EIPGeneratorTest.java
@@ -79,6 +79,14 @@ class EIPGeneratorTest {
     }
 
     @Test
+    void shouldNotGetWhenSkipSendToEndpoint() {
+        var processorList = eipGenerator.getEIPNames();
+
+        assertFalse(processorList.contains("whenSkipSendToEndpoint"));
+    }
+
+
+    @Test
     void shouldGetModelJson() {
         var postJson = eipGenerator.getModelJson("post");
 
@@ -279,7 +287,7 @@ class EIPGeneratorTest {
     void shouldSetExpressionFormatToPropertyExpressionDefinition() {
         var processorsMap = eipGenerator.generate();
 
-        var oneOfNode= processorsMap.get("saga").withObject("propertiesSchema").withObject("definitions")
+        var oneOfNode = processorsMap.get("saga").withObject("propertiesSchema").withObject("definitions")
                 .withObject("org.apache.camel.model.PropertyExpressionDefinition").withArray("anyOf").get(0);
 
         assertTrue(oneOfNode.has("format"));


### PR DESCRIPTION
whenSkipSendToEndpoint was removed from camel-spring XSD schema in camel 3.11.7 and in 4.10 from camel-yaml-dsl.  