### PR TITLE
fix(xmlExpressionParser): trim the expression string

### DIFF
--- a/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
@@ -61,4 +61,18 @@ describe('Expression parser', () => {
     const result = ExpressionParser.parse(parentElement, props?.expression, 'when');
     expect(result).not.toBeDefined();
   });
+
+  it('should trim whitespace and newlines from expression text content', () => {
+    const expression = xmlParser.parseFromString(
+      `
+          <simple>
+                    \${header.foo} == 1
+                </simple>
+      `,
+      'application/xml',
+    ).documentElement;
+
+    const result = ExpressionParser.parse(expression);
+    expect(result).toEqual({ simple: { expression: '${header.foo} == 1' } });
+  });
 });

--- a/packages/ui/src/serializers/xml/parsers/expression-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.ts
@@ -50,7 +50,7 @@ export class ExpressionParser {
 
     return {
       [expressionType]: {
-        expression: expressionTypeProperties?.expression ? expressionElement.textContent : undefined,
+        expression: expressionTypeProperties?.expression ? expressionElement.textContent?.trim() : undefined,
         ...expressionAttributes,
         namespace: namespaces.length > 0 ? namespaces : undefined,
       },


### PR DESCRIPTION
### Context
This pull request improves the handling of whitespace in expression parsing within the XML serializers. The main changes ensure that expression text content is properly trimmed of whitespace and newlines, and that this behavior is covered by new tests.

fixes: https://github.com/KaotoIO/kaoto/issues/2717