### PR TITLE
feat(DataMapper): Support reading multiple mappings on a same collect…

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
@@ -3,6 +3,7 @@ import { useToggle } from '../../../hooks/useToggle';
 import { Dropdown, DropdownList, MenuToggle, ToolbarItem } from '@patternfly/react-core';
 import { ExportMappingFileDropdownItem } from './ExportMappingFileDropdownItem';
 import { ImportMappingFileDropdownItem } from './ImportMappingFileDropdownItem';
+import { ResetMappingsDropdownItem } from './ResetMappingsDropdownItem';
 
 export const MainMenuToolbarItem: FunctionComponent = () => {
   const { state: isOpen, toggle: onToggle, toggleOff } = useToggle(false);
@@ -20,6 +21,7 @@ export const MainMenuToolbarItem: FunctionComponent = () => {
         <DropdownList data-testid={'main-menu-dropdownlist'}>
           <ImportMappingFileDropdownItem onComplete={toggleOff} key={'import-mapping'} />
           <ExportMappingFileDropdownItem onComplete={toggleOff} key={'export-mapping'} />
+          <ResetMappingsDropdownItem onComplete={toggleOff} key={'reset-mappings'} />
         </DropdownList>
       </Dropdown>
     </ToolbarItem>

--- a/packages/ui/src/components/DataMapper/debug/ResetMappingsDropdownItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ResetMappingsDropdownItem.tsx
@@ -1,0 +1,23 @@
+import { DropdownItem } from '@patternfly/react-core';
+import { FunctionComponent, useCallback } from 'react';
+import { UndoIcon } from '@patternfly/react-icons';
+import { useDataMapper } from '../../../hooks/useDataMapper';
+
+type ResetMappingsDropdownItemProps = {
+  onComplete: () => void;
+};
+
+export const ResetMappingsDropdownItem: FunctionComponent<ResetMappingsDropdownItemProps> = ({ onComplete }) => {
+  const { resetMappingTree } = useDataMapper();
+
+  const onClick = useCallback(() => {
+    resetMappingTree();
+    onComplete();
+  }, [onComplete, resetMappingTree]);
+
+  return (
+    <DropdownItem icon={<UndoIcon />} onClick={onClick} data-testid="reset-mappings-button">
+      Reset Mappings
+    </DropdownItem>
+  );
+};

--- a/packages/ui/src/components/Document/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.tsx
@@ -1,7 +1,7 @@
 import { Label, Title, Truncate } from '@patternfly/react-core';
 import clsx from 'clsx';
 import { FunctionComponent } from 'react';
-import { MappingNodeData, NodeData } from '../../models/datamapper/visualization';
+import { FieldItemNodeData, MappingNodeData, NodeData } from '../../models/datamapper/visualization';
 import './Document.scss';
 
 interface INodeTitle {
@@ -11,7 +11,7 @@ interface INodeTitle {
 }
 
 export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, nodeData, isDocument }) => {
-  if (nodeData instanceof MappingNodeData) {
+  if (nodeData instanceof MappingNodeData && !(nodeData instanceof FieldItemNodeData)) {
     return (
       <Label>
         <Truncate content={nodeData.title ?? ''} className={clsx('truncate', className)} />

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -44,7 +44,8 @@ export class FieldItem extends MappingItem {
     public parent: MappingParentType,
     public field: IField,
   ) {
-    super(parent, 'field-' + field.name, field.id);
+    const name = 'field-' + field.name;
+    super(parent, name, getCamelRandomId(name, 4));
   }
   doClone() {
     return new FieldItem(this.parent, this.field);

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -97,6 +97,18 @@ export class MappingNodeData implements TargetNodeData {
   mappingTree: MappingTree;
 }
 
+export class FieldItemNodeData extends MappingNodeData {
+  constructor(
+    public parent: TargetNodeData,
+    public mapping: FieldItem,
+  ) {
+    super(parent, mapping);
+    this.title = mapping.field.name;
+    this.field = mapping.field;
+  }
+  public field: IField;
+}
+
 class SimpleNodePath extends NodePath {
   constructor(public path: string) {
     super();

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -1,5 +1,5 @@
 import { DataMapperProvider } from './datamapper.provider';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useDataMapper } from '../hooks/useDataMapper';
 import { FieldItem, MappingTree } from '../models/datamapper/mapping';
 import { useEffect } from 'react';
@@ -43,5 +43,34 @@ describe('DataMapperProvider', () => {
     expect(nextTree!).toBeDefined();
     expect(prevTree! !== nextTree!).toBeTruthy();
     expect(prevTree!.children[0] === nextTree!.children[0]).toBeTruthy();
+  });
+
+  it('resetMappingTree should reset the mappings', async () => {
+    let initialized = false;
+    let reset = false;
+    let tree: MappingTree;
+    const TestRefreshMappingTree = () => {
+      const { mappingTree, refreshMappingTree, resetMappingTree } = useDataMapper();
+      useEffect(() => {
+        if (!initialized) {
+          mappingTree.children.push(new FieldItem(mappingTree, {} as IField));
+          refreshMappingTree();
+          initialized = true;
+        } else if (!reset) {
+          resetMappingTree();
+          reset = true;
+        } else {
+          tree = mappingTree;
+        }
+      }, [mappingTree, refreshMappingTree, resetMappingTree]);
+      return <div data-testid="testdiv"></div>;
+    };
+    render(
+      <DataMapperProvider>
+        <TestRefreshMappingTree></TestRefreshMappingTree>
+      </DataMapperProvider>,
+    );
+    await waitFor(() => tree);
+    expect(tree!.children.length).toEqual(0);
   });
 });

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -57,6 +57,7 @@ export interface IDataMapperContext {
 
   mappingTree: MappingTree;
   refreshMappingTree(): void;
+  resetMappingTree(): void;
   setMappingTree(mappings: MappingTree): void;
 
   alerts: Partial<AlertProps>[];
@@ -157,7 +158,13 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     });
     newMapping.namespaceMap = mappingTree.namespaceMap;
     setMappingTree(newMapping);
-    onUpdateMappings && onUpdateMappings(MappingSerializerService.serialize(mappingTree, sourceParameterMap!));
+    onUpdateMappings?.(MappingSerializerService.serialize(mappingTree, sourceParameterMap));
+  }, [mappingTree, onUpdateMappings, sourceParameterMap]);
+
+  const resetMappingTree = useCallback(() => {
+    const newMapping = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    setMappingTree(newMapping);
+    onUpdateMappings?.(MappingSerializerService.serialize(mappingTree, sourceParameterMap));
   }, [mappingTree, onUpdateMappings, sourceParameterMap]);
 
   const removeStaleMappings = useCallback(
@@ -253,6 +260,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       updateDocumentDefinition,
       mappingTree,
       refreshMappingTree,
+      resetMappingTree,
       setMappingTree,
       alerts,
       addAlert,

--- a/packages/ui/src/services/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping.service.test.ts
@@ -16,6 +16,8 @@ import { IDocument } from '../models/datamapper/document';
 import {
   invoice850Xsd,
   message837Xsd,
+  shipOrderToShipOrderCollectionIndexXslt,
+  shipOrderToShipOrderMultipleForEachXslt,
   shipOrderToShipOrderXslt,
   TestUtil,
   x12837PDfdlXsd,
@@ -384,6 +386,18 @@ describe('MappingService', () => {
       MappingSerializerService.deserialize(x12850ForEachXslt, targetDoc, tree, paramsMap);
       const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.find((l) => l.sourceNodePath === 'sourceBody:X12-850.dfdl.xsd://')).toBeUndefined();
+    });
+
+    it('should generate mapping links for multiple for-each on a same target collection', () => {
+      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(10);
+    });
+
+    it('should generate mapping links for multiple field item on a same target collection', () => {
+      MappingSerializerService.deserialize(shipOrderToShipOrderCollectionIndexXslt, targetDoc, tree, paramsMap);
+      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(8);
     });
   });
 });

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -8,6 +8,7 @@ import {
   TargetNodeData,
   TargetFieldNodeData,
   TargetNodeDataType,
+  FieldItemNodeData,
 } from '../models/datamapper/visualization';
 import {
   ChooseItem,
@@ -69,19 +70,14 @@ export class VisualizationService {
           ? new FieldNodeData(parent, field)
           : new TargetFieldNodeData(parent as TargetNodeData, field);
         acc.push(fieldNodeData);
-        return acc;
+      } else {
+        mappingsForField
+          .filter((mapping) => !VisualizationService.isExistingMapping(acc as TargetNodeData[], mapping))
+          .sort((left, right) => MappingService.sortMappingItem(left, right))
+          .forEach((mapping) =>
+            acc.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, mapping)),
+          );
       }
-      mappingsForField
-        .filter((mapping) => !VisualizationService.isExistingMapping(acc as TargetNodeData[], mapping))
-        .sort((left, right) => MappingService.sortMappingItem(left, right))
-        .forEach((mapping) => {
-          if (mapping instanceof FieldItem) {
-            const fieldNodeData = new TargetFieldNodeData(parent as TargetNodeData, field, mapping);
-            acc.push(fieldNodeData);
-          } else {
-            acc.push(new MappingNodeData(parent as TargetNodeData, mapping));
-          }
-        });
       return acc;
     }, answer);
   }
@@ -91,27 +87,25 @@ export class VisualizationService {
   }
 
   static generateNonDocumentNodeDataChildren(parent: NodeData): NodeData[] {
-    if (parent instanceof MappingNodeData) {
+    if (parent instanceof FieldNodeData || parent instanceof FieldItemNodeData) {
+      DocumentService.resolveTypeFragment(parent.field);
+      return VisualizationService.doGenerateNodeDataFromFields(
+        parent,
+        parent.field.fields,
+        'mapping' in parent ? parent.mapping?.children : undefined,
+      );
+    } else if (parent instanceof MappingNodeData) {
       return parent.mapping?.children
         ? parent.mapping.children
             .sort((left, right) => MappingService.sortMappingItem(left, right))
             .map((m) => VisualizationService.createNodeDataFromMappingItem(parent, m))
         : [];
-    } else if (parent instanceof FieldNodeData) {
-      DocumentService.resolveTypeFragment(parent.field);
-      return VisualizationService.doGenerateNodeDataFromFields(
-        parent,
-        parent.field.fields,
-        parent instanceof TargetFieldNodeData ? parent.mapping?.children : undefined,
-      );
     }
     return [];
   }
 
-  private static createNodeDataFromMappingItem(parent: TargetNodeData, item: MappingItem): NodeData {
-    return item instanceof FieldItem
-      ? new TargetFieldNodeData(parent, item.field, item)
-      : new MappingNodeData(parent, item);
+  private static createNodeDataFromMappingItem(parent: TargetNodeData, mapping: MappingItem): MappingNodeData {
+    return mapping instanceof FieldItem ? new FieldItemNodeData(parent, mapping) : new MappingNodeData(parent, mapping);
   }
 
   static testNodePair(fromNode: NodeData, toNode: NodeData): MappingNodePairType {
@@ -132,7 +126,11 @@ export class VisualizationService {
   }
 
   static isCollectionField(nodeData: NodeData) {
-    return nodeData instanceof FieldNodeData && nodeData.field?.maxOccurs && nodeData.field.maxOccurs > 1;
+    return (
+      (nodeData instanceof FieldNodeData || nodeData instanceof FieldItemNodeData) &&
+      nodeData.field?.maxOccurs &&
+      nodeData.field.maxOccurs > 1
+    );
   }
 
   static isAttributeField(nodeData: NodeData) {
@@ -152,6 +150,11 @@ export class VisualizationService {
       if (isPrimitiveDocumentWithConditionItem) return true;
     }
     if (nodeData instanceof FieldNodeData) return DocumentService.hasChildren(nodeData.field);
+    if (nodeData instanceof FieldItemNodeData)
+      return (
+        DocumentService.hasChildren(nodeData.field) ||
+        nodeData.mapping.children.filter((m) => !(m instanceof ValueSelector)).length > 0
+      );
     if (nodeData instanceof MappingNodeData) return nodeData.mapping.children.length > 0;
     return false;
   }
@@ -211,7 +214,11 @@ export class VisualizationService {
   }
 
   static allowConditionMenu(nodeData: TargetNodeData) {
-    if (nodeData instanceof TargetFieldNodeData || nodeData instanceof TargetDocumentNodeData) {
+    if (
+      nodeData instanceof TargetFieldNodeData ||
+      nodeData instanceof TargetDocumentNodeData ||
+      nodeData instanceof FieldItemNodeData
+    ) {
       const isForEachField =
         'parent' in nodeData &&
         nodeData.parent instanceof MappingNodeData &&
@@ -308,13 +315,13 @@ export class VisualizationService {
 
   static engageMapping(mappingTree: MappingTree, sourceNode: SourceNodeDataType, targetNode: TargetNodeData) {
     const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
-    if (targetNode instanceof MappingNodeData) {
+    if (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData) {
+      const item = VisualizationService.getOrCreateFieldItem(targetNode);
+      MappingService.mapToField(sourceField, item as MappingItem);
+    } else if (targetNode instanceof MappingNodeData) {
       MappingService.mapToCondition(targetNode.mapping, sourceField);
     } else if (targetNode instanceof TargetDocumentNodeData) {
       MappingService.mapToDocument(mappingTree, sourceField);
-    } else if (targetNode instanceof TargetFieldNodeData) {
-      const item = VisualizationService.getOrCreateFieldItem(targetNode);
-      MappingService.mapToField(sourceField, item as MappingItem);
     }
   }
 

--- a/packages/ui/src/stubs/data-mapper.ts
+++ b/packages/ui/src/stubs/data-mapper.ts
@@ -56,6 +56,12 @@ export const shipOrderToShipOrderInvalidForEachXslt = fs
 export const shipOrderEmptyFirstLineXsd = fs
   .readFileSync(path.resolve(__dirname, '../xml-schema-ts/test-resources/ShipOrderEmptyFirstLine.xsd'))
   .toString();
+export const shipOrderToShipOrderMultipleForEachXslt = fs
+  .readFileSync(path.resolve(__dirname, '../xml-schema-ts/test-resources/ShipOrderToShipOrderMultipleForEach.xsl'))
+  .toString();
+export const shipOrderToShipOrderCollectionIndexXslt = fs
+  .readFileSync(path.resolve(__dirname, '../xml-schema-ts/test-resources/ShipOrderToShipOrderCollectionIndex.xsl'))
+  .toString();
 
 export const x12837PDfdlXsd = fs
   .readFileSync(path.resolve(__dirname, '../xml-schema-ts/test-resources/X12-837P.dfdl.xsd'))

--- a/packages/ui/src/xml-schema-ts/test-resources/ShipOrderToShipOrderCollectionIndex.xsl
+++ b/packages/ui/src/xml-schema-ts/test-resources/ShipOrderToShipOrderCollectionIndex.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <Item xmlns="">
+                <Title>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[0]/Title"/>
+                </Title>
+                <Note>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[0]/Note"/>
+                </Note>
+                <Quantity>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[0]/Quantity"/>
+                </Quantity>
+                <Price>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[0]/Price"/>
+                </Price>
+            </Item>
+            <Item xmlns="">
+                <Title>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[1]/Title"/>
+                </Title>
+                <Note>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[1]/Note"/>
+                </Note>
+                <Quantity>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[1]/Quantity"/>
+                </Quantity>
+                <Price>
+                    <xsl:value-of select="/ns0:ShipOrder/Item[1]/Price"/>
+                </Price>
+            </Item>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/xml-schema-ts/test-resources/ShipOrderToShipOrderMultipleForEach.xsl
+++ b/packages/ui/src/xml-schema-ts/test-resources/ShipOrderToShipOrderMultipleForEach.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:param name="sourceParam1" />
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:for-each select="/ns0:ShipOrder/Item">
+                <Item xmlns="">
+                    <Title>
+                        <xsl:value-of select="Title"/>
+                    </Title>
+                    <Note>
+                        <xsl:value-of select="Note"/>
+                    </Note>
+                    <Quantity>
+                        <xsl:value-of select="Quantity"/>
+                    </Quantity>
+                    <Price>
+                        <xsl:value-of select="Price"/>
+                    </Price>
+                </Item>
+            </xsl:for-each>
+            <xsl:for-each select="$sourceParam1/ns0:ShipOrder/Item">
+                <Item xmlns="">
+                    <Title>
+                        <xsl:value-of select="Title"/>
+                    </Title>
+                    <Note>
+                        <xsl:value-of select="Note"/>
+                    </Note>
+                    <Quantity>
+                        <xsl:value-of select="Quantity"/>
+                    </Quantity>
+                    <Price>
+                        <xsl:value-of select="Price"/>
+                    </Price>
+                </Item>
+            </xsl:for-each>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
…ion target field

The first step for https://github.com/KaotoIO/kaoto/issues/1845, deserializing multiple mappings on a same collection target field. The UI part of adding multiple mappings is to come separately. Introduced `FieldItemNodeData extends MappingNodeData` which represents the field node but it actually exists in the XSLT outcome, to be distinguished from the `TargetFieldNodeData` which represents the document fields that doesn't yet participate in any mappings. While document field has a consistent ID, `FieldItemNodeData` gets an unique ID for each mappings. This enables to distinguish the multiple field items for the same collection target field.

Also added `resetMappings` menu to the DataMapper debugger
![Screenshot From 2025-04-11 11-50-48](https://github.com/user-attachments/assets/0cfe8455-0a9e-482e-8a2d-5acfcb4ff5cb)
![Screenshot From 2025-04-11 11-51-09](https://github.com/user-attachments/assets/6376f435-c770-4c37-9d4b-2d5fa4639331)

