### PR TITLE
fix(DataMapper): Refactor AttachSchemaButton to parse the schema file…

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchemaButton.test.tsx
@@ -13,9 +13,6 @@ import {
   shipOrderXsd,
 } from '../../../stubs/datamapper/data-mapper';
 import { BrowserFilePickerMetadataProvider } from '../../../stubs/BrowserFilePickerMetadataProvider';
-import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
-import { useDataMapper } from '../../../hooks/useDataMapper';
-import { AlertProps } from '@patternfly/react-core';
 
 jest.mock('../../../stubs/read-file-as-string');
 const mockReadFileAsString = readFileAsString as jest.MockedFunction<typeof readFileAsString>;
@@ -131,24 +128,13 @@ describe('AttachSchemaButton', () => {
     });
   });
 
-  let capturedAlerts: Partial<AlertProps>[] = [];
-  const TestAlertCapture: FunctionComponent<PropsWithChildren> = ({ children }) => {
-    const { alerts } = useDataMapper();
-    useEffect(() => {
-      capturedAlerts = alerts;
-    }, [alerts]);
-    return <>{children}</>;
-  };
-
-  it('should show a toast alert for invalid schema', async () => {
+  it('should show inline error for invalid schema', async () => {
     mockReadFileAsString.mockResolvedValue(noTopElementXsd);
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <DataMapperCanvasProvider>
-            <TestAlertCapture>
-              <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
-            </TestAlertCapture>
+            <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
           </DataMapperCanvasProvider>
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -170,30 +156,22 @@ describe('AttachSchemaButton', () => {
     });
 
     await waitFor(() => {
+      const helperText = screen.getByTestId('attach-schema-modal-text-helper');
+      expect(helperText).toBeInTheDocument();
+      expect(helperText.textContent).toContain('no top level Element');
+
       const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
-      expect(text.value).toEqual('NoTopElement.xsd');
-    });
-
-    const commitButton = await screen.findByTestId('attach-schema-modal-btn-attach');
-    act(() => {
-      fireEvent.click(commitButton);
-    });
-
-    await waitFor(() => {
-      expect(capturedAlerts.length).toEqual(1);
-      expect(capturedAlerts[0].title).toContain('no top level Element');
+      expect(text.value).toEqual('');
     });
   });
 
-  it('should show a toast alert for XML parse error', async () => {
+  it('should show inline error for XML parse error', async () => {
     mockReadFileAsString.mockResolvedValue(shipOrderEmptyFirstLineXsd);
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <DataMapperCanvasProvider>
-            <TestAlertCapture>
-              <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
-            </TestAlertCapture>
+            <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
           </DataMapperCanvasProvider>
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -217,30 +195,22 @@ describe('AttachSchemaButton', () => {
     });
 
     await waitFor(() => {
+      const helperText = screen.getByTestId('attach-schema-modal-text-helper');
+      expect(helperText).toBeInTheDocument();
+      expect(helperText.textContent).toContain('an XML declaration must be at the start of the document');
+
       const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
-      expect(text.value).toEqual('ShipOrderEmptyFirstLine.xsd');
-    });
-
-    const commitButton = await screen.findByTestId('attach-schema-modal-btn-attach');
-    act(() => {
-      fireEvent.click(commitButton);
-    });
-
-    await waitFor(() => {
-      expect(capturedAlerts.length).toEqual(1);
-      expect(capturedAlerts[0].title).toContain('an XML declaration must be at the start of the document');
+      expect(text.value).toEqual('');
     });
   });
 
-  it('should show a toast alert when attaching JSON schema on the source body', async () => {
+  it('should show inline error when attaching JSON schema on the source body', async () => {
     mockReadFileAsString.mockResolvedValue(shipOrderJsonSchema);
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <DataMapperCanvasProvider>
-            <TestAlertCapture>
-              <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
-            </TestAlertCapture>
+            <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
           </DataMapperCanvasProvider>
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -263,29 +233,26 @@ describe('AttachSchemaButton', () => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
 
-    await waitFor(() => {
-      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
-      expect(text.value).toEqual('');
-    });
-
     const commitButton = (await screen.findByTestId('attach-schema-modal-btn-attach')) as HTMLInputElement;
     expect(commitButton.disabled).toEqual(true);
 
     await waitFor(() => {
-      expect(capturedAlerts.length).toEqual(1);
-      expect(capturedAlerts[0].title).toContain('JSON source body is not supported');
+      const helperText = screen.getByTestId('attach-schema-modal-text-helper');
+      expect(helperText).toBeInTheDocument();
+      expect(helperText.textContent).toContain('JSON source body is not supported');
+
+      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
+      expect(text.value).toEqual('');
     });
   });
 
-  it('should show a toast alert when attaching unknown file to source body', async () => {
+  it('should show inline error when attaching unknown file to source body', async () => {
     mockReadFileAsString.mockResolvedValue(shipOrderJsonXslt);
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <DataMapperCanvasProvider>
-            <TestAlertCapture>
-              <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
-            </TestAlertCapture>
+            <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
           </DataMapperCanvasProvider>
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -308,31 +275,28 @@ describe('AttachSchemaButton', () => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
 
-    await waitFor(() => {
-      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
-      expect(text.value).toEqual('');
-    });
-
     const commitButton = (await screen.findByTestId('attach-schema-modal-btn-attach')) as HTMLInputElement;
     expect(commitButton.disabled).toEqual(true);
 
     await waitFor(() => {
-      expect(capturedAlerts.length).toEqual(1);
-      expect(capturedAlerts[0].title).toContain(
+      const helperText = screen.getByTestId('attach-schema-modal-text-helper');
+      expect(helperText).toBeInTheDocument();
+      expect(helperText.textContent).toContain(
         "Unknown file extension '.xsl'. Only XML schema file (.xml, .xsd) is supported.",
       );
+
+      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
+      expect(text.value).toEqual('');
     });
   });
 
-  it('should show a toast alert when attaching unknown file to target body', async () => {
+  it('should show inline error when attaching unknown file to target body', async () => {
     mockReadFileAsString.mockResolvedValue(shipOrderJsonXslt);
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <DataMapperCanvasProvider>
-            <TestAlertCapture>
-              <AttachSchemaButton documentType={DocumentType.TARGET_BODY} documentId={BODY_DOCUMENT_ID} />
-            </TestAlertCapture>
+            <AttachSchemaButton documentType={DocumentType.TARGET_BODY} documentId={BODY_DOCUMENT_ID} />
           </DataMapperCanvasProvider>
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -355,19 +319,87 @@ describe('AttachSchemaButton', () => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
 
-    await waitFor(() => {
-      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
-      expect(text.value).toEqual('');
-    });
+    await waitFor(() => {});
 
     const commitButton = (await screen.findByTestId('attach-schema-modal-btn-attach')) as HTMLInputElement;
     expect(commitButton.disabled).toEqual(true);
 
     await waitFor(() => {
-      expect(capturedAlerts.length).toEqual(1);
-      expect(capturedAlerts[0].title).toContain(
+      const helperText = screen.getByTestId('attach-schema-modal-text-helper');
+      expect(helperText).toBeInTheDocument();
+      expect(helperText.textContent).toContain(
         "Unknown file extension '.xsl'. Either XML schema (.xsd, .xml) or JSON schema (.json) file is supported.",
       );
+
+      const text: HTMLInputElement = screen.getByTestId('attach-schema-modal-text');
+      expect(text.value).toEqual('');
     });
+  });
+
+  it('should close modal when cancel is clicked', async () => {
+    render(
+      <BrowserFilePickerMetadataProvider>
+        <DataMapperProvider>
+          <DataMapperCanvasProvider>
+            <AttachSchemaButton documentType={DocumentType.SOURCE_BODY} documentId={BODY_DOCUMENT_ID} />
+          </DataMapperCanvasProvider>
+        </DataMapperProvider>
+      </BrowserFilePickerMetadataProvider>,
+    );
+
+    const attachButton = await screen.findByTestId('attach-schema-sourceBody-Body-button');
+    act(() => {
+      fireEvent.click(attachButton);
+    });
+
+    let modal = screen.queryByTestId('attach-schema-modal');
+    expect(modal).toBeInTheDocument();
+
+    const cancelButton = await screen.findByTestId('attach-schema-modal-btn-cancel');
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+
+    await waitFor(() => {
+      modal = screen.queryByTestId('attach-schema-modal');
+      expect(modal).not.toBeInTheDocument();
+    });
+  });
+
+  it('should change schema type when radio button is clicked', async () => {
+    render(
+      <BrowserFilePickerMetadataProvider>
+        <DataMapperProvider>
+          <DataMapperCanvasProvider>
+            <AttachSchemaButton documentType={DocumentType.TARGET_BODY} documentId={BODY_DOCUMENT_ID} />
+          </DataMapperCanvasProvider>
+        </DataMapperProvider>
+      </BrowserFilePickerMetadataProvider>,
+    );
+
+    const attachButton = await screen.findByTestId('attach-schema-targetBody-Body-button');
+    act(() => {
+      fireEvent.click(attachButton);
+    });
+
+    const xmlRadio = await screen.findByTestId('attach-schema-modal-option-xml');
+    const jsonRadio = await screen.findByTestId('attach-schema-modal-option-json');
+
+    expect(xmlRadio).toBeChecked();
+    expect(jsonRadio).not.toBeChecked();
+
+    act(() => {
+      fireEvent.click(jsonRadio);
+    });
+
+    expect(xmlRadio).not.toBeChecked();
+    expect(jsonRadio).toBeChecked();
+
+    act(() => {
+      fireEvent.click(xmlRadio);
+    });
+
+    expect(xmlRadio).toBeChecked();
+    expect(jsonRadio).not.toBeChecked();
   });
 });

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
@@ -5,6 +5,7 @@ import { DetachSchemaButton } from './DetachSchemaButton';
 import { BODY_DOCUMENT_ID, DocumentType, IDocument, PrimitiveDocument } from '../../../models/datamapper/document';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 import { useDataMapper } from '../../../hooks/useDataMapper';
+import { DocumentService } from '../../../services/document.service';
 
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 
@@ -46,5 +47,236 @@ describe('DetachSchemaButton', () => {
     await screen.findByTestId('detachtest');
     expect(sourceDoc!.fields.length).toBe(0);
     expect(sourceDoc! instanceof PrimitiveDocument);
+  });
+
+  it('should open and close modal', async () => {
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachSchemaButton documentId={BODY_DOCUMENT_ID} documentType={DocumentType.SOURCE_BODY} />
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    let modal = screen.queryByTestId('detach-schema-modal');
+    expect(modal).not.toBeInTheDocument();
+
+    const detachBtn = await screen.findByTestId('detach-schema-sourceBody-Body-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    modal = screen.queryByTestId('detach-schema-modal');
+    expect(modal).toBeInTheDocument();
+
+    const cancelBtn = screen.getByTestId('detach-schema-modal-cancel-btn');
+    act(() => {
+      fireEvent.click(cancelBtn);
+    });
+
+    expect(screen.queryByTestId('detach-schema-modal')).not.toBeInTheDocument();
+  });
+
+  it('should handle detach with parameter document type', async () => {
+    const mockSendAlert = jest.fn();
+    const mockUpdateDocument = jest.fn();
+
+    const DetachTestParam: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const dataMapper = useDataMapper();
+      dataMapper.sendAlert = mockSendAlert;
+      dataMapper.updateDocument = mockUpdateDocument;
+      return <div data-testid="detachtest-param">{children}</div>;
+    };
+
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachTestParam>
+            <DetachSchemaButton documentId="testParam" documentType={DocumentType.PARAM} />
+          </DetachTestParam>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const detachBtn = await screen.findByTestId('detach-schema-param-testParam-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    const confirmBtn = screen.getByTestId('detach-schema-modal-confirm-btn');
+    act(() => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockUpdateDocument).toHaveBeenCalledTimes(1);
+    expect(mockSendAlert).not.toHaveBeenCalled();
+  });
+
+  it('should handle detach with target body document type', async () => {
+    const mockSendAlert = jest.fn();
+    const mockUpdateDocument = jest.fn();
+
+    const DetachTestTarget: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const dataMapper = useDataMapper();
+      dataMapper.sendAlert = mockSendAlert;
+      dataMapper.updateDocument = mockUpdateDocument;
+      return <div data-testid="detachtest-target">{children}</div>;
+    };
+
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachTestTarget>
+            <DetachSchemaButton documentId={BODY_DOCUMENT_ID} documentType={DocumentType.TARGET_BODY} />
+          </DetachTestTarget>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const detachBtn = await screen.findByTestId('detach-schema-targetBody-Body-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    const confirmBtn = screen.getByTestId('detach-schema-modal-confirm-btn');
+    act(() => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockUpdateDocument).toHaveBeenCalledTimes(1);
+    expect(mockSendAlert).not.toHaveBeenCalled();
+  });
+
+  it('should handle error when document creation fails', async () => {
+    // Mock DocumentService to simulate failure
+    const mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
+    mockCreatePrimitiveDocument.mockReturnValue({
+      validationStatus: 'error',
+      validationMessage: 'Failed to create primitive document',
+    });
+
+    const mockSendAlert = jest.fn();
+
+    const DetachTestError: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const dataMapper = useDataMapper();
+      dataMapper.sendAlert = mockSendAlert;
+      return <div data-testid="detachtest-error">{children}</div>;
+    };
+
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachTestError>
+            <DetachSchemaButton documentId={BODY_DOCUMENT_ID} documentType={DocumentType.SOURCE_BODY} />
+          </DetachTestError>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const detachBtn = await screen.findByTestId('detach-schema-sourceBody-Body-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    const confirmBtn = screen.getByTestId('detach-schema-modal-confirm-btn');
+    act(() => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockSendAlert).toHaveBeenCalledWith({
+      variant: 'danger',
+      title: 'Failed to create primitive document',
+    });
+
+    mockCreatePrimitiveDocument.mockRestore();
+  });
+
+  it('should handle warning when document creation returns warning', async () => {
+    // Mock DocumentService to simulate warning
+    const mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
+    mockCreatePrimitiveDocument.mockReturnValue({
+      validationStatus: 'warning',
+      validationMessage: 'Warning during document creation',
+    });
+
+    const mockSendAlert = jest.fn();
+
+    const DetachTestWarning: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const dataMapper = useDataMapper();
+      dataMapper.sendAlert = mockSendAlert;
+      return <div data-testid="detachtest-warning">{children}</div>;
+    };
+
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachTestWarning>
+            <DetachSchemaButton documentId={BODY_DOCUMENT_ID} documentType={DocumentType.SOURCE_BODY} />
+          </DetachTestWarning>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const detachBtn = await screen.findByTestId('detach-schema-sourceBody-Body-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    const confirmBtn = screen.getByTestId('detach-schema-modal-confirm-btn');
+    act(() => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockSendAlert).toHaveBeenCalledWith({
+      variant: 'warning',
+      title: 'Warning during document creation',
+    });
+
+    mockCreatePrimitiveDocument.mockRestore();
+  });
+
+  it('should handle case when document or documentDefinition is missing', async () => {
+    // Mock DocumentService to return success but with missing document/documentDefinition
+    const mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
+    mockCreatePrimitiveDocument.mockReturnValue({
+      validationStatus: 'success',
+      document: undefined,
+      documentDefinition: undefined,
+    });
+
+    const mockSendAlert = jest.fn();
+
+    const DetachTestMissing: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const dataMapper = useDataMapper();
+      dataMapper.sendAlert = mockSendAlert;
+      return <div data-testid="detachtest-missing">{children}</div>;
+    };
+
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <DetachTestMissing>
+            <DetachSchemaButton documentId={BODY_DOCUMENT_ID} documentType={DocumentType.SOURCE_BODY} />
+          </DetachTestMissing>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const detachBtn = await screen.findByTestId('detach-schema-sourceBody-Body-button');
+    act(() => {
+      fireEvent.click(detachBtn);
+    });
+
+    const confirmBtn = screen.getByTestId('detach-schema-modal-confirm-btn');
+    act(() => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockSendAlert).toHaveBeenCalledWith({
+      variant: 'danger',
+      title: 'Could not detach schema',
+    });
+
+    mockCreatePrimitiveDocument.mockRestore();
   });
 });

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -198,6 +198,13 @@ export class DocumentInitializationModel {
   ) {}
 }
 
+export interface CreateDocumentResult {
+  validationStatus: 'success' | 'warning' | 'error';
+  validationMessage?: string;
+  documentDefinition?: DocumentDefinition;
+  document?: IDocument;
+}
+
 export const SCHEMA_FILE_NAME_PATTERN = '**/*.{xsd,XSD,xml,XML,json,JSON}';
 export const SCHEMA_FILE_ACCEPT_PATTERN = '.xsd, .xml, .json';
 // camel XSLT (including saxon) doesn't support JSON body

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -2,6 +2,7 @@ import { DocumentType, IDocument, IField, PrimitiveDocument } from './document';
 import { ExpressionItem, FieldItem, IFunctionDefinition, MappingItem, MappingParentType, MappingTree } from './mapping';
 import { NodePath } from './nodepath';
 import { RefObject } from 'react';
+import { AlertProps } from '@patternfly/react-core';
 
 export interface NodeData {
   title: string;
@@ -187,3 +188,5 @@ export type LineProps = LineCoord & {
   isSelected?: boolean;
   svgRef?: RefObject<SVGSVGElement>;
 };
+
+export type SendAlertProps = Partial<AlertProps & { description: string }>;

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -1,15 +1,10 @@
 import { DocumentService } from './document.service';
 
 import { TestUtil } from '../stubs/datamapper/data-mapper';
-import {
-  DocumentDefinition,
-  DocumentDefinitionType,
-  DocumentType,
-  PathSegment,
-  PrimitiveDocument,
-} from '../models/datamapper';
+import { DocumentDefinitionType, DocumentType, PathSegment, PrimitiveDocument } from '../models/datamapper';
 import { XmlSchemaDocument } from './xml-schema-document.service';
 import { JsonSchemaDocument } from './json-schema-document.service';
+import { IMetadataApi } from '../providers';
 
 describe('DocumentService', () => {
   const sourceDoc = TestUtil.createSourceOrderDoc();
@@ -17,59 +12,137 @@ describe('DocumentService', () => {
   const namespaces = { kaoto: 'io.kaoto.datamapper.poc.test' };
 
   describe('createDocument()', () => {
-    it('should create a primitive document', () => {
-      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test', {});
-      const doc = DocumentService.createDocument(docDef);
-      expect(doc instanceof PrimitiveDocument).toBeTruthy();
-    });
-
-    it('should create a XML schema document', () => {
-      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test', {
-        schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    it('should create a XML schema document', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
                    <xs:element name="test" type="xs:string" />
-                 </xs:schema>`,
-      });
-      const doc = DocumentService.createDocument(docDef);
-      expect(doc instanceof XmlSchemaDocument).toBeTruthy();
-    });
+                 </xs:schema>`),
+      };
 
-    it('should throw an error if XML schema is not parseable', () => {
-      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test', {
-        schema: JSON.stringify({ type: 'string' }),
-      });
-      expect(() => DocumentService.createDocument(docDef)).toThrow();
-    });
-
-    it('should create a JSON schema document', () => {
-      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.JSON_SCHEMA, 'test', {
-        schema: JSON.stringify({ type: 'string' }),
-      });
-      const doc = DocumentService.createDocument(docDef);
-      expect(doc instanceof JsonSchemaDocument).toBeTruthy();
-    });
-
-    it('should throw an error if JSON schema is not parseable', () => {
-      const docDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.JSON_SCHEMA, 'test', {
-        schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                   <xs:element name="test" type="xs:string" />
-                 </xs:schema>`,
-      });
-      expect(() => DocumentService.createDocument(docDef)).toThrow();
-    });
-
-    it('should return null if type is unknown', () => {
-      const docDef = new DocumentDefinition(
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
         DocumentType.SOURCE_BODY,
-        'unknown' as unknown as DocumentDefinitionType,
+        DocumentDefinitionType.XML_SCHEMA,
         'test',
-        {
-          schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                   <xs:element name="test" type="xs:string" />
-                 </xs:schema>`,
-        },
+        ['test.xsd'],
       );
-      const doc = DocumentService.createDocument(docDef);
-      expect(doc).toBeNull();
+
+      expect(result.validationStatus).toBe('success');
+      expect(result.document instanceof XmlSchemaDocument).toBeTruthy();
+      expect(result.documentDefinition).toBeDefined();
+      expect(result.documentDefinition?.documentType).toBe(DocumentType.SOURCE_BODY);
+      expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.XML_SCHEMA);
+    });
+
+    it('should return error if XML schema is not parseable', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(JSON.stringify({ type: 'string' })),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test',
+        ['test.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('error');
+      expect(result.validationMessage).toBeDefined();
+      expect(result.document).toBeUndefined();
+      expect(result.documentDefinition).toBeUndefined();
+    });
+
+    it('should create a JSON schema document', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(JSON.stringify({ type: 'string' })),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test',
+        ['test.json'],
+      );
+
+      expect(result.validationStatus).toBe('success');
+      expect(result.document instanceof JsonSchemaDocument).toBeTruthy();
+      expect(result.documentDefinition).toBeDefined();
+      expect(result.documentDefinition?.documentType).toBe(DocumentType.SOURCE_BODY);
+      expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.JSON_SCHEMA);
+    });
+
+    it('should return error if JSON schema is not parseable', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                   <xs:element name="test" type="xs:string" />
+                 </xs:schema>`),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test',
+        ['test.json'],
+      );
+
+      expect(result.validationStatus).toBe('error');
+      expect(result.validationMessage).toBeDefined();
+      expect(result.document).toBeUndefined();
+      expect(result.documentDefinition).toBeUndefined();
+    });
+
+    it('should return error if file content is empty', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(''),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test',
+        ['test.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('error');
+      expect(result.validationMessage).toBe('Could not create a document from schema file(s)');
+      expect(result.document).toBeUndefined();
+      expect(result.documentDefinition).toBeUndefined();
+    });
+  });
+
+  describe('createPrimitiveDocument()', () => {
+    it('should create a primitive document', () => {
+      const result = DocumentService.createPrimitiveDocument(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.Primitive,
+        'test',
+      );
+      expect(result.validationStatus).toBe('success');
+      expect(result.document instanceof PrimitiveDocument).toBeTruthy();
+      expect(result.document?.documentId).toEqual('Body');
+      expect(result.documentDefinition).toBeDefined();
+      expect(result.documentDefinition?.documentType).toBe(DocumentType.SOURCE_BODY);
+      expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.Primitive);
+      expect(result.documentDefinition?.name).toBe('test');
+    });
+
+    it('should create a primitive document for a param', () => {
+      const result = DocumentService.createPrimitiveDocument(
+        DocumentType.PARAM,
+        DocumentDefinitionType.Primitive,
+        'test',
+      );
+      expect(result.validationStatus).toBe('success');
+      expect(result.document instanceof PrimitiveDocument).toBeTruthy();
+      expect(result.document?.documentId).toEqual('test');
+      expect(result.documentDefinition).toBeDefined();
+      expect(result.documentDefinition?.documentType).toBe(DocumentType.PARAM);
+      expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.Primitive);
+      expect(result.documentDefinition?.name).toBe('test');
     });
   });
 
@@ -100,6 +173,130 @@ describe('DocumentService', () => {
       expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[2])).toBeFalsy();
       expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[3])).toBeTruthy();
       expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[3])).toBeTruthy();
+    });
+  });
+
+  describe('createDocument() error handling', () => {
+    it('should handle API errors gracefully', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockRejectedValue(new Error('Network error')),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test',
+        ['test.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('error');
+      expect(result.validationMessage).toContain('Could not create a document from schema file(s)');
+      expect(result.document).toBeUndefined();
+      expect(result.documentDefinition).toBeUndefined();
+    });
+
+    it('should handle malformed JSON for JSON schema', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue('{invalid json'),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test',
+        ['test.json'],
+      );
+
+      expect(result.validationStatus).toBe('error');
+      expect(result.validationMessage).toBeDefined();
+      expect(result.document).toBeUndefined();
+      expect(result.documentDefinition).toBeUndefined();
+    });
+
+    it('should handle invalid XML content that looks valid initially', async () => {
+      // Mock XML that passes initial validation but fails during processing
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                   <xs:element name="test" type="xs:invalid-type" />
+                 </xs:schema>`),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test',
+        ['test.xsd'],
+      );
+
+      // Should handle gracefully even if schema has issues
+      expect(result.validationStatus).toBeDefined();
+      expect(['success', 'error']).toContain(result.validationStatus);
+    });
+  });
+
+  describe('createDocument() with multiple files', () => {
+    it('should handle multiple schema files', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValueOnce(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                     <xs:element name="test1" type="xs:string" />
+                   </xs:schema>`).mockResolvedValueOnce(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                     <xs:element name="test2" type="xs:string" />
+                   </xs:schema>`),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test',
+        ['test1.xsd', 'test2.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('success');
+      expect(result.document).toBeDefined();
+      expect(result.documentDefinition).toBeDefined();
+      expect(mockApi.getResourceContent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('createPrimitiveDocument() edge cases', () => {
+    it('should handle different document types correctly', () => {
+      const sourceResult = DocumentService.createPrimitiveDocument(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.Primitive,
+        'sourceTest',
+      );
+      expect(sourceResult.document?.documentId).toEqual('Body');
+
+      const targetResult = DocumentService.createPrimitiveDocument(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.Primitive,
+        'targetTest',
+      );
+      expect(targetResult.document?.documentId).toEqual('Body');
+
+      const paramResult = DocumentService.createPrimitiveDocument(
+        DocumentType.PARAM,
+        DocumentDefinitionType.Primitive,
+        'paramTest',
+      );
+      expect(paramResult.document?.documentId).toEqual('paramTest');
+    });
+
+    it('should create proper DocumentDefinition for primitives', () => {
+      const result = DocumentService.createPrimitiveDocument(
+        DocumentType.PARAM,
+        DocumentDefinitionType.Primitive,
+        'testParam',
+      );
+
+      expect(result.documentDefinition?.documentType).toBe(DocumentType.PARAM);
+      expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.Primitive);
+      expect(result.documentDefinition?.name).toBe('testParam');
+      expect(result.documentDefinition?.definitionFiles).toEqual({});
     });
   });
 });


### PR DESCRIPTION
… and show error message inline in the modal

Fixes: https://github.com/KaotoIO/kaoto/issues/2441

Parse the schema and create a Document object immediately when user chooses the file in the modal, and show the error inline if there is any. In the error case, it also disables the Submit button. This is also a preparation work to let user choose the root element (#1814), where once XML schema successfully parsed, a list of top level elements will be shown in the modal so that user can choose one from them.


https://github.com/user-attachments/assets/6ce60ccc-b6e5-417d-bc9e-aa74a811ccda

