### PR TITLE
Fix: get back the separator between groups in right-click menu

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -54,7 +54,3 @@ html body {
 .context-toolbar {
   padding: var(--pf-v6-c-toolbar__content-section--ColumnGap);
 }
-
-.pf-v6-c-divider {
-  display: none;
-}


### PR DESCRIPTION
the divider style to none was introduced with
https://github.com/KaotoIO/kaoto/commit/3bb398ca887b2f33fe4958b5064fad05423e38da but I found no trace of it elsewhere

this is to get back these line seprators in the contextual menu:
![image](https://github.com/user-attachments/assets/85f6dbcc-d8e4-4f15-bcbf-a4497a3f8537)
