### PR TITLE
feat(Datamapper): Improve Data Mapper connections

### DIFF
--- a/packages/ui/src/components/View/MappingLinkContainer.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.tsx
@@ -9,14 +9,19 @@ import './MappingLinkContainer.scss';
 export const MappingLinksContainer: FunctionComponent = () => {
   const [lineCoordList, setLineCoordList] = useState<LineProps[]>([]);
   const { getNodeReference } = useCanvas();
-  const { getMappingLinks } = useMappingLinks();
+  const { getMappingLinks, mappingLinkCanvasRef } = useMappingLinks();
   const svgRef = useRef<SVGSVGElement>(null);
 
   const refreshLinks = useCallback(() => {
     const links = getMappingLinks();
-    const answer = MappingLinksService.calculateMappingLinkCoordinates(links, svgRef, getNodeReference);
+    const answer = MappingLinksService.calculateMappingLinkCoordinates(
+      links,
+      svgRef,
+      getNodeReference,
+      mappingLinkCanvasRef,
+    );
     setLineCoordList(answer);
-  }, [getMappingLinks, getNodeReference]);
+  }, [getMappingLinks, getNodeReference, mappingLinkCanvasRef]);
 
   useEffect(() => {
     refreshLinks();
@@ -43,6 +48,8 @@ export const MappingLinksContainer: FunctionComponent = () => {
             sourceNodePath={lineProps.sourceNodePath}
             targetNodePath={lineProps.targetNodePath}
             isSelected={lineProps.isSelected}
+            clipDirection={lineProps.clipDirection}
+            clippedEnd={lineProps.clippedEnd}
           />
         ))}
       </g>

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -185,6 +185,8 @@ export type LineCoord = {
   y1: number;
   x2: number;
   y2: number;
+  clipDirection?: 'up' | 'down' | 'none';
+  clippedEnd?: 'source' | 'target' | 'both';
 };
 
 export type LineProps = LineCoord & {

--- a/packages/ui/src/services/mapping-links.service.ts
+++ b/packages/ui/src/services/mapping-links.service.ts
@@ -1,3 +1,4 @@
+import { MutableRefObject, RefObject } from 'react';
 import {
   ExpressionItem,
   FieldItem,
@@ -11,9 +12,8 @@ import {
   PrimitiveDocument,
   ValueSelector,
 } from '../models/datamapper';
-import { MutableRefObject, RefObject } from 'react';
-import { XPathService } from './xpath/xpath.service';
 import { DocumentService } from './document.service';
+import { XPathService } from './xpath/xpath.service';
 
 /**
  * A collection of the business logic for rendering mapping link lines.
@@ -96,6 +96,7 @@ export class MappingLinksService {
     mappingLinks: IMappingLink[],
     svgRef: RefObject<SVGSVGElement>,
     getNodeReference: (path: string) => MutableRefObject<NodeReference> | null,
+    canvasRef?: RefObject<HTMLDivElement> | null,
   ): LineProps[] {
     return mappingLinks
       .reduce((acc, { sourceNodePath, targetNodePath, isSelected }) => {
@@ -105,7 +106,7 @@ export class MappingLinksService {
           const sourceFieldRef = getNodeReference(sourceClosestPath);
           const targetFieldRef = getNodeReference(targetClosestPath);
           if (sourceFieldRef && !!targetFieldRef) {
-            const coord = MappingLinksService.getCoordFromFieldRef(svgRef, sourceFieldRef, targetFieldRef);
+            const coord = MappingLinksService.getCoordFromFieldRef(svgRef, sourceFieldRef, targetFieldRef, canvasRef);
             if (coord)
               acc.push({ ...coord, sourceNodePath: sourceNodePath, targetNodePath: targetNodePath, isSelected });
           }
@@ -157,6 +158,7 @@ export class MappingLinksService {
     svgRef: RefObject<SVGSVGElement>,
     sourceRef: MutableRefObject<NodeReference>,
     targetRef: MutableRefObject<NodeReference>,
+    canvasRef?: RefObject<HTMLDivElement> | null,
   ): LineCoord | undefined {
     const svgRect = svgRef.current?.getBoundingClientRect();
     const sourceRect = sourceRef.current?.headerRef?.getBoundingClientRect();
@@ -165,11 +167,74 @@ export class MappingLinksService {
       return;
     }
 
+    const originalX1 = sourceRect.right - (svgRect ? svgRect.left : 0);
+    const originalY1 = sourceRect.top + (sourceRect.bottom - sourceRect.top) / 2 - (svgRect ? svgRect.top : 0);
+    const originalX2 = targetRect.left - (svgRect ? svgRect.left : 0);
+    const originalY2 = targetRect.top + (targetRect.bottom - targetRect.top) / 2 - (svgRect ? svgRect.top : 0);
+    let x1 = originalX1;
+    let y1 = originalY1;
+    let x2 = originalX2;
+    let y2 = originalY2;
+    let clipDirection: 'up' | 'down' | 'none' = 'none';
+    let clippedEnd: 'source' | 'target' | 'both' | undefined = undefined;
+
+    // Check if source or target is outside the visible container bounds
+    if (svgRect && canvasRef?.current) {
+      const containerHeight = svgRect.height;
+      const containerBottom = containerHeight;
+      const canvasRect = canvasRef.current.getBoundingClientRect();
+
+      // Calculate canvas center point relative to SVG
+      const canvasCenterX = canvasRect.left + canvasRect.width / 2 - svgRect.left;
+
+      // Check clipping scenarios
+      const sourceAbove = originalY1 < 0;
+      const sourceBelow = originalY1 > containerBottom;
+      const targetAbove = originalY2 < 0;
+      const targetBelow = originalY2 > containerBottom;
+
+      if ((sourceAbove || sourceBelow) && (targetAbove || targetBelow)) {
+        // Case 5: Both source and target are not visible
+        x1 = canvasCenterX;
+        y1 = 20; // Top center
+        x2 = canvasCenterX;
+        y2 = containerBottom - 20; // Bottom center
+        clipDirection = 'down'; // For rendering purposes (both ends)
+        clippedEnd = 'both';
+      } else if (sourceAbove) {
+        // Case 3: Source above, target visible
+        x1 = canvasCenterX;
+        y1 = 20;
+        clipDirection = 'up';
+        clippedEnd = 'source';
+      } else if (sourceBelow) {
+        // Case 4: Source below, target visible
+        x1 = canvasCenterX;
+        y1 = containerBottom - 20;
+        clipDirection = 'down';
+        clippedEnd = 'source';
+      } else if (targetAbove) {
+        // Case 1: Source visible, target above
+        x2 = canvasCenterX;
+        y2 = 20;
+        clipDirection = 'up';
+        clippedEnd = 'target';
+      } else if (targetBelow) {
+        // Case 2: Source visible, target below
+        x2 = canvasCenterX;
+        y2 = containerBottom - 20;
+        clipDirection = 'down';
+        clippedEnd = 'target';
+      }
+    }
+
     return {
-      x1: sourceRect.right - (svgRect ? svgRect.left : 0),
-      y1: sourceRect.top + (sourceRect.bottom - sourceRect.top) / 2 - (svgRect ? svgRect.top : 0),
-      x2: targetRect.left - (svgRect ? svgRect.left : 0),
-      y2: targetRect.top + (targetRect.bottom - targetRect.top) / 2 - (svgRect ? svgRect.top : 0),
+      x1,
+      y1,
+      x2,
+      y2,
+      clipDirection,
+      clippedEnd,
     };
   }
 


### PR DESCRIPTION
### Context
Data mapper connection lines were extending outside their intended container boundaries, creating visual confusion when source or target elements were scrolled out of view.

### Changes
- Implemented 6 distinct clipping scenarios:
  1. Source visible → target above: curve to top center
  2. Source visible → target below: curve to bottom center  
  3. Source above → target visible: curve from top center
  4. Source below → target visible: curve from bottom center
  5. Both not visible: straight line top to bottom
  6. Both visible: unchanged behavior

### Screenshot
<img width="719" height="363" alt="image" src="https://github.com/user-attachments/assets/10b48cef-4d48-49a7-bdb1-50e3ca1dbd27" />

### Notes
Continuation of: https://github.com/KaotoIO/kaoto/pull/2464