### PR TITLE
fix(Form): Avoid stale value in StringField

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.test.tsx
@@ -1,0 +1,96 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { FieldActions, FieldActionsProps } from './FieldActions';
+
+describe('FieldActions', () => {
+  const defaultProps: FieldActionsProps = {
+    propName: 'testProp',
+    clearAriaLabel: 'Clear field',
+    toggleRawAriaLabel: 'Toggle RAW wrap for field',
+    onRemove: jest.fn(),
+    toggleRawValueWrap: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the MenuToggle button', () => {
+    const wrapper = render(<FieldActions {...defaultProps} />);
+
+    expect(wrapper.getByTestId('testProp__field-actions')).toBeInTheDocument();
+  });
+
+  it('opens and closes the dropdown when MenuToggle is clicked', async () => {
+    const wrapper = render(<FieldActions {...defaultProps} />);
+
+    const toggle = wrapper.getByTestId('testProp__field-actions');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(wrapper.getByRole('menu')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(wrapper.queryByTestId('testProp__clear')).not.toBeInTheDocument();
+  });
+
+  it('calls onRemove when Clear is clicked', async () => {
+    const wrapper = render(<FieldActions {...defaultProps} />);
+
+    await act(async () => {
+      fireEvent.click(wrapper.getByTestId('testProp__field-actions'));
+    });
+
+    const clearItem = wrapper.getByLabelText('Clear field');
+    await act(async () => {
+      fireEvent.click(clearItem);
+    });
+
+    expect(defaultProps.onRemove).toHaveBeenCalled();
+  });
+
+  it('calls toggleRawValueWrap when Raw is clicked', async () => {
+    const wrapper = render(<FieldActions {...defaultProps} />);
+
+    await act(async () => {
+      fireEvent.click(wrapper.getByTestId('testProp__field-actions'));
+    });
+
+    const rawItem = wrapper.getByLabelText('Toggle RAW wrap for field');
+    await act(async () => {
+      fireEvent.click(rawItem);
+    });
+
+    expect(defaultProps.toggleRawValueWrap).toHaveBeenCalled();
+  });
+
+  it('removes Raw item if toggleRawValueWrap is not provided', async () => {
+    const wrapper = render(<FieldActions {...defaultProps} toggleRawValueWrap={undefined} />);
+
+    await act(async () => {
+      fireEvent.click(wrapper.getByTestId('testProp__field-actions'));
+    });
+
+    const rawItem = wrapper.queryByTestId('testProp__toRaw');
+
+    expect(rawItem).not.toBeInTheDocument();
+  });
+
+  it('sets correct and titles', async () => {
+    const wrapper = render(<FieldActions {...defaultProps} />);
+
+    await act(async () => {
+      fireEvent.click(wrapper.getByTestId('testProp__field-actions'));
+    });
+
+    const clearItem = wrapper.getByTestId('testProp__clear');
+    expect(clearItem).toHaveAttribute('title', 'Clear field');
+
+    const rawItem = wrapper.getByTestId('testProp__toRaw');
+    expect(rawItem).toHaveAttribute('title', 'Toggle RAW wrap for field');
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/FieldActions.tsx
@@ -2,17 +2,23 @@ import { Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } f
 import { EllipsisVIcon, PortIcon, TimesIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useState } from 'react';
 import { DEFAULT_POPPER_PROPS } from '../../../../../models/popper-default';
-import { useFieldValue } from '../hooks/field-value';
 
 export interface FieldActionsProps {
   propName: string;
   clearAriaLabel: string;
+  toggleRawAriaLabel?: string;
+  toggleRawValueWrap?: () => void;
   onRemove: () => void;
 }
 
-export const FieldActions: FunctionComponent<FieldActionsProps> = ({ propName, clearAriaLabel, onRemove }) => {
+export const FieldActions: FunctionComponent<FieldActionsProps> = ({
+  propName,
+  clearAriaLabel,
+  toggleRawAriaLabel,
+  toggleRawValueWrap,
+  onRemove,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { value, wrapValueWithRaw } = useFieldValue(propName);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -51,14 +57,18 @@ export const FieldActions: FunctionComponent<FieldActionsProps> = ({ propName, c
         >
           Clear
         </DropdownItem>
-        <DropdownItem
-          onClick={wrapValueWithRaw}
-          data-testid={`${propName}__toRaw`}
-          disabled={value === ''}
-          icon={<PortIcon />}
-        >
-          Raw
-        </DropdownItem>
+
+        {toggleRawValueWrap && (
+          <DropdownItem
+            onClick={toggleRawValueWrap}
+            data-testid={`${propName}__toRaw`}
+            aria-label={toggleRawAriaLabel}
+            title={toggleRawAriaLabel}
+            icon={<PortIcon />}
+          >
+            Raw
+          </DropdownItem>
+        )}
       </DropdownList>
     </Dropdown>
   );

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/PasswordField.test.tsx
@@ -1,8 +1,8 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import { ROOT_PATH } from '../../../../../utils';
-import { PasswordField } from './PasswordField';
 import { ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
+import { PasswordField } from './PasswordField';
 
 describe('PasswordField', () => {
   it('should render', () => {
@@ -67,6 +67,48 @@ describe('PasswordField', () => {
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
+  });
+
+  it('should use onRemoveProps callback if specified when using the clear button', async () => {
+    const onPropertyChangeSpy = jest.fn();
+    const onRemoveSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="Value" onPropertyChange={onPropertyChangeSpy}>
+        <PasswordField propName={ROOT_PATH} onRemove={onRemoveSpy} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const clearButton = await wrapper.findByRole('menuitem', { name: /remove/i });
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    expect(onPropertyChangeSpy).not.toHaveBeenCalled();
+    expect(onRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(onRemoveSpy).toHaveBeenCalledWith(ROOT_PATH);
+  });
+
+  it('should show errors if available for its property path', () => {
+    const onPropertyChangeSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider
+        model="Value"
+        errors={{ [ROOT_PATH]: ['error message'] }}
+        onPropertyChange={onPropertyChangeSpy}
+      >
+        <PasswordField propName={ROOT_PATH} />
+      </ModelContextProvider>,
+    );
+
+    const errorMessage = wrapper.getByText('error message');
+    expect(errorMessage).toBeInTheDocument();
   });
 
   it('should hide password by default', () => {

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/fields/StringField.test.tsx
@@ -92,6 +92,31 @@ describe('StringField', () => {
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
   });
 
+  it('should use onRemoveProps callback if specified when using the clear button', async () => {
+    const onPropertyChangeSpy = jest.fn();
+    const onRemoveSpy = jest.fn();
+
+    const wrapper = render(
+      <ModelContextProvider model="Value" onPropertyChange={onPropertyChangeSpy}>
+        <StringField propName={ROOT_PATH} onRemove={onRemoveSpy} />
+      </ModelContextProvider>,
+    );
+
+    const fieldActions = wrapper.getByTestId(`${ROOT_PATH}__field-actions`);
+    act(() => {
+      fireEvent.click(fieldActions);
+    });
+
+    const clearButton = await wrapper.findByRole('menuitem', { name: /remove/i });
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    expect(onPropertyChangeSpy).not.toHaveBeenCalled();
+    expect(onRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(onRemoveSpy).toHaveBeenCalledWith(ROOT_PATH);
+  });
+
   it('should show errors if available for its property path', () => {
     const onPropertyChangeSpy = jest.fn();
 
@@ -153,5 +178,16 @@ describe('StringField', () => {
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'Test Value');
+  });
+
+  it('should show additional utility if provided', () => {
+    const additionalUtility = <span data-testid="additional-utility">Utility</span>;
+    const wrapper = render(
+      <ModelContextProvider model="Value" onPropertyChange={jest.fn()}>
+        <StringField propName={ROOT_PATH} additionalUtility={additionalUtility} />
+      </ModelContextProvider>,
+    );
+
+    expect(wrapper.getByTestId('additional-utility')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.test.tsx
@@ -8,24 +8,28 @@ describe('useFieldValue', () => {
   const mockErrors: Record<string, string[]> = { ['#.name']: ['Name is required'] };
   const mockOnPropertyChange = jest.fn();
 
-  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-    <ModelContext.Provider value={{ model: mockModel, errors: mockErrors, onPropertyChange: mockOnPropertyChange }}>
+  const Wrapper: FunctionComponent<PropsWithChildren<{ model?: unknown; errors?: Record<string, string[]> }>> = ({
+    children,
+    model = mockModel,
+    errors = mockErrors,
+  }) => (
+    <ModelContext.Provider value={{ model, errors, onPropertyChange: mockOnPropertyChange }}>
       {children}
     </ModelContext.Provider>
   );
 
   it('should return the correct value from the model', () => {
-    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
+    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper: Wrapper });
     expect(result.current.value).toBe('Test Name');
   });
 
   it('should return the correct errors from the model', () => {
-    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
+    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper: Wrapper });
     expect(result.current.errors).toEqual(['Name is required']);
   });
 
   it('should call onPropertyChange with the correct arguments when onChange is called', () => {
-    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
+    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper: Wrapper });
     act(() => {
       result.current.onChange('New Name');
     });
@@ -33,66 +37,12 @@ describe('useFieldValue', () => {
   });
 
   it('should return undefined for value if the property does not exist in the model', () => {
-    const { result } = renderHook(() => useFieldValue<string>('nonexistent'), { wrapper });
+    const { result } = renderHook(() => useFieldValue<string>('nonexistent'), { wrapper: Wrapper });
     expect(result.current.value).toBeUndefined();
   });
 
   it('should return undefined for errors if the property does not have errors', () => {
-    const { result } = renderHook(() => useFieldValue<string>('nonexistent'), { wrapper });
+    const { result } = renderHook(() => useFieldValue<string>('nonexistent'), { wrapper: Wrapper });
     expect(result.current.errors).toBeUndefined();
-  });
-
-  it('wraps value with RAW when not already wrapped', () => {
-    const mockModel = { name: 'Test Name' };
-    const mockOnPropertyChange = jest.fn();
-    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
-        {children}
-      </ModelContext.Provider>
-    );
-
-    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
-    act(() => {
-      result.current.wrapValueWithRaw();
-    });
-
-    expect(mockOnPropertyChange).toHaveBeenCalledWith('name', 'RAW(Test Name)');
-    expect(result.current.isRaw).toBe(true);
-  });
-
-  it('unwraps value from RAW when already wrapped', () => {
-    const mockModel = { name: 'RAW(Test Name)' };
-    const mockOnPropertyChange = jest.fn();
-    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
-        {children}
-      </ModelContext.Provider>
-    );
-
-    const { result } = renderHook(() => useFieldValue<string>('#.name'), { wrapper });
-    act(() => {
-      result.current.wrapValueWithRaw();
-    });
-
-    expect(mockOnPropertyChange).toHaveBeenCalledWith('name', 'Test Name');
-    expect(result.current.isRaw).toBe(false);
-  });
-
-  it('does nothing if value is not a string', () => {
-    const mockModel = { name: 123 };
-    const mockOnPropertyChange = jest.fn();
-    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <ModelContext.Provider value={{ model: mockModel, onPropertyChange: mockOnPropertyChange }}>
-        {children}
-      </ModelContext.Provider>
-    );
-
-    const { result } = renderHook(() => useFieldValue<number>('#.name'), { wrapper });
-    act(() => {
-      result.current.wrapValueWithRaw();
-    });
-
-    expect(mockOnPropertyChange).not.toHaveBeenCalled();
-    expect(result.current.isRaw).toBe(false);
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
+++ b/packages/ui/src/components/Visualization/Canvas/FormV2/hooks/field-value.ts
@@ -1,44 +1,28 @@
-import { useContext, useState } from 'react';
-import { safeGetValue } from '../../../../../utils';
+import { useCallback, useContext, useState } from 'react';
+import { isRawString, safeGetValue } from '../../../../../utils';
 import { ModelContext } from '../providers/ModelProvider';
-
-function checkIfWrappedWithRaw(value: unknown): boolean {
-  if (!value || typeof value !== 'string') return false;
-  return value.startsWith('RAW(') && value.endsWith(')');
-}
 
 export const useFieldValue = <T = unknown>(propertyPath: string) => {
   const { model, errors, onPropertyChange, disabled } = useContext(ModelContext);
   const propertyName = propertyPath.replace('#.', '');
-  const value = safeGetValue(model, propertyName) as T | undefined;
-  const [isRaw, setIsRaw] = useState(checkIfWrappedWithRaw(value));
-
   const propertyErrors = errors?.[propertyPath];
+  const value = safeGetValue(model, propertyName) as T | undefined;
 
-  const onChange = (value: T) => {
-    onPropertyChange(propertyName, value);
-    setIsRaw(checkIfWrappedWithRaw(value));
-  };
+  const [isRaw, setIsRaw] = useState<boolean>(isRawString(value));
 
-  const wrapValueWithRaw = () => {
-    if (typeof value !== 'string') return;
-
-    if (!isRaw) {
-      onChange(`RAW(${value})` as T);
-      setIsRaw(true);
-    } else {
-      const newValue = value.substring(4, value.length - 1);
-      onChange(newValue as T);
-      setIsRaw(false);
-    }
-  };
+  const onChange = useCallback(
+    (newValue: T) => {
+      setIsRaw(isRawString(newValue));
+      onPropertyChange(propertyName, newValue);
+    },
+    [onPropertyChange, propertyName],
+  );
 
   return {
     value,
     errors: propertyErrors,
-    onChange,
-    wrapValueWithRaw,
-    isRaw,
     disabled,
+    isRaw,
+    onChange,
   };
 };

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './init-visible-flows';
 export * from './is-datamapper';
 export * from './is-defined';
 export * from './is-enum-type';
+export * from './is-raw-string';
 export * from './is-same-array';
 export * from './is-to-processor';
 export * from './is-xslt-component';

--- a/packages/ui/src/utils/is-raw-string.test.ts
+++ b/packages/ui/src/utils/is-raw-string.test.ts
@@ -1,0 +1,43 @@
+import { isRawString } from './is-raw-string';
+
+describe('isRawString', () => {
+  it('should return true for a valid RAW string', () => {
+    expect(isRawString('RAW(some value)')).toBe(true);
+  });
+
+  it('should return false for a string not starting with RAW(', () => {
+    expect(isRawString('raw(some value)')).toBe(false);
+    expect(isRawString('SOMETHING(some value)')).toBe(false);
+    expect(isRawString('(some value)')).toBe(false);
+  });
+
+  it('should return false for a string not ending with )', () => {
+    expect(isRawString('RAW(some value')).toBe(false);
+    expect(isRawString('RAW(some value]')).toBe(false);
+  });
+
+  it('should return false for non-string values', () => {
+    expect(isRawString(null)).toBe(false);
+    expect(isRawString(undefined)).toBe(false);
+    expect(isRawString(123)).toBe(false);
+    expect(isRawString({})).toBe(false);
+    expect(isRawString([])).toBe(false);
+    expect(isRawString(true)).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isRawString('')).toBe(false);
+  });
+
+  it('should return true for RAW() (empty content)', () => {
+    expect(isRawString('RAW()')).toBe(true);
+  });
+
+  it('should return false for RAW( without closing parenthesis', () => {
+    expect(isRawString('RAW(')).toBe(false);
+  });
+
+  it('should return false for )RAW(some value)', () => {
+    expect(isRawString(')RAW(some value)')).toBe(false);
+  });
+});

--- a/packages/ui/src/utils/is-raw-string.ts
+++ b/packages/ui/src/utils/is-raw-string.ts
@@ -1,0 +1,5 @@
+export const isRawString = (value: unknown): boolean => {
+  if (!value || typeof value !== 'string') return false;
+
+  return value.startsWith('RAW(') && value.endsWith(')');
+};


### PR DESCRIPTION
### Context
While handling https://github.com/KaotoIO/kaoto/issues/1653, the update caused the `StringField` to keep stale values because of how the `value` was handled in the `useFieldValue` hook.

### Fix
The fix is to keep the `value` updated by the `StringField` in case of adding `RAW()` or cleaning the property altogether. This allows React to rerender the `StringField` component, avoiding stale data.

### Changes
- Introduced and updated logic for form field actions, particularly for handling "RAW" value wrapping in fields.
- Refactored the PasswordField and StringField components to support toggling RAW wrapping, improved error handling, and added test coverage for these features.
- Extracted `isRawString` function to add unit tests.
- Simplified `useFieldValue` hook logic.

fix: https://github.com/KaotoIO/kaoto/issues/2295
fix: https://github.com/KaotoIO/kaoto/issues/2296