### PR TITLE
fix(xml-step-parser): Parse uri to object with parameters

### DIFF
--- a/packages/ui-tests/cypress/e2e/xmlSupport/editingSourceXml.cy.ts
+++ b/packages/ui-tests/cypress/e2e/xmlSupport/editingSourceXml.cy.ts
@@ -15,17 +15,24 @@ describe('Tests for edit of XML document in code editor', () => {
     const yamlRoute = [
       'id: camel-route',
       'from:',
-      'uri: timer:test',
+      'uri: timer',
+      'parameters:',
+      'timerName: test',
       'steps:',
       '- setHeader:',
       'name: test',
       '- to:',
       'description: insert-field-XML',
-      'uri: log:InfoLogger?level=DEBUG',
+      'uri: log',
+      'parameters:',
+      'level: DEBUG',
+      'loggerName: InfoLogger',
       '- marshal:',
       'id: marshal-1234',
       '- to:',
-      'uri: log:test',
+      'uri: log',
+      'parameters:',
+      'loggerName: test',
     ];
     cy.openSourceCode();
     cy.checkMultiLineContent(yamlRoute);

--- a/packages/ui-tests/cypress/e2e/xmlSupport/importFileXml.cy.ts
+++ b/packages/ui-tests/cypress/e2e/xmlSupport/importFileXml.cy.ts
@@ -12,14 +12,18 @@ describe('Tests for import of XML route', () => {
     const yamlRoute = [
       'id: camel-route',
       'from:',
-      'uri: timer:test',
+      'uri: timer',
+      'parameters:',
+      'timerName: test',
       'steps:',
       '- setHeader:',
       'name: test',
       '- marshal:',
       'id: marshal-1234',
       '- to:',
-      'uri: log:test',
+      'uri: log',
+      'parameters:',
+      'loggerName: test',
     ];
     cy.openSourceCode();
     cy.checkMultiLineContent(yamlRoute);

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -516,4 +516,22 @@ export class CamelComponentSchemaService {
 
     return Object.keys(processorDefinition?.properties ?? {}).includes('disabled');
   }
+
+  static getComponentDefinitionFromUri(uri: string): { uri: string; parameters?: ParsedParameters } {
+    const componentName = CamelComponentSchemaService.getComponentNameFromUri(uri);
+    if (!componentName) return { uri: uri };
+
+    const component = CamelCatalogService.getComponent(CatalogKind.Component, componentName);
+    if (!component) {
+      return { uri: uri };
+    }
+
+    const [path, query] = uri.split('?');
+    const pathParams = CamelUriHelper.getParametersFromPathString(component?.component.syntax, path, {
+      requiredParameters: component?.propertiesSchema.required as [],
+    });
+
+    const queryParams = CamelUriHelper.getParametersFromQueryString(query);
+    return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
+  }
 }

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -18,6 +18,7 @@ import { DoCatch, DoTry, ProcessorDefinition, When1 as When } from '@kaoto/camel
 import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition, ICamelProcessorProperty } from '../../../models';
 import { ARRAY_TYPE_NAMES, extractAttributesFromXmlElement, PROCESSOR_NAMES } from '../utils/xml-utils';
 import { ExpressionParser } from './expression-parser';
+import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
 
 export type ElementTransformer = (element: Element) => unknown;
 
@@ -70,7 +71,7 @@ export class StepParser {
           break;
         case 'attribute':
           if (element.hasAttribute(name)) {
-            processor[name] = element.getAttribute(name);
+            processor = { ...processor, ...this.parseAttributeType(name, element) };
           }
           break;
         case 'expression':
@@ -110,6 +111,18 @@ export class StepParser {
     }
 
     return undefined;
+  }
+
+  private static parseAttributeType(name: string, element: Element): { [key: string]: unknown } {
+    if (name === 'uri') {
+      const uriString = element.getAttribute('uri');
+      if (!uriString) return {};
+      return CamelComponentSchemaService.getComponentDefinitionFromUri(uriString) ?? {};
+    }
+    if (element.hasAttribute(name)) {
+      return { [name]: element.getAttribute(name) };
+    }
+    return {};
   }
 
   private static findSingleElement(


### PR DESCRIPTION
This pull request introduces enhancements to the `CamelComponentSchemaService` and `StepParser` to improve URI parsing and streamline the handling of Camel component definitions. The key changes include the addition of a new method for parsing URIs, updates to unit tests to cover the new functionality.

### Enhancements to `CamelComponentSchemaService`:

* **New URI Parsing Method**: Added the `getComponentDefinitionFromUri` method to parse component URIs into structured definitions, including support for path and query parameters.
[[1]](diffhunk://#diff-0c53154d7a0becbc8f47579bcbc55076f6814b5bfa02868cec0de1eeacecb759L176-R183) 

### Integration with `StepParser`:

* **Enhanced Attribute Parsing**: Introduced the `parseAttributeType` method to handle `uri` attributes by leveraging the new `getComponentDefinitionFromUri` method from `CamelComponentSchemaService`.
* **Updated Attribute Handling**: Modified the `StepParser` to use the new `parseAttributeType` method for cleaner and more extensible attribute parsing.

relates #2089