### PR TITLE
feat(DataMapper): Allow multiple mappings to the collection field

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -57,7 +57,7 @@ describe('DebugLayout', () => {
     );
     await screen.findAllByText('ShipOrder');
     const targetNodes = screen.getAllByTestId(/node-target-.*/);
-    expect(targetNodes.length).toEqual(20);
+    expect(targetNodes.length).toEqual(21);
     expect(mappingLinks.length).toEqual(11);
     const nodeRefsLog = mockLog.mock.calls.filter((call) => call[0].startsWith('Node References: ['));
     expect(nodeRefsLog.length).toBeGreaterThan(0);

--- a/packages/ui/src/components/Document/Document.scss
+++ b/packages/ui/src/components/Document/Document.scss
@@ -40,6 +40,28 @@
     flex-grow: 1;
     justify-content: end;
   }
+
+  &__add__mapping {
+    &__header {
+      border-bottom: 1px dashed var(--pf-t--global--color--disabled--100);
+      border-left: 1px dashed var(--pf-t--global--color--disabled--100);
+      padding-left: var(--pf-t--global--spacer--md);
+      border-bottom-left-radius: var(--pf-v6-c-panel--BorderRadius);
+    }
+
+    &__text {
+      color: var(--pf-t--global--text--color--disabled);
+    }
+
+    &__icon {
+      color: var(--pf-t--global--icon--color--disabled);
+    }
+
+    &__actions {
+      flex-grow: 1;
+      justify-content: left;
+    }
+  }
 }
 
 img {

--- a/packages/ui/src/components/Document/NodeContainer.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.tsx
@@ -1,7 +1,7 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import clsx from 'clsx';
 import { forwardRef, FunctionComponent, PropsWithChildren } from 'react';
-import { DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
+import { AddMappingNodeData, DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
 import { isDefined } from '../../utils';
 import './NodeContainer.scss';
 import { VisualizationService } from '../../services/visualization.service';
@@ -73,7 +73,9 @@ type NodeContainerProps = PropsWithChildren & {
 };
 
 export const NodeContainer = forwardRef<HTMLDivElement, NodeContainerProps>(({ children, nodeData }, forwardedRef) => {
-  return nodeData && !(nodeData instanceof DocumentNodeData && !nodeData.isPrimitive) ? (
+  return nodeData &&
+    !(nodeData instanceof DocumentNodeData && !nodeData.isPrimitive) &&
+    !(nodeData instanceof AddMappingNodeData) ? (
     <div ref={forwardedRef}>
       <DnDContainer nodeData={nodeData}>{children}</DnDContainer>
     </div>

--- a/packages/ui/src/components/Document/TargetDocument.tsx
+++ b/packages/ui/src/components/Document/TargetDocument.tsx
@@ -1,11 +1,18 @@
-import { Icon } from '@patternfly/react-core';
-import { AngleDownIcon, AtIcon, GripVerticalIcon, LayerGroupIcon } from '@patternfly/react-icons';
+import { ActionList, ActionListGroup, ActionListItem, Button, Icon } from '@patternfly/react-core';
+import {
+  AngleDownIcon,
+  AtIcon,
+  GripVerticalIcon,
+  LayerGroupIcon,
+  PlusCircleIcon,
+  PlusIcon,
+} from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent, useCallback, useRef, useState } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { IDocument } from '../../models/datamapper/document';
-import { TargetDocumentNodeData, TargetNodeData } from '../../models/datamapper/visualization';
+import { AddMappingNodeData, TargetDocumentNodeData, TargetNodeData } from '../../models/datamapper/visualization';
 import { NodeReference } from '../../providers/datamapper-canvas.provider';
 import { VisualizationService } from '../../services/visualization.service';
 import { DocumentActions } from './actions/DocumentActions';
@@ -13,6 +20,7 @@ import { TargetNodeActions } from './actions/TargetNodeActions';
 import './Document.scss';
 import { NodeContainer } from './NodeContainer';
 import { NodeTitle } from './NodeTitle';
+import { ConditionMenuAction } from './actions/ConditionMenuAction';
 
 type DocumentProps = {
   document: IDocument;
@@ -127,17 +135,81 @@ const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({
 
         {hasChildren && !collapsed && (
           <div className={clsx({ node__children: !isDocument })}>
-            {children.map((child) => (
-              <TargetDocumentNode
-                nodeData={child}
-                key={child.id}
-                expandAll={expandAll}
-                initialExpandedRank={initialExpandedRank}
-                rank={rank + 1}
-              />
-            ))}
+            {children.map((child) =>
+              child instanceof AddMappingNodeData ? (
+                <AddMappingNode nodeData={child} key={child.id}></AddMappingNode>
+              ) : (
+                <TargetDocumentNode
+                  nodeData={child}
+                  key={child.id}
+                  expandAll={expandAll}
+                  initialExpandedRank={initialExpandedRank}
+                  rank={rank + 1}
+                />
+              ),
+            )}
           </div>
         )}
+      </NodeContainer>
+    </div>
+  );
+};
+
+const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData }> = ({ nodeData }) => {
+  const { refreshMappingTree } = useDataMapper();
+  const { getNodeReference, setNodeReference } = useCanvas();
+
+  const headerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nodeReference = useRef<NodeReference>({
+    get headerRef() {
+      return headerRef.current;
+    },
+    get containerRef() {
+      return containerRef.current;
+    },
+  });
+  const nodeRefId = nodeData.path.toString();
+  getNodeReference(nodeRefId) !== nodeReference && setNodeReference(nodeRefId, nodeReference);
+
+  const handleAddMapping = useCallback(() => {
+    VisualizationService.addMapping(nodeData);
+    refreshMappingTree();
+  }, [nodeData, refreshMappingTree]);
+
+  return (
+    <div data-testid={`node-target-${nodeData.id}`} className={clsx({ node__container: true })}>
+      <NodeContainer ref={containerRef} nodeData={nodeData}>
+        <div className={clsx({ node__add__mapping__header: true })}>
+          <NodeContainer ref={headerRef} nodeData={nodeData}>
+            <section className="node__row" data-draggable={false}>
+              <span className="node__row">
+                <Icon className="node__spacer">
+                  <PlusIcon className="node__add__mapping__icon" />
+                </Icon>
+                <Icon className="node__spacer">
+                  <LayerGroupIcon className="node__add__mapping__icon" />
+                </Icon>
+                <NodeTitle className="node__spacer node__add__mapping__text" nodeData={nodeData} isDocument={false} />
+              </span>
+
+              <ActionList>
+                <ActionListGroup className="node__add__mapping__actions">
+                  <ActionListItem>
+                    <Button icon={<PlusCircleIcon />} variant="tertiary" onClick={handleAddMapping}>
+                      Add Mapping
+                    </Button>
+                  </ActionListItem>
+                  <ConditionMenuAction
+                    nodeData={nodeData}
+                    dropdownLabel="Add Conditional Mapping"
+                    onUpdate={refreshMappingTree}
+                  />
+                </ActionListGroup>
+              </ActionList>
+            </section>
+          </NodeContainer>
+        </div>
       </NodeContainer>
     </div>
   );

--- a/packages/ui/src/components/Document/actions/ConditionMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/ConditionMenuAction.test.tsx
@@ -2,7 +2,12 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { BODY_DOCUMENT_ID } from '../../../models/datamapper/document';
 import { ChooseItem, FieldItem, MappingTree } from '../../../models/datamapper/mapping';
 import { DocumentType } from '../../../models/datamapper/path';
-import { MappingNodeData, TargetDocumentNodeData, TargetFieldNodeData } from '../../../models/datamapper/visualization';
+import {
+  AddMappingNodeData,
+  MappingNodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../../../models/datamapper/visualization';
 import { MappingService } from '../../../services/mapping.service';
 import { VisualizationService } from '../../../services/visualization.service';
 import { TestUtil } from '../../../stubs/data-mapper';
@@ -178,5 +183,27 @@ describe('ConditionMenuAction', () => {
     });
 
     waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
+  });
+
+  it('should render Add Conditional Mapping dropdown for the add mapping placeholder', async () => {
+    const onUpdateSpy = jest.fn();
+    const nodeData = new AddMappingNodeData(documentNodeData, targetDoc.fields[0].fields[3]);
+    const wrapper = render(
+      <ConditionMenuAction nodeData={nodeData} dropdownLabel="Add Conditional Mapping" onUpdate={onUpdateSpy} />,
+    );
+
+    act(() => {
+      const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
+      expect(actionToggle.textContent).toEqual('Add Conditional Mapping');
+      fireEvent.click(actionToggle);
+    });
+
+    act(() => {
+      const forEachList = wrapper.getByTestId('transformation-actions-foreach');
+      const forEachButton = forEachList.getElementsByTagName('button');
+      fireEvent.click(forEachButton[0]);
+    });
+
+    await waitFor(() => expect(onUpdateSpy).toHaveBeenCalled());
   });
 });

--- a/packages/ui/src/components/Document/actions/ConditionMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/ConditionMenuAction.tsx
@@ -9,10 +9,11 @@ import {
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
-import { EllipsisVIcon } from '@patternfly/react-icons';
+import { AddCircleOIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ChooseItem } from '../../../models/datamapper/mapping';
 
 type ConditionMenuProps = {
+  dropdownLabel?: string;
   nodeData: TargetNodeData;
   onUpdate: () => void;
 };
@@ -22,7 +23,7 @@ const DEFAULT_POPPER_PROPS = {
   preventOverflow: true,
 } as const;
 
-export const ConditionMenuAction: FunctionComponent<ConditionMenuProps> = ({ nodeData, onUpdate }) => {
+export const ConditionMenuAction: FunctionComponent<ConditionMenuProps> = ({ dropdownLabel, nodeData, onUpdate }) => {
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
   const allowIfChoose = VisualizationService.allowIfChoose(nodeData);
   const allowForEach = VisualizationService.allowForEach(nodeData);
@@ -75,14 +76,15 @@ export const ConditionMenuAction: FunctionComponent<ConditionMenuProps> = ({ nod
           onSelect={onSelectAction}
           toggle={(toggleRef: Ref<MenuToggleElement>) => (
             <MenuToggle
+              icon={dropdownLabel ? <AddCircleOIcon /> : <EllipsisVIcon />}
               ref={toggleRef}
               onClick={onToggleActionMenu}
-              variant="plain"
+              variant={dropdownLabel ? 'secondary' : 'plain'}
               isExpanded={isActionMenuOpen}
               aria-label="Transformation Action list"
               data-testid="transformation-actions-menu-toggle"
             >
-              <EllipsisVIcon />
+              {dropdownLabel}
             </MenuToggle>
           )}
           isOpen={isActionMenuOpen}

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -109,6 +109,26 @@ export class FieldItemNodeData extends MappingNodeData {
   public field: IField;
 }
 
+export class AddMappingNodeData implements TargetNodeData {
+  constructor(
+    public parent: TargetNodeData,
+    public field: IField,
+  ) {
+    const ID_PREFIX = 'add-mapping-';
+    this.id = ID_PREFIX + field.id;
+    this.path = NodePath.childOf(parent.path, this.id);
+    this.title = field.name;
+    this.isPrimitive = parent.isPrimitive;
+    this.mappingTree = parent.mappingTree;
+  }
+  id: string;
+  isPrimitive: boolean;
+  isSource = false;
+  mappingTree: MappingTree;
+  path: NodePath;
+  title: string;
+}
+
 class SimpleNodePath extends NodePath {
   constructor(public path: string) {
     super();

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -39,4 +39,19 @@ describe('DocumentService', () => {
       expect(field?.name).toEqual('ShipTo');
     });
   });
+
+  describe('isCollectionField()', () => {
+    it('', () => {
+      expect(DocumentService.isCollectionField(sourceDoc.fields[0])).toBeFalsy();
+      expect(DocumentService.isCollectionField(targetDoc.fields[0])).toBeFalsy();
+      expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[0])).toBeFalsy();
+      expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[0])).toBeFalsy();
+      expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[1])).toBeFalsy();
+      expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[1])).toBeFalsy();
+      expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[2])).toBeFalsy();
+      expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[2])).toBeFalsy();
+      expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[3])).toBeTruthy();
+      expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[3])).toBeTruthy();
+    });
+  });
 });

--- a/packages/ui/src/services/document.service.ts
+++ b/packages/ui/src/services/document.service.ts
@@ -200,4 +200,8 @@ export class DocumentService {
   static hasChildren(field: IField) {
     return field.fields.length > 0 || field.namedTypeFragmentRefs.length > 0;
   }
+
+  static isCollectionField(field: IField) {
+    return !!field.maxOccurs && field.maxOccurs > 1;
+  }
 }

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -1,5 +1,6 @@
 import { VisualizationService } from './visualization.service';
 import {
+  AddMappingNodeData,
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
@@ -528,7 +529,7 @@ describe('VisualizationService', () => {
         expect(VisualizationService.allowConditionMenu(targetDocNode)).toBeTruthy();
         expect(VisualizationService.allowConditionMenu(targetDocChildren[0] as TargetNodeData)).toBeTruthy();
 
-        expect(shipOrderChildren.length).toEqual(4);
+        expect(shipOrderChildren.length).toEqual(5);
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
         expect(orderIdNode.title).toEqual('OrderId');
         expect(VisualizationService.allowConditionMenu(orderIdNode)).toBeFalsy();
@@ -544,6 +545,15 @@ describe('VisualizationService', () => {
         const forEachNode = shipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toEqual('for-each');
         expect(VisualizationService.allowConditionMenu(forEachNode)).toBeFalsy();
+
+        expect(shipOrderChildren[4] instanceof AddMappingNodeData).toBeTruthy();
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        expect(addMappingNode.title).toEqual('Item');
+        expect(addMappingNode.id).toContain('add-mapping-field-Item');
+        expect(VisualizationService.allowForEach(addMappingNode)).toBeTruthy();
+        expect(VisualizationService.allowIfChoose(addMappingNode)).toBeTruthy();
+        expect(VisualizationService.allowConditionMenu(addMappingNode)).toBeTruthy();
+        expect(VisualizationService.allowValueSelector(addMappingNode)).toBeFalsy();
       });
     });
 
@@ -563,6 +573,26 @@ describe('VisualizationService', () => {
         expect(otherwiseChildDndId).toContain('otherwise');
       });
     });
+
+    describe('addMapping()', () => {
+      it('should add an empty mapping', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        expect(shipOrderChildren.length).toEqual(5);
+
+        const shipOrderMappingItem = targetDocNode.mappingTree.children[0];
+
+        expect(shipOrderChildren[4] instanceof AddMappingNodeData).toBeTruthy();
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        expect(shipOrderMappingItem.children.length).toEqual(4);
+        VisualizationService.addMapping(addMappingNode);
+
+        expect(shipOrderMappingItem.children.length).toEqual(5);
+        expect(shipOrderMappingItem.children[4] instanceof FieldItem).toBeTruthy();
+        const itemItem = shipOrderMappingItem.children[4] as FieldItem;
+        expect(itemItem.field.name).toEqual('Item');
+      });
+    });
   });
 
   it('should generate for multiple for-each on a same collection target field', () => {
@@ -571,12 +601,13 @@ describe('VisualizationService', () => {
 
     const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
     const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
-    expect(shipOrderChildren.length).toEqual(5);
+    expect(shipOrderChildren.length).toEqual(6);
     expect(shipOrderChildren[0].title).toEqual('OrderId');
     expect(shipOrderChildren[1].title).toEqual('OrderPerson');
     expect(shipOrderChildren[2].title).toEqual('ShipTo');
     expect(shipOrderChildren[3].title).toEqual('for-each');
     expect(shipOrderChildren[4].title).toEqual('for-each');
+    expect(shipOrderChildren[5].title).toEqual('Item');
 
     const forEach1Node = shipOrderChildren[3] as MappingNodeData;
     expect((forEach1Node.mapping as ForEachItem).expression).toEqual('/ns0:ShipOrder/Item');
@@ -601,6 +632,13 @@ describe('VisualizationService', () => {
     expect(forEach2ItemChildren[0].title).toEqual('Title');
     const title2Selector = (forEach2ItemChildren[0] as FieldItemNodeData).mapping.children[0] as ValueSelector;
     expect(title2Selector.expression).toEqual('Title');
+
+    expect(shipOrderChildren[5] instanceof AddMappingNodeData).toBeTruthy();
+    const addMappingNode = shipOrderChildren[5] as AddMappingNodeData;
+    expect(addMappingNode.title).toEqual('Item');
+    expect(addMappingNode.id).toContain('add-mapping-field-Item');
+    expect(addMappingNode.field.name).toEqual('Item');
+    expect(addMappingNode.field.maxOccurs).toBeGreaterThan(1);
   });
 
   it('should generate for multiple indexed collection mappings on a same collection target field', () => {
@@ -613,7 +651,7 @@ describe('VisualizationService', () => {
 
     const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
     const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
-    expect(shipOrderChildren.length).toEqual(5);
+    expect(shipOrderChildren.length).toEqual(6);
     expect(shipOrderChildren[0].title).toEqual('OrderId');
     expect(shipOrderChildren[1].title).toEqual('OrderPerson');
     expect(shipOrderChildren[2].title).toEqual('ShipTo');
@@ -622,6 +660,7 @@ describe('VisualizationService', () => {
     expect(shipOrderChildren[4].title).toEqual('Item');
     expect(VisualizationService.isCollectionField(shipOrderChildren[4])).toBeTruthy();
     expect(shipOrderChildren[3].id).not.toEqual(shipOrderChildren[4].id);
+    expect(shipOrderChildren[5].title).toEqual('Item');
 
     const item1Children = VisualizationService.generateNonDocumentNodeDataChildren(shipOrderChildren[3]);
     expect(item1Children.length).toEqual(4);
@@ -634,5 +673,12 @@ describe('VisualizationService', () => {
     expect(item2Children[0].title).toEqual('Title');
     const title2Selector = (item2Children[0] as FieldItemNodeData).mapping.children[0] as ValueSelector;
     expect(title2Selector.expression).toEqual('/ns0:ShipOrder/Item[1]/Title');
+
+    expect(shipOrderChildren[5] instanceof AddMappingNodeData).toBeTruthy();
+    const addMappingNode = shipOrderChildren[5] as AddMappingNodeData;
+    expect(addMappingNode.title).toEqual('Item');
+    expect(addMappingNode.id).toContain('add-mapping-field-Item');
+    expect(addMappingNode.field.name).toEqual('Item');
+    expect(addMappingNode.field.maxOccurs).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/1845

The 2nd and final step for supporting multiple mappings to the same collection field, adding the UI part of "Add Mapping". It also adds "Add Conditional Mapping" menu which allows to directly add a conditional mapping such as `for-each`, which is a short cut for "Add Mapping" and then "Wrap with for-each" for example.


https://github.com/user-attachments/assets/96f11fd1-425d-4424-b9be-a64ea82fd022

