### PR TITLE
fix(Route Image): Downgrade html-to-image to 1.11.11

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,7 +62,7 @@
     "ajv-formats": "^3.0.0",
     "chevrotain": "10.5.0",
     "clsx": "^2.1.0",
-    "html-to-image": "1.11.13",
+    "html-to-image": "1.11.11",
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "monaco-editor": "^0.50.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,7 +3053,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.35.2"
     eslint-plugin-react-hooks: "npm:5.1.0-rc-eb3ad065-20240822"
     globals: "npm:^15.9.0"
-    html-to-image: "npm:1.11.13"
+    html-to-image: "npm:1.11.11"
     jest: "npm:^29.7.0"
     jest-canvas-mock: "npm:^2.5.2"
     jest-environment-jsdom: "npm:^29.4.2"
@@ -11647,10 +11647,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-to-image@npm:1.11.13":
-  version: 1.11.13
-  resolution: "html-to-image@npm:1.11.13"
-  checksum: 10/f5950a0221b4ed4e59853db09917606309ebe3ddd2051c2f89aed3e37026d1893880f76e61bc2ca2280e3f1bbc0ad5b9ea5325188ff339987c8eeccbe8284f3f
+"html-to-image@npm:1.11.11":
+  version: 1.11.11
+  resolution: "html-to-image@npm:1.11.11"
+  checksum: 10/099206c3aaa54ca36d0df91426fe2b05258fe73c913dca6874dd8250973d47f629d3f45e427d5d51cc416ee305b898ce8db0a71336b3700a059ef1116b64d944
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes: #2162

html-to-image version 1.11.13 breaks the route image, as if it doesn't honor some or all of CSS. There're couple of issues reported on html-to-image repo for similar issues that CSS is not honored as expected. We would want to stay with 1.11.11 until the problem is addressed upstream.