### PR TITLE
Fix(DataMapper): Remove delete button for all FieldItem Mappings

### DIFF
--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -27,6 +27,7 @@ import {
   TargetNodeData,
 } from '../models/datamapper/visualization';
 import {
+  conditionalMappingsToShipOrderXslt,
   contactsXsd,
   extensionComplexXsd,
   extensionSimpleXsd,
@@ -962,5 +963,24 @@ describe('VisualizationService', () => {
     expect(addMappingNode.id).toContain('add-mapping-fx-Item');
     expect(addMappingNode.field.name).toEqual('Item');
     expect(addMappingNode.field.maxOccurs).toBeGreaterThan(1);
+  });
+
+  describe('isDeletableNode', () => {
+    it('should identify deletable nodes', () => {
+      MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+      const docData = new TargetDocumentNodeData(targetDoc, tree);
+
+      const fieldNodeData = new FieldItemNodeData(docData, tree.children[0] as FieldItem);
+      expect(VisualizationService.isDeletableNode(fieldNodeData)).toBeFalsy();
+
+      const forEachNodeData = new MappingNodeData(docData, tree.children[0].children[0] as ForEachItem);
+      expect(VisualizationService.isDeletableNode(forEachNodeData)).toBeTruthy();
+
+      const valueSelectorNodeData = new MappingNodeData(
+        docData,
+        tree.children[0].children[0].children[0] as ValueSelector,
+      );
+      expect(VisualizationService.isDeletableNode(valueSelectorNodeData)).toBeTruthy();
+    });
   });
 });

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -209,7 +209,7 @@ export class VisualizationService {
   }
 
   static isDeletableNode(nodeData: TargetNodeData) {
-    if (nodeData instanceof MappingNodeData) return true;
+    if (nodeData instanceof MappingNodeData && !(nodeData instanceof FieldItemNodeData)) return true;
     return VisualizationService.getFieldValueSelector(nodeData) !== undefined;
   }
 


### PR DESCRIPTION
Fixes #2629

Before:
<img width="1292" height="987" alt="image" src="https://github.com/user-attachments/assets/9399bfb2-0f9d-447a-a407-f2d182114bb8" />

After:
<img width="1292" height="987" alt="image" src="https://github.com/user-attachments/assets/ebd25ee2-e5ef-460e-b722-0fbb94d8a068" />
