### PR TITLE
feat: create DataSourceBeanField with default values and DataSource filtering

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
@@ -56,9 +56,9 @@ describe('BeanField', () => {
 
     await formPageObject.inputText('Type', 'io.kaoto.test.TestBean');
 
-    const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
+    const createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
     await act(async () => {
-      fireEvent.click(createButton);
+      fireEvent.click(createButton!);
     });
   };
 
@@ -69,9 +69,9 @@ describe('BeanField', () => {
   };
 
   const clickCreateButton = async () => {
-    const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
+    const createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
     await act(async () => {
-      fireEvent.click(createButton);
+      fireEvent.click(createButton!);
     });
   };
 
@@ -208,9 +208,9 @@ describe('BeanField', () => {
     it('should not update the BeanField when closing the modal', async () => {
       await createBean('myNewBean', 'Bean');
 
-      const [cancelButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Cancel');
+      const cancelButton = screen.getAllByRole('button').find((b) => b.textContent === 'Cancel');
       await act(async () => {
-        fireEvent.click(cancelButton);
+        fireEvent.click(cancelButton!);
       });
 
       expect(onPropertyChangeSpy).not.toHaveBeenCalled();
@@ -226,9 +226,9 @@ describe('BeanField', () => {
       const clearButton = await screen.findByRole('menuitem', { name: /Clear type field/i });
       fireEvent.click(clearButton);
 
-      const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
+      const createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
       await act(async () => {
-        fireEvent.click(createButton);
+        fireEvent.click(createButton!);
       });
 
       expect(onPropertyChangeSpy).not.toHaveBeenCalled();
@@ -405,9 +405,9 @@ describe('BeanField', () => {
     it('should not update the BeanField when closing the modal', async () => {
       await createBean('myNewBean', 'Ref');
 
-      const [cancelButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Cancel');
+      const cancelButton = screen.getAllByRole('button').find((b) => b.textContent === 'Cancel');
       await act(async () => {
-        fireEvent.click(cancelButton);
+        fireEvent.click(cancelButton!);
       });
 
       expect(onPropertyChangeSpy).not.toHaveBeenCalled();
@@ -460,9 +460,9 @@ describe('BeanField', () => {
       await formPageObject.selectTypeaheadItem('create-new-with-name');
       await formPageObject.inputText('Type', 'io.kaoto.test.ExistingBean');
 
-      const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
+      const createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
       await act(async () => {
-        fireEvent.click(createButton);
+        fireEvent.click(createButton!);
       });
 
       cleanup();
@@ -506,9 +506,9 @@ describe('BeanField', () => {
       await formPageObject.selectTypeaheadItem('create-new-with-name');
       await formPageObject.inputText('Type', 'io.kaoto.test.AnotherBean');
 
-      const [createButton] = screen.getAllByRole('button').filter((b) => b.textContent === 'Create');
+      const createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
       await act(async () => {
-        fireEvent.click(createButton);
+        fireEvent.click(createButton!);
       });
 
       cleanup();
@@ -593,7 +593,7 @@ describe('BeanField', () => {
       expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'default');
     });
 
-    it('should filter beans to only show DataSource types', async () => {
+    it('should find beans to only show DataSource types', async () => {
       const { Provider } = TestProvidersWrapper();
 
       // First create regular bean and DataSource bean
@@ -615,9 +615,9 @@ describe('BeanField', () => {
       await formPageObject.selectTypeaheadItem('create-new-with-name');
       await formPageObject.inputText('Type', 'io.kaoto.test.RegularBean');
 
-      let createButton = screen.getAllByRole('button').filter((b) => b.textContent === 'Create')[0];
+      let createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
       await act(async () => {
-        fireEvent.click(createButton);
+        fireEvent.click(createButton!);
       });
 
       cleanup();
@@ -639,9 +639,9 @@ describe('BeanField', () => {
       await formPageObject.selectTypeaheadItem('create-new-with-name');
       await formPageObject.inputText('Type', 'javax.sql.DataSource');
 
-      createButton = screen.getAllByRole('button').filter((b) => b.textContent === 'Create')[0];
+      createButton = screen.getAllByRole('button').find((b) => b.textContent === 'Create');
       await act(async () => {
-        fireEvent.click(createButton);
+        fireEvent.click(createButton!);
       });
 
       cleanup();

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -1,5 +1,5 @@
 import { CustomFieldsFactory, EnumField } from '@kaoto/forms';
-import { PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
+import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 
 export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
@@ -10,6 +10,8 @@ export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
     return PrefixedBeanField;
   } else if (schema.type === 'string' && schema.title === 'Ref') {
     return UnprefixedBeanField;
+  } else if (schema.type === 'string' && schema.title?.includes('Data Source')) {
+    return DataSourceBeanField;
   } else if (schema.format === 'expression' || schema.format === 'expressionProperty') {
     return ExpressionField;
   }


### PR DESCRIPTION
- Add DataSourceBeanField component with predefined default items (default, dataSource)
- Implement DataSource-specific bean filtering to show only beans with DataSource in type
- Configure DataSourceBeanField to use unprefixed bean names
- Add comprehensive test suite covering default items, filtering, and bean creation
- Refactor BeanFieldBase to support optional defaultItems and isDataSource props

#closes [#967](https://github.com/KaotoIO/kaoto/issues/967)
<img width="1157" height="927" alt="Screenshot 2025-09-26 at 15 04 29" src="https://github.com/user-attachments/assets/c9614f91-6ae1-4417-b69d-f8c31c0a9b07" />
