### PR TITLE
feat(Form): Dynamically serialize string & numbers

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/stepConfiguration.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/stepConfiguration.cy.ts
@@ -26,7 +26,7 @@ describe('Tests for Design page', () => {
 
     // CHECK they are reflected in the code editor
     cy.openSourceCode();
-    cy.checkCodeSpanLine('period: "3000"');
+    cy.checkCodeSpanLine('period: 3000');
     cy.checkCodeSpanLine('message: ""', 0);
     cy.checkCodeSpanLine('topic: topicname');
     cy.checkCodeSpanLine('bootstrapServers: bootstrap');

--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
@@ -30,7 +30,7 @@ describe('Test URI node config', () => {
       cy.openSourceCode();
       cy.checkCodeSpanLine('delay: 2000', 1);
       cy.checkCodeSpanLine('period: "3000"', 1);
-      cy.checkCodeSpanLine('repeatCount: "5"', 1);
+      cy.checkCodeSpanLine('repeatCount: 5', 1);
     });
   });
 

--- a/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/onException.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialCamelRoutes/onException.cy.ts
@@ -71,8 +71,8 @@ describe('Test for root on exception container', () => {
     cy.checkCodeSpanLine('redeliveryPolicy:');
     cy.checkCodeSpanLine('allowRedeliveryWhileStopping: true');
     cy.checkCodeSpanLine('asyncDelayedRedelivery: true');
-    cy.checkCodeSpanLine('backOffMultiplier: "3.0"');
-    cy.checkCodeSpanLine('collisionAvoidanceFactor: "0.2"');
+    cy.checkCodeSpanLine('backOffMultiplier: 3');
+    cy.checkCodeSpanLine('collisionAvoidanceFactor: 0.2');
     cy.checkCodeSpanLine('delayPattern: testRedeliveryPolicyDelayPattern');
     cy.checkCodeSpanLine('disableRedelivery: true');
     cy.checkCodeSpanLine('exchangeFormatterRef: testExchangeFormatterRef');
@@ -85,10 +85,10 @@ describe('Test for root on exception container', () => {
     cy.checkCodeSpanLine('logRetryAttempted: true');
     cy.checkCodeSpanLine('logRetryStackTrace: true');
     cy.checkCodeSpanLine('logStackTrace: true');
-    cy.checkCodeSpanLine('maximumRedeliveries: "10"');
+    cy.checkCodeSpanLine('maximumRedeliveries: 10');
     cy.checkCodeSpanLine('maximumRedeliveryDelay: "40000"');
     cy.checkCodeSpanLine('redeliveryDelay: "2000"');
-    cy.checkCodeSpanLine('retryAttemptedLogInterval: "2"');
+    cy.checkCodeSpanLine('retryAttemptedLogInterval: 2');
     cy.checkCodeSpanLine('redeliveryPolicyRef: testRedeliveryPolicyRef');
 
     cy.checkCodeSpanLine('retriesExhaustedLogLevel: INFO');

--- a/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialStepConfiguration/dataFormatStepConfig.cy.ts
@@ -19,7 +19,7 @@ describe('Tests for sidebar dataformat configuration', () => {
 
     // CHECK they are reflected in the code editor
     cy.openSourceCode();
-    cy.checkCodeSpanLine('lineLength: "128"', 1);
+    cy.checkCodeSpanLine('lineLength: 128', 1);
     cy.checkCodeSpanLine('id: simpleDataformatId', 1);
     cy.checkCodeSpanLine('lineSeparator: simpleLineSeparator', 1);
     cy.checkCodeSpanLine('urlSafe: true', 1);

--- a/packages/ui-tests/cypress/e2e/metadata.cy.ts
+++ b/packages/ui-tests/cypress/e2e/metadata.cy.ts
@@ -50,8 +50,8 @@ describe('Test for Metadata Editor support', () => {
     cy.checkCodeSpanLine('creationTimestamp: testCreationTimestamp');
     cy.checkCodeSpanLine('deletionTimestamp: testDeletionTimestamp');
     cy.checkCodeSpanLine('generateName: testGenerateName');
-    cy.checkCodeSpanLine('generation: "10"');
-    cy.checkCodeSpanLine('deletionGracePeriodSeconds: "1000"');
+    cy.checkCodeSpanLine('generation: 10');
+    cy.checkCodeSpanLine('deletionGracePeriodSeconds: 1000');
     cy.checkCodeSpanLine('namespace: testNamespace');
     cy.checkCodeSpanLine('resourceVersion: testResourceVersion');
     cy.checkCodeSpanLine('selfLink: testSelfLink');

--- a/packages/ui-tests/cypress/e2e/pipeErrorHandler.cy.ts
+++ b/packages/ui-tests/cypress/e2e/pipeErrorHandler.cy.ts
@@ -14,8 +14,8 @@ describe('Test for Pipe Error handler support', () => {
     cy.checkCodeSpanLine('errorHandler:');
     cy.checkCodeSpanLine('log:');
     cy.checkCodeSpanLine('parameters:');
-    cy.checkCodeSpanLine('maximumRedeliveries: "5"');
-    cy.checkCodeSpanLine('redeliveryDelay: "1000"');
+    cy.checkCodeSpanLine('maximumRedeliveries: 5');
+    cy.checkCodeSpanLine('redeliveryDelay: 1000');
 
     cy.openPipeErrorHandler();
 
@@ -38,8 +38,8 @@ describe('Test for Pipe Error handler support', () => {
     cy.checkCodeSpanLine('name: test-name');
     cy.checkCodeSpanLine('message: test-message');
     cy.checkCodeSpanLine('additionalProperties: test-additionalProperties');
-    cy.checkCodeSpanLine('maximumRedeliveries: "3"');
-    cy.checkCodeSpanLine('redeliveryDelay: "2000"');
+    cy.checkCodeSpanLine('maximumRedeliveries: 3');
+    cy.checkCodeSpanLine('redeliveryDelay: 2000');
   });
 
   it('ErrorHandler - edit in errorHandler editor', () => {
@@ -50,8 +50,8 @@ describe('Test for Pipe Error handler support', () => {
     cy.get(`input[name="#.log.parameters.redeliveryDelay"]`).clear().type('1000');
     cy.openSourceCode();
     // CHECK the errorHandler update was reflected in the code editor
-    cy.checkCodeSpanLine('maximumRedeliveries: "5"');
-    cy.checkCodeSpanLine('redeliveryDelay: "1000"');
+    cy.checkCodeSpanLine('maximumRedeliveries: 5');
+    cy.checkCodeSpanLine('redeliveryDelay: 1000');
   });
 
   it('ErrorHandler - delete errorHandler properties using the ErrorHandler editor', () => {


### PR DESCRIPTION
### Context
Currently, `Number` schemas are serialized as `String` due to both schemas using `StringField`.

### Changes
This commit dynamically chooses how to serialize the value, depending on the schema type and the actual value.

For example, for a `Number` schema, numbers will be serialized as numbers, while placeholders like `{{ property }}` will be serialized as text.

fix: https://github.com/KaotoIO/kaoto/issues/1653