### PR TITLE
fix(1988): Flows list doesn't need to be split toggle

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.scss
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.scss
@@ -1,5 +1,9 @@
+.flows-list-btn {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
 .flows-menu {
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 300px;

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
@@ -22,41 +22,36 @@ export const FlowsMenu: FunctionComponent = () => {
   };
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle
-      data-testid="flows-list-dropdown"
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isFullWidth
-      splitButtonItems={[
-        <MenuToggleAction
-          id="flows-list-btn"
-          key="flows-list-btn"
-          data-testid="flows-list-btn"
-          aria-label="flows list"
-          onClick={onToggleClick}
-        >
-          <div className="flows-menu">
-            <Icon isInline>
-              <ListIcon />
-            </Icon>
-            <span
-              title={singleFlowId ?? 'Routes'}
-              data-testid="flows-list-route-id"
-              className="pf-v6-u-m-sm flows-menu-display"
-            >
-              {`${singleFlowId ?? 'Routes'}`}
-            </span>
-            <Badge
-              title={`Showing ${visibleFlowsCount} out of ${totalFlowsCount} flows`}
-              data-testid="flows-list-route-count"
-              isRead
-            >
-              {visibleFlowsCount}/{totalFlowsCount}
-            </Badge>
-          </div>
-        </MenuToggleAction>,
-      ]}
-    />
+    <MenuToggle data-testid="flows-list-dropdown" ref={toggleRef} onClick={onToggleClick} isFullWidth>
+      <MenuToggleAction
+        id="flows-list-btn"
+        key="flows-list-btn"
+        data-testid="flows-list-btn"
+        aria-label="flows list"
+        onClick={onToggleClick}
+        className="flows-list-btn"
+      >
+        <div className="flows-menu">
+          <Icon isInline>
+            <ListIcon />
+          </Icon>
+          <span
+            title={singleFlowId ?? 'Routes'}
+            data-testid="flows-list-route-id"
+            className="pf-v6-u-m-sm flows-menu-display"
+          >
+            {`${singleFlowId ?? 'Routes'}`}
+          </span>
+          <Badge
+            title={`Showing ${visibleFlowsCount} out of ${totalFlowsCount} flows`}
+            data-testid="flows-list-route-count"
+            isRead
+          >
+            {visibleFlowsCount}/{totalFlowsCount}
+          </Badge>
+        </div>
+      </MenuToggleAction>
+    </MenuToggle>
   );
 
   return (


### PR DESCRIPTION
fix https://github.com/KaotoIO/kaoto/issues/1988

removed the split line:
![Screenshot from 2025-03-21 13-31-32](https://github.com/user-attachments/assets/f0242aaf-5a35-49ba-acb8-cab2acab5470)
