### PR TITLE
feat(Datamapper): Split documents

### DIFF
--- a/packages/ui-tests/cypress/e2e/datamapper/json-to-json.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/json-to-json.ts
@@ -13,7 +13,7 @@ describe('Test for DataMapper : JSON to JSON', () => {
     cy.addParameter('OrderSequence');
     cy.importMappings('datamapper/xslt/ShipOrderJson.xsl');
 
-    cy.get('[data-testid^="node-source-fj-string-AccountId"]').click();
+    cy.get('[data-testid^="node-source-fj-string-AccountId"]').click({ force: true });
 
     cy.checkFieldSelected('source', 'fj', 'string-AccountId', true);
     cy.checkFieldSelected('target', 'fj', 'string-OrderId', true);
@@ -38,58 +38,58 @@ describe('Test for DataMapper : JSON to JSON', () => {
     cy.addParameter('OrderSequence');
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-AccountId'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderId'],
+      ['document-doc-param-Account', 'node-source-fj-string-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderId'],
       "$Account-x/fn:map/fn:string[@key='AccountId']",
     );
     cy.engageMapping(
-      ['node-source-doc-param-OrderSequence'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderId'],
+      ['document-doc-param-OrderSequence'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderId'],
       "$Account-x/fn:map/fn:string[@key='AccountId'], $OrderSequence",
     );
-    cy.get('[data-testid^="mapping-link-"]').should('be.visible').first().click();
+    cy.get('[data-testid^="mapping-link-"]').should('be.visible').first().click({ force: true });
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderPerson'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderPerson'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Street']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='City']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='State']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Country']",
     );
 
     cy.engageForEachMapping(
-      ['node-source-fj-array', 'node-source-fj-map'],
-      ['node-target-fj-map', 'node-target-fj-array-Item', 'node-target-fj-map'],
+      ['document-doc-param-Cart', 'node-source-fj-map'],
+      ['document-doc-targetBody-Body', 'node-target-fj-array-Item', 'node-target-fj-map'],
       '$Cart-x/fn:array/fn:map',
     );
 
     cy.engageMapping(
-      ['node-source-fj-array', 'node-source-fj-map', 'node-source-fj-string-Title'],
+      ['document-doc-param-Cart', 'node-source-fj-map', 'node-source-fj-string-Title'],
       [
-        'node-target-fj-map',
+        'document-doc-targetBody-Body',
         'node-target-fj-array-Item',
         'node-target-for-each',
         'node-target-fj-map',
@@ -98,9 +98,9 @@ describe('Test for DataMapper : JSON to JSON', () => {
       "fn:string[@key='Title']",
     );
     cy.engageMapping(
-      ['node-source-fj-array', 'node-source-fj-map', 'node-source-fj-number-Quantity'],
+      ['document-doc-param-Cart', 'node-source-fj-map', 'node-source-fj-number-Quantity'],
       [
-        'node-target-fj-map',
+        'document-doc-targetBody-Body',
         'node-target-fj-array-Item',
         'node-target-for-each',
         'node-target-fj-map',
@@ -109,9 +109,9 @@ describe('Test for DataMapper : JSON to JSON', () => {
       "fn:number[@key='Quantity']",
     );
     cy.engageMapping(
-      ['node-source-fj-array', 'node-source-fj-map', 'node-source-fj-number-Price'],
+      ['document-doc-param-Cart', 'node-source-fj-map', 'node-source-fj-number-Price'],
       [
-        'node-target-fj-map',
+        'document-doc-targetBody-Body',
         'node-target-fj-array-Item',
         'node-target-for-each',
         'node-target-fj-map',
@@ -130,39 +130,39 @@ describe('Test for DataMapper : JSON to JSON', () => {
     cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-AccountId'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderId'],
+      ['document-doc-param-Account', 'node-source-fj-string-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderId'],
       "$Account-x/fn:map/fn:string[@key='AccountId']",
     );
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderPerson'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderPerson'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Street']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='City']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='State']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Country']",
     );
 
@@ -179,39 +179,39 @@ describe('Test for DataMapper : JSON to JSON', () => {
     cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-AccountId'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderId'],
+      ['document-doc-param-Account', 'node-source-fj-string-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderId'],
       "$Account-x/fn:map/fn:string[@key='AccountId']",
     );
 
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-string-OrderPerson'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-string-OrderPerson'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-string-Name'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
+      ['document-doc-param-Account', 'node-source-fj-string-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Name'],
       "$Account-x/fn:map/fn:string[@key='Name']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Street'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Street'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Street']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-City'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-City'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='City']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-State'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-State'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='State']",
     );
     cy.engageMapping(
-      ['node-source-fj-map', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
-      ['node-target-fj-map', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
+      ['document-doc-param-Account', 'node-source-fj-map-Address', 'node-source-fj-string-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fj-map-ShipTo', 'node-target-fj-string-Country'],
       "$Account-x/fn:map/fn:map[@key='Address']/fn:string[@key='Country']",
     );
 

--- a/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
@@ -11,7 +11,7 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
     cy.importMappings('datamapper/xslt/ShipOrderToShipOrder.xsl');
 
-    cy.get('[data-testid^="node-source-fx-OrderId"]').click();
+    cy.get('[data-testid^="node-source-fx-OrderId"]').click({ force: true });
 
     cy.checkFieldSelected('source', 'fx', 'OrderId', true);
     cy.checkFieldSelected('target', 'fx', 'OrderId', true);
@@ -34,8 +34,8 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-AccountId'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-OrderId'],
+      ['document-doc-param-Account', 'node-source-fx-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fx-OrderId'],
       '$Account/ns0:Account/@AccountId',
     );
 
@@ -44,50 +44,50 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.get('[data-testid^="mapping-link-"]').should('be.visible').click({ force: true });
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Name'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
+      ['document-doc-param-Account', 'node-source-fx-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
       '$Account/ns0:Account/Name',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Address'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
+      ['document-doc-param-Account', 'node-source-fx-Address'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
       '$Account/ns0:Account/Address',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-City'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-City'],
+      ['document-doc-param-Account', 'node-source-fx-City'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-City'],
       '$Account/ns0:Account/City',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Country'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
+      ['document-doc-param-Account', 'node-source-fx-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
       '$Account/ns0:Account/Country',
     );
 
     cy.engageForEachMapping(
-      ['node-source-fx-Cart', 'node-source-fx-Item'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-Item'],
+      ['document-doc-sourceBody-Body', 'node-source-fx-Item'],
+      ['document-doc-targetBody-Body', 'node-target-fx-Item'],
       '/ns0:Cart/Item',
     );
 
     cy.engageMapping(
-      ['node-source-fx-Cart', 'node-source-fx-Item', 'node-source-fx-Title'],
-      ['node-target-fx-ShipOrder', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Title'],
+      ['document-doc-sourceBody-Body', 'node-source-fx-Item', 'node-source-fx-Title'],
+      ['document-doc-targetBody-Body', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Title'],
       'Title',
     );
     cy.engageMapping(
-      ['node-source-fx-Cart', 'node-source-fx-Item', 'node-source-fx-Note'],
-      ['node-target-fx-ShipOrder', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Note'],
+      ['document-doc-sourceBody-Body', 'node-source-fx-Item', 'node-source-fx-Note'],
+      ['document-doc-targetBody-Body', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Note'],
       'Note',
     );
     cy.engageMapping(
-      ['node-source-fx-Cart', 'node-source-fx-Item', 'node-source-fx-Quantity'],
-      ['node-target-fx-ShipOrder', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Quantity'],
+      ['document-doc-sourceBody-Body', 'node-source-fx-Item', 'node-source-fx-Quantity'],
+      ['document-doc-targetBody-Body', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Quantity'],
       'Quantity',
     );
     cy.engageMapping(
-      ['node-source-fx-Cart', 'node-source-fx-Item', 'node-source-fx-Price'],
-      ['node-target-fx-ShipOrder', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Price'],
+      ['document-doc-sourceBody-Body', 'node-source-fx-Item', 'node-source-fx-Price'],
+      ['document-doc-targetBody-Body', 'node-target-for-each', 'node-target-fx-Item', 'node-target-fx-Price'],
       'Price',
     );
 
@@ -101,29 +101,29 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-AccountId'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-OrderId'],
+      ['document-doc-param-Account', 'node-source-fx-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fx-OrderId'],
       '$Account/ns0:Account/@AccountId',
     );
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Name'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
+      ['document-doc-param-Account', 'node-source-fx-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
       '$Account/ns0:Account/Name',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Address'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
+      ['document-doc-param-Account', 'node-source-fx-Address'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
       '$Account/ns0:Account/Address',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-City'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-City'],
+      ['document-doc-param-Account', 'node-source-fx-City'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-City'],
       '$Account/ns0:Account/City',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Country'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
+      ['document-doc-param-Account', 'node-source-fx-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
       '$Account/ns0:Account/Country',
     );
 
@@ -140,29 +140,29 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-AccountId'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-OrderId'],
+      ['document-doc-param-Account', 'node-source-fx-AccountId'],
+      ['document-doc-targetBody-Body', 'node-target-fx-OrderId'],
       '$Account/ns0:Account/@AccountId',
     );
 
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Name'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
+      ['document-doc-param-Account', 'node-source-fx-Name'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Name'],
       '$Account/ns0:Account/Name',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Address'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
+      ['document-doc-param-Account', 'node-source-fx-Address'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Address'],
       '$Account/ns0:Account/Address',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-City'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-City'],
+      ['document-doc-param-Account', 'node-source-fx-City'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-City'],
       '$Account/ns0:Account/City',
     );
     cy.engageMapping(
-      ['node-source-fx-Account', 'node-source-fx-Country'],
-      ['node-target-fx-ShipOrder', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
+      ['document-doc-param-Account', 'node-source-fx-Country'],
+      ['document-doc-targetBody-Body', 'node-target-fx-ShipTo', 'node-target-fx-Country'],
       '$Account/ns0:Account/Country',
     );
 

--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -82,9 +82,9 @@ describe('DataMapperPage', () => {
     let executed = false;
     await waitFor(() => {
       expect(screen.getByTestId('card-source-parameters-header')).toBeInTheDocument();
-      expect(screen.getByTestId('node-source-doc-param-testparam1')).toBeInTheDocument();
-      expect(screen.getByTestId('node-source-doc-sourceBody-Body')).toBeInTheDocument();
-      expect(screen.getByTestId('node-target-doc-targetBody-Body')).toBeInTheDocument();
+      expect(screen.getByTestId('document-doc-param-testparam1')).toBeInTheDocument();
+      expect(screen.getByTestId('document-doc-sourceBody-Body')).toBeInTheDocument();
+      expect(screen.getByTestId('document-doc-targetBody-Body')).toBeInTheDocument();
       expect(screen.getByTestId(/node-source-fx-OrderId-\n*/)).toBeInTheDocument();
       expect(screen.getByTestId(/node-target-fx-OrderId-\n*/)).toBeInTheDocument();
       executed = true;

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -57,7 +57,9 @@ describe('DebugLayout', () => {
       </DataMapperProvider>,
     );
     await screen.findAllByText('ShipOrder');
-    const targetNodes = screen.getAllByTestId(/node-target-.*/);
+    const targetDocuments = screen.queryAllByTestId(/^document-doc-targetBody-.*/);
+    const targetFields = screen.queryAllByTestId(/^node-target-.*/);
+    const targetNodes = [...targetDocuments, ...targetFields];
     expect(targetNodes.length).toEqual(21);
     expect(mappingLinks.length).toEqual(11);
     expect(mappingLinks.filter((link) => link.isSelected).length).toEqual(0);
@@ -106,7 +108,7 @@ describe('DebugLayout', () => {
       expect(selectedNodeReference?.current.path).toMatch(/targetBody:Body:\/\/fx-ShipOrder-.*\/fx-OrderId-.*/);
     });
 
-    const sourceOrderId = await screen.findByTestId(/node-source-selected-fx-OrderId-.*/);
+    const sourceOrderId = await screen.findByTestId(/node-source-fx-OrderId-.*/);
     act(() => {
       fireEvent.click(sourceOrderId);
     });

--- a/packages/ui/src/components/Document/AddMappingNode.scss
+++ b/packages/ui/src/components/Document/AddMappingNode.scss
@@ -1,0 +1,21 @@
+.node {
+  &__add__mapping {
+    &__text {
+      color: var(--pf-t--global--text--color--disabled);
+    }
+
+    &__icon {
+      fill: var(--pf-t--global--icon--color--disabled);
+    }
+
+    &__actions {
+      margin-left: auto;
+    }
+  }
+
+  // Remove left border from AddMappingNode row only
+  // stylelint-disable-next-line selector-class-pattern
+  &__row:has(.node__add__mapping__text) {
+    border-left: none;
+  }
+}

--- a/packages/ui/src/components/Document/AddMappingNode.tsx
+++ b/packages/ui/src/components/Document/AddMappingNode.tsx
@@ -1,34 +1,19 @@
 import { ActionList, ActionListGroup, ActionListItem, Button, Icon } from '@patternfly/react-core';
 import { LayerGroupIcon, PlusCircleIcon, PlusIcon } from '@patternfly/react-icons';
-import clsx from 'clsx';
-import { FunctionComponent, useCallback, useRef } from 'react';
-import { useCanvas } from '../../hooks/useCanvas';
+import { FunctionComponent, useCallback } from 'react';
 import { useDataMapper } from '../../hooks/useDataMapper';
-import { AddMappingNodeData, NodeReference } from '../../models/datamapper/visualization';
+import { AddMappingNodeData } from '../../models/datamapper/visualization';
 import { VisualizationService } from '../../services/visualization.service';
 import { ConditionMenuAction } from './actions/ConditionMenuAction';
-import './Document.scss';
-import { NodeContainer } from './NodeContainer';
 import { NodeTitle } from './NodeTitle';
+import { BaseNode } from './Nodes/BaseNode';
+import './AddMappingNode.scss';
 
-export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData }> = ({ nodeData }) => {
+export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData; rank: number }> = ({
+  nodeData,
+  rank,
+}) => {
   const { refreshMappingTree } = useDataMapper();
-  const { getNodeReference, setNodeReference } = useCanvas();
-
-  const headerRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const nodeRefId = nodeData.path.toString();
-  const nodeReference = useRef<NodeReference>({
-    path: nodeRefId,
-    isSource: false,
-    get headerRef() {
-      return headerRef.current;
-    },
-    get containerRef() {
-      return containerRef.current;
-    },
-  });
-  getNodeReference(nodeRefId) !== nodeReference && setNodeReference(nodeRefId, nodeReference);
 
   const handleAddMapping = useCallback(() => {
     VisualizationService.addMapping(nodeData);
@@ -36,44 +21,44 @@ export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData }>
   }, [nodeData, refreshMappingTree]);
 
   return (
-    <div data-testid={`node-target-${nodeData.id}`} className={clsx({ node__container: true })}>
-      <NodeContainer ref={containerRef} nodeData={nodeData}>
-        <div className={clsx({ node__add__mapping__header: true })}>
-          <NodeContainer ref={headerRef} nodeData={nodeData}>
-            <section className="node__row" data-draggable={false}>
-              <span className="node__row">
-                <Icon className="node__spacer">
-                  <PlusIcon className="node__add__mapping__icon" />
-                </Icon>
-                <Icon className="node__spacer">
-                  <LayerGroupIcon className="node__add__mapping__icon" />
-                </Icon>
-                <NodeTitle
-                  className="node__spacer node__add__mapping__text"
-                  nodeData={nodeData}
-                  isDocument={false}
-                  rank={0}
-                />
-              </span>
-
-              <ActionList>
-                <ActionListGroup className="node__add__mapping__actions">
-                  <ActionListItem>
-                    <Button icon={<PlusCircleIcon />} variant="tertiary" onClick={handleAddMapping}>
-                      Add Mapping
-                    </Button>
-                  </ActionListItem>
-                  <ConditionMenuAction
-                    nodeData={nodeData}
-                    dropdownLabel="Add Conditional Mapping"
-                    onUpdate={refreshMappingTree}
-                  />
-                </ActionListGroup>
-              </ActionList>
-            </section>
-          </NodeContainer>
-        </div>
-      </NodeContainer>
+    <div data-testid={`node-target-${nodeData.id}`} className="node__container">
+      <BaseNode
+        data-testid={nodeData.title}
+        isExpandable={false}
+        isDraggable={false}
+        title={
+          <>
+            <Icon className="node__spacer">
+              <PlusIcon className="node__add__mapping__icon" />
+            </Icon>
+            <NodeTitle
+              className="node__spacer node__add__mapping__text"
+              nodeData={nodeData}
+              isDocument={false}
+              rank={rank}
+            />
+            <Icon className="node__spacer">
+              <LayerGroupIcon className="node__add__mapping__icon" />
+            </Icon>
+          </>
+        }
+        rank={rank}
+      >
+        <ActionList>
+          <ActionListGroup className="node__add__mapping__actions">
+            <ActionListItem>
+              <Button icon={<PlusCircleIcon />} variant="tertiary" onClick={handleAddMapping}>
+                Add Mapping
+              </Button>
+            </ActionListItem>
+            <ConditionMenuAction
+              nodeData={nodeData}
+              dropdownLabel="Add Conditional Mapping"
+              onUpdate={refreshMappingTree}
+            />
+          </ActionListGroup>
+        </ActionList>
+      </BaseNode>
     </div>
   );
 };

--- a/packages/ui/src/components/Document/BaseDocument.scss
+++ b/packages/ui/src/components/Document/BaseDocument.scss
@@ -1,0 +1,45 @@
+.document {
+  &__container {
+    padding: var(--pf-t--global--spacer--xs) 0;
+  }
+
+  &__header {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+  }
+
+  &__actions {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+
+    --pf-v6-c-action-list--child--spacer-base: 0.5rem;
+    --pf-v6-c-action-list--group--spacer-base: 0.5rem;
+
+    /* stylelint-disable-next-line selector-class-pattern */
+    .pf-v6-c-button {
+      --pf-v6-c-button--PaddingLeft: 0.5rem;
+      --pf-v6-c-button--PaddingRight: 0.5rem;
+    }
+
+    /* Make input group expand like in BaseNode */
+    /* stylelint-disable-next-line selector-class-pattern */
+    .pf-v6-c-input-group {
+      flex: 1;
+    }
+
+    /* Make ActionListItem with input group expand */
+    /* stylelint-disable-next-line selector-class-pattern */
+    .pf-v6-c-action-list__item {
+      display: flex;
+
+      &.input-group {
+        flex: 1;
+      }
+    }
+  }
+}

--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -1,0 +1,515 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../../models/datamapper/document';
+import { DocumentTree } from '../../models/datamapper/document-tree';
+import { DocumentNodeData } from '../../models/datamapper/visualization';
+import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
+import { DataMapperProvider } from '../../providers/datamapper.provider';
+import { TreeUIService } from '../../services/tree-ui.service';
+import { useDocumentTreeStore } from '../../store';
+import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { BaseDocument } from './BaseDocument';
+
+describe('BaseDocument', () => {
+  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+    <DataMapperProvider>
+      <DataMapperCanvasProvider>{children}</DataMapperCanvasProvider>
+    </DataMapperProvider>
+  );
+
+  beforeEach(() => {
+    act(() => {
+      useDocumentTreeStore.setState({ expansionState: {} });
+    });
+  });
+
+  describe('Basic Rendering', () => {
+    it('should render document with header', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div data-testid="custom-header">Custom Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId('custom-header')).toBeInTheDocument();
+    });
+
+    it('should render with document__container class', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      const { container } = render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(container.querySelector('.document__container')).toBeInTheDocument();
+    });
+
+    it('should throw error if treeNode is not a document node', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+      const fieldNode = tree.root.children[0]; // Get a field, not a document
+
+      // Temporarily suppress console.error for this test
+      const originalError = console.error;
+      console.error = jest.fn();
+
+      expect(() => {
+        render(
+          <BaseDocument
+            header={<div>Header</div>}
+            treeNode={fieldNode}
+            documentId={documentNodeData.id}
+            isReadOnly={false}
+          />,
+          { wrapper },
+        );
+      }).toThrow('BaseDocument requires a document node');
+
+      console.error = originalError;
+    });
+  });
+
+  describe('Document Actions', () => {
+    it('should render Attach and Detach schema buttons when not read-only', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      // Use semantic queries - find buttons by their aria-label
+      expect(screen.getByLabelText('Attach schema')).toBeInTheDocument();
+      expect(screen.getByLabelText('Detach schema')).toBeInTheDocument();
+    });
+
+    it('should not render Attach and Detach schema buttons when read-only', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={true}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.queryByLabelText('Attach schema')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Detach schema')).not.toBeInTheDocument();
+    });
+
+    it('should render additional actions when provided', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      const additionalActions = [
+        <div key="action1" data-testid="additional-action-1">
+          Action 1
+        </div>,
+        <div key="action2" data-testid="additional-action-2">
+          Action 2
+        </div>,
+      ];
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          additionalActions={additionalActions}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId('additional-action-1')).toBeInTheDocument();
+      expect(screen.getByTestId('additional-action-2')).toBeInTheDocument();
+    });
+
+    it('should stop event propagation when clicking on actions', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+      const parentClickHandler = jest.fn();
+
+      const { container } = render(
+        <div onClick={parentClickHandler}>
+          <BaseDocument
+            header={<div>Header</div>}
+            treeNode={tree.root}
+            documentId={documentNodeData.id}
+            isReadOnly={false}
+          />
+        </div>,
+        { wrapper },
+      );
+
+      const actionsGroup = container.querySelector('.document__actions');
+      expect(actionsGroup).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(actionsGroup!);
+      });
+
+      expect(parentClickHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Expansion/Collapse', () => {
+    it('should show expand icon when document has children', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: true,
+            },
+          },
+        });
+      });
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`)).toBeInTheDocument();
+    });
+
+    it('should not show expand icon when document has no children', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.queryByTestId(`expand-icon-${tree.root.nodeData.title}`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`collapse-icon-${tree.root.nodeData.title}`)).not.toBeInTheDocument();
+    });
+
+    it('should call TreeUIService.toggleNode when expand icon is clicked', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+      const toggleNodeSpy = jest.spyOn(TreeUIService, 'toggleNode');
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: true,
+            },
+          },
+        });
+      });
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
+
+      act(() => {
+        fireEvent.click(expandIcon);
+      });
+
+      expect(toggleNodeSpy).toHaveBeenCalledWith(documentNodeData.id, tree.root.path);
+
+      toggleNodeSpy.mockRestore();
+    });
+
+    it('should show ChevronRight when collapsed', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: false,
+            },
+          },
+        });
+      });
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId(`collapse-icon-${tree.root.nodeData.title}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`expand-icon-${tree.root.nodeData.title}`)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Children Rendering', () => {
+    it('should render children using renderNodes function when expanded', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: true,
+            },
+          },
+        });
+      });
+
+      const renderNodes = jest.fn((childNode) => (
+        <div key={childNode.path} data-testid={`child-${childNode.path}`}>
+          Child Node
+        </div>
+      ));
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          renderNodes={renderNodes}
+        />,
+        { wrapper },
+      );
+
+      // Verify renderNodes was called for children
+      expect(renderNodes).toHaveBeenCalled();
+      expect(renderNodes.mock.calls.length).toBeGreaterThan(0);
+
+      // Verify all children are rendered
+      for (const child of tree.root.children) {
+        expect(screen.getByTestId(`child-${child.path}`)).toBeInTheDocument();
+      }
+    });
+
+    it('should not render children when collapsed', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: false,
+            },
+          },
+        });
+      });
+
+      const renderNodes = jest.fn((childNode) => <div data-testid={`child-${childNode.path}`}>Child Node</div>);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          renderNodes={renderNodes}
+        />,
+        { wrapper },
+      );
+
+      expect(renderNodes).not.toHaveBeenCalled();
+    });
+
+    it('should pass isReadOnly to renderNodes function', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = TreeUIService.createTree(documentNodeData);
+
+      act(() => {
+        useDocumentTreeStore.setState({
+          expansionState: {
+            [documentNodeData.id]: {
+              [tree.root.path]: true,
+            },
+          },
+        });
+      });
+
+      const renderNodes = jest.fn((childNode, isReadOnly) => (
+        <div data-testid={`child-${childNode.path}-readonly-${isReadOnly}`}>Child Node</div>
+      ));
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={true}
+          renderNodes={renderNodes}
+        />,
+        { wrapper },
+      );
+
+      for (let index = 0; index < tree.root.children.length; index++) {
+        const child = tree.root.children[index];
+        expect(renderNodes).toHaveBeenNthCalledWith(index + 1, child, true);
+      }
+    });
+  });
+
+  describe('Selection', () => {
+    it('should render document container with stable test-id', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId(`document-${documentNodeData.id}`)).toBeInTheDocument();
+    });
+
+    it('should toggle selection when clicked', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      const documentContainer = screen.getByTestId(`document-${documentNodeData.id}`);
+
+      act(() => {
+        fireEvent.click(documentContainer);
+      });
+
+      // After first click, should be selected (data-selected="true")
+      expect(documentContainer).toHaveAttribute('data-selected', 'true');
+
+      act(() => {
+        fireEvent.click(documentContainer);
+      });
+
+      // After second click, should be deselected (data-selected="false")
+      expect(documentContainer).toHaveAttribute('data-selected', 'false');
+    });
+
+    it('should apply data-selected attribute when selected', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      render(
+        <BaseDocument
+          header={<div>Header</div>}
+          treeNode={tree.root}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+        />,
+        { wrapper },
+      );
+
+      const documentContainer = screen.getByTestId(`document-${documentNodeData.id}`);
+
+      act(() => {
+        fireEvent.click(documentContainer);
+      });
+
+      expect(documentContainer).toHaveAttribute('data-selected', 'true');
+    });
+
+    it('should stop event propagation on document click', () => {
+      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+      const parentClickHandler = jest.fn();
+
+      render(
+        <div onClick={parentClickHandler}>
+          <BaseDocument
+            header={<div>Header</div>}
+            treeNode={tree.root}
+            documentId={documentNodeData.id}
+            isReadOnly={false}
+          />
+        </div>,
+        { wrapper },
+      );
+
+      const documentContainer = screen.getByTestId(`document-${documentNodeData.id}`);
+
+      act(() => {
+        fireEvent.click(documentContainer);
+      });
+
+      expect(parentClickHandler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui/src/components/Document/BaseDocument.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.tsx
@@ -1,0 +1,149 @@
+import { ActionListGroup, ActionListItem, Icon } from '@patternfly/react-core';
+import { ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
+import clsx from 'clsx';
+import { FunctionComponent, MouseEvent, ReactNode, useCallback, useRef } from 'react';
+import { useCanvas } from '../../hooks/useCanvas';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
+import { DocumentType } from '../../models/datamapper/document';
+import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
+import { NodeReference } from '../../models/datamapper/visualization';
+import { VisualizationService } from '../../services/visualization.service';
+import { TreeUIService } from '../../services/tree-ui.service';
+import { useDocumentTreeStore } from '../../store';
+import { NodeContainer } from './NodeContainer';
+import { AttachSchemaButton } from './actions/AttachSchemaButton';
+import { DetachSchemaButton } from './actions/DetachSchemaButton';
+import { useDataMapper } from '../../hooks/useDataMapper';
+import './BaseDocument.scss';
+
+type DocumentProps = {
+  header: ReactNode;
+  treeNode: DocumentTreeNode;
+  documentId: string;
+  isReadOnly: boolean;
+  additionalActions?: React.ReactNode[];
+  renderNodes?: (childNode: DocumentTreeNode, isReadOnly: boolean) => ReactNode; // Function to render child nodes
+};
+
+/**
+ * Document component - Pure composition container for document roots
+ * Handles document header, actions, and delegates child rendering via renderNodes
+ */
+export const BaseDocument: FunctionComponent<DocumentProps> = ({
+  header,
+  treeNode,
+  documentId,
+  isReadOnly,
+  additionalActions = [],
+  renderNodes,
+}) => {
+  const { getNodeReference, setNodeReference, reloadNodeReferences } = useCanvas();
+  const { isInSelectedMapping, toggleSelectedNodeReference } = useMappingLinks();
+
+  const isExpanded = useDocumentTreeStore((state) => state.isExpanded(documentId, treeNode.path));
+  const nodeData = treeNode.nodeData;
+  const { mappingTree } = useDataMapper();
+
+  if (!nodeData.document) {
+    throw new Error('BaseDocument requires a document node');
+  }
+
+  const documentType = nodeData.document.documentType;
+  const documentReferenceId = nodeData.document.getReferenceId(mappingTree.namespaceMap);
+  const hasChildren = VisualizationService.hasChildren(nodeData);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nodeRefId = nodeData.path.toString();
+  const nodeReference = useRef<NodeReference>({
+    path: nodeRefId,
+    isSource: nodeData.isSource,
+    get headerRef() {
+      return headerRef.current;
+    },
+    get containerRef() {
+      return containerRef.current;
+    },
+  });
+  getNodeReference(nodeRefId) !== nodeReference && setNodeReference(nodeRefId, nodeReference);
+
+  const handleClickToggle = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      if (!hasChildren) return;
+      TreeUIService.toggleNode(documentId, treeNode.path);
+      reloadNodeReferences();
+    },
+    [hasChildren, documentId, treeNode.path, reloadNodeReferences],
+  );
+
+  const isSelected = isInSelectedMapping(nodeReference);
+  const handleClickField = useCallback(
+    (event: MouseEvent) => {
+      toggleSelectedNodeReference(nodeReference);
+      event.stopPropagation();
+    },
+    [toggleSelectedNodeReference],
+  );
+  const handleStopPropagation = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  const isSourceBodyDocument = nodeData.document.documentType === DocumentType.SOURCE_BODY;
+
+  return (
+    <div
+      data-testid={`document-${nodeData.id}`}
+      data-selected={isSelected}
+      className={'document__container'}
+      onClick={handleClickField}
+    >
+      <NodeContainer ref={containerRef} nodeData={nodeData} enableDnD={!isSourceBodyDocument}>
+        <div ref={headerRef} className={clsx('document__header', { 'selected-container': isSelected })}>
+          <Icon className="node__expand node__spacer" onClick={hasChildren ? handleClickToggle : undefined}>
+            {hasChildren && isExpanded && <ChevronDown data-testid={`expand-icon-${nodeData.title}`} />}
+            {hasChildren && !isExpanded && <ChevronRight data-testid={`collapse-icon-${nodeData.title}`} />}
+          </Icon>
+          <Icon className="node__spacer" data-drag-handler>
+            <Draggable />
+          </Icon>
+          {header}
+          {/* Document-level actions */}
+          <ActionListGroup
+            key={`document-actions-${documentId}`}
+            onClick={handleStopPropagation}
+            className={'document__actions'}
+          >
+            {!isReadOnly && (
+              <>
+                {additionalActions}
+                <ActionListItem>
+                  <AttachSchemaButton
+                    documentType={documentType}
+                    documentId={nodeData.document.documentId}
+                    documentReferenceId={documentReferenceId}
+                    hasSchema={!nodeData.isPrimitive}
+                  />
+                </ActionListItem>
+                <ActionListItem>
+                  <DetachSchemaButton
+                    documentType={documentType}
+                    documentId={nodeData.document.documentId}
+                    documentReferenceId={documentReferenceId}
+                  />
+                </ActionListItem>
+              </>
+            )}
+          </ActionListGroup>
+        </div>
+
+        {hasChildren && isExpanded && renderNodes && (
+          <div className={clsx({ node__children: false })}>
+            {treeNode.children.map((childTreeNode) => (
+              <div key={childTreeNode.path}>{renderNodes(childTreeNode, isReadOnly)}</div>
+            ))}
+          </div>
+        )}
+      </NodeContainer>
+    </div>
+  );
+};

--- a/packages/ui/src/components/Document/NodeContainer.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.tsx
@@ -1,11 +1,10 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import clsx from 'clsx';
 import { forwardRef, FunctionComponent, PropsWithChildren } from 'react';
-import { AddMappingNodeData, DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
+import { DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
 import { isDefined } from '../../utils';
 import './NodeContainer.scss';
 import { VisualizationService } from '../../services/visualization.service';
-import { DocumentType } from '../../models/datamapper/document';
 
 type DnDContainerProps = PropsWithChildren & {
   nodeData: NodeData;
@@ -75,32 +74,18 @@ const DnDContainer: FunctionComponent<DnDContainerProps> = ({ nodeData, children
 type NodeContainerProps = PropsWithChildren & {
   className?: string;
   nodeData?: NodeData;
+  enableDnD?: boolean;
 };
 
 export const NodeContainer = forwardRef<HTMLDivElement, NodeContainerProps>(
-  ({ children, className, nodeData }, forwardedRef) => {
-    if (!nodeData) {
-      return (
-        <div ref={forwardedRef} className={className}>
-          {children}
-        </div>
-      );
-    }
-
-    const isPrimitiveSourceBody =
-      nodeData.isPrimitive &&
-      nodeData instanceof DocumentNodeData &&
-      nodeData.document?.documentType === DocumentType.SOURCE_BODY;
-
-    const hasDnD = !(
-      isPrimitiveSourceBody ||
-      nodeData instanceof AddMappingNodeData ||
-      (nodeData instanceof DocumentNodeData && !nodeData.isPrimitive)
-    );
-
-    return (
+  ({ children, className, nodeData, enableDnD = true }, forwardedRef) => {
+    return enableDnD && nodeData && !(nodeData instanceof DocumentNodeData && !nodeData.isPrimitive) ? (
       <div ref={forwardedRef} className={className}>
-        {hasDnD ? <DnDContainer nodeData={nodeData}>{children}</DnDContainer> : <>{children}</>}
+        <DnDContainer nodeData={nodeData}>{children}</DnDContainer>
+      </div>
+    ) : (
+      <div ref={forwardedRef} className={className}>
+        {children}
       </div>
     );
   },

--- a/packages/ui/src/components/Document/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle.scss
@@ -5,6 +5,7 @@
     white-space: nowrap;
     max-width: 100%;
     display: inline-block;
+    vertical-align: middle;
   }
 }
 

--- a/packages/ui/src/components/Document/Nodes/BaseNode.scss
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.scss
@@ -1,0 +1,63 @@
+@use '../../../styles/dnd';
+
+.node {
+  &__row {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    height: 2rem;
+
+    // Rank-based indentation - expand icon + margins = ~1.5rem per level
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+
+    &[data-draggable='true'] {
+      @include dnd.cursor-grab;
+    }
+
+    // Leaf nodes (no children) have grey font color
+    &:not([data-expandable='true']) {
+      color: var(--pf-t--global--color--text--subtle);
+      border-left: 1px dotted gray;
+      padding-left: var(--pf-t--global--spacer--sm);
+    }
+
+    // Make inputs/buttons fit within row height
+    // stylelint-disable-next-line selector-class-pattern
+    .pf-v6-c-action-list__item,
+    .pf-v6-c-input-group {
+      height: 1.75rem;
+    }
+
+    .pf-v6-c-input-group {
+      flex: 1;
+    }
+
+    input,
+    button,
+    .pf-v6-c-text-input,
+    .pf-v6-c-button {
+      height: 1.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  // Selected row styling - blue font color and bold (overrides leaf node grey)
+  &__row[data-selected='true'] {
+    color: var(--pf-t--global--color--brand--default) !important;
+    font-weight: bold;
+  }
+
+  &__expand {
+    left: var(--pf-t--global--spacer--sm);
+  }
+
+  &__spacer {
+    margin: 0 var(--pf-t--global--spacer--sm);
+
+    svg {
+      display: block;
+    }
+  }
+}

--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Types } from '../../../models/datamapper';
+import { BaseNode } from './BaseNode';
+
+describe('BaseNode', () => {
+  describe('Basic Rendering', () => {
+    it('should render title as string', () => {
+      render(<BaseNode title="Test Title" data-testid="test-node" />);
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+    });
+
+    it('should render title as ReactNode', () => {
+      render(<BaseNode title={<span data-testid="custom-title">Custom Title</span>} data-testid="test-node" />);
+      expect(screen.getByTestId('custom-title')).toBeInTheDocument();
+      expect(screen.getByText('Custom Title')).toBeInTheDocument();
+    });
+
+    it('should render children', () => {
+      render(
+        <BaseNode title="Title" data-testid="test-node">
+          <span data-testid="child-element">Child Content</span>
+        </BaseNode>,
+      );
+      expect(screen.getByTestId('child-element')).toBeInTheDocument();
+    });
+
+    it('should render with node__row class', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" />);
+      const section = container.querySelector('section.node__row');
+      expect(section).toBeInTheDocument();
+    });
+  });
+
+  describe('Expansion Controls', () => {
+    it('should not show expand icon when isExpandable is false', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isExpandable={false} />);
+      expect(screen.queryByTestId('expand-icon-test-node')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('collapse-icon-test-node')).not.toBeInTheDocument();
+    });
+
+    it('should show ChevronDown when expandable and expanded', () => {
+      render(
+        <BaseNode
+          title="Title"
+          data-testid="test-node"
+          isExpandable={true}
+          isExpanded={true}
+          onExpandChange={() => {}}
+        />,
+      );
+      expect(screen.getByTestId('expand-icon-test-node')).toBeInTheDocument();
+      expect(screen.queryByTestId('collapse-icon-test-node')).not.toBeInTheDocument();
+    });
+
+    it('should show ChevronRight when expandable and collapsed', () => {
+      render(
+        <BaseNode
+          title="Title"
+          data-testid="test-node"
+          isExpandable={true}
+          isExpanded={false}
+          onExpandChange={() => {}}
+        />,
+      );
+      expect(screen.getByTestId('collapse-icon-test-node')).toBeInTheDocument();
+      expect(screen.queryByTestId('expand-icon-test-node')).not.toBeInTheDocument();
+    });
+
+    it('should call onExpandChange when expand icon is clicked', () => {
+      const onExpandChange = jest.fn();
+      render(
+        <BaseNode
+          title="Title"
+          data-testid="test-node"
+          isExpandable={true}
+          isExpanded={true}
+          onExpandChange={onExpandChange}
+        />,
+      );
+
+      const expandIcon = screen.getByTestId('expand-icon-test-node');
+      fireEvent.click(expandIcon);
+
+      expect(onExpandChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Draggable Controls', () => {
+    it('should show drag icon when isDraggable is true', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" isDraggable={true} />);
+      const dragHandler = container.querySelector('[data-drag-handler]');
+      expect(dragHandler).toBeInTheDocument();
+    });
+
+    it('should not show drag icon when isDraggable is false', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" isDraggable={false} />);
+      const dragHandler = container.querySelector('[data-drag-handler]');
+      expect(dragHandler).not.toBeInTheDocument();
+    });
+
+    it('should set data-draggable attribute to true when isDraggable is true', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" isDraggable={true} />);
+      const section = container.querySelector('[data-draggable="true"]');
+      expect(section).toBeInTheDocument();
+    });
+
+    it('should set data-draggable attribute to false when isDraggable is false', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" isDraggable={false} />);
+      const section = container.querySelector('[data-draggable="false"]');
+      expect(section).toBeInTheDocument();
+    });
+  });
+
+  describe('Field Icons', () => {
+    it('should render field icon when iconType is provided', () => {
+      render(<BaseNode title="Title" data-testid="test-node" iconType={Types.String} />);
+      // FieldIcon component should be rendered - testing via class
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" iconType={Types.String} />);
+      expect(container.querySelector('.node__spacer')).toBeInTheDocument();
+    });
+
+    it('should render collection icon when isCollectionField is true', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isCollectionField={true} />);
+      expect(screen.getByTestId('collection-field-icon')).toBeInTheDocument();
+    });
+
+    it('should not render collection icon when isCollectionField is false', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isCollectionField={false} />);
+      expect(screen.queryByTestId('collection-field-icon')).not.toBeInTheDocument();
+    });
+
+    it('should render attribute icon when isAttributeField is true', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isAttributeField={true} />);
+      expect(screen.getByTestId('attribute-field-icon')).toBeInTheDocument();
+    });
+
+    it('should not render attribute icon when isAttributeField is false', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isAttributeField={false} />);
+      expect(screen.queryByTestId('attribute-field-icon')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Combined States', () => {
+    it('should render all icons when all flags are true', () => {
+      const { container } = render(
+        <BaseNode
+          title="Title"
+          data-testid="test-node"
+          isExpandable={true}
+          isExpanded={true}
+          isDraggable={true}
+          iconType={Types.String}
+          isCollectionField={true}
+          isAttributeField={true}
+          onExpandChange={() => {}}
+        />,
+      );
+
+      expect(screen.getByTestId('expand-icon-test-node')).toBeInTheDocument();
+      expect(container.querySelector('[data-drag-handler]')).toBeInTheDocument();
+      expect(screen.getByTestId('collection-field-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('attribute-field-icon')).toBeInTheDocument();
+    });
+
+    it('should render minimal node when no optional props provided', () => {
+      const { container } = render(<BaseNode title="Title" data-testid="test-node" />);
+
+      expect(screen.queryByTestId('expand-icon-test-node')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('collapse-icon-test-node')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-drag-handler]')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('collection-field-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('attribute-field-icon')).not.toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -1,0 +1,85 @@
+import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
+import { Icon } from '@patternfly/react-core';
+import { LayerGroupIcon } from '@patternfly/react-icons';
+import { FunctionComponent, MouseEventHandler, PropsWithChildren, ReactNode } from 'react';
+import { IDataTestID } from '../../../models';
+import { Types } from '../../../models/datamapper';
+import { FieldIcon } from '../FieldIcon';
+import './BaseNode.scss';
+
+interface BaseNodeProps extends IDataTestID {
+  /** Controls whether the Expansion icon is shown */
+  isExpandable?: boolean;
+  /** Expansion status. Requires `isExpandable=true` */
+  isExpanded?: boolean;
+  /** Expansion handler */
+  onExpandChange?: MouseEventHandler<HTMLElement>;
+
+  /** Controls whether the Drag icon is shown */
+  isDraggable?: boolean;
+  iconType?: Types;
+  isCollectionField?: boolean;
+  isAttributeField?: boolean;
+
+  /** Title node */
+  title: ReactNode;
+
+  /** Hierarchical depth level for indentation */
+  rank?: number;
+
+  /** Selection state */
+  isSelected?: boolean;
+}
+
+export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
+  isExpandable,
+  isExpanded,
+  onExpandChange,
+  isDraggable,
+  iconType,
+  isCollectionField,
+  isAttributeField,
+  title,
+  rank,
+  isSelected,
+  'data-testid': dataTestId,
+  children,
+}) => {
+  return (
+    <section
+      className="node__row"
+      data-draggable={isDraggable}
+      data-expandable={isExpandable}
+      data-selected={isSelected}
+      style={{ '--node-rank': rank } as React.CSSProperties}
+    >
+      {isExpandable && (
+        <Icon className="node__expand" onClick={onExpandChange}>
+          {isExpanded && <ChevronDown data-testid={`expand-icon-${dataTestId}`} />}
+          {!isExpanded && <ChevronRight data-testid={`collapse-icon-${dataTestId}`} />}
+        </Icon>
+      )}
+
+      {isDraggable && (
+        <Icon className="node__spacer" data-drag-handler>
+          <Draggable />
+        </Icon>
+      )}
+      {title}
+      {isCollectionField && (
+        <Icon className="node__spacer" data-testid="collection-field-icon">
+          <LayerGroupIcon />
+        </Icon>
+      )}
+      <FieldIcon className="node__spacer" type={iconType} />
+
+      {isAttributeField && (
+        <Icon className="node__spacer" data-testid="attribute-field-icon">
+          <At />
+        </Icon>
+      )}
+
+      {children}
+    </section>
+  );
+};

--- a/packages/ui/src/components/Document/ParameterDocument.tsx
+++ b/packages/ui/src/components/Document/ParameterDocument.tsx
@@ -1,0 +1,83 @@
+import { Title } from '@patternfly/react-core';
+import { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { useDataMapper } from '../../hooks/useDataMapper';
+import { useToggle } from '../../hooks/useToggle';
+import { BaseDocument } from './BaseDocument';
+import { ParameterInputPlaceholder } from './ParameterInputPlaceholder';
+import { DeleteParameterButton } from './actions/DeleteParameterButton';
+import { RenameParameterButton } from './actions/RenameParameterButton';
+import { DocumentNodeData, IDocument } from '../../models/datamapper';
+import { DocumentTree } from '../../models/datamapper/document-tree';
+import { TreeUIService } from '../../services/tree-ui.service';
+import { SourceDocumentNode } from './SourceDocumentNode';
+
+type EditableParameterTitleProps = {
+  parameterName: string;
+  isRenaming: boolean;
+  onComplete: () => void;
+};
+
+/**
+ * Editable parameter title - shows title or input based on rename state
+ */
+const EditableParameterTitle: FunctionComponent<EditableParameterTitleProps> = ({
+  parameterName,
+  isRenaming,
+  onComplete,
+}) => {
+  if (isRenaming) {
+    return <ParameterInputPlaceholder parameter={parameterName} onComplete={onComplete} />;
+  }
+
+  return <Title headingLevel="h5">{parameterName}</Title>;
+};
+
+type ParameterDocProps = {
+  document: IDocument;
+  isReadOnly: boolean;
+};
+
+/**
+ * Parameter document component - wraps DMDocument with parameter-specific actions
+ * Uses composition to add rename and delete functionality
+ */
+export const ParameterDocument: FunctionComponent<ParameterDocProps> = ({ document, isReadOnly }) => {
+  const { mappingTree } = useDataMapper();
+  const documentNodeData = useMemo(() => new DocumentNodeData(document), [document]);
+  const [treeNode, setTreeNode] = useState<DocumentTree | undefined>(undefined);
+  const documentId = documentNodeData.id;
+  const parameterName = document.documentId;
+
+  useEffect(() => {
+    setTreeNode(TreeUIService.createTree(documentNodeData));
+  }, [documentNodeData]);
+
+  const documentReferenceId = document.getReferenceId(mappingTree.namespaceMap);
+
+  // Track rename state
+  const { state: isRenaming, toggleOn: startRenaming, toggleOff: stopRenaming } = useToggle(false);
+
+  // Parameter-specific actions: rename and delete
+  const parameterActions = [
+    <RenameParameterButton key="rename" parameterName={parameterName} onRenameClick={startRenaming} />,
+    <DeleteParameterButton key="delete" parameterName={parameterName} parameterReferenceId={documentReferenceId} />,
+  ];
+  if (!treeNode) {
+    return <div>Loading tree...</div>;
+  }
+
+  return (
+    <BaseDocument
+      header={
+        <EditableParameterTitle parameterName={parameterName} isRenaming={isRenaming} onComplete={stopRenaming} />
+      }
+      treeNode={treeNode.root}
+      documentId={documentId}
+      isReadOnly={isReadOnly}
+      additionalActions={parameterActions}
+      renderNodes={(childNode, readOnly) => (
+        <SourceDocumentNode treeNode={childNode} documentId={documentId} isReadOnly={readOnly} rank={1} />
+      )}
+    />
+  );
+};

--- a/packages/ui/src/components/Document/Parameters.scss
+++ b/packages/ui/src/components/Document/Parameters.scss
@@ -1,0 +1,20 @@
+.parameter-card {
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-card__header {
+    padding-block: 0;
+    padding-inline: 0;
+  }
+}
+
+.parameter-actions {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+
+  --pf-v6-c-action-list--child--spacer-base: 0.5rem;
+  --pf-v6-c-action-list--group--spacer-base: 0.5rem;
+
+  .pf-v6-c-button {
+    --pf-v6-c-button--PaddingLeft: 0.5rem;
+    --pf-v6-c-button--PaddingRight: 0.5rem;
+  }
+}

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -16,10 +16,10 @@ import { useCanvas } from '../../hooks/useCanvas';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { useToggle } from '../../hooks/useToggle';
 import { NodeReference } from '../../models/datamapper';
-import './Document.scss';
 import { NodeContainer } from './NodeContainer';
 import { ParameterInputPlaceholder } from './ParameterInputPlaceholder';
-import { SourceDocument } from './SourceDocument';
+import { ParameterDocument } from './ParameterDocument';
+import './Parameters.scss';
 
 type ParametersProps = {
   isReadOnly: boolean;
@@ -106,7 +106,7 @@ export const Parameters: FunctionComponent<ParametersProps> = ({ isReadOnly }) =
             )}
             {Array.from(sourceParameterMap.entries()).map(([documentId, doc]) => (
               <StackItem key={documentId}>
-                <SourceDocument document={doc} isReadOnly={isReadOnly} />
+                <ParameterDocument document={doc} isReadOnly={isReadOnly} />
               </StackItem>
             ))}
           </Stack>

--- a/packages/ui/src/components/Document/SourceDocument.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocument.test.tsx
@@ -4,6 +4,7 @@ import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.prov
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
 import { SourceDocument } from './SourceDocument';
+import { ParameterDocument } from './ParameterDocument';
 
 describe('SourceDocument', () => {
   it('should render primitive document', async () => {
@@ -23,7 +24,7 @@ describe('SourceDocument', () => {
     render(
       <DataMapperProvider>
         <DataMapperCanvasProvider>
-          <SourceDocument document={document} isReadOnly={false} />
+          <ParameterDocument document={document} isReadOnly={false} />
         </DataMapperCanvasProvider>
       </DataMapperProvider>,
     );

--- a/packages/ui/src/components/Document/SourceDocument.tsx
+++ b/packages/ui/src/components/Document/SourceDocument.tsx
@@ -1,10 +1,11 @@
 import { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { Title } from '@patternfly/react-core';
 import { IDocument } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/tree-ui.service';
-import './Document.scss';
 import { SourceDocumentNode } from './SourceDocumentNode';
+import { BaseDocument } from './BaseDocument';
 
 type DocumentTreeProps = {
   document: IDocument;
@@ -28,5 +29,15 @@ export const SourceDocument: FunctionComponent<DocumentTreeProps> = ({ document,
     return <div>Loading tree...</div>;
   }
 
-  return <SourceDocumentNode treeNode={treeNode.root} documentId={documentId} isReadOnly={isReadOnly} rank={0} />;
+  return (
+    <BaseDocument
+      treeNode={treeNode.root}
+      documentId={documentId}
+      isReadOnly={isReadOnly}
+      header={<Title headingLevel="h5">Body</Title>}
+      renderNodes={(childNode, readOnly) => (
+        <SourceDocumentNode treeNode={childNode} documentId={documentId} isReadOnly={readOnly} rank={1} />
+      )}
+    />
+  );
 };

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -251,7 +251,7 @@ describe('SourceDocumentNode', () => {
         );
       });
 
-      const expandIcon = screen.getByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).toBeInTheDocument();
 
       act(() => {
@@ -281,8 +281,8 @@ describe('SourceDocumentNode', () => {
         );
       });
 
-      const expandIcon = screen.queryByTestId(`expand-source-icon-${leafNode!.nodeData.title}`);
-      const collapseIcon = screen.queryByTestId(`collapse-source-icon-${leafNode!.nodeData.title}`);
+      const expandIcon = screen.queryByTestId(`expand-icon-${leafNode!.nodeData.title}`);
+      const collapseIcon = screen.queryByTestId(`collapse-icon-${leafNode!.nodeData.title}`);
 
       expect(expandIcon).not.toBeInTheDocument();
       expect(collapseIcon).not.toBeInTheDocument();
@@ -313,10 +313,10 @@ describe('SourceDocumentNode', () => {
         );
       });
 
-      const expandIcon = screen.getByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).toBeInTheDocument();
 
-      const collapseIcon = screen.queryByTestId(`collapse-source-icon-${tree.root.nodeData.title}`);
+      const collapseIcon = screen.queryByTestId(`collapse-icon-${tree.root.nodeData.title}`);
       expect(collapseIcon).not.toBeInTheDocument();
     });
 
@@ -345,10 +345,10 @@ describe('SourceDocumentNode', () => {
         );
       });
 
-      const collapseIcon = screen.getByTestId(`collapse-source-icon-${tree.root.nodeData.title}`);
+      const collapseIcon = screen.getByTestId(`collapse-icon-${tree.root.nodeData.title}`);
       expect(collapseIcon).toBeInTheDocument();
 
-      const expandIcon = screen.queryByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.queryByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).not.toBeInTheDocument();
     });
 
@@ -379,7 +379,7 @@ describe('SourceDocumentNode', () => {
         );
       });
 
-      const expandIcon = screen.getByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
 
       act(() => {
         fireEvent.click(expandIcon);
@@ -414,8 +414,7 @@ describe('SourceDocumentNode', () => {
         fireEvent.click(nodeContainer);
       });
 
-      const selectedNode = screen.getByTestId(`node-source-selected-${documentNodeData.id}`);
-      expect(selectedNode).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
 
     it('should apply selected-container class when selected', () => {
@@ -465,8 +464,7 @@ describe('SourceDocumentNode', () => {
         fireEvent.click(nodeContainer);
       });
 
-      const selectedNode = screen.getByTestId(`node-source-selected-${documentNodeData.id}`);
-      expect(selectedNode).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
 
       act(() => {
         fireEvent.click(nodeContainer);
@@ -544,59 +542,6 @@ describe('SourceDocumentNode', () => {
       );
 
       expect(screen.getByTestId(`node-source-${documentNodeData.id}`)).toBeInTheDocument();
-    });
-  });
-
-  describe('Parameter Renaming', () => {
-    it('should show ParameterInputPlaceholder when renaming', () => {
-      const document = new PrimitiveDocument(DocumentType.PARAM, 'param1');
-      const documentNodeData = new DocumentNodeData(document);
-      const tree = new DocumentTree(documentNodeData);
-
-      render(<SourceDocumentNode treeNode={tree.root} documentId={documentNodeData.id} isReadOnly={false} rank={0} />, {
-        wrapper,
-      });
-
-      expect(screen.getByText('param1')).toBeInTheDocument();
-
-      const renameButton = screen.getByTestId('rename-parameter-param1-button');
-      fireEvent.click(renameButton);
-
-      expect(screen.getByTestId('new-parameter-name-input')).toBeInTheDocument();
-    });
-
-    it('should call toggleOffRenamingParameter on complete', () => {
-      const document = new PrimitiveDocument(DocumentType.PARAM, 'param1');
-      const documentNodeData = new DocumentNodeData(document);
-      const tree = new DocumentTree(documentNodeData);
-
-      render(<SourceDocumentNode treeNode={tree.root} documentId={documentNodeData.id} isReadOnly={false} rank={0} />, {
-        wrapper,
-      });
-
-      const renameButton = screen.getByTestId('rename-parameter-param1-button');
-      fireEvent.click(renameButton);
-
-      expect(screen.getByTestId('new-parameter-name-input')).toBeInTheDocument();
-
-      const cancelButton = screen.getByTestId('new-parameter-cancel-btn');
-      fireEvent.click(cancelButton);
-
-      expect(screen.queryByTestId('new-parameter-name-input')).not.toBeInTheDocument();
-    });
-
-    it('should not show DocumentActions for non-document nodes', () => {
-      const document = TestUtil.createSourceOrderDoc();
-      const documentNodeData = new DocumentNodeData(document);
-      const tree = new DocumentTree(documentNodeData);
-      TreeParsingService.parseTree(tree);
-      const fieldNode = tree.root.children[0]; // Get a field node, not a document node
-
-      render(<SourceDocumentNode treeNode={fieldNode} documentId={documentNodeData.id} isReadOnly={false} rank={1} />, {
-        wrapper,
-      });
-
-      expect(screen.queryByTestId(`rename-parameter-${fieldNode.nodeData.id}-button`)).not.toBeInTheDocument();
     });
   });
 
@@ -689,18 +634,6 @@ describe('SourceDocumentNode', () => {
   });
 
   describe('Read-only Mode', () => {
-    it('should hide DocumentActions when isReadOnly is true', () => {
-      const document = new PrimitiveDocument(DocumentType.PARAM, 'param1');
-      const documentNodeData = new DocumentNodeData(document);
-      const tree = new DocumentTree(documentNodeData);
-
-      render(<SourceDocumentNode treeNode={tree.root} documentId={documentNodeData.id} isReadOnly={true} rank={0} />, {
-        wrapper,
-      });
-
-      expect(screen.queryByTestId('rename-parameter-param1-button')).not.toBeInTheDocument();
-    });
-
     it('should still allow expansion/collapse in read-only mode', () => {
       const document = TestUtil.createSourceOrderDoc();
       const documentNodeData = new DocumentNodeData(document);
@@ -722,7 +655,7 @@ describe('SourceDocumentNode', () => {
       });
 
       // Expand icon should still be visible
-      const expandIcon = screen.getByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).toBeInTheDocument();
 
       // Should be able to click the expand icon
@@ -761,7 +694,7 @@ describe('SourceDocumentNode', () => {
         { wrapper },
       );
 
-      const expandIcon = screen.getByTestId(`expand-source-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
 
       act(() => {
         fireEvent.click(expandIcon);
@@ -811,8 +744,8 @@ describe('SourceDocumentNode', () => {
       });
 
       // Should not have expand/collapse icons
-      expect(screen.queryByTestId(`expand-source-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
-      expect(screen.queryByTestId(`collapse-source-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`expand-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`collapse-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
 
       // Clicking the node should still work for selection
       const nodeContainer = screen.getByTestId(`node-source-${leafNode!.nodeData.id}`);
@@ -821,7 +754,7 @@ describe('SourceDocumentNode', () => {
       });
 
       // Node should be selected
-      expect(screen.getByTestId(`node-source-selected-${leafNode!.nodeData.id}`)).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
   });
 });

--- a/packages/ui/src/components/Document/SourceDocumentNode.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.tsx
@@ -1,22 +1,15 @@
-import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
-import { Icon, StackItem } from '@patternfly/react-core';
-import { LayerGroupIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent, MouseEvent, useCallback, useRef } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
 import { useMappingLinks } from '../../hooks/useMappingLinks';
-import { useToggle } from '../../hooks/useToggle';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import { NodeReference } from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/tree-ui.service';
 import { VisualizationService } from '../../services/visualization.service';
 import { useDocumentTreeStore } from '../../store';
-import { DocumentActions } from './actions/DocumentActions';
-import './Document.scss';
-import { FieldIcon } from './FieldIcon';
 import { NodeContainer } from './NodeContainer';
+import { BaseNode } from './Nodes/BaseNode';
 import { NodeTitle } from './NodeTitle';
-import { ParameterInputPlaceholder } from './ParameterInputPlaceholder';
 
 type TreeSourceNodeProps = {
   treeNode: DocumentTreeNode;
@@ -37,11 +30,6 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
 }) => {
   const { getNodeReference, reloadNodeReferences, setNodeReference } = useCanvas();
   const { isInSelectedMapping, toggleSelectedNodeReference } = useMappingLinks();
-  const {
-    state: isRenamingParameter,
-    toggleOn: toggleOnRenamingParameter,
-    toggleOff: toggleOffRenamingParameter,
-  } = useToggle(false);
 
   const isExpanded = useDocumentTreeStore((state) => state.isExpanded(documentId, treeNode.path));
   const nodeData = treeNode.nodeData;
@@ -89,73 +77,32 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
 
   return (
     <div
-      data-testid={`node-source-${isSelected ? 'selected-' : ''}${nodeData.id}`}
-      className={clsx({ node__container: !isDocument })}
+      data-testid={`node-source-${nodeData.id}`}
+      data-selected={isSelected}
+      className="node__container"
       onClick={handleClickField}
     >
       <NodeContainer ref={containerRef} nodeData={nodeData}>
-        <div className={clsx({ node__header: !isDocument })}>
+        <div className="node__header">
           <NodeContainer nodeData={nodeData} ref={headerRef} className={clsx({ 'selected-container': isSelected })}>
-            <section className="node__row" data-draggable={isDraggable}>
-              {hasChildren && (
-                <Icon className="node__expand node__spacer" onClick={handleClickToggle}>
-                  {isExpanded && <ChevronDown data-testid={`expand-source-icon-${nodeData.title}`} />}
-                  {!isExpanded && <ChevronRight data-testid={`collapse-source-icon-${nodeData.title}`} />}
-                </Icon>
-              )}
-
-              <Icon className="node__spacer" data-drag-handler>
-                <Draggable />
-              </Icon>
-
-              <FieldIcon className="node__spacer" type={nodeData.type} />
-
-              {isCollectionField && (
-                <Icon className="node__spacer" data-testid="collection-field-icon">
-                  <LayerGroupIcon />
-                </Icon>
-              )}
-
-              {isAttributeField && (
-                <Icon className="node__spacer" data-testid="attribute-field-icon">
-                  <At />
-                </Icon>
-              )}
-
-              {isRenamingParameter && (
-                <StackItem>
-                  <ParameterInputPlaceholder
-                    onComplete={() => toggleOffRenamingParameter()}
-                    parameter={nodeData.title}
-                  />
-                </StackItem>
-              )}
-
-              {!isRenamingParameter && (
-                <NodeTitle
-                  className="node__spacer"
-                  data-rank={rank}
-                  nodeData={nodeData}
-                  isDocument={isDocument}
-                  rank={rank}
-                />
-              )}
-
-              {!isRenamingParameter && !isReadOnly && isDocument ? (
-                <DocumentActions
-                  className="node__target__actions"
-                  nodeData={nodeData}
-                  onRenameClick={() => toggleOnRenamingParameter()}
-                />
-              ) : (
-                <span className="node__target__actions" />
-              )}
-            </section>
+            <BaseNode
+              data-testid={nodeData.title}
+              isExpandable={hasChildren}
+              isExpanded={isExpanded}
+              onExpandChange={handleClickToggle}
+              isDraggable={isDraggable}
+              iconType={nodeData.type}
+              isCollectionField={isCollectionField}
+              isAttributeField={isAttributeField}
+              title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
+              rank={rank}
+              isSelected={isSelected}
+            ></BaseNode>
           </NodeContainer>
         </div>
 
         {hasChildren && isExpanded && (
-          <div className={clsx({ node__children: !isDocument })}>
+          <div className="node__children">
             {treeNode.children.map((childTreeNode) => (
               <SourceDocumentNode
                 treeNode={childTreeNode}

--- a/packages/ui/src/components/Document/TargetDocument.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocument.test.tsx
@@ -1,10 +1,17 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
+import { MappingTree } from '../../models/datamapper/mapping';
+import { MappingSerializerService } from '../../services/mapping-serializer.service';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { useDocumentTreeStore } from '../../store';
-import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { shipOrderToShipOrderXslt, TestUtil } from '../../stubs/datamapper/data-mapper';
 import { TargetDocument } from './TargetDocument';
 
 describe('TargetDocument', () => {
@@ -53,7 +60,7 @@ describe('TargetDocument', () => {
 
     await screen.findByText('OrderPerson');
 
-    const expandIcon = screen.getByTestId('expand-target-icon-Body');
+    const expandIcon = screen.getByTestId('expand-icon-Body');
     expect(expandIcon).toBeInTheDocument();
 
     act(() => {
@@ -61,17 +68,17 @@ describe('TargetDocument', () => {
     });
 
     await waitFor(() => {
-      const collapseIcon = screen.getByTestId('collapse-target-icon-Body');
+      const collapseIcon = screen.getByTestId('collapse-icon-Body');
       expect(collapseIcon).toBeInTheDocument();
     });
 
     act(() => {
-      const collapseIcon = screen.getByTestId('collapse-target-icon-Body');
+      const collapseIcon = screen.getByTestId('collapse-icon-Body');
       fireEvent.click(collapseIcon);
     });
 
     await waitFor(() => {
-      const expandIconAgain = screen.getByTestId('expand-target-icon-Body');
+      const expandIconAgain = screen.getByTestId('expand-icon-Body');
       expect(expandIconAgain).toBeInTheDocument();
     });
   });
@@ -82,13 +89,13 @@ describe('TargetDocument', () => {
 
     await screen.findByText('OrderPerson');
 
-    const expandIcon = screen.getByTestId('expand-target-icon-Body');
+    const expandIcon = screen.getByTestId('expand-icon-Body');
     act(() => {
       fireEvent.click(expandIcon);
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('collapse-target-icon-Body')).toBeInTheDocument();
+      expect(screen.getByTestId('collapse-icon-Body')).toBeInTheDocument();
     });
 
     const store = useDocumentTreeStore.getState();
@@ -101,7 +108,7 @@ describe('TargetDocument', () => {
       const expansionStateAfter = storeAfter.expansionState[documentId];
 
       expect(expansionStateAfter).toBeDefined();
-      expect(screen.getByTestId('collapse-target-icon-Body')).toBeInTheDocument();
+      expect(screen.getByTestId('collapse-icon-Body')).toBeInTheDocument();
     });
   });
 
@@ -111,7 +118,9 @@ describe('TargetDocument', () => {
 
     await screen.findByText('OrderPerson');
 
-    const nodes = screen.getAllByTestId(/^node-target-/);
+    const documents = screen.queryAllByTestId(/^document-doc-targetBody-/);
+    const fields = screen.queryAllByTestId(/^node-target-/);
+    const nodes = [...documents, ...fields];
     expect(nodes.length).toEqual(14);
   });
 
@@ -121,10 +130,42 @@ describe('TargetDocument', () => {
 
     await waitFor(
       () => {
-        const nodes = container.querySelectorAll('[data-testid^="node-target-"]');
+        const documents = container.querySelectorAll('[data-testid^="document-doc-targetBody-"]');
+        const fields = container.querySelectorAll('[data-testid^="node-target-"]');
+        const nodes = [...documents, ...fields];
         expect(nodes.length).toEqual(15);
       },
       { timeout: 3000 },
     );
+  });
+
+  it('should trigger handleUpdate callback when interacting with XPath input', async () => {
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const paramsMap = TestUtil.createParameterMap();
+    const tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+
+    // Deserialize XSLT to create mappings
+    MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, tree, paramsMap);
+
+    const { container } = render(<TargetDocument document={targetDoc} />, { wrapper });
+
+    await screen.findByText('OrderPerson');
+
+    // Find an XPath input field
+    const xpathInputs = container.querySelectorAll('[data-testid="transformation-xpath-input"]');
+    if (xpathInputs.length > 0) {
+      const xpathInput = xpathInputs[0] as HTMLInputElement;
+      const originalValue = xpathInput.value;
+
+      // Change the XPath value to trigger handleUpdate
+      act(() => {
+        fireEvent.change(xpathInput, { target: { value: '/modified/path' } });
+      });
+
+      await waitFor(() => {
+        // Value should be updated
+        expect(xpathInput.value).not.toBe(originalValue);
+      });
+    }
   });
 });

--- a/packages/ui/src/components/Document/TargetDocument.tsx
+++ b/packages/ui/src/components/Document/TargetDocument.tsx
@@ -1,11 +1,17 @@
-import { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { Title } from '@patternfly/react-core';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { IDocument } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { TargetDocumentNodeData } from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/tree-ui.service';
-import './Document.scss';
+import { VisualizationService } from '../../services/visualization.service';
+import { BaseDocument } from './BaseDocument';
 import { TargetDocumentNode } from './TargetDocumentNode';
+import { XPathInputAction } from './actions/XPathInputAction';
+import { XPathEditorAction } from './actions/XPathEditorAction';
+import { DeleteMappingItemAction } from './actions/DeleteMappingItemAction';
+import { ConditionMenuAction } from './actions/ConditionMenuAction';
 
 type DocumentProps = {
   document: IDocument;
@@ -17,7 +23,7 @@ type DocumentProps = {
  * Rebuilds tree when mappings change while preserving expansion state
  */
 export const TargetDocument: FunctionComponent<DocumentProps> = ({ document }) => {
-  const { mappingTree } = useDataMapper();
+  const { mappingTree, refreshMappingTree } = useDataMapper();
   const documentNodeData = useMemo(() => new TargetDocumentNodeData(document, mappingTree), [document, mappingTree]);
 
   const documentId = documentNodeData.id;
@@ -27,9 +33,59 @@ export const TargetDocument: FunctionComponent<DocumentProps> = ({ document }) =
     setTree(TreeUIService.createTree(documentNodeData));
   }, [documentNodeData]);
 
+  const handleUpdate = useCallback(() => {
+    refreshMappingTree();
+  }, [refreshMappingTree]);
+
+  // Get expression item for primitive target body (if it has a mapping)
+  const expressionItem = useMemo(() => {
+    if (!documentNodeData.isPrimitive) return null;
+    return VisualizationService.getExpressionItemForNode(documentNodeData);
+  }, [documentNodeData]);
+
+  // Actions for target body document
+  const documentActions = useMemo(() => {
+    const actions = [];
+
+    if (VisualizationService.allowConditionMenu(documentNodeData)) {
+      actions.push(<ConditionMenuAction key="condition-menu" nodeData={documentNodeData} onUpdate={handleUpdate} />);
+    }
+
+    // XPath actions for primitive target body with mapping
+    if (expressionItem) {
+      actions.push(
+        <XPathInputAction key="xpath-input" mapping={expressionItem} onUpdate={handleUpdate} />,
+        <XPathEditorAction
+          key="xpath-editor"
+          nodeData={documentNodeData}
+          mapping={expressionItem}
+          onUpdate={handleUpdate}
+        />,
+      );
+
+      // Add delete action if the mapping is deletable
+      if (VisualizationService.isDeletableNode(documentNodeData)) {
+        actions.push(
+          <DeleteMappingItemAction key="delete-mapping" nodeData={documentNodeData} onDelete={handleUpdate} />,
+        );
+      }
+    }
+
+    return actions;
+  }, [expressionItem, documentNodeData, handleUpdate]);
+
   if (!tree) {
     return <div>Loading tree...</div>;
   }
 
-  return <TargetDocumentNode treeNode={tree.root} documentId={documentId} rank={0} />;
+  return (
+    <BaseDocument
+      header={<Title headingLevel="h5">Body</Title>}
+      treeNode={tree.root}
+      documentId={documentId}
+      isReadOnly={false}
+      additionalActions={documentActions}
+      renderNodes={(childNode) => <TargetDocumentNode treeNode={childNode} documentId={documentId} rank={1} />}
+    />
+  );
 };

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -235,7 +235,7 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      const expandIcon = screen.getByTestId(`expand-target-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).toBeInTheDocument();
 
       act(() => {
@@ -262,8 +262,8 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      const expandIcon = screen.queryByTestId(`expand-target-icon-${leafNode!.nodeData.title}`);
-      const collapseIcon = screen.queryByTestId(`collapse-target-icon-${leafNode!.nodeData.title}`);
+      const expandIcon = screen.queryByTestId(`expand-icon-${leafNode!.nodeData.title}`);
+      const collapseIcon = screen.queryByTestId(`collapse-icon-${leafNode!.nodeData.title}`);
 
       expect(expandIcon).not.toBeInTheDocument();
       expect(collapseIcon).not.toBeInTheDocument();
@@ -291,10 +291,10 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      const expandIcon = screen.getByTestId(`expand-target-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).toBeInTheDocument();
 
-      const collapseIcon = screen.queryByTestId(`collapse-target-icon-${tree.root.nodeData.title}`);
+      const collapseIcon = screen.queryByTestId(`collapse-icon-${tree.root.nodeData.title}`);
       expect(collapseIcon).not.toBeInTheDocument();
     });
 
@@ -320,10 +320,10 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      const collapseIcon = screen.getByTestId(`collapse-target-icon-${tree.root.nodeData.title}`);
+      const collapseIcon = screen.getByTestId(`collapse-icon-${tree.root.nodeData.title}`);
       expect(collapseIcon).toBeInTheDocument();
 
-      const expandIcon = screen.queryByTestId(`expand-target-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.queryByTestId(`expand-icon-${tree.root.nodeData.title}`);
       expect(expandIcon).not.toBeInTheDocument();
     });
 
@@ -351,7 +351,7 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      const expandIcon = screen.getByTestId(`expand-target-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
 
       act(() => {
         fireEvent.click(expandIcon);
@@ -383,8 +383,7 @@ describe('TargetDocumentNode', () => {
         fireEvent.click(nodeContainer);
       });
 
-      const selectedNode = screen.getByTestId(`node-target-selected-${documentNodeData.id}`);
-      expect(selectedNode).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
 
     it('should apply selected-container class when selected', () => {
@@ -428,8 +427,7 @@ describe('TargetDocumentNode', () => {
         fireEvent.click(nodeContainer);
       });
 
-      const selectedNode = screen.getByTestId(`node-target-selected-${documentNodeData.id}`);
-      expect(selectedNode).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
 
       act(() => {
         fireEvent.click(nodeContainer);
@@ -706,7 +704,7 @@ describe('TargetDocumentNode', () => {
         { wrapper },
       );
 
-      const expandIcon = screen.getByTestId(`expand-target-icon-${tree.root.nodeData.title}`);
+      const expandIcon = screen.getByTestId(`expand-icon-${tree.root.nodeData.title}`);
 
       act(() => {
         fireEvent.click(expandIcon);
@@ -754,8 +752,8 @@ describe('TargetDocumentNode', () => {
       });
 
       // Should not have expand/collapse icons
-      expect(screen.queryByTestId(`expand-target-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
-      expect(screen.queryByTestId(`collapse-target-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`expand-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`collapse-icon-${leafNode!.nodeData.title}`)).not.toBeInTheDocument();
 
       // Clicking the node should still work for selection
       const nodeContainer = screen.getByTestId(`node-target-${leafNode!.nodeData.id}`);
@@ -764,7 +762,7 @@ describe('TargetDocumentNode', () => {
       });
 
       // Node should be selected
-      expect(screen.getByTestId(`node-target-selected-${leafNode!.nodeData.id}`)).toBeInTheDocument();
+      expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
   });
 

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -1,6 +1,3 @@
-import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
-import { Icon } from '@patternfly/react-core';
-import { LayerGroupIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent, MouseEvent, useCallback, useRef } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
@@ -19,9 +16,8 @@ import { useDocumentTreeStore } from '../../store';
 import { DocumentActions } from './actions/DocumentActions';
 import { TargetNodeActions } from './actions/TargetNodeActions';
 import { AddMappingNode } from './AddMappingNode';
-import './Document.scss';
-import { FieldIcon } from './FieldIcon';
 import { NodeContainer } from './NodeContainer';
+import { BaseNode } from './Nodes/BaseNode';
 import { NodeTitle } from './NodeTitle';
 
 type DocumentNodeProps = {
@@ -90,41 +86,27 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
 
   return (
     <div
-      data-testid={`node-target-${isSelected ? 'selected-' : ''}${nodeData.id}`}
-      className={clsx({ node__container: !isDocument })}
+      data-testid={`node-target-${nodeData.id}`}
+      data-selected={isSelected}
+      className="node__container"
       onClick={handleClickField}
     >
       <NodeContainer ref={containerRef} nodeData={nodeData}>
-        <div className={clsx({ node__header: !isDocument })}>
+        <div className="node__header">
           <NodeContainer nodeData={nodeData} ref={headerRef} className={clsx({ 'selected-container': isSelected })}>
-            <section className="node__row" data-draggable={isDraggable}>
-              {hasChildren && (
-                <Icon className="node__expand node__spacer" onClick={handleClickToggle}>
-                  {isExpanded && <ChevronDown data-testid={`expand-target-icon-${nodeData.title}`} />}
-                  {!isExpanded && <ChevronRight data-testid={`collapse-target-icon-${nodeData.title}`} />}
-                </Icon>
-              )}
-
-              <Icon className="node__spacer" data-drag-handler>
-                <Draggable />
-              </Icon>
-
-              <FieldIcon className="node__spacer" type={nodeData.type} />
-
-              {isCollectionField && (
-                <Icon className="node__spacer">
-                  <LayerGroupIcon />
-                </Icon>
-              )}
-
-              {isAttributeField && (
-                <Icon className="node__spacer">
-                  <At />
-                </Icon>
-              )}
-
-              <NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />
-
+            <BaseNode
+              data-testid={nodeData.title}
+              isExpandable={hasChildren}
+              isExpanded={isExpanded}
+              onExpandChange={handleClickToggle}
+              isDraggable={isDraggable}
+              iconType={nodeData.type}
+              isCollectionField={isCollectionField}
+              isAttributeField={isAttributeField}
+              title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
+              rank={rank}
+              isSelected={isSelected}
+            >
               {showNodeActions ? (
                 <TargetNodeActions
                   className="node__target__actions"
@@ -136,15 +118,15 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
               )}
 
               {isDocument && <DocumentActions nodeData={nodeData as TargetDocumentNodeData} onRenameClick={() => {}} />}
-            </section>
+            </BaseNode>
           </NodeContainer>
         </div>
 
         {hasChildren && isExpanded && (
-          <div className={clsx({ node__children: !isDocument })}>
+          <div className="node__children">
             {treeNode.children.map((childTreeNode) =>
               childTreeNode.nodeData instanceof AddMappingNodeData ? (
-                <AddMappingNode nodeData={childTreeNode.nodeData} key={childTreeNode.path} />
+                <AddMappingNode nodeData={childTreeNode.nodeData} key={childTreeNode.path} rank={rank} />
               ) : (
                 <TargetDocumentNode
                   treeNode={childTreeNode}

--- a/packages/ui/src/components/Document/actions/DocumentActions.tsx
+++ b/packages/ui/src/components/Document/actions/DocumentActions.tsx
@@ -2,7 +2,6 @@ import { ActionListGroup, ActionListItem } from '@patternfly/react-core';
 import { FunctionComponent, MouseEvent, useCallback } from 'react';
 import { DocumentType } from '../../../models/datamapper/document';
 import { DocumentNodeData } from '../../../models/datamapper/visualization';
-import '../Document.scss';
 import { AttachSchemaButton } from './AttachSchemaButton';
 import { DeleteParameterButton } from './DeleteParameterButton';
 import { DetachSchemaButton } from './DetachSchemaButton';

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.scss
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.scss
@@ -1,0 +1,9 @@
+.node {
+  &__target__actions {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    position: relative;
+    right: var(--pf-t--global--spacer--md);
+  }
+}

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
@@ -6,7 +6,7 @@ import { ConditionMenuAction } from './ConditionMenuAction';
 import { XPathEditorAction } from './XPathEditorAction';
 import { TargetNodeData } from '../../../models/datamapper/visualization';
 import { VisualizationService } from '../../../services/visualization.service';
-import '../Document.scss';
+import './TargetNodeActions.scss';
 
 type TargetNodeActionsProps = {
   className?: string;

--- a/packages/ui/src/services/mapping-links.service.ts
+++ b/packages/ui/src/services/mapping-links.service.ts
@@ -159,17 +159,40 @@ export class MappingLinksService {
     targetRef: MutableRefObject<NodeReference>,
   ): LineCoord | undefined {
     const svgRect = svgRef.current?.getBoundingClientRect();
-    const sourceRect = sourceRef.current?.headerRef?.getBoundingClientRect();
-    const targetRect = targetRef.current?.headerRef?.getBoundingClientRect();
+    const sourceHeaderRef = sourceRef.current?.headerRef;
+    const targetHeaderRef = targetRef.current?.headerRef;
+    const sourceRect = sourceHeaderRef?.getBoundingClientRect();
+    const targetRect = targetHeaderRef?.getBoundingClientRect();
     if (!sourceRect || !targetRect) {
       return;
     }
 
+    // Use BaseNode row edges if available (they have correct rank-based positioning)
+    const sourceNodeRow = sourceHeaderRef?.querySelector ? sourceHeaderRef.querySelector('.node__row') : null;
+    const targetNodeRow = targetHeaderRef?.querySelector ? targetHeaderRef.querySelector('.node__row') : null;
+
+    const sourceNodeRowRect = sourceNodeRow?.getBoundingClientRect();
+    const targetNodeRowRect = targetNodeRow?.getBoundingClientRect();
+
+    // Offset to avoid collision with content
+    const CONNECTION_OFFSET = 5;
+
+    const svgOffsetLeft = svgRect ? svgRect.left : 0;
+    const svgOffsetTop = svgRect ? svgRect.top : 0;
+
+    const sourceX = sourceNodeRowRect
+      ? sourceNodeRowRect.right - CONNECTION_OFFSET - svgOffsetLeft
+      : sourceRect.right - svgOffsetLeft;
+
+    const targetX = targetNodeRowRect
+      ? targetNodeRowRect.left + CONNECTION_OFFSET - svgOffsetLeft
+      : targetRect.left - svgOffsetLeft;
+
     return {
-      x1: sourceRect.right - (svgRect ? svgRect.left : 0),
-      y1: sourceRect.top + (sourceRect.bottom - sourceRect.top) / 2 - (svgRect ? svgRect.top : 0),
-      x2: targetRect.left - (svgRect ? svgRect.left : 0),
-      y2: targetRect.top + (targetRect.bottom - targetRect.top) / 2 - (svgRect ? svgRect.top : 0),
+      x1: sourceX,
+      y1: sourceRect.top + (sourceRect.bottom - sourceRect.top) / 2 - svgOffsetTop,
+      x2: targetX,
+      y2: targetRect.top + (targetRect.bottom - targetRect.top) / 2 - svgOffsetTop,
     };
   }
 


### PR DESCRIPTION
### Context
Currently, the `SourceDocumentNode` component contains diverse logic for renaming parameters, setting schemas, and more, as this component is used for the Schema header, node rows, and parameters.

### Changes
This PR extracts each domain logic into dedicated components. For instance, the rename parameter functionality was moved to a dedicated `ParameterDocument` component; this way, it's easier to reason about the component's responsibilities.

### Note
This is a prerequisite for introducing virtual scrolling.