### PR TITLE
chore: Remove innerRef warning when loading Datamapper

### DIFF
--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -7,7 +7,6 @@ import {
   PanelMain,
   Stack,
   StackItem,
-  Truncate,
 } from '@patternfly/react-core';
 import { FunctionComponent } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
@@ -29,7 +28,7 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
       <PanelHeader>
         <Content>
           <Content component={ContentVariants.h3}>
-            <Truncate content="Source" className="source-target-view__truncate" />
+            <span className="source-target-view__truncate">Source</span>
           </Content>
         </Content>
       </PanelHeader>

--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -1,4 +1,6 @@
 import {
+  Content,
+  ContentVariants,
   Divider,
   Panel,
   PanelHeader,
@@ -7,19 +9,16 @@ import {
   SplitItem,
   Stack,
   StackItem,
-  Content,
-  ContentVariants,
-  Truncate,
 } from '@patternfly/react-core';
 import { FunctionComponent, useEffect, useRef } from 'react';
-import { useDataMapper } from '../../hooks/useDataMapper';
-import { MappingLinksContainer } from './MappingLinkContainer';
-import './SourceTargetView.scss';
 import { useCanvas } from '../../hooks/useCanvas';
-import { SourcePanel } from './SourcePanel';
+import { useDataMapper } from '../../hooks/useDataMapper';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { SourceTargetDnDHandler } from '../../providers/dnd/SourceTargetDnDHandler';
 import { TargetDocument } from '../Document/TargetDocument';
-import { useMappingLinks } from '../../hooks/useMappingLinks';
+import { MappingLinksContainer } from './MappingLinkContainer';
+import { SourcePanel } from './SourcePanel';
+import './SourceTargetView.scss';
 
 export const SourceTargetView: FunctionComponent = () => {
   const { targetBodyDocument } = useDataMapper();
@@ -49,7 +48,7 @@ export const SourceTargetView: FunctionComponent = () => {
           <PanelHeader>
             <Content>
               <Content component={ContentVariants.h3}>
-                <Truncate content="Target" className="source-target-view__truncate" />
+                <span className="source-target-view__truncate">Target</span>
               </Content>
             </Content>
           </PanelHeader>


### PR DESCRIPTION
### Context
Currently, the `Truncate` component from Patternfly seems to be passing a `ref` property into the underlying DOM nodes, and this is causing an error to be thrown in the browser's console.

### Changes
A workaround for this situation is to remove the `Truncate` component and replace it with a simple `span` DOM node instead.