### PR TITLE
fix(DataMapper): mapping serializer uses xf:string for integer field …

### DIFF
--- a/packages/ui/src/services/mapping-serializer-json-addon.test.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.test.ts
@@ -143,6 +143,13 @@ describe('mappingSerializerJsonAddon', () => {
       expect(created!.namespaceURI).toEqual(NS_XPATH_FUNCTIONS);
       expect(created!.localName).toEqual('boolean');
       expect(created!.getAttribute('key')).toEqual('SomeBoolean');
+
+      const integerField = new JsonSchemaField(doc, 'SomeInteger', Types.Integer);
+      fieldItem = new FieldItem(mappings, integerField);
+      created = MappingSerializerJsonAddon.populateFieldItem(root!, fieldItem);
+      expect(created!.namespaceURI).toEqual(NS_XPATH_FUNCTIONS);
+      expect(created!.localName).toEqual('number');
+      expect(created!.getAttribute('key')).toEqual('SomeInteger');
     });
 
     it('should not populate a FieldItem if not JSON field', () => {

--- a/packages/ui/src/services/mapping-serializer-json-addon.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.ts
@@ -87,6 +87,7 @@ export class MappingSerializerJsonAddon {
         elementName = 'array';
         break;
       case Types.Numeric:
+      case Types.Integer:
         elementName = 'number';
         break;
       case Types.Boolean:


### PR DESCRIPTION
…where it's supposed to be xf:number

Fixes: https://github.com/KaotoIO/kaoto/issues/2497