### PR TITLE
chore(deps): Update Camel Catalog versions

### DIFF
--- a/packages/catalog-generator/scripts/build-catalogs.mjs
+++ b/packages/catalog-generator/scripts/build-catalogs.mjs
@@ -18,9 +18,9 @@ const CATALOGS = {
   Main: [
     //
     '4.11.0',
-    '4.10.3',
+    '4.10.4',
     '4.8.6',
-    '4.8.3.redhat-00004',
+    '4.8.5.redhat-00008',
     '4.4.0.redhat-00046',
   ],
   // https://repo1.maven.org/maven2/org/apache/camel/quarkus/camel-quarkus-catalog/
@@ -37,9 +37,9 @@ const CATALOGS = {
   SpringBoot: [
     //
     '4.11.0',
-    '4.10.3',
+    '4.10.4',
     '4.8.6',
-    '4.8.3.redhat-00009',
+    '4.8.5.redhat-00008',
     '4.4.0.redhat-00039',
   ],
 };

--- a/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
@@ -5,19 +5,19 @@ describe('Test for catalog versions', () => {
 
   const testData = [
     { type: 'Main', version: 'Camel Main 4.11.0' },
-    { type: 'Main', version: 'Camel Main 4.10.3' },
-    { type: 'Main', version: 'Camel Main 4.4.0.redhat-00046' },
-    { type: 'Main', version: 'Camel Main 4.8.3.redhat-00004' },
+    { type: 'Main', version: 'Camel Main 4.10.4' },
     { type: 'Main', version: 'Camel Main 4.8.6' },
+    { type: 'Main', version: 'Camel Main 4.8.5.redhat-00008' },
+    { type: 'Main', version: 'Camel Main 4.4.0.redhat-00046' },
     { type: 'Quarkus', version: 'Camel Quarkus 3.20.0' },
     { type: 'Quarkus', version: 'Camel Quarkus 3.15.3' },
     { type: 'Quarkus', version: 'Camel Quarkus 3.15.0.redhat-00010' },
     { type: 'Quarkus', version: 'Camel Quarkus 3.8.0.redhat-00018' },
-    { type: 'Spring Boot', version: 'Camel Spring Boot 4.4.0.redhat-00039' },
-    { type: 'Spring Boot', version: 'Camel Spring Boot 4.8.3.redhat-00009' },
-    { type: 'Spring Boot', version: 'Camel Spring Boot 4.8.6' },
-    { type: 'Spring Boot', version: 'Camel Spring Boot 4.10.3' },
     { type: 'Spring Boot', version: 'Camel Spring Boot 4.11.0' },
+    { type: 'Spring Boot', version: 'Camel Spring Boot 4.10.4' },
+    { type: 'Spring Boot', version: 'Camel Spring Boot 4.8.6' },
+    { type: 'Spring Boot', version: 'Camel Spring Boot 4.8.5.redhat-00008' },
+    { type: 'Spring Boot', version: 'Camel Spring Boot 4.4.0.redhat-00039' },
   ];
   testData.forEach((data) => {
     it(`Catalog version test for ${data.version}`, { tags: ['weekly'] }, () => {


### PR DESCRIPTION
### Context
Upgrading Camel Catalog to:
Camel 4.10.3 -> 4.10.4
Camel 4.8.3.redhat-00004 -> 4.8.5.redhat-00008

fix: https://github.com/KaotoIO/kaoto/issues/2231