### PR TITLE
fix(Form): Align Field context menu to the left

### DIFF
--- a/packages/ui/src/components/Document/actions/ConditionMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/ConditionMenuAction.tsx
@@ -1,6 +1,3 @@
-import { FunctionComponent, Ref, MouseEvent, useCallback, useState } from 'react';
-import { MappingNodeData, TargetFieldNodeData, TargetNodeData } from '../../../models/datamapper/visualization';
-import { VisualizationService } from '../../../services/visualization.service';
 import {
   ActionListItem,
   Dropdown,
@@ -10,18 +7,17 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core';
 import { AddCircleOIcon, EllipsisVIcon } from '@patternfly/react-icons';
+import { FunctionComponent, MouseEvent, Ref, useCallback, useState } from 'react';
 import { ChooseItem } from '../../../models/datamapper/mapping';
+import { MappingNodeData, TargetFieldNodeData, TargetNodeData } from '../../../models/datamapper/visualization';
+import { DEFAULT_POPPER_PROPS } from '../../../models/popper-default';
+import { VisualizationService } from '../../../services/visualization.service';
 
 type ConditionMenuProps = {
   dropdownLabel?: string;
   nodeData: TargetNodeData;
   onUpdate: () => void;
 };
-
-const DEFAULT_POPPER_PROPS = {
-  position: 'end',
-  preventOverflow: true,
-} as const;
 
 export const ConditionMenuAction: FunctionComponent<ConditionMenuProps> = ({ dropdownLabel, nodeData, onUpdate }) => {
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
@@ -1,6 +1,7 @@
-import { FunctionComponent, useState } from 'react';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { EllipsisVIcon, PortIcon, TimesIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useState } from 'react';
+import { DEFAULT_POPPER_PROPS } from '../../../../../models/popper-default';
 import { useFieldValue } from '../hooks/field-value';
 
 export interface FieldActionsProps {
@@ -38,6 +39,7 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ propName, c
         />
       )}
       shouldFocusToggleOnSelect
+      popperProps={DEFAULT_POPPER_PROPS}
     >
       <DropdownList>
         <DropdownItem

--- a/packages/ui/src/components/typeahead/Typeahead.tsx
+++ b/packages/ui/src/components/typeahead/Typeahead.tsx
@@ -21,15 +21,11 @@ import {
   useRef,
   useState,
 } from 'react';
+import { DEFAULT_POPPER_PROPS } from '../../models/popper-default';
 import { isDefined } from '../../utils';
 import { TypeaheadProps } from './Typeahead.types';
 
 export const CREATE_NEW_ITEM = 'create-new-with-name';
-
-const DEFAULT_POPPER_PROPS = {
-  position: 'end',
-  preventOverflow: true,
-} as const;
 
 export const Typeahead: FunctionComponent<TypeaheadProps> = ({
   selectedItem,

--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -5,12 +5,12 @@ import {
   DropdownItem,
   Icon,
   Masthead,
-  MastheadLogo,
+  MastheadBrand,
   MastheadContent,
+  MastheadLogo,
   MastheadMain,
   MastheadProps,
   MastheadToggle,
-  MastheadBrand,
   MenuToggle,
   MenuToggleElement,
   ToolbarItem,
@@ -22,6 +22,7 @@ import { Link } from 'react-router-dom';
 import camelLogo from '../assets/camel-logo.svg';
 import logo from '../assets/logo-kaoto.png';
 import { useComponentLink } from '../hooks/ComponentLink';
+import { DEFAULT_POPPER_PROPS } from '../models/popper-default';
 import { Links } from '../router/links.models';
 import { KaotoAboutModal } from './KaotoAboutModal';
 
@@ -32,11 +33,6 @@ interface ITopBar {
 const displayObject: MastheadProps['display'] = {
   default: 'inline',
 };
-
-const DEFAULT_POPPER_PROPS = {
-  position: 'end',
-  preventOverflow: true,
-} as const;
 
 export const TopBar: FunctionComponent<ITopBar> = (props) => {
   const logoLink = useComponentLink(Links.Home);

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -10,6 +10,7 @@ export * from './kamelets-catalog';
 export * from './kaoto-schema';
 export * from './loading-status';
 export * from './local-storage-keys';
+export * from './popper-default';
 export * from './react-component';
 export * from './settings';
 export * from './validation';

--- a/packages/ui/src/models/popper-default.ts
+++ b/packages/ui/src/models/popper-default.ts
@@ -1,0 +1,6 @@
+import { DropdownPopperProps } from '@patternfly/react-core';
+
+export const DEFAULT_POPPER_PROPS: DropdownPopperProps = {
+  position: 'end',
+  preventOverflow: true,
+};


### PR DESCRIPTION
### Context
When displaying the Field's contextual menu in VS Code, it gets out of the screen.

### Changes
The solution is to align the contextual menu to the left, so it renders from the trigger button toward the inner part of the UI.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/83d729f1-6043-4604-a7ed-167125a5ea3a) | ![image](https://github.com/user-attachments/assets/a22150a0-2c8d-444e-9180-fe63e5035c5b) |


fix: https://github.com/KaotoIO/kaoto/issues/2202