### PR TITLE
feat: Add Raw wrapper for string and password inputs

### DIFF
--- a/packages/ui-tests/cypress/e2e/xmlSupport/basicXml.cy.ts
+++ b/packages/ui-tests/cypress/e2e/xmlSupport/basicXml.cy.ts
@@ -111,6 +111,7 @@ describe('Tests for basic XML operations', () => {
     cy.openStepConfigurationTab('timer');
     cy.selectFormTab('All');
 
+    cy.get('[data-testid="#.parameters.timerName__field-actions"]').click();
     cy.get('[data-testid="#.parameters.timerName__clear"]').click();
 
     cy.openSourceCode();

--- a/packages/ui/src/components/MetadataEditor/__snapshots__/MetadataEditor.test.tsx.snap
+++ b/packages/ui/src/components/MetadataEditor/__snapshots__/MetadataEditor.test.tsx.snap
@@ -275,18 +275,17 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         class="pf-v6-c-text-input-group__utilities"
                       >
                         <button
-                          aria-disabled="false"
-                          aria-label="Clear name field"
-                          class="pf-v6-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                          data-ouia-component-type="PF6/Button"
+                          aria-expanded="false"
+                          aria-label="#.name__field-actions"
+                          class="pf-v6-c-menu-toggle pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+                          data-ouia-component-type="PF6/MenuToggle"
                           data-ouia-safe="true"
-                          data-testid="#.name__clear"
-                          title="Clear name field"
+                          data-testid="#.name__field-actions"
                           type="button"
                         >
                           <span
-                            class="pf-v6-c-button__icon"
+                            class="pf-v6-c-menu-toggle__icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -294,11 +293,11 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                               fill="currentColor"
                               height="1em"
                               role="img"
-                              viewBox="0 0 352 512"
+                              viewBox="0 0 192 512"
                               width="1em"
                             >
                               <path
-                                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                               />
                             </svg>
                           </span>
@@ -342,7 +341,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                           aria-disabled="false"
                           aria-label="More info for type field"
                           class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           role="button"
@@ -399,18 +398,17 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         class="pf-v6-c-text-input-group__utilities"
                       >
                         <button
-                          aria-disabled="false"
-                          aria-label="Clear type field"
-                          class="pf-v6-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                          data-ouia-component-type="PF6/Button"
+                          aria-expanded="false"
+                          aria-label="#.type__field-actions"
+                          class="pf-v6-c-menu-toggle pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-MenuToggle-plain-2"
+                          data-ouia-component-type="PF6/MenuToggle"
                           data-ouia-safe="true"
-                          data-testid="#.type__clear"
-                          title="Clear type field"
+                          data-testid="#.type__field-actions"
                           type="button"
                         >
                           <span
-                            class="pf-v6-c-button__icon"
+                            class="pf-v6-c-menu-toggle__icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -418,11 +416,11 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                               fill="currentColor"
                               height="1em"
                               role="img"
-                              viewBox="0 0 352 512"
+                              viewBox="0 0 192 512"
                               width="1em"
                             >
                               <path
-                                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                               />
                             </svg>
                           </span>
@@ -466,7 +464,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                           aria-disabled="false"
                           aria-label="More info for [object Object] field"
                           class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           role="button"
@@ -517,7 +515,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                           aria-disabled="false"
                           aria-label="Add a new property"
                           class="pf-v6-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           data-testid="#.properties__add"
@@ -901,18 +899,17 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       class="pf-v6-c-text-input-group__utilities"
                     >
                       <button
-                        aria-disabled="false"
-                        aria-label="Clear name field"
-                        class="pf-v6-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                        data-ouia-component-type="PF6/Button"
+                        aria-expanded="false"
+                        aria-label="#.name__field-actions"
+                        class="pf-v6-c-menu-toggle pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+                        data-ouia-component-type="PF6/MenuToggle"
                         data-ouia-safe="true"
-                        data-testid="#.name__clear"
-                        title="Clear name field"
+                        data-testid="#.name__field-actions"
                         type="button"
                       >
                         <span
-                          class="pf-v6-c-button__icon"
+                          class="pf-v6-c-menu-toggle__icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -920,11 +917,11 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 352 512"
+                            viewBox="0 0 192 512"
                             width="1em"
                           >
                             <path
-                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                             />
                           </svg>
                         </span>
@@ -968,7 +965,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         aria-disabled="false"
                         aria-label="More info for type field"
                         class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         role="button"
@@ -1025,18 +1022,17 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       class="pf-v6-c-text-input-group__utilities"
                     >
                       <button
-                        aria-disabled="false"
-                        aria-label="Clear type field"
-                        class="pf-v6-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                        data-ouia-component-type="PF6/Button"
+                        aria-expanded="false"
+                        aria-label="#.type__field-actions"
+                        class="pf-v6-c-menu-toggle pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-MenuToggle-plain-2"
+                        data-ouia-component-type="PF6/MenuToggle"
                         data-ouia-safe="true"
-                        data-testid="#.type__clear"
-                        title="Clear type field"
+                        data-testid="#.type__field-actions"
                         type="button"
                       >
                         <span
-                          class="pf-v6-c-button__icon"
+                          class="pf-v6-c-menu-toggle__icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -1044,11 +1040,11 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 352 512"
+                            viewBox="0 0 192 512"
                             width="1em"
                           >
                             <path
-                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                             />
                           </svg>
                         </span>
@@ -1092,7 +1088,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         aria-disabled="false"
                         aria-label="More info for [object Object] field"
                         class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         role="button"
@@ -1143,7 +1139,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         aria-disabled="false"
                         aria-label="Add a new property"
                         class="pf-v6-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         data-testid="#.properties__add"

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -91,18 +91,17 @@ exports[`SettingsForm should render 1`] = `
           class="pf-v6-c-text-input-group__utilities"
         >
           <button
-            aria-disabled="false"
-            aria-label="Clear catalogUrl field"
-            class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
-            data-ouia-component-type="PF6/Button"
+            aria-expanded="false"
+            aria-label="#.catalogUrl__field-actions"
+            class="pf-v6-c-menu-toggle pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+            data-ouia-component-type="PF6/MenuToggle"
             data-ouia-safe="true"
-            data-testid="#.catalogUrl__clear"
-            title="Clear catalogUrl field"
+            data-testid="#.catalogUrl__field-actions"
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon"
+              class="pf-v6-c-menu-toggle__icon"
             >
               <svg
                 aria-hidden="true"
@@ -110,11 +109,11 @@ exports[`SettingsForm should render 1`] = `
                 fill="currentColor"
                 height="1em"
                 role="img"
-                viewBox="0 0 352 512"
+                viewBox="0 0 192 512"
                 width="1em"
               >
                 <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                 />
               </svg>
             </span>
@@ -151,7 +150,7 @@ exports[`SettingsForm should render 1`] = `
             aria-disabled="false"
             aria-label="More info for Node label to display in canvas field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-3"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -214,7 +213,7 @@ exports[`SettingsForm should render 1`] = `
               aria-disabled="false"
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeLabel__clear"
@@ -303,7 +302,7 @@ exports[`SettingsForm should render 1`] = `
             aria-disabled="false"
             aria-label="More info for Open Node toolbar field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
+            data-ouia-component-id="OUIA-Generated-Button-plain-4"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -366,7 +365,7 @@ exports[`SettingsForm should render 1`] = `
               aria-disabled="false"
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeToolbarTrigger__clear"
@@ -445,7 +444,7 @@ exports[`SettingsForm should render 1`] = `
           aria-disabled="false"
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-7"
+          data-ouia-component-id="OUIA-Generated-Button-plain-6"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.experimentalFeatures__remove"
@@ -489,7 +488,7 @@ exports[`SettingsForm should render 1`] = `
                 aria-disabled="false"
                 aria-label="More info for Experimental features field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                data-ouia-component-id="OUIA-Generated-Button-plain-7"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -551,7 +550,7 @@ exports[`SettingsForm should render 1`] = `
                 aria-disabled="false"
                 aria-label="More info for Enable Drag & Drop field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                data-ouia-component-id="OUIA-Generated-Button-plain-8"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"

--- a/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
@@ -261,18 +261,17 @@ exports[`CanvasForm should render 1`] = `
                 class="pf-v6-c-text-input-group__utilities"
               >
                 <button
-                  aria-disabled="false"
-                  aria-label="Clear message field"
-                  class="pf-v6-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                  data-ouia-component-type="PF6/Button"
+                  aria-expanded="false"
+                  aria-label="#.message__field-actions"
+                  class="pf-v6-c-menu-toggle pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+                  data-ouia-component-type="PF6/MenuToggle"
                   data-ouia-safe="true"
-                  data-testid="#.message__clear"
-                  title="Clear message field"
+                  data-testid="#.message__field-actions"
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon"
+                    class="pf-v6-c-menu-toggle__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -280,11 +279,11 @@ exports[`CanvasForm should render 1`] = `
                       fill="currentColor"
                       height="1em"
                       role="img"
-                      viewBox="0 0 352 512"
+                      viewBox="0 0 192 512"
                       width="1em"
                     >
                       <path
-                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                        d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                       />
                     </svg>
                   </span>
@@ -411,7 +410,7 @@ exports[`CanvasForm should render nothing if no schema and no definition is avai
             <button
               aria-disabled="false"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"
@@ -671,7 +670,7 @@ exports[`CanvasForm should render nothing if no schema is available 1`] = `
             <button
               aria-disabled="false"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/__snapshots__/KaotoForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/__snapshots__/KaotoForm.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`KaotoForm should validate the model 1`] = `
               aria-disabled="false"
               aria-label="More info for Name field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -121,18 +121,17 @@ exports[`KaotoForm should validate the model 1`] = `
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear name field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-12"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.name__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-6"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.name__clear"
-              title="Clear name field"
+              data-testid="#.name__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -140,11 +139,11 @@ exports[`KaotoForm should validate the model 1`] = `
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/ArrayField/ArrayField.test.tsx
@@ -57,8 +57,11 @@ describe('ArrayField', () => {
       );
     });
 
-    const removeButtons = await wrapper!.findAllByRole('button', { name: /remove/i });
-    fireEvent.click(removeButtons[0]);
+    const fieldActions = wrapper!.getByTestId(`#.0__field-actions`);
+    fireEvent.click(fieldActions);
+
+    const clearButton = await wrapper!.findByRole('menuitem', { name: /remove/i });
+    fireEvent.click(clearButton);
 
     expect(onChange).toHaveBeenCalledWith(ROOT_PATH, ['item2']);
   });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/BeanField.test.tsx
@@ -183,10 +183,11 @@ describe('BeanField', () => {
     it('should not allow to create a bean without a type', async () => {
       await createBean('myNewBean');
 
-      const clearTypeField = screen.getByRole('button', { name: /clear type field/i });
-      await act(async () => {
-        fireEvent.click(clearTypeField);
-      });
+      const fieldActions = screen.getByTestId(`#.type__field-actions`);
+      fireEvent.click(fieldActions);
+
+      const clearButton = await screen.findByRole('menuitem', { name: /Clear type field/i });
+      fireEvent.click(clearButton);
 
       const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
       await act(async () => {

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
@@ -1,21 +1,17 @@
-import { Children, FunctionComponent, isValidElement, ReactElement, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
-
-function isDropdownItem(element: React.ReactNode): element is ReactElement<typeof DropdownItem> {
-  return (
-    isValidElement(element) &&
-    (element.type === DropdownItem || (typeof element.type === 'object' && element.type === 'DropdownItem'))
-  );
-}
+import { EllipsisVIcon, PortIcon, TimesIcon } from '@patternfly/react-icons';
+import { useFieldValue } from '../hooks/field-value';
 
 export interface FieldActionsProps {
-  children: ReactElement<typeof DropdownItem> | ReactElement<typeof DropdownItem>[];
-  dataTestId?: string;
+  propName: string;
+  clearAriaLabel: string;
+  onRemove: () => void;
 }
 
-export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children, dataTestId }) => {
+export const FieldActions: FunctionComponent<FieldActionsProps> = ({ propName, clearAriaLabel, onRemove }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const { value, wrapValueWithRaw } = useFieldValue(propName);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -25,12 +21,6 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children, d
     setIsOpen(false);
   };
 
-  // Validate that all children are DropdownItem components
-  const validChildren = Children.toArray(children).every(isDropdownItem);
-  if (!validChildren) {
-    console.warn('FieldActions: All children must be DropdownItem components');
-  }
-
   return (
     <Dropdown
       isOpen={isOpen}
@@ -39,8 +29,8 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children, d
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
-          data-testid={dataTestId ?? 'field-actions'}
-          aria-label={dataTestId ?? 'field-actions'}
+          data-testid={`${propName}__field-actions`}
+          aria-label={`${propName}__field-actions`}
           variant="plain"
           onClick={onToggleClick}
           isExpanded={isOpen}
@@ -49,7 +39,25 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children, d
       )}
       shouldFocusToggleOnSelect
     >
-      <DropdownList>{children}</DropdownList>
+      <DropdownList>
+        <DropdownItem
+          onClick={onRemove}
+          data-testid={`${propName}__clear`}
+          aria-label={clearAriaLabel}
+          title={clearAriaLabel}
+          icon={<TimesIcon />}
+        >
+          Clear
+        </DropdownItem>
+        <DropdownItem
+          onClick={wrapValueWithRaw}
+          data-testid={`${propName}__toRaw`}
+          disabled={value === ''}
+          icon={<PortIcon />}
+        >
+          Raw
+        </DropdownItem>
+      </DropdownList>
     </Dropdown>
   );
 };

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
@@ -11,9 +11,10 @@ function isDropdownItem(element: React.ReactNode): element is ReactElement<typeo
 
 export interface FieldActionsProps {
   children: ReactElement<typeof DropdownItem> | ReactElement<typeof DropdownItem>[];
+  dataTestId?: string;
 }
 
-export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children }) => {
+export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children, dataTestId }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const onToggleClick = () => {
@@ -38,7 +39,8 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children })
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
-          aria-label="kebab dropdown toggle"
+          data-testid={dataTestId ?? 'field-actions'}
+          aria-label={dataTestId ?? 'field-actions'}
           variant="plain"
           onClick={onToggleClick}
           isExpanded={isOpen}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
@@ -1,0 +1,53 @@
+import { Children, FunctionComponent, isValidElement, ReactElement, useState } from 'react';
+import { Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
+
+function isDropdownItem(element: React.ReactNode): element is ReactElement<typeof DropdownItem> {
+  return (
+    isValidElement(element) &&
+    (element.type === DropdownItem || (typeof element.type === 'object' && element.type === 'DropdownItem'))
+  );
+}
+
+export interface FieldActionsProps {
+  children: ReactElement<typeof DropdownItem> | ReactElement<typeof DropdownItem>[];
+}
+
+export const FieldActions: FunctionComponent<FieldActionsProps> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, _value: string | number | undefined) => {
+    setIsOpen(false);
+  };
+
+  // Validate that all children are DropdownItem components
+  const validChildren = Children.toArray(children).every(isDropdownItem);
+  if (!validChildren) {
+    console.warn('FieldActions: All children must be DropdownItem components');
+  }
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onSelect={onSelect}
+      onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          aria-label="kebab dropdown toggle"
+          variant="plain"
+          onClick={onToggleClick}
+          isExpanded={isOpen}
+          icon={<EllipsisVIcon />}
+        />
+      )}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>{children}</DropdownList>
+    </Dropdown>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.test.tsx
@@ -50,4 +50,24 @@ describe('FieldWrapper', () => {
 
     expect(wrapper.getByText('error message')).toBeInTheDocument();
   });
+
+  it('displays raw badge when isRaw is true', () => {
+    const wrapper = render(
+      <FieldWrapper {...defaultProps} isRaw>
+        Test Children
+      </FieldWrapper>,
+    );
+
+    expect(wrapper.getByText('raw')).toBeInTheDocument();
+  });
+
+  it('does not display raw badge when isRaw is false', () => {
+    const wrapper = render(
+      <FieldWrapper {...defaultProps} isRaw={false}>
+        Test Children
+      </FieldWrapper>,
+    );
+
+    expect(wrapper.queryByText('raw')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldWrapper.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   FormGroup,
   FormGroupLabelHelp,
   FormHelperText,
@@ -18,6 +19,7 @@ interface FieldWrapperProps extends FieldProps {
   defaultValue?: string;
   errors?: string[];
   isRow?: boolean;
+  isRaw?: boolean;
 }
 
 export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps>> = ({
@@ -30,6 +32,7 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
   errors,
   isRow = false,
   children,
+  isRaw = false,
 }) => {
   const id = `${propName}-popover`;
   const label = title ?? propName.split('.').pop();
@@ -42,6 +45,7 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
         fieldId={propName}
         label={label}
         isRequired={required}
+        labelInfo={isRaw && <Badge isRead>raw</Badge>}
         labelHelp={
           <Popover
             id={id}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
@@ -46,7 +46,7 @@ describe('PasswordField', () => {
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'New Value');
   });
 
-  it('should clear the input when using the clear button', () => {
+  it('should clear the input when using the clear button', async () => {
     const onPropertyChangeSpy = jest.fn();
 
     const wrapper = render(
@@ -55,10 +55,11 @@ describe('PasswordField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = wrapper.getByTestId(`${ROOT_PATH}__clear`);
-    act(() => {
-      fireEvent.click(clearButton);
-    });
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    fireEvent.click(fieldActions);
+
+    const clearButton = await wrapper.findByRole('menuitem', { name: /clear/i });
+    fireEvent.click(clearButton);
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
@@ -56,10 +56,14 @@ describe('PasswordField', () => {
     );
 
     const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
-    fireEvent.click(fieldActions);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
 
     const clearButton = await wrapper.findByRole('menuitem', { name: /clear/i });
-    fireEvent.click(clearButton);
+    act(() => {
+      fireEvent.click(clearButton);
+    });
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
@@ -92,5 +96,51 @@ describe('PasswordField', () => {
     const input = wrapper.getByRole('textbox');
 
     expect(input.getAttribute('type')).toBe('text');
+  });
+
+  it('wraps value with RAW when Raw button is clicked', async () => {
+    const onPropertyChangeSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="SecretPassword" onPropertyChange={onPropertyChangeSpy}>
+        <PasswordField propName={ROOT_PATH} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const rawItem = await wrapper.findByRole('menuitem', { name: /raw/i });
+    act(() => {
+      fireEvent.click(rawItem);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'RAW(SecretPassword)');
+  });
+
+  it('unwraps value from RAW when already wrapped', async () => {
+    const onPropertyChangeSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="RAW(SecretPassword)" onPropertyChange={onPropertyChangeSpy}>
+        <PasswordField propName={ROOT_PATH} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const rawItem = await wrapper.findByRole('menuitem', { name: /raw/i });
+    act(() => {
+      fireEvent.click(rawItem);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'SecretPassword');
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
@@ -70,7 +70,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
           >
             {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
           </Button>
-          <FieldActions>
+          <FieldActions dataTestId={`${propName}__field-actions`}>
             <DropdownItem
               onClick={onRemove}
               key={propName + '-dropdown-remove'}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
@@ -6,7 +6,7 @@ import {
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon, PortIcon, TimesIcon } from '@patternfly/react-icons';
-import { FunctionComponent, useContext, useEffect, useState } from 'react';
+import { FunctionComponent, useContext, useState } from 'react';
 import { isDefined } from '../../../../../utils';
 import { useFieldValue } from '../hooks/field-value';
 import { SchemaContext } from '../providers/SchemaProvider';
@@ -17,19 +17,13 @@ import { FieldActions } from './FieldActions';
 export const PasswordField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
   const [passwordHidden, setPasswordHidden] = useState<boolean>(true);
-  const { value = '', onChange } = useFieldValue<string>(propName);
+  const { value = '', onChange, isRaw, wrapValueWithRaw } = useFieldValue<string>(propName);
   const lastPropName = propName.split('.').pop();
   const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
-  const [isRaw, setIsRaw] = useState(false);
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
   };
-
-  useEffect(() => {
-    const match = value?.match(/^RAW\((.*)\)$/);
-    setIsRaw(!!match);
-  }, [value]);
 
   const onRemove = () => {
     if (isDefined(onRemoveProps)) {
@@ -38,17 +32,6 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     }
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
-  };
-
-  const wrapValueWithRaw = () => {
-    if (!isRaw) {
-      onChange(`RAW(${value})`);
-      setIsRaw(true);
-    } else {
-      const match = value?.match(/^RAW\((.*)\)$/);
-      onChange(match ? match[1] : (value ?? ''));
-      setIsRaw(false);
-    }
   };
 
   const id = `${propName}-popover`;

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  DropdownItem,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-} from '@patternfly/react-core';
-import { EyeIcon, EyeSlashIcon, PortIcon, TimesIcon } from '@patternfly/react-icons';
+import { Button, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useContext, useState } from 'react';
 import { isDefined } from '../../../../../utils';
 import { useFieldValue } from '../hooks/field-value';
@@ -17,7 +11,7 @@ import { FieldActions } from './FieldActions';
 export const PasswordField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
   const [passwordHidden, setPasswordHidden] = useState<boolean>(true);
-  const { value = '', onChange, isRaw, wrapValueWithRaw } = useFieldValue<string>(propName);
+  const { value = '', onChange, isRaw } = useFieldValue<string>(propName);
   const lastPropName = propName.split('.').pop();
   const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
 
@@ -70,27 +64,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
           >
             {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
           </Button>
-          <FieldActions dataTestId={`${propName}__field-actions`}>
-            <DropdownItem
-              onClick={onRemove}
-              key={propName + '-dropdown-remove'}
-              data-testid={`${propName}__clear`}
-              aria-label={ariaLabel}
-              title={ariaLabel}
-              icon={<TimesIcon />}
-            >
-              Clear
-            </DropdownItem>
-            <DropdownItem
-              value={0}
-              key={propName + 'dropdown-toRaw'}
-              onClick={() => wrapValueWithRaw()}
-              disabled={value === ''}
-              icon={<PortIcon />}
-            >
-              Raw
-            </DropdownItem>
-          </FieldActions>
+          <FieldActions propName={propName} clearAriaLabel={ariaLabel} onRemove={onRemove} />
         </TextInputGroupUtilities>
       </TextInputGroup>
     </FieldWrapper>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
@@ -81,4 +81,50 @@ describe('StringField', () => {
     const errorMessage = wrapper.getByText('error message');
     expect(errorMessage).toBeInTheDocument();
   });
+
+  it('wraps value with RAW when Raw button is clicked', async () => {
+    const onPropertyChangeSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="Value" onPropertyChange={onPropertyChangeSpy}>
+        <StringField propName={ROOT_PATH} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const clearButton = await wrapper.findByRole('menuitem', { name: /raw/i });
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'RAW(Value)');
+  });
+
+  it('unwraps value from RAW when already wrapped', async () => {
+    const onPropertyChangeSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="RAW(Test Value)" onPropertyChange={onPropertyChangeSpy}>
+        <StringField propName={ROOT_PATH} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const raw = await wrapper.findByRole('menuitem', { name: /raw/i });
+    act(() => {
+      fireEvent.click(raw);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'Test Value');
+  });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
@@ -46,7 +46,7 @@ describe('StringField', () => {
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'New Value');
   });
 
-  it('should clear the input when using the clear button', () => {
+  it('should clear the input when using the clear button', async () => {
     const onPropertyChangeSpy = jest.fn();
 
     const wrapper = render(
@@ -55,10 +55,11 @@ describe('StringField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = wrapper.getByTestId(`${ROOT_PATH}__clear`);
-    act(() => {
-      fireEvent.click(clearButton);
-    });
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    fireEvent.click(fieldActions);
+
+    const clearButton = await wrapper.findByRole('menuitem', { name: /clear/i });
+    fireEvent.click(clearButton);
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
@@ -56,10 +56,14 @@ describe('StringField', () => {
     );
 
     const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
-    fireEvent.click(fieldActions);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
 
     const clearButton = await wrapper.findByRole('menuitem', { name: /clear/i });
-    fireEvent.click(clearButton);
+    act(() => {
+      fireEvent.click(clearButton);
+    });
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
@@ -56,7 +56,7 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
         />
 
         <TextInputGroupUtilities>
-          <FieldActions>
+          <FieldActions dataTestId={`${propName}__field-actions`}>
             <DropdownItem
               onClick={onRemove}
               key={propName + '-dropdown-remove'}

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
@@ -1,5 +1,4 @@
-import { DropdownItem, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
-import { PortIcon, TimesIcon } from '@patternfly/react-icons';
+import { TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
 import { FunctionComponent, useContext } from 'react';
 import { isDefined } from '../../../../../utils';
 import { useFieldValue } from '../hooks/field-value';
@@ -10,7 +9,7 @@ import { FieldActions } from './FieldActions';
 
 export const StringField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
- const { value = '', errors, onChange, isRaw, wrapValueWithRaw, disabled } = useFieldValue<string>(propName);
+  const { value = '', errors, onChange, isRaw, disabled } = useFieldValue<string>(propName);
   const lastPropName = propName.split('.').pop();
   const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
 
@@ -56,27 +55,7 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
         />
 
         <TextInputGroupUtilities>
-          <FieldActions dataTestId={`${propName}__field-actions`}>
-            <DropdownItem
-              onClick={onRemove}
-              key={propName + '-dropdown-remove'}
-              data-testid={`${propName}__clear`}
-              aria-label={ariaLabel}
-              title={ariaLabel}
-              icon={<TimesIcon />}
-            >
-              Clear
-            </DropdownItem>
-            <DropdownItem
-              value={0}
-              key={propName + '-dropdown-toRaw'}
-              onClick={() => wrapValueWithRaw()}
-              disabled={value === ''}
-              icon={<PortIcon />}
-            >
-              Raw
-            </DropdownItem>
-          </FieldActions>
+          <FieldActions propName={propName} clearAriaLabel={ariaLabel} onRemove={onRemove} />
         </TextInputGroupUtilities>
       </TextInputGroup>
     </FieldWrapper>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
@@ -1,6 +1,6 @@
 import { DropdownItem, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
 import { PortIcon, TimesIcon } from '@patternfly/react-icons';
-import { FunctionComponent, useContext, useEffect, useState } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import { isDefined } from '../../../../../utils';
 import { useFieldValue } from '../hooks/field-value';
 import { SchemaContext } from '../providers/SchemaProvider';
@@ -10,15 +10,9 @@ import { FieldActions } from './FieldActions';
 
 export const StringField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
-  const [isRaw, setIsRaw] = useState(false);
-  const { value = '', errors, onChange, disabled } = useFieldValue<string>(propName);
+ const { value = '', errors, onChange, isRaw, wrapValueWithRaw, disabled } = useFieldValue<string>(propName);
   const lastPropName = propName.split('.').pop();
   const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
-
-  useEffect(() => {
-    const match = value?.match(/^RAW\((.*)\)$/);
-    setIsRaw(!!match);
-  }, [value]);
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
@@ -32,16 +26,6 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
 
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
-  };
-  const wrapValueWithRaw = () => {
-    if (!isRaw) {
-      onChange(`RAW(${value})`);
-      setIsRaw(true);
-    } else {
-      const match = value?.match(/^RAW\((.*)\)$/);
-      onChange(match ? match[1] : (value ?? ''));
-      setIsRaw(false);
-    }
   };
 
   const id = `${propName}-popover`;

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.tsx
@@ -1,17 +1,24 @@
-import { Button, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
-import { FunctionComponent, useContext } from 'react';
+import { DropdownItem, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
+import { PortIcon, TimesIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import { isDefined } from '../../../../../utils';
 import { useFieldValue } from '../hooks/field-value';
 import { SchemaContext } from '../providers/SchemaProvider';
 import { FieldProps } from '../typings';
 import { FieldWrapper } from './FieldWrapper';
+import { FieldActions } from './FieldActions';
 
 export const StringField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
+  const [isRaw, setIsRaw] = useState(false);
   const { value = '', errors, onChange, disabled } = useFieldValue<string>(propName);
   const lastPropName = propName.split('.').pop();
   const ariaLabel = isDefined(onRemoveProps) ? 'Remove' : `Clear ${lastPropName} field`;
+
+  useEffect(() => {
+    const match = value?.match(/^RAW\((.*)\)$/);
+    setIsRaw(!!match);
+  }, [value]);
 
   const onFieldChange = (_event: unknown, value: string) => {
     onChange(value);
@@ -26,6 +33,16 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
     /** Clear field by removing its value */
     onChange(undefined as unknown as string);
   };
+  const wrapValueWithRaw = () => {
+    if (!isRaw) {
+      onChange(`RAW(${value})`);
+      setIsRaw(true);
+    } else {
+      const match = value?.match(/^RAW\((.*)\)$/);
+      onChange(match ? match[1] : (value ?? ''));
+      setIsRaw(false);
+    }
+  };
 
   const id = `${propName}-popover`;
 
@@ -38,6 +55,7 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
       description={schema.description}
       defaultValue={schema.default?.toString()}
       errors={errors}
+      isRaw={isRaw}
     >
       <TextInputGroup validated={errors ? 'error' : undefined} isDisabled={disabled}>
         <TextInputGroupMain
@@ -54,14 +72,27 @@ export const StringField: FunctionComponent<FieldProps> = ({ propName, required,
         />
 
         <TextInputGroupUtilities>
-          <Button
-            variant="plain"
-            data-testid={`${propName}__clear`}
-            onClick={onRemove}
-            aria-label={ariaLabel}
-            title={ariaLabel}
-            icon={<TimesIcon />}
-          />
+          <FieldActions>
+            <DropdownItem
+              onClick={onRemove}
+              key={propName + '-dropdown-remove'}
+              data-testid={`${propName}__clear`}
+              aria-label={ariaLabel}
+              title={ariaLabel}
+              icon={<TimesIcon />}
+            >
+              Clear
+            </DropdownItem>
+            <DropdownItem
+              value={0}
+              key={propName + '-dropdown-toRaw'}
+              onClick={() => wrapValueWithRaw()}
+              disabled={value === ''}
+              icon={<PortIcon />}
+            >
+              Raw
+            </DropdownItem>
+          </FieldActions>
         </TextInputGroupUtilities>
       </TextInputGroup>
     </FieldWrapper>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/__snapshots__/PasswordField.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/__snapshots__/PasswordField.test.tsx.snap
@@ -114,18 +114,17 @@ exports[`PasswordField should render 1`] = `
             </span>
           </button>
           <button
-            aria-disabled="false"
-            aria-label="Clear # field"
-            class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-3"
-            data-ouia-component-type="PF6/Button"
+            aria-expanded="false"
+            aria-label="#__field-actions"
+            class="pf-v6-c-menu-toggle pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+            data-ouia-component-type="PF6/MenuToggle"
             data-ouia-safe="true"
-            data-testid="#__clear"
-            title="Clear # field"
+            data-testid="#__field-actions"
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon"
+              class="pf-v6-c-menu-toggle__icon"
             >
               <svg
                 aria-hidden="true"
@@ -133,11 +132,11 @@ exports[`PasswordField should render 1`] = `
                 fill="currentColor"
                 height="1em"
                 role="img"
-                viewBox="0 0 352 512"
+                viewBox="0 0 192 512"
                 width="1em"
               >
                 <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                 />
               </svg>
             </span>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/__snapshots__/StringField.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/__snapshots__/StringField.test.tsx.snap
@@ -86,18 +86,17 @@ exports[`StringField should render 1`] = `
           class="pf-v6-c-text-input-group__utilities"
         >
           <button
-            aria-disabled="false"
-            aria-label="Clear # field"
-            class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
-            data-ouia-component-type="PF6/Button"
+            aria-expanded="false"
+            aria-label="#__field-actions"
+            class="pf-v6-c-menu-toggle pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+            data-ouia-component-type="PF6/MenuToggle"
             data-ouia-safe="true"
-            data-testid="#__clear"
-            title="Clear # field"
+            data-testid="#__field-actions"
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon"
+              class="pf-v6-c-menu-toggle__icon"
             >
               <svg
                 aria-hidden="true"
@@ -105,11 +104,11 @@ exports[`StringField should render 1`] = `
                 fill="currentColor"
                 height="1em"
                 role="img"
-                viewBox="0 0 352 512"
+                viewBox="0 0 192 512"
                 width="1em"
               >
                 <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                 />
               </svg>
             </span>

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.test.tsx
@@ -41,4 +41,58 @@ describe('useFieldValue', () => {
     const { result } = renderHook(() => useFieldValue<string>('nonexistent'), { wrapper });
     expect(result.current.errors).toBeUndefined();
   });
+
+  it('wraps value with RAW when not already wrapped', () => {
+    const mockModel = { name: 'Test Name' };
+    const mockOnPropertyChange = jest.fn();
+    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
+        {children}
+      </ModelContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
+    act(() => {
+      result.current.wrapValueWithRaw();
+    });
+
+    expect(mockOnPropertyChange).toHaveBeenCalledWith('name', 'RAW(Test Name)');
+    expect(result.current.isRaw).toBe(true);
+  });
+
+  it('unwraps value from RAW when already wrapped', () => {
+    const mockModel = { name: 'RAW(Test Name)' };
+    const mockOnPropertyChange = jest.fn();
+    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
+        {children}
+      </ModelContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
+    act(() => {
+      result.current.wrapValueWithRaw();
+    });
+
+    expect(mockOnPropertyChange).toHaveBeenCalledWith('name', 'Test Name');
+    expect(result.current.isRaw).toBe(false);
+  });
+
+  it('does nothing if value is not a string', () => {
+    const mockModel = { name: 123 };
+    const mockOnPropertyChange = jest.fn();
+    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
+        {children}
+      </ModelContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldValue<number>('#.name'), { wrapper });
+    act(() => {
+      result.current.wrapValueWithRaw();
+    });
+
+    expect(mockOnPropertyChange).not.toHaveBeenCalled();
+    expect(result.current.isRaw).toBe(false);
+  });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
@@ -1,22 +1,44 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { safeGetValue } from '../../../../../utils';
 import { ModelContext } from '../providers/ModelProvider';
+
+function checkIfWrappedWithRaw(value: unknown): boolean {
+  if (!value || typeof value !== 'string') return false;
+  return value.startsWith('RAW(') && value.endsWith(')');
+}
 
 export const useFieldValue = <T = unknown>(propertyPath: string) => {
   const { model, errors, onPropertyChange, disabled } = useContext(ModelContext);
   const propertyName = propertyPath.replace('#.', '');
   const value = safeGetValue(model, propertyName) as T | undefined;
+  const [isRaw, setIsRaw] = useState(checkIfWrappedWithRaw(value));
 
   const propertyErrors = errors?.[propertyPath];
 
   const onChange = (value: T) => {
     onPropertyChange(propertyName, value);
+    setIsRaw(checkIfWrappedWithRaw(value));
+  };
+
+  const wrapValueWithRaw = () => {
+    if (typeof value !== 'string') return;
+
+    if (!isRaw) {
+      onChange(`RAW(${value})` as T);
+      setIsRaw(true);
+    } else {
+      const newValue = value.substring(4, value.length - 1);
+      onChange(newValue as T);
+      setIsRaw(false);
+    }
   };
 
   return {
     value,
     errors: propertyErrors,
     onChange,
+    wrapValueWithRaw,
+    isRaw,
     disabled,
   };
 };

--- a/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
+++ b/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
@@ -227,18 +227,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear creationTimestamp field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.creationTimestamp__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.creationTimestamp__clear"
-              title="Clear creationTimestamp field"
+              data-testid="#.creationTimestamp__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -246,11 +245,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -287,7 +286,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for deletionGracePeriodSeconds field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -343,18 +342,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear deletionGracePeriodSeconds field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.deletionGracePeriodSeconds__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-2"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.deletionGracePeriodSeconds__clear"
-              title="Clear deletionGracePeriodSeconds field"
+              data-testid="#.deletionGracePeriodSeconds__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -362,11 +360,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -403,7 +401,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for deletionTimestamp field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -459,18 +457,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear deletionTimestamp field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-8"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.deletionTimestamp__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-3"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.deletionTimestamp__clear"
-              title="Clear deletionTimestamp field"
+              data-testid="#.deletionTimestamp__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -478,11 +475,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -509,7 +506,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             aria-disabled="false"
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-9"
+            data-ouia-component-id="OUIA-Generated-Button-plain-6"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.finalizers__add"
@@ -553,7 +550,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   aria-disabled="false"
                   aria-label="More info for finalizers field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -612,7 +609,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for generateName field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -668,18 +665,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear generateName field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-12"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.generateName__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-4"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.generateName__clear"
-              title="Clear generateName field"
+              data-testid="#.generateName__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -687,11 +683,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -728,7 +724,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for generation field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-13"
+              data-ouia-component-id="OUIA-Generated-Button-plain-9"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -784,18 +780,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear generation field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-14"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.generation__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-5"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.generation__clear"
-              title="Clear generation field"
+              data-testid="#.generation__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -803,11 +798,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -851,7 +846,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for [object Object] field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-15"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -902,7 +897,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="Add a new property"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-16"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.labels__add"
@@ -956,7 +951,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             aria-disabled="false"
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-17"
+            data-ouia-component-id="OUIA-Generated-Button-plain-12"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.managedFields__add"
@@ -1000,7 +995,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   aria-disabled="false"
                   aria-label="More info for managedFields field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -1059,7 +1054,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for name field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-id="OUIA-Generated-Button-plain-14"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1115,18 +1110,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear name field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-20"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.name__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-6"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.name__clear"
-              title="Clear name field"
+              data-testid="#.name__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -1134,11 +1128,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -1175,7 +1169,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for namespace field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-21"
+              data-ouia-component-id="OUIA-Generated-Button-plain-15"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1231,18 +1225,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear namespace field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-22"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.namespace__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-7"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.namespace__clear"
-              title="Clear namespace field"
+              data-testid="#.namespace__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -1250,11 +1243,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -1281,7 +1274,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             aria-disabled="false"
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-23"
+            data-ouia-component-id="OUIA-Generated-Button-plain-16"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.ownerReferences__add"
@@ -1325,7 +1318,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   aria-disabled="false"
                   aria-label="More info for ownerReferences field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-17"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -1384,7 +1377,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for resourceVersion field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-25"
+              data-ouia-component-id="OUIA-Generated-Button-plain-18"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1440,18 +1433,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear resourceVersion field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-26"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.resourceVersion__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-8"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.resourceVersion__clear"
-              title="Clear resourceVersion field"
+              data-testid="#.resourceVersion__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -1459,11 +1451,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -1500,7 +1492,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for selfLink field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-27"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1556,18 +1548,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear selfLink field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-28"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.selfLink__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-9"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.selfLink__clear"
-              title="Clear selfLink field"
+              data-testid="#.selfLink__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -1575,11 +1566,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>
@@ -1616,7 +1607,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
               aria-disabled="false"
               aria-label="More info for uid field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-29"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1672,18 +1663,17 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
-              aria-disabled="false"
-              aria-label="Clear uid field"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-30"
-              data-ouia-component-type="PF6/Button"
+              aria-expanded="false"
+              aria-label="#.uid__field-actions"
+              class="pf-v6-c-menu-toggle pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-10"
+              data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
-              data-testid="#.uid__clear"
-              title="Clear uid field"
+              data-testid="#.uid__field-actions"
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-menu-toggle__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -1691,11 +1681,11 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                   fill="currentColor"
                   height="1em"
                   role="img"
-                  viewBox="0 0 352 512"
+                  viewBox="0 0 192 512"
                   width="1em"
                 >
                   <path
-                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                   />
                 </svg>
               </span>


### PR DESCRIPTION
This PR creates new drowdown menu for string/password inputs with  option to wrap the input value with `RAW(%s)` : 
<img width="527" alt="Screenshot 2025-03-31 at 18 25 18" src="https://github.com/user-attachments/assets/54d53ae7-04c7-4e68-8682-4a9f4e36882d" />

<img width="474" alt="Screenshot 2025-03-31 at 18 29 53" src="https://github.com/user-attachments/assets/7f71e1b8-51ff-4f03-ab8f-2e4838eef6b9" />

fixes: #1666