### PR TITLE
fix(DataMapper): Fix copy/paste/duplicate DataMapper step

### DIFF
--- a/packages/ui/src/components/DataMapper/datamapper-utils.ts
+++ b/packages/ui/src/components/DataMapper/datamapper-utils.ts
@@ -1,0 +1,28 @@
+import { ProcessorDefinition, Step, To } from '@kaoto/camel-catalog/types';
+import { XSLT_COMPONENT_NAME } from '../../utils';
+
+/**
+ * Find an XSLT step inside the DataMapper steps array. Note that this assumes that the XSLT step is only one
+ * in the DataMapper step. In case we add more XSLT execution in a single DataMapper step, we have to update this.
+ * @param dataMapperSteps
+ */
+export const findXsltStep = (dataMapperSteps: ProcessorDefinition[]): To | undefined => {
+  const xsltStep = dataMapperSteps.find(
+    (step) => typeof step.to === 'object' && step.to?.uri?.startsWith(XSLT_COMPONENT_NAME),
+  );
+  return xsltStep?.to;
+};
+
+export const setXsltUri = (dataMapperStepDef: Step, xsltPath = ''): void => {
+  const steps = dataMapperStepDef.steps;
+  if (steps && steps.length > 0) {
+    const toStep = findXsltStep(steps);
+    if (toStep && typeof toStep === 'object') {
+      toStep.uri = `${XSLT_COMPONENT_NAME}:${xsltPath}`;
+    }
+  }
+};
+
+export const clearXsltUri = (dataMapperStepDef: Step): void => {
+  setXsltUri(dataMapperStepDef, '');
+};

--- a/packages/ui/src/components/DataMapper/on-delete-datamapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-delete-datamapper.test.ts
@@ -1,0 +1,70 @@
+import { onDeleteDataMapper, ACTION_ID_DELETE_STEP_AND_FILE, ACTION_ID_DELETE_STEP_ONLY } from './on-delete-datamapper';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { IMetadataApi } from '../../providers';
+import { createVisualizationNode } from '../../models';
+
+jest.mock('../../services/datamapper-metadata.service');
+
+describe('onDeleteDataMapper', () => {
+  let mockApi: jest.Mocked<IMetadataApi>;
+  const metadataId = 'test-metadata-id';
+
+  beforeEach(() => {
+    mockApi = {
+      getMetadata: jest.fn(),
+      setMetadata: jest.fn(),
+      deleteMetadata: jest.fn(),
+      getResourceContent: jest.fn(),
+      saveResourceContent: jest.fn(),
+      deleteResourceContent: jest.fn(),
+    } as unknown as jest.Mocked<IMetadataApi>;
+
+    jest.spyOn(DataMapperMetadataService, 'getDataMapperMetadataId').mockReturnValue(metadataId);
+    jest.spyOn(DataMapperMetadataService, 'deleteXsltFile').mockResolvedValue(undefined);
+    jest.spyOn(DataMapperMetadataService, 'deleteMetadata').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete step and file when modal answer is ACTION_ID_DELETE_STEP_AND_FILE', async () => {
+    const vizNode = createVisualizationNode('test', {});
+
+    await onDeleteDataMapper(mockApi, vizNode, ACTION_ID_DELETE_STEP_AND_FILE);
+
+    expect(DataMapperMetadataService.getDataMapperMetadataId).toHaveBeenCalledWith(vizNode);
+    expect(DataMapperMetadataService.deleteXsltFile).toHaveBeenCalledWith(mockApi, metadataId);
+    expect(DataMapperMetadataService.deleteMetadata).toHaveBeenCalledWith(mockApi, metadataId);
+  });
+
+  it('should delete step only when modal answer is ACTION_ID_DELETE_STEP_ONLY', async () => {
+    const vizNode = createVisualizationNode('test', {});
+
+    await onDeleteDataMapper(mockApi, vizNode, ACTION_ID_DELETE_STEP_ONLY);
+
+    expect(DataMapperMetadataService.getDataMapperMetadataId).toHaveBeenCalledWith(vizNode);
+    expect(DataMapperMetadataService.deleteXsltFile).not.toHaveBeenCalled();
+    expect(DataMapperMetadataService.deleteMetadata).toHaveBeenCalledWith(mockApi, metadataId);
+  });
+
+  it('should delete step only when modal answer is undefined', async () => {
+    const vizNode = createVisualizationNode('test', {});
+
+    await onDeleteDataMapper(mockApi, vizNode, undefined);
+
+    expect(DataMapperMetadataService.getDataMapperMetadataId).toHaveBeenCalledWith(vizNode);
+    expect(DataMapperMetadataService.deleteXsltFile).not.toHaveBeenCalled();
+    expect(DataMapperMetadataService.deleteMetadata).toHaveBeenCalledWith(mockApi, metadataId);
+  });
+
+  it('should delete step only when modal answer is a different value', async () => {
+    const vizNode = createVisualizationNode('test', {});
+
+    await onDeleteDataMapper(mockApi, vizNode, 'some-other-action');
+
+    expect(DataMapperMetadataService.getDataMapperMetadataId).toHaveBeenCalledWith(vizNode);
+    expect(DataMapperMetadataService.deleteXsltFile).not.toHaveBeenCalled();
+    expect(DataMapperMetadataService.deleteMetadata).toHaveBeenCalledWith(mockApi, metadataId);
+  });
+});

--- a/packages/ui/src/components/DataMapper/on-duplicate-datamapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-duplicate-datamapper.test.ts
@@ -1,0 +1,142 @@
+import { onDuplicateDataMapper } from './on-duplicate-datamapper';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { IMetadataApi } from '../../providers';
+import { IVisualizationNode } from '../../models';
+import { IDataMapperMetadata } from '../../models/datamapper/metadata';
+import { DocumentDefinitionType } from '../../models/datamapper';
+import { IClipboardCopyObject } from '../../models/visualization/clipboard';
+import { SourceSchemaType } from '../../models/camel/source-schema-type';
+import { XSLT_COMPONENT_NAME } from '../../utils';
+
+describe('onDuplicateDataMapper', () => {
+  let mockApi: jest.Mocked<IMetadataApi>;
+  let mockVizNode: jest.Mocked<IVisualizationNode>;
+  const originalMetadataId = 'kaoto-datamapper-original-id';
+  const newStepId = 'kaoto-datamapper-new-id';
+
+  beforeEach(() => {
+    mockApi = {
+      getMetadata: jest.fn(),
+      setMetadata: jest.fn(),
+      getResourceContent: jest.fn(),
+      saveResourceContent: jest.fn(),
+      deleteResource: jest.fn(),
+      askUserForFileSelection: jest.fn(),
+      shouldSaveSchema: true,
+    } as unknown as jest.Mocked<IMetadataApi>;
+
+    mockVizNode = {} as jest.Mocked<IVisualizationNode>;
+
+    jest.spyOn(DataMapperMetadataService, 'getDataMapperMetadataId').mockReturnValue(originalMetadataId);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create metadata and copy XSLT file for duplicated DataMapper step', async () => {
+    const originalMetadata: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['source.xsd'] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['target.json'] },
+      xsltPath: `${originalMetadataId}.xsl`,
+    };
+
+    const xsltContent = '<xsl:stylesheet>...</xsl:stylesheet>';
+
+    mockApi.getMetadata.mockResolvedValue(originalMetadata);
+    mockApi.getResourceContent.mockResolvedValue(xsltContent);
+
+    const content: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {
+        id: newStepId,
+        steps: [{ to: { uri: 'xslt-saxon:test.xsl' } }],
+      },
+    };
+
+    await onDuplicateDataMapper(mockApi, { sourceVizNode: mockVizNode, content });
+
+    expect(mockApi.getMetadata).toHaveBeenCalledWith(originalMetadataId);
+
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(
+      newStepId,
+      DataMapperMetadataService.cloneMetadata(originalMetadata, `${newStepId}.xsl`),
+    );
+
+    expect(mockApi.getResourceContent).toHaveBeenCalledWith(originalMetadata.xsltPath);
+
+    expect(mockApi.saveResourceContent).toHaveBeenCalledWith(`${newStepId}.xsl`, xsltContent);
+
+    const stepDef = content.definition as Record<string, unknown>;
+    const steps = stepDef.steps as Array<Record<string, Record<string, unknown>>>;
+    expect(steps[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:${newStepId}.xsl`);
+  });
+
+  it('should handle missing duplicated content gracefully', async () => {
+    await onDuplicateDataMapper(mockApi, { sourceVizNode: mockVizNode, content: undefined });
+
+    expect(mockApi.getMetadata).not.toHaveBeenCalled();
+    expect(mockApi.setMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should handle missing new step ID gracefully', async () => {
+    const content: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {},
+    };
+
+    await onDuplicateDataMapper(mockApi, { sourceVizNode: mockVizNode, content });
+
+    expect(mockApi.setMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should create empty metadata and set XSLT URI to empty when original metadata is not found', async () => {
+    mockApi.getMetadata.mockResolvedValue(undefined);
+
+    const content: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {
+        id: newStepId,
+        steps: [{ to: { uri: `${XSLT_COMPONENT_NAME}:test.xsl` } }],
+      },
+    };
+
+    await onDuplicateDataMapper(mockApi, { sourceVizNode: mockVizNode, content });
+
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(newStepId, DataMapperMetadataService.createMetadata());
+
+    const stepDef = content.definition as Record<string, unknown>;
+    const steps = stepDef.steps as Array<Record<string, Record<string, unknown>>>;
+    expect(steps[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:`);
+  });
+
+  it('should handle missing XSLT content', async () => {
+    const originalMetadata: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+      xsltPath: `${originalMetadataId}.xsl`,
+    };
+
+    mockApi.getMetadata.mockResolvedValue(originalMetadata);
+    mockApi.getResourceContent.mockResolvedValue(undefined);
+
+    const content: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {
+        id: newStepId,
+      },
+    };
+
+    await onDuplicateDataMapper(mockApi, { sourceVizNode: mockVizNode, content });
+
+    expect(mockApi.setMetadata).toHaveBeenCalled();
+
+    expect(mockApi.saveResourceContent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/DataMapper/on-duplicate-datamapper.ts
+++ b/packages/ui/src/components/DataMapper/on-duplicate-datamapper.ts
@@ -1,0 +1,54 @@
+import { Step } from '@kaoto/camel-catalog/types';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { IMetadataApi } from '../../providers';
+import { IVisualizationNode } from '../../models';
+import { IDataMapperMetadata } from '../../models/datamapper/metadata';
+import { IClipboardCopyObject } from '../../models/visualization/clipboard';
+import { clearXsltUri, setXsltUri } from './datamapper-utils';
+
+export const onDuplicateDataMapper = async (
+  api: IMetadataApi | undefined,
+  parameters: {
+    sourceVizNode: IVisualizationNode;
+    content: IClipboardCopyObject | undefined;
+  },
+): Promise<IClipboardCopyObject | undefined> => {
+  if (!parameters.content) return parameters.content;
+
+  const stepDef = parameters.content.definition as Step;
+  const newStepId = stepDef?.id;
+
+  if (!newStepId) return parameters.content;
+
+  if (!api) {
+    clearXsltUri(stepDef);
+    return parameters.content;
+  }
+
+  const originalMetadataId = DataMapperMetadataService.getDataMapperMetadataId(parameters.sourceVizNode);
+
+  const originalMetadata = await api.getMetadata<IDataMapperMetadata>(originalMetadataId);
+
+  // If the associated DataMapper step metadata for the original step is not found, create an empty one.
+  // Do not copy anything from unknown DataMapper step.
+  if (!originalMetadata) {
+    const newMetadata = DataMapperMetadataService.createMetadata();
+
+    await api.setMetadata(newStepId, newMetadata);
+
+    clearXsltUri(stepDef);
+
+    return parameters.content;
+  }
+
+  const newXsltPath = `${newStepId}.xsl`;
+  const newMetadata = DataMapperMetadataService.cloneMetadata(originalMetadata, newXsltPath);
+
+  await api.setMetadata(newStepId, newMetadata);
+
+  await DataMapperMetadataService.duplicateXsltFile(api, originalMetadata, newXsltPath);
+
+  setXsltUri(stepDef, newXsltPath);
+
+  return parameters.content;
+};

--- a/packages/ui/src/components/DataMapper/on-paste-data-mapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-paste-data-mapper.test.ts
@@ -1,0 +1,335 @@
+import { onPasteDataMapper } from './on-paste-data-mapper';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { IMetadataApi } from '../../providers';
+import { IVisualizationNode } from '../../models';
+import { IDataMapperMetadata } from '../../models/datamapper/metadata';
+import { DocumentDefinitionType } from '../../models/datamapper';
+import { IClipboardCopyObject } from '../../models/visualization/clipboard';
+import { SourceSchemaType } from '../../models/camel/source-schema-type';
+import { XSLT_COMPONENT_NAME } from '../../utils';
+
+describe('onPasteDataMapper', () => {
+  let mockApi: jest.Mocked<IMetadataApi>;
+  let mockVizNode: jest.Mocked<IVisualizationNode>;
+  const originalStepId = 'kaoto-datamapper-original-id';
+  const newStepId = 'kaoto-datamapper-new-id';
+
+  beforeEach(() => {
+    mockApi = {
+      getMetadata: jest.fn(),
+      setMetadata: jest.fn(),
+      getResourceContent: jest.fn(),
+      saveResourceContent: jest.fn(),
+      deleteResource: jest.fn(),
+      askUserForFileSelection: jest.fn(),
+      shouldSaveSchema: true,
+    } as unknown as jest.Mocked<IMetadataApi>;
+
+    mockVizNode = {} as jest.Mocked<IVisualizationNode>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return early when originalContent is undefined', async () => {
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent: undefined,
+      updatedContent: {} as IClipboardCopyObject,
+    });
+
+    expect(mockApi.getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should return early when updatedContent is undefined', async () => {
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent: {} as IClipboardCopyObject,
+      updatedContent: undefined,
+    });
+
+    expect(mockApi.getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should return early when originalContent is not a DataMapper node', async () => {
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'to',
+      definition: {
+        to: { uri: 'direct:test' },
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'to',
+      definition: {
+        to: { uri: 'direct:test' },
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should return early when no DataMapper IDs are found', async () => {
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {
+        step: {
+          steps: [{ to: { uri: 'direct:test' } }],
+        },
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'step',
+      definition: {
+        step: {
+          steps: [{ to: { uri: 'direct:test' } }],
+        },
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('should create metadata and copy XSLT file for pasted DataMapper step', async () => {
+    const originalMetadata: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['source.xsd'] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['target.json'] },
+      xsltPath: `${originalStepId}.xsl`,
+    };
+
+    const xsltContent = '<xsl:stylesheet>...</xsl:stylesheet>';
+
+    mockApi.getMetadata.mockResolvedValue(originalMetadata);
+    mockApi.getResourceContent.mockResolvedValue(xsltContent);
+
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: originalStepId,
+      definition: {
+        id: originalStepId,
+        steps: [{ to: { uri: 'xslt-saxon:original.xsl' } }],
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: newStepId,
+      definition: {
+        id: newStepId,
+        steps: [{ to: { uri: 'xslt-saxon:new.xsl' } }],
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.getMetadata).toHaveBeenCalledWith(originalStepId);
+
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(
+      newStepId,
+      DataMapperMetadataService.cloneMetadata(originalMetadata, `${newStepId}.xsl`),
+    );
+
+    expect(mockApi.getResourceContent).toHaveBeenCalledWith(originalMetadata.xsltPath);
+
+    expect(mockApi.saveResourceContent).toHaveBeenCalledWith(`${newStepId}.xsl`, xsltContent);
+
+    const stepDef = updatedContent.definition as Record<string, unknown>;
+    const steps = stepDef.steps as Array<Record<string, Record<string, unknown>>>;
+    expect(steps[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:${newStepId}.xsl`);
+  });
+
+  it('should create empty metadata and update XSLT URI when original metadata is not found', async () => {
+    mockApi.getMetadata.mockResolvedValue(undefined);
+
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: originalStepId,
+      definition: {
+        id: originalStepId,
+        steps: [{ to: { uri: `${XSLT_COMPONENT_NAME}:original.xsl` } }],
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: newStepId,
+      definition: {
+        id: newStepId,
+        steps: [{ to: { uri: `${XSLT_COMPONENT_NAME}:new.xsl` } }],
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(newStepId, DataMapperMetadataService.createMetadata());
+
+    const stepDef = updatedContent.definition as Record<string, unknown>;
+    const steps = stepDef.steps as Array<Record<string, Record<string, unknown>>>;
+    expect(steps[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:`);
+  });
+
+  it('should handle missing XSLT content gracefully', async () => {
+    const originalMetadata: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+      xsltPath: `${originalStepId}.xsl`,
+    };
+
+    mockApi.getMetadata.mockResolvedValue(originalMetadata);
+    mockApi.getResourceContent.mockResolvedValue(undefined);
+
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: originalStepId,
+      definition: {
+        id: originalStepId,
+        steps: [{ to: { uri: 'xslt-saxon:test.xsl' } }],
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: newStepId,
+      definition: {
+        id: newStepId,
+        steps: [{ to: { uri: 'xslt-saxon:test.xsl' } }],
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.setMetadata).toHaveBeenCalled();
+
+    expect(mockApi.saveResourceContent).not.toHaveBeenCalled();
+  });
+
+  it('should handle multiple nested DataMapper steps', async () => {
+    const originalMetadata1: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['source1.xsd'] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['target1.json'] },
+      xsltPath: 'kaoto-datamapper-original-id-1.xsl',
+    };
+
+    const originalMetadata2: IDataMapperMetadata = {
+      sourceBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['source2.xsd'] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['target2.json'] },
+      xsltPath: 'kaoto-datamapper-original-id-2.xsl',
+    };
+
+    mockApi.getMetadata.mockResolvedValueOnce(originalMetadata1).mockResolvedValueOnce(originalMetadata2);
+    mockApi.getResourceContent
+      .mockResolvedValueOnce('<xsl:stylesheet>1</xsl:stylesheet>')
+      .mockResolvedValueOnce('<xsl:stylesheet>2</xsl:stylesheet>');
+
+    const originalContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'choice',
+      definition: {
+        choice: {
+          when: [
+            {
+              step: {
+                id: 'kaoto-datamapper-original-id-1',
+                steps: [{ to: { uri: 'xslt-saxon:test1.xsl' } }],
+              },
+            },
+            {
+              step: {
+                id: 'kaoto-datamapper-original-id-2',
+                steps: [{ to: { uri: 'xslt-saxon:test2.xsl' } }],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const updatedContent: IClipboardCopyObject = {
+      type: SourceSchemaType.Route,
+      name: 'choice',
+      definition: {
+        choice: {
+          when: [
+            {
+              step: {
+                id: 'kaoto-datamapper-new-id-1',
+                steps: [{ to: { uri: 'xslt-saxon:test1.xsl' } }],
+              },
+            },
+            {
+              step: {
+                id: 'kaoto-datamapper-new-id-2',
+                steps: [{ to: { uri: 'xslt-saxon:test2.xsl' } }],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    await onPasteDataMapper(mockApi, {
+      targetVizNode: mockVizNode,
+      originalContent,
+      updatedContent,
+    });
+
+    expect(mockApi.getMetadata).toHaveBeenCalledTimes(2);
+    expect(mockApi.getMetadata).toHaveBeenCalledWith('kaoto-datamapper-original-id-1');
+    expect(mockApi.getMetadata).toHaveBeenCalledWith('kaoto-datamapper-original-id-2');
+
+    expect(mockApi.setMetadata).toHaveBeenCalledTimes(2);
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(
+      'kaoto-datamapper-new-id-1',
+      DataMapperMetadataService.cloneMetadata(originalMetadata1, 'kaoto-datamapper-new-id-1.xsl'),
+    );
+    expect(mockApi.setMetadata).toHaveBeenCalledWith(
+      'kaoto-datamapper-new-id-2',
+      DataMapperMetadataService.cloneMetadata(originalMetadata2, 'kaoto-datamapper-new-id-2.xsl'),
+    );
+
+    expect(mockApi.saveResourceContent).toHaveBeenCalledTimes(2);
+
+    const choiceDef = (updatedContent.definition as Record<string, Record<string, unknown[]>>).choice;
+    const whenSteps = choiceDef.when;
+    const step1 = (whenSteps[0] as Record<string, unknown>).step as Record<string, unknown>;
+    const step2 = (whenSteps[1] as Record<string, unknown>).step as Record<string, unknown>;
+    const steps1 = step1.steps as Array<Record<string, Record<string, unknown>>>;
+    const steps2 = step2.steps as Array<Record<string, Record<string, unknown>>>;
+    expect(steps1[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:kaoto-datamapper-new-id-1.xsl`);
+    expect(steps2[0].to.uri).toBe(`${XSLT_COMPONENT_NAME}:kaoto-datamapper-new-id-2.xsl`);
+  });
+});

--- a/packages/ui/src/components/DataMapper/on-paste-data-mapper.ts
+++ b/packages/ui/src/components/DataMapper/on-paste-data-mapper.ts
@@ -1,0 +1,120 @@
+import { Step } from '@kaoto/camel-catalog/types';
+import { IVisualizationNode } from '../../models';
+import { IClipboardCopyObject } from '../../models/visualization/clipboard';
+import { IMetadataApi } from '../../providers';
+import { isDataMapperNode } from '../../utils/is-datamapper';
+import { IDataMapperMetadata } from '../../models/datamapper/metadata';
+import { clearXsltUri, setXsltUri } from './datamapper-utils';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+
+type DataMapperNodeCollection = { idMap: Map<string, string>; updatedNodes: Map<string, Step> };
+
+const collectDataMapperNodesFromChildren = (
+  dmNodes: DataMapperNodeCollection,
+  originalNode: object,
+  updatedNode: object,
+) => {
+  for (const key of Object.keys(originalNode)) {
+    const origValue = (originalNode as Record<string, unknown>)[key];
+    const updatedValue = (updatedNode as Record<string, unknown>)[key];
+    if (Array.isArray(origValue) && Array.isArray(updatedValue)) {
+      for (const [i, item] of origValue.entries()) {
+        if (updatedValue[i]) {
+          collectDataMapperNodesRecursively(dmNodes, item as object, updatedValue[i] as object);
+        }
+      }
+    } else if (typeof origValue === 'object' && origValue !== null) {
+      collectDataMapperNodesRecursively(dmNodes, origValue, updatedValue as object);
+    }
+  }
+};
+
+const collectDataMapperNodesRecursively = (
+  dmNodes: DataMapperNodeCollection,
+  originalNode: object,
+  updatedNode: object,
+): void => {
+  if (!originalNode || !updatedNode || typeof originalNode !== 'object' || typeof updatedNode !== 'object') {
+    return;
+  }
+
+  if (isDataMapperNode(originalNode)) {
+    const originalId = (originalNode as Step).id;
+    const updatedId = (updatedNode as Step).id;
+    if (originalId && updatedId) {
+      dmNodes.idMap.set(originalId, updatedId);
+      dmNodes.updatedNodes.set(updatedId, updatedNode as Step);
+    }
+  }
+
+  collectDataMapperNodesFromChildren(dmNodes, originalNode, updatedNode);
+};
+
+const collectDataMapperNodes = (originalNode: object, updatedNode: object): DataMapperNodeCollection => {
+  const idMap = new Map<string, string>();
+  const updatedNodes = new Map<string, Step>();
+
+  collectDataMapperNodesRecursively({ idMap, updatedNodes }, originalNode, updatedNode);
+  return { idMap, updatedNodes };
+};
+
+const generateDataMapperMetadata = async (
+  api: IMetadataApi | undefined,
+  updatedNodes: Map<string, Step>,
+  originalId: string,
+  newId: string,
+) => {
+  if (!api) {
+    const updatedNode = updatedNodes.get(newId);
+    if (updatedNode) {
+      clearXsltUri(updatedNode);
+    }
+    return;
+  }
+
+  const originalMetadata = await api.getMetadata<IDataMapperMetadata>(originalId);
+
+  if (!originalMetadata) {
+    const newMetadata = DataMapperMetadataService.createMetadata();
+
+    await api.setMetadata(newId, newMetadata);
+
+    const updatedNode = updatedNodes.get(newId);
+    if (updatedNode) {
+      clearXsltUri(updatedNode);
+    }
+    return;
+  }
+
+  const newXsltPath = `${newId}.xsl`;
+  const newMetadata = DataMapperMetadataService.cloneMetadata(originalMetadata, newXsltPath);
+
+  await api.setMetadata(newId, newMetadata);
+
+  await DataMapperMetadataService.duplicateXsltFile(api, originalMetadata, newXsltPath);
+
+  const updatedNode = updatedNodes.get(newId);
+  if (updatedNode) {
+    setXsltUri(updatedNode, newXsltPath);
+  }
+};
+
+export const onPasteDataMapper = async (
+  api: IMetadataApi | undefined,
+  parameters: {
+    targetVizNode: IVisualizationNode;
+    originalContent: IClipboardCopyObject | undefined;
+    updatedContent: IClipboardCopyObject | undefined;
+  },
+): Promise<void> => {
+  if (!parameters.originalContent || !parameters.updatedContent) return;
+
+  const { idMap, updatedNodes } = collectDataMapperNodes(
+    parameters.originalContent.definition,
+    parameters.updatedContent.definition,
+  );
+
+  for (const [originalId, newId] of idMap.entries()) {
+    await generateDataMapperMetadata(api, updatedNodes, originalId, newId);
+  }
+};

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -88,7 +88,7 @@ describe('ItemDeleteGroup', () => {
       registerInteractionAddon: jest.fn(),
       getRegisteredInteractionAddons: (
         _interaction: IInteractionType,
-        _vizNode: IVisualizationNode,
+        _vizNode?: IVisualizationNode,
       ): IRegisteredInteractionAddon[] =>
         [
           { type: IInteractionType.ON_DELETE, activationFn: () => true, callback: mockAddon } as IOnDeleteAddon,

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteStep.test.tsx
@@ -74,7 +74,7 @@ describe('ItemDeleteStep', () => {
       registerInteractionAddon: jest.fn(),
       getRegisteredInteractionAddons: (
         _interaction: IInteractionType,
-        _vizNode: IVisualizationNode,
+        _vizNode?: IVisualizationNode,
       ): IRegisteredInteractionAddon[] =>
         [
           { type: IInteractionType.ON_DELETE, activationFn: () => true, callback: mockAddon } as IOnDeleteAddon,

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -76,7 +76,7 @@ describe('ItemReplaceStep', () => {
       registerInteractionAddon: jest.fn(),
       getRegisteredInteractionAddons: (
         _interaction: IInteractionType,
-        _vizNode: IVisualizationNode,
+        _vizNode?: IVisualizationNode,
       ): IRegisteredInteractionAddon[] =>
         [
           { type: IInteractionType.ON_DELETE, activationFn: () => true, callback: mockAddon } as IOnDeleteAddon,

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.test.ts
@@ -1,11 +1,23 @@
-import { processOnDeleteAddonRecursively } from './item-interaction-helper';
+import {
+  findOnDeleteModalCustomizationRecursively,
+  processOnCopyAddon,
+  processOnDeleteAddonRecursively,
+  processOnDuplicateAddonRecursively,
+  processOnPasteAddon,
+} from './item-interaction-helper';
 import { createVisualizationNode } from '../../../../models';
 import {
   IInteractionType,
+  IModalCustomization,
+  IOnCopyAddon,
   IOnDeleteAddon,
+  IOnDuplicateAddon,
+  IOnPasteAddon,
   IRegisteredInteractionAddon,
 } from '../../../registers/interactions/node-interaction-addon.model';
 import { ACTION_ID_CONFIRM } from '../../../../providers';
+import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
+import { ButtonVariant } from '@patternfly/react-core';
 
 describe('item-interaction-helper', () => {
   describe('processOnDeleteAddonRecursively', () => {
@@ -22,6 +34,386 @@ describe('item-interaction-helper', () => {
       vizNode.addChild(childVn);
       processOnDeleteAddonRecursively(vizNode, ACTION_ID_CONFIRM, (vn) => (addons[vn.id] ?? []) as IOnDeleteAddon[]);
       expect(mockAddon.callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOnDeleteModalCustomizationRecursively', () => {
+    it('should collect modal customizations from addons', () => {
+      const mockCustomization: IModalCustomization = {
+        buttonOptions: {
+          [ACTION_ID_CONFIRM]: {
+            variant: ButtonVariant.danger,
+            buttonText: 'Delete',
+          },
+        },
+        additionalText: 'Are you sure?',
+      };
+
+      const vizNode = createVisualizationNode('test', {});
+      const mockAddon: IOnDeleteAddon = {
+        type: IInteractionType.ON_DELETE,
+        activationFn: () => true,
+        callback: jest.fn(),
+        modalCustomization: mockCustomization,
+      };
+
+      const result = findOnDeleteModalCustomizationRecursively(vizNode, () => [mockAddon]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(mockCustomization);
+    });
+
+    it('should collect modal customizations from children recursively', () => {
+      const parentCustomization: IModalCustomization = {
+        buttonOptions: {
+          [ACTION_ID_CONFIRM]: {
+            variant: ButtonVariant.danger,
+            buttonText: 'Delete Parent',
+          },
+        },
+        additionalText: 'Delete parent?',
+      };
+      const childCustomization: IModalCustomization = {
+        buttonOptions: {
+          [ACTION_ID_CONFIRM]: {
+            variant: ButtonVariant.danger,
+            buttonText: 'Delete Child',
+          },
+        },
+        additionalText: 'Delete child?',
+      };
+
+      const parentNode = createVisualizationNode('parent', {});
+      const childNode = createVisualizationNode('child', {});
+      parentNode.addChild(childNode);
+
+      const parentAddon: IOnDeleteAddon = {
+        type: IInteractionType.ON_DELETE,
+        activationFn: () => true,
+        callback: jest.fn(),
+        modalCustomization: parentCustomization,
+      };
+      const childAddon: IOnDeleteAddon = {
+        type: IInteractionType.ON_DELETE,
+        activationFn: () => true,
+        callback: jest.fn(),
+        modalCustomization: childCustomization,
+      };
+
+      const addons: Record<string, IOnDeleteAddon[]> = {
+        parent: [parentAddon],
+        child: [childAddon],
+      };
+
+      const result = findOnDeleteModalCustomizationRecursively(parentNode, (vn) => addons[vn.id] || []);
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(parentCustomization);
+      expect(result).toContain(childCustomization);
+    });
+
+    it('should deduplicate modal customizations', () => {
+      const sharedCustomization: IModalCustomization = {
+        buttonOptions: {
+          [ACTION_ID_CONFIRM]: {
+            variant: ButtonVariant.danger,
+            buttonText: 'Delete',
+          },
+        },
+        additionalText: 'Are you sure?',
+      };
+
+      const parentNode = createVisualizationNode('parent', {});
+      const childNode = createVisualizationNode('child', {});
+      parentNode.addChild(childNode);
+
+      const addon: IOnDeleteAddon = {
+        type: IInteractionType.ON_DELETE,
+        activationFn: () => true,
+        callback: jest.fn(),
+        modalCustomization: sharedCustomization,
+      };
+
+      const result = findOnDeleteModalCustomizationRecursively(parentNode, () => [addon]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(sharedCustomization);
+    });
+  });
+
+  describe('processOnCopyAddon', () => {
+    it('should invoke addon callback with correct parameters', () => {
+      const mockContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'test' } },
+      };
+      const mockCallback = jest.fn().mockReturnValue(mockContent);
+      const vizNode = createVisualizationNode('test', {});
+
+      const mockAddon: IOnCopyAddon = {
+        type: IInteractionType.ON_COPY,
+        activationFn: () => true,
+        callback: mockCallback,
+      };
+
+      const result = processOnCopyAddon(vizNode, mockContent, () => [mockAddon]);
+
+      expect(mockCallback).toHaveBeenCalledWith({
+        sourceVizNode: vizNode,
+        content: mockContent,
+      });
+      expect(result).toBe(mockContent);
+    });
+  });
+
+  describe('processOnDuplicateAddonRecursively', () => {
+    it('should process addon transformation', async () => {
+      const mockContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'test' } },
+      };
+      const transformedContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'transformed' } },
+      };
+
+      const mockCallback = jest.fn().mockResolvedValue(transformedContent);
+      const vizNode = createVisualizationNode('test', { path: 'route.from.steps.0.log' });
+
+      const mockAddon: IOnDuplicateAddon = {
+        type: IInteractionType.ON_DUPLICATE,
+        activationFn: () => true,
+        callback: mockCallback,
+      };
+
+      const result = await processOnDuplicateAddonRecursively(vizNode, mockContent, () => [mockAddon]);
+
+      expect(mockCallback).toHaveBeenCalledWith({
+        sourceVizNode: vizNode,
+        content: mockContent,
+      });
+      expect(result).toBe(transformedContent);
+    });
+
+    it('should return content when no addons return transformation', async () => {
+      const mockContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'test' } },
+      };
+
+      const mockCallback = jest.fn().mockResolvedValue(undefined);
+      const vizNode = createVisualizationNode('test', { path: 'route.from.steps.0.log' });
+
+      const mockAddon: IOnDuplicateAddon = {
+        type: IInteractionType.ON_DUPLICATE,
+        activationFn: () => true,
+        callback: mockCallback,
+      };
+
+      const result = await processOnDuplicateAddonRecursively(vizNode, mockContent, () => [mockAddon]);
+
+      expect(result).toBe(mockContent);
+    });
+
+    it('should return undefined when content is undefined', async () => {
+      const vizNode = createVisualizationNode('test', { path: 'route.from.steps.0.log' });
+
+      const result = await processOnDuplicateAddonRecursively(vizNode, undefined, () => []);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should process children when path and children are available', async () => {
+      const childContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'child' } },
+      };
+
+      const parentContent = {
+        type: SourceSchemaType.Route,
+        name: 'step',
+        definition: {
+          step: {
+            id: 'parent-step',
+            steps: [{ log: { message: 'original-child' } }],
+          },
+        },
+      };
+
+      const parentNode = createVisualizationNode('parent', { path: 'route.from.steps.0.step' });
+      const childNode = createVisualizationNode('child', { path: 'route.from.steps.0.step.steps.0.log' });
+      parentNode.addChild(childNode);
+
+      jest.spyOn(childNode, 'getCopiedContent').mockReturnValue(childContent);
+
+      const mockAddon: IOnDuplicateAddon = {
+        type: IInteractionType.ON_DUPLICATE,
+        activationFn: () => true,
+        callback: jest.fn().mockImplementation(({ content }) => Promise.resolve(content)),
+      };
+
+      const result = await processOnDuplicateAddonRecursively(parentNode, parentContent, () => [mockAddon]);
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('processOnPasteAddon', () => {
+    it('should invoke addon callback with correct parameters', async () => {
+      const originalContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'original' } },
+      };
+      const updatedContent = {
+        type: SourceSchemaType.Route,
+        name: 'log',
+        definition: { log: { message: 'updated' } },
+      };
+
+      const mockCallback = jest.fn().mockResolvedValue(undefined);
+      const vizNode = createVisualizationNode('test', {});
+
+      const mockAddon: IOnPasteAddon = {
+        type: IInteractionType.ON_PASTE,
+        activationFn: () => true,
+        callback: mockCallback,
+      };
+
+      await processOnPasteAddon(vizNode, originalContent, updatedContent, () => [mockAddon]);
+
+      expect(mockCallback).toHaveBeenCalledWith({
+        targetVizNode: vizNode,
+        originalContent,
+        updatedContent,
+      });
+    });
+
+    it('should call all registered addons regardless of target vizNode', async () => {
+      const originalContent = {
+        type: SourceSchemaType.Route,
+        name: 'choice',
+        definition: {
+          choice: {
+            when: [
+              {
+                id: 'datamapper-original-1',
+                steps: [{ to: { uri: 'xslt-saxon:original.xsl' } }],
+              },
+            ],
+          },
+        },
+      };
+
+      const updatedContent = {
+        type: SourceSchemaType.Route,
+        name: 'choice',
+        definition: {
+          choice: {
+            when: [
+              {
+                id: 'datamapper-new-1',
+                steps: [{ to: { uri: 'xslt-saxon:new.xsl' } }],
+              },
+            ],
+          },
+        },
+      };
+
+      const targetVizNode = createVisualizationNode('route', {});
+
+      const mockCallback = jest.fn().mockResolvedValue(undefined);
+
+      const mockAddon: IOnPasteAddon = {
+        type: IInteractionType.ON_PASTE,
+        activationFn: (vizNode) => vizNode.id === 'specific-node',
+        callback: mockCallback,
+      };
+
+      await processOnPasteAddon(targetVizNode, originalContent, updatedContent, () => [mockAddon]);
+
+      expect(mockCallback).toHaveBeenCalledWith({
+        targetVizNode,
+        originalContent,
+        updatedContent,
+      });
+    });
+
+    it('should process multiple addons with nested DataMapper content', async () => {
+      const originalContent = {
+        type: SourceSchemaType.Route,
+        name: 'choice',
+        definition: {
+          choice: {
+            when: [
+              {
+                id: 'datamapper-original-1',
+                steps: [{ to: { uri: 'xslt-saxon:original1.xsl' } }],
+              },
+              {
+                id: 'datamapper-original-2',
+                steps: [{ to: { uri: 'xslt-saxon:original2.xsl' } }],
+              },
+            ],
+          },
+        },
+      };
+
+      const updatedContent = {
+        type: SourceSchemaType.Route,
+        name: 'choice',
+        definition: {
+          choice: {
+            when: [
+              {
+                id: 'datamapper-new-1',
+                steps: [{ to: { uri: 'xslt-saxon:new1.xsl' } }],
+              },
+              {
+                id: 'datamapper-new-2',
+                steps: [{ to: { uri: 'xslt-saxon:new2.xsl' } }],
+              },
+            ],
+          },
+        },
+      };
+
+      const targetVizNode = createVisualizationNode('route', {});
+
+      const mockCallback1 = jest.fn().mockResolvedValue(undefined);
+      const mockCallback2 = jest.fn().mockResolvedValue(undefined);
+
+      const mockAddon1: IOnPasteAddon = {
+        type: IInteractionType.ON_PASTE,
+        activationFn: () => true,
+        callback: mockCallback1,
+      };
+
+      const mockAddon2: IOnPasteAddon = {
+        type: IInteractionType.ON_PASTE,
+        activationFn: () => true,
+        callback: mockCallback2,
+      };
+
+      await processOnPasteAddon(targetVizNode, originalContent, updatedContent, () => [mockAddon1, mockAddon2]);
+
+      expect(mockCallback1).toHaveBeenCalledTimes(1);
+      expect(mockCallback2).toHaveBeenCalledTimes(1);
+      expect(mockCallback1).toHaveBeenCalledWith({
+        targetVizNode,
+        originalContent,
+        updatedContent,
+      });
+      expect(mockCallback2).toHaveBeenCalledWith({
+        targetVizNode,
+        originalContent,
+        updatedContent,
+      });
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.ts
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.ts
@@ -3,9 +3,21 @@ import {
   IModalCustomization,
   IOnCopyAddon,
   IOnDeleteAddon,
+  IOnDuplicateAddon,
+  IOnPasteAddon,
 } from '../../../registers/interactions/node-interaction-addon.model';
 import { IClipboardCopyObject } from '../../../../models/visualization/clipboard';
+import { get, set } from 'lodash';
 
+const ARRAY_INDEX_REGEXP = /\.(\d+)/g;
+
+/**
+ * Processes the registered addons for the {@link ON_DELETE} interaction being processed for the {@link parentVizNode}.
+ * This traverses visualization node children recursively.
+ * @param parentVizNode
+ * @param modalAnswer
+ * @param getAddons
+ */
 export const processOnDeleteAddonRecursively = (
   parentVizNode: IVisualizationNode,
   modalAnswer: string | undefined,
@@ -21,10 +33,16 @@ export const processOnDeleteAddonRecursively = (
   }
 };
 
+/**
+ * Collects modal customization requirements from the registered addons for the {@link ON_DELETE} interaction
+ * being processed for the {@link parentVizNode}. This traverses visualization node children recursively.
+ * @param parentVizNode
+ * @param getAddons
+ */
 export const findOnDeleteModalCustomizationRecursively = (
   parentVizNode: IVisualizationNode,
   getAddons: (vizNode: IVisualizationNode) => IOnDeleteAddon[],
-) => {
+): IModalCustomization[] => {
   const modalCustomizations: IModalCustomization[] = [];
   // going breadth-first while addon processes depth-first... do we want?
   for (const addon of getAddons(parentVizNode)) {
@@ -62,4 +80,100 @@ export const processOnCopyAddon = (
   }
 
   return processedContent;
+};
+
+const computeRelativePath = (parentPath: string, childPath: string): string | undefined => {
+  if (!childPath.startsWith(parentPath)) return;
+
+  const relativePath = childPath.substring(parentPath.length + 1);
+  ARRAY_INDEX_REGEXP.lastIndex = 0;
+  return relativePath.replace(ARRAY_INDEX_REGEXP, '[$1]');
+};
+
+const processOnDuplicateAddonForChildren = async (
+  parentPath: string,
+  children: IVisualizationNode[],
+  content: IClipboardCopyObject,
+  getAddons: (vizNode: IVisualizationNode) => IOnDuplicateAddon[],
+) => {
+  for (const child of children) {
+    const childPath = child.data.path;
+    if (!childPath) continue;
+
+    const relativePath = computeRelativePath(parentPath, childPath);
+    if (!relativePath) continue;
+
+    const childDefinitionValue = get(content.definition, relativePath);
+    if (!childDefinitionValue || typeof childDefinitionValue !== 'object') continue;
+
+    const childContentFromParent = child.getCopiedContent();
+    if (!childContentFromParent) continue;
+
+    const childContent: IClipboardCopyObject = {
+      ...childContentFromParent,
+      definition: childDefinitionValue,
+    };
+
+    const transformedChildContent = await processOnDuplicateAddonRecursively(child, childContent, getAddons);
+
+    if (!transformedChildContent) continue;
+
+    set(content.definition, relativePath, transformedChildContent.definition);
+  }
+};
+
+/**
+ * Processes the registered addons for the {@link ON_DUPLICATE} interaction being processed for the {@link parentVizNode}.
+ * This traverses visualization node children recursively.
+ * @param parentVizNode
+ * @param content
+ * @param getAddons
+ */
+export const processOnDuplicateAddonRecursively = async (
+  parentVizNode: IVisualizationNode,
+  content: IClipboardCopyObject | undefined,
+  getAddons: (vizNode: IVisualizationNode) => IOnDuplicateAddon[],
+): Promise<IClipboardCopyObject | undefined> => {
+  if (!content) return content;
+
+  const children = parentVizNode.getChildren();
+  const parentPath = parentVizNode.data.path;
+  if (children && parentPath) {
+    await processOnDuplicateAddonForChildren(parentPath, children, content, getAddons);
+  }
+
+  let result = content;
+  for (const addon of getAddons(parentVizNode)) {
+    const transformed = await addon.callback({ sourceVizNode: parentVizNode, content: result });
+    if (transformed) result = transformed;
+  }
+
+  return result;
+};
+
+/**
+ * Process {@link ON_PASTE} addons on the passed-in clipboard contents. {@link originalContent} is the raw clipboard
+ * content that is being pasted, and the {@link updatedContent} is the clipboard content updated with re-generated ID
+ * for each steps in order to avoid ID conflicts. We need the original content to identify the metadata associated with
+ * the original step ID.
+ * This doesn't traverse the clipboard contents by itself. The addons are responsible to find the corresponding step
+ * in the clipboard content and act accordingly.
+ * @param targetVizNode
+ * @param originalContent
+ * @param updatedContent
+ * @param getAddons
+ */
+export const processOnPasteAddon = async (
+  targetVizNode: IVisualizationNode,
+  originalContent: IClipboardCopyObject | undefined,
+  updatedContent: IClipboardCopyObject | undefined,
+  getAddons: () => IOnPasteAddon[],
+): Promise<void> => {
+  for (const addon of getAddons()) {
+    await addon.callback({
+      targetVizNode,
+      originalContent,
+      updatedContent,
+    });
+  }
 };

--- a/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
+++ b/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
@@ -7,17 +7,21 @@ import {
   onDeleteDataMapper,
 } from '../DataMapper/on-delete-datamapper';
 import { onCopyDataMapper } from '../DataMapper/on-copy-datamapper';
+import { onDuplicateDataMapper } from '../DataMapper/on-duplicate-datamapper';
+import { onPasteDataMapper } from '../DataMapper/on-paste-data-mapper';
 import { NodeInteractionAddonContext } from './interactions/node-interaction-addon.provider';
 import {
   IInteractionType,
   IOnCopyAddon,
   IOnDeleteAddon,
+  IOnDuplicateAddon,
+  IOnPasteAddon,
   IRegisteredInteractionAddon,
 } from './interactions/node-interaction-addon.model';
 import { ButtonVariant } from '@patternfly/react-core';
 
 export const RegisterNodeInteractionAddons: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  const metadataApi = useContext(MetadataContext)!;
+  const metadataApi = useContext(MetadataContext);
   const { registerInteractionAddon } = useContext(NodeInteractionAddonContext);
   const addonsToRegister = useRef<IRegisteredInteractionAddon[]>([
     {
@@ -46,6 +50,16 @@ export const RegisterNodeInteractionAddons: FunctionComponent<PropsWithChildren>
       activationFn: datamapperActivationFn,
       callback: onCopyDataMapper,
     } as IOnCopyAddon,
+    {
+      type: IInteractionType.ON_DUPLICATE,
+      activationFn: datamapperActivationFn,
+      callback: (parameters) => onDuplicateDataMapper(metadataApi, parameters),
+    } as IOnDuplicateAddon,
+    {
+      type: IInteractionType.ON_PASTE,
+      activationFn: datamapperActivationFn,
+      callback: (parameters) => onPasteDataMapper(metadataApi, parameters),
+    } as IOnPasteAddon,
   ]);
 
   for (const interaction of addonsToRegister.current) {

--- a/packages/ui/src/components/registers/interactions/node-interaction-addon.model.ts
+++ b/packages/ui/src/components/registers/interactions/node-interaction-addon.model.ts
@@ -5,6 +5,8 @@ import { IClipboardCopyObject } from '../../../models/visualization/clipboard';
 export enum IInteractionType {
   ON_DELETE = 'onDelete',
   ON_COPY = 'onCopy',
+  ON_DUPLICATE = 'onDuplicate',
+  ON_PASTE = 'onPaste',
 }
 
 export interface IModalCustomization {
@@ -14,9 +16,8 @@ export interface IModalCustomization {
 
 /**
  * Registered interaction addon.
- * @template T The type of interaction addon (ON_DELETE, ON_COPY, etc)
  */
-export type IRegisteredInteractionAddon = IOnDeleteAddon | IOnCopyAddon;
+export type IRegisteredInteractionAddon = IOnDeleteAddon | IOnCopyAddon | IOnDuplicateAddon | IOnPasteAddon;
 
 export interface IOnDeleteAddon {
   type: IInteractionType.ON_DELETE;
@@ -32,6 +33,25 @@ export interface IOnCopyAddon {
     sourceVizNode: IVisualizationNode;
     content: IClipboardCopyObject | undefined;
   }) => IClipboardCopyObject;
+}
+
+export interface IOnDuplicateAddon {
+  type: IInteractionType.ON_DUPLICATE;
+  activationFn: (vizNode: IVisualizationNode) => boolean;
+  callback: (parameters: {
+    sourceVizNode: IVisualizationNode;
+    content: IClipboardCopyObject | undefined;
+  }) => Promise<IClipboardCopyObject>;
+}
+
+export interface IOnPasteAddon {
+  type: IInteractionType.ON_PASTE;
+  activationFn: (vizNode: IVisualizationNode) => boolean;
+  callback: (parameters: {
+    targetVizNode: IVisualizationNode;
+    originalContent: IClipboardCopyObject | undefined;
+    updatedContent: IClipboardCopyObject | undefined;
+  }) => Promise<void>;
 }
 
 export interface INodeInteractionAddonContext {
@@ -66,11 +86,11 @@ export interface INodeInteractionAddonContext {
    *    });
    * ```
    * @param type   The interaction addon type enum value
-   * @param vizNode   The visualization node to pass to the interaction
+   * @param vizNode   The visualization node to pass to the interaction. If not provided, returns all addons of the given type.
    * @returns `IRegisteredInteraction` An array of registered interactions
    */
   getRegisteredInteractionAddons: (
     type: IInteractionType,
-    vizNode: IVisualizationNode,
+    vizNode?: IVisualizationNode,
   ) => IRegisteredInteractionAddon[];
 }

--- a/packages/ui/src/components/registers/interactions/node-interaction-addon.provider.tsx
+++ b/packages/ui/src/components/registers/interactions/node-interaction-addon.provider.tsx
@@ -18,9 +18,9 @@ export const NodeInteractionAddonProvider: FunctionComponent<PropsWithChildren> 
     registeredInteractionAddons.current.push(interaction);
   }, []);
 
-  const getRegisteredInteractionAddons = useCallback((interaction: IInteractionType, vizNode: IVisualizationNode) => {
+  const getRegisteredInteractionAddons = useCallback((interaction: IInteractionType, vizNode?: IVisualizationNode) => {
     return registeredInteractionAddons.current.filter(
-      (addon) => addon.type === interaction && addon.activationFn(vizNode),
+      (addon) => addon.type === interaction && (!vizNode || addon.activationFn(vizNode)),
     );
   }, []);
 

--- a/packages/ui/src/utils/ClipboardManager.test.ts
+++ b/packages/ui/src/utils/ClipboardManager.test.ts
@@ -112,7 +112,7 @@ describe('ClipboardManager', () => {
 
       const result = await ClipboardManager.paste();
       expect(navigator.clipboard.read).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(updateIds(testClipboardObject));
+      expect(result).toEqual(testClipboardObject);
     });
 
     it('should fetch fm the KAOTO_MIME_TYPE content from the clipboard', async () => {
@@ -137,7 +137,7 @@ describe('ClipboardManager', () => {
 
       const result = await ClipboardManager.paste();
       expect(navigator.clipboard.read).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(updateIds(testClipboardObject));
+      expect(result).toEqual(testClipboardObject);
     });
 
     it('should return null if clipboard content is not Kaoto-specific', async () => {

--- a/packages/ui/src/utils/ClipboardManager.ts
+++ b/packages/ui/src/utils/ClipboardManager.ts
@@ -1,5 +1,4 @@
 import { IClipboardCopyObject } from '../models/visualization/clipboard';
-import { updateIds } from './update-ids';
 
 export class ClipboardManager {
   static readonly KAOTO_MIME_TYPE = 'web text/kaoto';
@@ -56,8 +55,7 @@ export class ClipboardManager {
           item.types.includes(ClipboardManager.KAOTO_MIME_TYPE)
         ) {
           const blob = await item.getType(ClipboardManager.KAOTO_MIME_TYPE);
-          const parsedContent = JSON.parse(await blob.text());
-          return updateIds(parsedContent);
+          return JSON.parse(await blob.text());
         } else if (item.types.includes(ClipboardManager.TEXT_MIME_TYPE)) {
           const blob = await item.getType(ClipboardManager.TEXT_MIME_TYPE);
           const parsedContent = JSON.parse(await blob.text());
@@ -65,7 +63,7 @@ export class ClipboardManager {
           // Validate the marker to ensure it's Kaoto-specific content
           if (parsedContent.__kaoto_marker === ClipboardManager.KAOTO_MARKER) {
             delete parsedContent.__kaoto_marker;
-            return updateIds(parsedContent);
+            return parsedContent;
           }
         }
       }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2545

Following up https://github.com/KaotoIO/kaoto/pull/2653

### In VS Code
Duplicate the metadata reference (e.g. schema) and XSLT contents, but copy the XSLT file contents into a different file so that the mappings won't mix

https://github.com/user-attachments/assets/af291fd7-2f6f-4cfb-85bb-47d511068bfa

### Browser
Since ATM we don't have external file handling capability in the browser, we just copy&paste/duplicate the step in YAML, but clear the XSLT file URI. Once we implement the MetadataContext for browser, it will automatically get to work for copy/paste/duplicate.

https://github.com/user-attachments/assets/a3e5ef14-d75e-474c-9b67-3d2aca719987

