### PR TITLE
fix(Canvas): Avoid auto-fitting canvas

### DIFF
--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -1,0 +1,18 @@
+jest.mock('./utils/color-scheme', () => ({
+  setColorScheme: jest.fn(),
+}));
+
+import { act, render } from '@testing-library/react';
+import App from './App';
+import { ColorScheme } from './models';
+import { setColorScheme } from './utils/color-scheme';
+
+describe('App', () => {
+  it('should set color theme', () => {
+    act(() => {
+      render(<App />);
+    });
+
+    expect(setColorScheme).toHaveBeenCalledWith(ColorScheme.Auto);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,7 +16,7 @@ import {
   RuntimeProvider,
   SchemasLoaderProvider,
   SettingsProvider,
-  SourceCodeProvider,
+  SourceCodeLocalStorageProvider,
   VisibleFlowsProvider,
 } from './providers';
 import { isDefined } from './utils';
@@ -41,7 +41,7 @@ function App() {
   return (
     <ReloadProvider>
       <SettingsProvider adapter={settingsAdapter}>
-        <SourceCodeProvider>
+        <SourceCodeLocalStorageProvider>
           <RuntimeProvider catalogUrl={catalogUrl}>
             <SchemasLoaderProvider>
               <CatalogLoaderProvider>
@@ -67,7 +67,7 @@ function App() {
               </CatalogLoaderProvider>
             </SchemasLoaderProvider>
           </RuntimeProvider>
-        </SourceCodeProvider>
+        </SourceCodeLocalStorageProvider>
       </SettingsProvider>
     </ReloadProvider>
   );

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -25,6 +25,7 @@ import {
   useState,
 } from 'react';
 import { useLocalStorage } from '../../../hooks';
+import { usePrevious } from '../../../hooks/previous.hook';
 import { LocalStorageKeys } from '../../../models';
 import { BaseVisualCamelEntity } from '../../../models/visualization/base-visual-entity';
 import { CatalogModalContext } from '../../../providers/catalog-modal.provider';
@@ -37,7 +38,6 @@ import { CanvasSideBar } from './CanvasSideBar';
 import { CanvasDefaults } from './canvas.defaults';
 import { CanvasEdge, CanvasNode, LayoutType } from './canvas.models';
 import { FlowService } from './flow.service';
-import { usePrevious } from '../../../hooks/previous.hook';
 
 interface CanvasProps {
   entities: BaseVisualCamelEntity[];
@@ -97,7 +97,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
       setInitialized(true);
 
       requestAnimationFrame(() => {
-        controller.getGraph().fit(80);
+        controller.getGraph().fit(CanvasDefaults.CANVAS_FIT_PADDING);
       });
       return;
     }
@@ -183,7 +183,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
       resetViewCallback: action(() => {
         controller.getGraph().reset();
         controller.getGraph().layout();
-        controller.getGraph().fit(80);
+        controller.getGraph().fit(CanvasDefaults.CANVAS_FIT_PADDING);
       }),
       legend: false,
       customButtons,

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -37,6 +37,7 @@ import { CanvasSideBar } from './CanvasSideBar';
 import { CanvasDefaults } from './canvas.defaults';
 import { CanvasEdge, CanvasNode, LayoutType } from './canvas.models';
 import { FlowService } from './flow.service';
+import { usePrevious } from '../../../hooks/previous.hook';
 
 interface CanvasProps {
   entities: BaseVisualCamelEntity[];
@@ -64,6 +65,8 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
     return areNoFlows || areAllFlowsHidden;
   }, [entities.length, visibleFlows]);
 
+  const wasEmptyStateVisible = usePrevious(shouldShowEmptyState);
+
   /** Draw graph */
   useEffect(() => {
     setSelectedNode(undefined);
@@ -89,7 +92,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
       },
     };
 
-    if (!initialized) {
+    if (!initialized || wasEmptyStateVisible) {
       controller.fromModel(model, false);
       setInitialized(true);
 

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -92,6 +92,10 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
     if (!initialized) {
       controller.fromModel(model, false);
       setInitialized(true);
+
+      requestAnimationFrame(() => {
+        controller.getGraph().fit(80);
+      });
       return;
     }
 
@@ -176,6 +180,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
       resetViewCallback: action(() => {
         controller.getGraph().reset();
         controller.getGraph().layout();
+        controller.getGraph().fit(80);
       }),
       legend: false,
       customButtons,

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -564,10 +564,10 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-6"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-7"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-12"
+                    id="pf-topology-control-bar-14"
                     style="background-color: transparent;"
                   >
                     <div
@@ -588,7 +588,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-27"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-32"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -628,7 +628,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-28"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-33"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -668,7 +668,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-29"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-34"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -708,7 +708,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-30"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-35"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -747,7 +747,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-31"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-36"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1370,10 +1370,10 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-5"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-6"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-10"
+                    id="pf-topology-control-bar-12"
                     style="background-color: transparent;"
                   >
                     <div
@@ -1394,7 +1394,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-21"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-26"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -1434,7 +1434,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-22"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-27"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -1474,7 +1474,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-23"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-28"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -1514,7 +1514,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-24"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-29"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -1553,7 +1553,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-25"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-30"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1592,7 +1592,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-26"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-31"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-catalog-button"
@@ -1787,10 +1787,10 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-8"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-9"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-16"
+                    id="pf-topology-control-bar-18"
                     style="background-color: transparent;"
                   >
                     <div
@@ -1811,7 +1811,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-37"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-42"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -1851,7 +1851,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-38"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-43"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -1891,7 +1891,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-39"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-44"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -1931,7 +1931,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-40"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-45"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -1970,7 +1970,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-41"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-46"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -2230,10 +2230,10 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-7"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-8"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-14"
+                    id="pf-topology-control-bar-16"
                     style="background-color: transparent;"
                   >
                     <div
@@ -2254,7 +2254,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-32"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-37"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -2294,7 +2294,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-33"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-38"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -2334,7 +2334,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-34"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-39"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -2374,7 +2374,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-35"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-40"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -2413,7 +2413,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-36"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-41"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"

--- a/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
@@ -21,4 +21,6 @@ export class CanvasDefaults {
 
   static readonly HOVER_DELAY_IN = 200;
   static readonly HOVER_DELAY_OUT = 500;
+
+  static readonly CANVAS_FIT_PADDING = 80;
 }

--- a/packages/ui/src/components/Visualization/Canvas/controller.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/controller.service.test.ts
@@ -6,6 +6,15 @@ import { LayoutType } from './canvas.models';
 import { ControllerService } from './controller.service';
 
 describe('ControllerService', () => {
+  it('should not enable setFitToScreenOnLayout when creating the controller', () => {
+    const setFitToScreenOnLayoutSpy = jest.spyOn(Visualization.prototype, 'setFitToScreenOnLayout');
+
+    const controller = ControllerService.createController();
+
+    expect(controller).toBeInstanceOf(Visualization);
+    expect(setFitToScreenOnLayoutSpy).not.toHaveBeenCalled();
+  });
+
   it('should allow consumers to create a new controller and register its factories', () => {
     const layoutFactorySpy = jest.spyOn(Visualization.prototype, 'registerLayoutFactory');
     const componentFactorySpy = jest.spyOn(Visualization.prototype, 'registerComponentFactory');

--- a/packages/ui/src/components/Visualization/Canvas/controller.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/controller.service.ts
@@ -23,7 +23,6 @@ export class ControllerService {
     newController.registerLayoutFactory(this.baselineLayoutFactory);
     newController.registerComponentFactory(this.baselineComponentFactory);
     newController.registerElementFactory(this.baselineElementFactory);
-    newController.setFitToScreenOnLayout(true, 80);
     newController.fromModel({
       graph: {
         id: 'g1',

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -68,7 +68,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
       }
       event.stopPropagation();
     },
-    [areFlowsVisible, allFlowsVisible, visualFlowsApi, searchString],
+    [visualEntities, areFlowsVisible, searchString, visualFlowsApi],
   );
 
   return isListEmpty ? (

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.tsx
@@ -1,6 +1,6 @@
 import { Badge, Icon, MenuToggle, MenuToggleElement, Select } from '@patternfly/react-core';
 import { ListIcon } from '@patternfly/react-icons';
-import { FunctionComponent, Ref, useCallback, useContext, useState } from 'react';
+import { FunctionComponent, Ref, useContext, useState } from 'react';
 import { getVisibleFlowsInformation } from '../../../../models/visualization/flows/support/flows-visibility';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 
@@ -10,11 +10,7 @@ import './FlowsMenu.scss';
 export const FlowsMenu: FunctionComponent = () => {
   const { visibleFlows } = useContext(VisibleFlowsContext)!;
   const [isOpen, setIsOpen] = useState(false);
-  const visibleFlowsInformation = useCallback(() => {
-    return getVisibleFlowsInformation(visibleFlows);
-  }, [visibleFlows]);
-
-  const { singleFlowId, visibleFlowsCount, totalFlowsCount } = visibleFlowsInformation();
+  const { singleFlowId, visibleFlowsCount, totalFlowsCount } = getVisibleFlowsInformation(visibleFlows);
 
   /** Toggle the DSL dropdown */
   const onToggleClick = () => {

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './local-storage.hook';
+export * from './previous.hook';

--- a/packages/ui/src/hooks/previous.hook.test.ts
+++ b/packages/ui/src/hooks/previous.hook.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { usePrevious } from './previous.hook';
+
+describe('usePrevious', () => {
+  it('should return undefined on initial render', () => {
+    const { result } = renderHook(() => usePrevious(0));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return the previous value after an update', () => {
+    const { result, rerender } = renderHook((props) => usePrevious(props), {
+      initialProps: 0,
+    });
+
+    rerender(1);
+    expect(result.current).toBe(0);
+
+    rerender(2);
+    expect(result.current).toBe(1);
+  });
+
+  it('should work with non-primitive values', () => {
+    const { result, rerender } = renderHook((props) => usePrevious(props), {
+      initialProps: { key: 'value' },
+    });
+
+    rerender({ key: 'newValue' });
+    expect(result.current).toEqual({ key: 'value' });
+
+    rerender({ key: 'anotherValue' });
+    expect(result.current).toEqual({ key: 'newValue' });
+  });
+
+  it('should return undefined if no previous value exists', () => {
+    const { result } = renderHook(() => usePrevious(undefined));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/ui/src/hooks/previous.hook.ts
+++ b/packages/ui/src/hooks/previous.hook.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};

--- a/packages/ui/src/layout/Shell.test.tsx
+++ b/packages/ui/src/layout/Shell.test.tsx
@@ -1,0 +1,55 @@
+import { act, render, screen } from '@testing-library/react';
+import { useLocalStorage } from '../hooks/local-storage.hook';
+import { Shell } from './Shell';
+
+jest.mock('../hooks/local-storage.hook', () => ({
+  useLocalStorage: jest.fn(),
+}));
+
+jest.mock('./Navigation', () => ({
+  Navigation: ({ isNavOpen }: { isNavOpen: boolean }) => <div data-testid="navigation" data-is-open={isNavOpen}></div>,
+}));
+
+jest.mock('./TopBar', () => ({
+  TopBar: ({ navToggle }: { navToggle: () => void }) => (
+    <button title="button" type="button" data-testid="topbar" onClick={navToggle} />
+  ),
+}));
+
+describe('Shell Component', () => {
+  it('renders the Shell component with children', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([true, jest.fn()]);
+
+    render(
+      <Shell>
+        <div data-testid="child">Child Content</div>
+      </Shell>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.getByTestId('navigation')).toHaveAttribute('data-is-open', 'true');
+    expect(screen.getByTestId('topbar')).toBeInTheDocument();
+  });
+
+  it('toggles navigation state when navToggle is called', () => {
+    const setIsNavOpenMock = jest.fn();
+    (useLocalStorage as jest.Mock).mockReturnValue([true, setIsNavOpenMock]);
+
+    render(<Shell />);
+
+    act(() => {
+      const topBarButton = screen.getByTestId('topbar');
+      topBarButton.click();
+    });
+
+    expect(setIsNavOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it('renders navigation as closed when isNavOpen is false', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([false, jest.fn()]);
+
+    render(<Shell />);
+
+    expect(screen.getByTestId('navigation')).toHaveAttribute('data-is-open', 'false');
+  });
+});

--- a/packages/ui/src/layout/Shell.tsx
+++ b/packages/ui/src/layout/Shell.tsx
@@ -1,50 +1,17 @@
 import { Page, PageSection } from '@patternfly/react-core';
-import { FunctionComponent, PropsWithChildren, useCallback, useContext, useEffect } from 'react';
+import { FunctionComponent, PropsWithChildren, useCallback } from 'react';
 import { useLocalStorage } from '../hooks/local-storage.hook';
 import { LocalStorageKeys } from '../models';
-import { SourceCodeApiContext } from '../providers/source-code.provider';
-import { EventNotifier } from '../utils/event-notifier';
 import { Navigation } from './Navigation';
 import './Shell.scss';
 import { TopBar } from './TopBar';
 
 export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
-  const eventNotifier = EventNotifier.getInstance();
   const [isNavOpen, setIsNavOpen] = useLocalStorage(LocalStorageKeys.NavigationExpanded, true);
-  const sourceCodeApiContext = useContext(SourceCodeApiContext)!;
 
   const navToggle = useCallback(() => {
     setIsNavOpen(!isNavOpen);
   }, [isNavOpen, setIsNavOpen]);
-
-  /**
-   * Set the source code, entities, and visual entities from localStorage if available
-   * We don't use the useLocalStorage hook because we don't want to re-render the app
-   * as we just want to set the initial values
-   */
-  useEffect(() => {
-    const localSourceCode = localStorage.getItem(LocalStorageKeys.SourceCode) ?? '[]';
-    sourceCodeApiContext.setCodeAndNotify(localSourceCode);
-  }, [sourceCodeApiContext]);
-
-  /**
-   * Save the source code into the localStorage
-   * We don't use the useLocalStorage hook because we don't want to re-render the app
-   * as we just want to store the value
-   */
-  useEffect(() => {
-    const unSubscribeFromEntities = eventNotifier.subscribe('entities:updated', (code) => {
-      localStorage.setItem(LocalStorageKeys.SourceCode, code);
-    });
-    const unSubscribeFromCode = eventNotifier.subscribe('code:updated', ({ code }) => {
-      localStorage.setItem(LocalStorageKeys.SourceCode, code);
-    });
-
-    return () => {
-      unSubscribeFromEntities();
-      unSubscribeFromCode();
-    };
-  }, [eventNotifier]);
 
   return (
     <Page isContentFilled masthead={<TopBar navToggle={navToggle} />} sidebar={<Navigation isNavOpen={isNavOpen} />}>

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -10,5 +10,6 @@ export * from './metadata.provider';
 export * from './reload.provider';
 export * from './runtime.provider';
 export * from './schemas.provider';
+export * from './source-code-local-storage.provider';
 export * from './source-code.provider';
 export * from './visible-flows.provider';

--- a/packages/ui/src/providers/source-code-local-storage.provider.test.tsx
+++ b/packages/ui/src/providers/source-code-local-storage.provider.test.tsx
@@ -1,0 +1,82 @@
+import { act, render } from '@testing-library/react';
+import { LocalStorageKeys } from '../models';
+import { EventNotifier } from '../utils/event-notifier';
+import { SourceCodeLocalStorageProvider } from './source-code-local-storage.provider';
+
+describe('SourceCodeLocalStorageProvider', () => {
+  it('should render children within SourceCodeProvider', () => {
+    const { getByText } = render(
+      <SourceCodeLocalStorageProvider>
+        <div>Test Child</div>
+      </SourceCodeLocalStorageProvider>,
+    );
+
+    expect(getByText('Test Child')).toBeInTheDocument();
+  });
+
+  it('should initialize source code from localStorage', () => {
+    const localStorageGetItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+
+    render(<SourceCodeLocalStorageProvider />);
+
+    expect(localStorageGetItemSpy).toHaveBeenCalledWith(LocalStorageKeys.SourceCode);
+    localStorageGetItemSpy.mockRestore();
+  });
+
+  it('should subscribe to eventNotifier events', () => {
+    const mockSubscribe = jest.fn();
+    const mockUnsubscribe = jest.fn();
+
+    jest.spyOn(EventNotifier, 'getInstance').mockReturnValueOnce({
+      subscribe: mockSubscribe.mockImplementation(() => mockUnsubscribe),
+    } as unknown as EventNotifier);
+
+    render(<SourceCodeLocalStorageProvider />);
+
+    expect(mockSubscribe).toHaveBeenCalledWith('entities:updated', expect.any(Function));
+    expect(mockSubscribe).toHaveBeenCalledWith('code:updated', expect.any(Function));
+  });
+
+  it('should unsubscribe from eventNotifier events on unmount', () => {
+    const mockSubscribe = jest.fn();
+    const mockUnsubscribe = jest.fn();
+
+    jest.spyOn(EventNotifier, 'getInstance').mockReturnValueOnce({
+      subscribe: mockSubscribe.mockImplementation(() => mockUnsubscribe),
+    } as unknown as EventNotifier);
+
+    const { unmount } = render(<SourceCodeLocalStorageProvider />);
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('should update localStorage when entities:updated event is triggered', () => {
+    const localStorageSetItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    render(<SourceCodeLocalStorageProvider />);
+
+    act(() => {
+      EventNotifier.getInstance().next('entities:updated', 'new code');
+    });
+
+    expect(localStorageSetItemSpy).toHaveBeenCalledWith(LocalStorageKeys.SourceCode, 'new code');
+    localStorageSetItemSpy.mockRestore();
+  });
+
+  it('should update localStorage when code:updated event is triggered', () => {
+    const localStorageSetItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    render(<SourceCodeLocalStorageProvider />);
+
+    act(() => {
+      EventNotifier.getInstance().next('code:updated', { code: 'new code', path: 'new path' });
+    });
+
+    expect(localStorageSetItemSpy).toHaveBeenCalledWith(LocalStorageKeys.SourceCode, 'new code');
+    localStorageSetItemSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/providers/source-code-local-storage.provider.tsx
+++ b/packages/ui/src/providers/source-code-local-storage.provider.tsx
@@ -1,0 +1,36 @@
+import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
+import { LocalStorageKeys } from '../models';
+import { EventNotifier } from '../utils';
+import { SourceCodeProvider } from './source-code.provider';
+
+export const SourceCodeLocalStorageProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const eventNotifier = EventNotifier.getInstance();
+
+  /**
+   * Set the source code, entities, and visual entities from localStorage if available
+   * We don't use the useLocalStorage hook because we don't want to re-render the app
+   * as we just want to set the initial values
+   */
+  const localSourceCode = localStorage.getItem(LocalStorageKeys.SourceCode) ?? '[]';
+
+  /**
+   * Save the source code into the localStorage
+   * We don't use the useLocalStorage hook because we don't want to re-render the app
+   * as we just want to store the value
+   */
+  useEffect(() => {
+    const unSubscribeFromEntities = eventNotifier.subscribe('entities:updated', (code) => {
+      localStorage.setItem(LocalStorageKeys.SourceCode, code);
+    });
+    const unSubscribeFromCode = eventNotifier.subscribe('code:updated', ({ code }) => {
+      localStorage.setItem(LocalStorageKeys.SourceCode, code);
+    });
+
+    return () => {
+      unSubscribeFromEntities();
+      unSubscribeFromCode();
+    };
+  }, [eventNotifier]);
+
+  return <SourceCodeProvider initialSourceCode={localSourceCode}>{children}</SourceCodeProvider>;
+};

--- a/packages/ui/src/providers/source-code.provider.tsx
+++ b/packages/ui/src/providers/source-code.provider.tsx
@@ -14,12 +14,20 @@ interface ISourceCodeApi {
   setCodeAndNotify: (sourceCode: string, path?: string) => void;
 }
 
+interface SourceCodeProviderProps extends PropsWithChildren {
+  /** The initial source code */
+  initialSourceCode?: string;
+}
+
 export const SourceCodeContext = createContext<string>('');
 export const SourceCodeApiContext = createContext<ISourceCodeApi>({ setCodeAndNotify: () => {} });
 
-export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) => {
+export const SourceCodeProvider: FunctionComponent<SourceCodeProviderProps> = ({
+  initialSourceCode = '',
+  children,
+}) => {
   const eventNotifier = EventNotifier.getInstance();
-  const [sourceCode, setSourceCode] = useState<string>('');
+  const [sourceCode, setSourceCode] = useState<string>(initialSourceCode);
 
   useLayoutEffect(() => {
     return eventNotifier.subscribe('entities:updated', (code) => {
@@ -44,7 +52,7 @@ export const SourceCodeProvider: FunctionComponent<PropsWithChildren> = (props) 
 
   return (
     <SourceCodeApiContext.Provider value={sourceCodeApi}>
-      <SourceCodeContext.Provider value={sourceCode}>{props.children}</SourceCodeContext.Provider>
+      <SourceCodeContext.Provider value={sourceCode}>{children}</SourceCodeContext.Provider>
     </SourceCodeApiContext.Provider>
   );
 };


### PR DESCRIPTION
### Context
Currently, when adding or removing steps in the canvas, there's a process of auto-fitting that makes the current zoom and position be lost.

### Todo
- [x] Avoid autofitting when changing routes
- [x] Fix load source code upon restarting Kaoto after a setting change
- [x] Enable autofit when going from an empty canvas to showing a single or multiple routes

### Changes
The fix is to remove the `setFitToScreenOnLayout` method call and schedule a single autofit when loading the routes for the first time.

In addition to that, this commit removes the double rendering of the `Canvas` component due to the `SourceCodeProvider` being initialized with an empty string (`""`) and then updated from the `LocalStorage` with an `useEffect` call in the `Shell` component.

fix: https://github.com/KaotoIO/kaoto/issues/2216