### PR TITLE
fix(Routes): Wrong Intercept* order

### DIFF
--- a/packages/ui/src/models/camel/entity-ordering.service.test.ts
+++ b/packages/ui/src/models/camel/entity-ordering.service.test.ts
@@ -66,9 +66,12 @@ describe('EntityOrderingService', () => {
   describe('RUNTIME_PRIORITY_ENTITIES', () => {
     it('should define the correct runtime priority entities', () => {
       expect(EntityOrderingService.RUNTIME_PRIORITY_ENTITIES).toEqual([
-        EntityType.OnException,
         EntityType.ErrorHandler,
+        EntityType.OnException,
         EntityType.OnCompletion,
+        EntityType.Intercept,
+        EntityType.InterceptFrom,
+        EntityType.InterceptSendToEndpoint,
       ]);
     });
 
@@ -198,9 +201,9 @@ describe('EntityOrderingService', () => {
       expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.RestConfiguration)).toBe(false);
       expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.Rest)).toBe(false);
       expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.RouteConfiguration)).toBe(false);
-      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.Intercept)).toBe(false);
-      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.InterceptFrom)).toBe(false);
-      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.InterceptSendToEndpoint)).toBe(false);
+      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.Intercept)).toBe(true);
+      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.InterceptFrom)).toBe(true);
+      expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.InterceptSendToEndpoint)).toBe(true);
       expect(EntityOrderingService.isRuntimePriorityEntity(EntityType.Beans)).toBe(false);
     });
 

--- a/packages/ui/src/models/camel/entity-ordering.service.ts
+++ b/packages/ui/src/models/camel/entity-ordering.service.ts
@@ -40,9 +40,12 @@ export class EntityOrderingService {
    * This preserves the existing behavior for error handling entities
    */
   static readonly RUNTIME_PRIORITY_ENTITIES = [
-    EntityType.OnException,
     EntityType.ErrorHandler,
+    EntityType.OnException,
     EntityType.OnCompletion,
+    EntityType.Intercept,
+    EntityType.InterceptFrom,
+    EntityType.InterceptSendToEndpoint,
   ];
 
   /**


### PR DESCRIPTION
### Context
Currently, the `intercept` and related entities are created using the creation order and not the priority defined in the XML schema.

### Changes
This commit adds those entities to the `entity-ordering.service` so they can be prioritized before `routes`.

fix: https://github.com/KaotoIO/kaoto/issues/2574
relates: https://github.com/KaotoIO/kaoto/issues/2467