### PR TITLE
Fix(Canvas): Making Flows visible after the source code change

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
@@ -81,35 +81,12 @@ describe('VisualFlowsApi', () => {
     });
 
     describe('initVisibleFlows', () => {
-      it('should not create a new state if all flows already exists', () => {
-        const initialState = { flowId1: true, flowId2: false };
-        action = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };
-        const newState = VisibleFlowsReducer(initialState, action);
-
-        expect(newState).toBe(initialState);
-      });
       it('should ensure at least one flow is visible on first render', () => {
         const initialState = {};
         const action: VisibleFlowAction = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };
         const newState = VisibleFlowsReducer(initialState, action);
 
         expect(newState).toEqual({ flowId1: true, flowId2: false });
-      });
-
-      it('should preserve visibility state on subsequent renders', () => {
-        const initialState = { flowId1: false, flowId2: true };
-        const action: VisibleFlowAction = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };
-        const newState = VisibleFlowsReducer(initialState, action);
-
-        expect(newState).toEqual({ flowId1: false, flowId2: true });
-      });
-
-      it('should keep existing visibility', () => {
-        const initialState = { flowId1: false, flowId2: true };
-        action = { type: 'initVisibleFlows', flowsIds: ['flowId1', 'flowId2'] };
-        const newState = VisibleFlowsReducer(initialState, action);
-
-        expect(newState).toEqual({ flowId1: false, flowId2: true });
       });
     });
 

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -85,19 +85,28 @@ export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAct
     case 'clearFlows':
       return {};
 
+    // case 'initVisibleFlows': {
+    //   const firstRender = Object.keys(state).length === 0;
+    //   if (
+    //     action.flowsIds.length === Object.keys(state).length &&
+    //     action.flowsIds.every((flowId) => isDefined(state[flowId]))
+    //   ) {
+    //     return state;
+    //   }
+    //   const visibleFlows = action.flowsIds.reduce((acc, flowId) => {
+    //     acc[flowId] = state[flowId] ?? false;
+    //     return acc;
+    //   }, {} as IVisibleFlows);
+    //   return firstRender ? ensureAtLeastOneVisibleFlow(visibleFlows) : visibleFlows;
+    // }
+
     case 'initVisibleFlows': {
-      const firstRender = Object.keys(state).length === 0;
-      if (
-        action.flowsIds.length === Object.keys(state).length &&
-        action.flowsIds.every((flowId) => isDefined(state[flowId]))
-      ) {
-        return state;
-      }
       const visibleFlows = action.flowsIds.reduce((acc, flowId) => {
         acc[flowId] = state[flowId] ?? false;
         return acc;
       }, {} as IVisibleFlows);
-      return firstRender ? ensureAtLeastOneVisibleFlow(visibleFlows) : visibleFlows;
+
+      return ensureAtLeastOneVisibleFlow(visibleFlows);
     }
 
     case 'renameFlow':

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -1,4 +1,4 @@
-import { isDefined } from '../../../../utils';
+import { initVisibleFlows } from '../../../../utils/init-visible-flows';
 
 export interface IVisibleFlowsInformation {
   singleFlowId: string | undefined;
@@ -46,14 +46,6 @@ export type VisibleFlowAction =
   | { type: 'initVisibleFlows'; flowsIds: string[] }
   | { type: 'renameFlow'; flowId: string; newName: string };
 
-const ensureAtLeastOneVisibleFlow = (state: IVisibleFlows) => {
-  const entries = Object.keys(state);
-  if (entries.length > 0 && Object.values(state).every((visible) => !visible)) {
-    state[entries[0]] = true;
-  }
-  return state;
-};
-
 export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAction) {
   switch (action.type) {
     case 'toggleFlowVisible':
@@ -85,28 +77,8 @@ export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAct
     case 'clearFlows':
       return {};
 
-    // case 'initVisibleFlows': {
-    //   const firstRender = Object.keys(state).length === 0;
-    //   if (
-    //     action.flowsIds.length === Object.keys(state).length &&
-    //     action.flowsIds.every((flowId) => isDefined(state[flowId]))
-    //   ) {
-    //     return state;
-    //   }
-    //   const visibleFlows = action.flowsIds.reduce((acc, flowId) => {
-    //     acc[flowId] = state[flowId] ?? false;
-    //     return acc;
-    //   }, {} as IVisibleFlows);
-    //   return firstRender ? ensureAtLeastOneVisibleFlow(visibleFlows) : visibleFlows;
-    // }
-
     case 'initVisibleFlows': {
-      const visibleFlows = action.flowsIds.reduce((acc, flowId) => {
-        acc[flowId] = state[flowId] ?? false;
-        return acc;
-      }, {} as IVisibleFlows);
-
-      return ensureAtLeastOneVisibleFlow(visibleFlows);
+      return initVisibleFlows(action.flowsIds);
     }
 
     case 'renameFlow':

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -78,7 +78,7 @@ export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAct
       return {};
 
     case 'initVisibleFlows': {
-      return initVisibleFlows(action.flowsIds);
+      return initVisibleFlows(action.flowsIds, state);
     }
 
     case 'renameFlow':

--- a/packages/ui/src/providers/__snapshots__/visible-flows.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/visible-flows.provider.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VisibleFlowsProvider should initialize visible flows correctly 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="visible-flows"
+  >
+    {
+    "route-1234": true
+}
+  </div>
+  <div
+    data-testid="all-flows-visible"
+  >
+    true
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VisibleFlowsProvider should initialize visible flows with an empty context 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="visible-flows"
+  >
+    {}
+  </div>
+  <div
+    data-testid="all-flows-visible"
+  >
+    true
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/providers/visible-flows.provider.test.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { FunctionComponent, useContext } from 'react';
+import { CamelRouteResource } from '../models/camel/camel-route-resource';
+import { EntityType } from '../models/camel/entities';
+import { TestProvidersWrapper } from '../stubs';
+import { VisibleFlowsContext, VisibleFlowsProvider } from './visible-flows.provider';
+
+describe('VisibleFlowsProvider', () => {
+  it('should initialize visible flows correctly', () => {
+    const camelResource = new CamelRouteResource();
+    camelResource.addNewEntity(EntityType.Route);
+
+    const { Provider } = TestProvidersWrapper({ camelResource });
+
+    const wrapper = render(
+      <Provider>
+        <VisibleFlowsProvider>
+          <MockComponent />
+        </VisibleFlowsProvider>
+      </Provider>,
+    );
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it('should initialize visible flows with an empty context', () => {
+    const camelResource = new CamelRouteResource();
+    const { Provider } = TestProvidersWrapper({ camelResource });
+
+    const wrapper = render(
+      <Provider>
+        <VisibleFlowsProvider>
+          <MockComponent />
+        </VisibleFlowsProvider>
+      </Provider>,
+    );
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+});
+
+const MockComponent: FunctionComponent = () => {
+  const context = useContext(VisibleFlowsContext);
+
+  return (
+    <>
+      <div data-testid="visible-flows">{JSON.stringify(context?.visibleFlows, undefined, 4)}</div>
+      <div data-testid="all-flows-visible">{JSON.stringify(context?.allFlowsVisible, undefined, 4)}</div>
+    </>
+  );
+};

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -6,6 +6,7 @@ import {
 } from '../models/visualization/flows/support/flows-visibility';
 import { initVisibleFlows } from '../utils';
 import { EntitiesContext } from './entities.provider';
+import { usePrevious } from '../hooks';
 
 export interface VisibleFlowsContextResult {
   visibleFlows: IVisibleFlows;
@@ -28,8 +29,17 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
     return new VisualFlowsApi(dispatch);
   }, [dispatch]);
 
+  const previousVisualEntitiesIds = usePrevious(visualEntitiesIds);
+
   useEffect(() => {
-    visualFlowsApi.initVisibleFlows(visualEntitiesIds);
+    const hasSameIds =
+      Array.isArray(previousVisualEntitiesIds) &&
+      previousVisualEntitiesIds.length === visualEntitiesIds.length &&
+      previousVisualEntitiesIds.every((id) => visualEntitiesIds.includes(id));
+
+    if (!hasSameIds) {
+      visualFlowsApi.initVisibleFlows(visualEntitiesIds);
+    }
   }, [visualEntitiesIds, visualFlowsApi]);
 
   const value = useMemo(() => {

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -4,9 +4,8 @@ import {
   VisibleFlowsReducer,
   VisualFlowsApi,
 } from '../models/visualization/flows/support/flows-visibility';
-import { initVisibleFlows } from '../utils';
+import { initVisibleFlows, isSameArray } from '../utils';
 import { EntitiesContext } from './entities.provider';
-import { usePrevious } from '../hooks';
 
 export interface VisibleFlowsContextResult {
   visibleFlows: IVisibleFlows;
@@ -29,18 +28,21 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
     return new VisualFlowsApi(dispatch);
   }, [dispatch]);
 
-  const previousVisualEntitiesIds = usePrevious(visualEntitiesIds);
+  const visibleFlowsIds = useMemo(() => Object.keys(visibleFlows), [visibleFlows]);
 
   useEffect(() => {
-    const hasSameIds =
-      Array.isArray(previousVisualEntitiesIds) &&
-      previousVisualEntitiesIds.length === visualEntitiesIds.length &&
-      previousVisualEntitiesIds.every((id) => visualEntitiesIds.includes(id));
+    const hasSameIds = isSameArray(visualEntitiesIds, visibleFlowsIds);
 
+    /**
+     * If the ids of the visual entities are different from the ids of the visible flows,
+     * we need to initialize the visible flows with the new ids.
+     * This is important because the visible flows are stored in the state and
+     * if the ids change, we need to update the state to reflect the new ids.
+     */
     if (!hasSameIds) {
       visualFlowsApi.initVisibleFlows(visualEntitiesIds);
     }
-  }, [visualEntitiesIds, visualFlowsApi]);
+  }, [visibleFlowsIds, visualEntitiesIds, visualFlowsApi]);
 
   const value = useMemo(() => {
     return {

--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -42,7 +42,7 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
     if (!hasSameIds) {
       visualFlowsApi.initVisibleFlows(visualEntitiesIds);
     }
-  }, [visibleFlowsIds, visualEntitiesIds, visualFlowsApi]);
+  }, [visualEntitiesIds, visualFlowsApi]);
 
   const value = useMemo(() => {
     return {

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './init-visible-flows';
 export * from './is-datamapper';
 export * from './is-defined';
 export * from './is-enum-type';
+export * from './is-same-array';
 export * from './is-to-processor';
 export * from './is-xslt-component';
 export * from './join-path';

--- a/packages/ui/src/utils/init-visible-flows.ts
+++ b/packages/ui/src/utils/init-visible-flows.ts
@@ -1,8 +1,18 @@
 import { IVisibleFlows } from '../models/visualization/flows/support/flows-visibility';
 
-export const initVisibleFlows = (flowsIds: string[]) => {
-  return flowsIds.reduce((flows, id, index) => {
-    flows[id] = index === 0;
+const ensureAtLeastOneVisibleFlow = (state: IVisibleFlows) => {
+  const entries = Object.keys(state);
+  if (entries.length > 0 && Object.values(state).every((visible) => !visible)) {
+    state[entries[0]] = true;
+  }
+  return state;
+};
+
+export const initVisibleFlows = (flowsIds: string[], state: IVisibleFlows = {}): IVisibleFlows => {
+  const visibleFlows = flowsIds.reduce((flows, id) => {
+    flows[id] = state[id] ?? false;
     return flows;
   }, {} as IVisibleFlows);
+
+  return ensureAtLeastOneVisibleFlow(visibleFlows);
 };

--- a/packages/ui/src/utils/is-same-array.test.ts
+++ b/packages/ui/src/utils/is-same-array.test.ts
@@ -1,0 +1,33 @@
+import { isSameArray } from './is-same-array';
+
+describe('isSameArray', () => {
+  it('should return true for arrays with the same elements in the same order', () => {
+    expect(isSameArray([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  it('should return true for arrays with the same elements in a different order', () => {
+    expect(isSameArray([1, 2, 3], [3, 2, 1])).toBe(true);
+  });
+
+  it('should return false for arrays with different elements', () => {
+    expect(isSameArray([1, 2, 3], [4, 5, 6])).toBe(false);
+  });
+
+  it('should return false for arrays with different lengths', () => {
+    expect(isSameArray([1, 2, 3], [1, 2])).toBe(false);
+  });
+
+  it('should return true for empty arrays', () => {
+    expect(isSameArray([], [])).toBe(true);
+  });
+
+  it('should return false if one array is empty and the other is not', () => {
+    expect(isSameArray([], [1, 2, 3])).toBe(false);
+    expect(isSameArray([1, 2, 3], [])).toBe(false);
+  });
+
+  it('should handle arrays with different types of elements', () => {
+    expect(isSameArray([1, '2', 'true'], ['true', '2', 1])).toBe(true);
+    expect(isSameArray([1, '2', 'true'], [1, '2', 'false'])).toBe(false);
+  });
+});

--- a/packages/ui/src/utils/is-same-array.ts
+++ b/packages/ui/src/utils/is-same-array.ts
@@ -1,0 +1,16 @@
+/**
+ * Check if two arrays have the same elements
+ * It assumes that the arrays are made out of strings or numbers
+ * and doesn't contain duplicates
+ *
+ * @param array1 The first array
+ * @param array2 The second array
+ * @returns True if the arrays have the same elements, false otherwise
+ */
+export const isSameArray = (array1: Array<string | number>, array2: Array<string | number>): boolean => {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+
+  return array1.every((id) => array2.includes(id));
+};


### PR DESCRIPTION
### Context    
Going to the source code editor and pasting a completely new route definition, when returning back to the design page, the route is hidden by default.

### Changes    
The fix is to keep the visibility of the existing routes, if possible. This is possible by checking the IDs from the VisualEntities and comparing them against the VisibleFlows object.

fix: https://github.com/KaotoIO/kaoto/issues/2214