### PR TITLE
fix(#2215): Azure-related icons seems small

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -28,7 +28,7 @@
 
         img {
           max-width: 100%;
-          max-height: 100%;
+          height: 100%;
         }
       }
 


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/2215

![Screenshot from 2025-04-23 09-21-41](https://github.com/user-attachments/assets/4a7ac955-5b42-46cc-ab0e-1c4d2647e6ff)
