### PR TITLE
test: Add e2e test to check if the group stays collapsed after the route change

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
@@ -91,4 +91,24 @@ describe('Test toolbar on hover actions', () => {
     cy.checkNodeExist('otherwise', 1);
     cy.checkNodeExist('log', 1);
   });
+
+  it('Keep group collapsed after the change in the route', () => {
+    cy.uploadFixture('flows/camelRoute/complex.yaml');
+    cy.openDesignPage();
+
+    cy.openGroupConfigurationTab('choice');
+
+    cy.get(`[data-testid="step-toolbar-button-collapse"]`).click({ force: true });
+    cy.checkNodeExist('when', 0);
+    cy.checkNodeExist('otherwise', 0);
+
+    cy.selectReplaceNode('timer');
+    cy.chooseFromCatalog('component', 'aws2-s3');
+
+    cy.checkNodeExist('aws2-s3', 1);
+    cy.checkNodeExist('timer', 0);
+
+    cy.checkNodeExist('when', 0);
+    cy.checkNodeExist('otherwise', 0);
+  });
 });


### PR DESCRIPTION
This pull request adds a new test case to the `hoverToolbarActions.cy.ts` file to verify that a group remains collapsed after a route change in the design interface. 

closes: [#1646](https://github.com/KaotoIO/kaoto/issues/1646)
relates to: https://github.com/KaotoIO/kaoto/pull/1922