### PR TITLE
fix(SourceCode): OnFallback default generation

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.test.ts
@@ -1,6 +1,6 @@
 import { CamelComponentDefaultService } from './camel-component-default.service';
 import { DefinedComponent } from '../../../camel-catalog-index';
-import { DoCatch } from '@kaoto/camel-catalog/types';
+import { DoCatch, OnFallback } from '@kaoto/camel-catalog/types';
 
 describe('CamelComponentDefaultService', () => {
   describe('getDefaultNodeDefinitionValue', () => {
@@ -148,6 +148,16 @@ describe('CamelComponentDefaultService', () => {
       expect((filterDefault.filter!.id as string).startsWith('filter-')).toBeTruthy();
       expect((filterDefault.filter!.expression as any).simple).toEqual({});
       expect(filterDefault.filter!.steps).toBeUndefined();
+    });
+
+    it('should return the default value for a onFallback', () => {
+      const onFallbackDef = CamelComponentDefaultService.getDefaultNodeDefinitionValue({
+        type: 'processor',
+        name: 'onFallback',
+      } as DefinedComponent) as OnFallback;
+      expect(onFallbackDef).toBeDefined();
+      expect((onFallbackDef.id as string).startsWith('onFallback-')).toBeTruthy();
+      expect(onFallbackDef.steps).toHaveLength(1);
     });
 
     it('should return the default value for a removeHeaders processor', () => {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -90,6 +90,15 @@ export class CamelComponentDefaultService {
                 message: "\${body}"
         `);
 
+      case 'onFallback' as keyof ProcessorDefinition:
+        return parse(`
+        id: ${getCamelRandomId('onFallback')}
+        steps:
+          - log:
+              id: ${getCamelRandomId('log')}
+              message: "\${body}"
+      `);
+
       case 'choice':
         return parse(`
         choice:
@@ -118,9 +127,9 @@ export class CamelComponentDefaultService {
           simple:
             expression: "\${header.foo} == 1"
         steps:
-        - log:
-            id: ${getCamelRandomId('log')}
-            message: "\${body}"
+          - log:
+              id: ${getCamelRandomId('log')}
+              message: "\${body}"
       `);
 
       case 'doTry':


### PR DESCRIPTION
### Context
When adding a `onFallback` property in the `circuitBreaker` EIP, it's nested one additional level, making the route fail.

### Changes
This commit adds a default value for `onFallback` to fix this issue.

fix: https://github.com/KaotoIO/kaoto/issues/2119