### PR TITLE
chore(MA): Define public API to query suggestions

### DIFF
--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@kaoto/camel-catalog": "^0.1.2",
-    "@kaoto/forms": "^1.2.0",
+    "@kaoto/forms": "^1.2.1",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.2.3",
     "@patternfly/react-code-editor": "^6.2.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
-    "@kaoto/forms": "^1.2.0",
+    "@kaoto/forms": "^1.2.1",
     "@kie-tools-core/editor": "^10.0.0",
     "@kie-tools-core/notifications": "^10.0.0",
     "@visx/shape": "^3.12.0",

--- a/packages/ui/src/multiplying-architecture/KaotoEditorChannelApi.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorChannelApi.ts
@@ -1,3 +1,4 @@
+import { Suggestion, SuggestionRequestContext } from '@kaoto/forms';
 import { KogitoEditorChannelApi } from '@kie-tools-core/editor/dist/api';
 import { ISettingsModel } from '../models/settings';
 
@@ -57,4 +58,13 @@ export interface KaotoEditorChannelApi extends KogitoEditorChannelApi {
     exclude?: string,
     options?: Record<string, unknown>,
   ): Promise<string[] | string | undefined>;
+
+  /**
+   * Query the host application for suggestions
+   * @param topic The topic for which suggestions are being requested (e.g., "properties", "kubernetes", "beans", etc.)
+   * @param word The current word or input value for which suggestions are being requested
+   * @param context Additional context for the suggestions, such as the property name and current input value.
+   * @returns A promise that resolves to an array of suggestions, each containing a value, optional description, and optional group.
+   */
+  getSuggestions(topic: string, word: string, context: SuggestionRequestContext): Promise<Suggestion[]>;
 }

--- a/packages/ui/src/multiplying-architecture/index.ts
+++ b/packages/ui/src/multiplying-architecture/index.ts
@@ -1,2 +1,3 @@
-export * from './KaotoEditorFactory';
+export type { Suggestion, SuggestionRequestContext } from '@kaoto/forms';
 export * from './KaotoEditorChannelApi';
+export * from './KaotoEditorFactory';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,9 +2950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/forms@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@kaoto/forms@npm:1.2.0"
+"@kaoto/forms@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@kaoto/forms@npm:1.2.1"
   dependencies:
     ajv: "npm:^8.12.0"
     clsx: "npm:^2.1.0"
@@ -2964,7 +2964,7 @@ __metadata:
     "@patternfly/react-icons": ^6.2.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10/7f517a325e8d4de40c3745d45c5eceaffebd206f810aa419b3fae83245c1446f5b90c90231857b7e87871be2507b30de4a6f8f024db39962e4af4daefe319f55
+  checksum: 10/85ce6c51479856ea8043d98fbf73c2099ba8c52a503d78944bca8521c6e1708bbee2bb3adeb83acca7f6f5369ca7d653f32af752dd94f54fbf918aacd2c67a03
   languageName: node
   linkType: hard
 
@@ -2975,7 +2975,7 @@ __metadata:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.1.2"
-    "@kaoto/forms": "npm:^1.2.0"
+    "@kaoto/forms": "npm:^1.2.1"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.2.3"
     "@patternfly/react-code-editor": "npm:^6.2.2"
@@ -3032,7 +3032,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.1.2"
-    "@kaoto/forms": "npm:^1.2.0"
+    "@kaoto/forms": "npm:^1.2.1"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
     "@patternfly/patternfly": "npm:^6.2.3"


### PR DESCRIPTION
Define a public API for the suggestions query. It might be beneficial to merge it in a similar order, like @apupier suggested for the Maven-related feature, first define the API, then implement it, and lastly merge this one.

relates: https://github.com/KaotoIO/kaoto/issues/494
relates: https://github.com/KaotoIO/vscode-kaoto/issues/975