### PR TITLE
feat(move-steps): Reorder steps on the canvas

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@patternfly/react-core';
 import {
+  AngleDoubleDownIcon,
+  AngleDoubleUpIcon,
   BanIcon,
   CheckIcon,
   CodeBranchIcon,
@@ -19,6 +21,7 @@ import { useEnableAllSteps } from '../../Custom/hooks/enable-all-steps.hook';
 import { useInsertStep } from '../../Custom/hooks/insert-step.hook';
 import { useReplaceStep } from '../../Custom/hooks/replace-step.hook';
 import './StepToolbar.scss';
+import { useMoveStep } from '../../Custom/hooks/move-step.hook';
 
 interface IStepToolbar extends IDataTestID {
   vizNode: IVisualizationNode;
@@ -43,9 +46,39 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
   const { onReplaceNode } = useReplaceStep(vizNode);
   const { onDeleteStep } = useDeleteStep(vizNode);
   const { onDeleteGroup } = useDeleteGroup(vizNode);
+  const { canBeMoved: canMoveBefore, onMoveStep: onMoveBefore } = useMoveStep(vizNode, AddStepMode.PrependStep);
+  const { canBeMoved: canMoveAfter, onMoveStep: onMoveAfter } = useMoveStep(vizNode, AddStepMode.AppendStep);
 
   return (
     <div className={clsx(className, 'step-toolbar')} data-testid={dataTestId}>
+      {canMoveBefore && (
+        <Button
+          icon={<AngleDoubleUpIcon />}
+          className="step-toolbar__button"
+          data-testid="step-toolbar-button-move-before"
+          variant="control"
+          title="Move before"
+          onClick={(event) => {
+            onMoveBefore();
+            event.stopPropagation();
+          }}
+        ></Button>
+      )}
+
+      {canMoveAfter && (
+        <Button
+          icon={<AngleDoubleDownIcon />}
+          className="step-toolbar__button"
+          data-testid="step-toolbar-button-move-after"
+          variant="control"
+          title="Move after"
+          onClick={(event) => {
+            onMoveAfter();
+            event.stopPropagation();
+          }}
+        ></Button>
+      )}
+
       {canHaveSpecialChildren && (
         <Button
           icon={<CodeBranchIcon />}

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.test.tsx
@@ -1,0 +1,68 @@
+import { AngleDoubleDownIcon, AngleDoubleUpIcon } from '@patternfly/react-icons';
+import { fireEvent, render } from '@testing-library/react';
+import { AddStepMode, createVisualizationNode } from '../../../../models';
+import { useMoveStep } from '../hooks/move-step.hook';
+import { ItemMoveStep } from './ItemMoveStep';
+
+// Mock the `useMoveStep` hook
+jest.mock('../hooks/move-step.hook', () => ({
+  useMoveStep: jest.fn(),
+}));
+
+describe('ItemMoveStep', () => {
+  const vizNode = createVisualizationNode('test', {});
+  const mockOnMoveStep = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render Move Next ContextMenuItem', () => {
+    // Mock the `useMoveStep` hook to return compatible state
+    (useMoveStep as jest.Mock).mockReturnValue({
+      onMoveStep: mockOnMoveStep,
+      canBeMoved: true,
+    });
+
+    const { container } = render(
+      <ItemMoveStep vizNode={vizNode} mode={AddStepMode.AppendStep}>
+        <AngleDoubleDownIcon /> Move Next
+      </ItemMoveStep>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should not render Move Before ContextMenuItem', () => {
+    // Mock the `useMoveStep` hook to return compatible state
+    (useMoveStep as jest.Mock).mockReturnValue({
+      onMoveStep: mockOnMoveStep,
+      canBeMoved: false,
+    });
+
+    const { container } = render(
+      <ItemMoveStep vizNode={vizNode} mode={AddStepMode.AppendStep}>
+        <AngleDoubleUpIcon /> Move Before
+      </ItemMoveStep>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should call onMoveStep when the context menu item is clicked', () => {
+    // Mock the `useMoveStep` hook to return compatible state
+    (useMoveStep as jest.Mock).mockReturnValue({
+      onMoveStep: mockOnMoveStep,
+      canBeMoved: true,
+    });
+
+    const wrapper = render(
+      <ItemMoveStep vizNode={vizNode} mode={AddStepMode.AppendStep}>
+        <AngleDoubleDownIcon /> Move Next
+      </ItemMoveStep>,
+    );
+    fireEvent.click(wrapper.getByText('Move Next'));
+
+    expect(mockOnMoveStep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.tsx
@@ -1,0 +1,22 @@
+import { ContextMenuItem } from '@patternfly/react-topology';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import { IDataTestID } from '../../../../models';
+import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { useMoveStep } from '../hooks/move-step.hook';
+
+interface ItemMoveStepProps extends PropsWithChildren<IDataTestID> {
+  mode: AddStepMode.AppendStep | AddStepMode.PrependStep;
+  vizNode: IVisualizationNode;
+}
+
+export const ItemMoveStep: FunctionComponent<ItemMoveStepProps> = (props) => {
+  const { canBeMoved, onMoveStep } = useMoveStep(props.vizNode, props.mode);
+
+  if (!canBeMoved) return null;
+
+  return (
+    <ContextMenuItem onClick={onMoveStep} data-testid={props['data-testid']}>
+      {props.children}
+    </ContextMenuItem>
+  );
+};

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemPasteStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemPasteStep.test.tsx
@@ -8,7 +8,7 @@ jest.mock('../hooks/paste-step.hook', () => ({
   usePasteStep: jest.fn(),
 }));
 
-describe('ItemCopyStep', () => {
+describe('ItemPasteStep', () => {
   const vizNode = createVisualizationNode('test', {});
   const mockOnPasteStep = jest.fn();
 

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
@@ -1,4 +1,11 @@
-import { ArrowDownIcon, ArrowUpIcon, CodeBranchIcon, PlusIcon } from '@patternfly/react-icons';
+import {
+  AngleDoubleDownIcon,
+  AngleDoubleUpIcon,
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CodeBranchIcon,
+  PlusIcon,
+} from '@patternfly/react-icons';
 import { ContextMenuSeparator, ElementModel, GraphElement } from '@patternfly/react-topology';
 import { forwardRef, ReactElement } from 'react';
 import { AddStepMode, IVisualizationNode, NodeInteraction } from '../../../../models/visualization/base-visual-entity';
@@ -12,6 +19,7 @@ import { ItemInsertStep } from './ItemInsertStep';
 import { ItemReplaceStep } from './ItemReplaceStep';
 import { ItemCopyStep } from './ItemCopyStep';
 import { ItemPasteStep } from './ItemPasteStep';
+import { ItemMoveStep } from './ItemMoveStep';
 
 export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode['data']>) => {
   const items: ReactElement[] = [];
@@ -52,6 +60,28 @@ export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode
   if (nodeInteractions.canHavePreviousStep || nodeInteractions.canHaveNextStep) {
     items.push(<ContextMenuSeparator key="context-menu-separator-add" />);
   }
+
+  items.push(
+    <ItemMoveStep
+      key="context-menu-item-move-before"
+      data-testid="context-menu-item-move-before"
+      mode={AddStepMode.PrependStep}
+      vizNode={vizNode}
+    >
+      <AngleDoubleUpIcon /> Move Before
+    </ItemMoveStep>,
+  );
+
+  items.push(
+    <ItemMoveStep
+      key="context-menu-item-move-next"
+      data-testid="context-menu-item-move-next"
+      mode={AddStepMode.AppendStep}
+      vizNode={vizNode}
+    >
+      <AngleDoubleDownIcon /> Move Next
+    </ItemMoveStep>,
+  );
 
   if (nodeInteractions.canHaveChildren) {
     items.push(

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/__snapshots__/ItemMoveStep.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/__snapshots__/ItemMoveStep.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ItemPasteStep should not render Paste ContextMenuItem 1`] = `<div />`;
+exports[`ItemMoveStep should not render Move Before ContextMenuItem 1`] = `<div />`;
 
-exports[`ItemPasteStep should render Paste ContextMenuItem 1`] = `
+exports[`ItemMoveStep should render Move Next ContextMenuItem 1`] = `
 <div>
   <li
     class="pf-v6-c-menu__list-item"
@@ -29,15 +29,14 @@ exports[`ItemPasteStep should render Paste ContextMenuItem 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
-            viewBox="0 0 448 512"
+            viewBox="0 0 320 512"
             width="1em"
           >
             <path
-              d="M128 184c0-30.879 25.122-56 56-56h136V56c0-13.255-10.745-24-24-24h-80.61C204.306 12.89 183.637 0 160 0s-44.306 12.89-55.39 32H24C10.745 32 0 42.745 0 56v336c0 13.255 10.745 24 24 24h104V184zm32-144c13.255 0 24 10.745 24 24s-10.745 24-24 24-24-10.745-24-24 10.745-24 24-24zm184 248h104v200c0 13.255-10.745 24-24 24H184c-13.255 0-24-10.745-24-24V184c0-13.255 10.745-24 24-24h136v104c0 13.2 10.8 24 24 24zm104-38.059V256h-96v-96h6.059a24 24 0 0 1 16.97 7.029l65.941 65.941a24.002 24.002 0 0 1 7.03 16.971z"
+              d="M143 256.3L7 120.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0L313 86.3c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.4 9.5-24.6 9.5-34 .1zm34 192l136-136c9.4-9.4 9.4-24.6 0-33.9l-22.6-22.6c-9.4-9.4-24.6-9.4-33.9 0L160 352.1l-96.4-96.4c-9.4-9.4-24.6-9.4-33.9 0L7 278.3c-9.4 9.4-9.4 24.6 0 33.9l136 136c9.4 9.5 24.6 9.5 34 .1z"
             />
           </svg>
-           
-          Paste as child
+           Move Next
         </span>
       </span>
     </button>

--- a/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.test.tsx
@@ -9,7 +9,7 @@ describe('useCopyStep', () => {
   const copiedContent = {
     type: SourceSchemaType.Route,
     name: 'exampleNode',
-    defaultValue: { id: 'node1', type: 'exampleType' },
+    definition: { id: 'node1', type: 'exampleType' },
   };
 
   afterEach(() => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
@@ -6,7 +6,6 @@ import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
 export interface IClipboardCopyObject {
   type: SourceSchemaType;
   name: string;
-  // can the type be more specific like: ProcessorDefinition[keyof ProcessorDefinition]
   definition: object;
 }
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
@@ -1,0 +1,186 @@
+import { renderHook } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import { useMoveStep } from './move-step.hook';
+import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { EntitiesContext } from '../../../../providers/entities.provider';
+import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
+import { getPotentialPath } from '../../../../utils/get-potential-path';
+import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/camel-route-visual-entity';
+import { camelRouteJson } from '../../../../stubs/camel-route';
+import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
+import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
+import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
+
+const mockController = {
+  getGraph: jest.fn(),
+};
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: () => mockController,
+}));
+
+jest.mock('../../../../utils/get-viznodes-from-graph');
+const mockGetVisualizationNodesFromGraph = getVisualizationNodesFromGraph as jest.MockedFunction<
+  typeof getVisualizationNodesFromGraph
+>;
+
+jest.mock('../../../../utils/get-potential-path');
+const mockGetPotentialPath = getPotentialPath as jest.MockedFunction<typeof getPotentialPath>;
+
+describe('useMoveStep', () => {
+  const visualEntity = new CamelRouteVisualEntity(camelRouteJson);
+  const vizNode = createVisualizationNode('test', { path: 'route.from.steps.1.to', entity: visualEntity });
+
+  const camelResource = new CamelRouteResource();
+  const mockEntitiesContext = {
+    camelResource,
+    entities: camelResource.getEntities(),
+    visualEntities: camelResource.getVisualEntities(),
+    currentSchemaType: camelResource.getType(),
+    updateSourceCodeFromEntities: jest.fn(),
+    updateEntitiesFromCamelResource: jest.fn(),
+  };
+
+  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+    <EntitiesContext.Provider value={mockEntitiesContext}>{children}</EntitiesContext.Provider>
+  );
+
+  const vizNodeCopiedContent = {
+    type: SourceSchemaType.Route,
+    name: 'exampleVizNode',
+    definition: { id: 'vizNode', Parameters: 'testParameters' },
+  };
+
+  const targetVizNodeCopiedContent = {
+    type: SourceSchemaType.Route,
+    name: 'exampleTargetVizNode',
+    definition: { id: 'targetVizNode', type: 'testExampleType' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should maintain stable reference when dependencies do not change', () => {
+    mockGetPotentialPath.mockReturnValue(undefined);
+
+    const { result, rerender } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), {
+      wrapper,
+    });
+
+    const firstResult = result.current;
+    rerender();
+
+    expect(result.current).toBe(firstResult);
+  });
+
+  describe('canBeMoved logic', () => {
+    it('should return true when target node is found for append mode', () => {
+      mockGetPotentialPath.mockReturnValue('route.from.steps.2');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([createVisualizationNode('target', {})]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+
+      expect(result.current.canBeMoved).toBe(true);
+      expect(mockGetPotentialPath).toHaveBeenCalledWith('route.from.steps.1.to', 'forward');
+    });
+
+    it('should return true when target node is found for prepend mode', () => {
+      mockGetPotentialPath.mockReturnValue('route.from.steps.0');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([createVisualizationNode('target', {})]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.PrependStep), { wrapper });
+
+      expect(result.current.canBeMoved).toBe(true);
+      expect(mockGetPotentialPath).toHaveBeenCalledWith('route.from.steps.1.to', 'backward');
+    });
+
+    it('should return false when no potential path is found', () => {
+      mockGetPotentialPath.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+
+      expect(result.current.canBeMoved).toBe(false);
+    });
+
+    it('should return false when no matching nodes are found', () => {
+      mockGetPotentialPath.mockReturnValue('route.from.steps.2');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+
+      expect(result.current.canBeMoved).toBe(false);
+    });
+
+    it('should find shortest path when multiple nodes match', () => {
+      const longPathVizNode = createVisualizationNode('longPath', { path: 'route.from.steps.2.choice.when' });
+      const shortPathVizNode = createVisualizationNode('shortPath', { path: 'route.from.steps.2.choice' });
+      const longPathVizNodeSpy = jest.spyOn(longPathVizNode, 'getCopiedContent');
+      const shortPathVizNodeSpy = jest.spyOn(shortPathVizNode, 'getCopiedContent');
+
+      mockGetPotentialPath.mockReturnValue('route.from.steps.2');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([longPathVizNode, shortPathVizNode]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+      result.current.onMoveStep();
+
+      // shortPathVizNode.getCopiedContent() call indicates that it was chosen as the target node
+      expect(shortPathVizNodeSpy).toHaveBeenCalled();
+      expect(longPathVizNodeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onMoveStep functionality', () => {
+    it('should return without calling pasteBaseEntityStep() and updateEntitiesFromCamelResource()', () => {
+      const VizNodeGetCopiedContentSpy = jest
+        .spyOn(vizNode, 'getCopiedContent')
+        .mockReturnValueOnce(vizNodeCopiedContent);
+      const VizNodePasteBaseEntityStepSpy = jest.spyOn(vizNode, 'pasteBaseEntityStep');
+
+      const targetVizNode = {
+        getCopiedContent: jest.fn().mockReturnValue(undefined),
+        pasteBaseEntityStep: jest.fn(),
+      } as unknown as IVisualizationNode;
+
+      mockGetPotentialPath.mockReturnValue('route.from.steps.2');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([targetVizNode]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+      result.current.onMoveStep();
+
+      expect(VizNodeGetCopiedContentSpy).toHaveBeenCalledTimes(1);
+      expect(targetVizNode.getCopiedContent).toHaveBeenCalledTimes(1);
+
+      expect(VizNodePasteBaseEntityStepSpy).not.toHaveBeenCalled();
+      expect(targetVizNode.pasteBaseEntityStep).not.toHaveBeenCalled();
+
+      expect(mockEntitiesContext.updateEntitiesFromCamelResource as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it('should call getCopiedContent(), pasteBaseEntityStep() and finally updateEntitiesFromCamelResource()', () => {
+      const VizNodeGetCopiedContentSpy = jest
+        .spyOn(vizNode, 'getCopiedContent')
+        .mockReturnValueOnce(vizNodeCopiedContent);
+      const VizNodePasteBaseEntityStepSpy = jest.spyOn(vizNode, 'pasteBaseEntityStep');
+
+      const targetVizNode = {
+        getCopiedContent: jest.fn().mockReturnValue(targetVizNodeCopiedContent),
+        pasteBaseEntityStep: jest.fn(),
+      } as unknown as IVisualizationNode;
+
+      mockGetPotentialPath.mockReturnValue('route.from.steps.2');
+      mockGetVisualizationNodesFromGraph.mockReturnValue([targetVizNode]);
+
+      const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
+      result.current.onMoveStep();
+
+      expect(VizNodeGetCopiedContentSpy).toHaveBeenCalledTimes(1);
+      expect(targetVizNode.getCopiedContent).toHaveBeenCalledTimes(1);
+
+      expect(VizNodePasteBaseEntityStepSpy).toHaveBeenCalledTimes(1);
+      expect(targetVizNode.pasteBaseEntityStep).toHaveBeenCalledTimes(1);
+
+      expect(mockEntitiesContext.updateEntitiesFromCamelResource as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useContext, useMemo } from 'react';
+import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { EntitiesContext } from '../../../../providers/entities.provider';
+import { isDefined } from '@kaoto/forms';
+import { useVisualizationController } from '@patternfly/react-topology';
+import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
+import { getPotentialPath } from '../../../../utils/get-potential-path';
+
+export const useMoveStep = (vizNode: IVisualizationNode, mode: AddStepMode.AppendStep | AddStepMode.PrependStep) => {
+  const entitiesContext = useContext(EntitiesContext);
+  const controller = useVisualizationController();
+
+  const targetNode = useMemo(() => {
+    const nodePath = vizNode.data.path;
+    const targetPath =
+      mode === AddStepMode.AppendStep ? getPotentialPath(nodePath, 'forward') : getPotentialPath(nodePath, 'backward');
+
+    if (!isDefined(targetPath)) return undefined;
+
+    const nodes = getVisualizationNodesFromGraph(
+      controller.getGraph(),
+      (node: IVisualizationNode) => (node.data.path ?? '').startsWith(targetPath) && node.getId() === vizNode.getId(),
+    );
+
+    if (nodes.length > 1) {
+      return nodes.reduce(
+        (shortest, current) =>
+          (current.data.path ?? '').length < (shortest.data.path ?? '').length ? current : shortest,
+        nodes[0],
+      );
+    }
+
+    return nodes.length === 1 ? nodes[0] : undefined;
+  }, [vizNode, controller, mode]);
+
+  const canBeMoved = isDefined(targetNode);
+
+  const onMoveStep = useCallback(async () => {
+    if (!vizNode || !entitiesContext) return;
+
+    const currentNodeContent = vizNode.getCopiedContent();
+    const targetNodeContent = targetNode?.getCopiedContent();
+
+    if (!currentNodeContent || !targetNodeContent) return;
+
+    /** Replace the content of the target node with the current node content
+        and vice versa  */
+    vizNode.pasteBaseEntityStep(targetNodeContent, AddStepMode.ReplaceStep);
+    targetNode?.pasteBaseEntityStep(currentNodeContent, AddStepMode.ReplaceStep);
+
+    /** Update entity */
+    entitiesContext.updateEntitiesFromCamelResource();
+  }, [entitiesContext, targetNode, vizNode]);
+
+  const value = useMemo(
+    () => ({
+      onMoveStep,
+      canBeMoved,
+    }),
+    [canBeMoved, onMoveStep],
+  );
+
+  return value;
+};

--- a/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/abstract-camel-visual-entity.test.ts.snap
@@ -440,3 +440,97 @@ exports[`AbstractCamelVisualEntity pasteStep should insert a new special child s
   },
 }
 `;
+
+exports[`AbstractCamelVisualEntity pasteStep should repace the special child step belonging to an array like when or doCatch 1`] = `
+{
+  "choice": {
+    "otherwise": {
+      "steps": [
+        {
+          "to": {
+            "uri": "amqp:queue:",
+          },
+        },
+        {
+          "to": {
+            "uri": "amqp:queue:",
+          },
+        },
+        {
+          "log": {
+            "id": "log-2",
+            "message": "We got a \${body}",
+          },
+        },
+      ],
+    },
+    "when": [
+      {
+        "expression": "simple("\${body} contains 'test'")",
+        "id": "when-replaced",
+        "steps": [
+          {
+            "log": {
+              "message": "Test message",
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`AbstractCamelVisualEntity pasteStep should replace the step 1`] = `
+[
+  {
+    "set-header": {
+      "name": "myChoice",
+      "simple": "\${random(2)}",
+    },
+  },
+  {
+    "choice": {
+      "otherwise": {
+        "steps": [
+          {
+            "to": {
+              "uri": "amqp:queue:",
+            },
+          },
+          {
+            "to": {
+              "uri": "amqp:queue:",
+            },
+          },
+          {
+            "log": {
+              "id": "log-2",
+              "message": "We got a \${body}",
+            },
+          },
+        ],
+      },
+      "when": [
+        {
+          "simple": "\${header.myChoice} == 1",
+          "steps": [
+            {
+              "log": {
+                "id": "log-1",
+                "message": "We got a one.",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "log": {
+      "id": "test-id",
+      "message": "Test message",
+    },
+  },
+]
+`;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -443,6 +443,57 @@ describe('AbstractCamelVisualEntity', () => {
       expect(abstractVisualEntity.entityDef.route.from.steps).toHaveLength(3);
       expect(abstractVisualEntity.entityDef.route.from.steps[1]).toMatchSnapshot();
     });
+
+    it('should replace the step', () => {
+      abstractVisualEntity.pasteStep({
+        clipboardContent: {
+          name: 'log',
+          type: SourceSchemaType.Route,
+          definition: {
+            id: 'test-id',
+            message: 'Test message',
+          },
+        },
+        mode: AddStepMode.ReplaceStep,
+        data: {
+          path: 'route.from.steps.2.to',
+          processorName: 'to',
+          componentName: 'direct',
+        },
+      });
+
+      expect(abstractVisualEntity.entityDef.route.from.steps).toHaveLength(3);
+      expect(abstractVisualEntity.entityDef.route.from.steps).toMatchSnapshot();
+    });
+
+    it('should repace the special child step belonging to an array like when or doCatch', () => {
+      abstractVisualEntity.pasteStep({
+        clipboardContent: {
+          name: 'when',
+          type: SourceSchemaType.Route,
+          definition: {
+            expression: 'simple("${body} contains \'test\'")',
+            id: 'when-replaced',
+            steps: [
+              {
+                log: {
+                  message: 'Test message',
+                },
+              },
+            ],
+          },
+        },
+        mode: AddStepMode.ReplaceStep,
+        data: {
+          path: 'route.from.steps.1.choice.when.0',
+          icon: '/src/assets/eip/when.png',
+          processorName: 'when',
+          isGroup: true,
+        },
+      });
+
+      expect(abstractVisualEntity.entityDef.route.from.steps[1]).toMatchSnapshot();
+    });
   });
 
   describe('getCopiedContent', () => {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -358,6 +358,23 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
 
       return;
     }
+
+    /**
+     * If the last segment is a number and the penultimate is a string, it also means the target is member of an array
+     *
+     * f.i. route.from.steps.0.choice.when.0
+     * penultimate: when
+     * last: 0
+     */
+    if (Number.isInteger(Number(last)) && !Number.isInteger(Number(penultimate))) {
+      const stepsArray = getArrayProperty(this.entityDef, pathArray.slice(0, -1).join('.'));
+
+      /** If we're in Replace mode, we need to delete the existing step */
+      const deleteCount = mode === AddStepMode.ReplaceStep ? 1 : 0;
+
+      /** Add the dragged node before the drop target */
+      stepsArray.splice(Number(last), deleteCount, defaultValue);
+    }
   }
 
   private insertChildStep(

--- a/packages/ui/src/utils/get-potential-path.test.ts
+++ b/packages/ui/src/utils/get-potential-path.test.ts
@@ -1,0 +1,65 @@
+import { getPotentialPath } from './get-potential-path';
+
+describe('getPotentialPath', () => {
+  describe('forward direction', () => {
+    it('should increment last element when it is integer and penultimate is not', () => {
+      expect(getPotentialPath('route.from.steps.0', 'forward')).toBe('route.from.steps.1');
+      expect(getPotentialPath('route.from.steps.5', 'forward')).toBe('route.from.steps.6');
+    });
+
+    it('should increment penultimate element when last is not integer and penultimate is', () => {
+      expect(getPotentialPath('route.from.steps.0.when', 'forward')).toBe('route.from.steps.1');
+      expect(getPotentialPath('route.from.steps.3.doCatch', 'forward')).toBe('route.from.steps.4');
+    });
+
+    it('should handle single element paths', () => {
+      expect(getPotentialPath('0', 'forward')).toBeUndefined();
+      expect(getPotentialPath('route', 'forward')).toBeUndefined();
+    });
+  });
+
+  describe('backward direction', () => {
+    it('should decrement last element when it is integer and penultimate is not', () => {
+      expect(getPotentialPath('route.from.steps.1', 'backward')).toBe('route.from.steps.0');
+      expect(getPotentialPath('route.from.steps.5', 'backward')).toBe('route.from.steps.4');
+    });
+
+    it('should decrement penultimate element when last is not integer and penultimate is', () => {
+      expect(getPotentialPath('route.from.steps.1.when', 'backward')).toBe('route.from.steps.0');
+      expect(getPotentialPath('route.from.steps.3.doCatch', 'backward')).toBe('route.from.steps.2');
+    });
+
+    it('should return undefined when trying to go below 0', () => {
+      expect(getPotentialPath('route.from.steps.0', 'backward')).toBeUndefined();
+      expect(getPotentialPath('route.from.steps.0.when', 'backward')).toBeUndefined();
+      expect(getPotentialPath('0', 'backward')).toBeUndefined();
+    });
+
+    it('should handle single element paths', () => {
+      expect(getPotentialPath('1', 'backward')).toBeUndefined();
+      expect(getPotentialPath('route  ', 'backward')).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return undefined for empty or invalid paths', () => {
+      expect(getPotentialPath()).toBeUndefined();
+      expect(getPotentialPath('')).toBeUndefined();
+      expect(getPotentialPath('.')).toBeUndefined();
+    });
+
+    it('should return undefined when no integer pattern is found', () => {
+      expect(getPotentialPath('route.from', 'forward')).toBeUndefined();
+      expect(getPotentialPath('route.from.steps', 'forward')).toBeUndefined();
+    });
+
+    it('should handle negative numbers correctly', () => {
+      expect(getPotentialPath('route.from.steps.-1', 'forward')).toBeUndefined();
+      expect(getPotentialPath('route.from.steps.1.when', 'backward')).toBe('route.from.steps.0');
+    });
+
+    it('should use forward as default direction', () => {
+      expect(getPotentialPath('route.from.steps.0')).toBe('route.from.steps.1');
+    });
+  });
+});

--- a/packages/ui/src/utils/get-potential-path.ts
+++ b/packages/ui/src/utils/get-potential-path.ts
@@ -1,0 +1,48 @@
+import { isDefined } from './is-defined';
+
+const isValidInteger = (value?: string): boolean => {
+  if (value === undefined || value === null) return false;
+
+  const num = Number(value);
+  return Number.isInteger(num) && num >= 0;
+};
+
+const incrementPath = (pathArray: string[], target: string, direction: string): string | undefined => {
+  const currentValue = Number(target);
+
+  if (direction === 'backward' && currentValue === 0) {
+    return undefined; // Prevent going to negative index
+  }
+
+  const newValue = direction === 'forward' ? currentValue + 1 : currentValue - 1;
+  const newPath = pathArray.concat(newValue.toString());
+
+  return newPath.join('.');
+};
+
+export const getPotentialPath = (path?: string, direction: string = 'forward'): string | undefined => {
+  if (!path) return undefined;
+
+  const pathArray = path.split('.');
+  const length = pathArray.length;
+
+  if (length < 1) return undefined;
+
+  const last = pathArray[length - 1];
+  const penultimate = pathArray[length - 2];
+  const lastIsInteger = isValidInteger(last);
+  const penultimateIsInteger = isValidInteger(penultimate);
+
+  // Last element is integer, penultimate is not
+  if (lastIsInteger && isDefined(penultimate) && !penultimateIsInteger) {
+    return incrementPath(pathArray.slice(0, -1), last, direction);
+  }
+
+  // Last element is not integer, penultimate is integer
+  if (!lastIsInteger && penultimateIsInteger) {
+    return incrementPath(pathArray.slice(0, -2), penultimate, direction);
+  }
+
+  // No valid pattern found
+  return undefined;
+};


### PR DESCRIPTION
Fixes #1484 
Note: This just not works for choice nodes. It enables Move functionality for all entity type!
Check this out here: https://shivamg640.github.io/kaoto/