### PR TITLE
feat(Form): Switch between to, toD and poll

### DIFF
--- a/packages/ui/src/components/ComponentMode/ComponentMode.scss
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.scss
@@ -1,0 +1,5 @@
+.component-mode {
+  display: flex;
+  justify-content: end;
+  margin-top: var(--pf-t--global--spacer--md);
+}

--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -1,0 +1,196 @@
+import { CatalogLibrary } from '@kaoto/camel-catalog/catalog-index.d.ts';
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { act, render } from '@testing-library/react';
+import { CamelCatalogService, CatalogKind, IVisualizationNode } from '../../models';
+import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { ComponentMode } from './ComponentMode';
+
+let mockUpdateSourceCodeFromEntities: jest.Mock;
+jest.mock('../../hooks/useEntityContext/useEntityContext', () => ({
+  useEntityContext: () => ({ updateSourceCodeFromEntities: mockUpdateSourceCodeFromEntities }),
+}));
+
+describe('ComponentMode', () => {
+  beforeEach(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, { ...catalogsMap.patternCatalogMap });
+
+    mockUpdateSourceCodeFromEntities = jest.fn();
+  });
+
+  const getMockVizNode = (processorName = 'to'): IVisualizationNode => {
+    return {
+      data: { processorName, path: `route.from.steps.0.${processorName}` },
+      getComponentSchema: () => ({ definition: {} }),
+      updateModel: jest.fn(),
+    } as unknown as IVisualizationNode;
+  };
+
+  it('renders the three toggle buttons', () => {
+    const wrapper = render(<ComponentMode vizNode={getMockVizNode('to')} />);
+
+    expect(wrapper.getByText('Static')).toBeInTheDocument();
+    expect(wrapper.getByText('Dynamic')).toBeInTheDocument();
+    expect(wrapper.getByText('Poll')).toBeInTheDocument();
+  });
+
+  it('should not call updateSourceCodeFromEntities if there is no VizNode', () => {
+    render(<ComponentMode vizNode={undefined} />);
+
+    expect(mockUpdateSourceCodeFromEntities).not.toHaveBeenCalled();
+  });
+
+  it('should not call updateSourceCodeFromEntities if we are switching to the same EIP', async () => {
+    const vizNode = getMockVizNode('to');
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.getByText('Static');
+    expect(toButton).toBeInTheDocument();
+
+    await act(async () => {
+      toButton.click();
+    });
+
+    expect(mockUpdateSourceCodeFromEntities).not.toHaveBeenCalled();
+  });
+
+  it('should not call updateSourceCodeFromEntities if the vizNode does not contain a path', async () => {
+    const vizNode = getMockVizNode('to');
+    vizNode.data.path = undefined;
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.getByText('Static');
+    expect(toButton).toBeInTheDocument();
+
+    await act(async () => {
+      toButton.click();
+    });
+
+    expect(mockUpdateSourceCodeFromEntities).not.toHaveBeenCalled();
+  });
+
+  it('calls updateModel when switching from "to" to "poll"', async () => {
+    const vizNode = getMockVizNode('to');
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const pollButton = wrapper.getByText('Poll');
+    expect(pollButton).toBeInTheDocument();
+
+    await act(async () => {
+      pollButton.click();
+    });
+
+    expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
+    expect(vizNode.data.path).toBe('route.from.steps.0.poll');
+    expect(vizNode.updateModel).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls updateModel when switching from "to" to "toD"', async () => {
+    const vizNode = getMockVizNode('to');
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toDButton = wrapper.getByText('Dynamic');
+    expect(toDButton).toBeInTheDocument();
+
+    await act(async () => {
+      toDButton.click();
+    });
+
+    expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
+    expect(vizNode.data.path).toBe('route.from.steps.0.toD');
+    expect(vizNode.updateModel).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls updateModel when switching from "poll" to "to"', async () => {
+    const vizNode = getMockVizNode('poll');
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.getByText('Static');
+    expect(toButton).toBeInTheDocument();
+
+    await act(async () => {
+      toButton.click();
+    });
+
+    expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
+    expect(vizNode.data.path).toBe('route.from.steps.0.to');
+    expect(vizNode.updateModel).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls updateSourceCodeFromEntities when switching from "poll" to "to"', async () => {
+    const vizNode = getMockVizNode('poll');
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.getByText('Static');
+    expect(toButton).toBeInTheDocument();
+
+    await act(async () => {
+      toButton.click();
+    });
+
+    expect(mockUpdateSourceCodeFromEntities).toHaveBeenCalled();
+  });
+
+  it('should query the camel catalog for the component description', () => {
+    const getComponentSpy = jest.spyOn(CamelCatalogService, 'getComponent');
+    const vizNode = getMockVizNode('to');
+
+    render(<ComponentMode vizNode={vizNode} />);
+
+    expect(getComponentSpy).toHaveBeenCalledWith(CatalogKind.Pattern, 'to');
+    expect(getComponentSpy).toHaveBeenCalledWith(CatalogKind.Pattern, 'toD');
+    expect(getComponentSpy).toHaveBeenCalledWith(CatalogKind.Pattern, 'poll');
+    expect(getComponentSpy).not.toHaveBeenCalledWith(CatalogKind.Entity, 'from');
+  });
+
+  it('should not render the to button if the catalog is not available', () => {
+    const camelPatternsCatalog = CamelCatalogService.getCatalogByKey(CatalogKind.Pattern)!;
+    delete camelPatternsCatalog['to'];
+    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatternsCatalog);
+    const vizNode = getMockVizNode('to');
+
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.queryByText('Static');
+    const toDButton = wrapper.queryByText('Dynamic');
+    const pollButton = wrapper.queryByText('Poll');
+
+    expect(toButton).not.toBeInTheDocument();
+    expect(toDButton).toBeInTheDocument();
+    expect(pollButton).toBeInTheDocument();
+  });
+
+  it('should not render the toD button if the catalog is not available', () => {
+    const camelPatternsCatalog = CamelCatalogService.getCatalogByKey(CatalogKind.Pattern)!;
+    delete camelPatternsCatalog['toD'];
+    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatternsCatalog);
+    const vizNode = getMockVizNode('toD');
+
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.queryByText('Static');
+    const toDButton = wrapper.queryByText('Dynamic');
+    const pollButton = wrapper.queryByText('Poll');
+
+    expect(toButton).toBeInTheDocument();
+    expect(toDButton).not.toBeInTheDocument();
+    expect(pollButton).toBeInTheDocument();
+  });
+
+  it('should not render the poll button if the catalog is not available', () => {
+    const camelPatternsCatalog = CamelCatalogService.getCatalogByKey(CatalogKind.Pattern)!;
+    delete camelPatternsCatalog['poll'];
+    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatternsCatalog);
+    const vizNode = getMockVizNode('to');
+
+    const wrapper = render(<ComponentMode vizNode={vizNode} />);
+
+    const toButton = wrapper.queryByText('Static');
+    const toDButton = wrapper.queryByText('Dynamic');
+    const pollButton = wrapper.queryByText('Poll');
+
+    expect(toButton).toBeInTheDocument();
+    expect(toDButton).toBeInTheDocument();
+    expect(pollButton).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/ComponentMode/ComponentMode.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.tsx
@@ -1,0 +1,88 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useState } from 'react';
+import { useProcessorIcon } from '../../hooks/processor-icon.hook';
+import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext';
+import { IVisualizationNode } from '../../models';
+import { CamelRouteVisualEntityData } from '../../models/visualization/flows/support/camel-component-types';
+import './ComponentMode.scss';
+
+export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> = ({ vizNode }) => {
+  const { updateSourceCodeFromEntities } = useEntityContext();
+  const [processorName, setProcessorName] = useState<keyof ProcessorDefinition>(
+    (vizNode?.data as CamelRouteVisualEntityData)?.processorName,
+  );
+
+  const switchComponentMode = useCallback(
+    (newProcessorName: keyof ProcessorDefinition) => {
+      if (!vizNode || newProcessorName === processorName) return;
+
+      const path = vizNode.data.path;
+      const rootEipPath = path?.split('.').slice(0, -1).join('.');
+      const definition = vizNode.getComponentSchema()?.definition;
+      if (!definition || !rootEipPath) return;
+
+      /**
+       * Switch the used EIP for the component, it can go from 'to' to 'toD' or 'poll'
+       * and vice versa.
+       */
+      vizNode.data = { ...vizNode.data, path: rootEipPath };
+      vizNode.updateModel(undefined);
+
+      vizNode.data = { ...vizNode.data, path: `${rootEipPath}.${newProcessorName}`, processorName: newProcessorName };
+      vizNode.updateModel(definition);
+      updateSourceCodeFromEntities();
+      setProcessorName(newProcessorName);
+    },
+    [vizNode, processorName, updateSourceCodeFromEntities],
+  );
+
+  const { Icon: ToIcon, description: toDescription } = useProcessorIcon('to');
+  const { Icon: ToDIcon, description: toDDescription } = useProcessorIcon('toD');
+  const { Icon: PollIcon, description: pollDescription } = useProcessorIcon('poll');
+
+  return (
+    <section className="component-mode">
+      <ToggleGroup isCompact aria-label="Component Mode Toggle Group">
+        {toDescription && (
+          <ToggleGroupItem
+            icon={<ToIcon />}
+            text="Static"
+            buttonId="to"
+            title={toDescription}
+            isSelected={processorName === 'to'}
+            onChange={() => {
+              switchComponentMode('to');
+            }}
+          />
+        )}
+        {toDDescription && (
+          <ToggleGroupItem
+            icon={<ToDIcon />}
+            text="Dynamic"
+            buttonId="toD"
+            title={toDDescription}
+            isSelected={processorName === 'toD'}
+            onChange={() => {
+              switchComponentMode('toD');
+            }}
+          />
+        )}
+        {pollDescription && (
+          <ToggleGroupItem
+            icon={<PollIcon />}
+            text="Poll"
+            buttonId="poll"
+            title={pollDescription}
+            isSelected={processorName === 'poll'}
+            onChange={() => {
+              switchComponentMode('poll');
+            }}
+          />
+        )}
+      </ToggleGroup>
+    </section>
+  );
+};
+
+export default ComponentMode;

--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
@@ -1,0 +1,17 @@
+@use '../custom';
+
+.floating-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--custom-node-BackgroundColor);
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  border: 1px solid var(--custom-node-BorderColor);
+  box-shadow: var(--custom-node-Shadow);
+
+  [data-selected='true'] & {
+    @include custom.selected;
+  }
+}

--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import { FloatingCircle } from './FloatingCircle';
+
+describe('FloatingCircle', () => {
+  it('renders children correctly', () => {
+    const { container } = render(<FloatingCircle>Test Content</FloatingCircle>);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<FloatingCircle className="my-class">Content</FloatingCircle>);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders without children', () => {
+    const { container } = render(<FloatingCircle />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.tsx
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.tsx
@@ -1,0 +1,10 @@
+import clsx from 'clsx';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import './FloatingCircle.scss';
+
+export const FloatingCircle: FunctionComponent<PropsWithChildren<{ className?: string }>> = ({
+  children,
+  className,
+}) => {
+  return <div className={clsx('floating-circle', className)}>{children}</div>;
+};

--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/__snapshots__/FloatingCircle.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/__snapshots__/FloatingCircle.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FloatingCircle applies custom className 1`] = `
+<div>
+  <div
+    class="floating-circle my-class"
+  >
+    Content
+  </div>
+</div>
+`;
+
+exports[`FloatingCircle renders children correctly 1`] = `
+<div>
+  <div
+    class="floating-circle"
+  >
+    Test Content
+  </div>
+</div>
+`;
+
+exports[`FloatingCircle renders without children 1`] = `
+<div>
+  <div
+    class="floating-circle"
+  />
+</div>
+`;

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
@@ -52,6 +52,13 @@
         @include custom.disabled;
       }
     }
+
+    &__disabled-icon {
+      position: absolute;
+      top: 0;
+      right: 0;
+      margin: var(--pf-t--global--spacer--xs);
+    }
   }
 
   &__toolbar {

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -100,7 +100,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
               </div>
 
               {isDisabled && (
-                <Icon className="disabled-step-icon" title="Step disabled">
+                <Icon className="custom-group__disabled-icon" title="Step disabled">
                   <BanIcon />
                 </Icon>
               )}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -33,13 +33,16 @@
       }
 
       &:hover &__image,
+      &:hover .step-icon,
       [data-toolbar-open='true'] & &__image,
+      [data-toolbar-open='true'] & .step-icon,
       [data-selected='true'] & &__image {
         border-color: var(--custom-node-BorderColor-hover);
         box-shadow: var(--custom-node-Shadow);
       }
 
-      [data-selected='true'] & &__image {
+      [data-selected='true'] & &__image,
+      [data-selected='true'] & .step-icon {
         @include custom.selected;
       }
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -12,7 +12,6 @@ import {
   GraphElement,
   GraphElementProps,
   isNode,
-  LabelBadge,
   Layer,
   Node,
   observer,
@@ -28,8 +27,10 @@ import {
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
 import { FunctionComponent, useContext, useRef } from 'react';
+import { useProcessorIcon } from '../../../../hooks/processor-icon.hook';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { AddStepMode, IVisualizationNode, NodeToolbarTrigger } from '../../../../models';
+import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { SettingsContext } from '../../../../providers';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { CanvasNode, LayoutType } from '../../Canvas/canvas.models';
@@ -37,6 +38,7 @@ import { StepToolbar } from '../../Canvas/StepToolbar/StepToolbar';
 import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { customNodeDropTargetSpec } from '../customComponentUtils';
 import { AddStepIcon } from '../Edge/AddStepIcon';
+import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
 import { TargetAnchor } from '../target-anchor';
 import './CustomNode.scss';
 
@@ -59,6 +61,8 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const entitiesContext = useEntityContext();
     const settingsAdapter = useContext(SettingsContext);
     const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
+    const processorName = (vizNode?.data as CamelRouteVisualEntityData)?.processorName;
+    const { Icon: ProcessorIcon, description: processorDescription } = useProcessorIcon(processorName);
     const isDisabled = !!vizNode?.getComponentSchema()?.definition?.disabled;
     const tooltipContent = vizNode?.getTooltipContent();
     const validationText = vizNode?.getNodeValidationText();
@@ -175,10 +179,24 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               <div title={tooltipContent} className="custom-node__container__image">
                 <img alt={tooltipContent} src={vizNode.data.icon} />
 
+                {childCount > 0 && (
+                  <FloatingCircle className="step-icon step-icon__processor">
+                    <span title={`${childCount}`}>{childCount}</span>
+                  </FloatingCircle>
+                )}
+                {ProcessorIcon && (
+                  <FloatingCircle className="step-icon step-icon__processor">
+                    <Icon status="info" size="lg">
+                      <ProcessorIcon title={processorDescription} />
+                    </Icon>
+                  </FloatingCircle>
+                )}
                 {isDisabled && (
-                  <Icon className="disabled-step-icon" status="danger" size="lg">
-                    <BanIcon />
-                  </Icon>
+                  <FloatingCircle className="step-icon step-icon__disabled">
+                    <Icon status="danger" size="lg">
+                      <BanIcon />
+                    </Icon>
+                  </FloatingCircle>
                 )}
               </div>
             </div>
@@ -242,8 +260,6 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               </AddStepIcon>
             </foreignObject>
           )}
-
-          {childCount && <LabelBadge badge={`${childCount}`} x={0} y={0} />}
         </g>
       </Layer>
     );

--- a/packages/ui/src/components/Visualization/Custom/_custom.scss
+++ b/packages/ui/src/components/Visualization/Custom/_custom.scss
@@ -1,8 +1,15 @@
-.disabled-step-icon {
+.step-icon {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: -12px;
   margin: var(--pf-t--global--spacer--xs);
+
+  &__disabled {
+    right: -12px;
+  }
+
+  &__processor {
+    left: -12px;
+  }
 }
 
 @mixin highligth {

--- a/packages/ui/src/components/registers/RegisterComponents.tsx
+++ b/packages/ui/src/components/registers/RegisterComponents.tsx
@@ -3,6 +3,7 @@ import { RenderingAnchorContext } from '../RenderingAnchor/rendering.provider';
 import { IRegisteredComponent } from '../RenderingAnchor/rendering.provider.model';
 import { Anchors } from './anchors';
 import { datamapperActivationFn } from './datamapper.activationfn';
+import { componentModeActivationFn } from './component-mode.activationfn';
 
 export const RegisterComponents: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { registerComponent } = useContext(RenderingAnchorContext);
@@ -12,6 +13,11 @@ export const RegisterComponents: FunctionComponent<PropsWithChildren> = ({ child
       anchor: Anchors.CanvasFormHeader,
       activationFn: datamapperActivationFn,
       component: lazy(() => import('../DataMapper/DataMapperLauncher')),
+    },
+    {
+      anchor: Anchors.CanvasFormHeader,
+      activationFn: componentModeActivationFn,
+      component: lazy(() => import('../ComponentMode/ComponentMode')),
     },
   ]);
 

--- a/packages/ui/src/components/registers/component-mode.activationfn.test.ts
+++ b/packages/ui/src/components/registers/component-mode.activationfn.test.ts
@@ -1,0 +1,26 @@
+import { IVisualizationNode } from '../../models';
+import { componentModeActivationFn } from './component-mode.activationfn';
+
+describe('componentModeActivationFn', () => {
+  it('should return false if vizNode is `undefined`', () => {
+    const result = componentModeActivationFn();
+
+    expect(result).toBe(false);
+  });
+
+  const TEST_CASES = [
+    [true, 'to'],
+    [true, 'toD'],
+    [true, 'poll'],
+    [false, 'from'],
+    [false, 'log'],
+    [false, 'other'],
+  ];
+  it.each(TEST_CASES)('should return "%s" for "%s"', (expectedResult, processorName) => {
+    const result = componentModeActivationFn({
+      data: { processorName },
+    } as unknown as IVisualizationNode);
+
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/ui/src/components/registers/component-mode.activationfn.ts
+++ b/packages/ui/src/components/registers/component-mode.activationfn.ts
@@ -1,0 +1,14 @@
+import { IVisualizationNode } from '../../models/visualization/base-visual-entity';
+
+export const componentModeActivationFn = (vizNode?: IVisualizationNode): boolean => {
+  if (!vizNode) {
+    return false;
+  }
+
+  return (
+    'processorName' in vizNode.data &&
+    (vizNode.data.processorName === 'to' ||
+      vizNode.data.processorName === 'toD' ||
+      vizNode.data.processorName === 'poll')
+  );
+};

--- a/packages/ui/src/hooks/processor-icon.hook.test.tsx
+++ b/packages/ui/src/hooks/processor-icon.hook.test.tsx
@@ -1,0 +1,47 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { ArrowRightIcon, BoltIcon, DataSourceIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { renderHook } from '@testing-library/react';
+import { CamelCatalogService, ComponentsCatalogTypes } from '../models';
+import { useProcessorIcon } from './processor-icon.hook';
+
+describe('useProcessorIcon', () => {
+  const TEST_CASES = [
+    ['from', DataSourceIcon],
+    ['to', ArrowRightIcon],
+    ['toD', BoltIcon],
+    ['poll', SyncAltIcon],
+  ] as const;
+
+  it.each(TEST_CASES)('returns an icon and description for processorName="%s"', (name, icon) => {
+    const { result } = renderHook(() => useProcessorIcon(name as keyof ProcessorDefinition));
+
+    expect(result.current.Icon).toBe(icon);
+    expect(result.current.description).toBe('');
+  });
+
+  it('should return null for not specified processors', () => {
+    const { result } = renderHook(() => useProcessorIcon('unknown' as keyof ProcessorDefinition));
+
+    expect(result.current.Icon).toBe(null);
+    expect(result.current.description).toBeUndefined();
+  });
+
+  const DESCRIPTION_TEST_CASES = [
+    ['from', 'From: From Description'],
+    ['to', 'To: To Description'],
+    ['toD', 'ToD: ToD Description'],
+    ['poll', 'Poll: Poll Description'],
+  ] as const;
+  it.each(DESCRIPTION_TEST_CASES)(
+    'returns the correct description for processorName="%s"',
+    (name, expectedDescription) => {
+      jest.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce({
+        model: { description: expectedDescription.split(': ')[1] },
+      } as unknown as ComponentsCatalogTypes);
+
+      const { result } = renderHook(() => useProcessorIcon(name as keyof ProcessorDefinition));
+
+      expect(result.current.description).toBe(expectedDescription);
+    },
+  );
+});

--- a/packages/ui/src/hooks/processor-icon.hook.tsx
+++ b/packages/ui/src/hooks/processor-icon.hook.tsx
@@ -1,0 +1,33 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { ArrowRightIcon, BoltIcon, DataSourceIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { ElementType } from 'react';
+import { CamelCatalogService, CatalogKind } from '../models';
+
+export const useProcessorIcon = (
+  processorName: keyof ProcessorDefinition,
+): { Icon: ElementType; description: string } | { Icon: null; description: undefined } => {
+  let Icon: ElementType;
+  let description: string;
+
+  if (processorName === ('from' as keyof ProcessorDefinition)) {
+    Icon = DataSourceIcon;
+    const fromDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'from')?.model.description;
+    description = fromDescription ? `From: ${fromDescription}` : '';
+  } else if (processorName === 'to') {
+    Icon = ArrowRightIcon;
+    const toDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'to')?.model.description;
+    description = toDescription ? `To: ${toDescription}` : '';
+  } else if (processorName === 'toD') {
+    Icon = BoltIcon;
+    const toDDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'toD')?.model.description;
+    description = toDDescription ? `ToD: ${toDDescription}` : '';
+  } else if (processorName === 'poll') {
+    Icon = SyncAltIcon;
+    const pollDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'poll')?.model.description;
+    description = pollDescription ? `Poll: ${pollDescription}` : '';
+  } else {
+    return { Icon: null, description: undefined };
+  }
+
+  return { Icon, description };
+};


### PR DESCRIPTION
### Context
This commit adds support for the first part of the new `toD` configuration experience.

At this time, we offer the user a mechanism to switch between the related EIPs to leverage the existing configuration. Said EIPs are `to`, `toD`, and `poll`.

#### Screenshot
<img width="742" height="282" alt="image" src="https://github.com/user-attachments/assets/da9e7cc3-c7ce-47ad-bde7-b180cdd09818" />


relates: https://github.com/KaotoIO/kaoto/issues/2392