### PR TITLE
fix(Form): Prevent onSubmit event from firing

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.test.tsx
@@ -26,13 +26,13 @@ describe('KaotoForm', () => {
     const form = getByTestId('kaoto-form');
 
     const mockEvent = createEvent.submit(form);
-    const preventDefaulSpy = jest.spyOn(mockEvent, 'preventDefault');
+    const preventDefaultSpy = jest.spyOn(mockEvent, 'preventDefault');
 
     act(() => {
       fireEvent(form, mockEvent);
     });
 
-    expect(preventDefaulSpy).toHaveBeenCalled();
+    expect(preventDefaultSpy).toHaveBeenCalled();
   });
 
   it('displays "Schema not defined" when schema is not provided', () => {

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, createEvent, fireEvent, render, screen } from '@testing-library/react';
 import { useRef, useState } from 'react';
 import { KaotoForm, KaotoFormApi, KaotoFormProps } from './KaotoForm';
 import { KaotoFormPageObject } from './testing/KaotoFormPageObject';
@@ -19,6 +19,20 @@ describe('KaotoForm', () => {
   it('renders without crashing', () => {
     render(<KaotoForm {...defaultProps} />);
     expect(screen.getByTestId('kaoto-form')).toBeInTheDocument();
+  });
+
+  it('should prevent executing the default onSubmit action', () => {
+    const { getByTestId } = render(<KaotoForm {...defaultProps} />);
+    const form = getByTestId('kaoto-form');
+
+    const mockEvent = createEvent.submit(form);
+    const preventDefaulSpy = jest.spyOn(mockEvent, 'preventDefault');
+
+    act(() => {
+      fireEvent(form, mockEvent);
+    });
+
+    expect(preventDefaulSpy).toHaveBeenCalled();
   });
 
   it('displays "Schema not defined" when schema is not provided', () => {

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/KaotoForm.tsx
@@ -1,5 +1,14 @@
 import { Form } from '@patternfly/react-core';
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  FormEventHandler,
+} from 'react';
 import { IDataTestID, KaotoSchemaDefinition } from '../../../../models';
 import { isDefined, ROOT_PATH, setValue } from '../../../../utils';
 import { NoFieldFound } from '../../../Form/NoFieldFound';
@@ -96,6 +105,10 @@ export const KaotoForm = forwardRef<KaotoFormApi, KaotoFormProps>(
       schemaValidator,
     ]);
 
+    const onSubmit: FormEventHandler<HTMLFormElement> = useCallback((event) => {
+      event.preventDefault();
+    }, []);
+
     return (
       <FormComponentFactoryProvider>
         <SchemaDefinitionsProvider schema={schema} omitFields={omitFields}>
@@ -106,7 +119,7 @@ export const KaotoForm = forwardRef<KaotoFormApi, KaotoFormProps>(
               onPropertyChange={onPropertyChange}
               disabled={disabled}
             >
-              <Form className="kaoto-form kaoto-form__label" data-testid={dataTestId}>
+              <Form onSubmit={onSubmit} className="kaoto-form kaoto-form__label" data-testid={dataTestId}>
                 <AutoField propName={ROOT_PATH} />
               </Form>
               <NoFieldFound className="kaoto-form kaoto-form__empty" />

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/__snapshots__/KaotoForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/__snapshots__/KaotoForm.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`KaotoForm should validate the model 1`] = `
               aria-disabled="false"
               aria-label="More info for Name field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-id="OUIA-Generated-Button-plain-7"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -124,7 +124,7 @@ exports[`KaotoForm should validate the model 1`] = `
               aria-expanded="false"
               aria-label="#.name__field-actions"
               class="pf-v6-c-menu-toggle pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-6"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plain-7"
               data-ouia-component-type="PF6/MenuToggle"
               data-ouia-safe="true"
               data-testid="#.name__field-actions"
@@ -201,7 +201,7 @@ exports[`KaotoForm should validate the model 1`] = `
   </form>
   <div
     class="pf-v6-c-card kaoto-form kaoto-form__empty"
-    data-ouia-component-id="OUIA-Generated-Card-6"
+    data-ouia-component-id="OUIA-Generated-Card-7"
     data-ouia-component-type="PF6/Card"
     data-ouia-safe="true"
     data-testid="no-field-found"
@@ -212,7 +212,7 @@ exports[`KaotoForm should validate the model 1`] = `
     >
       <div
         class="pf-v6-c-alert pf-m-info"
-        data-ouia-component-id="OUIA-Generated-Alert-info-6"
+        data-ouia-component-id="OUIA-Generated-Alert-info-7"
         data-ouia-component-type="PF6/Alert"
         data-ouia-safe="true"
       >
@@ -250,7 +250,7 @@ exports[`KaotoForm should validate the model 1`] = `
           <button
             aria-disabled="false"
             class="pf-v6-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-6"
+            data-ouia-component-id="OUIA-Generated-Button-link-7"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             id="All"


### PR DESCRIPTION
### Context
Currently, when pressing `enter` in some form fields, the `onSubmit` event, making the UI to reload, and in case of VS Code, that leaves the user into a blank page.

### Changes
The fix is to intercept the `onSubmit` event and stop the default process.

fix: https://github.com/KaotoIO/kaoto/issues/2210