### PR TITLE
chore(DataMapper): Use pointer icon for Expand/Collapse button

### DIFF
--- a/packages/ui/src/components/Document/Document.scss
+++ b/packages/ui/src/components/Document/Document.scss
@@ -32,6 +32,10 @@
     padding: var(--pf-t--global--spacer--xs) var(--pf-t--global--spacer--md);
   }
 
+  &__row &__expand {
+    cursor: pointer;
+  }
+
   &__spacer {
     margin: var(--pf-t--global--spacer--sm) 0 var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   }
@@ -66,14 +70,6 @@
 
 img {
   transition: transform 0.5s ease-in-out;
-}
-
-.toggle-icon {
-  cursor: pointer;
-
-  &--collapsed {
-    transform: rotate(-90deg);
-  }
 }
 
 /* stylelint-disable-next-line selector-class-pattern */

--- a/packages/ui/src/components/Document/SourceDocument.tsx
+++ b/packages/ui/src/components/Document/SourceDocument.tsx
@@ -109,7 +109,7 @@ export const SourceDocumentNode: FunctionComponent<DocumentNodeProps> = ({
           <NodeContainer nodeData={nodeData} ref={headerRef} className={clsx({ 'selected-container': isSelected })}>
             <section className="node__row" data-draggable={isDraggable}>
               {hasChildren && (
-                <Icon className="node__spacer" onClick={handleClickToggle}>
+                <Icon className="node__expand node__spacer" onClick={handleClickToggle}>
                   {!collapsed && <ChevronDown data-testid={`expand-source-icon-${nodeData.title}`} />}
                   {collapsed && <ChevronRight data-testid={`collapse-source-icon-${nodeData.title}`} />}
                 </Icon>

--- a/packages/ui/src/components/Document/TargetDocument.tsx
+++ b/packages/ui/src/components/Document/TargetDocument.tsx
@@ -120,7 +120,7 @@ const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({
           <NodeContainer nodeData={nodeData} ref={headerRef} className={clsx({ 'selected-container': isSelected })}>
             <section className="node__row" data-draggable={isDraggable}>
               {hasChildren && (
-                <Icon className="node__spacer" onClick={handleClickToggle}>
+                <Icon className="node__expand node__spacer" onClick={handleClickToggle}>
                   {!collapsed && <ChevronDown data-testid={`expand-target-icon-${nodeData.title}`} />}
                   {collapsed && <ChevronRight data-testid={`collapse-target-icon-${nodeData.title}`} />}
                 </Icon>

--- a/packages/ui/src/components/Document/actions/DocumentActions.tsx
+++ b/packages/ui/src/components/Document/actions/DocumentActions.tsx
@@ -1,11 +1,11 @@
 import { ActionListGroup, ActionListItem } from '@patternfly/react-core';
-import { AttachSchemaButton } from './AttachSchemaButton';
-import { DetachSchemaButton } from './DetachSchemaButton';
+import { FunctionComponent, MouseEvent, useCallback } from 'react';
 import { DocumentType } from '../../../models/datamapper/document';
 import { DocumentNodeData } from '../../../models/datamapper/visualization';
-import { DeleteParameterButton } from './DeleteParameterButton';
-import { FunctionComponent, MouseEvent, useCallback } from 'react';
 import '../Document.scss';
+import { AttachSchemaButton } from './AttachSchemaButton';
+import { DeleteParameterButton } from './DeleteParameterButton';
+import { DetachSchemaButton } from './DetachSchemaButton';
 
 type DocumentActionsProps = {
   className?: string;
@@ -26,14 +26,10 @@ export const DocumentActions: FunctionComponent<DocumentActionsProps> = ({ class
       className={className}
     >
       <ActionListItem>
-        <AttachSchemaButton
-          documentType={documentType}
-          documentId={documentId}
-          hasSchema={!nodeData.isPrimitive}
-        ></AttachSchemaButton>
+        <AttachSchemaButton documentType={documentType} documentId={documentId} hasSchema={!nodeData.isPrimitive} />
       </ActionListItem>
       <ActionListItem>
-        <DetachSchemaButton documentType={documentType} documentId={documentId}></DetachSchemaButton>
+        <DetachSchemaButton documentType={documentType} documentId={documentId} />
       </ActionListItem>
       {documentType === DocumentType.PARAM && (
         <ActionListItem>


### PR DESCRIPTION
### Context
Use `pointer` cursor for the expand/collapse buttons in the Datamapper tree.

### Screenshot
<img width="212" height="62" alt="image" src="https://github.com/user-attachments/assets/7d6ca3db-2136-42c9-82bb-f89ef1da026b" />
