### PR TITLE
fix: reorder providers for catalog to be available for the entities provider

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -37,11 +37,11 @@ function App() {
     <ReloadProvider>
       <SettingsProvider adapter={settingsAdapter}>
         <SourceCodeProvider>
-          <EntitiesProvider>
-            <Shell>
-              <RuntimeProvider catalogUrl={catalogUrl}>
-                <SchemasLoaderProvider>
-                  <CatalogLoaderProvider>
+          <RuntimeProvider catalogUrl={catalogUrl}>
+            <SchemasLoaderProvider>
+              <CatalogLoaderProvider>
+                <EntitiesProvider>
+                  <Shell>
                     <CatalogTilesProvider>
                       <VisualizationProvider controller={controller}>
                         <VisibleFlowsProvider>
@@ -57,11 +57,11 @@ function App() {
                         </VisibleFlowsProvider>
                       </VisualizationProvider>
                     </CatalogTilesProvider>
-                  </CatalogLoaderProvider>
-                </SchemasLoaderProvider>
-              </RuntimeProvider>
-            </Shell>
-          </EntitiesProvider>
+                  </Shell>
+                </EntitiesProvider>
+              </CatalogLoaderProvider>
+            </SchemasLoaderProvider>
+          </RuntimeProvider>
         </SourceCodeProvider>
       </SettingsProvider>
     </ReloadProvider>


### PR DESCRIPTION
For properly parsing the XML catalog has to be available for the parser. Parsers are loaded in the entitiesContext so after initial load catalog was not available. This PR should fix that. 
fix: #2155 