### PR TITLE
fix(Toolbar): Fix nested `<Button>` in `<Button>`

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.scss
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.scss
@@ -1,8 +1,3 @@
-.flows-list-btn {
-  padding-bottom: 0;
-  padding-top: 0;
-}
-
 .flows-menu {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
@@ -43,7 +43,7 @@ describe('FlowsMenu.tsx', () => {
       </Provider>,
     );
 
-    const dropdown = await wrapper.findByTestId('flows-list-btn');
+    const dropdown = await wrapper.findByTestId('flows-list-dropdown');
 
     /** Open List */
     act(() => {
@@ -65,7 +65,7 @@ describe('FlowsMenu.tsx', () => {
       </Provider>,
     );
 
-    const dropdown = await wrapper.findByTestId('flows-list-btn');
+    const dropdown = await wrapper.findByTestId('flows-list-dropdown');
 
     /** Open List */
     act(() => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
@@ -1,4 +1,4 @@
-import { Badge, Icon, MenuToggle, MenuToggleAction, MenuToggleElement, Select } from '@patternfly/react-core';
+import { Badge, Icon, MenuToggle, MenuToggleElement, Select } from '@patternfly/react-core';
 import { ListIcon } from '@patternfly/react-icons';
 import { FunctionComponent, Ref, useCallback, useContext, useState } from 'react';
 import { getVisibleFlowsInformation } from '../../../../models/visualization/flows/support/flows-visibility';
@@ -22,35 +22,30 @@ export const FlowsMenu: FunctionComponent = () => {
   };
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle data-testid="flows-list-dropdown" ref={toggleRef} onClick={onToggleClick} isFullWidth>
-      <MenuToggleAction
-        id="flows-list-btn"
-        key="flows-list-btn"
-        data-testid="flows-list-btn"
-        aria-label="flows list"
-        onClick={onToggleClick}
-        className="flows-list-btn"
+    <MenuToggle
+      isFullWidth
+      data-testid="flows-list-dropdown"
+      className="flows-menu"
+      ref={toggleRef}
+      onClick={onToggleClick}
+    >
+      <Icon isInline>
+        <ListIcon />
+      </Icon>
+      <span
+        title={singleFlowId ?? 'Routes'}
+        data-testid="flows-list-route-id"
+        className="pf-v6-u-m-sm flows-menu-display"
       >
-        <div className="flows-menu">
-          <Icon isInline>
-            <ListIcon />
-          </Icon>
-          <span
-            title={singleFlowId ?? 'Routes'}
-            data-testid="flows-list-route-id"
-            className="pf-v6-u-m-sm flows-menu-display"
-          >
-            {`${singleFlowId ?? 'Routes'}`}
-          </span>
-          <Badge
-            title={`Showing ${visibleFlowsCount} out of ${totalFlowsCount} flows`}
-            data-testid="flows-list-route-count"
-            isRead
-          >
-            {visibleFlowsCount}/{totalFlowsCount}
-          </Badge>
-        </div>
-      </MenuToggleAction>
+        {`${singleFlowId ?? 'Routes'}`}
+      </span>
+      <Badge
+        title={`Showing ${visibleFlowsCount} out of ${totalFlowsCount} flows`}
+        data-testid="flows-list-route-count"
+        isRead
+      >
+        {visibleFlowsCount}/{totalFlowsCount}
+      </Badge>
     </MenuToggle>
   );
 


### PR DESCRIPTION
### Context
After switching the Flows List toggle from a split button to a regular one, the original button is placed as a children of another one, which is not correct.

### Changes
This commit updates the markdown to avoid this situation.

fix: https://github.com/KaotoIO/kaoto/issues/2116