### PR TITLE
fix: Stop making at least one route visible with useEffect

### DIFF
--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, PropsWithChildren, createContext, useContext, useEffect, useMemo, useReducer } from 'react';
+import { FunctionComponent, PropsWithChildren, createContext, useContext, useMemo, useReducer } from 'react';
 import {
   IVisibleFlows,
   VisibleFlowsReducer,
@@ -27,10 +27,6 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
   const visualFlowsApi = useMemo(() => {
     return new VisualFlowsApi(dispatch);
   }, [dispatch]);
-
-  useEffect(() => {
-    visualFlowsApi.initVisibleFlows(visualEntitiesIds);
-  }, [visualEntitiesIds, visualFlowsApi]);
 
   const value = useMemo(() => {
     return {


### PR DESCRIPTION
Fixes: #2136

This is triggered when the route ID is changed, and causes the flows shown in the canvas and the visibility states out of sync.

Verified it fixes the issue mentioned here - https://github.com/KaotoIO/kaoto/issues/2136#issuecomment-2773625025

https://github.com/user-attachments/assets/93ef7ed0-4162-4ccd-a7aa-3151ae18e27e

