### PR TITLE
Fix(drag-and-drop): Show different mouse pointers for draggable vs non-draggable nodes

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -1,4 +1,5 @@
 @use '../custom';
+@use '../../../../styles/dnd';
 
 .custom-node {
   @include custom.highligth {
@@ -15,6 +16,14 @@
 
       &__possibleDropTargets {
         @include custom.possible-drop-targets;
+      }
+
+      &__draggable {
+        @include dnd.cursor-grab;
+      }
+
+      &__nonDraggable {
+        @include custom.non-draggable;
       }
 
       &__image {

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -85,6 +85,8 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const shouldShowAddStep =
       shouldShowToolbar && vizNode?.getNodeInteraction().canHaveNextStep && vizNode.getNextNode() === undefined;
     const isHorizontal = element.getGraph().getLayout() === LayoutType.DagreHorizontal;
+    const dndSettingsEnabled = settingsAdapter.getSettings().experimentalFeatures.enableDragAndDrop;
+    const canDragNode = vizNode?.canDragNode() ?? false;
 
     useAnchor((element: Node) => {
       return new TargetAnchor(element);
@@ -109,11 +111,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
             });
         },
         canDrag: () => {
-          if (settingsAdapter.getSettings().experimentalFeatures.enableDragAndDrop) {
-            return element.getData()?.vizNode?.canDragNode();
-          }
-
-          return false;
+          return dndSettingsEnabled && canDragNode;
         },
         end(dropResult, monitor) {
           if (monitor.didDrop() && dropResult) {
@@ -145,7 +143,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
           }
         },
       }),
-      [element, entitiesContext, settingsAdapter],
+      [canDragNode, dndSettingsEnabled, element, entitiesContext],
     );
 
     const customNodeDropTargetSpec: DropTargetSpec<
@@ -226,6 +224,8 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
                 'custom-node__container__dropTarget': dndDropProps.canDrop && dndDropProps.hover,
                 'custom-node__container__possibleDropTargets':
                   dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
+                'custom-node__container__draggable': dndSettingsEnabled && canDragNode,
+                'custom-node__container__nonDraggable': dndSettingsEnabled && !canDragNode,
               })}
             >
               <div title={tooltipContent} className="custom-node__container__image">

--- a/packages/ui/src/components/Visualization/Custom/_custom.scss
+++ b/packages/ui/src/components/Visualization/Custom/_custom.scss
@@ -81,3 +81,7 @@
   border: 2px dashed var(--custom-node-BorderColor-possibleDropTargets);
   border-radius: var(--custom-node-BorderRadius);
 }
+
+@mixin non-draggable {
+  cursor: no-drop;
+}


### PR DESCRIPTION
Fix #2516 

Test this change here: https://shivamg640.github.io/kaoto/