### PR TITLE
feat(DataMapper): JSON schema inspection

### DIFF
--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -21,6 +21,7 @@ export interface IField {
   ownerDocument: IDocument;
   id: string;
   name: string;
+  expression: string;
   path: NodePath;
   type: Types;
   fields: IField[];
@@ -35,6 +36,9 @@ export interface IField {
 }
 
 export interface ITypeFragment {
+  type?: Types;
+  minOccurs?: number;
+  maxOccurs?: number;
   fields: IField[];
   namedTypeFragmentRefs: string[];
 }
@@ -71,6 +75,7 @@ export class PrimitiveDocument extends BaseDocument implements IField {
   constructor(documentType: DocumentType, documentId: string) {
     super(documentType, documentId);
     this.name = this.documentId;
+    this.expression = this.documentId;
     this.id = this.documentId;
     this.path = NodePath.fromDocument(documentType, documentId);
   }
@@ -86,6 +91,7 @@ export class PrimitiveDocument extends BaseDocument implements IField {
   type = Types.AnyType;
   path: NodePath;
   id: string;
+  expression: string;
   namedTypeFragmentRefs = [];
   totalFieldCount = 1;
   isNamespaceAware = false;
@@ -100,13 +106,21 @@ export class BaseField implements IField {
   ) {
     this.id = getCamelRandomId(`field-${this.name}`, 4);
     this.path = NodePath.childOf(parent.path, this.id);
+    this.expression = name;
   }
 
   id: string;
   path: NodePath;
+  expression: string;
   fields: IField[] = [];
   isAttribute: boolean = false;
-  type = Types.AnyType;
+  protected _type = Types.AnyType;
+  public get type() {
+    return this._type;
+  }
+  public set type(value) {
+    this._type = value;
+  }
   minOccurs: number = DEFAULT_MIN_OCCURS;
   maxOccurs: number = DEFAULT_MAX_OCCURS;
   defaultValue: string | null = null;
@@ -133,6 +147,7 @@ export class BaseField implements IField {
 export enum DocumentDefinitionType {
   Primitive = 'Primitive',
   XML_SCHEMA = 'XML Schema',
+  JSON_SCHEMA = 'JSON Schema',
 }
 
 export class DocumentDefinition {

--- a/packages/ui/src/models/datamapper/types.ts
+++ b/packages/ui/src/models/datamapper/types.ts
@@ -26,4 +26,5 @@ export enum Types {
   DocumentNode = 'document-node()',
   // custom types
   Container = 'Container',
+  Array = 'Array',
 }

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -1,10 +1,70 @@
 import { DocumentService } from './document.service';
 
 import { TestUtil } from '../stubs/data-mapper';
+import { DocumentDefinition, DocumentDefinitionType, DocumentType, PrimitiveDocument } from '../models/datamapper';
+import { XmlSchemaDocument } from './xml-schema-document.service';
+import { JsonSchemaDocument } from './json-schema-document.service';
 
 describe('DocumentService', () => {
   const sourceDoc = TestUtil.createSourceOrderDoc();
   const targetDoc = TestUtil.createTargetOrderDoc();
+
+  describe('creawteDocument()', () => {
+    it('should create a primitive document', () => {
+      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test', {});
+      const doc = DocumentService.createDocument(docDef);
+      expect(doc instanceof PrimitiveDocument).toBeTruthy();
+    });
+
+    it('should create a XML schema document', () => {
+      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test', {
+        schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                   <xs:element name="test" type="xs:string" />
+                 </xs:schema>`,
+      });
+      const doc = DocumentService.createDocument(docDef);
+      expect(doc instanceof XmlSchemaDocument).toBeTruthy();
+    });
+
+    it('should throw an error if XML schema is not parseable', () => {
+      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test', {
+        schema: JSON.stringify({ type: 'string' }),
+      });
+      expect(() => DocumentService.createDocument(docDef)).toThrow();
+    });
+
+    it('should create a JSON schema document', () => {
+      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.JSON_SCHEMA, 'test', {
+        schema: JSON.stringify({ type: 'string' }),
+      });
+      const doc = DocumentService.createDocument(docDef);
+      expect(doc instanceof JsonSchemaDocument).toBeTruthy();
+    });
+
+    it('should throw an error if JSON schema is not parseable', () => {
+      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.JSON_SCHEMA, 'test', {
+        schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                   <xs:element name="test" type="xs:string" />
+                 </xs:schema>`,
+      });
+      expect(() => DocumentService.createDocument(docDef)).toThrow();
+    });
+
+    it('should return null if type is unknown', () => {
+      const docDef = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        'unknown' as unknown as DocumentDefinitionType,
+        'test',
+        {
+          schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                   <xs:element name="test" type="xs:string" />
+                 </xs:schema>`,
+        },
+      );
+      const doc = DocumentService.createDocument(docDef);
+      expect(doc).toBeNull();
+    });
+  });
 
   describe('getFieldStack()', () => {
     it('', () => {

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -1,0 +1,266 @@
+import { camelYamlDslJsonSchema } from '../stubs/data-mapper';
+import { JsonSchemaDocumentService } from './json-schema-document.service';
+import { DocumentType } from '../models/datamapper/path';
+import { Types } from '../models/datamapper';
+import { JSONSchema7 } from 'json-schema';
+
+describe('JsonSchemaDocumentService', () => {
+  it('should parse string', () => {
+    const doc = JsonSchemaDocumentService.createJsonSchemaDocument(
+      DocumentType.SOURCE_BODY,
+      'test',
+      JSON.stringify({ type: 'string' }),
+    );
+
+    expect(doc).toBeDefined();
+    expect(doc.fields.length).toBe(1);
+
+    const rootField = doc.fields[0];
+    expect(rootField.type).toBe(Types.String);
+    expect(rootField.name).toBe('');
+    expect(rootField.maxOccurs).toEqual(1);
+    expect(rootField.expression).toEqual('xf:string');
+  });
+
+  it('should parse number', () => {
+    const doc = JsonSchemaDocumentService.createJsonSchemaDocument(
+      DocumentType.SOURCE_BODY,
+      'test',
+      JSON.stringify({ type: 'number' }),
+    );
+
+    expect(doc).toBeDefined();
+    expect(doc.fields.length).toBe(1);
+
+    const rootField = doc.fields[0];
+    expect(rootField.type).toBe(Types.Numeric);
+    expect(rootField.name).toBe('');
+    expect(rootField.maxOccurs).toEqual(1);
+    expect(rootField.expression).toEqual('xf:number');
+  });
+
+  it('should parse topmost string array', () => {
+    const doc = JsonSchemaDocumentService.createJsonSchemaDocument(
+      DocumentType.SOURCE_BODY,
+      'test',
+      JSON.stringify({
+        type: 'array',
+        items: { type: 'string' },
+      }),
+    );
+
+    expect(doc).toBeDefined();
+    expect(doc.fields.length).toBe(1);
+
+    const rootArrayField = doc.fields[0];
+    expect(rootArrayField.type).toBe(Types.Array);
+    expect(rootArrayField.name).toBe('');
+    expect(rootArrayField.maxOccurs).toEqual(1);
+    expect(rootArrayField.fields.length).toEqual(1);
+    expect(rootArrayField.expression).toEqual('xf:array');
+
+    const arrayItemField = rootArrayField.fields[0];
+    expect(arrayItemField.type).toBe(Types.String);
+    expect(arrayItemField.name).toBe('');
+    expect(arrayItemField.maxOccurs).toEqual(Number.MAX_SAFE_INTEGER);
+    expect(arrayItemField.expression).toEqual('xf:string');
+  });
+
+  it('should parse object', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        strProp: { type: 'string' },
+        numProp: { type: 'number' },
+        objProp: {
+          type: 'object',
+          properties: {
+            objOne: { type: 'string' },
+            objTwo: { type: 'string' },
+          },
+          required: ['objOne'],
+        },
+        arrProp: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              arrOne: { type: 'string' },
+              arrTwo: { type: 'string' },
+            },
+            required: ['arrTwo'],
+          },
+        },
+      },
+    };
+    const doc = JsonSchemaDocumentService.createJsonSchemaDocument(
+      DocumentType.SOURCE_BODY,
+      'test',
+      JSON.stringify(schema),
+    );
+
+    expect(doc).toBeDefined();
+    expect(doc.fields.length).toBe(1);
+
+    const root = doc.fields[0];
+    expect(root.type).toEqual(Types.Container);
+    expect(root.name).toBe('');
+    expect(root.maxOccurs).toEqual(1);
+    expect(root.fields.length).toBe(4);
+    expect(root.expression).toEqual('xf:map');
+
+    const strProp = root.fields[0];
+    expect(strProp.type).toEqual(Types.String);
+    expect(strProp.name).toBe('strProp');
+    expect(strProp.maxOccurs).toEqual(1);
+    expect(strProp.fields.length).toBe(0);
+    expect(strProp.expression).toEqual('xf:string[@key="strProp"]');
+
+    const numProp = root.fields[1];
+    expect(numProp.type).toEqual(Types.Numeric);
+    expect(numProp.name).toBe('numProp');
+    expect(numProp.maxOccurs).toEqual(1);
+    expect(numProp.fields.length).toBe(0);
+    expect(numProp.expression).toEqual('xf:number[@key="numProp"]');
+
+    const objProp = root.fields[2];
+    expect(objProp.type).toEqual(Types.Container);
+    expect(objProp.name).toBe('objProp');
+    expect(objProp.maxOccurs).toEqual(1);
+    expect(objProp.fields.length).toBe(2);
+    expect(objProp.expression).toEqual('xf:map[@key="objProp"]');
+
+    const objOne = objProp.fields[0];
+    expect(objOne.type).toEqual(Types.String);
+    expect(objOne.name).toBe('objOne');
+    expect(objOne.minOccurs).toEqual(1);
+    expect(objOne.maxOccurs).toEqual(1);
+    expect(objOne.fields.length).toBe(0);
+    expect(objOne.expression).toEqual('xf:string[@key="objOne"]');
+
+    const objTwo = objProp.fields[1];
+    expect(objTwo.type).toEqual(Types.String);
+    expect(objTwo.name).toBe('objTwo');
+    expect(objTwo.minOccurs).toEqual(0);
+    expect(objTwo.maxOccurs).toEqual(1);
+    expect(objTwo.fields.length).toBe(0);
+    expect(objTwo.expression).toEqual('xf:string[@key="objTwo"]');
+
+    const arrProp = root.fields[3];
+    expect(arrProp.type).toEqual(Types.Array);
+    expect(arrProp.name).toBe('arrProp');
+    expect(arrProp.maxOccurs).toEqual(1);
+    expect(arrProp.fields.length).toBe(1);
+    expect(arrProp.expression).toEqual('xf:array[@key="arrProp"]');
+
+    const arrItem = arrProp.fields[0];
+    expect(arrItem.type).toEqual(Types.Container);
+    expect(arrItem.name).toBe('');
+    expect(arrItem.maxOccurs).toEqual(Number.MAX_SAFE_INTEGER);
+    expect(arrItem.fields.length).toBe(2);
+    expect(arrItem.expression).toEqual('xf:map');
+
+    const arrOne = arrItem.fields[0];
+    expect(arrOne.type).toEqual(Types.String);
+    expect(arrOne.name).toBe('arrOne');
+    expect(arrOne.minOccurs).toEqual(0);
+    expect(arrOne.maxOccurs).toEqual(1);
+    expect(arrOne.fields.length).toBe(0);
+    expect(arrOne.expression).toEqual('xf:string[@key="arrOne"]');
+
+    const arrTwo = arrItem.fields[1];
+    expect(arrTwo.type).toEqual(Types.String);
+    expect(arrTwo.name).toBe('arrTwo');
+    expect(arrTwo.minOccurs).toEqual(1);
+    expect(arrTwo.maxOccurs).toEqual(1);
+    expect(arrTwo.fields.length).toBe(0);
+    expect(arrTwo.expression).toEqual('xf:string[@key="arrTwo"]');
+  });
+
+  it('should parse camelYamlDsl', () => {
+    const camelDoc = JsonSchemaDocumentService.createJsonSchemaDocument(
+      DocumentType.SOURCE_BODY,
+      'test',
+      camelYamlDslJsonSchema,
+    );
+
+    expect(camelDoc).toBeDefined();
+    expect(camelDoc.fields.length).toBe(1);
+
+    const rootArrayField = camelDoc.fields[0];
+    expect(rootArrayField.type).toEqual(Types.Array);
+    expect(rootArrayField.name).toEqual('');
+    expect(rootArrayField.maxOccurs).toEqual(1);
+    expect(rootArrayField.fields.length).toEqual(1);
+
+    const rootObjectField = rootArrayField.fields[0];
+    expect(rootObjectField.type).toEqual(Types.Container);
+    expect(rootObjectField.name).toEqual('');
+    expect(rootObjectField.maxOccurs).toEqual(Number.MAX_SAFE_INTEGER);
+    expect(rootObjectField.fields.length).toBeGreaterThan(10);
+
+    const beansField = rootObjectField.fields.find((f) => f.name === 'beans');
+    expect(beansField).toBeDefined();
+    expect(beansField!.type).toEqual(Types.AnyType);
+    expect(beansField!.namedTypeFragmentRefs.length).toBe(1);
+
+    const beansDef = camelDoc.namedTypeFragments[beansField!.namedTypeFragmentRefs[0]];
+    expect(beansDef).toBeDefined();
+    expect(beansDef.type).toEqual(Types.Array);
+    expect(beansDef.maxOccurs).toBe(1);
+    expect(beansDef.fields.length).toBe(1);
+    const beansArrayField = beansDef.fields[0];
+    expect(beansArrayField.type).toEqual(Types.AnyType);
+    expect(beansArrayField.name).toEqual('');
+    expect(beansArrayField.maxOccurs).toEqual(Number.MAX_SAFE_INTEGER);
+    expect(beansArrayField.namedTypeFragmentRefs.length).toBe(1);
+
+    const beanEntryDef = camelDoc.namedTypeFragments[beansArrayField.namedTypeFragmentRefs[0]];
+    expect(beanEntryDef).toBeDefined();
+    expect(beanEntryDef.type).toEqual(Types.Container);
+    expect(beanEntryDef.maxOccurs).toEqual(1);
+    expect(beanEntryDef.fields.length).toBeGreaterThan(10);
+
+    const setBodyDef = camelDoc.namedTypeFragments['#/items/definitions/org.apache.camel.model.SetBodyDefinition'];
+    expect(setBodyDef).toBeDefined();
+    expect(setBodyDef.type).toEqual(Types.Container);
+    expect(setBodyDef.minOccurs).toEqual(0);
+    expect(setBodyDef.maxOccurs).toEqual(1);
+    expect(setBodyDef.fields.length).toBeGreaterThan(25);
+    expect(setBodyDef.namedTypeFragmentRefs.length).toBe(1);
+    expect(setBodyDef.namedTypeFragmentRefs[0]).toEqual(
+      '#/items/definitions/org.apache.camel.model.language.ExpressionDefinition',
+    );
+
+    const setBodyExpression = setBodyDef.fields.find((f) => f.name === 'expression');
+    expect(setBodyExpression).toBeDefined();
+    expect(setBodyExpression!.name).toEqual('expression');
+    expect(setBodyExpression!.namedTypeFragmentRefs.length).toBe(1);
+    expect(setBodyExpression!.namedTypeFragmentRefs[0]).toEqual(
+      '#/items/definitions/org.apache.camel.model.language.ExpressionDefinition',
+    );
+
+    const setBodySimple = setBodyDef.fields.find((f) => f.name === 'simple');
+    expect(setBodySimple).toBeDefined();
+    expect(setBodySimple!.type).toEqual(Types.AnyType);
+    expect(setBodySimple!.name).toEqual('simple');
+    expect(setBodySimple!.namedTypeFragmentRefs.length).toBe(0);
+
+    const expressionDef =
+      camelDoc.namedTypeFragments['#/items/definitions/org.apache.camel.model.language.ExpressionDefinition'];
+    expect(expressionDef).toBeDefined();
+    expect(expressionDef.type).toEqual(Types.Container);
+    expect(expressionDef.minOccurs).toEqual(0);
+    expect(expressionDef.maxOccurs).toEqual(1);
+    expect(expressionDef.fields.length).toBeGreaterThan(25);
+
+    const expressionSimple = expressionDef.fields.find((f) => f.name === 'simple');
+    expect(expressionSimple).toBeDefined();
+    expect(expressionSimple!.type).toEqual(Types.AnyType);
+    expect(expressionSimple!.name).toEqual('simple');
+    expect(expressionSimple!.namedTypeFragmentRefs.length).toBe(1);
+    expect(expressionSimple!.namedTypeFragmentRefs[0]).toEqual(
+      '#/items/definitions/org.apache.camel.model.language.SimpleExpression',
+    );
+  });
+});

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -1,0 +1,287 @@
+import { DocumentType } from '../models/datamapper/path';
+import { BaseDocument, BaseField, ITypeFragment, Types } from '../models/datamapper';
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import { DocumentService } from './document.service';
+import { getCamelRandomId } from '../camel-utils/camel-random-id';
+
+export interface JsonSchemaTypeFragment extends ITypeFragment {
+  fields: JsonSchemaField[];
+}
+
+export interface JSONSchemaMetadata extends JSONSchema7 {
+  path: string;
+}
+
+export class JsonSchemaDocument extends BaseDocument {
+  isNamespaceAware: boolean = false;
+  totalFieldCount: number = 0;
+  fields: JsonSchemaField[] = [];
+  namedTypeFragments: Record<string, JsonSchemaTypeFragment> = {};
+
+  constructor(
+    public jsonSchema: JSONSchemaMetadata,
+    documentType: DocumentType,
+    documentId: string,
+  ) {
+    super(documentType, documentId);
+    this.name = documentId;
+    const field = JsonSchemaDocumentService.createFieldFromJSONSchema(this, '', this.jsonSchema);
+    this.fields.push(field);
+    this.schemaType = 'JSON';
+  }
+}
+
+type JsonSchemaParentType = JsonSchemaDocument | JsonSchemaField;
+
+/**
+ * Represents the field in JSON schema document.
+ *
+ * JSON schema allows to have an array of property types. We might eventually have to introduce an array
+ * of field types at {@link IField} level. Then UI would also have to support handling it, such as
+ * if this field is string, then do this, if it's object, then do that, etc.
+ * For now, it chooses one type and use it.
+ * Also in JSON schema, when `type` is omitted, it could be any type. This fact basically conflicts with what
+ * we want to do with XSLT3 lossless JSON representation where it explicitly has to specify the type.
+ * Until we get a concrete idea of how to handle this in DataMapper UI, just pick one type and use it.
+ */
+export class JsonSchemaField extends BaseField {
+  fields: JsonSchemaField[] = [];
+  namespaceURI: string | null = 'http://www.w3.org/2005/xpath-functions';
+  namespacePrefix: string | null = 'xf';
+  isAttribute = false;
+
+  constructor(
+    public parent: JsonSchemaParentType,
+    public name: string,
+    type: Types,
+  ) {
+    super(parent, DocumentService.getOwnerDocument<JsonSchemaDocument>(parent), name);
+    this.type = type;
+  }
+
+  public get type() {
+    return this._type;
+  }
+
+  public set type(type: Types) {
+    this._type = type;
+    // Set the field expression with XSLT3 lossless representation of the JSON,
+    // which is directly used for XPath
+    const nameQuery = this.name ? `[@key="${this.name}"]` : '';
+    switch (type) {
+      case Types.String:
+        this.expression = `${this.namespacePrefix}:string${nameQuery}`;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'string'}`, 4);
+        break;
+      case Types.Numeric:
+        this.expression = `${this.namespacePrefix}:number${nameQuery}`;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'number'}`, 4);
+        break;
+      case Types.Boolean:
+        this.expression = `${this.namespacePrefix}:boolean${nameQuery}`;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'boolean'}`, 4);
+        break;
+      case Types.Container:
+        this.expression = `${this.namespacePrefix}:map${nameQuery}`;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'map'}`, 4);
+        break;
+      case Types.Array:
+        this.expression = `${this.namespacePrefix}:array${nameQuery}`;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'array'}`, 4);
+        break;
+      default:
+        this.expression = this.name;
+        this.id = getCamelRandomId(`field-${this.name ? this.name : 'any'}`, 4);
+    }
+  }
+}
+
+export class JsonSchemaDocumentService {
+  static parseJsonSchema(content: string): JSONSchemaMetadata {
+    try {
+      const row = JSON.parse(content) as JSONSchema7;
+      return { ...row, path: '#' };
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      throw new Error(`Failed to parse JSON schema. Error: ${error.message}`);
+    }
+  }
+
+  static createJsonSchemaDocument(documentType: DocumentType, documentId: string, content: string) {
+    const schema = JsonSchemaDocumentService.parseJsonSchema(content);
+    return new JsonSchemaDocument(schema, documentType, documentId);
+  }
+
+  static createFieldFromJSONSchema(
+    parent: JsonSchemaParentType,
+    propName: string,
+    schema: JSONSchemaMetadata,
+  ): JsonSchemaField {
+    schema.definitions && JsonSchemaDocumentService.populateTypeFragmentFromDefinition(parent, schema);
+
+    let field: JsonSchemaField;
+    if (schema.$ref) {
+      field = new JsonSchemaField(parent, propName, Types.AnyType);
+      field.namedTypeFragmentRefs.push(schema.$ref);
+      return field;
+    }
+
+    const types = JsonSchemaDocumentService.getSchemaTypes(schema);
+
+    // choose one field type
+    if (types.includes('array')) {
+      field = new JsonSchemaField(parent, propName, Types.Array);
+      JsonSchemaDocumentService.populateArrayItems(field, schema);
+    } else if (types.includes('object')) {
+      field = new JsonSchemaField(parent, propName, Types.Container);
+      JsonSchemaDocumentService.populateObjectProperties(field, schema);
+    } else {
+      let fieldType: Types = Types.AnyType;
+      if (types.includes('string')) fieldType = Types.String;
+      else if (types.includes('number')) fieldType = Types.Numeric;
+      else if (types.includes('boolean')) fieldType = Types.Boolean;
+      field = new JsonSchemaField(parent, propName, fieldType);
+      JsonSchemaDocumentService.enrichFieldFromComposition(field, schema);
+    }
+
+    return field;
+  }
+
+  /**
+   * If `type` is omitted, pick one of them by looking at the `properties` and `items`
+   * @param schema
+   * @private
+   */
+  private static getSchemaTypes(schema: JSONSchemaMetadata) {
+    if (!schema.type) {
+      if (schema.items) {
+        return ['array'];
+      } else if (schema.properties) {
+        return ['object'];
+      } else {
+        return [];
+      }
+    }
+    return Array.isArray(schema.type) ? schema.type : [schema.type];
+  }
+
+  private static populateArrayItems(field: JsonSchemaField, schema: JSONSchemaMetadata) {
+    if (schema.items) {
+      const path = schema.path + '/items';
+      const arrayItems = Array.isArray(schema.items) ? schema.items : [schema.items];
+      arrayItems.forEach((arrayItem) => {
+        JsonSchemaDocumentService.populateFieldFromJSONSchemaDefinition(field, path, '', arrayItem);
+      });
+      field.fields.forEach((field) => {
+        field.maxOccurs = Number.MAX_SAFE_INTEGER;
+      });
+    }
+  }
+
+  private static populateObjectProperties(field: JsonSchemaField, schema: JSONSchemaMetadata) {
+    if (schema.properties) {
+      const path = schema.path + '/properties';
+      Object.entries(schema.properties).forEach(([childName, propSchemaDef]) => {
+        JsonSchemaDocumentService.populateFieldFromJSONSchemaDefinition(field, path, childName, propSchemaDef);
+      });
+    }
+    field.fields.forEach((subField) => {
+      subField.minOccurs = schema.required?.includes(subField.name) ? 1 : 0;
+    });
+    JsonSchemaDocumentService.enrichFieldFromComposition(field, schema);
+  }
+
+  private static populateTypeFragmentFromDefinition(parent: JsonSchemaParentType, schema: JSONSchemaMetadata) {
+    const ownerDocument = DocumentService.getOwnerDocument<JsonSchemaDocument>(parent);
+    const definitions = { ...schema.$defs, ...schema.definitions };
+    Object.entries(definitions).forEach(([definitionName, definitionSchema]) => {
+      if (typeof definitionSchema === 'boolean' || Object.keys(definitionSchema).length === 0) return;
+      const path =
+        schema.path + (schema.$defs && definitionName in schema.$defs ? '/$defs/' : '/definitions/') + definitionName;
+      const schemaMeta = { ...definitionSchema, path: path };
+      const field = JsonSchemaDocumentService.createFieldFromJSONSchema(parent, '', schemaMeta);
+      ownerDocument.namedTypeFragments[path] = {
+        type: field.type,
+        minOccurs: field.minOccurs,
+        maxOccurs: field.maxOccurs,
+        fields: field.fields,
+        namedTypeFragmentRefs: [...field.namedTypeFragmentRefs],
+      };
+    });
+  }
+
+  private static populateFieldFromJSONSchemaDefinition(
+    parent: JsonSchemaParentType,
+    parentPath: string,
+    fieldName: string,
+    schemaDef: JSONSchema7Definition,
+  ) {
+    const existingField = parent.fields.find((field) => field.name === fieldName);
+    if (existingField) {
+      JsonSchemaDocumentService.doEnrichWithJSONSchemaDefinition(
+        existingField,
+        schemaDef,
+        parentPath + `/${existingField.name}`,
+      );
+      return;
+    }
+
+    if (typeof schemaDef === 'boolean' || Object.keys(schemaDef).length === 0) {
+      // boolean or empty schema means it inherits from the composition, deferring to enrich it with composition
+      const field = new JsonSchemaField(parent, fieldName, Types.AnyType);
+      parent.fields.push(field);
+      return;
+    }
+
+    const field = JsonSchemaDocumentService.createFieldFromJSONSchema(parent, fieldName, {
+      ...schemaDef,
+      path: parentPath,
+    });
+    parent.fields.push(field);
+  }
+
+  private static enrichFieldFromComposition(field: JsonSchemaField, schema: JSONSchemaMetadata) {
+    schema.anyOf?.forEach((compositionSchemaDef) =>
+      JsonSchemaDocumentService.doEnrichWithJSONSchemaDefinition(field, compositionSchemaDef, schema.path + '/anyOf'),
+    );
+    schema.oneOf?.forEach((compositionSchemaDef) =>
+      JsonSchemaDocumentService.doEnrichWithJSONSchemaDefinition(field, compositionSchemaDef, schema.path + '/oneOf'),
+    );
+    schema.allOf?.forEach((compositionSchemaDef) =>
+      JsonSchemaDocumentService.doEnrichWithJSONSchemaDefinition(field, compositionSchemaDef, schema.path + '/allOf'),
+    );
+  }
+
+  private static doEnrichWithJSONSchemaDefinition(
+    field: JsonSchemaField,
+    schemaDef: JSONSchema7Definition,
+    schemaPath: string,
+  ) {
+    if (typeof schemaDef === 'boolean' || Object.keys(schemaDef).length === 0) return;
+    schemaDef.$ref && field.namedTypeFragmentRefs.push(schemaDef.$ref);
+
+    const schemaMeta = { ...schemaDef, path: schemaPath };
+    schemaDef.definitions && JsonSchemaDocumentService.populateTypeFragmentFromDefinition(field, schemaMeta);
+
+    const types = JsonSchemaDocumentService.getSchemaTypes(schemaMeta);
+
+    // update field type if necessary
+    if (types.includes('array')) {
+      field.type = Types.Array;
+      JsonSchemaDocumentService.populateArrayItems(field, schemaMeta);
+    } else if (types.includes('object') && field.type !== Types.Array) {
+      field.type = Types.Container;
+      JsonSchemaDocumentService.populateObjectProperties(field, schemaMeta);
+    } else if (![Types.Array, Types.Container].includes(field.type)) {
+      if (types.includes('string')) {
+        field.type = Types.String;
+      } else if (types.includes('number') && field.type !== Types.String) {
+        field.type = Types.Numeric;
+      } else if (types.includes('boolean') && ![Types.String, Types.Numeric].includes(field.type)) {
+        field.type = Types.Boolean;
+      }
+    }
+
+    JsonSchemaDocumentService.enrichFieldFromComposition(field, schemaMeta);
+  }
+}

--- a/packages/ui/src/stubs/camelYamlDsl.json
+++ b/packages/ui/src/stubs/camelYamlDsl.json
@@ -1,0 +1,16876 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "array",
+  "items" : {
+    "maxProperties" : 1,
+    "additionalProperties" : false,
+    "definitions" : {
+      "org.apache.camel.model.ProcessorDefinition" : {
+        "type" : "object",
+        "maxProperties" : 1,
+        "additionalProperties" : false,
+        "properties" : {
+          "aggregate" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.AggregateDefinition"
+          },
+          "bean" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.BeanDefinition"
+          },
+          "doCatch" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CatchDefinition"
+          },
+          "choice" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ChoiceDefinition"
+          },
+          "circuitBreaker" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.CircuitBreakerDefinition"
+          },
+          "claimCheck" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ClaimCheckDefinition"
+          },
+          "convertBodyTo" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertBodyDefinition"
+          },
+          "convertHeaderTo" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertHeaderDefinition"
+          },
+          "convertVariableTo" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertVariableDefinition"
+          },
+          "delay" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.DelayDefinition"
+          },
+          "dynamicRouter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.DynamicRouterDefinition"
+          },
+          "enrich" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.EnrichDefinition"
+          },
+          "filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FilterDefinition"
+          },
+          "doFinally" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FinallyDefinition"
+          },
+          "idempotentConsumer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.IdempotentConsumerDefinition"
+          },
+          "kamelet" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.KameletDefinition"
+          },
+          "loadBalance" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LoadBalanceDefinition"
+          },
+          "log" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LogDefinition"
+          },
+          "loop" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LoopDefinition"
+          },
+          "marshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.MarshalDefinition"
+          },
+          "multicast" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.MulticastDefinition"
+          },
+          "pausable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PausableDefinition"
+          },
+          "pipeline" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PipelineDefinition"
+          },
+          "policy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PolicyDefinition"
+          },
+          "poll" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PollDefinition"
+          },
+          "pollEnrich" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.PollEnrichDefinition"
+          },
+          "process" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ProcessDefinition"
+          },
+          "recipientList" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RecipientListDefinition"
+          },
+          "removeHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+          },
+          "removeHeaders" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+          },
+          "removeProperties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+          },
+          "removeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertyDefinition"
+          },
+          "removeVariable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveVariableDefinition"
+          },
+          "resequence" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ResequenceDefinition"
+          },
+          "resumable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ResumableDefinition"
+          },
+          "rollback" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RollbackDefinition"
+          },
+          "routingSlip" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RoutingSlipDefinition"
+          },
+          "saga" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaDefinition"
+          },
+          "sample" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SamplingDefinition"
+          },
+          "script" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ScriptDefinition"
+          },
+          "setBody" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetBodyDefinition"
+          },
+          "setExchangePattern" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetExchangePatternDefinition"
+          },
+          "setHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+          },
+          "setHeaders" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeadersDefinition"
+          },
+          "setProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
+          },
+          "setVariable" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetVariableDefinition"
+          },
+          "setVariables" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetVariablesDefinition"
+          },
+          "sort" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SortDefinition"
+          },
+          "split" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SplitDefinition"
+          },
+          "step" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.StepDefinition"
+          },
+          "stop" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.StopDefinition"
+          },
+          "threads" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThreadsDefinition"
+          },
+          "throttle" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThrottleDefinition"
+          },
+          "throwException" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ThrowExceptionDefinition"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "toD" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDynamicDefinition"
+          },
+          "tokenizer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TokenizerDefinition"
+          },
+          "transacted" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TransactedDefinition"
+          },
+          "transform" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TransformDefinition"
+          },
+          "doTry" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TryDefinition"
+          },
+          "unmarshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.UnmarshalDefinition"
+          },
+          "validate" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ValidateDefinition"
+          },
+          "wireTap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WireTapDefinition"
+          },
+          "serviceCall" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallDefinition"
+          }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.BeansDeserializer" : {
+        "type" : "array",
+        "additionalProperties" : false,
+        "items" : {
+          "$ref" : "#/items/definitions/org.apache.camel.model.BeanFactoryDefinition"
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.DataFormatsDefinitionDeserializer" : {
+        "type" : "array",
+        "additionalProperties" : false,
+        "items" : {
+          "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.DataFormatsDefinition"
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.ErrorHandlerDeserializer" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "deadLetterChannel" ],
+            "properties" : {
+              "deadLetterChannel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DeadLetterChannelDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "deadLetterChannel" ]
+              }, {
+                "required" : [ "defaultErrorHandler" ]
+              }, {
+                "required" : [ "jtaTransactionErrorHandler" ]
+              }, {
+                "required" : [ "noErrorHandler" ]
+              }, {
+                "required" : [ "refErrorHandler" ]
+              }, {
+                "required" : [ "springTransactionErrorHandler" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "defaultErrorHandler" ],
+            "properties" : {
+              "defaultErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jtaTransactionErrorHandler" ],
+            "properties" : {
+              "jtaTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "noErrorHandler" ],
+            "properties" : {
+              "noErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "refErrorHandler" ],
+            "properties" : {
+              "refErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.RefErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "springTransactionErrorHandler" ],
+            "properties" : {
+              "springTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "deadLetterChannel" : { },
+          "defaultErrorHandler" : { },
+          "jtaTransactionErrorHandler" : { },
+          "noErrorHandler" : { },
+          "refErrorHandler" : { },
+          "springTransactionErrorHandler" : { }
+        }
+      },
+      "org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "variableReceive" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "variableReceive" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.AggregateDefinition" : {
+        "title" : "Aggregate",
+        "description" : "Aggregates many messages into a single message",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "aggregateController" : {
+            "type" : "string",
+            "title" : "Aggregate Controller",
+            "description" : "To use a org.apache.camel.processor.aggregate.AggregateController to allow external sources to control this aggregator."
+          },
+          "aggregationRepository" : {
+            "type" : "string",
+            "title" : "Aggregation Repository",
+            "description" : "The AggregationRepository to use. Sets the custom aggregate repository to use. Will by default use org.apache.camel.processor.aggregate.MemoryAggregationRepository"
+          },
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "The AggregationStrategy to use. For example to lookup a bean with the name foo, the value is simply just #bean:foo. Configuring an AggregationStrategy is required, and is used to merge the incoming Exchange with the existing already merged exchanges. At first call the oldExchange parameter is null. On subsequent invocations the oldExchange contains the merged exchanges and newExchange is of course the new incoming Exchange."
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "boolean",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used for the very first aggregation. If this option is true then null values is used as the oldExchange (at the very first aggregation), when using beans as the AggregationStrategy."
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using beans as the AggregationStrategy."
+          },
+          "closeCorrelationKeyOnCompletion" : {
+            "type" : "number",
+            "title" : "Close Correlation Key On Completion",
+            "description" : "Closes a correlation key when its complete. Any late received exchanges which has a correlation key that has been closed, it will be defined and a ClosedCorrelationKeyException is thrown."
+          },
+          "completeAllOnStop" : {
+            "type" : "boolean",
+            "title" : "Complete All On Stop",
+            "description" : "Indicates to wait to complete all current and partial (pending) aggregated exchanges when the context is stopped. This also means that we will wait for all pending exchanges which are stored in the aggregation repository to complete so the repository is empty before we can stop. You may want to enable this when using the memory based aggregation repository that is memory based only, and do not store data on disk. When this option is enabled, then the aggregator is waiting to complete all those exchanges before its stopped, when stopping CamelContext or the route using it."
+          },
+          "completionFromBatchConsumer" : {
+            "type" : "boolean",
+            "title" : "Completion From Batch Consumer",
+            "description" : "Enables the batch completion mode where we aggregate from a org.apache.camel.BatchConsumer and aggregate the total number of exchanges the org.apache.camel.BatchConsumer has reported as total by checking the exchange property org.apache.camel.Exchange#BATCH_COMPLETE when its complete. This option cannot be used together with discardOnAggregationFailure."
+          },
+          "completionInterval" : {
+            "type" : "string",
+            "title" : "Completion Interval",
+            "description" : "A repeating period in millis by which the aggregator will complete all current aggregated exchanges. Camel has a background task which is triggered every period. You cannot use this option together with completionTimeout, only one of them can be used."
+          },
+          "completionOnNewCorrelationGroup" : {
+            "type" : "boolean",
+            "title" : "Completion On New Correlation Group",
+            "description" : "Enables completion on all previous groups when a new incoming correlation group. This can for example be used to complete groups with same correlation keys when they are in consecutive order. Notice when this is enabled then only 1 correlation group can be in progress as when a new correlation group starts, then the previous groups is forced completed."
+          },
+          "completionPredicate" : {
+            "title" : "Completion Predicate",
+            "description" : "A Predicate to indicate when an aggregated exchange is complete. If this is not specified and the AggregationStrategy object implements Predicate, the aggregationStrategy object will be used as the completionPredicate.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "completionSize" : {
+            "type" : "number",
+            "title" : "Completion Size",
+            "description" : "Number of messages aggregated before the aggregation is complete. This option can be set as either a fixed value or using an Expression which allows you to evaluate a size dynamically - will use Integer as result. If both are set Camel will fallback to use the fixed value if the Expression result was null or 0."
+          },
+          "completionSizeExpression" : {
+            "title" : "Completion Size Expression",
+            "description" : "Number of messages aggregated before the aggregation is complete. This option can be set as either a fixed value or using an Expression which allows you to evaluate a size dynamically - will use Integer as result. If both are set Camel will fallback to use the fixed value if the Expression result was null or 0.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "completionTimeout" : {
+            "type" : "string",
+            "title" : "Completion Timeout",
+            "description" : "Time in millis that an aggregated exchange should be inactive before its complete (timeout). This option can be set as either a fixed value or using an Expression which allows you to evaluate a timeout dynamically - will use Long as result. If both are set Camel will fallback to use the fixed value if the Expression result was null or 0. You cannot use this option together with completionInterval, only one of the two can be used. By default the timeout checker runs every second, you can use the completionTimeoutCheckerInterval option to configure how frequently to run the checker. The timeout is an approximation and there is no guarantee that the a timeout is triggered exactly after the timeout value. It is not recommended to use very low timeout values or checker intervals."
+          },
+          "completionTimeoutCheckerInterval" : {
+            "type" : "string",
+            "title" : "Completion Timeout Checker Interval",
+            "description" : "Interval in millis that is used by the background task that checks for timeouts ( org.apache.camel.TimeoutMap ). By default the timeout checker runs every second. The timeout is an approximation and there is no guarantee that the a timeout is triggered exactly after the timeout value. It is not recommended to use very low timeout values or checker intervals.",
+            "default" : "1000"
+          },
+          "completionTimeoutExpression" : {
+            "title" : "Completion Timeout Expression",
+            "description" : "Time in millis that an aggregated exchange should be inactive before its complete (timeout). This option can be set as either a fixed value or using an Expression which allows you to evaluate a timeout dynamically - will use Long as result. If both are set Camel will fallback to use the fixed value if the Expression result was null or 0. You cannot use this option together with completionInterval, only one of the two can be used. By default the timeout checker runs every second, you can use the completionTimeoutCheckerInterval option to configure how frequently to run the checker. The timeout is an approximation and there is no guarantee that the a timeout is triggered exactly after the timeout value. It is not recommended to use very low timeout values or checker intervals.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "correlationExpression" : {
+            "title" : "Correlation Expression",
+            "description" : "The expression used to calculate the correlation key to use for aggregation. The Exchange which has the same correlation key is aggregated together. If the correlation key could not be evaluated an Exception is thrown. You can disable this by using the ignoreBadCorrelationKeys option.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "discardOnAggregationFailure" : {
+            "type" : "boolean",
+            "title" : "Discard On Aggregation Failure",
+            "description" : "Discards the aggregated message when aggregation failed (an exception was thrown from AggregationStrategy . This means the partly aggregated message is dropped and not sent out of the aggregator. This option cannot be used together with completionFromBatchConsumer."
+          },
+          "discardOnCompletionTimeout" : {
+            "type" : "boolean",
+            "title" : "Discard On Completion Timeout",
+            "description" : "Discards the aggregated message on completion timeout. This means on timeout the aggregated message is dropped and not sent out of the aggregator."
+          },
+          "eagerCheckCompletion" : {
+            "type" : "boolean",
+            "title" : "Eager Check Completion",
+            "description" : "Use eager completion checking which means that the completionPredicate will use the incoming Exchange. As opposed to without eager completion checking the completionPredicate will use the aggregated Exchange."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "If using parallelProcessing you can specify a custom thread pool to be used. In fact also if you are not using parallelProcessing this custom thread pool is used to send out aggregated exchanges as well."
+          },
+          "forceCompletionOnStop" : {
+            "type" : "boolean",
+            "title" : "Force Completion On Stop",
+            "description" : "Indicates to complete all current aggregated exchanges when the context is stopped"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidCorrelationKeys" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Correlation Keys",
+            "description" : "If a correlation key cannot be successfully evaluated it will be ignored by logging a DEBUG and then just ignore the incoming Exchange."
+          },
+          "optimisticLockRetryPolicy" : {
+            "title" : "Optimistic Lock Retry Policy",
+            "description" : "Allows to configure retry settings when using optimistic locking.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OptimisticLockRetryPolicyDefinition"
+          },
+          "optimisticLocking" : {
+            "type" : "boolean",
+            "title" : "Optimistic Locking",
+            "description" : "Turns on using optimistic locking, which requires the aggregationRepository being used, is supporting this by implementing org.apache.camel.spi.OptimisticLockingAggregationRepository ."
+          },
+          "parallelProcessing" : {
+            "type" : "boolean",
+            "title" : "Parallel Processing",
+            "description" : "When aggregated are completed they are being send out of the aggregator. This option indicates whether or not Camel should use a thread pool with multiple threads for concurrency. If no custom thread pool has been specified then Camel creates a default pool with 10 concurrent threads."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "timeoutCheckerExecutorService" : {
+            "type" : "string",
+            "title" : "Timeout Checker Executor Service",
+            "description" : "If using either of the completionTimeout, completionTimeoutExpression, or completionInterval options a background thread is created to check for the completion for every aggregator. Set this option to provide a custom thread pool to be used rather than creating a new thread for every aggregator."
+          }
+        },
+        "required" : [ "aggregationStrategy" ]
+      },
+      "org.apache.camel.model.BeanDefinition" : {
+        "title" : "Bean",
+        "description" : "Calls a Java bean",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "beanType" : {
+              "type" : "string",
+              "title" : "Bean Type",
+              "description" : "Sets the class name (fully qualified) of the bean to use"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "method" : {
+              "type" : "string",
+              "title" : "Method",
+              "description" : "Sets the method name on the bean to use"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Sets a reference to an existing bean to use, which is looked up from the registry"
+            },
+            "scope" : {
+              "type" : "string",
+              "title" : "Scope",
+              "description" : "Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you want to store state on a bean while processing a request and you want to call the same bean instance multiple times while processing the request. The bean does not have to be thread-safe as the instance is only called from the same request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act as either singleton or prototype scope. So when using prototype scope then this depends on the bean registry implementation.",
+              "default" : "Singleton",
+              "enum" : [ "Singleton", "Request", "Prototype" ]
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.BeanFactoryDefinition" : {
+        "title" : "Bean Factory",
+        "description" : "Define custom beans that can be used in your Camel routes and in general.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "builderClass" : {
+            "type" : "string",
+            "title" : "Builder Class",
+            "description" : "Fully qualified class name of builder class to use for creating and configuring the bean. The builder will use the properties values to configure the bean."
+          },
+          "builderMethod" : {
+            "type" : "string",
+            "title" : "Builder Method",
+            "description" : "Name of method when using builder class. This method is invoked after configuring to create the actual bean. This method is often named build (used by default).",
+            "default" : "build"
+          },
+          "constructors" : {
+            "type" : "object",
+            "title" : "Constructors",
+            "description" : "Optional constructor arguments for creating the bean. Arguments correspond to specific index of the constructor argument list, starting from zero."
+          },
+          "destroyMethod" : {
+            "type" : "string",
+            "title" : "Destroy Method",
+            "description" : "The name of the custom destroy method to invoke on bean shutdown, such as when Camel is shutting down. The method must have no arguments, but may throw any exception."
+          },
+          "factoryBean" : {
+            "type" : "string",
+            "title" : "Factory Bean",
+            "description" : "Name of factory bean (bean id) to use for creating the bean."
+          },
+          "factoryMethod" : {
+            "type" : "string",
+            "title" : "Factory Method",
+            "description" : "Name of method to invoke when creating the bean via a factory bean."
+          },
+          "initMethod" : {
+            "type" : "string",
+            "title" : "Init Method",
+            "description" : "The name of the custom initialization method to invoke after setting bean properties. The method must have no arguments, but may throw any exception."
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The name of the bean (bean id)"
+          },
+          "properties" : {
+            "type" : "object",
+            "title" : "Properties",
+            "description" : "Optional properties to set on the created bean."
+          },
+          "script" : {
+            "type" : "string",
+            "title" : "Script",
+            "description" : "The script to execute that creates the bean when using scripting languages. If the script use the prefix resource: such as resource:classpath:com/foo/myscript.groovy, resource:file:/var/myscript.groovy, then its loaded from the external resource."
+          },
+          "scriptLanguage" : {
+            "type" : "string",
+            "title" : "Script Language",
+            "description" : "The script language to use when using inlined script for creating the bean, such as groovy, java, javascript etc."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "The class name (fully qualified) of the bean"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.CatchDefinition" : {
+        "title" : "Do Catch",
+        "description" : "Catches exceptions as part of a try, catch, finally block",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "exception" : {
+            "type" : "array",
+            "title" : "Exception",
+            "description" : "The exception(s) to catch.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onWhen" : {
+            "title" : "On When",
+            "description" : "Used for triggering doCatch in specific situations",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ChoiceDefinition" : {
+        "title" : "Choice",
+        "description" : "Route messages based on a series of predicates",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "otherwise" : {
+            "title" : "Otherwise",
+            "description" : "Sets the otherwise node",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OtherwiseDefinition"
+          },
+          "precondition" : {
+            "type" : "boolean",
+            "title" : "Precondition",
+            "description" : "Indicates whether this Choice EIP is in precondition mode or not. If so its branches (when/otherwise) are evaluated during startup to keep at runtime only the branch that matched."
+          },
+          "when" : {
+            "type" : "array",
+            "title" : "When",
+            "description" : "Sets the when nodes",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.CircuitBreakerDefinition" : {
+        "title" : "Circuit Breaker",
+        "description" : "Route messages in a fault tolerance way using Circuit Breaker",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "configuration" : {
+            "type" : "string",
+            "title" : "Configuration",
+            "description" : "Refers to a circuit breaker configuration (such as resillience4j, or microprofile-fault-tolerance) to use for configuring the circuit breaker EIP."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "faultToleranceConfiguration" : {
+            "title" : "Fault Tolerance Configuration",
+            "description" : "Configures the circuit breaker to use MicroProfile Fault Tolerance with the given configuration.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.FaultToleranceConfigurationDefinition"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onFallback" : {
+            "title" : "On Fallback",
+            "description" : "The fallback route path to execute that does not go over the network. This should be a static or cached result that can immediately be returned upon failure. If the fallback requires network connection then use onFallbackViaNetwork() .",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnFallbackDefinition"
+          },
+          "resilience4jConfiguration" : {
+            "title" : "Resilience4j Configuration",
+            "description" : "Configures the circuit breaker to use Resilience4j with the given configuration.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.Resilience4jConfigurationDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ClaimCheckDefinition" : {
+        "title" : "Claim Check",
+        "description" : "The Claim Check EIP allows you to replace message content with a claim check (a unique key), which can be used to retrieve the message content at a later time.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "To use a custom AggregationStrategy instead of the default implementation. Notice you cannot use both custom aggregation strategy and configure data at the same time."
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "filter" : {
+            "type" : "string",
+            "title" : "Filter",
+            "description" : "Specify a filter to control what data gets merged data back from the claim check repository. The following syntax is supported: body - to aggregate the message body attachments - to aggregate all the message attachments headers - to aggregate all the message headers header:pattern - to aggregate all the message headers that matches the pattern. The following pattern rules are applied in this order: exact match, returns true wildcard match (pattern ends with a and the name starts with the pattern), returns true regular expression match, returns true otherwise returns false You can specify multiple rules separated by comma. For example, the following includes the message body and all headers starting with foo: body,header:foo. The syntax supports the following prefixes which can be used to specify include,exclude, or remove - to include (which is the default mode) - - to exclude (exclude takes precedence over include) -- - to remove (remove takes precedence) For example to exclude a header name foo, and remove all headers starting with bar, -header:foo,--headers:bar Note you cannot have both include and exclude header:pattern at the same time."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "To use a specific key for claim check id (for dynamic keys use simple language syntax as the key)."
+          },
+          "operation" : {
+            "type" : "string",
+            "title" : "Operation",
+            "description" : "The claim check operation to use. The following operations are supported: Get - Gets (does not remove) the claim check by the given key. GetAndRemove - Gets and removes the claim check by the given key. Set - Sets a new (will override if key already exists) claim check with the given key. Push - Sets a new claim check on the stack (does not use key). Pop - Gets the latest claim check from the stack (does not use key).",
+            "enum" : [ "Get", "GetAndRemove", "Set", "Push", "Pop" ]
+          }
+        }
+      },
+      "org.apache.camel.model.ContextScanDefinition" : {
+        "title" : "Context Scan",
+        "description" : "Scans for Java org.apache.camel.builder.RouteBuilder instances in the context org.apache.camel.spi.Registry .",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "excludes" : {
+            "type" : "array",
+            "title" : "Excludes",
+            "description" : "Exclude finding route builder from these java package names.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "includeNonSingletons" : {
+            "type" : "boolean",
+            "title" : "Include Non Singletons",
+            "description" : "Whether to include non-singleton beans (prototypes) By default only singleton beans is included in the context scan"
+          },
+          "includes" : {
+            "type" : "array",
+            "title" : "Includes",
+            "description" : "Include finding route builder from these java package names.",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ConvertBodyDefinition" : {
+        "title" : "Convert Body To",
+        "description" : "Converts the message body to another type",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "charset" : {
+              "type" : "string",
+              "title" : "Charset",
+              "description" : "To use a specific charset when converting"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "mandatory" : {
+              "type" : "boolean",
+              "title" : "Mandatory",
+              "description" : "When mandatory then the conversion must return a value (cannot be null), if this is not possible then NoTypeConversionAvailableException is thrown. Setting this to false could mean conversion is not possible and the value is null."
+            },
+            "type" : {
+              "type" : "string",
+              "title" : "Type",
+              "description" : "The java type to convert to"
+            }
+          }
+        } ],
+        "required" : [ "type" ]
+      },
+      "org.apache.camel.model.ConvertHeaderDefinition" : {
+        "title" : "Convert Header To",
+        "description" : "Converts the message header to another type",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "charset" : {
+            "type" : "string",
+            "title" : "Charset",
+            "description" : "To use a specific charset when converting"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "mandatory" : {
+            "type" : "boolean",
+            "title" : "Mandatory",
+            "description" : "When mandatory then the conversion must return a value (cannot be null), if this is not possible then NoTypeConversionAvailableException is thrown. Setting this to false could mean conversion is not possible and the value is null."
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of message header to convert its value The simple language can be used to define a dynamic evaluated header name to be used. Otherwise a constant name will be used."
+          },
+          "toName" : {
+            "type" : "string",
+            "title" : "To Name",
+            "description" : "To use another header to store the result. By default, the result is stored in the same header. This option allows to use another header. The simple language can be used to define a dynamic evaluated header name to be used. Otherwise a constant name will be used."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "The java type to convert to"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.ConvertVariableDefinition" : {
+        "title" : "Convert Variable To",
+        "description" : "Converts the variable to another type",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "charset" : {
+            "type" : "string",
+            "title" : "Charset",
+            "description" : "To use a specific charset when converting"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "mandatory" : {
+            "type" : "boolean",
+            "title" : "Mandatory",
+            "description" : "When mandatory then the conversion must return a value (cannot be null), if this is not possible then NoTypeConversionAvailableException is thrown. Setting this to false could mean conversion is not possible and the value is null."
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of variable to convert its value The simple language can be used to define a dynamic evaluated header name to be used. Otherwise a constant name will be used."
+          },
+          "toName" : {
+            "type" : "string",
+            "title" : "To Name",
+            "description" : "To use another variable to store the result. By default, the result is stored in the same variable. This option allows to use another variable. The simple language can be used to define a dynamic evaluated variable name to be used. Otherwise a constant name will be used."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "The java type to convert to"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "org.apache.camel.model.DataFormatDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.DelayDefinition" : {
+        "title" : "Delay",
+        "description" : "Delays processing for a specified length of time",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to define how long time to wait (in millis)",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "asyncDelayed" : {
+            "type" : "boolean",
+            "title" : "Async Delayed",
+            "description" : "Enables asynchronous delay which means the thread will not block while delaying."
+          },
+          "callerRunsWhenRejected" : {
+            "type" : "boolean",
+            "title" : "Caller Runs When Rejected",
+            "description" : "Whether or not the caller should run the task when it was rejected by the thread pool. Is by default true"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom Thread Pool if asyncDelay has been enabled."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.DynamicRouterDefinition" : {
+        "title" : "Dynamic Router",
+        "description" : "Route messages based on dynamic rules",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to call that returns the endpoint(s) to route to in the dynamic routing. Important: The expression will be called in a while loop fashion, until the expression returns null which means the dynamic router is finished.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "cacheSize" : {
+            "type" : "number",
+            "title" : "Cache Size",
+            "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this dynamic router, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidEndpoints" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Endpoints",
+            "description" : "Ignore the invalidate endpoint exception when try to create a producer with that endpoint"
+          },
+          "uriDelimiter" : {
+            "type" : "string",
+            "title" : "Uri Delimiter",
+            "description" : "Sets the uri delimiter to use",
+            "default" : ","
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.EnrichDefinition" : {
+        "title" : "Enrich",
+        "description" : "Enriches a message with data from a secondary resource",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression that computes the endpoint uri to use as the resource endpoint to enrich from",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "aggregateOnException" : {
+            "type" : "boolean",
+            "title" : "Aggregate On Exception",
+            "description" : "If this option is false then the aggregate method is not used if there was an exception thrown while trying to retrieve the data to enrich from the resource. Setting this option to true allows end users to control what to do if there was an exception in the aggregate method. For example to suppress the exception or set a custom message body etc."
+          },
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "Sets the AggregationStrategy to be used to merge the reply from the external service, into a single outgoing message. By default Camel will use the reply from the external service as outgoing message."
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used if there was no data to enrich. If this option is true then null values is used as the oldExchange (when no data to enrich), when using POJOs as the AggregationStrategy."
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "allowOptimisedComponents" : {
+            "type" : "boolean",
+            "title" : "Allow Optimised Components",
+            "description" : "Whether to allow components to optimise enricher if they are org.apache.camel.spi.SendDynamicAware ."
+          },
+          "autoStartComponents" : {
+            "type" : "boolean",
+            "title" : "Auto Start Components",
+            "description" : "Whether to auto startup components when enricher is starting up."
+          },
+          "cacheSize" : {
+            "type" : "number",
+            "title" : "Cache Size",
+            "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producer when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidEndpoint" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Endpoint",
+            "description" : "Ignore the invalidate endpoint exception when try to create a producer with that endpoint"
+          },
+          "shareUnitOfWork" : {
+            "type" : "boolean",
+            "title" : "Share Unit Of Work",
+            "description" : "Shares the org.apache.camel.spi.UnitOfWork with the parent and the resource exchange. Enrich will by default not share unit of work between the parent exchange and the resource exchange. This means the resource exchange has its own individual unit of work."
+          },
+          "variableReceive" : {
+            "type" : "string",
+            "title" : "Variable Receive",
+            "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+          },
+          "variableSend" : {
+            "type" : "string",
+            "title" : "Variable Send",
+            "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.ErrorHandlerDefinition" : {
+        "title" : "Error Handler",
+        "description" : "Camel error handling.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "deadLetterChannel" ],
+            "properties" : {
+              "deadLetterChannel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DeadLetterChannelDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "deadLetterChannel" ]
+              }, {
+                "required" : [ "defaultErrorHandler" ]
+              }, {
+                "required" : [ "jtaTransactionErrorHandler" ]
+              }, {
+                "required" : [ "noErrorHandler" ]
+              }, {
+                "required" : [ "refErrorHandler" ]
+              }, {
+                "required" : [ "springTransactionErrorHandler" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "defaultErrorHandler" ],
+            "properties" : {
+              "defaultErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jtaTransactionErrorHandler" ],
+            "properties" : {
+              "jtaTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "noErrorHandler" ],
+            "properties" : {
+              "noErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.NoErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "refErrorHandler" ],
+            "properties" : {
+              "refErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.RefErrorHandlerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "springTransactionErrorHandler" ],
+            "properties" : {
+              "springTransactionErrorHandler" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "deadLetterChannel" : { },
+          "defaultErrorHandler" : { },
+          "jtaTransactionErrorHandler" : { },
+          "noErrorHandler" : { },
+          "refErrorHandler" : { },
+          "springTransactionErrorHandler" : { }
+        }
+      },
+      "org.apache.camel.model.ExpressionSubElementDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "constant" ],
+            "properties" : {
+              "constant" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csimple" ],
+            "properties" : {
+              "csimple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "datasonnet" ],
+            "properties" : {
+              "datasonnet" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "exchangeProperty" ],
+            "properties" : {
+              "exchangeProperty" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "groovy" ],
+            "properties" : {
+              "groovy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "header" ],
+            "properties" : {
+              "header" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7terser" ],
+            "properties" : {
+              "hl7terser" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "java" ],
+            "properties" : {
+              "java" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "joor" ],
+            "properties" : {
+              "joor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jq" ],
+            "properties" : {
+              "jq" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "js" ],
+            "properties" : {
+              "js" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaScriptExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonpath" ],
+            "properties" : {
+              "jsonpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "language" ],
+            "properties" : {
+              "language" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "method" ],
+            "properties" : {
+              "method" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mvel" ],
+            "properties" : {
+              "mvel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ognl" ],
+            "properties" : {
+              "ognl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python" ],
+            "properties" : {
+              "python" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.PythonExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ref" ],
+            "properties" : {
+              "ref" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "simple" ],
+            "properties" : {
+              "simple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "spel" ],
+            "properties" : {
+              "spel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tokenize" ],
+            "properties" : {
+              "tokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "variable" ],
+            "properties" : {
+              "variable" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.VariableExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "wasm" ],
+            "properties" : {
+              "wasm" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.WasmExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xpath" ],
+            "properties" : {
+              "xpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xquery" ],
+            "properties" : {
+              "xquery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xtokenize" ],
+            "properties" : {
+              "xtokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { }
+        }
+      },
+      "org.apache.camel.model.FaultToleranceConfigurationDefinition" : {
+        "title" : "Fault Tolerance Configuration",
+        "description" : "MicroProfile Fault Tolerance Circuit Breaker EIP configuration",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "bulkheadEnabled" : {
+            "type" : "boolean",
+            "title" : "Bulkhead Enabled",
+            "description" : "Whether bulkhead is enabled or not on the circuit breaker. Default is false."
+          },
+          "bulkheadExecutorService" : {
+            "type" : "string",
+            "title" : "Bulkhead Executor Service",
+            "description" : "References to a custom thread pool to use when bulkhead is enabled."
+          },
+          "bulkheadMaxConcurrentCalls" : {
+            "type" : "number",
+            "title" : "Bulkhead Max Concurrent Calls",
+            "description" : "Configures the max amount of concurrent calls the bulkhead will support.",
+            "default" : "10"
+          },
+          "bulkheadWaitingTaskQueue" : {
+            "type" : "number",
+            "title" : "Bulkhead Waiting Task Queue",
+            "description" : "Configures the task queue size for holding waiting tasks to be processed by the bulkhead.",
+            "default" : "10"
+          },
+          "circuitBreaker" : {
+            "type" : "string",
+            "title" : "Circuit Breaker",
+            "description" : "Refers to an existing io.smallrye.faulttolerance.core.circuit.breaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use."
+          },
+          "delay" : {
+            "type" : "string",
+            "title" : "Delay",
+            "description" : "Control how long the circuit breaker stays open. The default is 5 seconds.",
+            "default" : "5000"
+          },
+          "failureRatio" : {
+            "type" : "number",
+            "title" : "Failure Ratio",
+            "description" : "Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage.",
+            "default" : "50"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "requestVolumeThreshold" : {
+            "type" : "number",
+            "title" : "Request Volume Threshold",
+            "description" : "Controls the size of the rolling window used when the circuit breaker is closed",
+            "default" : "20"
+          },
+          "successThreshold" : {
+            "type" : "number",
+            "title" : "Success Threshold",
+            "description" : "Controls the number of trial calls which are allowed when the circuit breaker is half-open",
+            "default" : "1"
+          },
+          "timeoutDuration" : {
+            "type" : "string",
+            "title" : "Timeout Duration",
+            "description" : "Configures the thread execution timeout. Default value is 1 second.",
+            "default" : "1000"
+          },
+          "timeoutEnabled" : {
+            "type" : "boolean",
+            "title" : "Timeout Enabled",
+            "description" : "Whether timeout is enabled or not on the circuit breaker. Default is false."
+          },
+          "timeoutPoolSize" : {
+            "type" : "number",
+            "title" : "Timeout Pool Size",
+            "description" : "Configures the pool size of the thread pool when timeout is enabled. Default value is 10.",
+            "default" : "10"
+          },
+          "timeoutScheduledExecutorService" : {
+            "type" : "string",
+            "title" : "Timeout Scheduled Executor Service",
+            "description" : "References to a custom thread pool to use when timeout is enabled"
+          }
+        }
+      },
+      "org.apache.camel.model.FilterDefinition" : {
+        "title" : "Filter",
+        "description" : "Filter out messages based using a predicate",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to determine if the message should be filtered or not. If the expression returns an empty value or false then the message is filtered (dropped), otherwise the message is continued being routed.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "statusPropertyName" : {
+            "type" : "string",
+            "title" : "Status Property Name",
+            "description" : "Name of exchange property to use for storing the status of the filtering. Setting this allows to know if the filter predicate evaluated as true or false."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.FinallyDefinition" : {
+        "title" : "Do Finally",
+        "description" : "Path traversed when a try, catch, finally block exits",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.FromDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          },
+          "variableReceive" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.GlobalOptionDefinition" : {
+        "title" : "Global Option",
+        "description" : "Models a string key/value pair for configuring some global options on a Camel context such as max debug log length.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Global option key"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "Global option value"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.GlobalOptionsDefinition" : {
+        "title" : "Global Options",
+        "description" : "Models a series of string key/value pairs for configuring some global options on a Camel context such as max debug log length.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "globalOption" : {
+            "type" : "array",
+            "title" : "Global Option",
+            "description" : "A series of global options as key value pairs",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.GlobalOptionDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.IdempotentConsumerDefinition" : {
+        "title" : "Idempotent Consumer",
+        "description" : "Filters out duplicate messages",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression used to calculate the correlation key to use for duplicate check. The Exchange which has the same correlation key is regarded as a duplicate and will be rejected.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "completionEager" : {
+            "type" : "boolean",
+            "title" : "Completion Eager",
+            "description" : "Sets whether to complete the idempotent consumer eager or when the exchange is done. If this option is true to complete eager, then the idempotent consumer will trigger its completion when the exchange reached the end of the block of the idempotent consumer pattern. So if the exchange is continued routed after the block ends, then whatever happens there does not affect the state. If this option is false (default) to not complete eager, then the idempotent consumer will complete when the exchange is done being routed. So if the exchange is continued routed after the block ends, then whatever happens there also affect the state. For example if the exchange failed due to an exception, then the state of the idempotent consumer will be a rollback."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "eager" : {
+            "type" : "boolean",
+            "title" : "Eager",
+            "description" : "Sets whether to eagerly add the key to the idempotent repository or wait until the exchange is complete. Eager is default enabled."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "idempotentRepository" : {
+            "type" : "string",
+            "title" : "Idempotent Repository",
+            "description" : "Sets the reference name of the message id repository"
+          },
+          "removeOnFailure" : {
+            "type" : "boolean",
+            "title" : "Remove On Failure",
+            "description" : "Sets whether to remove or keep the key on failure. The default behavior is to remove the key on failure."
+          },
+          "skipDuplicate" : {
+            "type" : "boolean",
+            "title" : "Skip Duplicate",
+            "description" : "Sets whether to skip duplicates or not. The default behavior is to skip duplicates. A duplicate message would have the Exchange property org.apache.camel.Exchange#DUPLICATE_MESSAGE set to a Boolean#TRUE value. A none duplicate message will not have this property set."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        },
+        "required" : [ "idempotentRepository" ]
+      },
+      "org.apache.camel.model.InputTypeDefinition" : {
+        "title" : "Input Type",
+        "description" : "Set the expected data type of the input message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the transformation from/to XML.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "urn" : {
+            "type" : "string",
+            "title" : "Urn",
+            "description" : "The input type URN."
+          },
+          "validate" : {
+            "type" : "boolean",
+            "title" : "Validate",
+            "description" : "Whether if validation is required for this input type."
+          }
+        },
+        "required" : [ "urn" ]
+      },
+      "org.apache.camel.model.InterceptDefinition" : {
+        "title" : "Intercept",
+        "description" : "Intercepts a message at each step in the route",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onWhen" : {
+            "title" : "On When",
+            "description" : "To use an expression to only trigger intercepting in specific situations",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.InterceptFromDefinition" : {
+        "title" : "Intercept From",
+        "description" : "Intercepts incoming messages",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "onWhen" : {
+              "title" : "On When",
+              "description" : "To use an expression to only trigger intercepting in specific situations",
+              "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "Intercept incoming messages from the uri or uri pattern. If this option is not configured, then all incoming messages is intercepted."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.InterceptSendToEndpointDefinition" : {
+        "title" : "Intercept Send To Endpoint",
+        "description" : "Intercepts messages being sent to an endpoint",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "afterUri" : {
+              "type" : "string",
+              "title" : "After Uri",
+              "description" : "After sending to the endpoint then send the message to this uri which allows to process its result."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "onWhen" : {
+              "title" : "On When",
+              "description" : "To use an expression to only trigger intercepting sending to an endpoint in specific situations",
+              "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+            },
+            "skipSendToOriginalEndpoint" : {
+              "type" : "string",
+              "title" : "Skip Send To Original Endpoint",
+              "description" : "If set to true then the message is not sent to the original endpoint. By default (false) the message is both intercepted and then sent to the original endpoint."
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "Intercept sending to the uri or uri pattern."
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.KameletDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "name" : {
+              "type" : "string"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "steps" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+              }
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.LoadBalanceDefinition" : {
+        "title" : "Load Balance",
+        "description" : "Balances message processing among a number of nodes",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "customLoadBalancer" ],
+            "properties" : {
+              "customLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "customLoadBalancer" ]
+              }, {
+                "required" : [ "failoverLoadBalancer" ]
+              }, {
+                "required" : [ "randomLoadBalancer" ]
+              }, {
+                "required" : [ "roundRobinLoadBalancer" ]
+              }, {
+                "required" : [ "stickyLoadBalancer" ]
+              }, {
+                "required" : [ "topicLoadBalancer" ]
+              }, {
+                "required" : [ "weightedLoadBalancer" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "failoverLoadBalancer" ],
+            "properties" : {
+              "failoverLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "randomLoadBalancer" ],
+            "properties" : {
+              "randomLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "roundRobinLoadBalancer" ],
+            "properties" : {
+              "roundRobinLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "stickyLoadBalancer" ],
+            "properties" : {
+              "stickyLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.StickyLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "topicLoadBalancer" ],
+            "properties" : {
+              "topicLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "weightedLoadBalancer" ],
+            "properties" : {
+              "weightedLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "customLoadBalancer" : { },
+          "failoverLoadBalancer" : { },
+          "randomLoadBalancer" : { },
+          "roundRobinLoadBalancer" : { },
+          "stickyLoadBalancer" : { },
+          "topicLoadBalancer" : { },
+          "weightedLoadBalancer" : { }
+        }
+      },
+      "org.apache.camel.model.LogDefinition" : {
+        "title" : "Logger",
+        "description" : "Used for printing custom messages to the logger.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "logLanguage" : {
+              "type" : "string",
+              "title" : "Log Language",
+              "description" : "To configure the language to use. By default, the simple language is used. However, Camel also supports other languages such as groovy."
+            },
+            "logName" : {
+              "type" : "string",
+              "title" : "Log Name",
+              "description" : "Sets the name of the logger. The name is default the routeId or the source:line if source location is enabled. You can also specify the name using tokens: ${class} - the logger class name (org.apache.camel.processor.LogProcessor) ${contextId} - the camel context id ${routeId} - the route id ${groupId} - the route group id ${nodeId} - the node id ${nodePrefixId} - the node prefix id ${source} - the source:line (source location must be enabled) ${source.name} - the source filename (source location must be enabled) ${source.line} - the source line number (source location must be enabled) For example to use the route and node id you can specify the name as: ${routeId}/${nodeId}"
+            },
+            "logger" : {
+              "type" : "string",
+              "title" : "Logger",
+              "description" : "To refer to a custom logger instance to lookup from the registry."
+            },
+            "loggingLevel" : {
+              "type" : "string",
+              "title" : "Logging Level",
+              "description" : "Sets the logging level. The default value is INFO",
+              "default" : "INFO",
+              "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+            },
+            "marker" : {
+              "type" : "string",
+              "title" : "Marker",
+              "description" : "To use slf4j marker"
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "Sets the log message (uses simple language)"
+            }
+          }
+        } ],
+        "required" : [ "message" ]
+      },
+      "org.apache.camel.model.LoopDefinition" : {
+        "title" : "Loop",
+        "description" : "Processes a message multiple times",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to define how many times we should loop. Notice the expression is only evaluated once, and should return a number as how many times to loop. A value of zero or negative means no looping. The loop is like a for-loop fashion, if you want a while loop, then the dynamic router may be a better choice.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "breakOnShutdown" : {
+            "type" : "boolean",
+            "title" : "Break On Shutdown",
+            "description" : "If the breakOnShutdown attribute is true, then the loop will not iterate until it reaches the end when Camel is shut down."
+          },
+          "copy" : {
+            "type" : "boolean",
+            "title" : "Copy",
+            "description" : "If the copy attribute is true, a copy of the input Exchange is used for each iteration. That means each iteration will start from a copy of the same message. By default loop will loop the same exchange all over, so each iteration may have different message content."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "doWhile" : {
+            "type" : "boolean",
+            "title" : "Do While",
+            "description" : "Enables the while loop that loops until the predicate evaluates to false or null."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onPrepare" : {
+            "type" : "string",
+            "title" : "On Prepare",
+            "description" : "Uses the Processor when preparing the org.apache.camel.Exchange for each loop iteration. This can be used to deep-clone messages, or any custom logic needed before the looping executes."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.MarshalDefinition" : {
+        "title" : "Marshal",
+        "description" : "Marshals data into a specified format for transmission over a transport or component",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "asn1" ],
+            "properties" : {
+              "asn1" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "asn1" ]
+              }, {
+                "required" : [ "avro" ]
+              }, {
+                "required" : [ "barcode" ]
+              }, {
+                "required" : [ "base64" ]
+              }, {
+                "required" : [ "beanio" ]
+              }, {
+                "required" : [ "bindy" ]
+              }, {
+                "required" : [ "cbor" ]
+              }, {
+                "required" : [ "crypto" ]
+              }, {
+                "required" : [ "csv" ]
+              }, {
+                "required" : [ "custom" ]
+              }, {
+                "required" : [ "fhirJson" ]
+              }, {
+                "required" : [ "fhirXml" ]
+              }, {
+                "required" : [ "flatpack" ]
+              }, {
+                "required" : [ "fury" ]
+              }, {
+                "required" : [ "grok" ]
+              }, {
+                "required" : [ "gzipDeflater" ]
+              }, {
+                "required" : [ "hl7" ]
+              }, {
+                "required" : [ "ical" ]
+              }, {
+                "required" : [ "jacksonXml" ]
+              }, {
+                "required" : [ "jaxb" ]
+              }, {
+                "required" : [ "json" ]
+              }, {
+                "required" : [ "jsonApi" ]
+              }, {
+                "required" : [ "lzf" ]
+              }, {
+                "required" : [ "mimeMultipart" ]
+              }, {
+                "required" : [ "parquetAvro" ]
+              }, {
+                "required" : [ "pgp" ]
+              }, {
+                "required" : [ "protobuf" ]
+              }, {
+                "required" : [ "rss" ]
+              }, {
+                "required" : [ "smooks" ]
+              }, {
+                "required" : [ "soap" ]
+              }, {
+                "required" : [ "swiftMt" ]
+              }, {
+                "required" : [ "swiftMx" ]
+              }, {
+                "required" : [ "syslog" ]
+              }, {
+                "required" : [ "tarFile" ]
+              }, {
+                "required" : [ "thrift" ]
+              }, {
+                "required" : [ "tidyMarkup" ]
+              }, {
+                "required" : [ "univocityCsv" ]
+              }, {
+                "required" : [ "univocityFixed" ]
+              }, {
+                "required" : [ "univocityTsv" ]
+              }, {
+                "required" : [ "xmlSecurity" ]
+              }, {
+                "required" : [ "yaml" ]
+              }, {
+                "required" : [ "zipDeflater" ]
+              }, {
+                "required" : [ "zipFile" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "avro" ],
+            "properties" : {
+              "avro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "barcode" ],
+            "properties" : {
+              "barcode" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "base64" ],
+            "properties" : {
+              "base64" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "beanio" ],
+            "properties" : {
+              "beanio" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "bindy" ],
+            "properties" : {
+              "bindy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "cbor" ],
+            "properties" : {
+              "cbor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "crypto" ],
+            "properties" : {
+              "crypto" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csv" ],
+            "properties" : {
+              "csv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "custom" ],
+            "properties" : {
+              "custom" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirJson" ],
+            "properties" : {
+              "fhirJson" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirXml" ],
+            "properties" : {
+              "fhirXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "flatpack" ],
+            "properties" : {
+              "flatpack" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fury" ],
+            "properties" : {
+              "fury" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FuryDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "grok" ],
+            "properties" : {
+              "grok" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "gzipDeflater" ],
+            "properties" : {
+              "gzipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7" ],
+            "properties" : {
+              "hl7" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ical" ],
+            "properties" : {
+              "ical" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jacksonXml" ],
+            "properties" : {
+              "jacksonXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jaxb" ],
+            "properties" : {
+              "jaxb" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "json" ],
+            "properties" : {
+              "json" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonApi" ],
+            "properties" : {
+              "jsonApi" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "lzf" ],
+            "properties" : {
+              "lzf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mimeMultipart" ],
+            "properties" : {
+              "mimeMultipart" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "parquetAvro" ],
+            "properties" : {
+              "parquetAvro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ParquetAvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "pgp" ],
+            "properties" : {
+              "pgp" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "protobuf" ],
+            "properties" : {
+              "protobuf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "rss" ],
+            "properties" : {
+              "rss" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "smooks" ],
+            "properties" : {
+              "smooks" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SmooksDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "soap" ],
+            "properties" : {
+              "soap" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMt" ],
+            "properties" : {
+              "swiftMt" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMtDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMx" ],
+            "properties" : {
+              "swiftMx" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMxDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "syslog" ],
+            "properties" : {
+              "syslog" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tarFile" ],
+            "properties" : {
+              "tarFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "thrift" ],
+            "properties" : {
+              "thrift" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tidyMarkup" ],
+            "properties" : {
+              "tidyMarkup" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityCsv" ],
+            "properties" : {
+              "univocityCsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityFixed" ],
+            "properties" : {
+              "univocityFixed" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityTsv" ],
+            "properties" : {
+              "univocityTsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xmlSecurity" ],
+            "properties" : {
+              "xmlSecurity" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "yaml" ],
+            "properties" : {
+              "yaml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipDeflater" ],
+            "properties" : {
+              "zipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipFile" ],
+            "properties" : {
+              "zipFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "variableReceive" : {
+            "type" : "string",
+            "title" : "Variable Receive",
+            "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+          },
+          "variableSend" : {
+            "type" : "string",
+            "title" : "Variable Send",
+            "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+          },
+          "asn1" : { },
+          "avro" : { },
+          "barcode" : { },
+          "base64" : { },
+          "beanio" : { },
+          "bindy" : { },
+          "cbor" : { },
+          "crypto" : { },
+          "csv" : { },
+          "custom" : { },
+          "fhirJson" : { },
+          "fhirXml" : { },
+          "flatpack" : { },
+          "fury" : { },
+          "grok" : { },
+          "gzipDeflater" : { },
+          "hl7" : { },
+          "ical" : { },
+          "jacksonXml" : { },
+          "jaxb" : { },
+          "json" : { },
+          "jsonApi" : { },
+          "lzf" : { },
+          "mimeMultipart" : { },
+          "parquetAvro" : { },
+          "pgp" : { },
+          "protobuf" : { },
+          "rss" : { },
+          "smooks" : { },
+          "soap" : { },
+          "swiftMt" : { },
+          "swiftMx" : { },
+          "syslog" : { },
+          "tarFile" : { },
+          "thrift" : { },
+          "tidyMarkup" : { },
+          "univocityCsv" : { },
+          "univocityFixed" : { },
+          "univocityTsv" : { },
+          "xmlSecurity" : { },
+          "yaml" : { },
+          "zipDeflater" : { },
+          "zipFile" : { }
+        }
+      },
+      "org.apache.camel.model.MulticastDefinition" : {
+        "title" : "Multicast",
+        "description" : "Routes the same message to multiple paths either sequentially or in parallel.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "Refers to an AggregationStrategy to be used to assemble the replies from the multicasts, into a single outgoing message from the Multicast. By default Camel will use the last reply as the outgoing message. You can also use a POJO as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "boolean",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used if there was no data to enrich. If this option is true then null values is used as the oldExchange (when no data to enrich), when using POJOs as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "Refers to a custom Thread Pool to be used for parallel processing. Notice if you set this option, then parallel processing is automatic implied, and you do not have to enable that option as well."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onPrepare" : {
+            "type" : "string",
+            "title" : "On Prepare",
+            "description" : "Uses the Processor when preparing the org.apache.camel.Exchange to be send. This can be used to deep-clone messages that should be send, or any custom logic needed before the exchange is send."
+          },
+          "parallelAggregate" : {
+            "type" : "boolean",
+            "title" : "Parallel Aggregate",
+            "description" : "If enabled then the aggregate method on AggregationStrategy can be called concurrently. Notice that this would require the implementation of AggregationStrategy to be implemented as thread-safe. By default this is false meaning that Camel synchronizes the call to the aggregate method. Though in some use-cases this can be used to archive higher performance when the AggregationStrategy is implemented as thread-safe.",
+            "deprecated" : true
+          },
+          "parallelProcessing" : {
+            "type" : "boolean",
+            "title" : "Parallel Processing",
+            "description" : "If enabled then sending messages to the multicasts occurs concurrently. Note the caller thread will still wait until all messages has been fully processed, before it continues. Its only the sending and processing the replies from the multicasts which happens concurrently. When parallel processing is enabled, then the Camel routing engin will continue processing using last used thread from the parallel thread pool. However, if you want to use the original thread that called the multicast, then make sure to enable the synchronous option as well. In parallel processing mode, you may want to also synchronous = true to force this EIP to process the sub-tasks using the upper bounds of the thread-pool. If using synchronous = false then Camel will allow its reactive routing engine to use as many threads as possible, which may be available due to sub-tasks using other thread-pools such as CompletableFuture.runAsync or others."
+          },
+          "shareUnitOfWork" : {
+            "type" : "boolean",
+            "title" : "Share Unit Of Work",
+            "description" : "Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub messages. Multicast will by default not share unit of work between the parent exchange and each multicasted exchange. This means each sub exchange has its own individual unit of work."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stopOnException" : {
+            "type" : "boolean",
+            "title" : "Stop On Exception",
+            "description" : "Will now stop further processing if an exception or failure occurred during processing of an org.apache.camel.Exchange and the caused exception will be thrown. Will also stop if processing the exchange failed (has a fault message) or an exception was thrown and handled by the error handler (such as using onException). In all situations the multicast will stop further processing. This is the same behavior as in pipeline, which is used by the routing engine. The default behavior is to not stop but continue processing till the end"
+          },
+          "streaming" : {
+            "type" : "boolean",
+            "title" : "Streaming",
+            "description" : "If enabled then Camel will process replies out-of-order, eg in the order they come back. If disabled, Camel will process replies in the same order as defined by the multicast."
+          },
+          "synchronous" : {
+            "type" : "boolean",
+            "title" : "Synchronous",
+            "description" : "Sets whether synchronous processing should be strictly used. When enabled then the same thread is used to continue routing after the multicast is complete, even if parallel processing is enabled."
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Sets a total timeout specified in millis, when using parallel processing. If the Multicast hasn't been able to send and process all replies within the given timeframe, then the timeout triggers and the Multicast breaks out and continues. Notice if you provide a TimeoutAwareAggregationStrategy then the timeout method is invoked before breaking out. If the timeout is reached with running tasks still remaining, certain tasks for which it is difficult for Camel to shut down in a graceful manner may continue to run. So use this option with a bit of care.",
+            "default" : "0"
+          }
+        }
+      },
+      "org.apache.camel.model.OnCompletionDefinition" : {
+        "title" : "On Completion",
+        "description" : "Route to be executed when normal route processing completes",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom Thread Pool to be used for parallel processing. Notice if you set this option, then parallel processing is automatic implied, and you do not have to enable that option as well."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "mode" : {
+            "type" : "string",
+            "title" : "Mode",
+            "description" : "Sets the on completion mode. The default value is AfterConsumer",
+            "default" : "AfterConsumer",
+            "enum" : [ "AfterConsumer", "BeforeConsumer" ]
+          },
+          "onCompleteOnly" : {
+            "type" : "boolean",
+            "title" : "On Complete Only",
+            "description" : "Will only synchronize when the org.apache.camel.Exchange completed successfully (no errors)."
+          },
+          "onFailureOnly" : {
+            "type" : "boolean",
+            "title" : "On Failure Only",
+            "description" : "Will only synchronize when the org.apache.camel.Exchange ended with failure (exception or FAULT message)."
+          },
+          "onWhen" : {
+            "title" : "On When",
+            "description" : "To use an expression to only trigger routing this completion steps in specific situations",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+          },
+          "parallelProcessing" : {
+            "type" : "boolean",
+            "title" : "Parallel Processing",
+            "description" : "If enabled then the on completion process will run asynchronously by a separate thread from a thread pool. By default this is false, meaning the on completion process will run synchronously using the same caller thread as from the route."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input message body when an org.apache.camel.Exchange for this on completion. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the split message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        }
+      },
+      "org.apache.camel.model.OnExceptionDefinition" : {
+        "title" : "On Exception",
+        "description" : "Route to be executed when an exception is thrown",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "continued" : {
+            "title" : "Continued",
+            "description" : "Sets whether the exchange should handle and continue routing from the point of failure. If this option is enabled then its considered handled as well.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "exception" : {
+            "type" : "array",
+            "title" : "Exception",
+            "description" : "A set of exceptions to react upon.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "handled" : {
+            "title" : "Handled",
+            "description" : "Sets whether the exchange should be marked as handled or not.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onExceptionOccurredRef" : {
+            "type" : "string",
+            "title" : "On Exception Occurred Ref",
+            "description" : "Sets a reference to a processor that should be processed just after an exception occurred. Can be used to perform custom logging about the occurred exception at the exact time it happened. Important: Any exception thrown from this processor will be ignored."
+          },
+          "onRedeliveryRef" : {
+            "type" : "string",
+            "title" : "On Redelivery Ref",
+            "description" : "Sets a reference to a processor that should be processed before a redelivery attempt. Can be used to change the org.apache.camel.Exchange before its being redelivered."
+          },
+          "onWhen" : {
+            "title" : "On When",
+            "description" : "To use an expression to only trigger this in specific situations",
+            "$ref" : "#/items/definitions/org.apache.camel.model.OnWhenDefinition"
+          },
+          "redeliveryPolicy" : {
+            "title" : "Redelivery Policy",
+            "description" : "Used for configuring redelivery options",
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redeliveryPolicyRef" : {
+            "type" : "string",
+            "title" : "Redelivery Policy Ref",
+            "description" : "Sets a reference to a redelivery policy to lookup in the org.apache.camel.spi.Registry to be used."
+          },
+          "retryWhile" : {
+            "title" : "Retry While",
+            "description" : "Sets the retry while predicate. Will continue retrying until predicate returns false.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "useOriginalBody" : {
+            "type" : "boolean",
+            "title" : "Use Original Body",
+            "description" : "Will use the original input org.apache.camel.Message body (original body only) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the split message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input org.apache.camel.Message (original body and headers) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the split message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        }
+      },
+      "org.apache.camel.model.OnFallbackDefinition" : {
+        "title" : "On Fallback",
+        "description" : "Route to be executed when Circuit Breaker EIP executes fallback",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "fallbackViaNetwork" : {
+            "type" : "boolean",
+            "title" : "Fallback Via Network",
+            "description" : "Whether the fallback goes over the network. If the fallback will go over the network it is another possible point of failure. It is important to execute the fallback command on a separate thread-pool, otherwise if the main command were to become latent and fill the thread-pool this would prevent the fallback from running if the two commands share the same pool."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OnWhenDefinition" : {
+        "title" : "On When",
+        "description" : "To use a predicate to determine when to trigger this.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.OptimisticLockRetryPolicyDefinition" : {
+        "title" : "Optimistic Lock Retry Policy",
+        "description" : "To configure optimistic locking",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "exponentialBackOff" : {
+            "type" : "boolean",
+            "title" : "Exponential Back Off",
+            "description" : "Enable exponential backoff"
+          },
+          "maximumRetries" : {
+            "type" : "number",
+            "title" : "Maximum Retries",
+            "description" : "Sets the maximum number of retries"
+          },
+          "maximumRetryDelay" : {
+            "type" : "string",
+            "title" : "Maximum Retry Delay",
+            "description" : "Sets the upper value of retry in millis between retries, when using exponential or random backoff",
+            "default" : "1000"
+          },
+          "randomBackOff" : {
+            "type" : "boolean",
+            "title" : "Random Back Off",
+            "description" : "Enables random backoff"
+          },
+          "retryDelay" : {
+            "type" : "string",
+            "title" : "Retry Delay",
+            "description" : "Sets the delay in millis between retries",
+            "default" : "50"
+          }
+        }
+      },
+      "org.apache.camel.model.OtherwiseDefinition" : {
+        "title" : "Otherwise",
+        "description" : "Route to be executed when all other choices evaluate to false",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Disables this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled late at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OutputDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "disabled" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.OutputTypeDefinition" : {
+        "title" : "Output Type",
+        "description" : "Set the expected data type of the output message. If the actual message type is different at runtime, camel look for a required Transformer and apply if exists. If validate attribute is true then camel applies Validator as well. Type name consists of two parts, 'scheme' and 'name' connected with ':'. For Java type 'name' is a fully qualified class name. For example {code java:java.lang.String} , {code json:ABCOrder} . It's also possible to specify only scheme part, so that it works like a wildcard. If only 'xml' is specified, all the XML message matches. It's handy to add only one transformer/validator for all the XML-Java transformation.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "urn" : {
+            "type" : "string",
+            "title" : "Urn",
+            "description" : "Set output type URN."
+          },
+          "validate" : {
+            "type" : "boolean",
+            "title" : "Validate",
+            "description" : "Whether if validation is required for this output type."
+          }
+        },
+        "required" : [ "urn" ]
+      },
+      "org.apache.camel.model.PackageScanDefinition" : {
+        "title" : "Package Scan",
+        "description" : "Scans for Java org.apache.camel.builder.RouteBuilder classes in java packages",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "excludes" : {
+            "type" : "array",
+            "title" : "Excludes",
+            "description" : "Exclude finding route builder from these java package names.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "includes" : {
+            "type" : "array",
+            "title" : "Includes",
+            "description" : "Include finding route builder from these java package names.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "package" : {
+            "type" : "array",
+            "title" : "Package",
+            "description" : "Sets the java package names to use for scanning for route builder classes",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.PausableDefinition" : {
+        "title" : "Pausable",
+        "description" : "Pausable EIP to support resuming processing from last known offset.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "consumerListener" : {
+            "type" : "string",
+            "title" : "Consumer Listener",
+            "description" : "Sets the consumer listener to use"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "untilCheck" : {
+            "type" : "string",
+            "title" : "Until Check",
+            "description" : "References to a java.util.function.Predicate to use for until checks. The predicate is responsible for evaluating whether the processing can resume or not. Such predicate should return true if the consumption can resume, or false otherwise. The exact point of when the predicate is called is dependent on the component, and it may be called on either one of the available events. Implementations should not assume the predicate to be called at any specific point."
+          }
+        },
+        "required" : [ "consumerListener", "untilCheck" ]
+      },
+      "org.apache.camel.model.PipelineDefinition" : {
+        "title" : "Pipeline",
+        "description" : "Routes the message to a sequence of processors.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.PolicyDefinition" : {
+        "title" : "Policy",
+        "description" : "Defines a policy the route will use",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ref" : {
+            "type" : "string",
+            "title" : "Ref",
+            "description" : "Sets a reference to use for lookup the policy in the registry."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        },
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.PollDefinition" : {
+        "title" : "Poll",
+        "description" : "Polls a message from a static endpoint",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "timeout" : {
+              "type" : "string",
+              "title" : "Timeout",
+              "description" : "Timeout in millis when polling from the external service. The timeout has influence about the poll enrich behavior. It basically operations in three different modes: negative value - Waits until a message is available and then returns it. Warning that this method could block indefinitely if no messages are available. 0 - Attempts to receive a message exchange immediately without waiting and returning null if a message exchange is not available yet. positive value - Attempts to receive a message exchange, waiting up to the given timeout to expire if a message is not yet available. Returns null if timed out The default value is 20000 (20 seconds).",
+              "default" : "20000"
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "Sets the uri of the endpoint to poll from."
+            },
+            "variableReceive" : {
+              "type" : "string",
+              "title" : "Variable Receive",
+              "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.PollEnrichDefinition" : {
+        "title" : "Poll Enrich",
+        "description" : "Enriches messages with data polled from a secondary resource",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression that computes the endpoint uri to use as the resource endpoint to enrich from",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "aggregateOnException" : {
+            "type" : "boolean",
+            "title" : "Aggregate On Exception",
+            "description" : "If this option is false then the aggregate method is not used if there was an exception thrown while trying to retrieve the data to enrich from the resource. Setting this option to true allows end users to control what to do if there was an exception in the aggregate method. For example to suppress the exception or set a custom message body etc."
+          },
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "Sets the AggregationStrategy to be used to merge the reply from the external service, into a single outgoing message. By default Camel will use the reply from the external service as outgoing message."
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used if there was no data to enrich. If this option is true then null values is used as the oldExchange (when no data to enrich), when using POJOs as the AggregationStrategy."
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "allowOptimisedComponents" : {
+            "type" : "boolean",
+            "title" : "Allow Optimised Components",
+            "description" : "Whether to allow components to optimise if they are org.apache.camel.spi.SendDynamicAware ."
+          },
+          "autoStartComponents" : {
+            "type" : "boolean",
+            "title" : "Auto Start Components",
+            "description" : "Whether to auto startup components when poll enricher is starting up."
+          },
+          "cacheSize" : {
+            "type" : "number",
+            "title" : "Cache Size",
+            "description" : "Sets the maximum size used by the org.apache.camel.spi.ConsumerCache which is used to cache and reuse consumers when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidEndpoint" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Endpoint",
+            "description" : "Ignore the invalidate endpoint exception when try to create a producer with that endpoint"
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Timeout in millis when polling from the external service. The timeout has influence about the poll enrich behavior. It basically operations in three different modes: negative value - Waits until a message is available and then returns it. Warning that this method could block indefinitely if no messages are available. 0 - Attempts to receive a message exchange immediately without waiting and returning null if a message exchange is not available yet. positive value - Attempts to receive a message exchange, waiting up to the given timeout to expire if a message is not yet available. Returns null if timed out The default value is -1 and therefore the method could block indefinitely, and therefore its recommended to use a timeout value",
+            "default" : "-1"
+          },
+          "variableReceive" : {
+            "type" : "string",
+            "title" : "Variable Receive",
+            "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.ProcessDefinition" : {
+        "title" : "Process",
+        "description" : "Calls a Camel processor",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ref" : {
+            "type" : "string",
+            "title" : "Ref",
+            "description" : "Reference to the Processor to lookup in the registry to use. A Processor is a class of type org.apache.camel.Processor, which can are to be called by this EIP. In this processor you have custom Java code, that can work with the message, such as to do custom business logic, special message manipulations and so on. By default, the ref, will lookup the bean in the Camel registry. The ref can use prefix that controls how the processor is obtained. You can use #bean:myBean where myBean is the id of the Camel processor (lookup). Can also be used for creating new beans by their class name by prefixing with #class, eg #class:com.foo.MyClassType. And it is also possible to refer to singleton beans by their type in the registry by prefixing with #type: syntax, eg #type:com.foo.MyClassType"
+          }
+        },
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.PropertyDefinition" : {
+        "title" : "Property",
+        "description" : "A key value pair where the value is a literal value",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "The name of the property"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "The property value."
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.PropertyExpressionDefinition" : {
+        "title" : "Property Expression",
+        "description" : "A key value pair where the value is an expression.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Property values as an expression",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Property key"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.RecipientListDefinition" : {
+        "title" : "Recipient List",
+        "description" : "Route messages to a number of dynamically specified recipients",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression that returns which endpoints (url) to send the message to (the recipients). If the expression return an empty value then the message is not sent to any recipients.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "Sets the AggregationStrategy to be used to assemble the replies from the recipients, into a single outgoing message from the RecipientList. By default Camel will use the last reply as the outgoing message. You can also use a POJO as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "boolean",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used if there was no data to enrich. If this option is true then null values is used as the oldExchange (when no data to enrich), when using POJOs as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "cacheSize" : {
+            "type" : "number",
+            "title" : "Cache Size",
+            "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this recipient list, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+          },
+          "delimiter" : {
+            "type" : "string",
+            "title" : "Delimiter",
+            "description" : "Delimiter used if the Expression returned multiple endpoints. Can be turned off using the value false. The default value is ,",
+            "default" : ","
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom Thread Pool to be used for parallel processing. Notice if you set this option, then parallel processing is automatic implied, and you do not have to enable that option as well."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidEndpoints" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Endpoints",
+            "description" : "Ignore the invalidate endpoint exception when try to create a producer with that endpoint"
+          },
+          "onPrepare" : {
+            "type" : "string",
+            "title" : "On Prepare",
+            "description" : "Uses the Processor when preparing the org.apache.camel.Exchange to be used send. This can be used to deep-clone messages that should be send, or any custom logic needed before the exchange is send."
+          },
+          "parallelAggregate" : {
+            "type" : "boolean",
+            "title" : "Parallel Aggregate",
+            "description" : "If enabled then the aggregate method on AggregationStrategy can be called concurrently. Notice that this would require the implementation of AggregationStrategy to be implemented as thread-safe. By default this is false meaning that Camel synchronizes the call to the aggregate method. Though in some use-cases this can be used to archive higher performance when the AggregationStrategy is implemented as thread-safe.",
+            "deprecated" : true
+          },
+          "parallelProcessing" : {
+            "type" : "boolean",
+            "title" : "Parallel Processing",
+            "description" : "If enabled then sending messages to the recipients occurs concurrently. Note the caller thread will still wait until all messages has been fully processed, before it continues. Its only the sending and processing the replies from the recipients which happens concurrently. When parallel processing is enabled, then the Camel routing engin will continue processing using last used thread from the parallel thread pool. However, if you want to use the original thread that called the recipient list, then make sure to enable the synchronous option as well. In parallel processing mode, you may want to also synchronous = true to force this EIP to process the sub-tasks using the upper bounds of the thread-pool. If using synchronous = false then Camel will allow its reactive routing engine to use as many threads as possible, which may be available due to sub-tasks using other thread-pools such as CompletableFuture.runAsync or others."
+          },
+          "shareUnitOfWork" : {
+            "type" : "boolean",
+            "title" : "Share Unit Of Work",
+            "description" : "Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub messages. Recipient List will by default not share unit of work between the parent exchange and each recipient exchange. This means each sub exchange has its own individual unit of work."
+          },
+          "stopOnException" : {
+            "type" : "boolean",
+            "title" : "Stop On Exception",
+            "description" : "Will now stop further processing if an exception or failure occurred during processing of an org.apache.camel.Exchange and the caused exception will be thrown. Will also stop if processing the exchange failed (has a fault message) or an exception was thrown and handled by the error handler (such as using onException). In all situations the recipient list will stop further processing. This is the same behavior as in pipeline, which is used by the routing engine. The default behavior is to not stop but continue processing till the end"
+          },
+          "streaming" : {
+            "type" : "boolean",
+            "title" : "Streaming",
+            "description" : "If enabled then Camel will process replies out-of-order, eg in the order they come back. If disabled, Camel will process replies in the same order as defined by the recipient list."
+          },
+          "synchronous" : {
+            "type" : "boolean",
+            "title" : "Synchronous",
+            "description" : "Sets whether synchronous processing should be strictly used. When enabled then the same thread is used to continue routing after the recipient list is complete, even if parallel processing is enabled."
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Sets a total timeout specified in millis, when using parallel processing. If the Recipient List hasn't been able to send and process all replies within the given timeframe, then the timeout triggers and the Recipient List breaks out and continues. Notice if you provide a TimeoutAwareAggregationStrategy then the timeout method is invoked before breaking out. If the timeout is reached with running tasks still remaining, certain tasks for which it is difficult for Camel to shut down in a graceful manner may continue to run. So use this option with a bit of care.",
+            "default" : "0"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.RedeliveryPolicyDefinition" : {
+        "title" : "Redelivery Policy",
+        "description" : "To configure re-delivery for error handling",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowRedeliveryWhileStopping" : {
+            "type" : "boolean",
+            "title" : "Allow Redelivery While Stopping",
+            "description" : "Controls whether to allow redelivery while stopping/shutting down a route that uses error handling."
+          },
+          "asyncDelayedRedelivery" : {
+            "type" : "boolean",
+            "title" : "Async Delayed Redelivery",
+            "description" : "Allow asynchronous delayed redelivery. The route, in particular the consumer's component, must support the Asynchronous Routing Engine (e.g. seda)."
+          },
+          "backOffMultiplier" : {
+            "type" : "number",
+            "title" : "Back Off Multiplier",
+            "description" : "Sets the back off multiplier",
+            "default" : "2.0"
+          },
+          "collisionAvoidanceFactor" : {
+            "type" : "number",
+            "title" : "Collision Avoidance Factor",
+            "description" : "Sets the collision avoidance factor",
+            "default" : "0.15"
+          },
+          "delayPattern" : {
+            "type" : "string",
+            "title" : "Delay Pattern",
+            "description" : "Sets the delay pattern with delay intervals."
+          },
+          "disableRedelivery" : {
+            "type" : "boolean",
+            "title" : "Disable Redelivery",
+            "description" : "Disables redelivery (same as setting maximum redeliveries to 0)"
+          },
+          "exchangeFormatterRef" : {
+            "type" : "string",
+            "title" : "Exchange Formatter Ref",
+            "description" : "Sets the reference of the instance of org.apache.camel.spi.ExchangeFormatter to generate the log message from exchange."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "logContinued" : {
+            "type" : "boolean",
+            "title" : "Log Continued",
+            "description" : "Sets whether continued exceptions should be logged or not. Can be used to include or reduce verbose."
+          },
+          "logExhausted" : {
+            "type" : "boolean",
+            "title" : "Log Exhausted",
+            "description" : "Sets whether exhausted exceptions should be logged or not. Can be used to include or reduce verbose."
+          },
+          "logExhaustedMessageBody" : {
+            "type" : "boolean",
+            "title" : "Log Exhausted Message Body",
+            "description" : "Sets whether exhausted message body should be logged including message history or not (supports property placeholders). Can be used to include or reduce verbose. Requires logExhaustedMessageHistory to be enabled."
+          },
+          "logExhaustedMessageHistory" : {
+            "type" : "boolean",
+            "title" : "Log Exhausted Message History",
+            "description" : "Sets whether exhausted exceptions should be logged including message history or not (supports property placeholders). Can be used to include or reduce verbose."
+          },
+          "logHandled" : {
+            "type" : "boolean",
+            "title" : "Log Handled",
+            "description" : "Sets whether handled exceptions should be logged or not. Can be used to include or reduce verbose."
+          },
+          "logNewException" : {
+            "type" : "boolean",
+            "title" : "Log New Exception",
+            "description" : "Sets whether new exceptions should be logged or not. Can be used to include or reduce verbose. A new exception is an exception that was thrown while handling a previous exception."
+          },
+          "logRetryAttempted" : {
+            "type" : "boolean",
+            "title" : "Log Retry Attempted",
+            "description" : "Sets whether retry attempts should be logged or not. Can be used to include or reduce verbose."
+          },
+          "logRetryStackTrace" : {
+            "type" : "boolean",
+            "title" : "Log Retry Stack Trace",
+            "description" : "Sets whether stack traces should be logged when an retry attempt failed. Can be used to include or reduce verbose."
+          },
+          "logStackTrace" : {
+            "type" : "boolean",
+            "title" : "Log Stack Trace",
+            "description" : "Sets whether stack traces should be logged. Can be used to include or reduce verbose."
+          },
+          "maximumRedeliveries" : {
+            "type" : "number",
+            "title" : "Maximum Redeliveries",
+            "description" : "Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever"
+          },
+          "maximumRedeliveryDelay" : {
+            "type" : "string",
+            "title" : "Maximum Redelivery Delay",
+            "description" : "Sets the maximum delay between redelivery",
+            "default" : "60000"
+          },
+          "redeliveryDelay" : {
+            "type" : "string",
+            "title" : "Redelivery Delay",
+            "description" : "Sets the initial redelivery delay",
+            "default" : "1000"
+          },
+          "retriesExhaustedLogLevel" : {
+            "type" : "string",
+            "title" : "Retries Exhausted Log Level",
+            "description" : "Sets the logging level to use when retries have been exhausted",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "retryAttemptedLogInterval" : {
+            "type" : "number",
+            "title" : "Retry Attempted Log Interval",
+            "description" : "Sets the interval to use for logging retry attempts",
+            "default" : "1"
+          },
+          "retryAttemptedLogLevel" : {
+            "type" : "string",
+            "title" : "Retry Attempted Log Level",
+            "description" : "Sets the logging level to use for logging retry attempts",
+            "default" : "DEBUG",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "useCollisionAvoidance" : {
+            "type" : "boolean",
+            "title" : "Use Collision Avoidance",
+            "description" : "Turn on collision avoidance."
+          },
+          "useExponentialBackOff" : {
+            "type" : "boolean",
+            "title" : "Use Exponential Back Off",
+            "description" : "Turn on exponential back off"
+          }
+        }
+      },
+      "org.apache.camel.model.RemoveHeaderDefinition" : {
+        "title" : "Remove Header",
+        "description" : "Removes a named header from the message",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "Name of header to remove"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RemoveHeadersDefinition" : {
+        "title" : "Remove Headers",
+        "description" : "Removes message headers whose name matches a specified pattern",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "excludePattern" : {
+              "type" : "string",
+              "title" : "Exclude Pattern",
+              "description" : "Name or patter of headers to not remove. The pattern is matched in the following order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts with the pattern) 3 = regular expression (all of above is case in-sensitive)."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Name or pattern of headers to remove. The pattern is matched in the following order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts with the pattern) 3 = regular expression (all of above is case in-sensitive)."
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertiesDefinition" : {
+        "title" : "Remove Properties",
+        "description" : "Removes message exchange properties whose name matches a specified pattern",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "excludePattern" : {
+              "type" : "string",
+              "title" : "Exclude Pattern",
+              "description" : "Name or pattern of properties to not remove. The pattern is matched in the following order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts with the pattern) 3 = regular expression (all of above is case in-sensitive)."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Name or pattern of properties to remove. The pattern is matched in the following order: 1 = exact match 2 = wildcard (pattern ends with a and the name starts with the pattern) 3 = regular expression (all of above is case in-sensitive)."
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertyDefinition" : {
+        "title" : "Remove Property",
+        "description" : "Removes a named property from the message exchange",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "Name of property to remove."
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RemoveVariableDefinition" : {
+        "title" : "Remove Variable",
+        "description" : "Removes a named variable",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "Name of variable to remove."
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.ResequenceDefinition" : {
+        "title" : "Resequence",
+        "description" : "Resequences (re-order) messages based on an expression",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to use for re-ordering the messages, such as a header with a sequence number",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "batchConfig" ],
+            "properties" : {
+              "batchConfig" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.config.BatchResequencerConfig"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "batchConfig" ]
+              }, {
+                "required" : [ "streamConfig" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "streamConfig" ],
+            "properties" : {
+              "streamConfig" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.config.StreamResequencerConfig"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { },
+          "batchConfig" : { },
+          "streamConfig" : { }
+        }
+      },
+      "org.apache.camel.model.Resilience4jConfigurationDefinition" : {
+        "title" : "Resilience4j Configuration",
+        "description" : "Resilience4j Circuit Breaker EIP configuration",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "automaticTransitionFromOpenToHalfOpenEnabled" : {
+            "type" : "boolean",
+            "title" : "Automatic Transition From Open To Half Open Enabled",
+            "description" : "Enables automatic transition from OPEN to HALF_OPEN state once the waitDurationInOpenState has passed."
+          },
+          "bulkheadEnabled" : {
+            "type" : "boolean",
+            "title" : "Bulkhead Enabled",
+            "description" : "Whether bulkhead is enabled or not on the circuit breaker. Default is false."
+          },
+          "bulkheadMaxConcurrentCalls" : {
+            "type" : "number",
+            "title" : "Bulkhead Max Concurrent Calls",
+            "description" : "Configures the max amount of concurrent calls the bulkhead will support.",
+            "default" : "25"
+          },
+          "bulkheadMaxWaitDuration" : {
+            "type" : "number",
+            "title" : "Bulkhead Max Wait Duration",
+            "description" : "Configures a maximum amount of time which the calling thread will wait to enter the bulkhead. If bulkhead has space available, entry is guaranteed and immediate. If bulkhead is full, calling threads will contest for space, if it becomes available. maxWaitDuration can be set to 0. Note: for threads running on an event-loop or equivalent (rx computation pool, etc), setting maxWaitDuration to 0 is highly recommended. Blocking an event-loop thread will most likely have a negative effect on application throughput.",
+            "default" : "0"
+          },
+          "circuitBreaker" : {
+            "type" : "string",
+            "title" : "Circuit Breaker",
+            "description" : "Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreaker instance to lookup and use from the registry. When using this, then any other circuit breaker options are not in use."
+          },
+          "config" : {
+            "type" : "string",
+            "title" : "Config",
+            "description" : "Refers to an existing io.github.resilience4j.circuitbreaker.CircuitBreakerConfig instance to lookup and use from the registry."
+          },
+          "failureRateThreshold" : {
+            "type" : "number",
+            "title" : "Failure Rate Threshold",
+            "description" : "Configures the failure rate threshold in percentage. If the failure rate is equal or greater than the threshold the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 50 percentage.",
+            "default" : "50"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreException" : {
+            "type" : "array",
+            "title" : "Ignore Exception",
+            "description" : "Configure a list of exceptions that are ignored and neither count as a failure nor success. Any exception matching or inheriting from one of the list will not count as a failure nor success, even if the exceptions is part of recordExceptions.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "minimumNumberOfCalls" : {
+            "type" : "number",
+            "title" : "Minimum Number Of Calls",
+            "description" : "Configures the minimum number of calls which are required (per sliding window period) before the CircuitBreaker can calculate the error rate. For example, if minimumNumberOfCalls is 10, then at least 10 calls must be recorded, before the failure rate can be calculated. If only 9 calls have been recorded the CircuitBreaker will not transition to open even if all 9 calls have failed. Default minimumNumberOfCalls is 100",
+            "default" : "100"
+          },
+          "permittedNumberOfCallsInHalfOpenState" : {
+            "type" : "number",
+            "title" : "Permitted Number Of Calls In Half Open State",
+            "description" : "Configures the number of permitted calls when the CircuitBreaker is half open. The size must be greater than 0. Default size is 10.",
+            "default" : "10"
+          },
+          "recordException" : {
+            "type" : "array",
+            "title" : "Record Exception",
+            "description" : "Configure a list of exceptions that are recorded as a failure and thus increase the failure rate. Any exception matching or inheriting from one of the list counts as a failure, unless explicitly ignored via ignoreExceptions.",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "slidingWindowSize" : {
+            "type" : "number",
+            "title" : "Sliding Window Size",
+            "description" : "Configures the size of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. slidingWindowSize configures the size of the sliding window. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. The slidingWindowSize must be greater than 0. The minimumNumberOfCalls must be greater than 0. If the slidingWindowType is COUNT_BASED, the minimumNumberOfCalls cannot be greater than slidingWindowSize . If the slidingWindowType is TIME_BASED, you can pick whatever you want. Default slidingWindowSize is 100.",
+            "default" : "100"
+          },
+          "slidingWindowType" : {
+            "type" : "string",
+            "title" : "Sliding Window Type",
+            "description" : "Configures the type of the sliding window which is used to record the outcome of calls when the CircuitBreaker is closed. Sliding window can either be count-based or time-based. If slidingWindowType is COUNT_BASED, the last slidingWindowSize calls are recorded and aggregated. If slidingWindowType is TIME_BASED, the calls of the last slidingWindowSize seconds are recorded and aggregated. Default slidingWindowType is COUNT_BASED.",
+            "default" : "COUNT_BASED",
+            "enum" : [ "TIME_BASED", "COUNT_BASED" ]
+          },
+          "slowCallDurationThreshold" : {
+            "type" : "number",
+            "title" : "Slow Call Duration Threshold",
+            "description" : "Configures the duration threshold (seconds) above which calls are considered as slow and increase the slow calls percentage. Default value is 60 seconds.",
+            "default" : "60"
+          },
+          "slowCallRateThreshold" : {
+            "type" : "number",
+            "title" : "Slow Call Rate Threshold",
+            "description" : "Configures a threshold in percentage. The CircuitBreaker considers a call as slow when the call duration is greater than slowCallDurationThreshold Duration. When the percentage of slow calls is equal or greater the threshold, the CircuitBreaker transitions to open and starts short-circuiting calls. The threshold must be greater than 0 and not greater than 100. Default value is 100 percentage which means that all recorded calls must be slower than slowCallDurationThreshold.",
+            "default" : "100"
+          },
+          "throwExceptionWhenHalfOpenOrOpenState" : {
+            "type" : "boolean",
+            "title" : "Throw Exception When Half Open Or Open State",
+            "description" : "Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open."
+          },
+          "timeoutCancelRunningFuture" : {
+            "type" : "boolean",
+            "title" : "Timeout Cancel Running Future",
+            "description" : "Configures whether cancel is called on the running future. Defaults to true."
+          },
+          "timeoutDuration" : {
+            "type" : "number",
+            "title" : "Timeout Duration",
+            "description" : "Configures the thread execution timeout. Default value is 1 second.",
+            "default" : "1000"
+          },
+          "timeoutEnabled" : {
+            "type" : "boolean",
+            "title" : "Timeout Enabled",
+            "description" : "Whether timeout is enabled or not on the circuit breaker. Default is false."
+          },
+          "timeoutExecutorService" : {
+            "type" : "string",
+            "title" : "Timeout Executor Service",
+            "description" : "References to a custom thread pool to use when timeout is enabled (uses ForkJoinPool#commonPool() by default)"
+          },
+          "waitDurationInOpenState" : {
+            "type" : "number",
+            "title" : "Wait Duration In Open State",
+            "description" : "Configures the wait duration (in seconds) which specifies how long the CircuitBreaker should stay open, before it switches to half open. Default value is 60 seconds.",
+            "default" : "60"
+          },
+          "writableStackTraceEnabled" : {
+            "type" : "boolean",
+            "title" : "Writable Stack Trace Enabled",
+            "description" : "Enables writable stack traces. When set to false, Exception.getStackTrace returns a zero length array. This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls)."
+          }
+        }
+      },
+      "org.apache.camel.model.RestContextRefDefinition" : {
+        "title" : "Rest Context Ref",
+        "description" : "To refer to an XML file with rest services defined using the rest-dsl",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to the rest-dsl"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.ResumableDefinition" : {
+        "title" : "Resumable",
+        "description" : "Resume EIP to support resuming processing from last known offset.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "intermittent" : {
+            "type" : "boolean",
+            "title" : "Intermittent",
+            "description" : "Sets whether the offsets will be intermittently present or whether they must be present in every exchange"
+          },
+          "loggingLevel" : {
+            "type" : "string",
+            "title" : "Logging Level",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "resumeStrategy" : {
+            "type" : "string",
+            "title" : "Resume Strategy",
+            "description" : "Sets the resume strategy to use"
+          }
+        },
+        "required" : [ "resumeStrategy" ]
+      },
+      "org.apache.camel.model.RollbackDefinition" : {
+        "title" : "Rollback",
+        "description" : "Forces a rollback by stopping routing the message",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "markRollbackOnly" : {
+              "type" : "boolean",
+              "title" : "Mark Rollback Only",
+              "description" : "Mark the transaction for rollback only (cannot be overruled to commit)"
+            },
+            "markRollbackOnlyLast" : {
+              "type" : "boolean",
+              "title" : "Mark Rollback Only Last",
+              "description" : "Mark only last sub transaction for rollback only. When using sub transactions (if the transaction manager support this)"
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "Message to use in rollback exception"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.RouteBuilderDefinition" : {
+        "title" : "Route Builder",
+        "description" : "To refer to a Java org.apache.camel.builder.RouteBuilder instance to use.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to the route builder instance"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteConfigurationContextRefDefinition" : {
+        "title" : "Route Configuration Context Ref",
+        "description" : "To refer to an XML file with route configuration defined using the xml-dsl",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to the route templates in the xml dsl"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteConfigurationDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "errorHandler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ErrorHandlerDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "intercept" : {
+            "type" : "array",
+            "items" : {
+              "additionalProperties" : false,
+              "type" : "object",
+              "properties" : {
+                "intercept" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
+                }
+              }
+            }
+          },
+          "interceptFrom" : {
+            "type" : "array",
+            "items" : {
+              "additionalProperties" : false,
+              "type" : "object",
+              "properties" : {
+                "interceptFrom" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+                }
+              }
+            }
+          },
+          "interceptSendToEndpoint" : {
+            "type" : "array",
+            "items" : {
+              "additionalProperties" : false,
+              "type" : "object",
+              "properties" : {
+                "interceptSendToEndpoint" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+                }
+              }
+            }
+          },
+          "onCompletion" : {
+            "type" : "array",
+            "items" : {
+              "additionalProperties" : false,
+              "type" : "object",
+              "properties" : {
+                "onCompletion" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
+                }
+              }
+            }
+          },
+          "onException" : {
+            "type" : "array",
+            "items" : {
+              "additionalProperties" : false,
+              "type" : "object",
+              "properties" : {
+                "onException" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"
+                }
+              }
+            }
+          },
+          "precondition" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.RouteContextRefDefinition" : {
+        "title" : "Route Context Ref",
+        "description" : "To refer to an XML file with routes defined using the xml-dsl",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to the routes in the xml dsl"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.RouteDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "autoStartup" : {
+            "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "errorHandler" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ErrorHandlerDefinition"
+          },
+          "errorHandlerRef" : {
+            "type" : "string"
+          },
+          "from" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FromDefinition"
+          },
+          "group" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inputType" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.InputTypeDefinition"
+          },
+          "logMask" : {
+            "type" : "boolean"
+          },
+          "messageHistory" : {
+            "type" : "boolean"
+          },
+          "nodePrefixId" : {
+            "type" : "string"
+          },
+          "outputType" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OutputTypeDefinition"
+          },
+          "precondition" : {
+            "type" : "string"
+          },
+          "routeConfigurationId" : {
+            "type" : "string"
+          },
+          "routePolicy" : {
+            "type" : "string"
+          },
+          "shutdownRoute" : {
+            "type" : "string",
+            "description" : "To control how to shut down the route.",
+            "default" : "Default",
+            "enum" : [ "Default", "Defer" ]
+          },
+          "shutdownRunningTask" : {
+            "type" : "string",
+            "description" : "To control how to shut down the route.",
+            "default" : "CompleteCurrentTaskOnly",
+            "enum" : [ "CompleteCurrentTaskOnly", "CompleteAllTasks" ]
+          },
+          "startupOrder" : {
+            "type" : "number"
+          },
+          "streamCache" : {
+            "type" : "boolean"
+          },
+          "trace" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "from" ]
+      },
+      "org.apache.camel.model.RouteTemplateDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "beans" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.BeanFactoryDefinition"
+            }
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "from" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FromDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.RouteTemplateParameterDefinition"
+            }
+          },
+          "route" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
+          }
+        },
+        "required" : [ "id" ]
+      },
+      "org.apache.camel.model.RouteTemplateParameterDefinition" : {
+        "title" : "Template Parameter",
+        "description" : "A route template parameter",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "defaultValue" : {
+            "type" : "string",
+            "title" : "Default Value",
+            "description" : "Default value of the parameter. If a default value is provided then the parameter is implied not to be required."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Description of the parameter"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The name of the parameter"
+          },
+          "required" : {
+            "type" : "boolean",
+            "title" : "Required",
+            "description" : "Whether the parameter is required or not. A parameter is required unless this option is set to false or a default value has been configured."
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RoutingSlipDefinition" : {
+        "title" : "Routing Slip",
+        "description" : "Routes a message through a series of steps that are pre-determined (the slip)",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "anyOf" : [ {
+            "oneOf" : [ {
+              "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "expression" ]
+                }, {
+                  "required" : [ "constant" ]
+                }, {
+                  "required" : [ "csimple" ]
+                }, {
+                  "required" : [ "datasonnet" ]
+                }, {
+                  "required" : [ "exchangeProperty" ]
+                }, {
+                  "required" : [ "groovy" ]
+                }, {
+                  "required" : [ "header" ]
+                }, {
+                  "required" : [ "hl7terser" ]
+                }, {
+                  "required" : [ "java" ]
+                }, {
+                  "required" : [ "joor" ]
+                }, {
+                  "required" : [ "jq" ]
+                }, {
+                  "required" : [ "js" ]
+                }, {
+                  "required" : [ "jsonpath" ]
+                }, {
+                  "required" : [ "language" ]
+                }, {
+                  "required" : [ "method" ]
+                }, {
+                  "required" : [ "mvel" ]
+                }, {
+                  "required" : [ "ognl" ]
+                }, {
+                  "required" : [ "python" ]
+                }, {
+                  "required" : [ "ref" ]
+                }, {
+                  "required" : [ "simple" ]
+                }, {
+                  "required" : [ "spel" ]
+                }, {
+                  "required" : [ "tokenize" ]
+                }, {
+                  "required" : [ "variable" ]
+                }, {
+                  "required" : [ "wasm" ]
+                }, {
+                  "required" : [ "xpath" ]
+                }, {
+                  "required" : [ "xquery" ]
+                }, {
+                  "required" : [ "xtokenize" ]
+                } ]
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "expression" ],
+              "properties" : {
+                "expression" : {
+                  "title" : "Expression",
+                  "description" : "Expression to define the routing slip, which defines which endpoints to route the message in a pipeline style. Notice the expression is evaluated once, if you want a more dynamic style, then the dynamic router eip is a better choice.",
+                  "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+                }
+              }
+            } ]
+          } ],
+          "properties" : {
+            "cacheSize" : {
+              "type" : "number",
+              "title" : "Cache Size",
+              "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this routing slip, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "ignoreInvalidEndpoints" : {
+              "type" : "boolean",
+              "title" : "Ignore Invalid Endpoints",
+              "description" : "Ignore the invalidate endpoint exception when try to create a producer with that endpoint"
+            },
+            "uriDelimiter" : {
+              "type" : "string",
+              "title" : "Uri Delimiter",
+              "description" : "Sets the uri delimiter to use",
+              "default" : ","
+            },
+            "constant" : { },
+            "csimple" : { },
+            "datasonnet" : { },
+            "exchangeProperty" : { },
+            "groovy" : { },
+            "header" : { },
+            "hl7terser" : { },
+            "java" : { },
+            "joor" : { },
+            "jq" : { },
+            "js" : { },
+            "jsonpath" : { },
+            "language" : { },
+            "method" : { },
+            "mvel" : { },
+            "ognl" : { },
+            "python" : { },
+            "ref" : { },
+            "simple" : { },
+            "spel" : { },
+            "tokenize" : { },
+            "variable" : { },
+            "wasm" : { },
+            "xpath" : { },
+            "xquery" : { },
+            "xtokenize" : { },
+            "expression" : { }
+          }
+        } ]
+      },
+      "org.apache.camel.model.SagaActionUriDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "disabled" : {
+              "type" : "boolean"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.SagaDefinition" : {
+        "title" : "Saga",
+        "description" : "Enables Sagas on the route",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "compensation" : {
+            "title" : "Compensation",
+            "description" : "The compensation endpoint URI that must be called to compensate all changes done in the route. The route corresponding to the compensation URI must perform compensation and complete without error. If errors occur during compensation, the saga service may call again the compensation URI to retry.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaActionUriDefinition"
+          },
+          "completion" : {
+            "title" : "Completion",
+            "description" : "The completion endpoint URI that will be called when the Saga is completed successfully. The route corresponding to the completion URI must perform completion tasks and terminate without error. If errors occur during completion, the saga service may call again the completion URI to retry.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.SagaActionUriDefinition"
+          },
+          "completionMode" : {
+            "type" : "string",
+            "title" : "Completion Mode",
+            "description" : "Determine how the saga should be considered complete. When set to AUTO, the saga is completed when the exchange that initiates the saga is processed successfully, or compensated when it completes exceptionally. When set to MANUAL, the user must complete or compensate the saga using the saga:complete or saga:compensate endpoints.",
+            "default" : "AUTO",
+            "enum" : [ "AUTO", "MANUAL" ]
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "option" : {
+            "type" : "array",
+            "title" : "Option",
+            "description" : "Allows to save properties of the current exchange in order to re-use them in a compensation/completion callback route. Options are usually helpful e.g. to store and retrieve identifiers of objects that should be deleted in compensating actions. Option values will be transformed into input headers of the compensation/completion exchange.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyExpressionDefinition"
+            }
+          },
+          "propagation" : {
+            "type" : "string",
+            "title" : "Propagation",
+            "description" : "Set the Saga propagation mode (REQUIRED, REQUIRES_NEW, MANDATORY, SUPPORTS, NOT_SUPPORTED, NEVER).",
+            "default" : "REQUIRED",
+            "enum" : [ "REQUIRED", "REQUIRES_NEW", "MANDATORY", "SUPPORTS", "NOT_SUPPORTED", "NEVER" ]
+          },
+          "sagaService" : {
+            "type" : "string",
+            "title" : "Saga Service",
+            "description" : "Refers to the id to lookup in the registry for the specific CamelSagaService to use."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Set the maximum amount of time for the Saga. After the timeout is expired, the saga will be compensated automatically (unless a different decision has been taken in the meantime)."
+          }
+        }
+      },
+      "org.apache.camel.model.SamplingDefinition" : {
+        "title" : "Sample",
+        "description" : "Extract a sample of the messages passing through a route",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "messageFrequency" : {
+              "type" : "number",
+              "title" : "Message Frequency",
+              "description" : "Sets the sample message count which only a single Exchange will pass through after this many received."
+            },
+            "samplePeriod" : {
+              "type" : "string",
+              "title" : "Sample Period",
+              "description" : "Sets the sample period during which only a single Exchange will pass through.",
+              "default" : "1000"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.ScriptDefinition" : {
+        "title" : "Script",
+        "description" : "Executes a script from a language which does not change the message body.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to return the transformed message body (the new message body to use)",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.SetBodyDefinition" : {
+        "title" : "Set Body",
+        "description" : "Sets the contents of the message body",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression that returns the new body to use",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.SetExchangePatternDefinition" : {
+        "title" : "Set Exchange Pattern",
+        "description" : "Sets the exchange pattern on the message exchange",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Sets the new exchange pattern of the Exchange to be used from this point forward",
+              "enum" : [ "InOnly", "InOut" ]
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.SetHeaderDefinition" : {
+        "title" : "Set Header",
+        "description" : "Sets the value of a message header",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to return the value of the header",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of message header to set a new value The simple language can be used to define a dynamic evaluated header name to be used. Otherwise a constant name will be used."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetHeadersDefinition" : {
+        "title" : "Set Headers",
+        "description" : "Allows setting multiple headers on the message at the same time.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "headers" : {
+            "type" : "array",
+            "title" : "Headers",
+            "description" : "Contains the headers to be set",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.SetPropertyDefinition" : {
+        "title" : "Set Property",
+        "description" : "Sets a named property on the message exchange",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to return the value of the message exchange property",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of exchange property to set a new value. The simple language can be used to define a dynamic evaluated exchange property name to be used. Otherwise a constant name will be used."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetVariableDefinition" : {
+        "title" : "Set Variable",
+        "description" : "Sets the value of a variable",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to return the value of the variable",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of variable to set a new value The simple language can be used to define a dynamic evaluated variable name to be used. Otherwise a constant name will be used."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetVariablesDefinition" : {
+        "title" : "Set Variables",
+        "description" : "Allows setting multiple variables at the same time.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "variables" : {
+            "type" : "array",
+            "title" : "Variables",
+            "description" : "Contains the variables to be set",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.SetVariableDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.SortDefinition" : {
+        "title" : "Sort",
+        "description" : "Sorts the contents of the message",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Optional expression to sort by something else than the message body",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "comparator" : {
+            "type" : "string",
+            "title" : "Comparator",
+            "description" : "Sets the comparator to use for sorting"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.SplitDefinition" : {
+        "title" : "Split",
+        "description" : "Splits a single message into many sub-messages.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression of how to split the message body, such as as-is, using a tokenizer, or using a xpath.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "aggregationStrategy" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy",
+            "description" : "Sets a reference to the AggregationStrategy to be used to assemble the replies from the split messages, into a single outgoing message from the Splitter. By default Camel will use the original incoming message to the splitter (leave it unchanged). You can also use a POJO as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodAllowNull" : {
+            "type" : "boolean",
+            "title" : "Aggregation Strategy Method Allow Null",
+            "description" : "If this option is false then the aggregate method is not used if there was no data to enrich. If this option is true then null values is used as the oldExchange (when no data to enrich), when using POJOs as the AggregationStrategy"
+          },
+          "aggregationStrategyMethodName" : {
+            "type" : "string",
+            "title" : "Aggregation Strategy Method Name",
+            "description" : "This option can be used to explicit declare the method name to use, when using POJOs as the AggregationStrategy."
+          },
+          "delimiter" : {
+            "type" : "string",
+            "title" : "Delimiter",
+            "description" : "Delimiter used in splitting messages. Can be turned off using the value false. To force not splitting then the delimiter can be set to single to use the value as a single list, this can be needed in some special situations. The default value is comma.",
+            "default" : ","
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom Thread Pool to be used for parallel processing. Notice if you set this option, then parallel processing is automatically implied, and you do not have to enable that option as well."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "onPrepare" : {
+            "type" : "string",
+            "title" : "On Prepare",
+            "description" : "Uses the Processor when preparing the org.apache.camel.Exchange to be sent. This can be used to deep-clone messages that should be sent, or any custom logic needed before the exchange is sent."
+          },
+          "parallelAggregate" : {
+            "type" : "boolean",
+            "title" : "Parallel Aggregate",
+            "description" : "If enabled then the aggregate method on AggregationStrategy can be called concurrently. Notice that this would require the implementation of AggregationStrategy to be implemented as thread-safe. By default this is false meaning that Camel synchronizes the call to the aggregate method. Though in some use-cases this can be used to archive higher performance when the AggregationStrategy is implemented as thread-safe.",
+            "deprecated" : true
+          },
+          "parallelProcessing" : {
+            "type" : "boolean",
+            "title" : "Parallel Processing",
+            "description" : "If enabled then processing each split messages occurs concurrently. Note the caller thread will still wait until all messages has been fully processed, before it continues. It's only processing the sub messages from the splitter which happens concurrently. When parallel processing is enabled, then the Camel routing engin will continue processing using last used thread from the parallel thread pool. However, if you want to use the original thread that called the splitter, then make sure to enable the synchronous option as well. In parallel processing mode, you may want to also synchronous = true to force this EIP to process the sub-tasks using the upper bounds of the thread-pool. If using synchronous = false then Camel will allow its reactive routing engine to use as many threads as possible, which may be available due to sub-tasks using other thread-pools such as CompletableFuture.runAsync or others."
+          },
+          "shareUnitOfWork" : {
+            "type" : "boolean",
+            "title" : "Share Unit Of Work",
+            "description" : "Shares the org.apache.camel.spi.UnitOfWork with the parent and each of the sub messages. Splitter will by default not share unit of work between the parent exchange and each split exchange. This means each split exchange has its own individual unit of work."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stopOnException" : {
+            "type" : "boolean",
+            "title" : "Stop On Exception",
+            "description" : "Will now stop further processing if an exception or failure occurred during processing of an org.apache.camel.Exchange and the caused exception will be thrown. Will also stop if processing the exchange failed (has a fault message) or an exception was thrown and handled by the error handler (such as using onException). In all situations the splitter will stop further processing. This is the same behavior as in pipeline, which is used by the routing engine. The default behavior is to not stop but continue processing till the end"
+          },
+          "streaming" : {
+            "type" : "boolean",
+            "title" : "Streaming",
+            "description" : "When in streaming mode, then the splitter splits the original message on-demand, and each split message is processed one by one. This reduces memory usage as the splitter do not split all the messages first, but then we do not know the total size, and therefore the org.apache.camel.Exchange#SPLIT_SIZE is empty. In non-streaming mode (default) the splitter will split each message first, to know the total size, and then process each message one by one. This requires to keep all the split messages in memory and therefore requires more memory. The total size is provided in the org.apache.camel.Exchange#SPLIT_SIZE header. The streaming mode also affects the aggregation behavior. If enabled then Camel will process replies out-of-order, e.g. in the order they come back. If disabled, Camel will process replies in the same order as the messages was split."
+          },
+          "synchronous" : {
+            "type" : "boolean",
+            "title" : "Synchronous",
+            "description" : "Sets whether synchronous processing should be strictly used. When enabled then the same thread is used to continue routing after the split is complete, even if parallel processing is enabled."
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Sets a total timeout specified in millis, when using parallel processing. If the Splitter hasn't been able to split and process all the sub messages within the given timeframe, then the timeout triggers and the Splitter breaks out and continues. Notice if you provide a TimeoutAwareAggregationStrategy then the timeout method is invoked before breaking out. If the timeout is reached with running tasks still remaining, certain tasks for which it is difficult for Camel to shut down in a graceful manner may continue to run. So use this option with a bit of care.",
+            "default" : "0"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.StepDefinition" : {
+        "title" : "Step",
+        "description" : "Routes the message to a sequence of processors which is grouped together as one logical name",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.StopDefinition" : {
+        "title" : "Stop",
+        "description" : "Stops the processing of the current message",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.TemplatedRouteDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "beans" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.BeanFactoryDefinition"
+            }
+          },
+          "parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteParameterDefinition"
+            }
+          },
+          "prefixId" : {
+            "type" : "string"
+          },
+          "routeId" : {
+            "type" : "string"
+          },
+          "routeTemplateRef" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "routeTemplateRef" ]
+      },
+      "org.apache.camel.model.TemplatedRouteParameterDefinition" : {
+        "title" : "Templated Route Parameter",
+        "description" : "An input parameter of a route template.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The name of the parameter"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "The value of the parameter."
+          }
+        },
+        "required" : [ "name", "value" ]
+      },
+      "org.apache.camel.model.ThreadPoolProfileDefinition" : {
+        "title" : "Thread Pool Profile",
+        "description" : "To configure thread pools",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowCoreThreadTimeOut" : {
+            "type" : "boolean",
+            "title" : "Allow Core Thread Time Out",
+            "description" : "Whether idle core threads is allowed to timeout and therefore can shrink the pool size below the core pool size Is by default true"
+          },
+          "defaultProfile" : {
+            "type" : "boolean",
+            "title" : "Default Profile",
+            "description" : "Whether this profile is the default thread pool profile"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "keepAliveTime" : {
+            "type" : "number",
+            "title" : "Keep Alive Time",
+            "description" : "Sets the keep alive time for idle threads in the pool"
+          },
+          "maxPoolSize" : {
+            "type" : "number",
+            "title" : "Max Pool Size",
+            "description" : "Sets the maximum pool size"
+          },
+          "maxQueueSize" : {
+            "type" : "number",
+            "title" : "Max Queue Size",
+            "description" : "Sets the maximum number of tasks in the work queue. Use -1 or Integer.MAX_VALUE for an unbounded queue"
+          },
+          "poolSize" : {
+            "type" : "number",
+            "title" : "Pool Size",
+            "description" : "Sets the core pool size"
+          },
+          "rejectedPolicy" : {
+            "type" : "string",
+            "title" : "Rejected Policy",
+            "description" : "Sets the handler for tasks which cannot be executed by the thread pool.",
+            "enum" : [ "Abort", "CallerRuns" ]
+          },
+          "timeUnit" : {
+            "type" : "string",
+            "title" : "Time Unit",
+            "description" : "Sets the time unit to use for keep alive time By default SECONDS is used.",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          }
+        }
+      },
+      "org.apache.camel.model.ThreadsDefinition" : {
+        "title" : "Threads",
+        "description" : "Specifies that all steps after this node are processed asynchronously",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowCoreThreadTimeOut" : {
+            "type" : "boolean",
+            "title" : "Allow Core Thread Time Out",
+            "description" : "Whether idle core threads are allowed to timeout and therefore can shrink the pool size below the core pool size Is by default false"
+          },
+          "callerRunsWhenRejected" : {
+            "type" : "string",
+            "title" : "Caller Runs When Rejected",
+            "description" : "Whether or not to use as caller runs as fallback when a task is rejected being added to the thread pool (when its full). This is only used as fallback if no rejectedPolicy has been configured, or the thread pool has no configured rejection handler. Is by default true",
+            "default" : "true"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom thread pool"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "keepAliveTime" : {
+            "type" : "number",
+            "title" : "Keep Alive Time",
+            "description" : "Sets the keep alive time for idle threads"
+          },
+          "maxPoolSize" : {
+            "type" : "number",
+            "title" : "Max Pool Size",
+            "description" : "Sets the maximum pool size"
+          },
+          "maxQueueSize" : {
+            "type" : "number",
+            "title" : "Max Queue Size",
+            "description" : "Sets the maximum number of tasks in the work queue. Use -1 or Integer.MAX_VALUE for an unbounded queue"
+          },
+          "poolSize" : {
+            "type" : "number",
+            "title" : "Pool Size",
+            "description" : "Sets the core pool size"
+          },
+          "rejectedPolicy" : {
+            "type" : "string",
+            "title" : "Rejected Policy",
+            "description" : "Sets the handler for tasks which cannot be executed by the thread pool.",
+            "enum" : [ "Abort", "CallerRuns" ]
+          },
+          "threadName" : {
+            "type" : "string",
+            "title" : "Thread Name",
+            "description" : "Sets the thread name to use.",
+            "default" : "Threads"
+          },
+          "timeUnit" : {
+            "type" : "string",
+            "title" : "Time Unit",
+            "description" : "Sets the keep alive time unit. By default SECONDS is used.",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          }
+        }
+      },
+      "org.apache.camel.model.ThrottleDefinition" : {
+        "title" : "Throttle",
+        "description" : "Controls the rate at which messages are passed to the next node in the route",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to configure the maximum number of messages to throttle per request",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "asyncDelayed" : {
+            "type" : "boolean",
+            "title" : "Async Delayed",
+            "description" : "Enables asynchronous delay which means the thread will not block while delaying."
+          },
+          "callerRunsWhenRejected" : {
+            "type" : "boolean",
+            "title" : "Caller Runs When Rejected",
+            "description" : "Whether or not the caller should run the task when it was rejected by the thread pool. Is by default true"
+          },
+          "correlationExpression" : {
+            "title" : "Correlation Expression",
+            "description" : "The expression used to calculate the correlation key to use for throttle grouping. The Exchange which has the same correlation key is throttled together.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "To use a custom thread pool (ScheduledExecutorService) by the throttler."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "mode" : {
+            "type" : "string",
+            "title" : "Mode",
+            "description" : "Sets the throttling mode to one of the available modes enumerated in ThrottlingMode",
+            "default" : "TotalRequests",
+            "enum" : [ "TotalRequests", "ConcurrentRequests" ]
+          },
+          "rejectExecution" : {
+            "type" : "boolean",
+            "title" : "Reject Execution",
+            "description" : "Whether or not throttler throws the ThrottlerRejectedExecutionException when the exchange exceeds the request limit Is by default false"
+          },
+          "timePeriodMillis" : {
+            "type" : "string",
+            "title" : "Time Period Millis",
+            "description" : "Sets the time period during which the maximum request count is valid for",
+            "default" : "1000"
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.ThrowExceptionDefinition" : {
+        "title" : "Throw Exception",
+        "description" : "Throws an exception",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "exceptionType" : {
+            "type" : "string",
+            "title" : "Exception Type",
+            "description" : "The class of the exception to create using the message."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "message" : {
+            "type" : "string",
+            "title" : "Message",
+            "description" : "To create a new exception instance and use the given message as caused message (supports simple language)"
+          },
+          "ref" : {
+            "type" : "string",
+            "title" : "Ref",
+            "description" : "Reference to the exception instance to lookup from the registry to throw"
+          }
+        }
+      },
+      "org.apache.camel.model.ToDefinition" : {
+        "title" : "To",
+        "description" : "Sends the message to a static endpoint",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Sets the optional ExchangePattern used to invoke this endpoint",
+              "enum" : [ "InOnly", "InOut" ]
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "Sets the uri of the endpoint to send to."
+            },
+            "variableReceive" : {
+              "type" : "string",
+              "title" : "Variable Receive",
+              "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+            },
+            "variableSend" : {
+              "type" : "string",
+              "title" : "Variable Send",
+              "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.ToDynamicDefinition" : {
+        "title" : "To D",
+        "description" : "Sends the message to a dynamic endpoint",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allowOptimisedComponents" : {
+              "type" : "boolean",
+              "title" : "Allow Optimised Components",
+              "description" : "Whether to allow components to optimise toD if they are org.apache.camel.spi.SendDynamicAware ."
+            },
+            "autoStartComponents" : {
+              "type" : "boolean",
+              "title" : "Auto Start Components",
+              "description" : "Whether to auto startup components when toD is starting up."
+            },
+            "cacheSize" : {
+              "type" : "number",
+              "title" : "Cache Size",
+              "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this recipient list, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "ignoreInvalidEndpoint" : {
+              "type" : "boolean",
+              "title" : "Ignore Invalid Endpoint",
+              "description" : "Whether to ignore invalid endpoint URIs and skip sending the message."
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Sets the optional ExchangePattern used to invoke this endpoint",
+              "enum" : [ "InOnly", "InOut" ]
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "The uri of the endpoint to send to. The uri can be dynamic computed using the org.apache.camel.language.simple.SimpleLanguage expression."
+            },
+            "variableReceive" : {
+              "type" : "string",
+              "title" : "Variable Receive",
+              "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+            },
+            "variableSend" : {
+              "type" : "string",
+              "title" : "Variable Send",
+              "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.TokenizerDefinition" : {
+        "title" : "Specialized tokenizer for AI applications",
+        "description" : "Represents a Camel tokenizer for AI.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "langChain4jCharacterTokenizer" : { },
+          "langChain4jLineTokenizer" : { },
+          "langChain4jParagraphTokenizer" : { },
+          "langChain4jSentenceTokenizer" : { },
+          "langChain4jWordTokenizer" : { }
+        },
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "langChain4jCharacterTokenizer" ],
+            "properties" : {
+              "langChain4jCharacterTokenizer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jCharacterTokenizerDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "langChain4jCharacterTokenizer" ]
+              }, {
+                "required" : [ "langChain4jLineTokenizer" ]
+              }, {
+                "required" : [ "langChain4jParagraphTokenizer" ]
+              }, {
+                "required" : [ "langChain4jSentenceTokenizer" ]
+              }, {
+                "required" : [ "langChain4jWordTokenizer" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "langChain4jLineTokenizer" ],
+            "properties" : {
+              "langChain4jLineTokenizer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jTokenizerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "langChain4jParagraphTokenizer" ],
+            "properties" : {
+              "langChain4jParagraphTokenizer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jParagraphTokenizerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "langChain4jSentenceTokenizer" ],
+            "properties" : {
+              "langChain4jSentenceTokenizer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jSentenceTokenizerDefinition"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "langChain4jWordTokenizer" ],
+            "properties" : {
+              "langChain4jWordTokenizer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.tokenizer.LangChain4jWordTokenizerDefinition"
+              }
+            }
+          } ]
+        } ]
+      },
+      "org.apache.camel.model.TokenizerImplementationDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.TransactedDefinition" : {
+        "title" : "Transacted",
+        "description" : "Enables transaction on the route",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ref" : {
+            "type" : "string",
+            "title" : "Ref",
+            "description" : "Sets a reference to use for lookup the policy in the registry."
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.TransformDefinition" : {
+        "title" : "Transform",
+        "description" : "Transforms the message body based on an expression",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to return the transformed message body (the new message body to use)",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "fromType" : {
+            "type" : "string",
+            "title" : "From Type",
+            "description" : "From type used in data type transformation."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "toType" : {
+            "type" : "string",
+            "title" : "To Type",
+            "description" : "To type used as a target data type in the transformation."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.TryDefinition" : {
+        "title" : "Do Try",
+        "description" : "Marks the beginning of a try, catch, finally block",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "doCatch" : {
+            "type" : "array",
+            "title" : "Do Catch",
+            "description" : "Catches exceptions as part of a try, catch, finally block",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.CatchDefinition"
+            }
+          },
+          "doFinally" : {
+            "title" : "Do Finally",
+            "description" : "Path traversed when a try, catch, finally block exits",
+            "$ref" : "#/items/definitions/org.apache.camel.model.FinallyDefinition"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.UnmarshalDefinition" : {
+        "title" : "Unmarshal",
+        "description" : "Converts the message data received from the wire into a format that Apache Camel processors can consume",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowNullBody" : {
+            "type" : "boolean",
+            "title" : "Allow Null Body",
+            "description" : "Indicates whether null is allowed as value of a body to unmarshall."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "variableReceive" : {
+            "type" : "string",
+            "title" : "Variable Receive",
+            "description" : "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message."
+          },
+          "variableSend" : {
+            "type" : "string",
+            "title" : "Variable Send",
+            "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+          },
+          "asn1" : { },
+          "avro" : { },
+          "barcode" : { },
+          "base64" : { },
+          "beanio" : { },
+          "bindy" : { },
+          "cbor" : { },
+          "crypto" : { },
+          "csv" : { },
+          "custom" : { },
+          "fhirJson" : { },
+          "fhirXml" : { },
+          "flatpack" : { },
+          "fury" : { },
+          "grok" : { },
+          "gzipDeflater" : { },
+          "hl7" : { },
+          "ical" : { },
+          "jacksonXml" : { },
+          "jaxb" : { },
+          "json" : { },
+          "jsonApi" : { },
+          "lzf" : { },
+          "mimeMultipart" : { },
+          "parquetAvro" : { },
+          "pgp" : { },
+          "protobuf" : { },
+          "rss" : { },
+          "smooks" : { },
+          "soap" : { },
+          "swiftMt" : { },
+          "swiftMx" : { },
+          "syslog" : { },
+          "tarFile" : { },
+          "thrift" : { },
+          "tidyMarkup" : { },
+          "univocityCsv" : { },
+          "univocityFixed" : { },
+          "univocityTsv" : { },
+          "xmlSecurity" : { },
+          "yaml" : { },
+          "zipDeflater" : { },
+          "zipFile" : { }
+        },
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "asn1" ],
+            "properties" : {
+              "asn1" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "asn1" ]
+              }, {
+                "required" : [ "avro" ]
+              }, {
+                "required" : [ "barcode" ]
+              }, {
+                "required" : [ "base64" ]
+              }, {
+                "required" : [ "beanio" ]
+              }, {
+                "required" : [ "bindy" ]
+              }, {
+                "required" : [ "cbor" ]
+              }, {
+                "required" : [ "crypto" ]
+              }, {
+                "required" : [ "csv" ]
+              }, {
+                "required" : [ "custom" ]
+              }, {
+                "required" : [ "fhirJson" ]
+              }, {
+                "required" : [ "fhirXml" ]
+              }, {
+                "required" : [ "flatpack" ]
+              }, {
+                "required" : [ "fury" ]
+              }, {
+                "required" : [ "grok" ]
+              }, {
+                "required" : [ "gzipDeflater" ]
+              }, {
+                "required" : [ "hl7" ]
+              }, {
+                "required" : [ "ical" ]
+              }, {
+                "required" : [ "jacksonXml" ]
+              }, {
+                "required" : [ "jaxb" ]
+              }, {
+                "required" : [ "json" ]
+              }, {
+                "required" : [ "jsonApi" ]
+              }, {
+                "required" : [ "lzf" ]
+              }, {
+                "required" : [ "mimeMultipart" ]
+              }, {
+                "required" : [ "parquetAvro" ]
+              }, {
+                "required" : [ "pgp" ]
+              }, {
+                "required" : [ "protobuf" ]
+              }, {
+                "required" : [ "rss" ]
+              }, {
+                "required" : [ "smooks" ]
+              }, {
+                "required" : [ "soap" ]
+              }, {
+                "required" : [ "swiftMt" ]
+              }, {
+                "required" : [ "swiftMx" ]
+              }, {
+                "required" : [ "syslog" ]
+              }, {
+                "required" : [ "tarFile" ]
+              }, {
+                "required" : [ "thrift" ]
+              }, {
+                "required" : [ "tidyMarkup" ]
+              }, {
+                "required" : [ "univocityCsv" ]
+              }, {
+                "required" : [ "univocityFixed" ]
+              }, {
+                "required" : [ "univocityTsv" ]
+              }, {
+                "required" : [ "xmlSecurity" ]
+              }, {
+                "required" : [ "yaml" ]
+              }, {
+                "required" : [ "zipDeflater" ]
+              }, {
+                "required" : [ "zipFile" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "avro" ],
+            "properties" : {
+              "avro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "barcode" ],
+            "properties" : {
+              "barcode" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "base64" ],
+            "properties" : {
+              "base64" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "beanio" ],
+            "properties" : {
+              "beanio" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "bindy" ],
+            "properties" : {
+              "bindy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "cbor" ],
+            "properties" : {
+              "cbor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "crypto" ],
+            "properties" : {
+              "crypto" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csv" ],
+            "properties" : {
+              "csv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "custom" ],
+            "properties" : {
+              "custom" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirJson" ],
+            "properties" : {
+              "fhirJson" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirXml" ],
+            "properties" : {
+              "fhirXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "flatpack" ],
+            "properties" : {
+              "flatpack" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fury" ],
+            "properties" : {
+              "fury" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FuryDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "grok" ],
+            "properties" : {
+              "grok" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "gzipDeflater" ],
+            "properties" : {
+              "gzipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7" ],
+            "properties" : {
+              "hl7" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ical" ],
+            "properties" : {
+              "ical" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jacksonXml" ],
+            "properties" : {
+              "jacksonXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jaxb" ],
+            "properties" : {
+              "jaxb" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "json" ],
+            "properties" : {
+              "json" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonApi" ],
+            "properties" : {
+              "jsonApi" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "lzf" ],
+            "properties" : {
+              "lzf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mimeMultipart" ],
+            "properties" : {
+              "mimeMultipart" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "parquetAvro" ],
+            "properties" : {
+              "parquetAvro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ParquetAvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "pgp" ],
+            "properties" : {
+              "pgp" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "protobuf" ],
+            "properties" : {
+              "protobuf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "rss" ],
+            "properties" : {
+              "rss" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "smooks" ],
+            "properties" : {
+              "smooks" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SmooksDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "soap" ],
+            "properties" : {
+              "soap" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMt" ],
+            "properties" : {
+              "swiftMt" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMtDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMx" ],
+            "properties" : {
+              "swiftMx" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMxDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "syslog" ],
+            "properties" : {
+              "syslog" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tarFile" ],
+            "properties" : {
+              "tarFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "thrift" ],
+            "properties" : {
+              "thrift" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tidyMarkup" ],
+            "properties" : {
+              "tidyMarkup" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityCsv" ],
+            "properties" : {
+              "univocityCsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityFixed" ],
+            "properties" : {
+              "univocityFixed" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityTsv" ],
+            "properties" : {
+              "univocityTsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xmlSecurity" ],
+            "properties" : {
+              "xmlSecurity" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "yaml" ],
+            "properties" : {
+              "yaml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipDeflater" ],
+            "properties" : {
+              "zipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipFile" ],
+            "properties" : {
+              "zipFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+              }
+            }
+          } ]
+        } ]
+      },
+      "org.apache.camel.model.ValidateDefinition" : {
+        "title" : "Validate",
+        "description" : "Validates a message based on an expression",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression to use for validation as a predicate. The expression should return either true or false. If returning false the message is invalid and an exception is thrown.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "predicateExceptionFactory" : {
+            "type" : "string",
+            "title" : "Predicate Exception Factory",
+            "description" : "The bean id of custom PredicateExceptionFactory to use for creating the exception when the validation fails. By default, Camel will throw PredicateValidationException. By using a custom factory you can control which exception to throw instead."
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.ValueDefinition" : {
+        "title" : "Value",
+        "description" : "A single value",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "value" : {
+              "type" : "string",
+              "title" : "Value",
+              "description" : "Property value"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.WhenDefinition" : {
+        "title" : "When",
+        "description" : "Triggers a route when the expression evaluates to true",
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              }, {
+                "required" : [ "constant" ]
+              }, {
+                "required" : [ "csimple" ]
+              }, {
+                "required" : [ "datasonnet" ]
+              }, {
+                "required" : [ "exchangeProperty" ]
+              }, {
+                "required" : [ "groovy" ]
+              }, {
+                "required" : [ "header" ]
+              }, {
+                "required" : [ "hl7terser" ]
+              }, {
+                "required" : [ "java" ]
+              }, {
+                "required" : [ "joor" ]
+              }, {
+                "required" : [ "jq" ]
+              }, {
+                "required" : [ "js" ]
+              }, {
+                "required" : [ "jsonpath" ]
+              }, {
+                "required" : [ "language" ]
+              }, {
+                "required" : [ "method" ]
+              }, {
+                "required" : [ "mvel" ]
+              }, {
+                "required" : [ "ognl" ]
+              }, {
+                "required" : [ "python" ]
+              }, {
+                "required" : [ "ref" ]
+              }, {
+                "required" : [ "simple" ]
+              }, {
+                "required" : [ "spel" ]
+              }, {
+                "required" : [ "tokenize" ]
+              }, {
+                "required" : [ "variable" ]
+              }, {
+                "required" : [ "wasm" ]
+              }, {
+                "required" : [ "xpath" ]
+              }, {
+                "required" : [ "xquery" ]
+              }, {
+                "required" : [ "xtokenize" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Expression used as the predicate to evaluate whether this when should trigger and route the message or not.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Disables this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled late at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.WireTapDefinition" : {
+        "title" : "Wire Tap",
+        "description" : "Routes a copy of a message (or creates a new message) to a secondary destination while continue routing the original message.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowOptimisedComponents" : {
+            "type" : "boolean",
+            "title" : "Allow Optimised Components",
+            "description" : "Whether to allow components to optimise toD if they are org.apache.camel.spi.SendDynamicAware ."
+          },
+          "autoStartComponents" : {
+            "type" : "boolean",
+            "title" : "Auto Start Components",
+            "description" : "Whether to auto startup components when toD is starting up."
+          },
+          "cacheSize" : {
+            "type" : "number",
+            "title" : "Cache Size",
+            "description" : "Sets the maximum size used by the org.apache.camel.spi.ProducerCache which is used to cache and reuse producers when using this recipient list, when uris are reused. Beware that when using dynamic endpoints then it affects how well the cache can be utilized. If each dynamic endpoint is unique then its best to turn off caching by setting this to -1, which allows Camel to not cache both the producers and endpoints; they are regarded as prototype scoped and will be stopped and discarded after use. This reduces memory usage as otherwise producers/endpoints are stored in memory in the caches. However if there are a high degree of dynamic endpoints that have been used before, then it can benefit to use the cache to reuse both producers and endpoints and therefore the cache size can be set accordingly or rely on the default size (1000). If there is a mix of unique and used before dynamic endpoints, then setting a reasonable cache size can help reduce memory usage to avoid storing too many non frequent used producers."
+          },
+          "copy" : {
+            "type" : "boolean",
+            "title" : "Copy",
+            "description" : "Uses a copy of the original exchange"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+          },
+          "dynamicUri" : {
+            "type" : "boolean",
+            "title" : "Dynamic Uri",
+            "description" : "Whether the uri is dynamic or static. If the uri is dynamic then the simple language is used to evaluate a dynamic uri to use as the wire-tap destination, for each incoming message. This works similar to how the toD EIP pattern works. If static then the uri is used as-is as the wire-tap destination."
+          },
+          "executorService" : {
+            "type" : "string",
+            "title" : "Executor Service",
+            "description" : "Uses a custom thread pool"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "ignoreInvalidEndpoint" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Endpoint",
+            "description" : "Whether to ignore invalid endpoint URIs and skip sending the message."
+          },
+          "onPrepare" : {
+            "type" : "string",
+            "title" : "On Prepare",
+            "description" : "Uses the Processor when preparing the org.apache.camel.Exchange to be sent. This can be used to deep-clone messages that should be sent, or any custom logic needed before the exchange is sent."
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "pattern" : {
+            "type" : "string",
+            "title" : "Pattern",
+            "description" : "Sets the optional ExchangePattern used to invoke this endpoint",
+            "enum" : [ "InOnly", "InOut" ]
+          },
+          "uri" : {
+            "type" : "string",
+            "title" : "Uri",
+            "description" : "The uri of the endpoint to send to. The uri can be dynamic computed using the org.apache.camel.language.simple.SimpleLanguage expression."
+          },
+          "variableReceive" : {
+            "type" : "string",
+            "title" : "Variable Receive",
+            "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+          },
+          "variableSend" : {
+            "type" : "string",
+            "title" : "Variable Send",
+            "description" : "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual."
+          }
+        },
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.app.BeanConstructorDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "index" : {
+            "type" : "number"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "value" ]
+      },
+      "org.apache.camel.model.app.BeanConstructorsDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "constructor" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.app.BeanConstructorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.app.BeanPropertiesDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "property" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.app.BeanPropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.app.BeanPropertyDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.app.BeanPropertiesDefinition"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.app.ComponentScanDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "basePackage" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration" : {
+        "title" : "Blacklist Service Filter",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "servers" : {
+            "type" : "array",
+            "title" : "Servers",
+            "description" : "Sets the server blacklist. Each entry can be a list of servers separated by comma in the format: servicehost:port,servicehost2:port,servicehost3:port",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Caching Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "combinedServiceDiscovery" ],
+            "properties" : {
+              "combinedServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "combinedServiceDiscovery" ]
+              }, {
+                "required" : [ "consulServiceDiscovery" ]
+              }, {
+                "required" : [ "dnsServiceDiscovery" ]
+              }, {
+                "required" : [ "kubernetesServiceDiscovery" ]
+              }, {
+                "required" : [ "staticServiceDiscovery" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "consulServiceDiscovery" ],
+            "properties" : {
+              "consulServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "dnsServiceDiscovery" ],
+            "properties" : {
+              "dnsServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "kubernetesServiceDiscovery" ],
+            "properties" : {
+              "kubernetesServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "staticServiceDiscovery" ],
+            "properties" : {
+              "staticServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "timeout" : {
+            "type" : "number",
+            "title" : "Timeout",
+            "description" : "Set the time the services will be retained.",
+            "default" : "60"
+          },
+          "units" : {
+            "type" : "string",
+            "title" : "Units",
+            "description" : "Set the time unit for the timeout.",
+            "default" : "SECONDS",
+            "enum" : [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+          },
+          "combinedServiceDiscovery" : { },
+          "consulServiceDiscovery" : { },
+          "dnsServiceDiscovery" : { },
+          "kubernetesServiceDiscovery" : { },
+          "staticServiceDiscovery" : { }
+        }
+      },
+      "org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Combined Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "cachingServiceDiscovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+          },
+          "consulServiceDiscovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+          },
+          "dnsServiceDiscovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "kubernetesServiceDiscovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "staticServiceDiscovery" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration" : {
+        "title" : "Combined Service Filter",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "blacklistServiceFilter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+          },
+          "customServiceFilter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+          },
+          "healthyServiceFilter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "passThroughServiceFilter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Consul Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "aclToken" : {
+            "type" : "string",
+            "title" : "Acl Token",
+            "description" : "Sets the ACL token to be used with Consul"
+          },
+          "blockSeconds" : {
+            "type" : "number",
+            "title" : "Block Seconds",
+            "description" : "The seconds to wait for a watch event, default 10 seconds",
+            "default" : "10"
+          },
+          "connectTimeoutMillis" : {
+            "type" : "number",
+            "title" : "Connect Timeout Millis",
+            "description" : "Connect timeout for OkHttpClient"
+          },
+          "datacenter" : {
+            "type" : "string",
+            "title" : "Datacenter",
+            "description" : "The data center"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "password" : {
+            "type" : "string",
+            "title" : "Password",
+            "description" : "Sets the password to be used for basic authentication"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "readTimeoutMillis" : {
+            "type" : "number",
+            "title" : "Read Timeout Millis",
+            "description" : "Read timeout for OkHttpClient"
+          },
+          "url" : {
+            "type" : "string",
+            "title" : "Url",
+            "description" : "The Consul agent URL"
+          },
+          "userName" : {
+            "type" : "string",
+            "title" : "User Name",
+            "description" : "Sets the username to be used for basic authentication"
+          },
+          "writeTimeoutMillis" : {
+            "type" : "number",
+            "title" : "Write Timeout Millis",
+            "description" : "Write timeout for OkHttpClient"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration" : {
+        "title" : "Custom Service Filter",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "ref" : {
+            "type" : "string",
+            "title" : "Ref",
+            "description" : "Reference of a ServiceFilter"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration" : {
+        "title" : "Default Load Balancer",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Dns Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "domain" : {
+            "type" : "string",
+            "title" : "Domain",
+            "description" : "The domain name;"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "proto" : {
+            "type" : "string",
+            "title" : "Proto",
+            "description" : "The transport protocol of the desired service.",
+            "default" : "_tcp"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration" : {
+        "title" : "Healthy Service Filter",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Kubernetes Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiVersion" : {
+            "type" : "string",
+            "title" : "Api Version",
+            "description" : "Sets the API version when using client lookup"
+          },
+          "caCertData" : {
+            "type" : "string",
+            "title" : "Ca Cert Data",
+            "description" : "Sets the Certificate Authority data when using client lookup"
+          },
+          "caCertFile" : {
+            "type" : "string",
+            "title" : "Ca Cert File",
+            "description" : "Sets the Certificate Authority data that are loaded from the file when using client lookup"
+          },
+          "clientCertData" : {
+            "type" : "string",
+            "title" : "Client Cert Data",
+            "description" : "Sets the Client Certificate data when using client lookup"
+          },
+          "clientCertFile" : {
+            "type" : "string",
+            "title" : "Client Cert File",
+            "description" : "Sets the Client Certificate data that are loaded from the file when using client lookup"
+          },
+          "clientKeyAlgo" : {
+            "type" : "string",
+            "title" : "Client Key Algo",
+            "description" : "Sets the Client Keystore algorithm, such as RSA when using client lookup"
+          },
+          "clientKeyData" : {
+            "type" : "string",
+            "title" : "Client Key Data",
+            "description" : "Sets the Client Keystore data when using client lookup"
+          },
+          "clientKeyFile" : {
+            "type" : "string",
+            "title" : "Client Key File",
+            "description" : "Sets the Client Keystore data that are loaded from the file when using client lookup"
+          },
+          "clientKeyPassphrase" : {
+            "type" : "string",
+            "title" : "Client Key Passphrase",
+            "description" : "Sets the Client Keystore passphrase when using client lookup"
+          },
+          "dnsDomain" : {
+            "type" : "string",
+            "title" : "Dns Domain",
+            "description" : "Sets the DNS domain to use for DNS lookup."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "lookup" : {
+            "type" : "string",
+            "title" : "Lookup",
+            "description" : "How to perform service lookup. Possible values: client, dns, environment. When using client, then the client queries the kubernetes master to obtain a list of active pods that provides the service, and then random (or round robin) select a pod. When using dns the service name is resolved as name.namespace.svc.dnsDomain. When using dnssrv the service name is resolved with SRV query for _._...svc... When using environment then environment variables are used to lookup the service. By default environment is used.",
+            "default" : "environment",
+            "enum" : [ "environment", "dns", "client" ]
+          },
+          "masterUrl" : {
+            "type" : "string",
+            "title" : "Master Url",
+            "description" : "Sets the URL to the master when using client lookup"
+          },
+          "namespace" : {
+            "type" : "string",
+            "title" : "Namespace",
+            "description" : "Sets the namespace to use. Will by default use namespace from the ENV variable KUBERNETES_MASTER."
+          },
+          "oauthToken" : {
+            "type" : "string",
+            "title" : "Oauth Token",
+            "description" : "Sets the OAUTH token for authentication (instead of username/password) when using client lookup"
+          },
+          "password" : {
+            "type" : "string",
+            "title" : "Password",
+            "description" : "Sets the password for authentication when using client lookup"
+          },
+          "portName" : {
+            "type" : "string",
+            "title" : "Port Name",
+            "description" : "Sets the Port Name to use for DNS/DNSSRV lookup."
+          },
+          "portProtocol" : {
+            "type" : "string",
+            "title" : "Port Protocol",
+            "description" : "Sets the Port Protocol to use for DNS/DNSSRV lookup."
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "trustCerts" : {
+            "type" : "boolean",
+            "title" : "Trust Certs",
+            "description" : "Sets whether to turn on trust certificate check when using client lookup"
+          },
+          "username" : {
+            "type" : "string",
+            "title" : "Username",
+            "description" : "Sets the username for authentication when using client lookup"
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration" : {
+        "title" : "Pass Through Service Filter",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallConfigurationDefinition" : {
+        "title" : "Service Call Configuration",
+        "description" : "Remote service call configuration",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "blacklistServiceFilter" ],
+            "properties" : {
+              "blacklistServiceFilter" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "blacklistServiceFilter" ]
+              }, {
+                "required" : [ "combinedServiceFilter" ]
+              }, {
+                "required" : [ "customServiceFilter" ]
+              }, {
+                "required" : [ "healthyServiceFilter" ]
+              }, {
+                "required" : [ "passThroughServiceFilter" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "combinedServiceFilter" ],
+            "properties" : {
+              "combinedServiceFilter" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "customServiceFilter" ],
+            "properties" : {
+              "customServiceFilter" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "healthyServiceFilter" ],
+            "properties" : {
+              "healthyServiceFilter" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "passThroughServiceFilter" ],
+            "properties" : {
+              "passThroughServiceFilter" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+              }
+            }
+          } ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "cachingServiceDiscovery" ],
+            "properties" : {
+              "cachingServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "cachingServiceDiscovery" ]
+              }, {
+                "required" : [ "combinedServiceDiscovery" ]
+              }, {
+                "required" : [ "consulServiceDiscovery" ]
+              }, {
+                "required" : [ "dnsServiceDiscovery" ]
+              }, {
+                "required" : [ "kubernetesServiceDiscovery" ]
+              }, {
+                "required" : [ "staticServiceDiscovery" ]
+              }, {
+                "required" : [ "zookeeperServiceDiscovery" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "combinedServiceDiscovery" ],
+            "properties" : {
+              "combinedServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "consulServiceDiscovery" ],
+            "properties" : {
+              "consulServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "dnsServiceDiscovery" ],
+            "properties" : {
+              "dnsServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "kubernetesServiceDiscovery" ],
+            "properties" : {
+              "kubernetesServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "staticServiceDiscovery" ],
+            "properties" : {
+              "staticServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zookeeperServiceDiscovery" ],
+            "properties" : {
+              "zookeeperServiceDiscovery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration"
+              }
+            }
+          } ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "defaultLoadBalancer" ],
+            "properties" : {
+              "defaultLoadBalancer" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "defaultLoadBalancer" ]
+              } ]
+            }
+          } ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "title" : "Expression",
+                "description" : "Configures the Expression using the given configuration.",
+                "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallExpressionConfiguration"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              } ]
+            }
+          } ]
+        } ],
+        "properties" : {
+          "component" : {
+            "type" : "string",
+            "title" : "Component",
+            "description" : "The component to use.",
+            "default" : "http"
+          },
+          "expressionRef" : {
+            "type" : "string",
+            "title" : "Expression Ref",
+            "description" : "Set a reference to a custom Expression to use."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "loadBalancerRef" : {
+            "type" : "string",
+            "title" : "Load Balancer Ref",
+            "description" : "Sets a reference to a custom ServiceLoadBalancer to use."
+          },
+          "pattern" : {
+            "type" : "string",
+            "title" : "Pattern",
+            "description" : "Sets the optional ExchangePattern used to invoke this endpoint",
+            "enum" : [ "InOnly", "InOut" ]
+          },
+          "serviceChooserRef" : {
+            "type" : "string",
+            "title" : "Service Chooser Ref",
+            "description" : "Sets a reference to a custom ServiceChooser to use."
+          },
+          "serviceDiscoveryRef" : {
+            "type" : "string",
+            "title" : "Service Discovery Ref",
+            "description" : "Sets a reference to a custom ServiceDiscovery to use."
+          },
+          "serviceFilterRef" : {
+            "type" : "string",
+            "title" : "Service Filter Ref",
+            "description" : "Sets a reference to a custom ServiceFilter to use."
+          },
+          "uri" : {
+            "type" : "string",
+            "title" : "Uri",
+            "description" : "The uri of the endpoint to send to. The uri can be dynamic computed using the simple language expression."
+          },
+          "blacklistServiceFilter" : { },
+          "combinedServiceFilter" : { },
+          "customServiceFilter" : { },
+          "healthyServiceFilter" : { },
+          "passThroughServiceFilter" : { },
+          "cachingServiceDiscovery" : { },
+          "combinedServiceDiscovery" : { },
+          "consulServiceDiscovery" : { },
+          "dnsServiceDiscovery" : { },
+          "kubernetesServiceDiscovery" : { },
+          "staticServiceDiscovery" : { },
+          "zookeeperServiceDiscovery" : { },
+          "defaultLoadBalancer" : { },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallDefinition" : {
+        "title" : "Service Call",
+        "description" : "To call remote services",
+        "deprecated" : true,
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "anyOf" : [ {
+            "oneOf" : [ {
+              "type" : "object",
+              "required" : [ "blacklistServiceFilter" ],
+              "properties" : {
+                "blacklistServiceFilter" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.BlacklistServiceCallServiceFilterConfiguration"
+                }
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "blacklistServiceFilter" ]
+                }, {
+                  "required" : [ "combinedServiceFilter" ]
+                }, {
+                  "required" : [ "customServiceFilter" ]
+                }, {
+                  "required" : [ "healthyServiceFilter" ]
+                }, {
+                  "required" : [ "passThroughServiceFilter" ]
+                } ]
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "combinedServiceFilter" ],
+              "properties" : {
+                "combinedServiceFilter" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceFilterConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "customServiceFilter" ],
+              "properties" : {
+                "customServiceFilter" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CustomServiceCallServiceFilterConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "healthyServiceFilter" ],
+              "properties" : {
+                "healthyServiceFilter" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.HealthyServiceCallServiceFilterConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "passThroughServiceFilter" ],
+              "properties" : {
+                "passThroughServiceFilter" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.PassThroughServiceCallServiceFilterConfiguration"
+                }
+              }
+            } ]
+          }, {
+            "oneOf" : [ {
+              "type" : "object",
+              "required" : [ "cachingServiceDiscovery" ],
+              "properties" : {
+                "cachingServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CachingServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "cachingServiceDiscovery" ]
+                }, {
+                  "required" : [ "combinedServiceDiscovery" ]
+                }, {
+                  "required" : [ "consulServiceDiscovery" ]
+                }, {
+                  "required" : [ "dnsServiceDiscovery" ]
+                }, {
+                  "required" : [ "kubernetesServiceDiscovery" ]
+                }, {
+                  "required" : [ "staticServiceDiscovery" ]
+                }, {
+                  "required" : [ "zookeeperServiceDiscovery" ]
+                } ]
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "combinedServiceDiscovery" ],
+              "properties" : {
+                "combinedServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.CombinedServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "consulServiceDiscovery" ],
+              "properties" : {
+                "consulServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ConsulServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "dnsServiceDiscovery" ],
+              "properties" : {
+                "dnsServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DnsServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "kubernetesServiceDiscovery" ],
+              "properties" : {
+                "kubernetesServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.KubernetesServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "staticServiceDiscovery" ],
+              "properties" : {
+                "staticServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            }, {
+              "type" : "object",
+              "required" : [ "zookeeperServiceDiscovery" ],
+              "properties" : {
+                "zookeeperServiceDiscovery" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration"
+                }
+              }
+            } ]
+          }, {
+            "oneOf" : [ {
+              "type" : "object",
+              "required" : [ "defaultLoadBalancer" ],
+              "properties" : {
+                "defaultLoadBalancer" : {
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.DefaultServiceCallServiceLoadBalancerConfiguration"
+                }
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "defaultLoadBalancer" ]
+                } ]
+              }
+            } ]
+          }, {
+            "oneOf" : [ {
+              "type" : "object",
+              "required" : [ "expression" ],
+              "properties" : {
+                "expression" : {
+                  "title" : "Expression",
+                  "description" : "Configures the Expression using the given configuration.",
+                  "$ref" : "#/items/definitions/org.apache.camel.model.cloud.ServiceCallExpressionConfiguration"
+                }
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "expression" ]
+                } ]
+              }
+            } ]
+          } ],
+          "properties" : {
+            "component" : {
+              "type" : "string",
+              "title" : "Component",
+              "description" : "The component to use.",
+              "default" : "http"
+            },
+            "configurationRef" : {
+              "type" : "string",
+              "title" : "Configuration Ref",
+              "description" : "Refers to a ServiceCall configuration to use"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Sets the description of this node"
+            },
+            "disabled" : {
+              "type" : "boolean",
+              "title" : "Disabled",
+              "description" : "Whether to disable this EIP from the route during build time. Once an EIP has been disabled then it cannot be enabled later at runtime."
+            },
+            "expressionRef" : {
+              "type" : "string",
+              "title" : "Expression Ref",
+              "description" : "Set a reference to a custom Expression to use."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "loadBalancerRef" : {
+              "type" : "string",
+              "title" : "Load Balancer Ref",
+              "description" : "Sets a reference to a custom ServiceLoadBalancer to use."
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "Sets the name of the service to use"
+            },
+            "pattern" : {
+              "type" : "string",
+              "title" : "Pattern",
+              "description" : "Sets the optional ExchangePattern used to invoke this endpoint",
+              "enum" : [ "InOnly", "InOut" ]
+            },
+            "serviceChooserRef" : {
+              "type" : "string",
+              "title" : "Service Chooser Ref",
+              "description" : "Sets a reference to a custom ServiceChooser to use."
+            },
+            "serviceDiscoveryRef" : {
+              "type" : "string",
+              "title" : "Service Discovery Ref",
+              "description" : "Sets a reference to a custom ServiceDiscovery to use."
+            },
+            "serviceFilterRef" : {
+              "type" : "string",
+              "title" : "Service Filter Ref",
+              "description" : "Sets a reference to a custom ServiceFilter to use."
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "The uri of the endpoint to send to. The uri can be dynamic computed using the org.apache.camel.language.simple.SimpleLanguage expression."
+            },
+            "blacklistServiceFilter" : { },
+            "combinedServiceFilter" : { },
+            "customServiceFilter" : { },
+            "healthyServiceFilter" : { },
+            "passThroughServiceFilter" : { },
+            "cachingServiceDiscovery" : { },
+            "combinedServiceDiscovery" : { },
+            "consulServiceDiscovery" : { },
+            "dnsServiceDiscovery" : { },
+            "kubernetesServiceDiscovery" : { },
+            "staticServiceDiscovery" : { },
+            "zookeeperServiceDiscovery" : { },
+            "defaultLoadBalancer" : { },
+            "expression" : { }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.cloud.ServiceCallExpressionConfiguration" : {
+        "title" : "Service Expression",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "expressionType" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "hostHeader" : {
+            "type" : "string",
+            "title" : "Host Header",
+            "description" : "The header that holds the service host information, default ServiceCallConstants.SERVICE_HOST",
+            "default" : "CamelServiceCallServiceHost"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "portHeader" : {
+            "type" : "string",
+            "title" : "Port Header",
+            "description" : "The header that holds the service port information, default ServiceCallConstants.SERVICE_PORT",
+            "default" : "CamelServiceCallServicePort"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceChooserConfiguration" : {
+        "title" : "Service Chooser Configuration",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Service Discovery Configuration",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceFilterConfiguration" : {
+        "title" : "Service Filter Configuration",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ServiceCallServiceLoadBalancerConfiguration" : {
+        "title" : "Load Balancer Configuration",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.StaticServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Static Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "servers" : {
+            "type" : "array",
+            "title" : "Servers",
+            "description" : "Sets the server list. Each entry can be a list of servers separated by comma in the format: servicehost:port,servicehost2:port,servicehost3:port",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.cloud.ZooKeeperServiceCallServiceDiscoveryConfiguration" : {
+        "title" : "Zookeeper Service Discovery",
+        "deprecated" : true,
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "basePath" : {
+            "type" : "string",
+            "title" : "Base Path",
+            "description" : "Set the base path to store in ZK"
+          },
+          "connectionTimeout" : {
+            "type" : "string",
+            "title" : "Connection Timeout",
+            "description" : "Connection timeout."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "namespace" : {
+            "type" : "string",
+            "title" : "Namespace",
+            "description" : "As ZooKeeper is a shared space, users of a given cluster should stay within a pre-defined namespace. If a namespace is set here, all paths will get pre-pended with the namespace"
+          },
+          "nodes" : {
+            "type" : "string",
+            "title" : "Nodes",
+            "description" : "A comma separate list of servers to connect to in the form host:port"
+          },
+          "properties" : {
+            "type" : "array",
+            "title" : "Properties",
+            "description" : "Set client properties to use. These properties are specific to what service call implementation are in use. For example if using a different one, then the client properties are defined according to the specific service in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+            }
+          },
+          "reconnectBaseSleepTime" : {
+            "type" : "string",
+            "title" : "Reconnect Base Sleep Time",
+            "description" : "Initial amount of time to wait between retries."
+          },
+          "reconnectMaxRetries" : {
+            "type" : "string",
+            "title" : "Reconnect Max Retries",
+            "description" : "Max number of times to retry"
+          },
+          "reconnectMaxSleepTime" : {
+            "type" : "string",
+            "title" : "Reconnect Max Sleep Time",
+            "description" : "Max time in ms to sleep on each retry"
+          },
+          "sessionTimeout" : {
+            "type" : "string",
+            "title" : "Session Timeout",
+            "description" : "Session timeout."
+          }
+        },
+        "required" : [ "basePath", "nodes" ]
+      },
+      "org.apache.camel.model.config.BatchResequencerConfig" : {
+        "title" : "Batch Config",
+        "description" : "Configures batch-processing resequence eip.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowDuplicates" : {
+            "type" : "boolean",
+            "title" : "Allow Duplicates",
+            "description" : "Whether to allow duplicates."
+          },
+          "batchSize" : {
+            "type" : "number",
+            "title" : "Batch Size",
+            "description" : "Sets the size of the batch to be re-ordered. The default size is 100.",
+            "default" : "100"
+          },
+          "batchTimeout" : {
+            "type" : "string",
+            "title" : "Batch Timeout",
+            "description" : "Sets the timeout for collecting elements to be re-ordered. The default timeout is 1000 msec.",
+            "default" : "1000"
+          },
+          "ignoreInvalidExchanges" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Exchanges",
+            "description" : "Whether to ignore invalid exchanges"
+          },
+          "reverse" : {
+            "type" : "boolean",
+            "title" : "Reverse",
+            "description" : "Whether to reverse the ordering."
+          }
+        }
+      },
+      "org.apache.camel.model.config.StreamResequencerConfig" : {
+        "title" : "Stream Config",
+        "description" : "Configures stream-processing resequence eip.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "capacity" : {
+            "type" : "number",
+            "title" : "Capacity",
+            "description" : "Sets the capacity of the resequencer inbound queue.",
+            "default" : "1000"
+          },
+          "comparator" : {
+            "type" : "string",
+            "title" : "Comparator",
+            "description" : "To use a custom comparator as a org.apache.camel.processor.resequencer.ExpressionResultComparator type."
+          },
+          "deliveryAttemptInterval" : {
+            "type" : "string",
+            "title" : "Delivery Attempt Interval",
+            "description" : "Sets the interval in milliseconds the stream resequencer will at most wait while waiting for condition of being able to deliver.",
+            "default" : "1000"
+          },
+          "ignoreInvalidExchanges" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Exchanges",
+            "description" : "Whether to ignore invalid exchanges"
+          },
+          "rejectOld" : {
+            "type" : "boolean",
+            "title" : "Reject Old",
+            "description" : "If true, throws an exception when messages older than the last delivered message are processed"
+          },
+          "timeout" : {
+            "type" : "string",
+            "title" : "Timeout",
+            "description" : "Sets minimum time (milliseconds) to wait for missing elements (messages).",
+            "default" : "1000"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ASN1DataFormat" : {
+        "title" : "ASN.1 File",
+        "description" : "Encode and decode data structures using Abstract Syntax Notation One (ASN.1).",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "unmarshalType" : {
+              "type" : "string",
+              "title" : "Unmarshal Type",
+              "description" : "Class to use when unmarshalling."
+            },
+            "usingIterator" : {
+              "type" : "boolean",
+              "title" : "Using Iterator",
+              "description" : "If the asn1 file has more than one entry, the setting this option to true, allows working with the splitter EIP, to split the data using an iterator in a streaming mode."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.AvroDataFormat" : {
+        "title" : "Avro",
+        "description" : "Serialize and deserialize messages using Apache Avro binary data format.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allowJmsType" : {
+              "type" : "boolean",
+              "title" : "Allow Jms Type",
+              "description" : "Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to unmarshal to."
+            },
+            "allowUnmarshallType" : {
+              "type" : "boolean",
+              "title" : "Allow Unmarshall Type",
+              "description" : "If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the unmarshalling. This should only be enabled when desired to be used."
+            },
+            "autoDiscoverObjectMapper" : {
+              "type" : "boolean",
+              "title" : "Auto Discover Object Mapper",
+              "description" : "If set to true then Jackson will lookup for an objectMapper into the registry"
+            },
+            "autoDiscoverSchemaResolver" : {
+              "type" : "boolean",
+              "title" : "Auto Discover Schema Resolver",
+              "description" : "When not disabled, the SchemaResolver will be looked up into the registry"
+            },
+            "collectionType" : {
+              "type" : "string",
+              "title" : "Collection Type",
+              "description" : "Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but allows to use different collection types than java.util.Collection based as default."
+            },
+            "contentTypeHeader" : {
+              "type" : "boolean",
+              "title" : "Content Type Header",
+              "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+            },
+            "disableFeatures" : {
+              "type" : "string",
+              "title" : "Disable Features",
+              "description" : "Set of features to disable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+            },
+            "enableFeatures" : {
+              "type" : "string",
+              "title" : "Enable Features",
+              "description" : "Set of features to enable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "include" : {
+              "type" : "string",
+              "title" : "Include",
+              "description" : "If you want to marshal a pojo to JSON, and the pojo has some fields with null values. And you want to skip these null values, you can set this option to NON_NULL"
+            },
+            "instanceClassName" : {
+              "type" : "string",
+              "title" : "Instance Class Name",
+              "description" : "Class name to use for marshal and unmarshalling"
+            },
+            "jsonView" : {
+              "type" : "string",
+              "title" : "Json View",
+              "description" : "When marshalling a POJO to JSON you might want to exclude certain fields from the JSON output. With Jackson you can use JSON views to accomplish this. This option is to refer to the class which has JsonView annotations"
+            },
+            "library" : {
+              "type" : "string",
+              "title" : "Library",
+              "description" : "Which Avro library to use.",
+              "default" : "avroJackson",
+              "enum" : [ "ApacheAvro", "Jackson" ]
+            },
+            "moduleClassNames" : {
+              "type" : "string",
+              "title" : "Module Class Names",
+              "description" : "To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as a String with FQN class names. Multiple classes can be separated by comma."
+            },
+            "moduleRefs" : {
+              "type" : "string",
+              "title" : "Module Refs",
+              "description" : "To use custom Jackson modules referred from the Camel registry. Multiple modules can be separated by comma."
+            },
+            "objectMapper" : {
+              "type" : "string",
+              "title" : "Object Mapper",
+              "description" : "Lookup and use the existing ObjectMapper with the given id when using Jackson."
+            },
+            "schemaResolver" : {
+              "type" : "string",
+              "title" : "Schema Resolver",
+              "description" : "Optional schema resolver used to lookup schemas for the data in transit."
+            },
+            "timezone" : {
+              "type" : "string",
+              "title" : "Timezone",
+              "description" : "If set then Jackson will use the Timezone when marshalling/unmarshalling."
+            },
+            "unmarshalType" : {
+              "type" : "string",
+              "title" : "Unmarshal Type",
+              "description" : "Class name of the java type to use when unmarshalling"
+            },
+            "useDefaultObjectMapper" : {
+              "type" : "boolean",
+              "title" : "Use Default Object Mapper",
+              "description" : "Whether to lookup and use default Jackson ObjectMapper from the registry."
+            },
+            "useList" : {
+              "type" : "boolean",
+              "title" : "Use List",
+              "description" : "To unmarshal to a List of Map or a List of Pojo."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.BarcodeDataFormat" : {
+        "title" : "Barcode",
+        "description" : "Transform strings to various 1D/2D barcode bitmap formats and back.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "barcodeFormat" : {
+            "type" : "string",
+            "title" : "Barcode Format",
+            "description" : "Barcode format such as QR-Code"
+          },
+          "height" : {
+            "type" : "number",
+            "title" : "Height",
+            "description" : "Height of the barcode"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "imageType" : {
+            "type" : "string",
+            "title" : "Image Type",
+            "description" : "Image type of the barcode such as png"
+          },
+          "width" : {
+            "type" : "number",
+            "title" : "Width",
+            "description" : "Width of the barcode"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.Base64DataFormat" : {
+        "title" : "Base64",
+        "description" : "Encode and decode data using Base64.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "lineLength" : {
+            "type" : "number",
+            "title" : "Line Length",
+            "description" : "To specific a maximum line length for the encoded data. By default 76 is used.",
+            "default" : "76"
+          },
+          "lineSeparator" : {
+            "type" : "string",
+            "title" : "Line Separator",
+            "description" : "The line separators to use. Uses new line characters (CRLF) by default."
+          },
+          "urlSafe" : {
+            "type" : "boolean",
+            "title" : "Url Safe",
+            "description" : "Instead of emitting '' and '/' we emit '-' and '_' respectively. urlSafe is only applied to encode operations. Decoding seamlessly handles both modes. Is by default false."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.BeanioDataFormat" : {
+        "title" : "BeanIO",
+        "description" : "Marshal and unmarshal Java beans to and from flat files (such as CSV, delimited, or fixed length formats).",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "beanReaderErrorHandlerType" : {
+            "type" : "string",
+            "title" : "Bean Reader Error Handler Type",
+            "description" : "To use a custom org.apache.camel.dataformat.beanio.BeanIOErrorHandler as error handler while parsing. Configure the fully qualified class name of the error handler. Notice the options ignoreUnidentifiedRecords, ignoreUnexpectedRecords, and ignoreInvalidRecords may not be in use when you use a custom error handler."
+          },
+          "encoding" : {
+            "type" : "string",
+            "title" : "Encoding",
+            "description" : "The charset to use. Is by default the JVM platform default charset."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreInvalidRecords" : {
+            "type" : "boolean",
+            "title" : "Ignore Invalid Records",
+            "description" : "Whether to ignore invalid records."
+          },
+          "ignoreUnexpectedRecords" : {
+            "type" : "boolean",
+            "title" : "Ignore Unexpected Records",
+            "description" : "Whether to ignore unexpected records."
+          },
+          "ignoreUnidentifiedRecords" : {
+            "type" : "boolean",
+            "title" : "Ignore Unidentified Records",
+            "description" : "Whether to ignore unidentified records."
+          },
+          "mapping" : {
+            "type" : "string",
+            "title" : "Mapping",
+            "description" : "The BeanIO mapping file. Is by default loaded from the classpath. You can prefix with file:, http:, or classpath: to denote from where to load the mapping file."
+          },
+          "streamName" : {
+            "type" : "string",
+            "title" : "Stream Name",
+            "description" : "The name of the stream to use."
+          },
+          "unmarshalSingleObject" : {
+            "type" : "boolean",
+            "title" : "Unmarshal Single Object",
+            "description" : "This options controls whether to unmarshal as a list of objects or as a single object only. The former is the default mode, and the latter is only intended in special use-cases where beanio maps the Camel message to a single POJO bean."
+          }
+        },
+        "required" : [ "mapping", "streamName" ]
+      },
+      "org.apache.camel.model.dataformat.BindyDataFormat" : {
+        "title" : "Bindy",
+        "description" : "Marshal and unmarshal Java beans from and to flat payloads (such as CSV, delimited, fixed length formats, or FIX messages).",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowEmptyStream" : {
+            "type" : "boolean",
+            "title" : "Allow Empty Stream",
+            "description" : "Whether to allow empty streams in the unmarshal process. If true, no exception will be thrown when a body without records is provided."
+          },
+          "classType" : {
+            "type" : "string",
+            "title" : "Class Type",
+            "description" : "Name of model class to use."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "locale" : {
+            "type" : "string",
+            "title" : "Locale",
+            "description" : "To configure a default locale to use, such as us for united states. To use the JVM platform default locale then use the name default"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Whether to use Csv, Fixed, or KeyValue.",
+            "enum" : [ "Csv", "Fixed", "KeyValue" ]
+          },
+          "unwrapSingleInstance" : {
+            "type" : "boolean",
+            "title" : "Unwrap Single Instance",
+            "description" : "When unmarshalling should a single instance be unwrapped and returned instead of wrapped in a java.util.List."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CBORDataFormat" : {
+        "title" : "CBOR",
+        "description" : "Unmarshal a CBOR payload to POJO and back.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowJmsType" : {
+            "type" : "boolean",
+            "title" : "Allow Jms Type",
+            "description" : "Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to unmarshal to."
+          },
+          "allowUnmarshallType" : {
+            "type" : "boolean",
+            "title" : "Allow Unmarshall Type",
+            "description" : "If enabled then Jackson CBOR is allowed to attempt to use the CamelCBORUnmarshalType header during the unmarshalling. This should only be enabled when desired to be used."
+          },
+          "collectionType" : {
+            "type" : "string",
+            "title" : "Collection Type",
+            "description" : "Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but allows to use different collection types than java.util.Collection based as default."
+          },
+          "disableFeatures" : {
+            "type" : "string",
+            "title" : "Disable Features",
+            "description" : "Set of features to disable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "enableFeatures" : {
+            "type" : "string",
+            "title" : "Enable Features",
+            "description" : "Set of features to enable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "objectMapper" : {
+            "type" : "string",
+            "title" : "Object Mapper",
+            "description" : "Lookup and use the existing CBOR ObjectMapper with the given id when using Jackson."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "To enable pretty printing output nicely formatted. Is by default false."
+          },
+          "unmarshalType" : {
+            "type" : "string",
+            "title" : "Unmarshal Type",
+            "description" : "Class name of the java type to use when unmarshalling"
+          },
+          "useDefaultObjectMapper" : {
+            "type" : "boolean",
+            "title" : "Use Default Object Mapper",
+            "description" : "Whether to lookup and use default Jackson CBOR ObjectMapper from the registry."
+          },
+          "useList" : {
+            "type" : "boolean",
+            "title" : "Use List",
+            "description" : "To unmarshal to a List of Map or a List of Pojo."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CryptoDataFormat" : {
+        "title" : "Crypto (Java Cryptographic Extension)",
+        "description" : "Encrypt and decrypt messages using Java Cryptography Extension (JCE).",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "algorithm" : {
+            "type" : "string",
+            "title" : "Algorithm",
+            "description" : "The JCE algorithm name indicating the cryptographic algorithm that will be used."
+          },
+          "algorithmParameterRef" : {
+            "type" : "string",
+            "title" : "Algorithm Parameter Ref",
+            "description" : "A JCE AlgorithmParameterSpec used to initialize the Cipher. Will lookup the type using the given name as a java.security.spec.AlgorithmParameterSpec type."
+          },
+          "bufferSize" : {
+            "type" : "number",
+            "title" : "Buffer Size",
+            "description" : "The size of the buffer used in the signature process.",
+            "default" : "4096"
+          },
+          "cryptoProvider" : {
+            "type" : "string",
+            "title" : "Crypto Provider",
+            "description" : "The name of the JCE Security Provider that should be used."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "initVectorRef" : {
+            "type" : "string",
+            "title" : "Init Vector Ref",
+            "description" : "Refers to a byte array containing the Initialization Vector that will be used to initialize the Cipher."
+          },
+          "inline" : {
+            "type" : "boolean",
+            "title" : "Inline",
+            "description" : "Flag indicating that the configured IV should be inlined into the encrypted data stream. Is by default false."
+          },
+          "keyRef" : {
+            "type" : "string",
+            "title" : "Key Ref",
+            "description" : "Refers to the secret key to lookup from the register to use."
+          },
+          "macAlgorithm" : {
+            "type" : "string",
+            "title" : "Mac Algorithm",
+            "description" : "The JCE algorithm name indicating the Message Authentication algorithm.",
+            "default" : "HmacSHA1"
+          },
+          "shouldAppendHMAC" : {
+            "type" : "boolean",
+            "title" : "Should Append HMAC",
+            "description" : "Flag indicating that a Message Authentication Code should be calculated and appended to the encrypted data."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CsvDataFormat" : {
+        "title" : "CSV",
+        "description" : "Handle CSV (Comma Separated Values) payloads.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allowMissingColumnNames" : {
+              "type" : "boolean",
+              "title" : "Allow Missing Column Names",
+              "description" : "Whether to allow missing column names."
+            },
+            "captureHeaderRecord" : {
+              "type" : "boolean",
+              "title" : "Capture Header Record",
+              "description" : "Whether the unmarshalling should capture the header record and store it in the message header"
+            },
+            "commentMarker" : {
+              "type" : "string",
+              "title" : "Comment Marker",
+              "description" : "Sets the comment marker of the reference format."
+            },
+            "commentMarkerDisabled" : {
+              "type" : "boolean",
+              "title" : "Comment Marker Disabled",
+              "description" : "Disables the comment marker of the reference format."
+            },
+            "delimiter" : {
+              "type" : "string",
+              "title" : "Delimiter",
+              "description" : "Sets the delimiter to use. The default value is , (comma)"
+            },
+            "escape" : {
+              "type" : "string",
+              "title" : "Escape",
+              "description" : "Sets the escape character to use"
+            },
+            "escapeDisabled" : {
+              "type" : "boolean",
+              "title" : "Escape Disabled",
+              "description" : "Use for disabling using escape character"
+            },
+            "formatName" : {
+              "type" : "string",
+              "title" : "Format Name",
+              "description" : "The name of the format to use, the default value is CSVFormat.DEFAULT",
+              "default" : "DEFAULT",
+              "enum" : [ "DEFAULT", "EXCEL", "INFORMIX_UNLOAD", "INFORMIX_UNLOAD_CSV", "MYSQL", "RFC4180" ]
+            },
+            "formatRef" : {
+              "type" : "string",
+              "title" : "Format Ref",
+              "description" : "The reference format to use, it will be updated with the other format options, the default value is CSVFormat.DEFAULT"
+            },
+            "header" : {
+              "type" : "array",
+              "title" : "Header",
+              "description" : "To configure the CSV headers",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "headerDisabled" : {
+              "type" : "boolean",
+              "title" : "Header Disabled",
+              "description" : "Use for disabling headers"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "ignoreEmptyLines" : {
+              "type" : "boolean",
+              "title" : "Ignore Empty Lines",
+              "description" : "Whether to ignore empty lines."
+            },
+            "ignoreHeaderCase" : {
+              "type" : "boolean",
+              "title" : "Ignore Header Case",
+              "description" : "Sets whether or not to ignore case when accessing header names."
+            },
+            "ignoreSurroundingSpaces" : {
+              "type" : "boolean",
+              "title" : "Ignore Surrounding Spaces",
+              "description" : "Whether to ignore surrounding spaces"
+            },
+            "lazyLoad" : {
+              "type" : "boolean",
+              "title" : "Lazy Load",
+              "description" : "Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must be read at one."
+            },
+            "marshallerFactoryRef" : {
+              "type" : "string",
+              "title" : "Marshaller Factory Ref",
+              "description" : "Sets the implementation of the CsvMarshallerFactory interface which is able to customize marshalling/unmarshalling behavior by extending CsvMarshaller or creating it from scratch."
+            },
+            "nullString" : {
+              "type" : "string",
+              "title" : "Null String",
+              "description" : "Sets the null string"
+            },
+            "nullStringDisabled" : {
+              "type" : "boolean",
+              "title" : "Null String Disabled",
+              "description" : "Used to disable null strings"
+            },
+            "quote" : {
+              "type" : "string",
+              "title" : "Quote",
+              "description" : "Sets the quote to use which by default is double-quote character"
+            },
+            "quoteDisabled" : {
+              "type" : "boolean",
+              "title" : "Quote Disabled",
+              "description" : "Used to disable quotes"
+            },
+            "quoteMode" : {
+              "type" : "string",
+              "title" : "Quote Mode",
+              "description" : "Sets the quote mode",
+              "enum" : [ "ALL", "ALL_NON_NULL", "MINIMAL", "NON_NUMERIC", "NONE" ]
+            },
+            "recordConverterRef" : {
+              "type" : "string",
+              "title" : "Record Converter Ref",
+              "description" : "Refers to a custom CsvRecordConverter to lookup from the registry to use."
+            },
+            "recordSeparator" : {
+              "type" : "string",
+              "title" : "Record Separator",
+              "description" : "Sets the record separator (aka new line) which by default is new line characters (CRLF)"
+            },
+            "recordSeparatorDisabled" : {
+              "type" : "string",
+              "title" : "Record Separator Disabled",
+              "description" : "Used for disabling record separator"
+            },
+            "skipHeaderRecord" : {
+              "type" : "boolean",
+              "title" : "Skip Header Record",
+              "description" : "Whether to skip the header record in the output"
+            },
+            "trailingDelimiter" : {
+              "type" : "boolean",
+              "title" : "Trailing Delimiter",
+              "description" : "Sets whether or not to add a trailing delimiter."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Sets whether or not to trim leading and trailing blanks."
+            },
+            "useMaps" : {
+              "type" : "boolean",
+              "title" : "Use Maps",
+              "description" : "Whether the unmarshalling should produce maps (HashMap)for the lines values instead of lists. It requires to have header (either defined or collected)."
+            },
+            "useOrderedMaps" : {
+              "type" : "boolean",
+              "title" : "Use Ordered Maps",
+              "description" : "Whether the unmarshalling should produce ordered maps (LinkedHashMap) for the lines values instead of lists. It requires to have header (either defined or collected)."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.CustomDataFormat" : {
+        "title" : "Custom",
+        "description" : "Delegate to a custom org.apache.camel.spi.DataFormat implementation via Camel registry.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to the custom org.apache.camel.spi.DataFormat to lookup from the Camel registry."
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.dataformat.DataFormatsDefinition" : {
+        "title" : "Data formats",
+        "description" : "Configure data formats.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "asn1" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+          },
+          "avro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+          },
+          "barcode" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+          },
+          "base64" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+          },
+          "beanio" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+          },
+          "bindy" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+          },
+          "cbor" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+          },
+          "crypto" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "custom" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+          },
+          "fhirJson" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+          },
+          "fhirXml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+          },
+          "flatpack" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+          },
+          "fury" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FuryDataFormat"
+          },
+          "grok" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+          },
+          "gzipDeflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+          },
+          "hl7" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+          },
+          "ical" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+          },
+          "jacksonXml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "jsonApi" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+          },
+          "lzf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+          },
+          "mimeMultipart" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+          },
+          "parquetAvro" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ParquetAvroDataFormat"
+          },
+          "pgp" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "rss" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+          },
+          "smooks" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SmooksDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "swiftMt" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMtDataFormat"
+          },
+          "swiftMx" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMxDataFormat"
+          },
+          "syslog" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+          },
+          "tarFile" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+          },
+          "thrift" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+          },
+          "tidyMarkup" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+          },
+          "univocityCsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+          },
+          "univocityFixed" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+          },
+          "univocityTsv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+          },
+          "xmlSecurity" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          },
+          "zipDeflater" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+          },
+          "zipFile" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FhirJsonDataFormat" : {
+        "title" : "FHIR JSon",
+        "description" : "Marshall and unmarshall FHIR objects to/from JSON.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "contentTypeHeader" : {
+            "type" : "boolean",
+            "title" : "Content Type Header",
+            "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+          },
+          "dontEncodeElements" : {
+            "type" : "string",
+            "title" : "Dont Encode Elements",
+            "description" : "If provided, specifies the elements which should NOT be encoded. Multiple elements can be separated by comma when using String parameter. Valid values for this field would include: Patient - Don't encode patient and all its children Patient.name - Don't encode the patient's name Patient.name.family - Don't encode the patient's family name .text - Don't encode the text element on any resource (only the very first position may contain a wildcard) DSTU2 note: Note that values including meta, such as Patient.meta will work for DSTU2 parsers, but values with subelements on meta such as Patient.meta.lastUpdated will only work in DSTU3 mode."
+          },
+          "dontStripVersionsFromReferencesAtPaths" : {
+            "type" : "string",
+            "title" : "Dont Strip Versions From References At Paths",
+            "description" : "If supplied value(s), any resource references at the specified paths will have their resource versions encoded instead of being automatically stripped during the encoding process. This setting has no effect on the parsing process. Multiple elements can be separated by comma when using String parameter. This method provides a finer-grained level of control than setStripVersionsFromReferences(String) and any paths specified by this method will be encoded even if setStripVersionsFromReferences(String) has been set to true (which is the default)"
+          },
+          "encodeElements" : {
+            "type" : "string",
+            "title" : "Encode Elements",
+            "description" : "If provided, specifies the elements which should be encoded, to the exclusion of all others. Multiple elements can be separated by comma when using String parameter. Valid values for this field would include: Patient - Encode patient and all its children Patient.name - Encode only the patient's name Patient.name.family - Encode only the patient's family name .text - Encode the text element on any resource (only the very first position may contain a wildcard) .(mandatory) - This is a special case which causes any mandatory fields (min 0) to be encoded"
+          },
+          "encodeElementsAppliesToChildResourcesOnly" : {
+            "type" : "boolean",
+            "title" : "Encode Elements Applies To Child Resources Only",
+            "description" : "If set to true (default is false), the values supplied to setEncodeElements(Set) will not be applied to the root resource (typically a Bundle), but will be applied to any sub-resources contained within it (i.e. search result resources in that bundle)"
+          },
+          "fhirContext" : {
+            "type" : "string",
+            "title" : "Fhir Context",
+            "description" : "To use a custom fhir context. Reference to object of type ca.uhn.fhir.context.FhirContext"
+          },
+          "fhirVersion" : {
+            "type" : "string",
+            "title" : "Fhir Version",
+            "description" : "The version of FHIR to use. Possible values are: DSTU2,DSTU2_HL7ORG,DSTU2_1,DSTU3,R4,R5",
+            "default" : "R4",
+            "enum" : [ "DSTU2", "DSTU2_HL7ORG", "DSTU2_1", "DSTU3", "R4", "R5" ]
+          },
+          "forceResourceId" : {
+            "type" : "string",
+            "title" : "Force Resource Id",
+            "description" : "When encoding, force this resource ID to be encoded as the resource ID. Reference to object of type org.hl7.fhir.instance.model.api.IIdType"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "omitResourceId" : {
+            "type" : "boolean",
+            "title" : "Omit Resource Id",
+            "description" : "If set to true (default is false) the ID of any resources being encoded will not be included in the output. Note that this does not apply to contained resources, only to root resources. In other words, if this is set to true, contained resources will still have local IDs but the outer/containing ID will not have an ID."
+          },
+          "overrideResourceIdWithBundleEntryFullUrl" : {
+            "type" : "boolean",
+            "title" : "Override Resource Id With Bundle Entry Full Url",
+            "description" : "If set to true (which is the default), the Bundle.entry.fullUrl will override the Bundle.entry.resource's resource id if the fullUrl is defined. This behavior happens when parsing the source data into a Bundle object. Set this to false if this is not the desired behavior (e.g. the client code wishes to perform additional validation checks between the fullUrl and the resource id)."
+          },
+          "parserErrorHandler" : {
+            "type" : "string",
+            "title" : "Parser Error Handler",
+            "description" : "Registers an error handler which will be invoked when any parse errors are found. Reference to object of type ca.uhn.fhir.parser.IParserErrorHandler"
+          },
+          "parserOptions" : {
+            "type" : "string",
+            "title" : "Parser Options",
+            "description" : "Sets the parser options object which will be used to supply default options to newly created parsers. Reference to object of type ca.uhn.fhir.context.ParserOptions."
+          },
+          "preferTypes" : {
+            "type" : "string",
+            "title" : "Prefer Types",
+            "description" : "If set (FQN class names), when parsing resources the parser will try to use the given types when possible, in the order that they are provided (from highest to lowest priority). For example, if a custom type which declares to implement the Patient resource is passed in here, and the parser is parsing a Bundle containing a Patient resource, the parser will use the given custom type. Multiple class names can be separated by comma."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "Sets the pretty print flag, meaning that the parser will encode resources with human-readable spacing and newlines between elements instead of condensing output as much as possible."
+          },
+          "serverBaseUrl" : {
+            "type" : "string",
+            "title" : "Server Base Url",
+            "description" : "Sets the server's base URL used by this parser. If a value is set, resource references will be turned into relative references if they are provided as absolute URLs but have a base matching the given base."
+          },
+          "stripVersionsFromReferences" : {
+            "type" : "boolean",
+            "title" : "Strip Versions From References",
+            "description" : "If set to true (which is the default), resource references containing a version will have the version removed when the resource is encoded. This is generally good behaviour because in most situations, references from one resource to another should be to the resource by ID, not by ID and version. In some cases though, it may be desirable to preserve the version in resource links. In that case, this value should be set to false. This method provides the ability to globally disable reference encoding. If finer-grained control is needed, use setDontStripVersionsFromReferencesAtPaths(List)"
+          },
+          "summaryMode" : {
+            "type" : "boolean",
+            "title" : "Summary Mode",
+            "description" : "If set to true (default is false) only elements marked by the FHIR specification as being summary elements will be included."
+          },
+          "suppressNarratives" : {
+            "type" : "boolean",
+            "title" : "Suppress Narratives",
+            "description" : "If set to true (default is false), narratives will not be included in the encoded values."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FhirXmlDataFormat" : {
+        "title" : "FHIR XML",
+        "description" : "Marshall and unmarshall FHIR objects to/from XML.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "contentTypeHeader" : {
+            "type" : "boolean",
+            "title" : "Content Type Header",
+            "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+          },
+          "dontEncodeElements" : {
+            "type" : "string",
+            "title" : "Dont Encode Elements",
+            "description" : "If provided, specifies the elements which should NOT be encoded. Multiple elements can be separated by comma when using String parameter. Valid values for this field would include: Patient - Don't encode patient and all its children Patient.name - Don't encode the patient's name Patient.name.family - Don't encode the patient's family name .text - Don't encode the text element on any resource (only the very first position may contain a wildcard) DSTU2 note: Note that values including meta, such as Patient.meta will work for DSTU2 parsers, but values with subelements on meta such as Patient.meta.lastUpdated will only work in DSTU3 mode."
+          },
+          "dontStripVersionsFromReferencesAtPaths" : {
+            "type" : "string",
+            "title" : "Dont Strip Versions From References At Paths",
+            "description" : "If supplied value(s), any resource references at the specified paths will have their resource versions encoded instead of being automatically stripped during the encoding process. This setting has no effect on the parsing process. Multiple elements can be separated by comma when using String parameter. This method provides a finer-grained level of control than setStripVersionsFromReferences(String) and any paths specified by this method will be encoded even if setStripVersionsFromReferences(String) has been set to true (which is the default)"
+          },
+          "encodeElements" : {
+            "type" : "string",
+            "title" : "Encode Elements",
+            "description" : "If provided, specifies the elements which should be encoded, to the exclusion of all others. Multiple elements can be separated by comma when using String parameter. Valid values for this field would include: Patient - Encode patient and all its children Patient.name - Encode only the patient's name Patient.name.family - Encode only the patient's family name .text - Encode the text element on any resource (only the very first position may contain a wildcard) .(mandatory) - This is a special case which causes any mandatory fields (min 0) to be encoded"
+          },
+          "encodeElementsAppliesToChildResourcesOnly" : {
+            "type" : "boolean",
+            "title" : "Encode Elements Applies To Child Resources Only",
+            "description" : "If set to true (default is false), the values supplied to setEncodeElements(Set) will not be applied to the root resource (typically a Bundle), but will be applied to any sub-resources contained within it (i.e. search result resources in that bundle)"
+          },
+          "fhirContext" : {
+            "type" : "string",
+            "title" : "Fhir Context",
+            "description" : "To use a custom fhir context. Reference to object of type ca.uhn.fhir.context.FhirContext"
+          },
+          "fhirVersion" : {
+            "type" : "string",
+            "title" : "Fhir Version",
+            "description" : "The version of FHIR to use. Possible values are: DSTU2,DSTU2_HL7ORG,DSTU2_1,DSTU3,R4,R5",
+            "default" : "R4",
+            "enum" : [ "DSTU2", "DSTU2_HL7ORG", "DSTU2_1", "DSTU3", "R4", "R5" ]
+          },
+          "forceResourceId" : {
+            "type" : "string",
+            "title" : "Force Resource Id",
+            "description" : "When encoding, force this resource ID to be encoded as the resource ID. Reference to object of type org.hl7.fhir.instance.model.api.IIdType"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "omitResourceId" : {
+            "type" : "boolean",
+            "title" : "Omit Resource Id",
+            "description" : "If set to true (default is false) the ID of any resources being encoded will not be included in the output. Note that this does not apply to contained resources, only to root resources. In other words, if this is set to true, contained resources will still have local IDs but the outer/containing ID will not have an ID."
+          },
+          "overrideResourceIdWithBundleEntryFullUrl" : {
+            "type" : "boolean",
+            "title" : "Override Resource Id With Bundle Entry Full Url",
+            "description" : "If set to true (which is the default), the Bundle.entry.fullUrl will override the Bundle.entry.resource's resource id if the fullUrl is defined. This behavior happens when parsing the source data into a Bundle object. Set this to false if this is not the desired behavior (e.g. the client code wishes to perform additional validation checks between the fullUrl and the resource id)."
+          },
+          "parserErrorHandler" : {
+            "type" : "string",
+            "title" : "Parser Error Handler",
+            "description" : "Registers an error handler which will be invoked when any parse errors are found. Reference to object of type ca.uhn.fhir.parser.IParserErrorHandler"
+          },
+          "parserOptions" : {
+            "type" : "string",
+            "title" : "Parser Options",
+            "description" : "Sets the parser options object which will be used to supply default options to newly created parsers. Reference to object of type ca.uhn.fhir.context.ParserOptions."
+          },
+          "preferTypes" : {
+            "type" : "string",
+            "title" : "Prefer Types",
+            "description" : "If set (FQN class names), when parsing resources the parser will try to use the given types when possible, in the order that they are provided (from highest to lowest priority). For example, if a custom type which declares to implement the Patient resource is passed in here, and the parser is parsing a Bundle containing a Patient resource, the parser will use the given custom type. Multiple class names can be separated by comma."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "Sets the pretty print flag, meaning that the parser will encode resources with human-readable spacing and newlines between elements instead of condensing output as much as possible."
+          },
+          "serverBaseUrl" : {
+            "type" : "string",
+            "title" : "Server Base Url",
+            "description" : "Sets the server's base URL used by this parser. If a value is set, resource references will be turned into relative references if they are provided as absolute URLs but have a base matching the given base."
+          },
+          "stripVersionsFromReferences" : {
+            "type" : "boolean",
+            "title" : "Strip Versions From References",
+            "description" : "If set to true (which is the default), resource references containing a version will have the version removed when the resource is encoded. This is generally good behaviour because in most situations, references from one resource to another should be to the resource by ID, not by ID and version. In some cases though, it may be desirable to preserve the version in resource links. In that case, this value should be set to false. This method provides the ability to globally disable reference encoding. If finer-grained control is needed, use setDontStripVersionsFromReferencesAtPaths(List)"
+          },
+          "summaryMode" : {
+            "type" : "boolean",
+            "title" : "Summary Mode",
+            "description" : "If set to true (default is false) only elements marked by the FHIR specification as being summary elements will be included."
+          },
+          "suppressNarratives" : {
+            "type" : "boolean",
+            "title" : "Suppress Narratives",
+            "description" : "If set to true (default is false), narratives will not be included in the encoded values."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FlatpackDataFormat" : {
+        "title" : "Flatpack",
+        "description" : "Marshal and unmarshal Java lists and maps to/from flat files (such as CSV, delimited, or fixed length formats) using Flatpack library.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowShortLines" : {
+            "type" : "boolean",
+            "title" : "Allow Short Lines",
+            "description" : "Allows for lines to be shorter than expected and ignores the extra characters"
+          },
+          "definition" : {
+            "type" : "string",
+            "title" : "Definition",
+            "description" : "The flatpack pzmap configuration file. Can be omitted in simpler situations, but its preferred to use the pzmap."
+          },
+          "delimiter" : {
+            "type" : "string",
+            "title" : "Delimiter",
+            "description" : "The delimiter char (could be ; , or similar)",
+            "default" : ","
+          },
+          "fixed" : {
+            "type" : "boolean",
+            "title" : "Fixed",
+            "description" : "Delimited or fixed. Is by default false = delimited"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreExtraColumns" : {
+            "type" : "boolean",
+            "title" : "Ignore Extra Columns",
+            "description" : "Allows for lines to be longer than expected and ignores the extra characters."
+          },
+          "ignoreFirstRecord" : {
+            "type" : "boolean",
+            "title" : "Ignore First Record",
+            "description" : "Whether the first line is ignored for delimited files (for the column headers). Is by default true."
+          },
+          "parserFactoryRef" : {
+            "type" : "string",
+            "title" : "Parser Factory Ref",
+            "description" : "References to a custom parser factory to lookup in the registry"
+          },
+          "textQualifier" : {
+            "type" : "string",
+            "title" : "Text Qualifier",
+            "description" : "If the text is qualified with a character. Uses quote character by default."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.FuryDataFormat" : {
+        "title" : "Fury",
+        "description" : "Serialize and deserialize messages using Apache Fury",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowAutoWiredFury" : {
+            "type" : "boolean",
+            "title" : "Allow Auto Wired Fury",
+            "description" : "Whether to auto-discover Fury from the registry"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "requireClassRegistration" : {
+            "type" : "boolean",
+            "title" : "Require Class Registration",
+            "description" : "Whether to require register classes"
+          },
+          "threadSafe" : {
+            "type" : "boolean",
+            "title" : "Thread Safe",
+            "description" : "Whether to use the threadsafe fury"
+          },
+          "unmarshalType" : {
+            "type" : "string",
+            "title" : "Unmarshal Type",
+            "description" : "Class of the java type to use when unmarshalling"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.GrokDataFormat" : {
+        "title" : "Grok",
+        "description" : "Unmarshal unstructured data to objects using Logstash based Grok patterns.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowMultipleMatchesPerLine" : {
+            "type" : "boolean",
+            "title" : "Allow Multiple Matches Per Line",
+            "description" : "If false, every line of input is matched for pattern only once. Otherwise the line can be scanned multiple times when non-terminal pattern is used."
+          },
+          "flattened" : {
+            "type" : "boolean",
+            "title" : "Flattened",
+            "description" : "Turns on flattened mode. In flattened mode the exception is thrown when there are multiple pattern matches with same key."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "namedOnly" : {
+            "type" : "boolean",
+            "title" : "Named Only",
+            "description" : "Whether to capture named expressions only or not (i.e. %{IP:ip} but not ${IP})"
+          },
+          "pattern" : {
+            "type" : "string",
+            "title" : "Pattern",
+            "description" : "The grok pattern to match lines of input"
+          }
+        },
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.dataformat.GzipDeflaterDataFormat" : {
+        "title" : "GZip Deflater",
+        "description" : "Compress and decompress messages using java.util.zip.GZIPStream.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.HL7DataFormat" : {
+        "title" : "HL7",
+        "description" : "Marshal and unmarshal HL7 (Health Care) model objects using the HL7 MLLP codec.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "validate" : {
+            "type" : "boolean",
+            "title" : "Validate",
+            "description" : "Whether to validate the HL7 message Is by default true."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.IcalDataFormat" : {
+        "title" : "iCal",
+        "description" : "Marshal and unmarshal iCal (.ics) documents to/from model objects.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "validating" : {
+            "type" : "boolean",
+            "title" : "Validating",
+            "description" : "Whether to validate."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JacksonXMLDataFormat" : {
+        "title" : "Jackson XML",
+        "description" : "Unmarshal an XML payloads to POJOs and back using XMLMapper extension of Jackson.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowJmsType" : {
+            "type" : "boolean",
+            "title" : "Allow Jms Type",
+            "description" : "Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to unmarshal to."
+          },
+          "allowUnmarshallType" : {
+            "type" : "boolean",
+            "title" : "Allow Unmarshall Type",
+            "description" : "If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the unmarshalling. This should only be enabled when desired to be used."
+          },
+          "collectionType" : {
+            "type" : "string",
+            "title" : "Collection Type",
+            "description" : "Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but allows to use different collection types than java.util.Collection based as default."
+          },
+          "contentTypeHeader" : {
+            "type" : "boolean",
+            "title" : "Content Type Header",
+            "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+          },
+          "disableFeatures" : {
+            "type" : "string",
+            "title" : "Disable Features",
+            "description" : "Set of features to disable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "enableFeatures" : {
+            "type" : "string",
+            "title" : "Enable Features",
+            "description" : "Set of features to enable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "enableJaxbAnnotationModule" : {
+            "type" : "boolean",
+            "title" : "Enable Jaxb Annotation Module",
+            "description" : "Whether to enable the JAXB annotations module when using jackson. When enabled then JAXB annotations can be used by Jackson."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "include" : {
+            "type" : "string",
+            "title" : "Include",
+            "description" : "If you want to marshal a pojo to JSON, and the pojo has some fields with null values. And you want to skip these null values, you can set this option to NON_NULL"
+          },
+          "jsonView" : {
+            "type" : "string",
+            "title" : "Json View",
+            "description" : "When marshalling a POJO to JSON you might want to exclude certain fields from the JSON output. With Jackson you can use JSON views to accomplish this. This option is to refer to the class which has JsonView annotations"
+          },
+          "moduleClassNames" : {
+            "type" : "string",
+            "title" : "Module Class Names",
+            "description" : "To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as a String with FQN class names. Multiple classes can be separated by comma."
+          },
+          "moduleRefs" : {
+            "type" : "string",
+            "title" : "Module Refs",
+            "description" : "To use custom Jackson modules referred from the Camel registry. Multiple modules can be separated by comma."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "To enable pretty printing output nicely formatted. Is by default false."
+          },
+          "timezone" : {
+            "type" : "string",
+            "title" : "Timezone",
+            "description" : "If set then Jackson will use the Timezone when marshalling/unmarshalling."
+          },
+          "unmarshalType" : {
+            "type" : "string",
+            "title" : "Unmarshal Type",
+            "description" : "Class name of the java type to use when unmarshalling"
+          },
+          "useList" : {
+            "type" : "boolean",
+            "title" : "Use List",
+            "description" : "To unmarshal to a List of Map or a List of Pojo."
+          },
+          "xmlMapper" : {
+            "type" : "string",
+            "title" : "Xml Mapper",
+            "description" : "Lookup and use the existing XmlMapper with the given id."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JaxbDataFormat" : {
+        "title" : "JAXB",
+        "description" : "Unmarshal XML payloads to POJOs and back using JAXB2 XML marshalling standard.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "accessExternalSchemaProtocols" : {
+            "type" : "string",
+            "title" : "Access External Schema Protocols",
+            "description" : "Only in use if schema validation has been enabled. Restrict access to the protocols specified for external reference set by the schemaLocation attribute, Import and Include element. Examples of protocols are file, http, jar:file. false or none to deny all access to external references; a specific protocol, such as file, to give permission to only the protocol; the keyword all to grant permission to all protocols.",
+            "default" : "false"
+          },
+          "contentTypeHeader" : {
+            "type" : "boolean",
+            "title" : "Content Type Header",
+            "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+          },
+          "contextPath" : {
+            "type" : "string",
+            "title" : "Context Path",
+            "description" : "Package name where your JAXB classes are located."
+          },
+          "contextPathIsClassName" : {
+            "type" : "boolean",
+            "title" : "Context Path Is Class Name",
+            "description" : "This can be set to true to mark that the contextPath is referring to a classname and not a package name."
+          },
+          "encoding" : {
+            "type" : "string",
+            "title" : "Encoding",
+            "description" : "To overrule and use a specific encoding"
+          },
+          "filterNonXmlChars" : {
+            "type" : "boolean",
+            "title" : "Filter Non Xml Chars",
+            "description" : "To ignore non xml characheters and replace them with an empty space."
+          },
+          "fragment" : {
+            "type" : "boolean",
+            "title" : "Fragment",
+            "description" : "To turn on marshalling XML fragment trees. By default JAXB looks for XmlRootElement annotation on given class to operate on whole XML tree. This is useful but not always - sometimes generated code does not have XmlRootElement annotation, sometimes you need unmarshall only part of tree. In that case you can use partial unmarshalling. To enable this behaviours you need set property partClass. Camel will pass this class to JAXB's unmarshaler."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreJAXBElement" : {
+            "type" : "boolean",
+            "title" : "Ignore JAXBElement",
+            "description" : "Whether to ignore JAXBElement elements - only needed to be set to false in very special use-cases."
+          },
+          "jaxbProviderProperties" : {
+            "type" : "string",
+            "title" : "Jaxb Provider Properties",
+            "description" : "Refers to a custom java.util.Map to lookup in the registry containing custom JAXB provider properties to be used with the JAXB marshaller."
+          },
+          "mustBeJAXBElement" : {
+            "type" : "boolean",
+            "title" : "Must Be JAXBElement",
+            "description" : "Whether marhsalling must be java objects with JAXB annotations. And if not then it fails. This option can be set to false to relax that, such as when the data is already in XML format."
+          },
+          "namespacePrefixRef" : {
+            "type" : "string",
+            "title" : "Namespace Prefix Ref",
+            "description" : "When marshalling using JAXB or SOAP then the JAXB implementation will automatic assign namespace prefixes, such as ns2, ns3, ns4 etc. To control this mapping, Camel allows you to refer to a map which contains the desired mapping."
+          },
+          "noNamespaceSchemaLocation" : {
+            "type" : "string",
+            "title" : "No Namespace Schema Location",
+            "description" : "To define the location of the namespaceless schema"
+          },
+          "objectFactory" : {
+            "type" : "boolean",
+            "title" : "Object Factory",
+            "description" : "Whether to allow using ObjectFactory classes to create the POJO classes during marshalling. This only applies to POJO classes that has not been annotated with JAXB and providing jaxb.index descriptor files."
+          },
+          "partClass" : {
+            "type" : "string",
+            "title" : "Part Class",
+            "description" : "Name of class used for fragment parsing. See more details at the fragment option."
+          },
+          "partNamespace" : {
+            "type" : "string",
+            "title" : "Part Namespace",
+            "description" : "XML namespace to use for fragment parsing. See more details at the fragment option."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "To enable pretty printing output nicely formatted. Is by default false."
+          },
+          "schema" : {
+            "type" : "string",
+            "title" : "Schema",
+            "description" : "To validate against an existing schema. Your can use the prefix classpath:, file: or http: to specify how the resource should be resolved. You can separate multiple schema files by using the ',' character."
+          },
+          "schemaLocation" : {
+            "type" : "string",
+            "title" : "Schema Location",
+            "description" : "To define the location of the schema"
+          },
+          "schemaSeverityLevel" : {
+            "type" : "string",
+            "title" : "Schema Severity Level",
+            "description" : "Sets the schema severity level to use when validating against a schema. This level determines the minimum severity error that triggers JAXB to stop continue parsing. The default value of 0 (warning) means that any error (warning, error or fatal error) will trigger JAXB to stop. There are the following three levels: 0=warning, 1=error, 2=fatal error.",
+            "default" : "0",
+            "enum" : [ "0", "1", "2" ]
+          },
+          "xmlStreamWriterWrapper" : {
+            "type" : "string",
+            "title" : "Xml Stream Writer Wrapper",
+            "description" : "To use a custom xml stream writer."
+          }
+        },
+        "required" : [ "contextPath" ]
+      },
+      "org.apache.camel.model.dataformat.JsonApiDataFormat" : {
+        "title" : "JSonApi",
+        "description" : "Marshal and unmarshal JSON:API resources using JSONAPI-Converter library.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "dataFormatTypes" : {
+            "type" : "string",
+            "title" : "Data Format Types",
+            "description" : "The classes to take into account for the marshalling. Multiple classes can be separated by comma."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "mainFormatType" : {
+            "type" : "string",
+            "title" : "Main Format Type",
+            "description" : "The class to take into account while unmarshalling."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JsonDataFormat" : {
+        "title" : "JSon",
+        "description" : "Marshal POJOs to JSON and back.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowJmsType" : {
+            "type" : "boolean",
+            "title" : "Allow Jms Type",
+            "description" : "Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to unmarshal to."
+          },
+          "allowUnmarshallType" : {
+            "type" : "boolean",
+            "title" : "Allow Unmarshall Type",
+            "description" : "If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the unmarshalling. This should only be enabled when desired to be used."
+          },
+          "autoDiscoverObjectMapper" : {
+            "type" : "boolean",
+            "title" : "Auto Discover Object Mapper",
+            "description" : "If set to true then Jackson will look for an objectMapper to use from the registry"
+          },
+          "autoDiscoverSchemaResolver" : {
+            "type" : "boolean",
+            "title" : "Auto Discover Schema Resolver",
+            "description" : "When not disabled, the SchemaResolver will be looked up into the registry"
+          },
+          "collectionType" : {
+            "type" : "string",
+            "title" : "Collection Type",
+            "description" : "Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but allows using different collection types than java.util.Collection based as default."
+          },
+          "combineUnicodeSurrogates" : {
+            "type" : "boolean",
+            "title" : "Combine Unicode Surrogates",
+            "description" : "Force generator that outputs JSON content to combine surrogate pairs (if any) into 4-byte characters. This should be preferred when using 4-byte characters such as Japanese."
+          },
+          "contentTypeHeader" : {
+            "type" : "boolean",
+            "title" : "Content Type Header",
+            "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+          },
+          "dateFormatPattern" : {
+            "type" : "string",
+            "title" : "Date Format Pattern",
+            "description" : "To configure the date format while marshall or unmarshall Date fields in JSON using Gson"
+          },
+          "disableFeatures" : {
+            "type" : "string",
+            "title" : "Disable Features",
+            "description" : "Set of features to disable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "enableFeatures" : {
+            "type" : "string",
+            "title" : "Enable Features",
+            "description" : "Set of features to enable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "include" : {
+            "type" : "string",
+            "title" : "Include",
+            "description" : "If you want to marshal a pojo to JSON, and the pojo has some fields with null values. And you want to skip these null values, you can set this option to NON_NULL"
+          },
+          "jsonView" : {
+            "type" : "string",
+            "title" : "Json View",
+            "description" : "When marshalling a POJO to JSON you might want to exclude certain fields from the JSON output. With Jackson you can use JSON views to accomplish this. This option is to refer to the class which has JsonView annotations"
+          },
+          "library" : {
+            "type" : "string",
+            "title" : "Library",
+            "description" : "Which json library to use.",
+            "default" : "Jackson",
+            "enum" : [ "Fastjson", "Gson", "Jackson", "Johnzon", "Jsonb" ]
+          },
+          "moduleClassNames" : {
+            "type" : "string",
+            "title" : "Module Class Names",
+            "description" : "To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as a String with FQN class names. Multiple classes can be separated by comma."
+          },
+          "moduleRefs" : {
+            "type" : "string",
+            "title" : "Module Refs",
+            "description" : "To use custom Jackson modules referred from the Camel registry. Multiple modules can be separated by comma."
+          },
+          "namingStrategy" : {
+            "type" : "string",
+            "title" : "Naming Strategy",
+            "description" : "If set then Jackson will use the the defined Property Naming Strategy.Possible values are: LOWER_CAMEL_CASE, LOWER_DOT_CASE, LOWER_CASE, KEBAB_CASE, SNAKE_CASE and UPPER_CAMEL_CASE"
+          },
+          "objectMapper" : {
+            "type" : "string",
+            "title" : "Object Mapper",
+            "description" : "Lookup and use the existing ObjectMapper with the given id when using Jackson."
+          },
+          "prettyPrint" : {
+            "type" : "boolean",
+            "title" : "Pretty Print",
+            "description" : "To enable pretty printing output nicely formatted. Is by default false."
+          },
+          "schemaResolver" : {
+            "type" : "string",
+            "title" : "Schema Resolver",
+            "description" : "Optional schema resolver used to lookup schemas for the data in transit."
+          },
+          "timezone" : {
+            "type" : "string",
+            "title" : "Timezone",
+            "description" : "If set then Jackson will use the Timezone when marshalling/unmarshalling. This option will have no effect on the others Json DataFormat, like gson and fastjson."
+          },
+          "unmarshalType" : {
+            "type" : "string",
+            "title" : "Unmarshal Type",
+            "description" : "Class name of the java type to use when unmarshalling"
+          },
+          "useDefaultObjectMapper" : {
+            "type" : "boolean",
+            "title" : "Use Default Object Mapper",
+            "description" : "Whether to lookup and use default Jackson ObjectMapper from the registry."
+          },
+          "useList" : {
+            "type" : "boolean",
+            "title" : "Use List",
+            "description" : "To unmarshal to a List of Map or a List of Pojo."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.LZFDataFormat" : {
+        "title" : "LZF Deflate Compression",
+        "description" : "Compress and decompress streams using LZF deflate algorithm.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "usingParallelCompression" : {
+            "type" : "boolean",
+            "title" : "Using Parallel Compression",
+            "description" : "Enable encoding (compress) using multiple processing cores."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.MimeMultipartDataFormat" : {
+        "title" : "MIME Multipart",
+        "description" : "Marshal Camel messages with attachments into MIME-Multipart messages and back.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "binaryContent" : {
+            "type" : "boolean",
+            "title" : "Binary Content",
+            "description" : "Defines whether the content of binary parts in the MIME multipart is binary (true) or Base-64 encoded (false) Default is false."
+          },
+          "headersInline" : {
+            "type" : "boolean",
+            "title" : "Headers Inline",
+            "description" : "Defines whether the MIME-Multipart headers are part of the message body (true) or are set as Camel headers (false). Default is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "includeHeaders" : {
+            "type" : "string",
+            "title" : "Include Headers",
+            "description" : "A regex that defines which Camel headers are also included as MIME headers into the MIME multipart. This will only work if headersInline is set to true. Default is to include no headers"
+          },
+          "multipartSubType" : {
+            "type" : "string",
+            "title" : "Multipart Sub Type",
+            "description" : "Specify the subtype of the MIME Multipart. Default is mixed.",
+            "default" : "mixed"
+          },
+          "multipartWithoutAttachment" : {
+            "type" : "boolean",
+            "title" : "Multipart Without Attachment",
+            "description" : "Defines whether a message without attachment is also marshaled into a MIME Multipart (with only one body part). Default is false."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.PGPDataFormat" : {
+        "title" : "PGP",
+        "description" : "Encrypt and decrypt messages using Java Cryptographic Extension (JCE) and PGP.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "algorithm" : {
+            "type" : "number",
+            "title" : "Algorithm",
+            "description" : "Symmetric key encryption algorithm; possible values are defined in org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags; for example 2 (= TRIPLE DES), 3 (= CAST5), 4 (= BLOWFISH), 6 (= DES), 7 (= AES_128). Only relevant for encrypting."
+          },
+          "armored" : {
+            "type" : "boolean",
+            "title" : "Armored",
+            "description" : "This option will cause PGP to base64 encode the encrypted text, making it available for copy/paste, etc."
+          },
+          "compressionAlgorithm" : {
+            "type" : "number",
+            "title" : "Compression Algorithm",
+            "description" : "Compression algorithm; possible values are defined in org.bouncycastle.bcpg.CompressionAlgorithmTags; for example 0 (= UNCOMPRESSED), 1 (= ZIP), 2 (= ZLIB), 3 (= BZIP2). Only relevant for encrypting."
+          },
+          "hashAlgorithm" : {
+            "type" : "number",
+            "title" : "Hash Algorithm",
+            "description" : "Signature hash algorithm; possible values are defined in org.bouncycastle.bcpg.HashAlgorithmTags; for example 2 (= SHA1), 8 (= SHA256), 9 (= SHA384), 10 (= SHA512), 11 (=SHA224). Only relevant for signing."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "integrity" : {
+            "type" : "boolean",
+            "title" : "Integrity",
+            "description" : "Adds an integrity check/sign into the encryption file. The default value is true."
+          },
+          "keyFileName" : {
+            "type" : "string",
+            "title" : "Key File Name",
+            "description" : "Filename of the keyring; must be accessible as a classpath resource (but you can specify a location in the file system by using the file: prefix)."
+          },
+          "keyUserid" : {
+            "type" : "string",
+            "title" : "Key Userid",
+            "description" : "The user ID of the key in the PGP keyring used during encryption. Can also be only a part of a user ID. For example, if the user ID is Test User then you can use the part Test User or to address the user ID."
+          },
+          "password" : {
+            "type" : "string",
+            "title" : "Password",
+            "description" : "Password used when opening the private key (not used for encryption)."
+          },
+          "provider" : {
+            "type" : "string",
+            "title" : "Provider",
+            "description" : "Java Cryptography Extension (JCE) provider, default is Bouncy Castle (BC). Alternatively you can use, for example, the IAIK JCE provider; in this case the provider must be registered beforehand and the Bouncy Castle provider must not be registered beforehand. The Sun JCE provider does not work."
+          },
+          "signatureKeyFileName" : {
+            "type" : "string",
+            "title" : "Signature Key File Name",
+            "description" : "Filename of the keyring to use for signing (during encryption) or for signature verification (during decryption); must be accessible as a classpath resource (but you can specify a location in the file system by using the file: prefix)."
+          },
+          "signatureKeyRing" : {
+            "type" : "string",
+            "title" : "Signature Key Ring",
+            "description" : "Keyring used for signing/verifying as byte array. You can not set the signatureKeyFileName and signatureKeyRing at the same time."
+          },
+          "signatureKeyUserid" : {
+            "type" : "string",
+            "title" : "Signature Key Userid",
+            "description" : "User ID of the key in the PGP keyring used for signing (during encryption) or signature verification (during decryption). During the signature verification process the specified User ID restricts the public keys from the public keyring which can be used for the verification. If no User ID is specified for the signature verficiation then any public key in the public keyring can be used for the verification. Can also be only a part of a user ID. For example, if the user ID is Test User then you can use the part Test User or to address the User ID."
+          },
+          "signaturePassword" : {
+            "type" : "string",
+            "title" : "Signature Password",
+            "description" : "Password used when opening the private key used for signing (during encryption)."
+          },
+          "signatureVerificationOption" : {
+            "type" : "string",
+            "title" : "Signature Verification Option",
+            "description" : "Controls the behavior for verifying the signature during unmarshaling. There are 4 values possible: optional: The PGP message may or may not contain signatures; if it does contain signatures, then a signature verification is executed. required: The PGP message must contain at least one signature; if this is not the case an exception (PGPException) is thrown. A signature verification is executed. ignore: Contained signatures in the PGP message are ignored; no signature verification is executed. no_signature_allowed: The PGP message must not contain a signature; otherwise an exception (PGPException) is thrown."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ParquetAvroDataFormat" : {
+        "title" : "Parquet File",
+        "description" : "Parquet Avro serialization and de-serialization.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "compressionCodecName" : {
+              "type" : "string",
+              "title" : "Compression Codec Name",
+              "description" : "Compression codec to use when marshalling.",
+              "default" : "GZIP",
+              "enum" : [ "UNCOMPRESSED", "SNAPPY", "GZIP", "LZO", "BROTLI", "LZ4", "ZSTD", "LZ4_RAW" ]
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "lazyLoad" : {
+              "type" : "boolean",
+              "title" : "Lazy Load",
+              "description" : "Whether the unmarshalling should produce an iterator of records or read all the records at once."
+            },
+            "unmarshalType" : {
+              "type" : "string",
+              "title" : "Unmarshal Type",
+              "description" : "Class to use when (un)marshalling. If omitted, parquet files are converted into Avro's GenericRecords for unmarshalling and input objects are assumed as GenericRecords for marshalling."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.ProtobufDataFormat" : {
+        "title" : "Protobuf",
+        "description" : "Serialize and deserialize Java objects using Google's Protocol buffers.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allowJmsType" : {
+              "type" : "boolean",
+              "title" : "Allow Jms Type",
+              "description" : "Used for JMS users to allow the JMSType header from the JMS spec to specify a FQN classname to use to unmarshal to."
+            },
+            "allowUnmarshallType" : {
+              "type" : "boolean",
+              "title" : "Allow Unmarshall Type",
+              "description" : "If enabled then Jackson is allowed to attempt to use the CamelJacksonUnmarshalType header during the unmarshalling. This should only be enabled when desired to be used."
+            },
+            "autoDiscoverObjectMapper" : {
+              "type" : "boolean",
+              "title" : "Auto Discover Object Mapper",
+              "description" : "If set to true then Jackson will lookup for an objectMapper into the registry"
+            },
+            "autoDiscoverSchemaResolver" : {
+              "type" : "boolean",
+              "title" : "Auto Discover Schema Resolver",
+              "description" : "When not disabled, the SchemaResolver will be looked up into the registry"
+            },
+            "collectionType" : {
+              "type" : "string",
+              "title" : "Collection Type",
+              "description" : "Refers to a custom collection type to lookup in the registry to use. This option should rarely be used, but allows to use different collection types than java.util.Collection based as default."
+            },
+            "contentTypeFormat" : {
+              "type" : "string",
+              "title" : "Content Type Format",
+              "description" : "Defines a content type format in which protobuf message will be serialized/deserialized from(to) the Java been. The format can either be native or json for either native protobuf or json fields representation. The default value is native.",
+              "default" : "native",
+              "enum" : [ "native", "json" ]
+            },
+            "contentTypeHeader" : {
+              "type" : "boolean",
+              "title" : "Content Type Header",
+              "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+            },
+            "disableFeatures" : {
+              "type" : "string",
+              "title" : "Disable Features",
+              "description" : "Set of features to disable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+            },
+            "enableFeatures" : {
+              "type" : "string",
+              "title" : "Enable Features",
+              "description" : "Set of features to enable on the Jackson com.fasterxml.jackson.databind.ObjectMapper. The features should be a name that matches a enum from com.fasterxml.jackson.databind.SerializationFeature, com.fasterxml.jackson.databind.DeserializationFeature, or com.fasterxml.jackson.databind.MapperFeature Multiple features can be separated by comma"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "include" : {
+              "type" : "string",
+              "title" : "Include",
+              "description" : "If you want to marshal a pojo to JSON, and the pojo has some fields with null values. And you want to skip these null values, you can set this option to NON_NULL"
+            },
+            "instanceClass" : {
+              "type" : "string",
+              "title" : "Instance Class",
+              "description" : "Name of class to use when unmarshalling"
+            },
+            "jsonView" : {
+              "type" : "string",
+              "title" : "Json View",
+              "description" : "When marshalling a POJO to JSON you might want to exclude certain fields from the JSON output. With Jackson you can use JSON views to accomplish this. This option is to refer to the class which has JsonView annotations"
+            },
+            "library" : {
+              "type" : "string",
+              "title" : "Library",
+              "description" : "Which Protobuf library to use.",
+              "default" : "GoogleProtobuf",
+              "enum" : [ "GoogleProtobuf", "Jackson" ]
+            },
+            "moduleClassNames" : {
+              "type" : "string",
+              "title" : "Module Class Names",
+              "description" : "To use custom Jackson modules com.fasterxml.jackson.databind.Module specified as a String with FQN class names. Multiple classes can be separated by comma."
+            },
+            "moduleRefs" : {
+              "type" : "string",
+              "title" : "Module Refs",
+              "description" : "To use custom Jackson modules referred from the Camel registry. Multiple modules can be separated by comma."
+            },
+            "objectMapper" : {
+              "type" : "string",
+              "title" : "Object Mapper",
+              "description" : "Lookup and use the existing ObjectMapper with the given id when using Jackson."
+            },
+            "schemaResolver" : {
+              "type" : "string",
+              "title" : "Schema Resolver",
+              "description" : "Optional schema resolver used to lookup schemas for the data in transit."
+            },
+            "timezone" : {
+              "type" : "string",
+              "title" : "Timezone",
+              "description" : "If set then Jackson will use the Timezone when marshalling/unmarshalling."
+            },
+            "unmarshalType" : {
+              "type" : "string",
+              "title" : "Unmarshal Type",
+              "description" : "Class name of the java type to use when unmarshalling"
+            },
+            "useDefaultObjectMapper" : {
+              "type" : "boolean",
+              "title" : "Use Default Object Mapper",
+              "description" : "Whether to lookup and use default Jackson ObjectMapper from the registry."
+            },
+            "useList" : {
+              "type" : "boolean",
+              "title" : "Use List",
+              "description" : "To unmarshal to a List of Map or a List of Pojo."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.RssDataFormat" : {
+        "title" : "RSS",
+        "description" : "Transform from ROME SyndFeed Java Objects to XML and vice-versa.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.SmooksDataFormat" : {
+        "title" : "Smooks",
+        "description" : "Transform and bind XML as well as non-XML data, including EDI, CSV, JSON, and YAML using Smooks.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "smooksConfig" : {
+            "type" : "string",
+            "title" : "Smooks Config",
+            "description" : "Path to the Smooks configuration file."
+          }
+        },
+        "required" : [ "smooksConfig" ]
+      },
+      "org.apache.camel.model.dataformat.SoapDataFormat" : {
+        "title" : "SOAP",
+        "description" : "Marshal Java objects to SOAP messages and back.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "contextPath" : {
+              "type" : "string",
+              "title" : "Context Path",
+              "description" : "Package name where your JAXB classes are located."
+            },
+            "elementNameStrategyRef" : {
+              "type" : "string",
+              "title" : "Element Name Strategy Ref",
+              "description" : "Refers to an element strategy to lookup from the registry. An element name strategy is used for two purposes. The first is to find a xml element name for a given object and soap action when marshaling the object into a SOAP message. The second is to find an Exception class for a given soap fault name. The following three element strategy class name is provided out of the box. QNameStrategy - Uses a fixed qName that is configured on instantiation. Exception lookup is not supported TypeNameStrategy - Uses the name and namespace from the XMLType annotation of the given type. If no namespace is set then package-info is used. Exception lookup is not supported ServiceInterfaceStrategy - Uses information from a webservice interface to determine the type name and to find the exception class for a SOAP fault All three classes is located in the package name org.apache.camel.dataformat.soap.name If you have generated the web service stub code with cxf-codegen or a similar tool then you probably will want to use the ServiceInterfaceStrategy. In the case you have no annotated service interface you should use QNameStrategy or TypeNameStrategy."
+            },
+            "encoding" : {
+              "type" : "string",
+              "title" : "Encoding",
+              "description" : "To overrule and use a specific encoding"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "namespacePrefixRef" : {
+              "type" : "string",
+              "title" : "Namespace Prefix Ref",
+              "description" : "When marshalling using JAXB or SOAP then the JAXB implementation will automatic assign namespace prefixes, such as ns2, ns3, ns4 etc. To control this mapping, Camel allows you to refer to a map which contains the desired mapping."
+            },
+            "schema" : {
+              "type" : "string",
+              "title" : "Schema",
+              "description" : "To validate against an existing schema. Your can use the prefix classpath:, file: or http: to specify how the resource should be resolved. You can separate multiple schema files by using the ',' character."
+            },
+            "version" : {
+              "type" : "string",
+              "title" : "Version",
+              "description" : "SOAP version should either be 1.1 or 1.2. Is by default 1.1",
+              "default" : "1.1",
+              "enum" : [ "1.1", "1.2" ]
+            }
+          }
+        } ],
+        "required" : [ "contextPath" ]
+      },
+      "org.apache.camel.model.dataformat.SwiftMtDataFormat" : {
+        "title" : "SWIFT MT",
+        "description" : "Encode and decode SWIFT MT messages.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "writeInJson" : {
+              "type" : "boolean",
+              "title" : "Write In Json",
+              "description" : "The flag indicating that messages must be marshalled in a JSON format."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.SwiftMxDataFormat" : {
+        "title" : "SWIFT MX",
+        "description" : "Encode and decode SWIFT MX messages.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "readConfigRef" : {
+            "type" : "string",
+            "title" : "Read Config Ref",
+            "description" : "Refers to a specific configuration to use when unmarshalling an input stream to lookup from the registry."
+          },
+          "readMessageId" : {
+            "type" : "string",
+            "title" : "Read Message Id",
+            "description" : "The type of MX message to produce when unmarshalling an input stream. If not set, it will be automatically detected from the namespace used."
+          },
+          "writeConfigRef" : {
+            "type" : "string",
+            "title" : "Write Config Ref",
+            "description" : "Refers to a specific configuration to use when marshalling a message to lookup from the registry."
+          },
+          "writeInJson" : {
+            "type" : "boolean",
+            "title" : "Write In Json",
+            "description" : "The flag indicating that messages must be marshalled in a JSON format."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.SyslogDataFormat" : {
+        "title" : "Syslog",
+        "description" : "Marshall SyslogMessages to RFC3164 and RFC5424 messages and back.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.TarFileDataFormat" : {
+        "title" : "Tar File",
+        "description" : "Archive files into tarballs or extract files from tarballs.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowEmptyDirectory" : {
+            "type" : "boolean",
+            "title" : "Allow Empty Directory",
+            "description" : "If the tar file has more than one entry, setting this option to true, allows to get the iterator even if the directory is empty"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxDecompressedSize" : {
+            "type" : "number",
+            "title" : "Max Decompressed Size",
+            "description" : "Set the maximum decompressed size of a tar file (in bytes). The default value if not specified corresponds to 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable setting a maximum decompressed size.",
+            "default" : "1073741824"
+          },
+          "preservePathElements" : {
+            "type" : "boolean",
+            "title" : "Preserve Path Elements",
+            "description" : "If the file name contains path elements, setting this option to true, allows the path to be maintained in the tar file."
+          },
+          "usingIterator" : {
+            "type" : "boolean",
+            "title" : "Using Iterator",
+            "description" : "If the tar file has more than one entry, the setting this option to true, allows working with the splitter EIP, to split the data using an iterator in a streaming mode."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ThriftDataFormat" : {
+        "title" : "Thrift",
+        "description" : "Serialize and deserialize messages using Apache Thrift binary data format.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "contentTypeFormat" : {
+              "type" : "string",
+              "title" : "Content Type Format",
+              "description" : "Defines a content type format in which thrift message will be serialized/deserialized from(to) the Java been. The format can either be native or json for either native binary thrift, json or simple json fields representation. The default value is binary.",
+              "default" : "binary",
+              "enum" : [ "binary", "json", "sjson" ]
+            },
+            "contentTypeHeader" : {
+              "type" : "boolean",
+              "title" : "Content Type Header",
+              "description" : "Whether the data format should set the Content-Type header with the type from the data format. For example application/xml for data formats marshalling to XML, or application/json for data formats marshalling to JSON"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "instanceClass" : {
+              "type" : "string",
+              "title" : "Instance Class",
+              "description" : "Name of class to use when unmarshalling"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.TidyMarkupDataFormat" : {
+        "title" : "TidyMarkup",
+        "description" : "Parse (potentially invalid) HTML into valid HTML or DOM.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "dataObjectType" : {
+            "type" : "string",
+            "title" : "Data Object Type",
+            "description" : "What data type to unmarshal as, can either be org.w3c.dom.Node or java.lang.String. Is by default org.w3c.dom.Node",
+            "default" : "org.w3c.dom.Node",
+            "enum" : [ "org.w3c.dom.Node", "java.lang.String" ]
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "omitXmlDeclaration" : {
+            "type" : "boolean",
+            "title" : "Omit Xml Declaration",
+            "description" : "When returning a String, do we omit the XML declaration in the top."
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityCsvDataFormat" : {
+        "title" : "uniVocity CSV",
+        "description" : "Marshal and unmarshal Java objects from and to CSV (Comma Separated Values) using UniVocity Parsers.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "asMap" : {
+            "type" : "boolean",
+            "title" : "As Map",
+            "description" : "Whether the unmarshalling should produce maps for the lines values instead of lists. It requires to have header (either defined or collected). The default value is false"
+          },
+          "comment" : {
+            "type" : "string",
+            "title" : "Comment",
+            "description" : "The comment symbol. The default value is #",
+            "default" : "#"
+          },
+          "delimiter" : {
+            "type" : "string",
+            "title" : "Delimiter",
+            "description" : "The delimiter of values",
+            "default" : ","
+          },
+          "emptyValue" : {
+            "type" : "string",
+            "title" : "Empty Value",
+            "description" : "The String representation of an empty value."
+          },
+          "headerExtractionEnabled" : {
+            "type" : "boolean",
+            "title" : "Header Extraction Enabled",
+            "description" : "Whether or not the header must be read in the first line of the test document. The default value is false"
+          },
+          "headersDisabled" : {
+            "type" : "boolean",
+            "title" : "Headers Disabled",
+            "description" : "Whether or not the headers are disabled. When defined, this option explicitly sets the headers as null which indicates that there is no header. The default value is false"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreLeadingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Leading Whitespaces",
+            "description" : "Whether or not the leading white spaces must be ignored. The default value is true"
+          },
+          "ignoreTrailingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Trailing Whitespaces",
+            "description" : "Whether or not the trailing white spaces must be ignored. The default value is true"
+          },
+          "lazyLoad" : {
+            "type" : "boolean",
+            "title" : "Lazy Load",
+            "description" : "Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must be read at once. The default value is false"
+          },
+          "lineSeparator" : {
+            "type" : "string",
+            "title" : "Line Separator",
+            "description" : "The line separator of the files. The default value is to use the JVM platform line separator"
+          },
+          "normalizedLineSeparator" : {
+            "type" : "string",
+            "title" : "Normalized Line Separator",
+            "description" : "The normalized line separator of the files. The default value is a new line character."
+          },
+          "nullValue" : {
+            "type" : "string",
+            "title" : "Null Value",
+            "description" : "The string representation of a null value. The default value is null"
+          },
+          "numberOfRecordsToRead" : {
+            "type" : "number",
+            "title" : "Number Of Records To Read",
+            "description" : "The maximum number of record to read."
+          },
+          "quote" : {
+            "type" : "string",
+            "title" : "Quote",
+            "description" : "The quote symbol.",
+            "default" : "\""
+          },
+          "quoteAllFields" : {
+            "type" : "boolean",
+            "title" : "Quote All Fields",
+            "description" : "Whether or not all values must be quoted when writing them."
+          },
+          "quoteEscape" : {
+            "type" : "string",
+            "title" : "Quote Escape",
+            "description" : "The quote escape symbol",
+            "default" : "\""
+          },
+          "skipEmptyLines" : {
+            "type" : "boolean",
+            "title" : "Skip Empty Lines",
+            "description" : "Whether or not the empty lines must be ignored. The default value is true"
+          },
+          "univocityHeader" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityFixedDataFormat" : {
+        "title" : "uniVocity Fixed Length",
+        "description" : "Marshal and unmarshal Java objects from and to fixed length records using UniVocity Parsers.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "asMap" : {
+            "type" : "boolean",
+            "title" : "As Map",
+            "description" : "Whether the unmarshalling should produce maps for the lines values instead of lists. It requires to have header (either defined or collected). The default value is false"
+          },
+          "comment" : {
+            "type" : "string",
+            "title" : "Comment",
+            "description" : "The comment symbol. The default value is #",
+            "default" : "#"
+          },
+          "emptyValue" : {
+            "type" : "string",
+            "title" : "Empty Value",
+            "description" : "The String representation of an empty value."
+          },
+          "headerExtractionEnabled" : {
+            "type" : "boolean",
+            "title" : "Header Extraction Enabled",
+            "description" : "Whether or not the header must be read in the first line of the test document. The default value is false"
+          },
+          "headersDisabled" : {
+            "type" : "boolean",
+            "title" : "Headers Disabled",
+            "description" : "Whether or not the headers are disabled. When defined, this option explicitly sets the headers as null which indicates that there is no header. The default value is false"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreLeadingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Leading Whitespaces",
+            "description" : "Whether or not the leading white spaces must be ignored. The default value is true"
+          },
+          "ignoreTrailingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Trailing Whitespaces",
+            "description" : "Whether or not the trailing white spaces must be ignored. The default value is true"
+          },
+          "lazyLoad" : {
+            "type" : "boolean",
+            "title" : "Lazy Load",
+            "description" : "Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must be read at once. The default value is false"
+          },
+          "lineSeparator" : {
+            "type" : "string",
+            "title" : "Line Separator",
+            "description" : "The line separator of the files. The default value is to use the JVM platform line separator"
+          },
+          "normalizedLineSeparator" : {
+            "type" : "string",
+            "title" : "Normalized Line Separator",
+            "description" : "The normalized line separator of the files. The default value is a new line character."
+          },
+          "nullValue" : {
+            "type" : "string",
+            "title" : "Null Value",
+            "description" : "The string representation of a null value. The default value is null"
+          },
+          "numberOfRecordsToRead" : {
+            "type" : "number",
+            "title" : "Number Of Records To Read",
+            "description" : "The maximum number of record to read."
+          },
+          "padding" : {
+            "type" : "string",
+            "title" : "Padding",
+            "description" : "The padding character. The default value is a space"
+          },
+          "recordEndsOnNewline" : {
+            "type" : "boolean",
+            "title" : "Record Ends On Newline",
+            "description" : "Whether or not the record ends on new line. The default value is false"
+          },
+          "skipEmptyLines" : {
+            "type" : "boolean",
+            "title" : "Skip Empty Lines",
+            "description" : "Whether or not the empty lines must be ignored. The default value is true"
+          },
+          "skipTrailingCharsUntilNewline" : {
+            "type" : "boolean",
+            "title" : "Skip Trailing Chars Until Newline",
+            "description" : "Whether or not the trailing characters until new line must be ignored. The default value is false"
+          },
+          "univocityHeader" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityHeader" : {
+        "title" : "uniVocity Header",
+        "description" : "To configure headers for UniVocity data formats.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "length" : {
+            "type" : "string",
+            "title" : "Length",
+            "description" : "Header length"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Header name"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.UniVocityTsvDataFormat" : {
+        "title" : "uniVocity TSV",
+        "description" : "Marshal and unmarshal Java objects from and to TSV (Tab-Separated Values) records using UniVocity Parsers.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "asMap" : {
+            "type" : "boolean",
+            "title" : "As Map",
+            "description" : "Whether the unmarshalling should produce maps for the lines values instead of lists. It requires to have header (either defined or collected). The default value is false"
+          },
+          "comment" : {
+            "type" : "string",
+            "title" : "Comment",
+            "description" : "The comment symbol. The default value is #",
+            "default" : "#"
+          },
+          "emptyValue" : {
+            "type" : "string",
+            "title" : "Empty Value",
+            "description" : "The String representation of an empty value."
+          },
+          "escapeChar" : {
+            "type" : "string",
+            "title" : "Escape Char",
+            "description" : "The escape character.",
+            "default" : "\\"
+          },
+          "headerExtractionEnabled" : {
+            "type" : "boolean",
+            "title" : "Header Extraction Enabled",
+            "description" : "Whether or not the header must be read in the first line of the test document. The default value is false"
+          },
+          "headersDisabled" : {
+            "type" : "boolean",
+            "title" : "Headers Disabled",
+            "description" : "Whether or not the headers are disabled. When defined, this option explicitly sets the headers as null which indicates that there is no header. The default value is false"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "ignoreLeadingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Leading Whitespaces",
+            "description" : "Whether or not the leading white spaces must be ignored. The default value is true"
+          },
+          "ignoreTrailingWhitespaces" : {
+            "type" : "boolean",
+            "title" : "Ignore Trailing Whitespaces",
+            "description" : "Whether or not the trailing white spaces must be ignored. The default value is true"
+          },
+          "lazyLoad" : {
+            "type" : "boolean",
+            "title" : "Lazy Load",
+            "description" : "Whether the unmarshalling should produce an iterator that reads the lines on the fly or if all the lines must be read at once. The default value is false"
+          },
+          "lineSeparator" : {
+            "type" : "string",
+            "title" : "Line Separator",
+            "description" : "The line separator of the files. The default value is to use the JVM platform line separator"
+          },
+          "normalizedLineSeparator" : {
+            "type" : "string",
+            "title" : "Normalized Line Separator",
+            "description" : "The normalized line separator of the files. The default value is a new line character."
+          },
+          "nullValue" : {
+            "type" : "string",
+            "title" : "Null Value",
+            "description" : "The string representation of a null value. The default value is null"
+          },
+          "numberOfRecordsToRead" : {
+            "type" : "number",
+            "title" : "Number Of Records To Read",
+            "description" : "The maximum number of record to read."
+          },
+          "skipEmptyLines" : {
+            "type" : "boolean",
+            "title" : "Skip Empty Lines",
+            "description" : "Whether or not the empty lines must be ignored. The default value is true"
+          },
+          "univocityHeader" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityHeader"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.XMLSecurityDataFormat" : {
+        "title" : "XML Security",
+        "description" : "Encrypt and decrypt XML payloads using Apache Santuario.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "addKeyValueForEncryptedKey" : {
+            "type" : "boolean",
+            "title" : "Add Key Value For Encrypted Key",
+            "description" : "Whether to add the public key used to encrypt the session key as a KeyValue in the EncryptedKey structure or not."
+          },
+          "digestAlgorithm" : {
+            "type" : "string",
+            "title" : "Digest Algorithm",
+            "description" : "The digest algorithm to use with the RSA OAEP algorithm. The available choices are: XMLCipher.SHA1 XMLCipher.SHA256 XMLCipher.SHA512 The default value is XMLCipher.SHA1",
+            "default" : "SHA1",
+            "enum" : [ "SHA1", "SHA256", "SHA512" ]
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "keyCipherAlgorithm" : {
+            "type" : "string",
+            "title" : "Key Cipher Algorithm",
+            "description" : "The cipher algorithm to be used for encryption/decryption of the asymmetric key. The available choices are: XMLCipher.RSA_v1dot5 XMLCipher.RSA_OAEP XMLCipher.RSA_OAEP_11 The default value is XMLCipher.RSA_OAEP",
+            "default" : "RSA_OAEP",
+            "enum" : [ "RSA_v1dot5", "RSA_OAEP", "RSA_OAEP_11" ]
+          },
+          "keyOrTrustStoreParametersRef" : {
+            "type" : "string",
+            "title" : "Key Or Trust Store Parameters Ref",
+            "description" : "Refers to a KeyStore instance to lookup in the registry, which is used for configuration options for creating and loading a KeyStore instance that represents the sender's trustStore or recipient's keyStore."
+          },
+          "keyPassword" : {
+            "type" : "string",
+            "title" : "Key Password",
+            "description" : "The password to be used for retrieving the private key from the KeyStore. This key is used for asymmetric decryption."
+          },
+          "mgfAlgorithm" : {
+            "type" : "string",
+            "title" : "Mgf Algorithm",
+            "description" : "The MGF Algorithm to use with the RSA OAEP algorithm. The available choices are: EncryptionConstants.MGF1_SHA1 EncryptionConstants.MGF1_SHA256 EncryptionConstants.MGF1_SHA512 The default value is EncryptionConstants.MGF1_SHA1",
+            "default" : "MGF1_SHA1",
+            "enum" : [ "MGF1_SHA1", "MGF1_SHA256", "MGF1_SHA512" ]
+          },
+          "passPhrase" : {
+            "type" : "string",
+            "title" : "Pass Phrase",
+            "description" : "A String used as passPhrase to encrypt/decrypt content. The passPhrase has to be provided. The passPhrase needs to be put together in conjunction with the appropriate encryption algorithm. For example using TRIPLEDES the passPhase can be a Only another 24 Byte key"
+          },
+          "passPhraseByte" : {
+            "type" : "string",
+            "title" : "Pass Phrase Byte",
+            "description" : "A byte used as passPhrase to encrypt/decrypt content. The passPhrase has to be provided. The passPhrase needs to be put together in conjunction with the appropriate encryption algorithm. For example using TRIPLEDES the passPhase can be a Only another 24 Byte key",
+            "format" : "binary"
+          },
+          "recipientKeyAlias" : {
+            "type" : "string",
+            "title" : "Recipient Key Alias",
+            "description" : "The key alias to be used when retrieving the recipient's public or private key from a KeyStore when performing asymmetric key encryption or decryption."
+          },
+          "secureTag" : {
+            "type" : "string",
+            "title" : "Secure Tag",
+            "description" : "The XPath reference to the XML Element selected for encryption/decryption. If no tag is specified, the entire payload is encrypted/decrypted."
+          },
+          "secureTagContents" : {
+            "type" : "boolean",
+            "title" : "Secure Tag Contents",
+            "description" : "A boolean value to specify whether the XML Element is to be encrypted or the contents of the XML Element. false = Element Level. true = Element Content Level."
+          },
+          "xmlCipherAlgorithm" : {
+            "type" : "string",
+            "title" : "Xml Cipher Algorithm",
+            "description" : "The cipher algorithm to be used for encryption/decryption of the XML message content. The available choices are: XMLCipher.TRIPLEDES XMLCipher.AES_128 XMLCipher.AES_128_GCM XMLCipher.AES_192 XMLCipher.AES_192_GCM XMLCipher.AES_256 XMLCipher.AES_256_GCM XMLCipher.SEED_128 XMLCipher.CAMELLIA_128 XMLCipher.CAMELLIA_192 XMLCipher.CAMELLIA_256 The default value is XMLCipher.AES_256_GCM",
+            "default" : "AES-256-GCM",
+            "enum" : [ "TRIPLEDES", "AES_128", "AES_128_GCM", "AES_192", "AES_192_GCM", "AES_256", "AES_256_GCM", "SEED_128", "CAMELLIA_128", "CAMELLIA_192", "CAMELLIA_256" ]
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.YAMLDataFormat" : {
+        "title" : "YAML",
+        "description" : "Marshal and unmarshal Java objects to and from YAML.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowAnyType" : {
+            "type" : "boolean",
+            "title" : "Allow Any Type",
+            "description" : "Allow any class to be un-marshaled"
+          },
+          "allowRecursiveKeys" : {
+            "type" : "boolean",
+            "title" : "Allow Recursive Keys",
+            "description" : "Set whether recursive keys are allowed."
+          },
+          "constructor" : {
+            "type" : "string",
+            "title" : "Constructor",
+            "description" : "BaseConstructor to construct incoming documents."
+          },
+          "dumperOptions" : {
+            "type" : "string",
+            "title" : "Dumper Options",
+            "description" : "DumperOptions to configure outgoing objects."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "library" : {
+            "type" : "string",
+            "title" : "Library",
+            "description" : "Which yaml library to use. By default it is SnakeYAML",
+            "default" : "SnakeYAML",
+            "enum" : [ "SnakeYAML" ]
+          },
+          "maxAliasesForCollections" : {
+            "type" : "number",
+            "title" : "Max Aliases For Collections",
+            "description" : "Set the maximum amount of aliases allowed for collections.",
+            "default" : "50"
+          },
+          "prettyFlow" : {
+            "type" : "boolean",
+            "title" : "Pretty Flow",
+            "description" : "Force the emitter to produce a pretty YAML document when using the flow style."
+          },
+          "representer" : {
+            "type" : "string",
+            "title" : "Representer",
+            "description" : "Representer to emit outgoing objects."
+          },
+          "resolver" : {
+            "type" : "string",
+            "title" : "Resolver",
+            "description" : "Resolver to detect implicit type"
+          },
+          "typeFilter" : {
+            "type" : "array",
+            "title" : "Type Filter",
+            "description" : "Set the types SnakeYAML is allowed to un-marshall",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLTypeFilterDefinition"
+            }
+          },
+          "unmarshalType" : {
+            "type" : "string",
+            "title" : "Unmarshal Type",
+            "description" : "Class name of the java type to use when unmarshalling"
+          },
+          "useApplicationContextClassLoader" : {
+            "type" : "boolean",
+            "title" : "Use Application Context Class Loader",
+            "description" : "Use ApplicationContextClassLoader as custom ClassLoader"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.YAMLTypeFilterDefinition" : {
+        "title" : "YAML Type Filter",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Whether to filter by class type or regular expression"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "Value of type such as class name or regular expression"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ZipDeflaterDataFormat" : {
+        "title" : "Zip Deflater",
+        "description" : "Compress and decompress streams using java.util.zip.Deflater and java.util.zip.Inflater.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "compressionLevel" : {
+            "type" : "string",
+            "title" : "Compression Level",
+            "description" : "To specify a specific compression between 0-9. -1 is default compression, 0 is no compression, and 9 is the best compression.",
+            "default" : "-1",
+            "enum" : [ "-1", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" ]
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ZipFileDataFormat" : {
+        "title" : "Zip File",
+        "description" : "Compression and decompress streams using java.util.zip.ZipStream.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowEmptyDirectory" : {
+            "type" : "boolean",
+            "title" : "Allow Empty Directory",
+            "description" : "If the zip file has more than one entry, setting this option to true, allows to get the iterator even if the directory is empty"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxDecompressedSize" : {
+            "type" : "number",
+            "title" : "Max Decompressed Size",
+            "description" : "Set the maximum decompressed size of a zip file (in bytes). The default value if not specified corresponds to 1 gigabyte. An IOException will be thrown if the decompressed size exceeds this amount. Set to -1 to disable setting a maximum decompressed size.",
+            "default" : "1073741824"
+          },
+          "preservePathElements" : {
+            "type" : "boolean",
+            "title" : "Preserve Path Elements",
+            "description" : "If the file name contains path elements, setting this option to true, allows the path to be maintained in the zip file."
+          },
+          "usingIterator" : {
+            "type" : "boolean",
+            "title" : "Using Iterator",
+            "description" : "If the zip file has more than one entry, the setting this option to true, allows working with the splitter EIP, to split the data using an iterator in a streaming mode."
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.DeadLetterChannelDefinition" : {
+        "title" : "Dead Letter Channel",
+        "description" : "Error handler with dead letter queue.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "deadLetterHandleNewException" : {
+            "type" : "boolean",
+            "title" : "Dead Letter Handle New Exception",
+            "description" : "Whether the dead letter channel should handle (and ignore) any new exception that may been thrown during sending the message to the dead letter endpoint. The default value is true which means any such kind of exception is handled and ignored. Set this to false to let the exception be propagated back on the org.apache.camel.Exchange . This can be used in situations where you use transactions, and want to use Camel's dead letter channel to deal with exceptions during routing, but if the dead letter channel itself fails because of a new exception being thrown, then by setting this to false the new exceptions is propagated back and set on the org.apache.camel.Exchange , which allows the transaction to detect the exception, and rollback."
+          },
+          "deadLetterUri" : {
+            "type" : "string",
+            "title" : "Dead Letter Uri",
+            "description" : "The dead letter endpoint uri for the Dead Letter error handler."
+          },
+          "executorServiceRef" : {
+            "type" : "string",
+            "title" : "Executor Service Ref",
+            "description" : "Sets a reference to a thread pool to be used by the error handler"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "level" : {
+            "type" : "string",
+            "title" : "Level",
+            "description" : "Logging level to use by error handler",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "logName" : {
+            "type" : "string",
+            "title" : "Log Name",
+            "description" : "Name of the logger to use by the error handler"
+          },
+          "loggerRef" : {
+            "type" : "string",
+            "title" : "Logger Ref",
+            "description" : "References to a logger to use as logger for the error handler"
+          },
+          "onExceptionOccurredRef" : {
+            "type" : "string",
+            "title" : "On Exception Occurred Ref",
+            "description" : "Sets a reference to a processor that should be processed just after an exception occurred. Can be used to perform custom logging about the occurred exception at the exact time it happened. Important: Any exception thrown from this processor will be ignored."
+          },
+          "onPrepareFailureRef" : {
+            "type" : "string",
+            "title" : "On Prepare Failure Ref",
+            "description" : "Sets a reference to a processor to prepare the org.apache.camel.Exchange before handled by the failure processor / dead letter channel. This allows for example to enrich the message before sending to a dead letter queue."
+          },
+          "onRedeliveryRef" : {
+            "type" : "string",
+            "title" : "On Redelivery Ref",
+            "description" : "Sets a reference to a processor that should be processed before a redelivery attempt. Can be used to change the org.apache.camel.Exchange before its being redelivered."
+          },
+          "redeliveryPolicy" : {
+            "title" : "Redelivery Policy",
+            "description" : "Sets the redelivery settings",
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redeliveryPolicyRef" : {
+            "type" : "string",
+            "title" : "Redelivery Policy Ref",
+            "description" : "Sets a reference to a RedeliveryPolicy to be used for redelivery settings."
+          },
+          "retryWhileRef" : {
+            "type" : "string",
+            "title" : "Retry While Ref",
+            "description" : "Sets a retry while predicate. Will continue retrying until the predicate evaluates to false."
+          },
+          "useOriginalBody" : {
+            "type" : "boolean",
+            "title" : "Use Original Body",
+            "description" : "Will use the original input org.apache.camel.Message body (original body only) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input org.apache.camel.Message (original body and headers) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        },
+        "required" : [ "deadLetterUri" ]
+      },
+      "org.apache.camel.model.errorhandler.DefaultErrorHandlerDefinition" : {
+        "title" : "Default Error Handler",
+        "description" : "The default error handler.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "executorServiceRef" : {
+            "type" : "string",
+            "title" : "Executor Service Ref",
+            "description" : "Sets a reference to a thread pool to be used by the error handler"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "level" : {
+            "type" : "string",
+            "title" : "Level",
+            "description" : "Logging level to use by error handler",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "logName" : {
+            "type" : "string",
+            "title" : "Log Name",
+            "description" : "Name of the logger to use by the error handler"
+          },
+          "loggerRef" : {
+            "type" : "string",
+            "title" : "Logger Ref",
+            "description" : "References to a logger to use as logger for the error handler"
+          },
+          "onExceptionOccurredRef" : {
+            "type" : "string",
+            "title" : "On Exception Occurred Ref",
+            "description" : "Sets a reference to a processor that should be processed just after an exception occurred. Can be used to perform custom logging about the occurred exception at the exact time it happened. Important: Any exception thrown from this processor will be ignored."
+          },
+          "onPrepareFailureRef" : {
+            "type" : "string",
+            "title" : "On Prepare Failure Ref",
+            "description" : "Sets a reference to a processor to prepare the org.apache.camel.Exchange before handled by the failure processor / dead letter channel. This allows for example to enrich the message before sending to a dead letter queue."
+          },
+          "onRedeliveryRef" : {
+            "type" : "string",
+            "title" : "On Redelivery Ref",
+            "description" : "Sets a reference to a processor that should be processed before a redelivery attempt. Can be used to change the org.apache.camel.Exchange before its being redelivered."
+          },
+          "redeliveryPolicy" : {
+            "title" : "Redelivery Policy",
+            "description" : "Sets the redelivery settings",
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redeliveryPolicyRef" : {
+            "type" : "string",
+            "title" : "Redelivery Policy Ref",
+            "description" : "Sets a reference to a RedeliveryPolicy to be used for redelivery settings."
+          },
+          "retryWhileRef" : {
+            "type" : "string",
+            "title" : "Retry While Ref",
+            "description" : "Sets a retry while predicate. Will continue retrying until the predicate evaluates to false."
+          },
+          "useOriginalBody" : {
+            "type" : "boolean",
+            "title" : "Use Original Body",
+            "description" : "Will use the original input org.apache.camel.Message body (original body only) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input org.apache.camel.Message (original body and headers) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.JtaTransactionErrorHandlerDefinition" : {
+        "title" : "Jta Transaction Error Handler",
+        "description" : "JTA based transactional error handler (requires camel-jta).",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "executorServiceRef" : {
+            "type" : "string",
+            "title" : "Executor Service Ref",
+            "description" : "Sets a reference to a thread pool to be used by the error handler"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "level" : {
+            "type" : "string",
+            "title" : "Level",
+            "description" : "Logging level to use by error handler",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "logName" : {
+            "type" : "string",
+            "title" : "Log Name",
+            "description" : "Name of the logger to use by the error handler"
+          },
+          "loggerRef" : {
+            "type" : "string",
+            "title" : "Logger Ref",
+            "description" : "References to a logger to use as logger for the error handler"
+          },
+          "onExceptionOccurredRef" : {
+            "type" : "string",
+            "title" : "On Exception Occurred Ref",
+            "description" : "Sets a reference to a processor that should be processed just after an exception occurred. Can be used to perform custom logging about the occurred exception at the exact time it happened. Important: Any exception thrown from this processor will be ignored."
+          },
+          "onPrepareFailureRef" : {
+            "type" : "string",
+            "title" : "On Prepare Failure Ref",
+            "description" : "Sets a reference to a processor to prepare the org.apache.camel.Exchange before handled by the failure processor / dead letter channel. This allows for example to enrich the message before sending to a dead letter queue."
+          },
+          "onRedeliveryRef" : {
+            "type" : "string",
+            "title" : "On Redelivery Ref",
+            "description" : "Sets a reference to a processor that should be processed before a redelivery attempt. Can be used to change the org.apache.camel.Exchange before its being redelivered."
+          },
+          "redeliveryPolicy" : {
+            "title" : "Redelivery Policy",
+            "description" : "Sets the redelivery settings",
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redeliveryPolicyRef" : {
+            "type" : "string",
+            "title" : "Redelivery Policy Ref",
+            "description" : "Sets a reference to a RedeliveryPolicy to be used for redelivery settings."
+          },
+          "retryWhileRef" : {
+            "type" : "string",
+            "title" : "Retry While Ref",
+            "description" : "Sets a retry while predicate. Will continue retrying until the predicate evaluates to false."
+          },
+          "rollbackLoggingLevel" : {
+            "type" : "string",
+            "title" : "Rollback Logging Level",
+            "description" : "Sets the logging level to use for logging transactional rollback. This option is default WARN.",
+            "default" : "WARN",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "transactedPolicyRef" : {
+            "type" : "string",
+            "title" : "Transacted Policy Ref",
+            "description" : "The transacted policy to use that is configured for either Spring or JTA based transactions. If no policy has been configured then Camel will attempt to auto-discover."
+          },
+          "useOriginalBody" : {
+            "type" : "boolean",
+            "title" : "Use Original Body",
+            "description" : "Will use the original input org.apache.camel.Message body (original body only) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input org.apache.camel.Message (original body and headers) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.NoErrorHandlerDefinition" : {
+        "title" : "No Error Handler",
+        "description" : "To not use an error handler.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.errorhandler.RefErrorHandlerDefinition" : {
+        "title" : "Ref Error Handler",
+        "description" : "References to an existing or custom error handler.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "References to an existing or custom error handler."
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.errorhandler.SpringTransactionErrorHandlerDefinition" : {
+        "title" : "Spring Transaction Error Handler",
+        "description" : "Spring based transactional error handler (requires camel-spring).",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "executorServiceRef" : {
+            "type" : "string",
+            "title" : "Executor Service Ref",
+            "description" : "Sets a reference to a thread pool to be used by the error handler"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "level" : {
+            "type" : "string",
+            "title" : "Level",
+            "description" : "Logging level to use by error handler",
+            "default" : "ERROR",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "logName" : {
+            "type" : "string",
+            "title" : "Log Name",
+            "description" : "Name of the logger to use by the error handler"
+          },
+          "loggerRef" : {
+            "type" : "string",
+            "title" : "Logger Ref",
+            "description" : "References to a logger to use as logger for the error handler"
+          },
+          "onExceptionOccurredRef" : {
+            "type" : "string",
+            "title" : "On Exception Occurred Ref",
+            "description" : "Sets a reference to a processor that should be processed just after an exception occurred. Can be used to perform custom logging about the occurred exception at the exact time it happened. Important: Any exception thrown from this processor will be ignored."
+          },
+          "onPrepareFailureRef" : {
+            "type" : "string",
+            "title" : "On Prepare Failure Ref",
+            "description" : "Sets a reference to a processor to prepare the org.apache.camel.Exchange before handled by the failure processor / dead letter channel. This allows for example to enrich the message before sending to a dead letter queue."
+          },
+          "onRedeliveryRef" : {
+            "type" : "string",
+            "title" : "On Redelivery Ref",
+            "description" : "Sets a reference to a processor that should be processed before a redelivery attempt. Can be used to change the org.apache.camel.Exchange before its being redelivered."
+          },
+          "redeliveryPolicy" : {
+            "title" : "Redelivery Policy",
+            "description" : "Sets the redelivery settings",
+            "$ref" : "#/items/definitions/org.apache.camel.model.RedeliveryPolicyDefinition"
+          },
+          "redeliveryPolicyRef" : {
+            "type" : "string",
+            "title" : "Redelivery Policy Ref",
+            "description" : "Sets a reference to a RedeliveryPolicy to be used for redelivery settings."
+          },
+          "retryWhileRef" : {
+            "type" : "string",
+            "title" : "Retry While Ref",
+            "description" : "Sets a retry while predicate. Will continue retrying until the predicate evaluates to false."
+          },
+          "rollbackLoggingLevel" : {
+            "type" : "string",
+            "title" : "Rollback Logging Level",
+            "description" : "Sets the logging level to use for logging transactional rollback. This option is default WARN.",
+            "default" : "WARN",
+            "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+          },
+          "transactedPolicyRef" : {
+            "type" : "string",
+            "title" : "Transacted Policy Ref",
+            "description" : "The transacted policy to use that is configured for either Spring or JTA based transactions. If no policy has been configured then Camel will attempt to auto-discover."
+          },
+          "useOriginalBody" : {
+            "type" : "boolean",
+            "title" : "Use Original Body",
+            "description" : "Will use the original input org.apache.camel.Message body (original body only) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          },
+          "useOriginalMessage" : {
+            "type" : "boolean",
+            "title" : "Use Original Message",
+            "description" : "Will use the original input org.apache.camel.Message (original body and headers) when an org.apache.camel.Exchange is moved to the dead letter queue. Notice: this only applies when all redeliveries attempt have failed and the org.apache.camel.Exchange is doomed for failure. Instead of using the current inprogress org.apache.camel.Exchange IN message we use the original IN message instead. This allows you to store the original input in the dead letter queue instead of the inprogress snapshot of the IN message. For instance if you route transform the IN body during routing and then failed. With the original exchange store in the dead letter queue it might be easier to manually re submit the org.apache.camel.Exchange again as the IN message is the same as when Camel received it. So you should be able to send the org.apache.camel.Exchange to the same input. The difference between useOriginalMessage and useOriginalBody is that the former includes both the original body and headers, where as the latter only includes the original body. You can use the latter to enrich the message with custom headers and include the original message body. The former wont let you do this, as its using the original message body and headers as they are. You cannot enable both useOriginalMessage and useOriginalBody. The original input message is defensively copied, and the copied message body is converted to org.apache.camel.StreamCache if possible (stream caching is enabled, can be disabled globally or on the original route), to ensure the body can be read when the original message is being used later. If the body is converted to org.apache.camel.StreamCache then the message body on the current org.apache.camel.Exchange is replaced with the org.apache.camel.StreamCache body. If the body is not converted to org.apache.camel.StreamCache then the body will not be able to re-read when accessed later. Important: The original input means the input message that are bounded by the current org.apache.camel.spi.UnitOfWork . An unit of work typically spans one route, or multiple routes if they are connected using internal endpoints such as direct or seda. When messages is passed via external endpoints such as JMS or HTTP then the consumer will create a new unit of work, with the message it received as input as the original input. Also some EIP patterns such as splitter, multicast, will create a new unit of work boundary for the messages in their sub-route (eg the splitted message); however these EIPs have an option named shareUnitOfWork which allows to combine with the parent unit of work in regard to error handling and therefore use the parent original message. By default this feature is off."
+          }
+        }
+      },
+      "org.apache.camel.model.language.CSimpleExpression" : {
+        "title" : "CSimple",
+        "description" : "Evaluate a compiled simple expression.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ConstantExpression" : {
+        "title" : "Constant",
+        "description" : "A fixed value set only once during the route startup.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.DatasonnetExpression" : {
+        "title" : "DataSonnet",
+        "description" : "To use DataSonnet scripts for message transformations.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "bodyMediaType" : {
+              "type" : "string",
+              "title" : "Body Media Type",
+              "description" : "The String representation of the message's body MediaType"
+            },
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "outputMediaType" : {
+              "type" : "string",
+              "title" : "Output Media Type",
+              "description" : "The String representation of the MediaType to output"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExchangePropertyExpression" : {
+        "title" : "ExchangeProperty",
+        "description" : "Gets a property from the Exchange.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExpressionDefinition" : {
+        "type" : "object",
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "constant" ],
+            "properties" : {
+              "constant" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csimple" ],
+            "properties" : {
+              "csimple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.CSimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "datasonnet" ],
+            "properties" : {
+              "datasonnet" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.DatasonnetExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "exchangeProperty" ],
+            "properties" : {
+              "exchangeProperty" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "groovy" ],
+            "properties" : {
+              "groovy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.GroovyExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "header" ],
+            "properties" : {
+              "header" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7terser" ],
+            "properties" : {
+              "hl7terser" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "java" ],
+            "properties" : {
+              "java" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "joor" ],
+            "properties" : {
+              "joor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JoorExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jq" ],
+            "properties" : {
+              "jq" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "js" ],
+            "properties" : {
+              "js" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JavaScriptExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonpath" ],
+            "properties" : {
+              "jsonpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "language" ],
+            "properties" : {
+              "language" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.LanguageExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "method" ],
+            "properties" : {
+              "method" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MethodCallExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mvel" ],
+            "properties" : {
+              "mvel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.MvelExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ognl" ],
+            "properties" : {
+              "ognl" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.OgnlExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "python" ],
+            "properties" : {
+              "python" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.PythonExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ref" ],
+            "properties" : {
+              "ref" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.RefExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "simple" ],
+            "properties" : {
+              "simple" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "spel" ],
+            "properties" : {
+              "spel" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.SpELExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tokenize" ],
+            "properties" : {
+              "tokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.TokenizerExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "variable" ],
+            "properties" : {
+              "variable" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.VariableExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "wasm" ],
+            "properties" : {
+              "wasm" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.WasmExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xpath" ],
+            "properties" : {
+              "xpath" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XPathExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xquery" ],
+            "properties" : {
+              "xquery" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XQueryExpression"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xtokenize" ],
+            "properties" : {
+              "xtokenize" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "constant" : { },
+          "csimple" : { },
+          "datasonnet" : { },
+          "exchangeProperty" : { },
+          "groovy" : { },
+          "header" : { },
+          "hl7terser" : { },
+          "java" : { },
+          "joor" : { },
+          "jq" : { },
+          "js" : { },
+          "jsonpath" : { },
+          "language" : { },
+          "method" : { },
+          "mvel" : { },
+          "ognl" : { },
+          "python" : { },
+          "ref" : { },
+          "simple" : { },
+          "spel" : { },
+          "tokenize" : { },
+          "variable" : { },
+          "wasm" : { },
+          "xpath" : { },
+          "xquery" : { },
+          "xtokenize" : { }
+        }
+      },
+      "org.apache.camel.model.language.GroovyExpression" : {
+        "title" : "Groovy",
+        "description" : "Evaluates a Groovy script.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.HeaderExpression" : {
+        "title" : "Header",
+        "description" : "Gets a header from the Exchange.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.Hl7TerserExpression" : {
+        "title" : "HL7 Terser",
+        "description" : "Get the value of a HL7 message field specified by terse location specification syntax.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JavaExpression" : {
+        "title" : "Java",
+        "description" : "Evaluates a Java (Java compiled once at runtime) expression.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "preCompile" : {
+              "type" : "boolean",
+              "title" : "Pre Compile",
+              "description" : "Whether the expression should be pre compiled once during initialization phase. If this is turned off, then the expression is reloaded and compiled on each evaluation."
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "singleQuotes" : {
+              "type" : "boolean",
+              "title" : "Single Quotes",
+              "description" : "Whether single quotes can be used as replacement for double quotes. This is convenient when you need to work with strings inside strings."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JavaScriptExpression" : {
+        "title" : "JavaScript",
+        "description" : "Evaluates a JavaScript expression.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JoorExpression" : {
+        "title" : "jOOR",
+        "description" : "Evaluates a jOOR (Java compiled once at runtime) expression.",
+        "deprecated" : true,
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "preCompile" : {
+              "type" : "boolean",
+              "title" : "Pre Compile",
+              "description" : "Whether the expression should be pre compiled once during initialization phase. If this is turned off, then the expression is reloaded and compiled on each evaluation."
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "singleQuotes" : {
+              "type" : "boolean",
+              "title" : "Single Quotes",
+              "description" : "Whether single quotes can be used as replacement for double quotes. This is convenient when you need to work with strings inside strings."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JqExpression" : {
+        "title" : "JQ",
+        "description" : "Evaluates a JQ expression against a JSON message body.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JsonPathExpression" : {
+        "title" : "JSONPath",
+        "description" : "Evaluates a JSONPath expression against a JSON message body.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allowEasyPredicate" : {
+              "type" : "boolean",
+              "title" : "Allow Easy Predicate",
+              "description" : "Whether to allow using the easy predicate parser to pre-parse predicates."
+            },
+            "allowSimple" : {
+              "type" : "boolean",
+              "title" : "Allow Simple",
+              "description" : "Whether to allow in inlined Simple exceptions in the JSONPath expression"
+            },
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "option" : {
+              "type" : "string",
+              "title" : "Option",
+              "description" : "To configure additional options on JSONPath. Multiple values can be separated by comma.",
+              "enum" : [ "DEFAULT_PATH_LEAF_TO_NULL", "ALWAYS_RETURN_LIST", "AS_PATH_LIST", "SUPPRESS_EXCEPTIONS", "REQUIRE_PROPERTIES" ]
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "suppressExceptions" : {
+              "type" : "boolean",
+              "title" : "Suppress Exceptions",
+              "description" : "Whether to suppress exceptions such as PathNotFoundException."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            },
+            "unpackArray" : {
+              "type" : "boolean",
+              "title" : "Unpack Array",
+              "description" : "Whether to unpack a single element json-array into an object."
+            },
+            "writeAsString" : {
+              "type" : "boolean",
+              "title" : "Write As String",
+              "description" : "Whether to write the output of each row/element as a JSON String value instead of a Map/POJO value."
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.LanguageExpression" : {
+        "title" : "Language",
+        "description" : "Evaluates a custom language.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "expression" : {
+            "type" : "string",
+            "title" : "Expression",
+            "description" : "The expression value in your chosen language syntax"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "language" : {
+            "type" : "string",
+            "title" : "Language",
+            "description" : "The name of the language to use"
+          },
+          "trim" : {
+            "type" : "boolean",
+            "title" : "Trim",
+            "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+          }
+        },
+        "required" : [ "expression", "language" ]
+      },
+      "org.apache.camel.model.language.MethodCallExpression" : {
+        "title" : "Bean Method",
+        "description" : "Calls a Java bean method.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "beanType" : {
+              "type" : "string",
+              "title" : "Bean Type",
+              "description" : "Class name (fully qualified) of the bean to use Will lookup in registry and if there is a single instance of the same type, then the existing bean is used, otherwise a new bean is created (requires a default no-arg constructor)."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "method" : {
+              "type" : "string",
+              "title" : "Method",
+              "description" : "Name of method to call"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Reference to an existing bean (bean id) to lookup in the registry"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "scope" : {
+              "type" : "string",
+              "title" : "Scope",
+              "description" : "Scope of bean. When using singleton scope (default) the bean is created or looked up only once and reused for the lifetime of the endpoint. The bean should be thread-safe in case concurrent threads is calling the bean at the same time. When using request scope the bean is created or looked up once per request (exchange). This can be used if you want to store state on a bean while processing a request and you want to call the same bean instance multiple times while processing the request. The bean does not have to be thread-safe as the instance is only called from the same request. When using prototype scope, then the bean will be looked up or created per call. However in case of lookup then this is delegated to the bean registry such as Spring or CDI (if in use), which depends on their configuration can act as either singleton or prototype scope. So when using prototype scope then this depends on the bean registry implementation.",
+              "default" : "Singleton",
+              "enum" : [ "Singleton", "Request", "Prototype" ]
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            },
+            "validate" : {
+              "type" : "boolean",
+              "title" : "Validate",
+              "description" : "Whether to validate the bean has the configured method."
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.language.MvelExpression" : {
+        "title" : "MVEL",
+        "description" : "Evaluates a MVEL template.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.OgnlExpression" : {
+        "title" : "OGNL",
+        "description" : "Evaluates an OGNL expression (Apache Commons OGNL).",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.PythonExpression" : {
+        "title" : "Python",
+        "description" : "Evaluates a Python expression.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.RefExpression" : {
+        "title" : "Ref",
+        "description" : "Uses an existing expression from the registry.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.SimpleExpression" : {
+        "title" : "Simple",
+        "description" : "Evaluates a Camel simple expression.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.SpELExpression" : {
+        "title" : "SpEL",
+        "description" : "Evaluates a Spring expression (SpEL).",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.TokenizerExpression" : {
+        "title" : "Tokenize",
+        "description" : "Tokenize text payloads using delimiter patterns.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "endToken" : {
+              "type" : "string",
+              "title" : "End Token",
+              "description" : "The end token to use as tokenizer if using start/end token pairs. You can use simple language as the token to support dynamic tokens."
+            },
+            "group" : {
+              "type" : "string",
+              "title" : "Group",
+              "description" : "To group N parts together, for example to split big files into chunks of 1000 lines. You can use simple language as the group to support dynamic group sizes."
+            },
+            "groupDelimiter" : {
+              "type" : "string",
+              "title" : "Group Delimiter",
+              "description" : "Sets the delimiter to use when grouping. If this has not been set then token will be used as the delimiter."
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "includeTokens" : {
+              "type" : "boolean",
+              "title" : "Include Tokens",
+              "description" : "Whether to include the tokens in the parts when using pairs. When including tokens then the endToken property must also be configured (to use pair mode). The default value is false"
+            },
+            "inheritNamespaceTagName" : {
+              "type" : "string",
+              "title" : "Inherit Namespace Tag Name",
+              "description" : "To inherit namespaces from a root/parent tag name when using XML You can use simple language as the tag name to support dynamic names."
+            },
+            "regex" : {
+              "type" : "boolean",
+              "title" : "Regex",
+              "description" : "If the token is a regular expression pattern. The default value is false"
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "skipFirst" : {
+              "type" : "boolean",
+              "title" : "Skip First",
+              "description" : "To skip the very first element"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "token" : {
+              "type" : "string",
+              "title" : "Token",
+              "description" : "The (start) token to use as tokenizer, for example you can use the new line token. You can use simple language as the token to support dynamic tokens."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            },
+            "xml" : {
+              "type" : "boolean",
+              "title" : "Xml",
+              "description" : "Whether the input is XML messages. This option must be set to true if working with XML payloads."
+            }
+          }
+        } ],
+        "required" : [ "token" ]
+      },
+      "org.apache.camel.model.language.VariableExpression" : {
+        "title" : "Variable",
+        "description" : "Gets a variable",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.WasmExpression" : {
+        "title" : "Wasm",
+        "description" : "Call a wasm (web assembly) function.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "module" : {
+              "type" : "string",
+              "title" : "Module",
+              "description" : "Set the module (the distributable, loadable, and executable unit of code in WebAssembly) resource that provides the expression function."
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression", "module" ]
+      },
+      "org.apache.camel.model.language.XMLTokenizerExpression" : {
+        "title" : "XML Tokenize",
+        "description" : "Tokenize XML payloads.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "group" : {
+              "type" : "number",
+              "title" : "Group",
+              "description" : "To group N parts together"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "mode" : {
+              "type" : "string",
+              "title" : "Mode",
+              "description" : "The extraction mode. The available extraction modes are: i - injecting the contextual namespace bindings into the extracted token (default) w - wrapping the extracted token in its ancestor context u - unwrapping the extracted token to its child content t - extracting the text content of the specified element",
+              "default" : "i",
+              "enum" : [ "i", "w", "u", "t" ]
+            },
+            "namespace" : {
+              "type" : "array",
+              "title" : "Namespace",
+              "description" : "Injects the XML Namespaces of prefix - uri mappings",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.XPathExpression" : {
+        "title" : "XPath",
+        "description" : "Evaluates an XPath expression against an XML payload.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "documentType" : {
+              "type" : "string",
+              "title" : "Document Type",
+              "description" : "Name of class for document type The default value is org.w3c.dom.Document"
+            },
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "factoryRef" : {
+              "type" : "string",
+              "title" : "Factory Ref",
+              "description" : "References to a custom XPathFactory to lookup in the registry"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "logNamespaces" : {
+              "type" : "boolean",
+              "title" : "Log Namespaces",
+              "description" : "Whether to log namespaces which can assist during troubleshooting"
+            },
+            "namespace" : {
+              "type" : "array",
+              "title" : "Namespace",
+              "description" : "Injects the XML Namespaces of prefix - uri mappings",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "objectModel" : {
+              "type" : "string",
+              "title" : "Object Model",
+              "description" : "The XPath object model to use"
+            },
+            "preCompile" : {
+              "type" : "boolean",
+              "title" : "Pre Compile",
+              "description" : "Whether to enable pre-compiling the xpath expression during initialization phase. pre-compile is enabled by default. This can be used to turn off, for example in cases the compilation phase is desired at the starting phase, such as if the application is ahead of time compiled (for example with camel-quarkus) which would then load the xpath factory of the built operating system, and not a JVM runtime."
+            },
+            "resultQName" : {
+              "type" : "string",
+              "title" : "Result QName",
+              "description" : "Sets the output type supported by XPath.",
+              "default" : "NODESET",
+              "enum" : [ "NUMBER", "STRING", "BOOLEAN", "NODESET", "NODE" ]
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "saxon" : {
+              "type" : "boolean",
+              "title" : "Saxon",
+              "description" : "Whether to use Saxon."
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "threadSafety" : {
+              "type" : "boolean",
+              "title" : "Thread Safety",
+              "description" : "Whether to enable thread-safety for the returned result of the xpath expression. This applies to when using NODESET as the result type, and the returned set has multiple elements. In this situation there can be thread-safety issues if you process the NODESET concurrently such as from a Camel Splitter EIP in parallel processing mode. This option prevents concurrency issues by doing defensive copies of the nodes. It is recommended to turn this option on if you are using camel-saxon or Saxon in your application. Saxon has thread-safety issues which can be prevented by turning this option on."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.XQueryExpression" : {
+        "title" : "XQuery",
+        "description" : "Evaluates an XQuery expressions against an XML payload.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "configurationRef" : {
+              "type" : "string",
+              "title" : "Configuration Ref",
+              "description" : "Reference to a saxon configuration instance in the registry to use for xquery (requires camel-saxon). This may be needed to add custom functions to a saxon configuration, so these custom functions can be used in xquery expressions."
+            },
+            "expression" : {
+              "type" : "string",
+              "title" : "Expression",
+              "description" : "The expression value in your chosen language syntax"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Sets the id of this node"
+            },
+            "namespace" : {
+              "type" : "array",
+              "title" : "Namespace",
+              "description" : "Injects the XML Namespaces of prefix - uri mappings",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "resultType" : {
+              "type" : "string",
+              "title" : "Result Type",
+              "description" : "Sets the class of the result type (type from output)"
+            },
+            "source" : {
+              "type" : "string",
+              "title" : "Source",
+              "description" : "Source to use, instead of message body. You can prefix with variable:, header:, or property: to specify kind of source. Otherwise, the source is assumed to be a variable. Use empty or null to use default source, which is the message body."
+            },
+            "trim" : {
+              "type" : "boolean",
+              "title" : "Trim",
+              "description" : "Whether to trim the value to remove leading and trailing whitespaces and line breaks"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition" : {
+        "title" : "Custom Load Balancer",
+        "description" : "To use a custom load balancer implementation.",
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of this node"
+            },
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "Refers to the custom load balancer to lookup from the registry"
+            }
+          }
+        } ],
+        "required" : [ "ref" ]
+      },
+      "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition" : {
+        "title" : "Failover Load Balancer",
+        "description" : "In case of failures the exchange will be tried on the next endpoint.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "exception" : {
+            "type" : "array",
+            "title" : "Exception",
+            "description" : "A list of class names for specific exceptions to monitor. If no exceptions are configured then all exceptions are monitored",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maximumFailoverAttempts" : {
+            "type" : "string",
+            "title" : "Maximum Failover Attempts",
+            "description" : "A value to indicate after X failover attempts we should exhaust (give up). Use -1 to indicate never give up and continuously try to failover. Use 0 to never failover. And use e.g. 3 to failover at most 3 times before giving up. This option can be used whether roundRobin is enabled or not.",
+            "default" : "-1"
+          },
+          "roundRobin" : {
+            "type" : "string",
+            "title" : "Round Robin",
+            "description" : "Whether or not the failover load balancer should operate in round robin mode or not. If not, then it will always start from the first endpoint when a new message is to be processed. In other words it restart from the top for every message. If round robin is enabled, then it keeps state and will continue with the next endpoint in a round robin fashion. You can also enable sticky mode together with round robin, if so then it will pick the last known good endpoint to use when starting the load balancing (instead of using the next when starting)."
+          },
+          "sticky" : {
+            "type" : "string",
+            "title" : "Sticky",
+            "description" : "Whether or not the failover load balancer should operate in sticky mode or not. If not, then it will always start from the first endpoint when a new message is to be processed. In other words it restart from the top for every message. If sticky is enabled, then it keeps state and will continue with the last known good endpoint. You can also enable sticky mode together with round robin, if so then it will pick the last known good endpoint to use when starting the load balancing (instead of using the next when starting)."
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition" : {
+        "title" : "Random Load Balancer",
+        "description" : "The destination endpoints are selected randomly.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition" : {
+        "title" : "Round Robin Load Balancer",
+        "description" : "The destination endpoints are selected in a round-robin fashion. This is a well-known and classic policy, which spreads the load evenly.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.StickyLoadBalancerDefinition" : {
+        "title" : "Sticky Load Balancer",
+        "description" : "Sticky load balancing using an expression to calculate a correlation key to perform the sticky load balancing.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "correlationExpression" : {
+            "title" : "Correlation Expression",
+            "description" : "The correlation expression to use to calculate the correlation key",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ExpressionSubElementDefinition"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition" : {
+        "title" : "Topic Load Balancer",
+        "description" : "Topic which sends to all destinations.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          }
+        }
+      },
+      "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition" : {
+        "title" : "Weighted Load Balancer",
+        "description" : "Uses a weighted load distribution ratio for each server with respect to others.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "distributionRatio" : {
+            "type" : "string",
+            "title" : "Distribution Ratio",
+            "description" : "The distribution ratio is a delimited String consisting on integer weights separated by delimiters for example 2,3,5. The distributionRatio must match the number of endpoints and/or processors specified in the load balancer list."
+          },
+          "distributionRatioDelimiter" : {
+            "type" : "string",
+            "title" : "Distribution Ratio Delimiter",
+            "description" : "Delimiter used to specify the distribution ratio. The default value is , (comma)",
+            "default" : ","
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "roundRobin" : {
+            "type" : "boolean",
+            "title" : "Round Robin",
+            "description" : "To enable round robin mode. By default the weighted distribution mode is used. The default value is false."
+          }
+        },
+        "required" : [ "distributionRatio" ]
+      },
+      "org.apache.camel.model.rest.ApiKeyDefinition" : {
+        "title" : "Api Key",
+        "description" : "Rest security basic auth definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "inCookie" : {
+            "type" : "boolean",
+            "title" : "In Cookie",
+            "description" : "To use a cookie as the location of the API key."
+          },
+          "inHeader" : {
+            "type" : "boolean",
+            "title" : "In Header",
+            "description" : "To use header as the location of the API key."
+          },
+          "inQuery" : {
+            "type" : "boolean",
+            "title" : "In Query",
+            "description" : "To use query parameter as the location of the API key."
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The name of the header or query parameter to be used."
+          }
+        },
+        "required" : [ "key", "name" ]
+      },
+      "org.apache.camel.model.rest.BasicAuthDefinition" : {
+        "title" : "Basic Auth",
+        "description" : "Rest security basic auth definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.BearerTokenDefinition" : {
+        "title" : "Bearer Token",
+        "description" : "Rest security bearer token authentication definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "format" : {
+            "type" : "string",
+            "title" : "Format",
+            "description" : "A hint to the client to identify how the bearer token is formatted."
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.DeleteDefinition" : {
+        "title" : "Delete",
+        "description" : "Rest DELETE command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.GetDefinition" : {
+        "title" : "Get",
+        "description" : "Rest GET command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.HeadDefinition" : {
+        "title" : "Head",
+        "description" : "Rest HEAD command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.MutualTLSDefinition" : {
+        "title" : "Mutual TLS",
+        "description" : "Rest security mutual TLS authentication definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.OAuth2Definition" : {
+        "title" : "Oauth2",
+        "description" : "Rest security OAuth2 definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "authorizationUrl" : {
+            "type" : "string",
+            "title" : "Authorization Url",
+            "description" : "The authorization URL to be used for this flow. This SHOULD be in the form of a URL. Required for implicit and access code flows"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "flow" : {
+            "type" : "string",
+            "title" : "Flow",
+            "description" : "The flow used by the OAuth2 security scheme. Valid values are implicit, password, application or accessCode.",
+            "enum" : [ "implicit", "password", "application", "clientCredentials", "accessCode", "authorizationCode" ]
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          },
+          "refreshUrl" : {
+            "type" : "string",
+            "title" : "Refresh Url",
+            "description" : "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL."
+          },
+          "scopes" : {
+            "type" : "array",
+            "title" : "Scopes",
+            "description" : "The available scopes for an OAuth2 security scheme",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "tokenUrl" : {
+            "type" : "string",
+            "title" : "Token Url",
+            "description" : "The token URL to be used for this flow. This SHOULD be in the form of a URL. Required for password, application, and access code flows."
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.rest.OpenApiDefinition" : {
+        "title" : "Open Api",
+        "description" : "To use OpenApi as contract-first with Camel Rest DSL.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable all the REST services from the OpenAPI contract from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "missingOperation" : {
+            "type" : "string",
+            "title" : "Missing Operation",
+            "description" : "Whether to fail, ignore or return a mock response for OpenAPI operations that are not mapped to a corresponding route.",
+            "default" : "fail",
+            "enum" : [ "fail", "ignore", "mock" ]
+          },
+          "mockIncludePattern" : {
+            "type" : "string",
+            "title" : "Mock Include Pattern",
+            "description" : "Used for inclusive filtering of mock data from directories. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by comma.",
+            "default" : "classpath:camel-mock/**"
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "specification" : {
+            "type" : "string",
+            "title" : "Specification",
+            "description" : "Path to the OpenApi specification file."
+          }
+        },
+        "required" : [ "specification" ]
+      },
+      "org.apache.camel.model.rest.OpenIdConnectDefinition" : {
+        "title" : "Open Id Connect",
+        "description" : "Rest security OpenID Connect definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "A short description for security scheme."
+          },
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          },
+          "url" : {
+            "type" : "string",
+            "title" : "Url",
+            "description" : "OpenId Connect URL to discover OAuth2 configuration values."
+          }
+        },
+        "required" : [ "key", "url" ]
+      },
+      "org.apache.camel.model.rest.ParamDefinition" : {
+        "title" : "Param",
+        "description" : "To specify the rest operation parameters.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowableValues" : {
+            "type" : "array",
+            "title" : "Allowable Values",
+            "description" : "Sets the parameter list of allowable values (enum).",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ValueDefinition"
+            }
+          },
+          "arrayType" : {
+            "type" : "string",
+            "title" : "Array Type",
+            "description" : "Sets the parameter array type. Required if data type is array. Describes the type of items in the array.",
+            "default" : "string"
+          },
+          "collectionFormat" : {
+            "type" : "string",
+            "title" : "Collection Format",
+            "description" : "Sets the parameter collection format.",
+            "default" : "csv",
+            "enum" : [ "csv", "multi", "pipes", "ssv", "tsv" ]
+          },
+          "dataFormat" : {
+            "type" : "string",
+            "title" : "Data Format",
+            "description" : "Sets the parameter data format."
+          },
+          "dataType" : {
+            "type" : "string",
+            "title" : "Data Type",
+            "description" : "Sets the parameter data type.",
+            "default" : "string"
+          },
+          "defaultValue" : {
+            "type" : "string",
+            "title" : "Default Value",
+            "description" : "Sets the parameter default value."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the parameter description."
+          },
+          "examples" : {
+            "type" : "array",
+            "title" : "Examples",
+            "description" : "Sets the parameter examples.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Sets the parameter name."
+          },
+          "required" : {
+            "type" : "boolean",
+            "title" : "Required",
+            "description" : "Sets the parameter required flag."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the parameter type.",
+            "default" : "path",
+            "enum" : [ "body", "formData", "header", "path", "query" ]
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.rest.PatchDefinition" : {
+        "title" : "Patch",
+        "description" : "Rest PATCH command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.PostDefinition" : {
+        "title" : "Post",
+        "description" : "Rest POST command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.PutDefinition" : {
+        "title" : "Put",
+        "description" : "Rest PUT command",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "deprecated" : {
+            "type" : "boolean",
+            "title" : "Deprecated",
+            "description" : "Marks this rest operation as deprecated in OpenApi documentation."
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data This option will override what may be configured on a parent level The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "param" : {
+            "type" : "array",
+            "title" : "Param",
+            "description" : "Information about parameters for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ParamDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "The path mapping URIs of this REST operation such as /{id}."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "responseMessage" : {
+            "type" : "array",
+            "title" : "Response Message",
+            "description" : "Response details for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseMessageDefinition"
+            }
+          },
+          "routeId" : {
+            "type" : "string",
+            "title" : "Route Id",
+            "description" : "Sets the id of the route"
+          },
+          "security" : {
+            "type" : "array",
+            "title" : "Security",
+            "description" : "Security settings for this REST operation",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "streamCache" : {
+            "type" : "boolean",
+            "title" : "Stream Cache",
+            "description" : "Whether stream caching is enabled on this rest operation."
+          },
+          "to" : {
+            "title" : "To",
+            "description" : "The Camel endpoint this REST service will call, such as a direct endpoint to link to an existing route that handles this REST call.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data This option will override what may be configured on a parent level. The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.ResponseHeaderDefinition" : {
+        "title" : "Response Header",
+        "description" : "To specify the rest operation response headers.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allowableValues" : {
+            "type" : "array",
+            "title" : "Allowable Values",
+            "description" : "Sets the parameter list of allowable values.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ValueDefinition"
+            }
+          },
+          "arrayType" : {
+            "type" : "string",
+            "title" : "Array Type",
+            "description" : "Sets the parameter array type. Required if data type is array. Describes the type of items in the array.",
+            "default" : "string"
+          },
+          "collectionFormat" : {
+            "type" : "string",
+            "title" : "Collection Format",
+            "description" : "Sets the parameter collection format.",
+            "default" : "csv",
+            "enum" : [ "csv", "multi", "pipes", "ssv", "tsv" ]
+          },
+          "dataFormat" : {
+            "type" : "string",
+            "title" : "Data Format",
+            "description" : "Sets the parameter data format."
+          },
+          "dataType" : {
+            "type" : "string",
+            "title" : "Data Type",
+            "description" : "Sets the header data type.",
+            "default" : "string"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Description of the parameter."
+          },
+          "example" : {
+            "type" : "string",
+            "title" : "Example",
+            "description" : "Sets the example"
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "Name of the parameter. This option is mandatory."
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.rest.ResponseMessageDefinition" : {
+        "title" : "Response Message",
+        "description" : "To specify the rest operation response messages.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "code" : {
+            "type" : "string",
+            "title" : "Code",
+            "description" : "The response code such as a HTTP status code",
+            "default" : "200"
+          },
+          "examples" : {
+            "type" : "array",
+            "title" : "Examples",
+            "description" : "Examples of response messages",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "header" : {
+            "type" : "array",
+            "title" : "Header",
+            "description" : "Adds a response header",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.ResponseHeaderDefinition"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "title" : "Message",
+            "description" : "The response message (description)"
+          },
+          "responseModel" : {
+            "type" : "string",
+            "title" : "Response Model",
+            "description" : "The response model"
+          }
+        },
+        "required" : [ "message" ]
+      },
+      "org.apache.camel.model.rest.RestBindingDefinition" : {
+        "title" : "Rest Binding",
+        "description" : "To configure rest binding",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. The default value is off",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "component" : {
+            "type" : "string",
+            "title" : "Component",
+            "description" : "Sets the component name that this definition will apply to"
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json"
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "outType" : {
+            "type" : "string",
+            "title" : "Out Type",
+            "description" : "Sets the class name to use for binding from POJO to output for the outgoing data The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json"
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "Sets the class name to use for binding from input to POJO for the incoming data The name of the class of the input data. Append a to the end of the name if you want the input to be an array type."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestConfigurationDefinition" : {
+        "title" : "Rest Configuration",
+        "description" : "To configure rest",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiComponent" : {
+            "type" : "string",
+            "title" : "Api Component",
+            "description" : "The name of the Camel component to use as the REST API. If no API Component has been explicit configured, then Camel will lookup if there is a Camel component responsible for servicing and generating the REST API documentation, or if a org.apache.camel.spi.RestApiProcessorFactory is registered in the registry. If either one is found, then that is being used.",
+            "enum" : [ "openapi", "swagger" ]
+          },
+          "apiContextPath" : {
+            "type" : "string",
+            "title" : "Api Context Path",
+            "description" : "Sets a leading context-path the REST API will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path."
+          },
+          "apiContextRouteId" : {
+            "type" : "string",
+            "title" : "Api Context Route Id",
+            "description" : "Sets the route id to use for the route that services the REST API. The route will by default use an auto assigned route id."
+          },
+          "apiHost" : {
+            "type" : "string",
+            "title" : "Api Host",
+            "description" : "To use a specific hostname for the API documentation (such as swagger or openapi) This can be used to override the generated host with this configured hostname"
+          },
+          "apiProperty" : {
+            "type" : "array",
+            "title" : "Api Property",
+            "description" : "Allows to configure as many additional properties for the api documentation. For example set property api.title to my cool stuff",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "apiVendorExtension" : {
+            "type" : "boolean",
+            "title" : "Api Vendor Extension",
+            "description" : "Whether vendor extension is enabled in the Rest APIs. If enabled then Camel will include additional information as vendor extension (eg keys starting with x-) such as route ids, class names etc. Not all 3rd party API gateways and tools supports vendor-extensions when importing your API docs."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. The default value is off",
+            "default" : "off",
+            "enum" : [ "auto", "json", "json_xml", "off", "xml" ]
+          },
+          "bindingPackageScan" : {
+            "type" : "string",
+            "title" : "Binding Package Scan",
+            "description" : "Package name to use as base (offset) for classpath scanning of POJO classes are located when using binding mode is enabled for JSon or XML. Multiple package names can be separated by comma."
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "component" : {
+            "type" : "string",
+            "title" : "Component",
+            "description" : "The Camel Rest component to use for the REST transport (consumer), such as netty-http, jetty, servlet, undertow. If no component has been explicit configured, then Camel will lookup if there is a Camel component that integrates with the Rest DSL, or if a org.apache.camel.spi.RestConsumerFactory is registered in the registry. If either one is found, then that is being used.",
+            "enum" : [ "platform-http", "servlet", "jetty", "undertow", "netty-http", "coap" ]
+          },
+          "componentProperty" : {
+            "type" : "array",
+            "title" : "Component Property",
+            "description" : "Allows to configure as many additional properties for the rest component in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "consumerProperty" : {
+            "type" : "array",
+            "title" : "Consumer Property",
+            "description" : "Allows to configure as many additional properties for the rest consumer in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "contextPath" : {
+            "type" : "string",
+            "title" : "Context Path",
+            "description" : "Sets a leading context-path the REST services will be using. This can be used when using components such as camel-servlet where the deployed web application is deployed using a context-path. Or for components such as camel-jetty or camel-netty-http that includes a HTTP server."
+          },
+          "corsHeaders" : {
+            "type" : "array",
+            "title" : "Cors Headers",
+            "description" : "Allows to configure custom CORS headers.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "dataFormatProperty" : {
+            "type" : "array",
+            "title" : "Data Format Property",
+            "description" : "Allows to configure as many additional properties for the data formats in use. For example set property prettyPrint to true to have json outputted in pretty mode. The properties can be prefixed to denote the option is only for either JSON or XML and for either the IN or the OUT. The prefixes are: json.in. json.out. xml.in. xml.out. For example a key with value xml.out.mustBeJAXBElement is only for the XML data format for the outgoing. A key without a prefix is a common key for all situations.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "endpointProperty" : {
+            "type" : "array",
+            "title" : "Endpoint Property",
+            "description" : "Allows to configure as many additional properties for the rest endpoint in use.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestPropertyDefinition"
+            }
+          },
+          "host" : {
+            "type" : "string",
+            "title" : "Host",
+            "description" : "The hostname to use for exposing the REST service."
+          },
+          "hostNameResolver" : {
+            "type" : "string",
+            "title" : "Host Name Resolver",
+            "description" : "If no hostname has been explicit configured, then this resolver is used to compute the hostname the REST service will be using.",
+            "default" : "allLocalIp",
+            "enum" : [ "allLocalIp", "localHostName", "localIp", "none" ]
+          },
+          "inlineRoutes" : {
+            "type" : "boolean",
+            "title" : "Inline Routes",
+            "description" : "Inline routes in rest-dsl which are linked using direct endpoints. Each service in Rest DSL is an individual route, meaning that you would have at least two routes per service (rest-dsl, and the route linked from rest-dsl). By inlining (default) allows Camel to optimize and inline this as a single route, however this requires to use direct endpoints, which must be unique per service. If a route is not using direct endpoint then the rest-dsl is not inlined, and will become an individual route. This option is default true."
+          },
+          "jsonDataFormat" : {
+            "type" : "string",
+            "title" : "Json Data Format",
+            "description" : "Name of specific json data format to use. By default jackson will be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance."
+          },
+          "port" : {
+            "type" : "string",
+            "title" : "Port",
+            "description" : "The port number to use for exposing the REST service. Notice if you use servlet component then the port number configured here does not apply, as the port number in use is the actual port number the servlet component is using. eg if using Apache Tomcat its the tomcat http port, if using Apache Karaf its the HTTP service in Karaf that uses port 8181 by default etc. Though in those situations setting the port number here, allows tooling and JMX to know the port number, so its recommended to set the port number to the number that the servlet engine uses."
+          },
+          "producerApiDoc" : {
+            "type" : "string",
+            "title" : "Producer Api Doc",
+            "description" : "Sets the location of the api document the REST producer will use to validate the REST uri and query parameters are valid accordingly to the api document. The location of the api document is loaded from classpath by default, but you can use file: or http: to refer to resources to load from file or http url."
+          },
+          "producerComponent" : {
+            "type" : "string",
+            "title" : "Producer Component",
+            "description" : "Sets the name of the Camel component to use as the REST producer",
+            "enum" : [ "vertx-http", "http", "undertow", "netty-http" ]
+          },
+          "scheme" : {
+            "type" : "string",
+            "title" : "Scheme",
+            "description" : "The scheme to use for exposing the REST service. Usually http or https is supported. The default value is http"
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do."
+          },
+          "useXForwardHeaders" : {
+            "type" : "boolean",
+            "title" : "Use XForward Headers",
+            "description" : "Whether to use X-Forward headers to set host etc. for OpenApi. This may be needed in special cases involving reverse-proxy and networking going from HTTP to HTTPS etc. Then the proxy can send X-Forward headers (X-Forwarded-Proto) that influences the host names in the OpenAPI schema that camel-openapi-java generates from Rest DSL routes."
+          },
+          "xmlDataFormat" : {
+            "type" : "string",
+            "title" : "Xml Data Format",
+            "description" : "Name of specific XML data format to use. By default jaxb will be used. Important: This option is only for setting a custom name of the data format, not to refer to an existing data format instance."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestDefinition" : {
+        "title" : "Rest",
+        "description" : "Defines a rest service using the rest-dsl",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiDocs" : {
+            "type" : "boolean",
+            "title" : "Api Docs",
+            "description" : "Whether to include or exclude this rest operation in API documentation. This option will override what may be configured on a parent level. The default value is true."
+          },
+          "bindingMode" : {
+            "type" : "string",
+            "title" : "Binding Mode",
+            "description" : "Sets the binding mode to use. This option will override what may be configured on a parent level The default value is auto",
+            "default" : "off",
+            "enum" : [ "off", "auto", "json", "xml", "json_xml" ]
+          },
+          "clientRequestValidation" : {
+            "type" : "boolean",
+            "title" : "Client Request Validation",
+            "description" : "Whether to enable validation of the client request to check: 1) Content-Type header matches what the Rest DSL consumes; returns HTTP Status 415 if validation error. 2) Accept header matches what the Rest DSL produces; returns HTTP Status 406 if validation error. 3) Missing required data (query parameters, HTTP headers, body); returns HTTP Status 400 if validation error. 4) Parsing error of the message body (JSon, XML or Auto binding mode must be enabled); returns HTTP Status 400 if validation error."
+          },
+          "consumes" : {
+            "type" : "string",
+            "title" : "Consumes",
+            "description" : "To define the content type what the REST service consumes (accept as input), such as application/xml or application/json. This option will override what may be configured on a parent level"
+          },
+          "delete" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.DeleteDefinition"
+            }
+          },
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "disabled" : {
+            "type" : "boolean",
+            "title" : "Disabled",
+            "description" : "Whether to disable this REST service from the route during build time. Once an REST service has been disabled then it cannot be enabled later at runtime."
+          },
+          "enableCORS" : {
+            "type" : "boolean",
+            "title" : "Enable CORS",
+            "description" : "Whether to enable CORS headers in the HTTP response. This option will override what may be configured on a parent level The default value is false."
+          },
+          "enableNoContentResponse" : {
+            "type" : "boolean",
+            "title" : "Enable No Content Response",
+            "description" : "Whether to return HTTP 204 with an empty body when a response contains an empty JSON object or XML root object. The default value is false."
+          },
+          "get" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.GetDefinition"
+            }
+          },
+          "head" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.HeadDefinition"
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "openApi" : {
+            "title" : "Open Api",
+            "description" : "To use an existing OpenAPI specification as contract-first for Camel Rest DSL.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.OpenApiDefinition"
+          },
+          "patch" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PatchDefinition"
+            }
+          },
+          "path" : {
+            "type" : "string",
+            "title" : "Path",
+            "description" : "Path of the rest service, such as /foo"
+          },
+          "post" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PostDefinition"
+            }
+          },
+          "produces" : {
+            "type" : "string",
+            "title" : "Produces",
+            "description" : "To define the content type what the REST service produces (uses for output), such as application/xml or application/json This option will override what may be configured on a parent level"
+          },
+          "put" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.PutDefinition"
+            }
+          },
+          "securityDefinitions" : {
+            "title" : "Security Definitions",
+            "description" : "Sets the security definitions such as Basic, OAuth2 etc.",
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestSecuritiesDefinition"
+          },
+          "securityRequirements" : {
+            "type" : "array",
+            "title" : "Security Requirements",
+            "description" : "Sets the security requirement(s) for all endpoints.",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.SecurityDefinition"
+            }
+          },
+          "skipBindingOnErrorCode" : {
+            "type" : "boolean",
+            "title" : "Skip Binding On Error Code",
+            "description" : "Whether to skip binding on output if there is a custom HTTP error code header. This allows to build custom error messages that do not bind to json / xml etc, as success messages otherwise will do. This option will override what may be configured on a parent level"
+          },
+          "tag" : {
+            "type" : "string",
+            "title" : "Tag",
+            "description" : "To configure a special tag for the operations within this rest definition."
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestPropertyDefinition" : {
+        "title" : "Rest Property",
+        "description" : "A key value pair",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Property key"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "Property value"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.rest.RestSecuritiesDefinition" : {
+        "title" : "Rest Security Definitions",
+        "description" : "To configure rest security definitions.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "apiKey" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.ApiKeyDefinition"
+          },
+          "basicAuth" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.BasicAuthDefinition"
+          },
+          "bearer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.BearerTokenDefinition"
+          },
+          "mutualTLS" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.MutualTLSDefinition"
+          },
+          "oauth2" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.OAuth2Definition"
+          },
+          "openIdConnect" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.rest.OpenIdConnectDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.rest.RestsDefinition" : {
+        "title" : "Rests",
+        "description" : "A series of rest services defined using the rest-dsl",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "title" : "Description",
+            "description" : "Sets the description of this node"
+          },
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "Sets the id of this node"
+          },
+          "rest" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.rest.SecurityDefinition" : {
+        "title" : "Rest Security",
+        "description" : "Rest security definition",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "title" : "Key",
+            "description" : "Key used to refer to this security definition"
+          },
+          "scopes" : {
+            "type" : "string",
+            "title" : "Scopes",
+            "description" : "The scopes to allow (separate multiple scopes by comma)"
+          }
+        },
+        "required" : [ "key" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jCharacterTokenizerDefinition" : {
+        "title" : "LangChain4J Tokenizer with character splitter",
+        "description" : "Camel AI: Tokenizer for splitting by character.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxOverlap" : {
+            "type" : "number",
+            "title" : "Max Overlap",
+            "description" : "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens" : {
+            "type" : "number",
+            "title" : "Max Tokens",
+            "description" : "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "title" : "Tokenizer Type",
+            "description" : "Sets the tokenizer type",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jLineTokenizerDefinition" : {
+        "title" : "LangChain4J Tokenizer with line splitter",
+        "description" : "Camel AI: Tokenizer for splitting line by line.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxOverlap" : {
+            "type" : "number",
+            "title" : "Max Overlap",
+            "description" : "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens" : {
+            "type" : "number",
+            "title" : "Max Tokens",
+            "description" : "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "title" : "Tokenizer Type",
+            "description" : "Sets the tokenizer type",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jParagraphTokenizerDefinition" : {
+        "title" : "LangChain4J Tokenizer with paragraph splitter",
+        "description" : "Camel AI: Tokenizer for splitting by paragraphs.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxOverlap" : {
+            "type" : "number",
+            "title" : "Max Overlap",
+            "description" : "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens" : {
+            "type" : "number",
+            "title" : "Max Tokens",
+            "description" : "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "title" : "Tokenizer Type",
+            "description" : "Sets the tokenizer type",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jSentenceTokenizerDefinition" : {
+        "title" : "LangChain4J Tokenizer with sentence splitter",
+        "description" : "Camel AI: Tokenizer for splitting by sentences.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxOverlap" : {
+            "type" : "number",
+            "title" : "Max Overlap",
+            "description" : "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens" : {
+            "type" : "number",
+            "title" : "Max Tokens",
+            "description" : "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "title" : "Tokenizer Type",
+            "description" : "Sets the tokenizer type",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jTokenizerDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "maxOverlap" : {
+            "type" : "number"
+          },
+          "maxTokens" : {
+            "type" : "number"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.tokenizer.LangChain4jWordTokenizerDefinition" : {
+        "title" : "LangChain4J Tokenizer with word splitter",
+        "description" : "Camel AI: Tokenizer for splitting by word.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "title" : "Id",
+            "description" : "The id of this node"
+          },
+          "maxOverlap" : {
+            "type" : "number",
+            "title" : "Max Overlap",
+            "description" : "Sets the maximum number of tokens that can overlap in each segment"
+          },
+          "maxTokens" : {
+            "type" : "number",
+            "title" : "Max Tokens",
+            "description" : "Sets the maximum number of tokens on each segment"
+          },
+          "tokenizerType" : {
+            "type" : "string",
+            "title" : "Tokenizer Type",
+            "description" : "Sets the tokenizer type",
+            "enum" : [ "OPEN_AI", "AZURE", "QWEN" ]
+          }
+        },
+        "required" : [ "maxOverlap", "maxTokens" ]
+      },
+      "org.apache.camel.model.transformer.CustomTransformerDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "className" : {
+            "type" : "string"
+          },
+          "fromType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "toType" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.DataFormatTransformerDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "asn1" ],
+            "properties" : {
+              "asn1" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "asn1" ]
+              }, {
+                "required" : [ "avro" ]
+              }, {
+                "required" : [ "barcode" ]
+              }, {
+                "required" : [ "base64" ]
+              }, {
+                "required" : [ "beanio" ]
+              }, {
+                "required" : [ "bindy" ]
+              }, {
+                "required" : [ "cbor" ]
+              }, {
+                "required" : [ "crypto" ]
+              }, {
+                "required" : [ "csv" ]
+              }, {
+                "required" : [ "custom" ]
+              }, {
+                "required" : [ "fhirJson" ]
+              }, {
+                "required" : [ "fhirXml" ]
+              }, {
+                "required" : [ "flatpack" ]
+              }, {
+                "required" : [ "fury" ]
+              }, {
+                "required" : [ "grok" ]
+              }, {
+                "required" : [ "gzipDeflater" ]
+              }, {
+                "required" : [ "hl7" ]
+              }, {
+                "required" : [ "ical" ]
+              }, {
+                "required" : [ "jacksonXml" ]
+              }, {
+                "required" : [ "jaxb" ]
+              }, {
+                "required" : [ "json" ]
+              }, {
+                "required" : [ "jsonApi" ]
+              }, {
+                "required" : [ "lzf" ]
+              }, {
+                "required" : [ "mimeMultipart" ]
+              }, {
+                "required" : [ "parquetAvro" ]
+              }, {
+                "required" : [ "pgp" ]
+              }, {
+                "required" : [ "protobuf" ]
+              }, {
+                "required" : [ "rss" ]
+              }, {
+                "required" : [ "smooks" ]
+              }, {
+                "required" : [ "soap" ]
+              }, {
+                "required" : [ "swiftMt" ]
+              }, {
+                "required" : [ "swiftMx" ]
+              }, {
+                "required" : [ "syslog" ]
+              }, {
+                "required" : [ "tarFile" ]
+              }, {
+                "required" : [ "thrift" ]
+              }, {
+                "required" : [ "tidyMarkup" ]
+              }, {
+                "required" : [ "univocityCsv" ]
+              }, {
+                "required" : [ "univocityFixed" ]
+              }, {
+                "required" : [ "univocityTsv" ]
+              }, {
+                "required" : [ "xmlSecurity" ]
+              }, {
+                "required" : [ "yaml" ]
+              }, {
+                "required" : [ "zipDeflater" ]
+              }, {
+                "required" : [ "zipFile" ]
+              } ]
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "avro" ],
+            "properties" : {
+              "avro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "barcode" ],
+            "properties" : {
+              "barcode" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "base64" ],
+            "properties" : {
+              "base64" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "beanio" ],
+            "properties" : {
+              "beanio" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "bindy" ],
+            "properties" : {
+              "bindy" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "cbor" ],
+            "properties" : {
+              "cbor" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "crypto" ],
+            "properties" : {
+              "crypto" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "csv" ],
+            "properties" : {
+              "csv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "custom" ],
+            "properties" : {
+              "custom" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirJson" ],
+            "properties" : {
+              "fhirJson" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fhirXml" ],
+            "properties" : {
+              "fhirXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "flatpack" ],
+            "properties" : {
+              "flatpack" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "fury" ],
+            "properties" : {
+              "fury" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.FuryDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "grok" ],
+            "properties" : {
+              "grok" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "gzipDeflater" ],
+            "properties" : {
+              "gzipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.GzipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "hl7" ],
+            "properties" : {
+              "hl7" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "ical" ],
+            "properties" : {
+              "ical" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jacksonXml" ],
+            "properties" : {
+              "jacksonXml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jaxb" ],
+            "properties" : {
+              "jaxb" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "json" ],
+            "properties" : {
+              "json" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "jsonApi" ],
+            "properties" : {
+              "jsonApi" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "lzf" ],
+            "properties" : {
+              "lzf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "mimeMultipart" ],
+            "properties" : {
+              "mimeMultipart" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "parquetAvro" ],
+            "properties" : {
+              "parquetAvro" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ParquetAvroDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "pgp" ],
+            "properties" : {
+              "pgp" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "protobuf" ],
+            "properties" : {
+              "protobuf" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "rss" ],
+            "properties" : {
+              "rss" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "smooks" ],
+            "properties" : {
+              "smooks" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SmooksDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "soap" ],
+            "properties" : {
+              "soap" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMt" ],
+            "properties" : {
+              "swiftMt" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMtDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "swiftMx" ],
+            "properties" : {
+              "swiftMx" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SwiftMxDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "syslog" ],
+            "properties" : {
+              "syslog" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tarFile" ],
+            "properties" : {
+              "tarFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "thrift" ],
+            "properties" : {
+              "thrift" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "tidyMarkup" ],
+            "properties" : {
+              "tidyMarkup" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityCsv" ],
+            "properties" : {
+              "univocityCsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityFixed" ],
+            "properties" : {
+              "univocityFixed" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityFixedDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "univocityTsv" ],
+            "properties" : {
+              "univocityTsv" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "xmlSecurity" ],
+            "properties" : {
+              "xmlSecurity" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "yaml" ],
+            "properties" : {
+              "yaml" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipDeflater" ],
+            "properties" : {
+              "zipDeflater" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+              }
+            }
+          }, {
+            "type" : "object",
+            "required" : [ "zipFile" ],
+            "properties" : {
+              "zipFile" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+              }
+            }
+          } ]
+        } ],
+        "properties" : {
+          "fromType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "toType" : {
+            "type" : "string"
+          },
+          "asn1" : { },
+          "avro" : { },
+          "barcode" : { },
+          "base64" : { },
+          "beanio" : { },
+          "bindy" : { },
+          "cbor" : { },
+          "crypto" : { },
+          "csv" : { },
+          "custom" : { },
+          "fhirJson" : { },
+          "fhirXml" : { },
+          "flatpack" : { },
+          "fury" : { },
+          "grok" : { },
+          "gzipDeflater" : { },
+          "hl7" : { },
+          "ical" : { },
+          "jacksonXml" : { },
+          "jaxb" : { },
+          "json" : { },
+          "jsonApi" : { },
+          "lzf" : { },
+          "mimeMultipart" : { },
+          "parquetAvro" : { },
+          "pgp" : { },
+          "protobuf" : { },
+          "rss" : { },
+          "smooks" : { },
+          "soap" : { },
+          "swiftMt" : { },
+          "swiftMx" : { },
+          "syslog" : { },
+          "tarFile" : { },
+          "thrift" : { },
+          "tidyMarkup" : { },
+          "univocityCsv" : { },
+          "univocityFixed" : { },
+          "univocityTsv" : { },
+          "xmlSecurity" : { },
+          "yaml" : { },
+          "zipDeflater" : { },
+          "zipFile" : { }
+        }
+      },
+      "org.apache.camel.model.transformer.EndpointTransformerDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "fromType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "toType" : {
+            "type" : "string"
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.LoadTransformerDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "defaults" : {
+            "type" : "boolean"
+          },
+          "fromType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "packageScan" : {
+            "type" : "string"
+          },
+          "scheme" : {
+            "type" : "string"
+          },
+          "toType" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.transformer.TransformersDefinition" : {
+        "title" : "Transformations",
+        "description" : "To configure transformers.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "customTransformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.CustomTransformerDefinition"
+          },
+          "dataFormatTransformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.DataFormatTransformerDefinition"
+          },
+          "endpointTransformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.EndpointTransformerDefinition"
+          },
+          "loadTransformer" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.transformer.LoadTransformerDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.CustomValidatorDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "className" : {
+            "type" : "string"
+          },
+          "ref" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.EndpointValidatorDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "ref" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.validator.PredicateValidatorDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "required" : [ "expression" ],
+            "properties" : {
+              "expression" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+              }
+            }
+          }, {
+            "not" : {
+              "anyOf" : [ {
+                "required" : [ "expression" ]
+              } ]
+            }
+          } ]
+        } ],
+        "properties" : {
+          "type" : {
+            "type" : "string"
+          },
+          "expression" : { }
+        }
+      },
+      "org.apache.camel.model.validator.ValidatorsDefinition" : {
+        "title" : "Validations",
+        "description" : "To configure validators.",
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "customValidator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.CustomValidatorDefinition"
+          },
+          "endpointValidator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.EndpointValidatorDefinition"
+          },
+          "predicateValidator" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.validator.PredicateValidatorDefinition"
+          }
+        }
+      }
+    },
+    "properties" : {
+      "beans" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.BeansDeserializer"
+      },
+      "dataFormats" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.DataFormatsDefinitionDeserializer"
+      },
+      "errorHandler" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.ErrorHandlerDeserializer"
+      },
+      "from" : {
+        "$ref" : "#/items/definitions/org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer"
+      },
+      "intercept" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptDefinition"
+      },
+      "interceptFrom" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptFromDefinition"
+      },
+      "interceptSendToEndpoint" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.InterceptSendToEndpointDefinition"
+      },
+      "onCompletion" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.OnCompletionDefinition"
+      },
+      "onException" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.OnExceptionDefinition"
+      },
+      "routeConfiguration" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteConfigurationDefinition"
+      },
+      "route" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteDefinition"
+      },
+      "routeTemplate" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.RouteTemplateDefinition"
+      },
+      "templatedRoute" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.TemplatedRouteDefinition"
+      },
+      "restConfiguration" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestConfigurationDefinition"
+      },
+      "rest" : {
+        "$ref" : "#/items/definitions/org.apache.camel.model.rest.RestDefinition"
+      }
+    }
+  }
+}

--- a/packages/ui/src/stubs/data-mapper.ts
+++ b/packages/ui/src/stubs/data-mapper.ts
@@ -83,6 +83,8 @@ export const x12850ForEachXslt = fs
   .readFileSync(path.resolve(__dirname, '../xml-schema-ts/test-resources/X12-850-Invoice-for-each.xsl'))
   .toString();
 
+export const camelYamlDslJsonSchema = fs.readFileSync(path.resolve(__dirname, './camelYamlDsl.json')).toString();
+
 export class TestUtil {
   static createSourceOrderDoc() {
     return XmlSchemaDocumentService.createXmlSchemaDocument(DocumentType.SOURCE_BODY, 'ShipOrder.xsd', shipOrderXsd);


### PR DESCRIPTION
Step1 for https://github.com/KaotoIO/kaoto/issues/1834 - Add [JsonSchemaDocumentService](https://github.com/KaotoIO/kaoto/compare/main...igarashitm:datamapper-json-inspection?expand=1#diff-2ea299a35f085ca0085d0a78e21b033ee3f160f52db13fcfbe4df793e360a57e)

Although there still must be rough edges here and there, it does minimal job so we can go to the next step.

This includes [camelYamlDsl.json](https://github.com/KaotoIO/kaoto/compare/main...igarashitm:datamapper-json-inspection?expand=1#diff-8657b5a4cf0e004736efea797154c754a2a75846c4e150d0f15c9ebd2fc65065) as a test resource, apologize for PR being bigger, however this most complex JSON schema helps a lot to test this JSON schema inspection.

relates: https://github.com/KaotoIO/kaoto/issues/1834