### PR TITLE
fix(DataMapper):  JSON: ghost sub-field is created for type=integer f…

### DIFF
--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -1,7 +1,7 @@
 import { DataMapperContext, DataMapperProvider } from './datamapper.provider';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { useDataMapper } from '../hooks/useDataMapper';
-import { FieldItem, ForEachItem, MappingTree } from '../models/datamapper/mapping';
+import { FieldItem, ForEachItem, MappingTree, ValueSelector } from '../models/datamapper/mapping';
 import { act, useContext, useEffect } from 'react';
 import {
   DocumentDefinition,
@@ -487,6 +487,14 @@ describe('DataMapperProvider', () => {
       const forEachItem = root?.children[3].children[0];
       expect(forEachItem instanceof ForEachItem).toBeTruthy();
       expect((forEachItem as ForEachItem).expression).toEqual('$Cart-x/xf:array/xf:map');
+
+      expect(forEachItem?.children[0].children.length).toEqual(3);
+      const title = forEachItem?.children[0].children[0].children[0] as ValueSelector;
+      expect(title.expression).toEqual("xf:string[@key='Title']");
+      const quantity = forEachItem?.children[0].children[1].children[0] as ValueSelector;
+      expect(quantity.expression).toEqual("xf:number[@key='Quantity']");
+      const price = forEachItem?.children[0].children[2].children[0] as ValueSelector;
+      expect(price.expression).toEqual("xf:number[@key='Price']");
     });
   });
 });

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -159,7 +159,7 @@ export class JsonSchemaDocumentService {
       return (
         'key' in f &&
         f.key === fieldKey &&
-        f.type === type &&
+        JsonSchemaDocumentService.toXsltTypeName(f.type) === JsonSchemaDocumentService.toXsltTypeName(type) &&
         ((!namespaceURI && !f.namespaceURI) || f.namespaceURI === namespaceURI)
       );
     });

--- a/packages/ui/src/services/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping-serializer.service.json.test.ts
@@ -45,6 +45,7 @@ describe('MappingSerializerService / JSON', () => {
     it('should deserialize XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(shipOrderJsonXslt, targetDoc, mappingTree, sourceParameterMap);
+      expect(targetDoc.fields[0].fields[3].fields[0].fields.length).toEqual(3);
       const namespaces = mappingTree.namespaceMap;
       expect(mappingTree.children.length).toBe(1);
       const root = mappingTree.children[0] as FieldItem;
@@ -156,7 +157,7 @@ describe('MappingSerializerService / JSON', () => {
       const quantity = forEachItem.children[1] as FieldItem;
       const quantityJsonField = quantity.field as JsonSchemaField;
       expect(quantityJsonField.key).toEqual('Quantity');
-      expect(quantityJsonField.type).toEqual(Types.Numeric);
+      expect(quantityJsonField.type).toEqual(Types.Integer);
       expect(quantityJsonField.getExpression(namespaces)).toEqual("xf:number[@key='Quantity']");
       expect(quantity.children.length).toBe(1);
       const quantityValue = quantity.children[0] as ValueSelector;

--- a/packages/ui/src/stubs/datamapper/json/Cart.schema.json
+++ b/packages/ui/src/stubs/datamapper/json/Cart.schema.json
@@ -12,7 +12,7 @@
           "type": "string"
         },
         "Quantity": {
-          "type": "number"
+          "type": "integer"
         },
         "Price": {
           "type": "number"

--- a/packages/ui/src/stubs/datamapper/json/ShipOrder.schema.json
+++ b/packages/ui/src/stubs/datamapper/json/ShipOrder.schema.json
@@ -45,7 +45,7 @@
               "type": "string"
             },
             "Quantity": {
-              "type": "number"
+              "type": "integer"
             },
             "Price": {
               "type": "number"


### PR DESCRIPTION
…ield mapping

Fixes: https://github.com/KaotoIO/kaoto/issues/2581

When a field is declared as `type: integer` in JSON schema and attached to the target body, it couldn't match with the mappings when desrializing XSLT, then deserializer unexpectedly created a separate field.
This is a leftover of `type: integer` handling in JSON schema. In XSLT JSON representation, both type are represented with `xf:number` and need to make them compatible.
cf.
- https://github.com/KaotoIO/kaoto/issues/2497
- https://github.com/KaotoIO/kaoto/issues/2476

<img width="2122" height="1221" alt="Screenshot From 2025-10-03 15-44-19" src="https://github.com/user-attachments/assets/cba92630-4620-482e-b898-7f097333d82a" />
