### PR TITLE
fat(Datamapper): Improve Data Mapper line clipping and container overflow handling

### DIFF
--- a/packages/ui/src/components/View/SourceTargetView.scss
+++ b/packages/ui/src/components/View/SourceTargetView.scss
@@ -2,6 +2,12 @@
   height: 100%;
   overflow-x: auto;
 
+  &__container {
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+  }
+
   &__source-split {
     width: 30%;
     min-width: 300px;

--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -37,35 +37,37 @@ export const SourceTargetView: FunctionComponent = () => {
   }, [setDefaultHandler]);
 
   return (
-    <Split className="source-target-view" onScroll={reloadNodeReferences}>
-      <SplitItem className="source-target-view__source-split" isFilled>
-        <SourcePanel />
-      </SplitItem>
-      <SplitItem className="source-target-view__line-blank">
-        <div ref={mappingLinkCanvasRef} />
-      </SplitItem>
-      <SplitItem className="source-target-view__target-split" isFilled>
-        <Panel id="panel-target" variant="bordered" isScrollable className="source-target-view__target-panel">
-          <PanelHeader>
-            <Content>
-              <Content component={ContentVariants.h3}>
-                <Truncate content="Target" className="source-target-view__truncate" />
+    <div className="source-target-view__container">
+      <Split className="source-target-view" onScroll={reloadNodeReferences}>
+        <SplitItem className="source-target-view__source-split" isFilled>
+          <SourcePanel />
+        </SplitItem>
+        <SplitItem className="source-target-view__line-blank">
+          <div ref={mappingLinkCanvasRef} />
+        </SplitItem>
+        <SplitItem className="source-target-view__target-split" isFilled>
+          <Panel id="panel-target" variant="bordered" isScrollable className="source-target-view__target-panel">
+            <PanelHeader>
+              <Content>
+                <Content component={ContentVariants.h3}>
+                  <Truncate content="Target" className="source-target-view__truncate" />
+                </Content>
               </Content>
-            </Content>
-          </PanelHeader>
-          <PanelMain onScroll={reloadNodeReferences} className="source-target-view__target-panel-main">
-            <Stack className="source-target-view__target-panel-main">
-              <StackItem>
-                <Divider component="div" inset={{ default: 'insetSm' }} className="source-target-view__divider" />
-              </StackItem>
-              <StackItem>
-                <TargetDocument document={targetBodyDocument} />
-              </StackItem>
-            </Stack>
-          </PanelMain>
-        </Panel>
-      </SplitItem>
+            </PanelHeader>
+            <PanelMain onScroll={reloadNodeReferences} className="source-target-view__target-panel-main">
+              <Stack className="source-target-view__target-panel-main">
+                <StackItem>
+                  <Divider component="div" inset={{ default: 'insetSm' }} className="source-target-view__divider" />
+                </StackItem>
+                <StackItem>
+                  <TargetDocument document={targetBodyDocument} />
+                </StackItem>
+              </Stack>
+            </PanelMain>
+          </Panel>
+        </SplitItem>
+      </Split>
       <MappingLinksContainer />
-    </Split>
+    </div>
   );
 };

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -180,6 +180,8 @@ export type LineCoord = {
   y1: number;
   x2: number;
   y2: number;
+  clipDirection?: 'up' | 'down' | 'none';
+  clippedEnd?: 'source' | 'target' | 'both';
 };
 
 export type LineProps = LineCoord & {


### PR DESCRIPTION
### Context
Data mapper connection lines were extending outside their intended container boundaries, creating visual confusion when source or target elements were scrolled out of view.

### Changes
- Implemented 6 distinct clipping scenarios:
  1. Source visible → target above: curve to top center
  2. Source visible → target below: curve to bottom center  
  3. Source above → target visible: curve from top center
  4. Source below → target visible: curve from bottom center
  5. Both not visible: straight line top to bottom
  6. Both visible: unchanged behavior

### Screenshot
<img width="719" height="363" alt="image" src="https://github.com/user-attachments/assets/10b48cef-4d48-49a7-bdb1-50e3ca1dbd27" />

