### PR TITLE
fix(Datamapper): Fix XPath function parsing

### DIFF
--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -231,6 +231,17 @@ describe('XPathService', () => {
       expect(paths.length).toEqual(1);
       expect(paths[0].isRelative).toBeFalsy();
     });
+
+    it('extract field paths from current() function in predicate', () => {
+      // This test reproduces the reported issue - should not throw error
+      const paths = XPathService.extractFieldPaths('Sub[current()/Sub/Typ="5032"]');
+      expect(paths.length).toBeGreaterThan(0);
+
+      // Should extract at least the main element path 'Sub' and the path from current() argument
+      const mainPath = paths.find((p) => p.pathSegments.length === 1 && p.pathSegments[0].name === 'Sub');
+      expect(mainPath).toBeDefined();
+      expect(mainPath?.pathSegments[0].predicates.length).toEqual(1);
+    });
   });
 
   it('getXPathFunctionDefinitions()', () => {

--- a/packages/ui/src/services/xpath/xpath.service.ts
+++ b/packages/ui/src/services/xpath/xpath.service.ts
@@ -133,11 +133,16 @@ export class XPathService {
 
     const varName = XPathService.getSingleNode(stepExpr, ['FilterExpr', 'VarRef', 'QName', 'NCName']);
     const contextItem = XPathService.getSingleNode(stepExpr, ['FilterExpr', 'ContextItemExpr']);
+    const functionCall = XPathService.getSingleNode(stepExpr, ['FilterExpr', 'FunctionCall']);
+
     if (varName && 'image' in varName) {
       answer.isRelative = false;
       answer.documentReferenceName = varName.image;
     } else if (contextItem && 'image' in contextItem) {
       answer.pathSegments.push(new PathSegment(contextItem.image, false));
+    } else if (functionCall) {
+      // Skip function calls in the path expression as they don't represent field paths
+      // The function arguments are already processed by extractPathExprNode/collectPathExprNodes
     } else {
       const segment = XPathService.extractSegmentFromStepExpr(stepExpr);
       if (segment) {


### PR DESCRIPTION
Considering the following path:

```
Sub[current()/Sub/Typ=&quot;5032&quot;]
```

The `XPathService` class needs to ignore the `current()` function call and just take the `Sub` and `[/Sub/Typ="5032"]` portion.

fix: https://github.com/KaotoIO/kaoto/issues/2432