### PR TITLE
fix(EnumField): Show `EnumField` for enum props

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
@@ -1,9 +1,16 @@
+import { EnumField } from '@kaoto/forms';
 import { KaotoSchemaDefinition } from '../../../../../models/kaoto-schema';
 import { PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
 import { customFieldsFactoryfactory } from './custom-fields-factory';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 
 describe('customFieldsFactoryfactory', () => {
+  it('returns EnumField for enums regardless of the schema type', () => {
+    const schema: KaotoSchemaDefinition['schema'] = { type: 'object', enum: ['option 1', 'option 2', 'option 3'] };
+    const result = customFieldsFactoryfactory(schema);
+    expect(result).toBe(EnumField);
+  });
+
   it('returns PrefixedBeanField for string type with format starting with "bean:"', () => {
     const schema: KaotoSchemaDefinition['schema'] = { type: 'string', format: 'bean:myBean' };
     const result = customFieldsFactoryfactory(schema);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -1,9 +1,12 @@
-import { CustomFieldsFactory } from '@kaoto/forms';
+import { CustomFieldsFactory, EnumField } from '@kaoto/forms';
 import { PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 
 export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
-  if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    /* Workaround for https://github.com/KaotoIO/kaoto/issues/2565 since the SNMP component has the wrong type */
+    return EnumField;
+  } else if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
     return PrefixedBeanField;
   } else if (schema.type === 'string' && schema.title === 'Ref') {
     return UnprefixedBeanField;


### PR DESCRIPTION
Currently, the `SNMP` component has a `enum` property without setting `type: enum` and this causes for Kaoto to render a `BeanField` instead.

Considering that waiting for the fix at the Camel catalog side will invalidate previos Camel versions, a workaround is provided to lower the sensitivity of the `enum` check and allow to show a `EnumField` for schemas containing a `enum` property.

fix: https://github.com/KaotoIO/kaoto/issues/2565
fix: https://github.com/KaotoIO/kaoto/issues/2623