### PR TITLE
chore: Add MavenRuntime information types

### DIFF
--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -13,5 +13,6 @@ export * from './local-storage-keys';
 export * from './popper-default';
 export * from './react-component';
 export * from './settings';
+export * from './runtime-maven-information';
 export * from './validation';
 export * from './visualization';

--- a/packages/ui/src/models/runtime-maven-information.ts
+++ b/packages/ui/src/models/runtime-maven-information.ts
@@ -1,0 +1,27 @@
+export interface CamelMainMavenInformation {
+  runtime: string;
+  camelVersion: string;
+}
+
+export interface CamelSpringBootMavenInformation extends CamelMainMavenInformation {
+  /* Spring Boot specific*/
+  camelSpringBootBomArtifactId?: string;
+  camelSpringBootBomGroupId?: string;
+  camelSpringBootVersion?: string;
+  springBootVersion?: string;
+}
+
+export interface CamelQuarkusMavenInformation extends CamelMainMavenInformation {
+  /* Quarkus specific*/
+  camelQuarkusVersion?: string;
+  quarkusVersion?: string;
+  quarkusBomGroupId?: string;
+  quarkusBomArtifactId?: string;
+  camelQuarkusBomGroupId?: string;
+  camelQuarkusBomArtifactId?: string;
+}
+
+export type RuntimeMavenInformation =
+  | CamelMainMavenInformation
+  | CamelSpringBootMavenInformation
+  | CamelQuarkusMavenInformation;

--- a/packages/ui/src/public-api.ts
+++ b/packages/ui/src/public-api.ts
@@ -7,6 +7,7 @@ export * from './components/Settings';
 export * from './components/Visualization/Canvas';
 export * from './components/Visualization/ContextToolbar';
 export * from './components/MetadataEditor';
+export * from './models/runtime-maven-information';
 export * from './multiplying-architecture';
 export * from './external/RouteVisualization/RouteVisualization';
 export * from './pages/PipeErrorHandler/PipeErrorHandlerPage';


### PR DESCRIPTION
This PR defines the Runtime types from the `camel dependency runtime` command. It can be merged now but it should wait until the next release in order to use it.

relates: https://github.com/KaotoIO/vscode-kaoto/issues/977