### PR TITLE
Fix(DataMapper): Skip adding the xml-to-json() entry to the XSLT when no mappings for a JSON target schema

### DIFF
--- a/packages/ui/src/services/mapping-serializer-json-addon.test.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.test.ts
@@ -17,7 +17,7 @@ import { MappingSerializerService } from './mapping-serializer.service';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.service';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/xslt';
 import { XmlSchemaDocumentService, XmlSchemaField } from './xml-schema-document.service';
-import { shipOrderXsd } from '../stubs/datamapper/data-mapper';
+import { cartToShipOrderJsonXslt, shipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 
 describe('mappingSerializerJsonAddon', () => {
   describe('populateXmlToJsonVariable()', () => {
@@ -29,6 +29,12 @@ describe('mappingSerializerJsonAddon', () => {
       stylesheet.appendChild(template);
 
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.JSON_SCHEMA);
+      MappingSerializerService.deserialize(
+        cartToShipOrderJsonXslt,
+        TestUtil.createTargetOrderDoc(),
+        mappings,
+        TestUtil.createParameterMap(),
+      );
       MappingSerializerJsonAddon.populateJsonTargetBase(mappings, template);
 
       expect(template.children.length).toBe(1);
@@ -55,6 +61,24 @@ describe('mappingSerializerJsonAddon', () => {
       stylesheet.appendChild(template);
 
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.XML_SCHEMA);
+      const root = MappingSerializerJsonAddon.populateJsonTargetBase(mappings, template);
+
+      expect(root).toBeNull();
+      expect(template.children.length).toBe(0);
+
+      expect(stylesheet.children.length).toBe(2);
+      const output = stylesheet.children[0];
+      expect(output.getAttribute('method')).toEqual('xml');
+    });
+
+    it('should not populate a variable in JSON target case when no mappings', () => {
+      const xsltDocument = MappingSerializerService.createNew();
+      const stylesheet = xsltDocument.children[0];
+      const template = xsltDocument.createElementNS(NS_XSL, 'template');
+      template.setAttribute('match', '/');
+      stylesheet.appendChild(template);
+
+      const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.JSON_SCHEMA);
       const root = MappingSerializerJsonAddon.populateJsonTargetBase(mappings, template);
 
       expect(root).toBeNull();
@@ -99,6 +123,12 @@ describe('mappingSerializerJsonAddon', () => {
 
     it('should populate a FieldItem', () => {
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.JSON_SCHEMA);
+      MappingSerializerService.deserialize(
+        cartToShipOrderJsonXslt,
+        TestUtil.createTargetOrderDoc(),
+        mappings,
+        TestUtil.createParameterMap(),
+      );
       const root = MappingSerializerJsonAddon.populateJsonTargetBase(mappings, template);
       const doc = new JsonSchemaDocument(DocumentType.TARGET_BODY, 'Body');
 

--- a/packages/ui/src/services/mapping-serializer-json-addon.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.ts
@@ -34,7 +34,8 @@ export class MappingSerializerJsonAddon {
    * @return `xs:variable` element for the mappings to be filled into if the target document is JSON, null otherwise
    */
   static populateJsonTargetBase(mappings: MappingTree, template: Element): Element | null {
-    if (mappings.documentDefinitionType !== DocumentDefinitionType.JSON_SCHEMA) return null;
+    if (mappings.documentDefinitionType !== DocumentDefinitionType.JSON_SCHEMA || mappings.children.length === 0)
+      return null;
 
     const xsltDocument = template.ownerDocument;
     const toJsonXmlVariable = xsltDocument.createElementNS(NS_XSL, 'variable');


### PR DESCRIPTION
fixes #2610 

Now Attaching the target as JSON schema with no mappings doesn't add the <xsl:value-of select="xml-to-json()"/> entry to the XSLT. However When deleting all the mapping, we again see <xsl:value-of select="xml-to-json()"/> entry in the XSLT. This will get automatically fixed once we delete the unnecessary mapping children when no mappings exist (https://github.com/KaotoIO/kaoto/issues/2618).
