### PR TITLE
refactor(kaoto-vscode): revert bottom margin for the canvas controls

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -33,7 +33,7 @@ export const ContextToolbar: FunctionComponent<{ additionalControls?: JSX.Elemen
   }
 
   return (
-    <Toolbar>
+    <Toolbar id="context-toolbar">
       <ToolbarContent>
         {toolbarItems.concat([
           <ToolbarItem key="toolbar-clipboard">

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -33,7 +33,7 @@ export const ContextToolbar: FunctionComponent<{ additionalControls?: JSX.Elemen
   }
 
   return (
-    <Toolbar id="context-toolbar">
+    <Toolbar className="context-toolbar">
       <ToolbarContent>
         {toolbarItems.concat([
           <ToolbarItem key="toolbar-clipboard">

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -51,10 +51,8 @@ html body {
   }
 }
 
-#context-toolbar {
-  padding-bottom: 5px;
-  padding-top: 5px;
-  padding-left: 5px;
+.context-toolbar {
+  padding: var(--pf-v6-c-toolbar__content-section--ColumnGap);
 }
 
 .pf-v6-c-divider {

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -51,7 +51,12 @@ html body {
   }
 }
 
-div[data-envelope-context='vscode'].shell .pf-v6-c-toolbar {
-  row-gap: 0;
-  padding-block: 0;
+#context-toolbar {
+  padding-bottom: 5px;
+  padding-top: 5px;
+  padding-left: 5px;
+}
+
+.pf-v6-c-divider {
+  display: none;
 }

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -65,11 +65,12 @@ export const KaotoEditor = () => {
     <div className="shell" data-envelope-context="vscode">
       <Tabs
         inset={inset.current}
-        isBox
+        isFilled
         unmountOnExit
         activeKey={currentPath}
         aria-label="Tabs in the Kaoto editor"
         role="region"
+        hasNoBorderBottom
       >
         {availableTabs.design && (
           <Link data-testid="design-tab" to={Links.Home}>


### PR DESCRIPTION
This PR refines a little bit kaoto style in VS-Code: 
- bottom margin reverted to the original state 
- clean up the tabs layout and contextToolbar: 


Light Theme: 
<img width="1270" alt="Screenshot 2025-05-02 at 15 56 28" src="https://github.com/user-attachments/assets/0150f943-c410-4707-947d-7531395edc82" />
BEFORE:
<img width="1221" alt="Screenshot 2025-05-02 at 15 56 34" src="https://github.com/user-attachments/assets/b60c2b42-8b83-4f76-92c0-1ff5b602fd93" />

Dark Theme:
<img width="1270" alt="Screenshot 2025-05-02 at 16 20 42" src="https://github.com/user-attachments/assets/0861987c-8878-4434-86bb-e68bd8d39534" />

Before:
<img width="1226" alt="Screenshot 2025-05-02 at 15 59 47" src="https://github.com/user-attachments/assets/c753dd99-9a2d-4013-a31e-909d2f047326" />

