### PR TITLE
fix(VSCode): Avoid returning async function in useEffect

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoBridge.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoBridge.tsx
@@ -211,7 +211,9 @@ export const KaotoBridge = forwardRef<EditorApi, PropsWithChildren<KaotoBridgePr
     });
 
     /** Set editor as Ready */
-    useEffect(onReady, [onReady]);
+    useEffect(() => {
+      onReady();
+    }, [onReady]);
 
     return (
       <ReloadProvider>

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -96,7 +96,7 @@ export class KaotoEditorApp implements Editor {
   async sendReady(): Promise<void> {
     this.envelopeContext.channelApi.notifications.kogitoEditor_ready.send();
 
-    return this.setContent(this.pendingPath, this.pendingContent);
+    await this.setContent(this.pendingPath, this.pendingContent);
   }
 
   async sendNewEdit(content: string): Promise<void> {


### PR DESCRIPTION
### Context
Switching the runtime in VS Code Kaoto, lead to an empty page.

The problem was the following `onReady` callback, switching from `() => void` to `() => Promise<void>`

```tsx
    useEffect(onReady, [onReady]);
```

`useEffect` expects a function to return `void ` or another function for cleanup purposes. Originally, the `onReady` callback was a function returning `void`, but with the addition of `XML` support, it was mutated to be an `async` function.

Here's the change: https://github.com/KaotoIO/kaoto/pull/2009/commits/879578d51e5a839447a1198cb6c969aaefd82685#diff-20b60620c7e3be7c2a4671ed42d59c6c7e5340e43993d6b0cc77e27fb9e86d64R97-R100

The fix is to call the `onReady` function isolated, so the `useEffect` doesn't receive an async function.

```tsx
    useEffect(() => {
      onReady();
    }, [onReady]);
```

This problem wasn't noticed in the web version due to the React mismatch between React 18 (Web) and React 17 (Multiplying Architecture)

fix: https://github.com/KaotoIO/kaoto/issues/2115
fix: https://github.com/KaotoIO/kaoto/issues/2126