### PR TITLE
chore: kaoto/form version update to 1.5.6

### DIFF
--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@kaoto/camel-catalog": "^0.2.2",
-    "@kaoto/forms": "^1.5.3",
+    "@kaoto/forms": "^1.5.6",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.3.0",
     "@patternfly/react-code-editor": "^6.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@carbon/icons-react": "^11.67.0",
     "@dnd-kit/core": "^6.1.0",
-    "@kaoto/forms": "^1.5.3",
+    "@kaoto/forms": "^1.5.6",
     "@kie-tools-core/editor": "^10.0.0",
     "@kie-tools-core/notifications": "^10.0.0",
     "@visx/shape": "^3.12.0",

--- a/packages/ui/src/pages/PipeErrorHandler/__snapshots__/PipeErrorHandlerPage.test.tsx.snap
+++ b/packages/ui/src/pages/PipeErrorHandler/__snapshots__/PipeErrorHandlerPage.test.tsx.snap
@@ -22,202 +22,271 @@ exports[`PipeErrorHandlerPage renders the KaotoForm when the resource type is su
     novalidate=""
   >
     <div
-      aria-labelledby="#-legend"
-      class="pf-v6-c-form__group"
-      role="group"
+      class="pf-v6-c-card"
+      data-ouia-component-id="OUIA-Generated-Card-1"
+      data-ouia-component-type="PF6/Card"
+      data-ouia-safe="true"
+      data-testid="#__field-wrapper"
+      id=""
     >
       <div
-        class="pf-v6-c-form__group-control pf-m-stack"
+        class="pf-v6-c-card__header"
       >
         <div
-          aria-label="# oneof list"
-          class="pf-v6-c-toggle-group"
-          data-testid="#__oneof-list"
-          id="#"
-          role="group"
+          class="pf-v6-c-card__actions"
         >
           <div
-            class="pf-v6-c-toggle-group__item"
+            aria-labelledby="#-legend"
+            class="pf-v6-c-form__group"
+            role="group"
           >
-            <button
-              aria-pressed="true"
-              class="pf-v6-c-toggle-group__button pf-m-selected"
-              id="No Pipe ErrorHandler"
-              type="button"
+            <div
+              class="pf-v6-c-form__group-control pf-m-stack"
             >
-              <span
-                class="pf-v6-c-toggle-group__text"
+              <div
+                aria-label="# oneof list"
+                class="pf-v6-c-toggle-group"
+                data-testid="#__oneof-list"
+                id="#"
+                role="group"
               >
-                No Pipe ErrorHandler
-              </span>
-            </button>
+                <div
+                  class="pf-v6-c-toggle-group__item"
+                >
+                  <button
+                    aria-pressed="true"
+                    class="pf-v6-c-toggle-group__button pf-m-selected"
+                    id="No Pipe ErrorHandler"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-toggle-group__text"
+                    >
+                      No Pipe ErrorHandler
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="pf-v6-c-toggle-group__item"
+                >
+                  <button
+                    aria-pressed="false"
+                    class="pf-v6-c-toggle-group__button"
+                    id="Log Pipe ErrorHandler"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-toggle-group__text"
+                    >
+                      Log Pipe ErrorHandler
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="pf-v6-c-toggle-group__item"
+                >
+                  <button
+                    aria-pressed="false"
+                    class="pf-v6-c-toggle-group__button"
+                    id="Sink Pipe ErrorHandler"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-toggle-group__text"
+                    >
+                      Sink Pipe ErrorHandler
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
+        </div>
+        <div
+          class="pf-v6-c-card__header-main"
+        >
           <div
-            class="pf-v6-c-toggle-group__item"
+            class="pf-v6-c-card__title"
           >
-            <button
-              aria-pressed="false"
-              class="pf-v6-c-toggle-group__button"
-              id="Log Pipe ErrorHandler"
-              type="button"
+            <div
+              class="pf-v6-c-card__title-text"
             >
-              <span
-                class="pf-v6-c-toggle-group__text"
+               
+              No Pipe ErrorHandler
+               
+              <div
+                style="display: contents;"
               >
-                Log Pipe ErrorHandler
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-toggle-group__item"
-          >
-            <button
-              aria-pressed="false"
-              class="pf-v6-c-toggle-group__button"
-              id="Sink Pipe ErrorHandler"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-toggle-group__text"
-              >
-                Sink Pipe ErrorHandler
-              </span>
-            </button>
+                <span
+                  aria-label="More info for No Pipe ErrorHandler field"
+                  class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  role="button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="pf-v6-c-form__group"
-      data-testid="#.none__field-wrapper"
-    >
       <div
-        class="pf-v6-c-form__group-label"
-      >
-        <label
-          class="pf-v6-c-form__label"
-          for="#.none"
-        >
-          <span
-            class="pf-v6-c-form__label-text"
-          >
-            none
-             
-            <span
-              class="pf-v6-c-badge pf-m-unread"
-              title="0 properties"
-            >
-              0
-            </span>
-          </span>
-          <span
-            aria-hidden="true"
-            class="pf-v6-c-form__label-required"
-          >
-             
-            *
-          </span>
-        </label>
-          
-        <span
-          class="pf-v6-c-form__group-label-help"
-        >
-          <div
-            style="display: contents;"
-          >
-            <span
-              aria-label="More info for [object Object] field"
-              class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-1"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              role="button"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 1024 1024"
-                  width="1em"
-                >
-                  <path
-                    d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </span>
-      </div>
-      <div
-        class="pf-v6-c-form__group-control"
+        class="pf-v6-c-card__body pf-v6-c-form kaoto-form__label"
+        data-testid="#__children"
       >
         <div
-          class="pf-v6-l-split pf-m-gutter"
+          class="pf-v6-c-form__group"
+          data-testid="#.none__field-wrapper"
         >
           <div
-            class="pf-v6-l-split__item pf-m-fill"
+            class="pf-v6-c-form__group-label"
           >
-            Key
-          </div>
-          <div
-            class="pf-v6-l-split__item pf-m-fill"
-          >
-            Value
-          </div>
-          <div
-            class="pf-v6-l-split__item"
-          >
-            <button
-              aria-label="Add a new property"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-2"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              data-testid="#.none__add"
-              title="Add a new property"
-              type="button"
+            <label
+              class="pf-v6-c-form__label"
+              for="#.none"
             >
               <span
-                class="pf-v6-c-button__icon"
+                class="pf-v6-c-form__label-text"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 448 512"
-                  width="1em"
+                none
+                 
+                <span
+                  class="pf-v6-c-badge pf-m-unread"
+                  title="0 properties"
                 >
-                  <path
-                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                  />
-                </svg>
+                  0
+                </span>
               </span>
-            </button>
+              <span
+                aria-hidden="true"
+                class="pf-v6-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+              
+            <span
+              class="pf-v6-c-form__group-label-help"
+            >
+              <div
+                style="display: contents;"
+              >
+                <span
+                  aria-label="More info for [object Object] field"
+                  class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  role="button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-form__group-control"
+          >
+            <div
+              class="pf-v6-l-split pf-m-gutter"
+            >
+              <div
+                class="pf-v6-l-split__item pf-m-fill"
+              >
+                Key
+              </div>
+              <div
+                class="pf-v6-l-split__item pf-m-fill"
+              >
+                Value
+              </div>
+              <div
+                class="pf-v6-l-split__item"
+              >
+                <button
+                  aria-label="Add a new property"
+                  class="pf-v6-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                  data-ouia-component-type="PF6/Button"
+                  data-ouia-safe="true"
+                  data-testid="#.none__add"
+                  title="Add a new property"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-button__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <hr
+              class="pf-v6-c-content--hr"
+              data-ouia-component-id="OUIA-Generated-Content-2"
+              data-ouia-component-type="PF6/Content"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            />
           </div>
         </div>
-        <hr
-          class="pf-v6-c-content--hr"
-          data-ouia-component-id="OUIA-Generated-Content-2"
-          data-ouia-component-type="PF6/Content"
-          data-ouia-safe="true"
-          data-pf-content="true"
-        />
       </div>
     </div>
   </form>
   <div
     class="pf-v6-c-card kaoto-form kaoto-form__empty"
-    data-ouia-component-id="OUIA-Generated-Card-1"
+    data-ouia-component-id="OUIA-Generated-Card-2"
     data-ouia-component-type="PF6/Card"
     data-ouia-safe="true"
     data-testid="no-field-found"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,9 +3094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/forms@npm:^1.5.3":
-  version: 1.5.3
-  resolution: "@kaoto/forms@npm:1.5.3"
+"@kaoto/forms@npm:^1.5.6":
+  version: 1.5.6
+  resolution: "@kaoto/forms@npm:1.5.6"
   dependencies:
     ajv: "npm:^8.12.0"
     clsx: "npm:^2.1.0"
@@ -3108,7 +3108,7 @@ __metadata:
     "@patternfly/react-icons": ^6.3.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10/f6dec44e43dca2f374677df03967366fe5b16e2436693a10b944aa8fdf06f9d8f28985245f1838a8788a83c004dda07444d1bb8ca858428543ab3667c63f60c4
+  checksum: 10/d106835b0be1d07c6dd0df5df7ef61e58f52e759dc5a867b6cd85526897372221ccced73f0e66b9b0b1a90b04797f2d9bd783b7e7fa7032e94447c09a469d6ec
   languageName: node
   linkType: hard
 
@@ -3119,7 +3119,7 @@ __metadata:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.2.2"
-    "@kaoto/forms": "npm:^1.5.3"
+    "@kaoto/forms": "npm:^1.5.6"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.3.0"
     "@patternfly/react-code-editor": "npm:^6.3.0"
@@ -3178,7 +3178,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.2.2"
-    "@kaoto/forms": "npm:^1.5.3"
+    "@kaoto/forms": "npm:^1.5.6"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
     "@patternfly/patternfly": "npm:^6.3.0"


### PR DESCRIPTION
Changes with this version upgrade:

- Pipe Error Handler Page

 <img width="1907" height="332" alt="image" src="https://github.com/user-attachments/assets/e2fa723f-636d-4850-b0c6-26c789f71df8" />

- Loadbalance type Fields 

<img width="515" height="445" alt="image" src="https://github.com/user-attachments/assets/e0530617-3a47-4406-915d-5f11df6ac38f" />

- data-format type Fields

<img width="523" height="545" alt="image" src="https://github.com/user-attachments/assets/f85f99b4-166a-489f-bc48-a55cacf84be8" />

- Error Handler Field

<img width="456" height="770" alt="image" src="https://github.com/user-attachments/assets/93a74216-6f43-4ee5-9e1c-d0174cbe129a" />



