### PR TITLE
fix: (#2121) filter out undefined parameters when creating query string

### DIFF
--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -169,6 +169,12 @@ describe('CamelUriHelper', () => {
       {
         uri: 'timer',
         syntax: 'timer:timerName',
+        parameters: { timerName: undefined },
+        result: 'timer',
+      },
+      {
+        uri: 'timer',
+        syntax: 'timer:timerName',
         parameters: null,
         result: 'timer',
       },

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -63,10 +63,16 @@ export class CamelUriHelper {
   }
 
   private static createQueryString(parameters: ParsedParameters): string {
+    if (!parameters || Object.keys(parameters).length === 0) {
+      return '';
+    }
+
     return Object.keys(parameters)
+      .filter((key) => parameters[key] !== undefined)
       .map((key) => `${key}=${encodeURIComponent(parameters[key].toString())}`)
       .join('&');
   }
+
   static getUriStringFromParameters(
     originalUri: string,
     uriSyntax: string,


### PR DESCRIPTION
fix: #2121 