### PR TITLE
Feat: Allow to delete filtered/all routes at once

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -172,7 +172,7 @@ describe('Canvas', () => {
 
     // Check if the remove function is called
     expect(removeSpy).toHaveBeenCalled();
-    expect(removeSpy).toHaveBeenCalledWith('route-8888');
+    expect(removeSpy).toHaveBeenCalledWith(['route-8888']);
   });
 
   it('should be able to delete the kamelets', async () => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -71,6 +71,23 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
     [visualEntities, areFlowsVisible, searchString, visualFlowsApi],
   );
 
+  const onDeleteAll = useCallback(
+    async (_event: MouseEvent<HTMLButtonElement>) => {
+      props.onClose?.();
+      const isDeleteConfirmed = await deleteModalContext?.actionConfirmation({
+        title: 'Do you want to delete the filtered routes ?',
+        text: 'All steps will be lost.',
+      });
+      if (isDeleteConfirmed !== ACTION_ID_CONFIRM) return;
+      const filteredIds = visualEntities.filter((flow) => flow.id.includes(searchString)).map((flow) => flow.id);
+      if (filteredIds.length === 0) {
+        return;
+      }
+      camelResource.removeEntity(filteredIds);
+      updateEntitiesFromCamelResource();
+    },
+    [searchString, visualEntities, camelResource],
+  );
   return isListEmpty ? (
     <FlowsListEmptyState data-testid="flows-list-empty-state" />
   ) : (
@@ -109,7 +126,16 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 variant="plain"
               />
             </Th>
-            <Th>{columnNames.current.delete}</Th>
+            <Th>
+              {' '}
+              <Button
+                title={`Delete filtered`}
+                data-testid={`delete-filtered-btn`}
+                icon={<TrashIcon />}
+                variant="plain"
+                onClick={onDeleteAll}
+              />
+            </Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -179,7 +205,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                       });
                       if (isDeleteConfirmed !== ACTION_ID_CONFIRM) return;
 
-                      camelResource.removeEntity(flow.id);
+                      camelResource.removeEntity([flow.id]);
                       updateEntitiesFromCamelResource();
                     }}
                   />

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -129,8 +129,8 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
             <Th>
               {' '}
               <Button
-                title={`Delete filtered`}
-                data-testid={`delete-filtered-btn`}
+                title="Delete all flows"
+                data-testid="delete-filtered-btn"
                 icon={<TrashIcon />}
                 variant="plain"
                 onClick={onDeleteAll}

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -71,7 +71,7 @@ describe('ItemDeleteGroup', () => {
     });
 
     await waitFor(() => {
-      expect(removeEntitySpy).toHaveBeenCalledWith(entityId);
+      expect(removeEntitySpy).toHaveBeenCalledWith([entityId]);
     });
   });
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.tsx
@@ -36,7 +36,7 @@ export const useDeleteGroup = (vizNode: IVisualizationNode) => {
       getRegisteredInteractionAddons(IInteractionAddonType.ON_DELETE, vn),
     );
 
-    entitiesContext?.camelResource.removeEntity(flowId);
+    entitiesContext?.camelResource.removeEntity(flowId ? [flowId] : undefined);
     entitiesContext?.updateEntitiesFromCamelResource();
   }, [deleteModalContext, entitiesContext, flowId, getRegisteredInteractionAddons, vizNode]);
 

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -52,7 +52,7 @@ export abstract class CamelKResource implements CamelResource {
     };
   }
 
-  removeEntity(_id?: string) {}
+  removeEntity(_id?: string[]) {}
   refreshVisualMetadata() {}
   createMetadataEntity() {
     this.resource.metadata = {};

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -10,7 +10,7 @@ export interface CamelResource {
   getVisualEntities(): BaseVisualCamelEntity[];
   getEntities(): BaseCamelEntity[];
   addNewEntity(entityType?: EntityType): string;
-  removeEntity(id?: string): void;
+  removeEntity(ids?: string[]): void;
   supportsMultipleVisualEntities(): boolean;
   toJSON(): unknown;
   toString(): string;

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -173,7 +173,7 @@ describe('CamelRouteResource', () => {
     it('should not do anything when providing a non existing ID', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
 
-      resource.removeEntity('non-existing-id');
+      resource.removeEntity(['non-existing-id']);
 
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
@@ -182,16 +182,25 @@ describe('CamelRouteResource', () => {
       const resource = new CamelRouteResource([camelRouteJson, camelFromJson]);
       const camelRouteEntity = resource.getVisualEntities()[0];
 
-      resource.removeEntity(camelRouteEntity.id);
+      resource.removeEntity([camelRouteEntity.id]);
 
       expect(resource.getVisualEntities()).toHaveLength(1);
+    });
+
+    it('should remove multiple entities when multiple IDs are provided', () => {
+      const resource = new CamelRouteResource([camelRouteJson, camelFromJson]);
+      const entitiesToRemove = resource.getVisualEntities().map((e) => e.id);
+
+      resource.removeEntity(entitiesToRemove);
+
+      expect(resource.getVisualEntities()).toHaveLength(0);
     });
 
     it('should NOT create a new entity after deleting them all', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
       const camelRouteEntity = resource.getVisualEntities()[0];
 
-      resource.removeEntity(camelRouteEntity.id);
+      resource.removeEntity([camelRouteEntity.id]);
 
       expect(resource.getVisualEntities()).toHaveLength(0);
     });

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -180,13 +180,9 @@ export class CamelRouteResource implements CamelResource, BeansAwareResource {
     }
   }
 
-  removeEntity(id?: string): void {
-    if (!isDefined(id)) return;
-    const index: number = this.entities.findIndex((e) => e.id === id);
-
-    if (index !== -1) {
-      this.entities.splice(index, 1);
-    }
+  removeEntity(ids?: string[]): void {
+    if (!isDefined(ids)) return;
+    this.entities = this.entities.filter((e) => !ids?.includes(e.id));
   }
 
   /** Components Catalog related methods */


### PR DESCRIPTION
This pull request introduces changes to support bulk deletion of entities in the visualization components and underlying models. It modifies the `removeEntity` method to accept multiple IDs and updates the UI and tests accordingly. The most important changes include refactoring the `removeEntity` method, adding a bulk delete feature in the `FlowsList` component, and updating tests to reflect these changes.

