### PR TITLE
fix(DataMapper): Improve rendering performance - batch 1

### DIFF
--- a/packages/ui/src/components/View/MappingLink.scss
+++ b/packages/ui/src/components/View/MappingLink.scss
@@ -1,0 +1,14 @@
+.mapping-link {
+  stroke: gray;
+  stroke-width: 3;
+  pointer-events: auto;
+
+  &:hover {
+    stroke-width: 6;
+  }
+
+  &--selected {
+    stroke: var(--pf-t--global--border--color--brand--default);
+    stroke-width: 6;
+  }
+}

--- a/packages/ui/src/components/View/MappingLink.test.tsx
+++ b/packages/ui/src/components/View/MappingLink.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { MappingLink } from './MappingLink';
+
+const mockGetNodeReference = jest.fn();
+const mockToggleSelectedNodeReference = jest.fn();
+
+jest.mock('../../hooks/useCanvas', () => ({
+  useCanvas: () => ({
+    getNodeReference: mockGetNodeReference,
+  }),
+}));
+
+jest.mock('../../hooks/useMappingLinks', () => ({
+  useMappingLinks: () => ({
+    mappingLinkCanvasRef: { current: { getBoundingClientRect: () => ({ left: 10, right: 110 }) } },
+    toggleSelectedNodeReference: mockToggleSelectedNodeReference,
+  }),
+}));
+
+describe('MappingLink', () => {
+  const defaultProps = {
+    x1: 10,
+    y1: 20,
+    x2: 100,
+    y2: 200,
+    sourceNodePath: 'source.path',
+    targetNodePath: 'target.path',
+    isSelected: false,
+    svgRef: { current: { getBoundingClientRect: () => ({ left: 0 }) } } as React.RefObject<SVGSVGElement>,
+  };
+
+  it('renders circles at endpoints', () => {
+    const { getAllByRole } = render(
+      <svg>
+        <MappingLink {...defaultProps} />
+      </svg>,
+    );
+    const circles = getAllByRole('presentation');
+    expect(circles.length).toBe(2);
+  });
+
+  it('renders LinePath with correct testid', () => {
+    const { getByTestId } = render(
+      <svg>
+        <MappingLink {...defaultProps} />
+      </svg>,
+    );
+    expect(getByTestId('mapping-link-10-20-100-200')).toBeInTheDocument();
+  });
+
+  it('applies selected class when isSelected is true', () => {
+    const { getByTestId } = render(
+      <svg>
+        <MappingLink {...defaultProps} isSelected={true} />
+      </svg>,
+    );
+    expect(getByTestId('mapping-link-selected-10-20-100-200').classList).toContain('mapping-link--selected');
+  });
+
+  it('calls toggleSelectedNodeReference on line click', () => {
+    mockGetNodeReference.mockReturnValue('node-ref');
+    const { getByTestId } = render(
+      <svg>
+        <MappingLink {...defaultProps} />
+      </svg>,
+    );
+    fireEvent.click(getByTestId('mapping-link-10-20-100-200'));
+    expect(mockGetNodeReference).toHaveBeenCalledWith('target.path');
+    expect(mockToggleSelectedNodeReference).toHaveBeenCalledWith('node-ref');
+  });
+
+  it('changes dot radius on mouse enter/leave', () => {
+    const { getByTestId, container } = render(
+      <svg>
+        <MappingLink {...defaultProps} />
+      </svg>,
+    );
+    const line = getByTestId('mapping-link-10-20-100-200');
+    const circles = container.querySelectorAll('circle');
+    expect(circles[0]).toHaveAttribute('r', '3');
+    fireEvent.mouseEnter(line);
+    expect(container.querySelectorAll('circle')[0]).toHaveAttribute('r', '6');
+    fireEvent.mouseLeave(line);
+    expect(container.querySelectorAll('circle')[0]).toHaveAttribute('r', '3');
+  });
+
+  it('sets xlink:title attribute', () => {
+    const { getByTestId } = render(
+      <svg>
+        <MappingLink {...defaultProps} />
+      </svg>,
+    );
+    expect(getByTestId('mapping-link-10-20-100-200')).toHaveAttribute(
+      'xlink:title',
+      'Source: source.path, Target: target.path',
+    );
+  });
+});

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -1,9 +1,11 @@
 import { curveMonotoneX } from '@visx/curve';
 import { Circle, LinePath } from '@visx/shape';
-import { CSSProperties, FunctionComponent, useCallback, useState } from 'react';
+import clsx from 'clsx';
+import { FunctionComponent, useCallback, useState } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
 import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { LineProps } from '../../models/datamapper';
+import './MappingLink.scss';
 
 const getY = (d: number[]) => d[1];
 const getX = (d: number[]) => d[0];
@@ -21,11 +23,6 @@ export const MappingLink: FunctionComponent<LineProps> = ({
   const { getNodeReference } = useCanvas();
   const { mappingLinkCanvasRef, toggleSelectedNodeReference } = useMappingLinks();
   const [isOver, setIsOver] = useState<boolean>(false);
-  const lineStyle: CSSProperties = {
-    stroke: isSelected ? 'var(--pf-t--global--border--color--brand--default)' : 'gray',
-    strokeWidth: isOver ? 6 : 3,
-    pointerEvents: 'auto' as CSSProperties['pointerEvents'],
-  };
   const dotRadius = isOver ? 6 : 3;
   const svgRect = svgRef?.current?.getBoundingClientRect();
   const canvasRect = mappingLinkCanvasRef?.current?.getBoundingClientRect();
@@ -51,14 +48,16 @@ export const MappingLink: FunctionComponent<LineProps> = ({
       <LinePath<[number, number]>
         data={[
           [x1, y1],
-          [canvasLeft ? canvasLeft : x1, y1],
-          [canvasRight ? canvasRight : x2, y2],
+          [canvasLeft ?? x1, y1],
+          [canvasRight ?? x2, y2],
           [x2, y2],
         ]}
         x={getX}
         y={getY}
         curve={curveMonotoneX}
-        style={lineStyle}
+        className={clsx('mapping-link', {
+          'mapping-link--selected': isSelected,
+        })}
         onClick={onLineClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -5,6 +5,9 @@ import { useCanvas } from '../../hooks/useCanvas';
 import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { LineProps } from '../../models/datamapper';
 
+const getY = (d: number[]) => d[1];
+const getX = (d: number[]) => d[0];
+
 export const MappingLink: FunctionComponent<LineProps> = ({
   x1,
   y1,
@@ -52,8 +55,8 @@ export const MappingLink: FunctionComponent<LineProps> = ({
           [canvasRight ? canvasRight : x2, y2],
           [x2, y2],
         ]}
-        x={(d) => d[0]}
-        y={(d) => d[1]}
+        x={getX}
+        y={getY}
         curve={curveMonotoneX}
         style={lineStyle}
         onClick={onLineClick}

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -1,12 +1,11 @@
-import { CSSProperties, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import { useCanvas } from '../../hooks/useCanvas';
-import { Circle, LinePath } from '@visx/shape';
 import { curveMonotoneX } from '@visx/curve';
+import { Circle, LinePath } from '@visx/shape';
+import { CSSProperties, FunctionComponent, useCallback, useState } from 'react';
+import { useCanvas } from '../../hooks/useCanvas';
 import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { LineProps } from '../../models/datamapper';
-import { MappingLinksService } from '../../services/mapping-links.service';
 
-const MappingLink: FunctionComponent<LineProps> = ({
+export const MappingLink: FunctionComponent<LineProps> = ({
   x1,
   y1,
   x2,
@@ -65,59 +64,5 @@ const MappingLink: FunctionComponent<LineProps> = ({
       />
       <Circle r={dotRadius} cx={x2} cy={y2} />
     </>
-  );
-};
-
-export const MappingLinksContainer: FunctionComponent = () => {
-  const [lineCoordList, setLineCoordList] = useState<LineProps[]>([]);
-  const { getNodeReference } = useCanvas();
-  const { getMappingLinks } = useMappingLinks();
-  const svgRef = useRef<SVGSVGElement>(null);
-
-  const refreshLinks = useCallback(() => {
-    const links = getMappingLinks();
-    const answer = MappingLinksService.calculateMappingLinkCoordinates(links, svgRef, getNodeReference);
-    setLineCoordList(answer);
-  }, [getMappingLinks, getNodeReference]);
-
-  useEffect(() => {
-    refreshLinks();
-    window.addEventListener('resize', refreshLinks);
-    window.addEventListener('scroll', refreshLinks);
-    return () => {
-      window.removeEventListener('resize', refreshLinks);
-      window.removeEventListener('scroll', refreshLinks);
-    };
-  }, [refreshLinks]);
-
-  return (
-    <svg
-      ref={svgRef}
-      data-testid="mapping-links"
-      style={{
-        position: 'absolute',
-        pointerEvents: 'none',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      <g z={0}>
-        {lineCoordList.map((lineProps, index) => (
-          <MappingLink
-            key={index}
-            svgRef={svgRef}
-            x1={lineProps.x1}
-            y1={lineProps.y1}
-            x2={lineProps.x2}
-            y2={lineProps.y2}
-            sourceNodePath={lineProps.sourceNodePath}
-            targetNodePath={lineProps.targetNodePath}
-            isSelected={lineProps.isSelected}
-          />
-        ))}
-      </g>
-    </svg>
   );
 };

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -44,7 +44,7 @@ export const MappingLink: FunctionComponent<LineProps> = ({
 
   return (
     <>
-      <Circle r={dotRadius} cx={x1} cy={y1} />
+      <Circle role="presentation" r={dotRadius} cx={x1} cy={y1} />
       <LinePath<[number, number]>
         data={[
           [x1, y1],
@@ -64,7 +64,7 @@ export const MappingLink: FunctionComponent<LineProps> = ({
         data-testid={`mapping-link-${isSelected ? 'selected-' : ''}${x1}-${y1}-${x2}-${y2}`}
         xlinkTitle={`Source: ${sourceNodePath}, Target: ${targetNodePath}`}
       />
-      <Circle r={dotRadius} cx={x2} cy={y2} />
+      <Circle role="presentation" r={dotRadius} cx={x2} cy={y2} />
     </>
   );
 };

--- a/packages/ui/src/components/View/MappingLinkContainer.scss
+++ b/packages/ui/src/components/View/MappingLinkContainer.scss
@@ -1,0 +1,8 @@
+.mapping-links-container {
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/ui/src/components/View/MappingLinkContainer.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.tsx
@@ -4,6 +4,7 @@ import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { LineProps } from '../../models/datamapper';
 import { MappingLinksService } from '../../services/mapping-links.service';
 import { MappingLink } from './MappingLink';
+import './MappingLinkContainer.scss';
 
 export const MappingLinksContainer: FunctionComponent = () => {
   const [lineCoordList, setLineCoordList] = useState<LineProps[]>([]);
@@ -21,6 +22,7 @@ export const MappingLinksContainer: FunctionComponent = () => {
     refreshLinks();
     window.addEventListener('resize', refreshLinks);
     window.addEventListener('scroll', refreshLinks);
+
     return () => {
       window.removeEventListener('resize', refreshLinks);
       window.removeEventListener('scroll', refreshLinks);
@@ -28,22 +30,11 @@ export const MappingLinksContainer: FunctionComponent = () => {
   }, [refreshLinks]);
 
   return (
-    <svg
-      ref={svgRef}
-      data-testid="mapping-links"
-      style={{
-        position: 'absolute',
-        pointerEvents: 'none',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-      }}
-    >
+    <svg className="mapping-links-container" ref={svgRef} data-testid="mapping-links">
       <g z={0}>
-        {lineCoordList.map((lineProps, index) => (
+        {lineCoordList.map((lineProps) => (
           <MappingLink
-            key={index}
+            key={`${lineProps.sourceNodePath}-${lineProps.targetNodePath}`}
             svgRef={svgRef}
             x1={lineProps.x1}
             y1={lineProps.y1}

--- a/packages/ui/src/components/View/MappingLinkContainer.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.tsx
@@ -1,0 +1,60 @@
+import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { useCanvas } from '../../hooks/useCanvas';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
+import { LineProps } from '../../models/datamapper';
+import { MappingLinksService } from '../../services/mapping-links.service';
+import { MappingLink } from './MappingLink';
+
+export const MappingLinksContainer: FunctionComponent = () => {
+  const [lineCoordList, setLineCoordList] = useState<LineProps[]>([]);
+  const { getNodeReference } = useCanvas();
+  const { getMappingLinks } = useMappingLinks();
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const refreshLinks = useCallback(() => {
+    const links = getMappingLinks();
+    const answer = MappingLinksService.calculateMappingLinkCoordinates(links, svgRef, getNodeReference);
+    setLineCoordList(answer);
+  }, [getMappingLinks, getNodeReference]);
+
+  useEffect(() => {
+    refreshLinks();
+    window.addEventListener('resize', refreshLinks);
+    window.addEventListener('scroll', refreshLinks);
+    return () => {
+      window.removeEventListener('resize', refreshLinks);
+      window.removeEventListener('scroll', refreshLinks);
+    };
+  }, [refreshLinks]);
+
+  return (
+    <svg
+      ref={svgRef}
+      data-testid="mapping-links"
+      style={{
+        position: 'absolute',
+        pointerEvents: 'none',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <g z={0}>
+        {lineCoordList.map((lineProps, index) => (
+          <MappingLink
+            key={index}
+            svgRef={svgRef}
+            x1={lineProps.x1}
+            y1={lineProps.y1}
+            x2={lineProps.x2}
+            y2={lineProps.y2}
+            sourceNodePath={lineProps.sourceNodePath}
+            targetNodePath={lineProps.targetNodePath}
+            isSelected={lineProps.isSelected}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+};

--- a/packages/ui/src/components/View/SourceTargetView.scss
+++ b/packages/ui/src/components/View/SourceTargetView.scss
@@ -1,6 +1,7 @@
 .source-target-view {
   height: 100%;
   overflow-x: auto;
+  position: relative;
 
   &__source-split {
     width: 30%;

--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { FunctionComponent, useEffect, useRef } from 'react';
 import { useDataMapper } from '../../hooks/useDataMapper';
-import { MappingLinksContainer } from './MappingLink';
+import { MappingLinksContainer } from './MappingLinkContainer';
 import './SourceTargetView.scss';
 import { useCanvas } from '../../hooks/useCanvas';
 import { SourcePanel } from './SourcePanel';


### PR DESCRIPTION
### Context
This PR improves the rendering performance of DataMapper edges through several small optimizations:

### Changes
- Extracted `MappingLinkContainer` from `MappingLink` to reduce component complexity
- Optimized key strategy: Changed to use `sourceNodePath` and `targetNodePath` as `React` keys for better reconciliation and reduced re-renders
- Moved `getX` and `getY` calculations outside render cycle to prevent unnecessary recalculations
- Extracted inline styles into separate SCSS classes for better performance and maintainability
- Added overflow containment to prevent mapping lines from extending outside their container
- Add missing tests for the MappingLink component

### Screenshots
#### Before
<img width="1918" height="964" alt="image" src="https://github.com/user-attachments/assets/945f11c0-997b-4755-b246-ac64177b2074" />

#### After
<img width="1918" height="964" alt="image" src="https://github.com/user-attachments/assets/76e57176-86a7-4ab2-91e8-0283abdcae73" />

relates: https://github.com/KaotoIO/kaoto/issues/2396