### PR TITLE
feat(UI): Add support for dark mode

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { VisualizationProvider } from '@patternfly/react-topology';
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import { Outlet } from 'react-router-dom';
 import { RenderingProvider } from './components/RenderingAnchor/rendering.provider';
 import { ControllerService } from './components/Visualization/Canvas/controller.service';
@@ -21,6 +21,7 @@ import {
 } from './providers';
 import { isDefined } from './utils';
 import { CatalogSchemaLoader } from './utils/catalog-schema-loader';
+import { setColorScheme } from './utils/color-scheme';
 
 function App() {
   const ReloadProvider = useReload();
@@ -28,10 +29,15 @@ function App() {
   const settingsAdapter = new LocalStorageSettingsAdapter();
   let catalogUrl = CatalogSchemaLoader.DEFAULT_CATALOG_PATH;
   const settingsCatalogUrl = settingsAdapter.getSettings().catalogUrl;
+  const colorSchema = settingsAdapter.getSettings().colorScheme;
 
   if (isDefined(settingsCatalogUrl) && settingsCatalogUrl !== '') {
     catalogUrl = settingsCatalogUrl;
   }
+
+  useLayoutEffect(() => {
+    setColorScheme(colorSchema);
+  }, [colorSchema]);
 
   return (
     <ReloadProvider>

--- a/packages/ui/src/assets/settingsSchema.json
+++ b/packages/ui/src/assets/settingsSchema.json
@@ -25,6 +25,13 @@
       "type": "string",
       "enum": ["onHover", "onSelection"]
     },
+    "colorScheme": {
+      "title": "Color scheme",
+      "description": "Choose the color scheme for the UI. Can be either `auto`, `light`, or `dark`",
+      "default": "auto",
+      "type": "string",
+      "enum": ["auto", "light", "dark"]
+    },
     "experimentalFeatures": {
       "title": "Experimental features",
       "description": "Enable / disable experimental features",

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -427,6 +427,158 @@ exports[`SettingsForm should render 1`] = `
     </div>
   </div>
   <div
+    class="pf-v6-c-form__group"
+    data-testid="#.colorScheme__field-wrapper"
+  >
+    <div
+      class="pf-v6-c-form__group-label"
+    >
+      <label
+        class="pf-v6-c-form__label"
+        for="#.colorScheme"
+      >
+        <span
+          class="pf-v6-c-form__label-text"
+        >
+          Color scheme
+        </span>
+      </label>
+        
+      <span
+        class="pf-v6-c-form__group-label-help"
+      >
+        <div
+          style="display: contents;"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="More info for Color scheme field"
+            class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+            data-ouia-component-id="OUIA-Generated-Button-plain-6"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </span>
+    </div>
+    <div
+      class="pf-v6-c-form__group-control"
+    >
+      <div
+        class="pf-v6-c-menu-toggle pf-m-full-width pf-m-typeahead"
+        id="#.colorScheme"
+      >
+        <div
+          class="pf-v6-c-text-input-group pf-m-plain"
+        >
+          <div
+            autocomplete="off"
+            class="pf-v6-c-text-input-group__main"
+            data-testid="#.colorScheme-typeahead-select-input"
+            id="#.colorScheme-typeahead-select-input"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                placeholder="auto"
+                type="text"
+                value="auto"
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Clear input value"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.colorScheme__clear"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <button
+          aria-expanded="false"
+          aria-label="undefined toggle"
+          class="pf-v6-c-menu-toggle__button"
+          data-ouia-component-id="OUIA-Generated-MenuToggle-typeahead-3"
+          data-ouia-component-type="PF6/MenuToggle"
+          data-ouia-safe="true"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="pf-v6-c-menu-toggle__controls"
+          >
+            <span
+              class="pf-v6-c-menu-toggle__toggle-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
     class="pf-v6-c-card"
     data-ouia-component-id="OUIA-Generated-Card-2"
     data-ouia-component-type="PF6/Card"
@@ -444,7 +596,7 @@ exports[`SettingsForm should render 1`] = `
           aria-disabled="false"
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-6"
+          data-ouia-component-id="OUIA-Generated-Button-plain-8"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.experimentalFeatures__remove"
@@ -488,7 +640,7 @@ exports[`SettingsForm should render 1`] = `
                 aria-disabled="false"
                 aria-label="More info for Experimental features field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                data-ouia-component-id="OUIA-Generated-Button-plain-9"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -550,7 +702,7 @@ exports[`SettingsForm should render 1`] = `
                 aria-disabled="false"
                 aria-label="More info for Enable Drag & Drop field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                data-ouia-component-id="OUIA-Generated-Button-plain-10"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"

--- a/packages/ui/src/components/SourceCode/SourceCode.tsx
+++ b/packages/ui/src/components/SourceCode/SourceCode.tsx
@@ -4,11 +4,12 @@ import { FunctionComponent, MutableRefObject, Ref, useCallback, useContext, useE
 import { EditorDidMount } from 'react-monaco-editor';
 import { sourceSchemaConfig, SourceSchemaType } from '../../models/camel';
 import { EntitiesContext } from '../../providers/entities.provider';
+import { isXML } from '../../serializers/xml/kaoto-xml-parser';
+import { isDarkModeEnabled } from '../../utils/color-scheme';
 import { RedoButton } from './RedoButton';
 import './SourceCode.scss';
 import { UndoButton } from './UndoButton';
 import './workers/enable-workers';
-import { isXML } from '../../serializers/xml/kaoto-xml-parser';
 
 interface SourceCodeProps {
   code: string;
@@ -28,6 +29,7 @@ const options: CodeEditorProps['options'] = {
 export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
   const editorRef = useRef<Parameters<EditorDidMount>[0] | null>(null);
   const entityContext = useContext(EntitiesContext);
+  const isDarkMode = isDarkModeEnabled();
   const schemaType: SourceSchemaType = entityContext?.currentSchemaType ?? SourceSchemaType.Route;
   const currentSchema = sourceSchemaConfig.config[schemaType].schema;
   const monacoYamlHandlerRef: MutableRefObject<ReturnType<typeof configureMonacoYaml> | undefined> = useRef(undefined);
@@ -93,6 +95,7 @@ export const SourceCode: FunctionComponent<SourceCodeProps> = (props) => {
   return (
     <CodeEditor
       className="source-code-editor"
+      isDarkTheme={isDarkMode}
       isFullHeight
       isCopyEnabled
       isDownloadEnabled

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
@@ -14,7 +14,8 @@
         display: flex;
         position: relative;
         font-weight: bold;
-        background-color: var(--pf-t--global--color--nonstatus--blue--default);
+        background-color: var(--pf-t--global--color--brand--100);
+        color: var(--pf-t--global--text--color--on-brand--default);
         padding: calc(var(--pf-t--global--spacer--xs) / 2) var(--pf-t--global--spacer--xs);
 
         img {
@@ -32,8 +33,7 @@
         }
 
         [data-selected='true'] & {
-          color: var(--pf-t--color--white);
-          background-color: var(--pf-t--global--color--brand--default);
+          background-color: var(--custom-node-BorderColor);
         }
       }
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -20,7 +20,7 @@
         align-items: center;
         border: 1px solid var(--custom-node-BorderColor);
         border-radius: var(--custom-node-BorderRadius);
-        background-color: var(--custom-node-BackgroundColor);
+        background-color: var(--pf-t--color--white);
         align-self: center;
         padding: var(--pf-t--global--spacer--sm);
         height: 60px;

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -175,7 +175,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
                 <img alt={tooltipContent} src={vizNode.data.icon} />
 
                 {isDisabled && (
-                  <Icon className="disabled-step-icon">
+                  <Icon className="disabled-step-icon" status="danger" size="lg">
                     <BanIcon />
                   </Icon>
                 )}

--- a/packages/ui/src/models/local-storage-keys.ts
+++ b/packages/ui/src/models/local-storage-keys.ts
@@ -6,4 +6,5 @@ export const enum LocalStorageKeys {
   NavigationExpanded = 'navigationExpanded',
   SelectedCatalog = 'selectedCatalog',
   Settings = 'settings',
+  ColorScheme = 'colorScheme',
 }

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -1,6 +1,6 @@
 import { LocalStorageKeys } from '../local-storage-keys';
 import { LocalStorageSettingsAdapter } from './localstorage-settings-adapter';
-import { NodeLabelType, NodeToolbarTrigger, SettingsModel } from './settings.model';
+import { ColorScheme, NodeLabelType, NodeToolbarTrigger, SettingsModel } from './settings.model';
 
 describe('LocalStorageSettingsAdapter', () => {
   it('should create an instance with the default settings', () => {
@@ -15,6 +15,7 @@ describe('LocalStorageSettingsAdapter', () => {
       catalogUrl: 'http://example.com',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: true,
       },
@@ -41,6 +42,7 @@ describe('LocalStorageSettingsAdapter', () => {
       catalogUrl: 'http://example.com',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: true,
       },

--- a/packages/ui/src/models/settings/settings.model.ts
+++ b/packages/ui/src/models/settings/settings.model.ts
@@ -8,10 +8,17 @@ export const enum NodeToolbarTrigger {
   onSelection = 'onSelection',
 }
 
+export const enum ColorScheme {
+  Auto = 'auto',
+  Light = 'light',
+  Dark = 'dark',
+}
+
 export interface ISettingsModel {
   catalogUrl: string;
   nodeLabel: NodeLabelType;
   nodeToolbarTrigger: NodeToolbarTrigger;
+  colorScheme: ColorScheme;
   experimentalFeatures: {
     enableDragAndDrop: boolean;
   };
@@ -26,6 +33,7 @@ export class SettingsModel implements ISettingsModel {
   catalogUrl: string = '';
   nodeLabel: NodeLabelType = NodeLabelType.Description;
   nodeToolbarTrigger: NodeToolbarTrigger = NodeToolbarTrigger.onHover;
+  colorScheme: ColorScheme = ColorScheme.Auto;
   experimentalFeatures = {
     enableDragAndDrop: false,
   };

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -19,6 +19,10 @@ html body {
   }
 }
 
+.pf-v6-theme-dark img[alt='Kaoto DataMapper icon'] {
+  filter: invert(1);
+}
+
 .shell {
   height: 100vh;
   width: 100vw;

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -1,9 +1,18 @@
+html body {
+  /*
+   * Remove the default white background color of the body element
+   * provided by the Multiplying Architecture theme.
+   */
+  background-color: transparent !important;
+}
+
 .shell {
   height: 100vh;
   width: 100vw;
   display: flex;
   flex-flow: column nowrap;
   position: relative;
+  background-color: var(--pf-t--global--background--color--secondary--default);
 
   // Tab header shouldn't grow or shrink
   > div[role='region'] {

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -4,6 +4,19 @@ html body {
    * provided by the Multiplying Architecture theme.
    */
   background-color: transparent !important;
+
+  /*
+   * The MA uses patternfly v4, which doesn't use CSS variables for
+   * the default font family. The following is taken from the
+   * patternfly v6 definition of the font family.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    margin: 0;
+    font-family: inherit;
+    font-size: 100%;
+    line-height: var(--pf-t--global--font--line-height--body);
+    color: var(--pf-t--global--text--color--regular);
+  }
 }
 
 .shell {

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -156,7 +156,7 @@ export const KaotoEditor = () => {
                 <>
                   <TabTitleIcon>
                     <Icon>
-                      <img src={icon_component_datamapper} alt="DataMapper icon" />
+                      <img src={icon_component_datamapper} alt="Kaoto DataMapper icon" />
                     </Icon>
                   </TabTitleIcon>
                   <TabTitleText>DataMapper</TabTitleText>

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -16,6 +16,9 @@ import { AbstractSettingsAdapter, ColorScheme, DefaultSettingsAdapter } from '..
 import { EditService } from './EditService';
 import { KaotoEditorApp } from './KaotoEditorApp';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
+import { setColorScheme } from '../utils/color-scheme';
+
+jest.mock('../utils/color-scheme');
 
 describe('KaotoEditorApp', () => {
   let kaotoEditorApp: KaotoEditorAppTest;
@@ -170,15 +173,9 @@ describe('KaotoEditorApp', () => {
   });
 
   it('setTheme', async () => {
-    const settingsSpy = jest.spyOn(settingsAdapter, 'saveSettings');
     await kaotoEditorApp.setTheme(EditorTheme.DARK);
 
-    expect(editorRef.current!.setTheme).not.toHaveBeenCalledWith(EditorTheme.DARK);
-    expect(settingsSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        colorScheme: ColorScheme.Dark,
-      }),
-    );
+    expect(editorRef.current!.setTheme).toHaveBeenCalledWith(EditorTheme.DARK);
   });
 
   it('sendReady', () => {
@@ -240,6 +237,12 @@ describe('KaotoEditorApp', () => {
     await kaotoEditorApp.saveResourceContent('path', 'content');
 
     expect(envelopeContext.channelApi.requests.saveResourceContent).toHaveBeenCalledWith('path', 'content');
+  });
+
+  it('should set the color theme upon opening the editor', () => {
+    kaotoEditorApp.af_onOpen();
+
+    expect(setColorScheme).toHaveBeenCalledWith(ColorScheme.Auto);
   });
 });
 

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -12,7 +12,7 @@ import { I18nService } from '@kie-tools-core/i18n/dist/envelope/I18nService';
 import { KeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService';
 import { OperatingSystem } from '@kie-tools-core/operating-system/dist/OperatingSystem';
 import { RefObject } from 'react';
-import { AbstractSettingsAdapter, DefaultSettingsAdapter } from '../models/settings';
+import { AbstractSettingsAdapter, ColorScheme, DefaultSettingsAdapter } from '../models/settings';
 import { EditService } from './EditService';
 import { KaotoEditorApp } from './KaotoEditorApp';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
@@ -170,9 +170,15 @@ describe('KaotoEditorApp', () => {
   });
 
   it('setTheme', async () => {
+    const settingsSpy = jest.spyOn(settingsAdapter, 'saveSettings');
     await kaotoEditorApp.setTheme(EditorTheme.DARK);
 
-    expect(editorRef.current!.setTheme).toHaveBeenCalledWith(EditorTheme.DARK);
+    expect(editorRef.current!.setTheme).not.toHaveBeenCalledWith(EditorTheme.DARK);
+    expect(settingsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        colorScheme: ColorScheme.Dark,
+      }),
+    );
   });
 
   it('sendReady', () => {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -91,7 +91,7 @@ export class KaotoEditorApp implements Editor {
   }
 
   async setTheme(theme: EditorTheme): Promise<void> {
-    this.editorRef.current?.setTheme(theme);
+    return this.editorRef.current?.setTheme(theme);
   }
 
   async sendReady(): Promise<void> {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -11,7 +11,7 @@ import { WorkspaceEdit } from '@kie-tools-core/workspace/dist/api';
 import '@patternfly/react-core/dist/styles/base.css'; // This import needs to be first
 import { RefObject, createRef } from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { AbstractSettingsAdapter, ColorScheme } from '../models/settings';
+import { AbstractSettingsAdapter } from '../models/settings';
 import { CatalogLoaderProvider } from '../providers/catalog.provider';
 import { EntitiesProvider } from '../providers/entities.provider';
 import { RuntimeProvider } from '../providers/runtime.provider';
@@ -91,9 +91,7 @@ export class KaotoEditorApp implements Editor {
   }
 
   async setTheme(theme: EditorTheme): Promise<void> {
-    const colorScheme = theme === EditorTheme.DARK ? ColorScheme.Dark : ColorScheme.Light;
-    this.settingsAdapter.saveSettings({ ...this.settingsAdapter.getSettings(), colorScheme });
-    setColorScheme(colorScheme);
+    this.editorRef.current?.setTheme(theme);
   }
 
   async sendReady(): Promise<void> {
@@ -146,9 +144,7 @@ export class KaotoEditorApp implements Editor {
   }
 
   af_onOpen(): void {
-    this.envelopeContext.channelApi.shared.kogitoEditor_theme.subscribe((theme: EditorTheme) => {
-      this.setTheme(theme);
-    });
+    setColorScheme(this.settingsAdapter.getSettings().colorScheme);
   }
 
   af_componentRoot() {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -11,12 +11,13 @@ import { WorkspaceEdit } from '@kie-tools-core/workspace/dist/api';
 import '@patternfly/react-core/dist/styles/base.css'; // This import needs to be first
 import { RefObject, createRef } from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { AbstractSettingsAdapter } from '../models/settings';
+import { AbstractSettingsAdapter, ColorScheme } from '../models/settings';
 import { CatalogLoaderProvider } from '../providers/catalog.provider';
 import { EntitiesProvider } from '../providers/entities.provider';
 import { RuntimeProvider } from '../providers/runtime.provider';
 import { SettingsProvider } from '../providers/settings.provider';
 import { SourceCodeProvider } from '../providers/source-code.provider';
+import { setColorScheme } from '../utils/color-scheme';
 import { EditService } from './EditService';
 import { KaotoBridge } from './KaotoBridge';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
@@ -90,7 +91,9 @@ export class KaotoEditorApp implements Editor {
   }
 
   async setTheme(theme: EditorTheme): Promise<void> {
-    return this.editorRef.current?.setTheme(theme);
+    const colorScheme = theme === EditorTheme.DARK ? ColorScheme.Dark : ColorScheme.Light;
+    this.settingsAdapter.saveSettings({ ...this.settingsAdapter.getSettings(), colorScheme });
+    setColorScheme(colorScheme);
   }
 
   async sendReady(): Promise<void> {
@@ -140,6 +143,12 @@ export class KaotoEditorApp implements Editor {
     options?: Record<string, unknown>,
   ): Promise<string[] | string | undefined> {
     return this.envelopeContext.channelApi.requests.askUserForFileSelection(include, exclude, options);
+  }
+
+  af_onOpen(): void {
+    this.envelopeContext.channelApi.shared.kogitoEditor_theme.subscribe((theme: EditorTheme) => {
+      this.setTheme(theme);
+    });
   }
 
   af_componentRoot() {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -1,7 +1,7 @@
 jest.mock('./KaotoEditorApp');
 jest.mock('react-router-dom');
 import { EditorInitArgs, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
-import { ISettingsModel, NodeLabelType, NodeToolbarTrigger } from '../models';
+import { ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger } from '../models';
 import { KaotoEditorApp } from './KaotoEditorApp';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
 import { KaotoEditorFactory } from './KaotoEditorFactory';
@@ -16,6 +16,7 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: 'catalog-url',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -44,6 +45,7 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: 'catalog-url',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -97,6 +99,7 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: '',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -105,6 +108,7 @@ describe('KaotoEditorFactory', () => {
       catalogUrl: 'path-prefix/camel-catalog/index.json',
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
+      colorScheme: ColorScheme.Auto,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },

--- a/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`SettingsProvider should render 1`] = `
 <p
   data-testid="settings"
 >
-  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","experimentalFeatures":{"enableDragAndDrop":false}}
+  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","experimentalFeatures":{"enableDragAndDrop":false}}
 </p>
 `;

--- a/packages/ui/src/utils/color-scheme.test.ts
+++ b/packages/ui/src/utils/color-scheme.test.ts
@@ -1,0 +1,66 @@
+import { DARK_MODE_PATTERN_FLY_CLASS_NAME, setColorScheme, isDarkModeEnabled } from './color-scheme';
+import { ColorScheme } from '../models';
+
+describe('color-scheme utilities', () => {
+  let htmlElement: HTMLElement;
+
+  beforeEach(() => {
+    htmlElement = document.createElement('html');
+    document.querySelector = jest.fn().mockReturnValue(htmlElement);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('setColorScheme', () => {
+    it('sets light mode by removing the dark mode class', () => {
+      htmlElement.classList.add(DARK_MODE_PATTERN_FLY_CLASS_NAME);
+
+      setColorScheme(ColorScheme.Light);
+
+      expect(htmlElement.classList.contains(DARK_MODE_PATTERN_FLY_CLASS_NAME)).toBe(false);
+    });
+
+    it('sets dark mode by adding the dark mode class', () => {
+      setColorScheme(ColorScheme.Dark);
+
+      expect(htmlElement.classList.contains(DARK_MODE_PATTERN_FLY_CLASS_NAME)).toBe(true);
+    });
+
+    it('sets color scheme to system preference when scheme is Auto', () => {
+      const mockMatchMedia = jest.fn().mockImplementation((query) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+      }));
+      window.matchMedia = mockMatchMedia;
+
+      setColorScheme(ColorScheme.Auto);
+
+      expect(htmlElement.classList.contains(DARK_MODE_PATTERN_FLY_CLASS_NAME)).toBe(true);
+    });
+
+    it('does nothing if the HTML element is not found', () => {
+      document.querySelector = jest.fn().mockReturnValue(null);
+
+      expect(() => setColorScheme(ColorScheme.Light)).not.toThrow();
+    });
+  });
+
+  describe('isDarkModeEnabled', () => {
+    it('returns true if the dark mode class is present', () => {
+      htmlElement.classList.add(DARK_MODE_PATTERN_FLY_CLASS_NAME);
+
+      expect(isDarkModeEnabled()).toBe(true);
+    });
+
+    it('returns false if the dark mode class is not present', () => {
+      expect(isDarkModeEnabled()).toBe(false);
+    });
+
+    it('returns false if the HTML element is not found', () => {
+      document.querySelector = jest.fn().mockReturnValue(null);
+
+      expect(isDarkModeEnabled()).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/utils/color-scheme.ts
+++ b/packages/ui/src/utils/color-scheme.ts
@@ -1,0 +1,31 @@
+import { ColorScheme } from '../models';
+
+export const DARK_MODE_PATTERN_FLY_CLASS_NAME = 'pf-v6-theme-dark';
+
+export const setColorScheme = (scheme: ColorScheme): void => {
+  const html = document.querySelector('html');
+  if (!html) return;
+
+  let colorScheme = scheme;
+  if (scheme === ColorScheme.Auto) {
+    colorScheme = getSystemColorScheme();
+  }
+
+  if (colorScheme === ColorScheme.Light) {
+    html.classList.remove(DARK_MODE_PATTERN_FLY_CLASS_NAME);
+  } else {
+    html.classList.add(DARK_MODE_PATTERN_FLY_CLASS_NAME);
+  }
+};
+
+const getSystemColorScheme = (): ColorScheme.Dark | ColorScheme.Light => {
+  if (!window.matchMedia) return ColorScheme.Light;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? ColorScheme.Dark : ColorScheme.Light;
+};
+
+export const isDarkModeEnabled = (): boolean => {
+  const html = document.querySelector('html');
+  if (!html) return false;
+
+  return html.classList.contains(DARK_MODE_PATTERN_FLY_CLASS_NAME);
+};


### PR DESCRIPTION
### Context
This PR adds support for selecting light and dark modes in Kaoto. The mechanism works in 3 ways:

* Auto: It will try to read the preference from the system
* Light: Light mode
* Dark: Dark mode

### Screenshot

#### Normal
![Normal](https://github.com/user-attachments/assets/4d2837a4-8a16-4cec-9ee2-3382e42b089c)

#### Selected
![Selected](https://github.com/user-attachments/assets/917fbabc-eee8-42b2-9220-fa1ccf6c5189)

### Source Code editor
![Source Code editor](https://github.com/user-attachments/assets/113ad52a-0be7-4645-9dbc-f7c4029eae92)

#### VS Code
![VSCode](https://github.com/user-attachments/assets/9f84b2a6-24e7-4c24-aa2c-35b2962090df)

### Todo
- [X] Propagate VS Code light / dark mode setting
- [X] Add tests for the DOM manipulation part
- [X] Find a better color scheme for the group title bar in dark mode

fix: https://github.com/KaotoIO/kaoto/issues/1543