### PR TITLE
feat(DataMapper): Select a mapping

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/DataMapperMonitor.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DataMapperMonitor.tsx
@@ -1,15 +1,22 @@
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import { useEffect } from 'react';
-import { MappingService } from '../../../services/mapping.service';
+import { useMappingLinks } from '../../../hooks/useMappingLinks';
+import { MappingLinksService } from '../../../services/mapping-links.service';
 
 export const DataMapperMonitor = () => {
   const { mappingTree, sourceParameterMap, sourceBodyDocument, targetBodyDocument } = useDataMapper();
+  const { getSelectedNodeReference } = useMappingLinks();
 
   useEffect(() => {
-    MappingService.extractMappingLinks(mappingTree, sourceParameterMap, sourceBodyDocument).forEach((mapping) => {
+    MappingLinksService.extractMappingLinks(
+      mappingTree,
+      sourceParameterMap,
+      sourceBodyDocument,
+      getSelectedNodeReference(),
+    ).forEach((mapping) => {
       console.log(`Mapping: [source={${mapping.sourceNodePath}}, target={${mapping.targetNodePath}}]`);
     });
-  }, [mappingTree, sourceBodyDocument, sourceParameterMap, targetBodyDocument]);
+  }, [getSelectedNodeReference, mappingTree, sourceBodyDocument, sourceParameterMap, targetBodyDocument]);
 
   return <></>;
 };

--- a/packages/ui/src/components/Document/Document.scss
+++ b/packages/ui/src/components/Document/Document.scss
@@ -116,3 +116,11 @@ img {
     --pf-v6-c-button--PaddingRight: 0.5rem;
   }
 }
+
+.selected-container {
+  font-weight: bold;
+  border-style: solid;
+  border-color: var(--pf-v6-c-draggable--m-dragging--after--BorderColor);
+  background-color: var(--pf-v6-c-draggable--m-dragging--BackgroundColor);
+  border-radius: var(--pf-v6-c-draggable--m-dragging--after--BorderRadius);
+}

--- a/packages/ui/src/components/Document/NodeContainer.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.tsx
@@ -69,17 +69,22 @@ const DnDContainer: FunctionComponent<DnDContainerProps> = ({ nodeData, children
 };
 
 type NodeContainerProps = PropsWithChildren & {
+  className?: string;
   nodeData?: NodeData;
 };
 
-export const NodeContainer = forwardRef<HTMLDivElement, NodeContainerProps>(({ children, nodeData }, forwardedRef) => {
-  return nodeData &&
-    !(nodeData instanceof DocumentNodeData && !nodeData.isPrimitive) &&
-    !(nodeData instanceof AddMappingNodeData) ? (
-    <div ref={forwardedRef}>
-      <DnDContainer nodeData={nodeData}>{children}</DnDContainer>
-    </div>
-  ) : (
-    <div ref={forwardedRef}>{children}</div>
-  );
-});
+export const NodeContainer = forwardRef<HTMLDivElement, NodeContainerProps>(
+  ({ children, className, nodeData }, forwardedRef) => {
+    return nodeData &&
+      !(nodeData instanceof DocumentNodeData && !nodeData.isPrimitive) &&
+      !(nodeData instanceof AddMappingNodeData) ? (
+      <div ref={forwardedRef} className={className}>
+        <DnDContainer nodeData={nodeData}>{children}</DnDContainer>
+      </div>
+    ) : (
+      <div ref={forwardedRef} className={className}>
+        {children}
+      </div>
+    );
+  },
+);

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -22,10 +22,10 @@ import { useDataMapper } from '../../hooks/useDataMapper';
 import { useToggle } from '../../hooks/useToggle';
 import { DocumentDefinition, DocumentDefinitionType } from '../../models/datamapper/document';
 import { DocumentType } from '../../models/datamapper/path';
-import { NodeReference } from '../../providers/datamapper-canvas.provider';
 import './Document.scss';
 import { NodeContainer } from './NodeContainer';
 import { SourceDocument } from './SourceDocument';
+import { NodeReference } from '../../models/datamapper';
 
 enum ParameterNameValidation {
   EMPTY,
@@ -148,9 +148,12 @@ export const Parameters: FunctionComponent<ParametersProps> = ({ isReadOnly }) =
   } = useToggle(false);
 
   const { getNodeReference, setNodeReference } = useCanvas();
-  const nodeReference = useRef<NodeReference>({ headerRef: null, containerRef: null });
+  const nodeRefId = 'param';
+  const nodeReference = useRef<NodeReference>({ isSource: true, path: nodeRefId, headerRef: null, containerRef: null });
   const headerRef = useRef<HTMLDivElement>(null);
   useImperativeHandle(nodeReference, () => ({
+    isSource: true,
+    path: nodeRefId,
     get headerRef() {
       return headerRef.current;
     },
@@ -158,7 +161,6 @@ export const Parameters: FunctionComponent<ParametersProps> = ({ isReadOnly }) =
       return headerRef.current;
     },
   }));
-  const nodeRefId = 'param';
   getNodeReference(nodeRefId) !== nodeReference && setNodeReference(nodeRefId, nodeReference);
 
   const handleAddNewParameter = useCallback(() => {

--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -19,10 +19,12 @@ import { useCanvas } from '../../hooks/useCanvas';
 import { SourcePanel } from './SourcePanel';
 import { SourceTargetDnDHandler } from '../../providers/dnd/SourceTargetDnDHandler';
 import { TargetDocument } from '../Document/TargetDocument';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
 
 export const SourceTargetView: FunctionComponent = () => {
   const { targetBodyDocument } = useDataMapper();
-  const { reloadNodeReferences, setDefaultHandler, setMappingLinkCanvasRef } = useCanvas();
+  const { reloadNodeReferences, setDefaultHandler } = useCanvas();
+  const { setMappingLinkCanvasRef } = useMappingLinks();
   const mappingLinkCanvasRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/packages/ui/src/hooks/useMappingLinks.tsx
+++ b/packages/ui/src/hooks/useMappingLinks.tsx
@@ -1,0 +1,10 @@
+import { MappingLinksContext, IMappingLinksContext } from '../providers/data-mapping-links.provider';
+import { useContext } from 'react';
+
+export const errorMessage = 'useMappingLinks should be called into MappingLinksProvider';
+
+export const useMappingLinks = (): IMappingLinksContext => {
+  const ctx = useContext(MappingLinksContext);
+  if (!ctx) throw new Error(errorMessage);
+  return ctx;
+};

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -1,6 +1,7 @@
 import { IDocument, IField, PrimitiveDocument } from './document';
 import { ExpressionItem, FieldItem, IFunctionDefinition, MappingItem, MappingParentType, MappingTree } from './mapping';
 import { DocumentType, NodePath } from './path';
+import { RefObject } from 'react';
 
 export interface NodeData {
   title: string;
@@ -163,4 +164,26 @@ export class FunctionNodeData implements NodeData {
 export interface IMappingLink {
   sourceNodePath: string;
   targetNodePath: string;
+  isSelected: boolean;
 }
+
+export interface NodeReference {
+  path: string;
+  isSource: boolean;
+  headerRef: HTMLDivElement | null;
+  containerRef: HTMLDivElement | null;
+}
+
+export type LineCoord = {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+export type LineProps = LineCoord & {
+  sourceNodePath: string;
+  targetNodePath: string;
+  isSelected?: boolean;
+  svgRef?: RefObject<SVGSVGElement>;
+};

--- a/packages/ui/src/providers/data-mapping-links.provider.test.tsx
+++ b/packages/ui/src/providers/data-mapping-links.provider.test.tsx
@@ -1,0 +1,25 @@
+import { DataMapperProvider } from './datamapper.provider';
+import { MappingLinksProvider } from './data-mapping-links.provider';
+import { render, screen } from '@testing-library/react';
+
+describe('DataMappingLinksProvider', () => {
+  it('should render', async () => {
+    render(
+      <DataMapperProvider>
+        <MappingLinksProvider>
+          <div data-testid="testdiv" />
+        </MappingLinksProvider>
+      </DataMapperProvider>,
+    );
+    expect(await screen.findByTestId('testdiv')).toBeInTheDocument();
+  });
+
+  it('should fail if not within DataMapperProvider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const thrower = () => {
+      render(<MappingLinksProvider></MappingLinksProvider>);
+    };
+    expect(thrower).toThrow();
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/providers/data-mapping-links.provider.tsx
+++ b/packages/ui/src/providers/data-mapping-links.provider.tsx
@@ -1,0 +1,70 @@
+import {
+  createContext,
+  FunctionComponent,
+  MutableRefObject,
+  PropsWithChildren,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { IMappingLink, NodeReference } from '../models/datamapper';
+import { useDataMapper } from '../hooks/useDataMapper';
+import { MappingLinksService } from '../services/mapping-links.service';
+
+export interface IMappingLinksContext {
+  mappingLinkCanvasRef: RefObject<HTMLDivElement> | null;
+  setMappingLinkCanvasRef: (ref: RefObject<HTMLDivElement>) => void;
+  getMappingLinks: () => IMappingLink[];
+  getSelectedNodeReference: () => MutableRefObject<NodeReference> | null;
+  setSelectedNodeReference: (ref: MutableRefObject<NodeReference> | null) => void;
+  toggleSelectedNodeReference: (ref: MutableRefObject<NodeReference> | null) => void;
+  isInSelectedMapping: (ref: MutableRefObject<NodeReference>) => boolean;
+}
+
+export const MappingLinksContext = createContext<IMappingLinksContext | undefined>(undefined);
+
+export const MappingLinksProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const { mappingTree, sourceParameterMap, sourceBodyDocument } = useDataMapper();
+  const [mappingLinkCanvasRef, setMappingLinkCanvasRef] = useState<RefObject<HTMLDivElement> | null>(null);
+  const [mappingLinks, setMappingLinks] = useState<IMappingLink[]>([]);
+  const [selectedNodeRef, setSelectedNodeRef] = useState<MutableRefObject<NodeReference> | null>(null);
+
+  useEffect(() => {
+    const links = MappingLinksService.extractMappingLinks(
+      mappingTree,
+      sourceParameterMap,
+      sourceBodyDocument,
+      selectedNodeRef,
+    );
+    setMappingLinks(links);
+  }, [mappingTree, selectedNodeRef, sourceBodyDocument, sourceParameterMap]);
+
+  const toggleSelectedNodeReference = useCallback(
+    (ref: MutableRefObject<NodeReference> | null) => {
+      setSelectedNodeRef(ref !== selectedNodeRef ? ref : null);
+    },
+    [selectedNodeRef],
+  );
+
+  const isInSelectedMapping = useCallback(
+    (ref: MutableRefObject<NodeReference>): boolean =>
+      selectedNodeRef === ref || MappingLinksService.isInSelectedMapping(mappingLinks, ref),
+    [mappingLinks, selectedNodeRef],
+  );
+
+  const value = useMemo(() => {
+    return {
+      mappingLinkCanvasRef,
+      setMappingLinkCanvasRef,
+      getMappingLinks: () => mappingLinks,
+      getSelectedNodeReference: () => selectedNodeRef,
+      setSelectedNodeReference: setSelectedNodeRef,
+      toggleSelectedNodeReference,
+      isInSelectedMapping,
+    };
+  }, [isInSelectedMapping, mappingLinkCanvasRef, mappingLinks, selectedNodeRef, toggleSelectedNodeReference]);
+
+  return <MappingLinksContext.Provider value={value}>{children}</MappingLinksContext.Provider>;
+};

--- a/packages/ui/src/providers/datamapper-canvas.provider.tsx
+++ b/packages/ui/src/providers/datamapper-canvas.provider.tsx
@@ -3,7 +3,6 @@ import {
   FunctionComponent,
   MutableRefObject,
   PropsWithChildren,
-  RefObject,
   useCallback,
   useEffect,
   useMemo,
@@ -13,11 +12,8 @@ import { DnDHandler } from './dnd/DnDHandler';
 import { DocumentType, NodePath } from '../models/datamapper/path';
 import { DatamapperDndProvider } from './datamapper-dnd.provider';
 import { useDataMapper } from '../hooks/useDataMapper';
-
-export interface NodeReference {
-  headerRef: HTMLDivElement | null;
-  containerRef: HTMLDivElement | null;
-}
+import { MappingLinksProvider } from './data-mapping-links.provider';
+import { NodeReference } from '../models/datamapper';
 
 export interface ICanvasContext {
   setNodeReference: (path: string, ref: MutableRefObject<NodeReference>) => void;
@@ -29,8 +25,6 @@ export interface ICanvasContext {
   setDefaultHandler: (handler: DnDHandler | undefined) => void;
   getActiveHandler: () => DnDHandler | undefined;
   setActiveHandler: (handler: DnDHandler | undefined) => void;
-  mappingLinkCanvasRef: RefObject<HTMLDivElement> | null;
-  setMappingLinkCanvasRef: (ref: RefObject<HTMLDivElement>) => void;
 }
 
 export const CanvasContext = createContext<ICanvasContext | undefined>(undefined);
@@ -39,7 +33,6 @@ export const DataMapperCanvasProvider: FunctionComponent<PropsWithChildren> = (p
   const { mappingTree } = useDataMapper();
   const [defaultHandler, setDefaultHandler] = useState<DnDHandler | undefined>();
   const [activeHandler, setActiveHandler] = useState<DnDHandler | undefined>();
-  const [mappingLinkCanvasRef, setMappingLinkCanvasRef] = useState<RefObject<HTMLDivElement> | null>(null);
 
   const [nodeReferenceMap, setNodeReferenceMap] = useState<Map<string, MutableRefObject<NodeReference>>>(
     new Map<string, MutableRefObject<NodeReference>>(),
@@ -117,8 +110,6 @@ export const DataMapperCanvasProvider: FunctionComponent<PropsWithChildren> = (p
       setDefaultHandler: handleSetDefaultHandler,
       getActiveHandler: () => activeHandler,
       setActiveHandler: handleSetActiveHandler,
-      mappingLinkCanvasRef,
-      setMappingLinkCanvasRef: (ref) => setMappingLinkCanvasRef(ref),
     };
   }, [
     setNodeReference,
@@ -130,12 +121,13 @@ export const DataMapperCanvasProvider: FunctionComponent<PropsWithChildren> = (p
     handleSetDefaultHandler,
     handleSetActiveHandler,
     activeHandler,
-    mappingLinkCanvasRef,
   ]);
 
   return (
     <CanvasContext.Provider value={value}>
-      <DatamapperDndProvider handler={activeHandler}>{props.children}</DatamapperDndProvider>
+      <DatamapperDndProvider handler={activeHandler}>
+        <MappingLinksProvider>{props.children}</MappingLinksProvider>
+      </DatamapperDndProvider>
     </CanvasContext.Provider>
   );
 };

--- a/packages/ui/src/services/mapping-links.service.test.ts
+++ b/packages/ui/src/services/mapping-links.service.test.ts
@@ -1,0 +1,219 @@
+import { XmlSchemaDocument, XmlSchemaDocumentService } from './xml-schema-document.service';
+import { MappingLinksService } from './mapping-links.service';
+import {
+  invoice850Xsd,
+  message837Xsd,
+  shipOrderToShipOrderCollectionIndexXslt,
+  shipOrderToShipOrderMultipleForEachXslt,
+  shipOrderToShipOrderXslt,
+  TestUtil,
+  x12837PDfdlXsd,
+  x12837PXslt,
+  x12850DfdlXsd,
+  x12850ForEachXslt,
+} from '../stubs/data-mapper';
+import { IDocument } from '../models/datamapper/document';
+import { MappingTree } from '../models/datamapper/mapping';
+import { NodeReference } from '../models/datamapper/visualization';
+import { MappingSerializerService } from './mapping-serializer.service';
+import { DocumentType } from '../models/datamapper/path';
+import { MutableRefObject, RefObject, useRef } from 'react';
+import { renderHook } from '@testing-library/react';
+
+describe('MappingLinksService', () => {
+  let sourceDoc: XmlSchemaDocument;
+  let targetDoc: XmlSchemaDocument;
+  let paramsMap: Map<string, IDocument>;
+  let tree: MappingTree;
+
+  beforeEach(() => {
+    sourceDoc = TestUtil.createSourceOrderDoc();
+    targetDoc = TestUtil.createTargetOrderDoc();
+    paramsMap = TestUtil.createParameterMap();
+    tree = new MappingTree(targetDoc.documentType, targetDoc.documentId);
+    MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, tree, paramsMap);
+  });
+
+  describe('extractMappingLinks()', () => {
+    it('should return IMappingLink[]', () => {
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(11);
+      expect(links[0].sourceNodePath).toMatch('OrderId');
+      expect(links[0].targetNodePath).toMatch('OrderId');
+      expect(links[1].sourceNodePath).toMatch('OrderPerson');
+      expect(links[1].targetNodePath).toMatch('/if-');
+      expect(links[2].sourceNodePath).toMatch('OrderPerson');
+      expect(links[2].targetNodePath).toMatch(/if-.*field-OrderPerson/);
+      expect(links[3].targetNodePath).toMatch('ShipTo');
+      expect(links[3].targetNodePath).toMatch('ShipTo');
+      expect(links[4].sourceNodePath).toMatch('Item');
+      expect(links[4].targetNodePath).toMatch('/for-each');
+      expect(links[5].sourceNodePath).toMatch('Title');
+      expect(links[5].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Title-.*/);
+      expect(links[6].sourceNodePath).toMatch('Note');
+      expect(links[6].targetNodePath).toMatch(/for-each-.*field-Item-.*choose-.*when-.*/);
+      expect(links[7].sourceNodePath).toMatch('Note');
+      expect(links[7].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Note-.*/);
+      expect(links[8].sourceNodePath).toMatch('Title');
+      expect(links[8].targetNodePath).toMatch(/for-each-.*field-Item-.*choose-.*otherwise-.*field-Note-.*/);
+      expect(links[9].sourceNodePath).toMatch('Quantity');
+      expect(links[9].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Quantity-.*/);
+      expect(links[10].sourceNodePath).toMatch('Price');
+      expect(links[10].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Price-.*/);
+    });
+
+    it('should generate mapping links for the cached type fragments field', () => {
+      sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
+        DocumentType.SOURCE_BODY,
+        'X12-837P.dfdl.xsd',
+        x12837PDfdlXsd,
+      );
+      targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
+        DocumentType.TARGET_BODY,
+        'Message837.xsd',
+        message837Xsd,
+      );
+      tree = new MappingTree(targetDoc.documentType, targetDoc.documentId);
+      MappingSerializerService.deserialize(x12837PXslt, targetDoc, tree, paramsMap);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(14);
+      expect(links[0].sourceNodePath).toMatch('field-GS-02');
+      expect(links[0].targetNodePath).toMatch('field-From');
+      expect(links[1].sourceNodePath).toMatch('field-GS-03');
+      expect(links[1].targetNodePath).toMatch('field-To');
+      expect(links[2].sourceNodePath).toMatch('field-GS-04');
+      expect(links[2].targetNodePath).toMatch('field-Date');
+      expect(links[3].sourceNodePath).toMatch('field-GS-05');
+      expect(links[3].targetNodePath).toMatch('field-Time');
+      expect(links[4].sourceNodePath).toMatch('field-Loop2000');
+      expect(links[4].targetNodePath).toMatch('for-each');
+      expect(links[5].sourceNodePath).toMatch('field-CLM-01');
+      expect(links[5].targetNodePath).toMatch('field-SubmitterId');
+      expect(links[6].sourceNodePath).toMatch('field-CLM-02');
+      expect(links[6].targetNodePath).toMatch('field-MonetaryAmount');
+      expect(links[7].sourceNodePath).toMatch('field-C023-01');
+      expect(links[7].targetNodePath).toMatch('field-FacilityCodeValue');
+      expect(links[8].sourceNodePath).toMatch('field-C023-02');
+      expect(links[8].targetNodePath).toMatch('field-FacilityCodeQualifier');
+      expect(links[9].sourceNodePath).toMatch('field-C023-03');
+      expect(links[9].targetNodePath).toMatch('field-ClaimFrequencyTypeCode');
+      expect(links[10].sourceNodePath).toMatch('field-CLM-06');
+      expect(links[10].targetNodePath).toMatch('field-YesNoConditionOrResponseCodeFile');
+      expect(links[11].sourceNodePath).toMatch('field-CLM-07');
+      expect(links[11].targetNodePath).toMatch('field-ProviderAcceptAssignmentCode');
+      expect(links[12].sourceNodePath).toMatch('field-CLM-08');
+      expect(links[12].targetNodePath).toMatch('field-YesNoConditionOrResponseCodeBenefits');
+      expect(links[13].sourceNodePath).toMatch('field-CLM-09');
+      expect(links[13].targetNodePath).toMatch('field-ReleaseOfInformationCode');
+    });
+
+    it('should not generate mapping link from the source body root', () => {
+      sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
+        DocumentType.SOURCE_BODY,
+        'X12-850.dfdl.xsd',
+        x12850DfdlXsd,
+      );
+      targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
+        DocumentType.TARGET_BODY,
+        'Invoice850.xsd',
+        invoice850Xsd,
+      );
+      tree = new MappingTree(targetDoc.documentType, targetDoc.documentId);
+      MappingSerializerService.deserialize(x12850ForEachXslt, targetDoc, tree, paramsMap);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.find((l) => l.sourceNodePath === 'sourceBody:X12-850.dfdl.xsd://')).toBeUndefined();
+    });
+
+    it('should generate mapping links for multiple for-each on a same target collection', () => {
+      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(10);
+    });
+
+    it('should generate mapping links for multiple field item on a same target collection', () => {
+      MappingSerializerService.deserialize(shipOrderToShipOrderCollectionIndexXslt, targetDoc, tree, paramsMap);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(8);
+    });
+  });
+
+  describe('isInSelectedMapping()', () => {
+    it('should detect selected mapping', () => {
+      const { result: refOrderId } = renderHook(() =>
+        useRef<NodeReference>({
+          path: 'sourceBody:ShipOrder.xsd://field-ShipOrder-1234/field-OrderId-1234',
+          isSource: true,
+          containerRef: null,
+          headerRef: null,
+        }),
+      );
+      const { result: refShipToName } = renderHook(() =>
+        useRef<NodeReference>({
+          path: 'sourceBody:ShipOrder.xsd://field-ShipOrder-1234/field-ShipTo-1234/field-Name-1234',
+          isSource: true,
+          containerRef: null,
+          headerRef: null,
+        }),
+      );
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc, refOrderId.current);
+      expect(MappingLinksService.isInSelectedMapping(links, refOrderId.current)).toBeTruthy();
+      expect(MappingLinksService.isInSelectedMapping(links, refShipToName.current)).toBeFalsy();
+    });
+  });
+
+  describe('calculateMappingLinkCoordinates()', () => {
+    const nodeReferences: Map<string, MutableRefObject<NodeReference>> = new Map<
+      string,
+      MutableRefObject<NodeReference>
+    >();
+
+    const mockRect = () => ({ a: 0, b: 0 });
+    const createNodeReference = (path: string) => {
+      const { result } = renderHook(() =>
+        useRef<NodeReference>({
+          path: path,
+          isSource: !path.startsWith('target'),
+          containerRef: null,
+          headerRef: {
+            getBoundingClientRect: mockRect,
+            getClientRects: mockRect,
+          } as unknown as HTMLDivElement,
+        }),
+      );
+      nodeReferences.set(path, result.current);
+    };
+
+    const getNodeReference = (path: string): MutableRefObject<NodeReference> => {
+      if (!nodeReferences.has(path)) createNodeReference(path);
+      return nodeReferences.get(path)!;
+    };
+
+    beforeEach(() => {
+      nodeReferences.clear();
+    });
+
+    it('should move selected mapping lines to last', () => {
+      const svgRef: RefObject<SVGSVGElement> = {
+        /* tslint:disable-next-line */
+        current: {
+          getBoundingClientRect: jest.fn(),
+        } as unknown as SVGSVGElement,
+      };
+
+      const refOrderId = getNodeReference('sourceBody:ShipOrder.xsd://field-ShipOrder-1234/field-OrderId-1234');
+
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc, refOrderId);
+      expect(links.length).toEqual(11);
+      expect(links[0].sourceNodePath).toContain('field-OrderId');
+      expect(links[0].targetNodePath).toContain('field-OrderId');
+      expect(links[0].isSelected).toBeTruthy();
+      const lineProps = MappingLinksService.calculateMappingLinkCoordinates(links, svgRef, getNodeReference);
+      expect(lineProps.length).toEqual(11);
+      expect(lineProps[0].sourceNodePath).not.toContain('field-OrderId');
+      expect(lineProps[0].isSelected).toBeFalsy();
+      expect(lineProps[10].sourceNodePath).toContain('field-OrderId');
+      expect(lineProps[10].targetNodePath).toContain('field-OrderId');
+      expect(lineProps[10].isSelected).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui/src/services/mapping-links.service.ts
+++ b/packages/ui/src/services/mapping-links.service.ts
@@ -1,0 +1,200 @@
+import { MappingService } from './mapping.service';
+import {
+  ExpressionItem,
+  FieldItem,
+  IDocument,
+  IMappingLink,
+  LineCoord,
+  LineProps,
+  MappingItem,
+  MappingTree,
+  NodeReference,
+  PrimitiveDocument,
+  ValueSelector,
+} from '../models/datamapper';
+import { MutableRefObject, RefObject } from 'react';
+import { XPathService } from './xpath/xpath.service';
+import { Path } from '../models/datamapper/path';
+import { DocumentService } from './document.service';
+
+/**
+ * A collection of the business logic for rendering mapping link lines.
+ */
+export class MappingLinksService {
+  static extractMappingLinks(
+    item: MappingTree | MappingItem,
+    sourceParameterMap: Map<string, IDocument>,
+    sourceBody: IDocument,
+    selectedNodeRef: MutableRefObject<NodeReference> | null = null,
+  ): IMappingLink[] {
+    const answer = [] as IMappingLink[];
+    const targetNodePath = item.nodePath.toString();
+    if (item instanceof ExpressionItem) {
+      answer.push(
+        ...MappingLinksService.doExtractMappingLinks(
+          item,
+          targetNodePath,
+          sourceParameterMap,
+          sourceBody,
+          selectedNodeRef,
+        ),
+      );
+    }
+    if ('children' in item) {
+      item.children.forEach((child) => {
+        if (
+          item instanceof FieldItem &&
+          !(item.field.ownerDocument instanceof PrimitiveDocument) &&
+          child instanceof ValueSelector
+        ) {
+          answer.push(
+            ...MappingLinksService.doExtractMappingLinks(
+              child,
+              targetNodePath,
+              sourceParameterMap,
+              sourceBody,
+              selectedNodeRef,
+            ),
+          );
+        } else {
+          answer.push(
+            ...MappingLinksService.extractMappingLinks(child, sourceParameterMap, sourceBody, selectedNodeRef),
+          );
+        }
+      });
+    }
+    return answer;
+  }
+
+  private static doExtractMappingLinks(
+    sourceExpressionItem: ExpressionItem,
+    targetNodePath: string,
+    sourceParameterMap: Map<string, IDocument>,
+    sourceBody: IDocument,
+    selectedNodeRef: MutableRefObject<NodeReference> | null,
+  ) {
+    const sourceXPath = sourceExpressionItem.expression;
+    const validationResult = XPathService.validate(sourceXPath);
+    if (!validationResult.getCst() || validationResult.dataMapperErrors.length > 0) return [];
+    const fieldPaths = XPathService.extractFieldPaths(sourceXPath);
+    return fieldPaths.reduce((acc, xpath) => {
+      const absolutePath = MappingService.getAbsolutePath(sourceExpressionItem, xpath);
+      const path = new Path(absolutePath);
+      const document = path.parameterName ? sourceParameterMap.get(path.parameterName) : sourceBody;
+      const sourceNodePath =
+        document &&
+        DocumentService.getFieldFromPathSegments(
+          document,
+          path.pathSegments.map((seg) => seg.name),
+        )?.path;
+
+      if (sourceNodePath) {
+        const sourceNodePathString = sourceNodePath.toString();
+        const isSelected = MappingLinksService.isLinkSelected(sourceNodePathString, targetNodePath, selectedNodeRef);
+        acc.push({ sourceNodePath: sourceNodePathString, targetNodePath: targetNodePath, isSelected });
+      }
+      return acc;
+    }, [] as IMappingLink[]);
+  }
+
+  static calculateMappingLinkCoordinates(
+    mappingLinks: IMappingLink[],
+    svgRef: RefObject<SVGSVGElement>,
+    getNodeReference: (path: string) => MutableRefObject<NodeReference> | null,
+  ): LineProps[] {
+    return mappingLinks
+      .reduce((acc, { sourceNodePath, targetNodePath, isSelected }) => {
+        const sourceClosestPath = MappingLinksService.getClosestExpandedPath(sourceNodePath, getNodeReference);
+        const targetClosestPath = MappingLinksService.getClosestExpandedPath(targetNodePath, getNodeReference);
+        if (sourceClosestPath && targetClosestPath) {
+          const sourceFieldRef = getNodeReference(sourceClosestPath);
+          const targetFieldRef = getNodeReference(targetClosestPath);
+          if (sourceFieldRef && !!targetFieldRef) {
+            const coord = MappingLinksService.getCoordFromFieldRef(svgRef, sourceFieldRef, targetFieldRef);
+            if (coord)
+              acc.push({ ...coord, sourceNodePath: sourceNodePath, targetNodePath: targetNodePath, isSelected });
+          }
+        }
+        return acc;
+      }, [] as LineProps[])
+      .sort((a, b) => {
+        // selected lines should be drawn after not-selected ones
+        if (a.isSelected && !b.isSelected) return 1;
+        if (!a.isSelected && b.isSelected) return -1;
+        return 0;
+      });
+  }
+
+  private static getClosestExpandedPath(
+    path: string,
+    getNodeReference: (path: string) => MutableRefObject<NodeReference> | null,
+  ) {
+    let tracedPath: string | null = path;
+    while (tracedPath && MappingLinksService.shouldTraceParent(tracedPath, getNodeReference)) {
+      const parentPath = MappingLinksService.getParentPath(tracedPath);
+      if (parentPath === tracedPath) break;
+      tracedPath = parentPath;
+    }
+    return tracedPath;
+  }
+
+  private static shouldTraceParent(
+    tracedPath: string,
+    getNodeReference: (path: string) => MutableRefObject<NodeReference> | null,
+  ): boolean {
+    if (getNodeReference(tracedPath)?.current == null) return true;
+    if (getNodeReference(tracedPath)?.current.headerRef == null) return true;
+    return getNodeReference(tracedPath)?.current.headerRef?.getClientRects().length === 0;
+  }
+
+  private static getParentPath(path: string) {
+    if (path.endsWith('://')) return path.substring(0, path.indexOf(':'));
+
+    const lastSeparatorIndex = path.lastIndexOf('/');
+    const endIndex =
+      lastSeparatorIndex !== -1 && path.charAt(lastSeparatorIndex - 1) === '/'
+        ? lastSeparatorIndex + 1
+        : lastSeparatorIndex;
+    return endIndex !== -1 ? path.substring(0, endIndex) : null;
+  }
+
+  private static getCoordFromFieldRef(
+    svgRef: RefObject<SVGSVGElement>,
+    sourceRef: MutableRefObject<NodeReference>,
+    targetRef: MutableRefObject<NodeReference>,
+  ): LineCoord | undefined {
+    const svgRect = svgRef.current?.getBoundingClientRect();
+    const sourceRect = sourceRef.current?.headerRef?.getBoundingClientRect();
+    const targetRect = targetRef.current?.headerRef?.getBoundingClientRect();
+    if (!sourceRect || !targetRect) {
+      return;
+    }
+
+    return {
+      x1: sourceRect.right - (svgRect ? svgRect.left : 0),
+      y1: sourceRect.top + (sourceRect.bottom - sourceRect.top) / 2 - (svgRect ? svgRect.top : 0),
+      x2: targetRect.left - (svgRect ? svgRect.left : 0),
+      y2: targetRect.top + (targetRect.bottom - targetRect.top) / 2 - (svgRect ? svgRect.top : 0),
+    };
+  }
+
+  private static isLinkSelected(
+    sourceNodePath: string,
+    targetNodePath: string,
+    selectedNodeRef: MutableRefObject<NodeReference> | null,
+  ): boolean {
+    if (!selectedNodeRef) return false;
+
+    if (selectedNodeRef.current.isSource) {
+      return selectedNodeRef.current.path === sourceNodePath;
+    } else {
+      return selectedNodeRef.current.path === targetNodePath;
+    }
+  }
+
+  static isInSelectedMapping(mappingLinks: IMappingLink[], ref: MutableRefObject<NodeReference>): boolean {
+    return !!mappingLinks
+      .filter((link) => link.isSelected)
+      .find((link) => MappingLinksService.isLinkSelected(link.sourceNodePath, link.targetNodePath, ref));
+  }
+}

--- a/packages/ui/src/services/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping.service.test.ts
@@ -11,21 +11,11 @@ import {
 } from '../models/datamapper/mapping';
 import { MappingSerializerService } from './mapping-serializer.service';
 import { DocumentType } from '../models/datamapper/path';
-import { XmlSchemaDocument, XmlSchemaDocumentService } from './xml-schema-document.service';
+import { XmlSchemaDocument } from './xml-schema-document.service';
 import { IDocument } from '../models/datamapper/document';
-import {
-  invoice850Xsd,
-  message837Xsd,
-  shipOrderToShipOrderCollectionIndexXslt,
-  shipOrderToShipOrderMultipleForEachXslt,
-  shipOrderToShipOrderXslt,
-  TestUtil,
-  x12837PDfdlXsd,
-  x12837PXslt,
-  x12850DfdlXsd,
-  x12850ForEachXslt,
-} from '../stubs/data-mapper';
+import { shipOrderToShipOrderXslt, TestUtil } from '../stubs/data-mapper';
 import { XPathService } from './xpath/xpath.service';
+import { MappingLinksService } from './mapping-links.service';
 
 describe('MappingService', () => {
   let sourceDoc: XmlSchemaDocument;
@@ -136,7 +126,7 @@ describe('MappingService', () => {
       expect(priceItem.children.length).toEqual(1);
       expect((priceItem.children[0] as ValueSelector).expression).toEqual('Price');
 
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(11);
       links.forEach((link) => expect(link.sourceNodePath.includes(sourceDoc.fields[0].id)).toBeTruthy());
     });
@@ -178,7 +168,7 @@ describe('MappingService', () => {
       expect(priceItem.children.length).toEqual(1);
       expect((priceItem.children[0] as ValueSelector).expression).toEqual('Price');
 
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(11);
       links.forEach((link) => expect(link.targetNodePath.includes(targetDoc.fields[0].id)).toBeTruthy());
     });
@@ -193,7 +183,7 @@ describe('MappingService', () => {
       expect(forEachItem.parent).toEqual(shipOrderItem);
       expect(forEachItem.children.length).toEqual(1);
 
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(1);
       expect(links[0].sourceNodePath.includes(sourceDoc.fields[0].id)).toBeTruthy();
     });
@@ -208,7 +198,7 @@ describe('MappingService', () => {
       expect(forEachItem.parent).toEqual(shipOrderItem);
       expect(forEachItem.children.length).toEqual(1);
 
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(1);
       expect(links[0].targetNodePath.includes(targetDoc.fields[0].id)).toBeTruthy();
     });
@@ -295,109 +285,6 @@ describe('MappingService', () => {
       const orderIdValueSelector = tree.children[0].children[0].children[0] as ValueSelector;
       MappingService.deleteMappingItem(orderIdValueSelector);
       expect(tree.children[0].children.length).toEqual(3);
-    });
-  });
-
-  describe('extractMappingLinks()', () => {
-    it('should return IMappingLink[]', () => {
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
-      expect(links.length).toEqual(11);
-      expect(links[0].sourceNodePath).toMatch('OrderId');
-      expect(links[0].targetNodePath).toMatch('OrderId');
-      expect(links[1].sourceNodePath).toMatch('OrderPerson');
-      expect(links[1].targetNodePath).toMatch('/if-');
-      expect(links[2].sourceNodePath).toMatch('OrderPerson');
-      expect(links[2].targetNodePath).toMatch(/if-.*field-OrderPerson/);
-      expect(links[3].targetNodePath).toMatch('ShipTo');
-      expect(links[3].targetNodePath).toMatch('ShipTo');
-      expect(links[4].sourceNodePath).toMatch('Item');
-      expect(links[4].targetNodePath).toMatch('/for-each');
-      expect(links[5].sourceNodePath).toMatch('Title');
-      expect(links[5].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Title-.*/);
-      expect(links[6].sourceNodePath).toMatch('Note');
-      expect(links[6].targetNodePath).toMatch(/for-each-.*field-Item-.*choose-.*when-.*/);
-      expect(links[7].sourceNodePath).toMatch('Note');
-      expect(links[7].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Note-.*/);
-      expect(links[8].sourceNodePath).toMatch('Title');
-      expect(links[8].targetNodePath).toMatch(/for-each-.*field-Item-.*choose-.*otherwise-.*field-Note-.*/);
-      expect(links[9].sourceNodePath).toMatch('Quantity');
-      expect(links[9].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Quantity-.*/);
-      expect(links[10].sourceNodePath).toMatch('Price');
-      expect(links[10].targetNodePath).toMatch(/for-each-.*field-Item-.*field-Price-.*/);
-    });
-
-    it('should generate mapping links for the cached type fragments field', () => {
-      sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
-        DocumentType.SOURCE_BODY,
-        'X12-837P.dfdl.xsd',
-        x12837PDfdlXsd,
-      );
-      targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
-        DocumentType.TARGET_BODY,
-        'Message837.xsd',
-        message837Xsd,
-      );
-      tree = new MappingTree(targetDoc.documentType, targetDoc.documentId);
-      MappingSerializerService.deserialize(x12837PXslt, targetDoc, tree, paramsMap);
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
-      expect(links.length).toEqual(14);
-      expect(links[0].sourceNodePath).toMatch('field-GS-02');
-      expect(links[0].targetNodePath).toMatch('field-From');
-      expect(links[1].sourceNodePath).toMatch('field-GS-03');
-      expect(links[1].targetNodePath).toMatch('field-To');
-      expect(links[2].sourceNodePath).toMatch('field-GS-04');
-      expect(links[2].targetNodePath).toMatch('field-Date');
-      expect(links[3].sourceNodePath).toMatch('field-GS-05');
-      expect(links[3].targetNodePath).toMatch('field-Time');
-      expect(links[4].sourceNodePath).toMatch('field-Loop2000');
-      expect(links[4].targetNodePath).toMatch('for-each');
-      expect(links[5].sourceNodePath).toMatch('field-CLM-01');
-      expect(links[5].targetNodePath).toMatch('field-SubmitterId');
-      expect(links[6].sourceNodePath).toMatch('field-CLM-02');
-      expect(links[6].targetNodePath).toMatch('field-MonetaryAmount');
-      expect(links[7].sourceNodePath).toMatch('field-C023-01');
-      expect(links[7].targetNodePath).toMatch('field-FacilityCodeValue');
-      expect(links[8].sourceNodePath).toMatch('field-C023-02');
-      expect(links[8].targetNodePath).toMatch('field-FacilityCodeQualifier');
-      expect(links[9].sourceNodePath).toMatch('field-C023-03');
-      expect(links[9].targetNodePath).toMatch('field-ClaimFrequencyTypeCode');
-      expect(links[10].sourceNodePath).toMatch('field-CLM-06');
-      expect(links[10].targetNodePath).toMatch('field-YesNoConditionOrResponseCodeFile');
-      expect(links[11].sourceNodePath).toMatch('field-CLM-07');
-      expect(links[11].targetNodePath).toMatch('field-ProviderAcceptAssignmentCode');
-      expect(links[12].sourceNodePath).toMatch('field-CLM-08');
-      expect(links[12].targetNodePath).toMatch('field-YesNoConditionOrResponseCodeBenefits');
-      expect(links[13].sourceNodePath).toMatch('field-CLM-09');
-      expect(links[13].targetNodePath).toMatch('field-ReleaseOfInformationCode');
-    });
-
-    it('should not generate mapping link from the source body root', () => {
-      sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
-        DocumentType.SOURCE_BODY,
-        'X12-850.dfdl.xsd',
-        x12850DfdlXsd,
-      );
-      targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(
-        DocumentType.TARGET_BODY,
-        'Invoice850.xsd',
-        invoice850Xsd,
-      );
-      tree = new MappingTree(targetDoc.documentType, targetDoc.documentId);
-      MappingSerializerService.deserialize(x12850ForEachXslt, targetDoc, tree, paramsMap);
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
-      expect(links.find((l) => l.sourceNodePath === 'sourceBody:X12-850.dfdl.xsd://')).toBeUndefined();
-    });
-
-    it('should generate mapping links for multiple for-each on a same target collection', () => {
-      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
-      expect(links.length).toEqual(10);
-    });
-
-    it('should generate mapping links for multiple field item on a same target collection', () => {
-      MappingSerializerService.deserialize(shipOrderToShipOrderCollectionIndexXslt, targetDoc, tree, paramsMap);
-      const links = MappingService.extractMappingLinks(tree, paramsMap, sourceDoc);
-      expect(links.length).toEqual(8);
     });
   });
 });


### PR DESCRIPTION
Fixes: #2204

This enables to select and highlight a mapping by clicking a field or a mapping line. If a field is clicked, the mappings clicked field participates are highlighted, which includes source fields, lines and target fields. If a line is clicked, it behaves as if the target field connected to that line is clicked.

https://github.com/user-attachments/assets/5694ffcf-e146-43d8-9a09-bd29e26cb711

