### PR TITLE
fix(DataMapper): XML schema parser fails to detect a collection field

### DIFF
--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -1,7 +1,7 @@
-import { TestUtil } from '../stubs/datamapper/data-mapper';
+import { camelSpringXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
-import { Types } from '../models/datamapper';
-import { XmlSchemaField } from './xml-schema-document.service';
+import { BODY_DOCUMENT_ID, DocumentType, Types } from '../models/datamapper';
+import { XmlSchemaDocumentService, XmlSchemaField } from './xml-schema-document.service';
 
 describe('DocumentUtilService', () => {
   const sourceDoc = TestUtil.createSourceOrderDoc();
@@ -52,6 +52,22 @@ describe('DocumentUtilService', () => {
       const refChildField = refField.fields[0];
       expect(refChildField.name).toEqual('testField');
       expect(refChildField.type).toEqual(Types.String);
+    });
+
+    it('should resolve collection type fragment', () => {
+      const document = XmlSchemaDocumentService.createXmlSchemaDocument(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        camelSpringXsd,
+        { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
+      );
+
+      const resolvedRoutes = DocumentUtilService.resolveTypeFragment(document.fields[0]);
+      const route = resolvedRoutes.fields.find((f) => f.name === 'route');
+      // https://github.com/KaotoIO/kaoto/issues/2457
+      // occurrences must be taken from the referrer as opposed to the other attributes
+      expect(route?.minOccurs).toEqual(0);
+      expect(route?.maxOccurs).toBeGreaterThan(1);
     });
   });
 });

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -55,6 +55,7 @@ describe('XmlSchemaDocumentService', () => {
     const aggregateDef = document.namedTypeFragments[aggregate.namedTypeFragmentRefs[0]];
     expect(aggregateDef.fields.length).toEqual(100);
     expect(aggregateDef.namedTypeFragmentRefs[0]).toEqual('{http://camel.apache.org/schema/spring}output');
+
     const outputDef = document.namedTypeFragments[aggregateDef.namedTypeFragmentRefs[0]];
     expect(outputDef.fields.length).toEqual(0);
     expect(outputDef.namedTypeFragmentRefs[0]).toEqual('{http://camel.apache.org/schema/spring}processorDefinition');
@@ -66,6 +67,24 @@ describe('XmlSchemaDocumentService', () => {
     const optionalIdentifiedDef = document.namedTypeFragments[processorDef.namedTypeFragmentRefs[0]];
     expect(optionalIdentifiedDef.fields.length).toEqual(3);
     expect(optionalIdentifiedDef.namedTypeFragmentRefs.length).toEqual(0);
+  });
+
+  it('should create XML schema document with routes as a root element', () => {
+    const document = XmlSchemaDocumentService.createXmlSchemaDocument(
+      DocumentType.TARGET_BODY,
+      BODY_DOCUMENT_ID,
+      camelSpringXsd,
+      { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
+    );
+    expect(document).toBeDefined();
+    expect(document.fields.length).toEqual(1);
+    const routes = document.fields[0];
+    expect(routes.fields.length).toEqual(0);
+    const routesRef = routes.namedTypeFragmentRefs[0];
+    const routeDef = document.namedTypeFragments[routesRef];
+    expect(routeDef.fields.length).toEqual(1);
+    const route = routeDef.fields[0];
+    expect(route.name).toEqual('route');
   });
 
   it('should create XML Schema Document', () => {

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -176,8 +176,9 @@ export class XmlSchemaDocumentService {
     field.namespaceURI = resolvedElement.getWireName()!.getNamespaceURI();
     field.namespacePrefix = resolvedElement.getWireName()!.getPrefix();
     field.defaultValue = resolvedElement.defaultValue || resolvedElement.fixedValue;
-    field.minOccurs = resolvedElement.getMinOccurs();
-    field.maxOccurs = resolvedElement.getMaxOccurs();
+    // The occurrences must be taken from the referrer as opposed to the other attributes
+    field.minOccurs = element.getMinOccurs();
+    field.maxOccurs = element.getMaxOccurs();
     fields.push(field);
 
     const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2457

<img width="1250" height="410" alt="Screenshot From 2025-08-19 15-53-12" src="https://github.com/user-attachments/assets/5b17117e-f0f9-4ae1-8481-844cf5f3f571" />
