### PR TITLE
feat(Catalog): Introduce `DynamicCatalog`

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { RegisterComponents } from './components/registers/RegisterComponents';
 import { RegisterNodeInteractionAddons } from './components/registers/RegisterNodeInteractionAddons';
 import { RenderingProvider } from './components/RenderingAnchor/rendering.provider';
 import { ControllerService } from './components/Visualization/Canvas/controller.service';
+import { DynamicCatalogRegistryProvider } from './dynamic-catalog';
 import { Shell } from './layout/Shell';
 import { LocalStorageSettingsAdapter } from './models/settings/localstorage-settings-adapter';
 import {
@@ -42,35 +43,37 @@ function App() {
   return (
     <SettingsProvider adapter={settingsAdapter}>
       <SourceCodeLocalStorageProvider>
-        <RuntimeProvider catalogUrl={catalogUrl}>
-          <SchemasLoaderProvider>
-            <CatalogLoaderProvider>
-              <EntitiesProvider>
-                <Shell>
-                  <CatalogTilesProvider>
-                    <VisualizationProvider controller={controller}>
-                      <VisibleFlowsProvider>
-                        <RenderingProvider>
-                          <RegisterComponents>
-                            <NodeInteractionAddonProvider>
-                              <RegisterNodeInteractionAddons>
-                                <SuggestionRegistryProvider>
-                                  <KeyboardShortcutsProvider>
-                                    <Outlet />
-                                  </KeyboardShortcutsProvider>
-                                </SuggestionRegistryProvider>
-                              </RegisterNodeInteractionAddons>
-                            </NodeInteractionAddonProvider>
-                          </RegisterComponents>
-                        </RenderingProvider>
-                      </VisibleFlowsProvider>
-                    </VisualizationProvider>
-                  </CatalogTilesProvider>
-                </Shell>
-              </EntitiesProvider>
-            </CatalogLoaderProvider>
-          </SchemasLoaderProvider>
-        </RuntimeProvider>
+        <DynamicCatalogRegistryProvider>
+          <RuntimeProvider catalogUrl={catalogUrl}>
+            <SchemasLoaderProvider>
+              <CatalogLoaderProvider>
+                <EntitiesProvider>
+                  <Shell>
+                    <CatalogTilesProvider>
+                      <VisualizationProvider controller={controller}>
+                        <VisibleFlowsProvider>
+                          <RenderingProvider>
+                            <RegisterComponents>
+                              <NodeInteractionAddonProvider>
+                                <RegisterNodeInteractionAddons>
+                                  <SuggestionRegistryProvider>
+                                    <KeyboardShortcutsProvider>
+                                      <Outlet />
+                                    </KeyboardShortcutsProvider>
+                                  </SuggestionRegistryProvider>
+                                </RegisterNodeInteractionAddons>
+                              </NodeInteractionAddonProvider>
+                            </RegisterComponents>
+                          </RenderingProvider>
+                        </VisibleFlowsProvider>
+                      </VisualizationProvider>
+                    </CatalogTilesProvider>
+                  </Shell>
+                </EntitiesProvider>
+              </CatalogLoaderProvider>
+            </SchemasLoaderProvider>
+          </RuntimeProvider>
+        </DynamicCatalogRegistryProvider>
       </SourceCodeLocalStorageProvider>
     </SettingsProvider>
   );

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.context.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.context.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+import { DynamicCatalogRegistry } from './dynamic-catalog-registry';
+import { IDynamicCatalogRegistry } from './models';
+
+export const DynamicCatalogRegistryContext = createContext<IDynamicCatalogRegistry>(DynamicCatalogRegistry.get());

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.provider.tsx
@@ -1,0 +1,5 @@
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+export const DynamicCatalogRegistryProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  return <>{children}</>;
+};

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
@@ -1,0 +1,356 @@
+import { KaotoFunction } from '@kaoto/camel-catalog/types';
+
+import {
+  ICamelComponentDefinition,
+  ICamelDataformatDefinition,
+  ICamelLanguageDefinition,
+  ICamelProcessorDefinition,
+  IKameletDefinition,
+} from '../models';
+import { CatalogKind } from '../models/catalog-kind';
+import { DynamicCatalog } from './dynamic-catalog';
+import { DynamicCatalogRegistry } from './dynamic-catalog-registry';
+import { ICatalogProvider, IDynamicCatalogRegistry } from './models';
+
+describe('DynamicCatalogRegistry', () => {
+  let registry: IDynamicCatalogRegistry;
+
+  beforeEach(() => {
+    registry = DynamicCatalogRegistry.get();
+  });
+  afterEach(() => {
+    registry.clearRegistry();
+  });
+
+  describe('setCatalog', () => {
+    it('should set a catalog provider for a given kind', () => {
+      const mockProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const catalog = new DynamicCatalog(mockProvider);
+
+      registry.setCatalog(CatalogKind.Component, catalog);
+
+      const retrievedCatalog = registry.getCatalog(CatalogKind.Component);
+      expect(retrievedCatalog).toBe(catalog);
+    });
+
+    it('should set multiple catalog providers for different kinds', () => {
+      const componentProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'component-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const processorProvider: ICatalogProvider<ICamelProcessorDefinition> = {
+        id: 'processor-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+
+      const componentCatalog = new DynamicCatalog(componentProvider);
+      const processorCatalog = new DynamicCatalog(processorProvider);
+
+      registry.setCatalog(CatalogKind.Component, componentCatalog);
+      registry.setCatalog(CatalogKind.Processor, processorCatalog);
+
+      expect(registry.getCatalog(CatalogKind.Component)).toBe(componentCatalog);
+      expect(registry.getCatalog(CatalogKind.Processor)).toBe(processorCatalog);
+    });
+
+    it('should override existing catalog provider when setting the same kind', () => {
+      const firstProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'first-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const secondProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'second-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+
+      const firstCatalog = new DynamicCatalog(firstProvider);
+      const secondCatalog = new DynamicCatalog(secondProvider);
+
+      registry.setCatalog(CatalogKind.Component, firstCatalog);
+      registry.setCatalog(CatalogKind.Component, secondCatalog);
+
+      const retrievedCatalog = registry.getCatalog(CatalogKind.Component);
+      expect(retrievedCatalog).toBe(secondCatalog);
+      expect(retrievedCatalog).not.toBe(firstCatalog);
+    });
+
+    it('should handle all catalog kinds', () => {
+      const componentProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'component-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const processorProvider: ICatalogProvider<ICamelProcessorDefinition> = {
+        id: 'processor-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const languageProvider: ICatalogProvider<ICamelLanguageDefinition> = {
+        id: 'language-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const dataformatProvider: ICatalogProvider<ICamelDataformatDefinition> = {
+        id: 'dataformat-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const kameletProvider: ICatalogProvider<IKameletDefinition> = {
+        id: 'kamelet-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+
+      registry.setCatalog(CatalogKind.Component, new DynamicCatalog(componentProvider));
+      registry.setCatalog(CatalogKind.Processor, new DynamicCatalog(processorProvider));
+      registry.setCatalog(CatalogKind.Pattern, new DynamicCatalog(processorProvider));
+      registry.setCatalog(CatalogKind.Entity, new DynamicCatalog(processorProvider));
+      registry.setCatalog(CatalogKind.Language, new DynamicCatalog(languageProvider));
+      registry.setCatalog(CatalogKind.Dataformat, new DynamicCatalog(dataformatProvider));
+      registry.setCatalog(CatalogKind.Loadbalancer, new DynamicCatalog(processorProvider));
+      registry.setCatalog(CatalogKind.Kamelet, new DynamicCatalog(kameletProvider));
+
+      expect(registry.getCatalog(CatalogKind.Component)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Processor)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Pattern)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Entity)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Language)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Dataformat)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Loadbalancer)).toBeDefined();
+      expect(registry.getCatalog(CatalogKind.Kamelet)).toBeDefined();
+    });
+  });
+
+  describe('getCatalog', () => {
+    it('should return undefined when catalog is not set', () => {
+      const catalog = registry.getCatalog(CatalogKind.Component);
+      expect(catalog).toBeUndefined();
+    });
+
+    it('should return the correct catalog for a given kind', () => {
+      const mockProvider: ICatalogProvider<ICamelLanguageDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const expectedCatalog = new DynamicCatalog(mockProvider);
+
+      registry.setCatalog(CatalogKind.Language, expectedCatalog);
+
+      const catalog = registry.getCatalog(CatalogKind.Language);
+      expect(catalog).toBe(expectedCatalog);
+    });
+
+    it('should return different catalogs for different kinds', () => {
+      const provider1: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'provider-1',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+      const provider2: ICatalogProvider<ICamelProcessorDefinition> = {
+        id: 'provider-2',
+        fetch: jest.fn(),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog1 = new DynamicCatalog(provider1);
+      const catalog2 = new DynamicCatalog(provider2);
+
+      registry.setCatalog(CatalogKind.Component, catalog1);
+      registry.setCatalog(CatalogKind.Pattern, catalog2);
+
+      expect(registry.getCatalog(CatalogKind.Component)).toBe(catalog1);
+      expect(registry.getCatalog(CatalogKind.Pattern)).toBe(catalog2);
+      expect(registry.getCatalog(CatalogKind.Component)).not.toBe(catalog2);
+    });
+  });
+
+  describe('getEntity', () => {
+    it('should return undefined when catalog is not set', async () => {
+      const entity = await registry.getEntity(CatalogKind.Component, 'test-key');
+      expect(entity).toBeUndefined();
+    });
+
+    it('should retrieve an entity from the catalog', async () => {
+      const mockEntity: ICamelComponentDefinition = {
+        component: {
+          name: 'test-component',
+          kind: 'component',
+        },
+      } as ICamelComponentDefinition;
+
+      const mockProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'component-provider',
+        fetch: jest.fn().mockResolvedValue(mockEntity),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      registry.setCatalog(CatalogKind.Component, catalog);
+
+      const entity = await registry.getEntity(CatalogKind.Component, 'test-component');
+
+      expect(entity).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledWith('test-component');
+    });
+
+    it('should pass options to catalog.get', async () => {
+      const mockEntity: ICamelComponentDefinition = {
+        component: {
+          name: 'test-component',
+          kind: 'component',
+        },
+      } as ICamelComponentDefinition;
+
+      const mockProvider: ICatalogProvider<ICamelComponentDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn().mockResolvedValue(mockEntity),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      const getSpy = jest.spyOn(catalog, 'get');
+      registry.setCatalog(CatalogKind.Component, catalog);
+
+      await registry.getEntity(CatalogKind.Component, 'test-key', { forceFresh: true });
+
+      expect(getSpy).toHaveBeenCalledWith('test-key', { forceFresh: true });
+    });
+
+    it('should use default options when not provided', async () => {
+      const mockEntity: IKameletDefinition = {
+        kind: 'Kamelet',
+        metadata: { name: 'test-kamelet' },
+        spec: { definition: {} },
+      } as IKameletDefinition;
+
+      const mockProvider: ICatalogProvider<IKameletDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn().mockResolvedValue(mockEntity),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      const getSpy = jest.spyOn(catalog, 'get');
+      registry.setCatalog(CatalogKind.Kamelet, catalog);
+
+      await registry.getEntity(CatalogKind.Kamelet, 'test-key');
+
+      expect(getSpy).toHaveBeenCalledWith('test-key', {});
+    });
+
+    it('should return cached entity when forceFresh is false', async () => {
+      const mockEntity = {
+        model: { name: 'test-language', kind: 'language' },
+        properties: {},
+        propertiesSchema: {},
+      } as unknown as ICamelLanguageDefinition;
+
+      const mockProvider: ICatalogProvider<ICamelLanguageDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn().mockResolvedValue(mockEntity),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      registry.setCatalog(CatalogKind.Language, catalog);
+
+      // First call - should fetch from provider
+      const firstResult = await registry.getEntity(CatalogKind.Language, 'test-key');
+      expect(firstResult).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+
+      // Second call - should return from cache
+      const secondResult = await registry.getEntity(CatalogKind.Language, 'test-key');
+      expect(secondResult).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1); // Still called only once
+    });
+
+    it('should bypass cache when forceFresh is true', async () => {
+      const mockEntity1 = {
+        model: { name: 'dataformat-v1' },
+        properties: {},
+        propertiesSchema: {},
+      } as unknown as ICamelDataformatDefinition;
+      const mockEntity2 = {
+        model: { name: 'dataformat-v2' },
+        properties: {},
+        propertiesSchema: {},
+      } as unknown as ICamelDataformatDefinition;
+
+      const mockProvider: ICatalogProvider<ICamelDataformatDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn().mockResolvedValueOnce(mockEntity1).mockResolvedValueOnce(mockEntity2),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      registry.setCatalog(CatalogKind.Dataformat, catalog);
+
+      // First call
+      const firstResult = await registry.getEntity(CatalogKind.Dataformat, 'test-key');
+      expect(firstResult).toBe(mockEntity1);
+
+      // Second call with forceFresh
+      const secondResult = await registry.getEntity(CatalogKind.Dataformat, 'test-key', { forceFresh: true });
+      expect(secondResult).toBe(mockEntity2);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return undefined when entity is not found', async () => {
+      const mockProvider: ICatalogProvider<ICamelProcessorDefinition> = {
+        id: 'test-provider',
+        fetch: jest.fn().mockResolvedValue(undefined),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog(mockProvider);
+      registry.setCatalog(CatalogKind.Processor, catalog);
+
+      const entity = await registry.getEntity(CatalogKind.Processor, 'non-existent-key');
+
+      expect(entity).toBeUndefined();
+      expect(mockProvider.fetch).toHaveBeenCalledWith('non-existent-key');
+    });
+
+    it('should handle different entity types correctly', async () => {
+      const mockEntity = {
+        name: 'customFunction',
+        displayName: 'Custom Function',
+        description: 'A custom function for testing',
+        returnType: 'String',
+        examples: [],
+      } as unknown as KaotoFunction;
+
+      const mockProvider: ICatalogProvider<KaotoFunction> = {
+        id: 'custom-provider',
+        fetch: jest.fn().mockResolvedValue(mockEntity),
+        fetchAll: jest.fn(),
+      };
+
+      const catalog = new DynamicCatalog<KaotoFunction>(mockProvider);
+      registry.setCatalog(CatalogKind.Function, catalog);
+
+      const entity = await registry.getEntity(CatalogKind.Function, 'custom-key');
+
+      expect(entity).toBe(mockEntity);
+      expect(entity?.name).toBe('customFunction');
+      expect(entity?.displayName).toBe('Custom Function');
+    });
+  });
+
+  it('should maintain a singleton registry', () => {
+    const registry1 = DynamicCatalogRegistry.get();
+    const registry2 = DynamicCatalogRegistry.get();
+
+    expect(registry1).toBe(registry2);
+  });
+});

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.ts
@@ -1,0 +1,39 @@
+import { CatalogKind } from '../models/catalog-kind';
+import { DynamicCatalogTypeMap, IDynamicCatalog, IDynamicCatalogRegistry } from './models';
+
+export class DynamicCatalogRegistry {
+  private static instance: CatalogsRegistry;
+
+  static get(): CatalogsRegistry {
+    if (!this.instance) {
+      this.instance = new CatalogsRegistry();
+    }
+
+    return this.instance;
+  }
+}
+
+class CatalogsRegistry implements IDynamicCatalogRegistry {
+  private readonly catalogs = new Map<CatalogKind, IDynamicCatalog<unknown>>();
+
+  setCatalog<K extends CatalogKind>(kind: K, catalog: IDynamicCatalog<DynamicCatalogTypeMap[K]>): void {
+    this.catalogs.set(kind, catalog);
+  }
+
+  getCatalog<K extends CatalogKind>(kind: K): IDynamicCatalog<DynamicCatalogTypeMap[K]> | undefined {
+    return this.catalogs.get(kind) as IDynamicCatalog<DynamicCatalogTypeMap[K]> | undefined;
+  }
+
+  async getEntity<K extends CatalogKind>(
+    kind: K,
+    key: string,
+    options: { forceFresh?: boolean } = {},
+  ): Promise<DynamicCatalogTypeMap[K] | undefined> {
+    const catalog = this.getCatalog(kind);
+    return catalog?.get(key, options) as Promise<DynamicCatalogTypeMap[K] | undefined>;
+  }
+
+  clearRegistry(): void {
+    this.catalogs.clear();
+  }
+}

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
@@ -1,0 +1,390 @@
+import { DynamicCatalog } from './dynamic-catalog';
+import { ICatalogProvider } from './models';
+
+interface TestEntity {
+  id: string;
+  name: string;
+  value: number;
+}
+
+describe('DynamicCatalog', () => {
+  let mockProvider: ICatalogProvider<TestEntity>;
+  let catalog: DynamicCatalog<TestEntity>;
+
+  beforeEach(() => {
+    mockProvider = {
+      id: 'test-provider',
+      fetch: jest.fn(),
+      fetchAll: jest.fn(),
+    };
+    catalog = new DynamicCatalog(mockProvider);
+  });
+
+  describe('get', () => {
+    it('should fetch entity from provider when not in cache', async () => {
+      const mockEntity: TestEntity = { id: '1', name: 'test-entity', value: 42 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(mockEntity);
+
+      const result = await catalog.get('entity-key');
+
+      expect(result).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledWith('entity-key');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return cached entity on subsequent calls', async () => {
+      const mockEntity: TestEntity = { id: '2', name: 'cached-entity', value: 99 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(mockEntity);
+
+      const firstResult = await catalog.get('cached-key');
+      expect(firstResult).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+
+      const secondResult = await catalog.get('cached-key');
+      expect(secondResult).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should bypass cache when forceFresh option is true', async () => {
+      const firstEntity: TestEntity = { id: '3', name: 'first-version', value: 1 };
+      const secondEntity: TestEntity = { id: '3', name: 'second-version', value: 2 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValueOnce(firstEntity).mockResolvedValueOnce(secondEntity);
+
+      const firstResult = await catalog.get('entity-key');
+      expect(firstResult).toBe(firstEntity);
+
+      const secondResult = await catalog.get('entity-key', { forceFresh: true });
+      expect(secondResult).toBe(secondEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use cache when forceFresh option is false', async () => {
+      const mockEntity: TestEntity = { id: '4', name: 'entity', value: 50 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(mockEntity);
+
+      await catalog.get('key');
+      const result = await catalog.get('key', { forceFresh: false });
+
+      expect(result).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return undefined when provider returns undefined', async () => {
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await catalog.get('non-existent-key');
+
+      expect(result).toBeUndefined();
+      expect(mockProvider.fetch).toHaveBeenCalledWith('non-existent-key');
+    });
+
+    it('should not cache undefined values', async () => {
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(undefined);
+
+      const firstResult = await catalog.get('missing-key');
+      expect(firstResult).toBeUndefined();
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+
+      const secondResult = await catalog.get('missing-key');
+      expect(secondResult).toBeUndefined();
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle multiple different keys independently', async () => {
+      const entity1: TestEntity = { id: '1', name: 'first', value: 10 };
+      const entity2: TestEntity = { id: '2', name: 'second', value: 20 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValueOnce(entity1).mockResolvedValueOnce(entity2);
+
+      const result1 = await catalog.get('key1');
+      const result2 = await catalog.get('key2');
+
+      expect(result1).toBe(entity1);
+      expect(result2).toBe(entity2);
+      expect(mockProvider.fetch).toHaveBeenCalledWith('key1');
+      expect(mockProvider.fetch).toHaveBeenCalledWith('key2');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use default options when no options provided', async () => {
+      const mockEntity: TestEntity = { id: '5', name: 'default-options', value: 123 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(mockEntity);
+
+      const result = await catalog.get('key');
+
+      expect(result).toBe(mockEntity);
+      expect(mockProvider.fetch).toHaveBeenCalledWith('key');
+    });
+
+    it('should handle provider errors gracefully', async () => {
+      const error = new Error('Provider fetch failed');
+      (mockProvider.fetch as jest.Mock).mockRejectedValue(error);
+
+      await expect(catalog.get('error-key')).rejects.toThrow('Provider fetch failed');
+    });
+  });
+
+  describe('getAll', () => {
+    it('should fetch all entities from provider when cache is empty', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+        { key: 'entity3', entity: { id: '3', name: 'third', value: 30 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const result = await catalog.getAll();
+
+      expect(result).toEqual({
+        entity1: entities[0].entity,
+        entity2: entities[1].entity,
+        entity3: entities[2].entity,
+      });
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return cached entities on subsequent calls', async () => {
+      const entities = [
+        { key: 'cached1', entity: { id: '1', name: 'cached-first', value: 100 } },
+        { key: 'cached2', entity: { id: '2', name: 'cached-second', value: 200 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const firstResult = await catalog.getAll();
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(1);
+
+      const secondResult = await catalog.getAll();
+      expect(secondResult).toEqual(firstResult);
+    });
+
+    it('should bypass cache when forceFresh option is true', async () => {
+      const firstEntities = [{ key: 'key1', entity: { id: '1', name: 'first', value: 1 } }];
+      const secondEntities = [{ key: 'key1', entity: { id: '1', name: 'updated', value: 2 } }];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValueOnce(firstEntities).mockResolvedValueOnce(secondEntities);
+
+      await catalog.getAll();
+      const result = await catalog.getAll({ forceFresh: true });
+
+      expect(result).toEqual({ key1: secondEntities[0].entity });
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(2);
+    });
+
+    it('should filter entities when filterFn is provided', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+        { key: 'entity3', entity: { id: '3', name: 'third', value: 30 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const filterFn = (_key: string, entity: TestEntity) => entity.value > 15;
+      const result = await catalog.getAll({ filterFn });
+
+      expect(result).toEqual({
+        entity2: entities[1].entity,
+        entity3: entities[2].entity,
+      });
+      expect(result).not.toHaveProperty('entity1');
+    });
+
+    it('should filter by key when filterFn uses key parameter', async () => {
+      const entities = [
+        { key: 'include-this', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'exclude-this', entity: { id: '2', name: 'second', value: 20 } },
+        { key: 'include-that', entity: { id: '3', name: 'third', value: 30 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const filterFn = (key: string) => key.startsWith('include');
+      const result = await catalog.getAll({ filterFn });
+
+      expect(result).toEqual({
+        'include-this': entities[0].entity,
+        'include-that': entities[2].entity,
+      });
+      expect(result).not.toHaveProperty('exclude-this');
+    });
+
+    it('should return empty object when all entities are filtered out', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const filterFn = () => false;
+      const result = await catalog.getAll({ filterFn });
+
+      expect(result).toEqual({});
+    });
+
+    it('should return all entities when filterFn is not provided', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      const result = await catalog.getAll();
+
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result).toHaveProperty('entity1');
+      expect(result).toHaveProperty('entity2');
+    });
+
+    it('should handle empty array from provider', async () => {
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue([]);
+
+      const result = await catalog.getAll();
+
+      expect(result).toEqual({});
+    });
+
+    it('should handle non-array response from provider', async () => {
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await catalog.getAll();
+
+      expect(result).toEqual({});
+    });
+
+    it('should cache entities from fetchAll for individual get calls', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      await catalog.getAll();
+
+      const result = await catalog.get('entity1');
+      expect(result).toBe(entities[0].entity);
+      expect(mockProvider.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should combine filterFn with forceFresh option', async () => {
+      const firstEntities = [{ key: 'key1', entity: { id: '1', name: 'old', value: 5 } }];
+      const secondEntities = [
+        { key: 'key1', entity: { id: '1', name: 'new', value: 15 } },
+        { key: 'key2', entity: { id: '2', name: 'another', value: 25 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValueOnce(firstEntities).mockResolvedValueOnce(secondEntities);
+
+      await catalog.getAll();
+      const filterFn = (_key: string, entity: TestEntity) => entity.value > 10;
+      const result = await catalog.getAll({ forceFresh: true, filterFn });
+
+      expect(result).toEqual({
+        key1: secondEntities[0].entity,
+        key2: secondEntities[1].entity,
+      });
+    });
+
+    it('should handle provider errors gracefully', async () => {
+      const error = new Error('FetchAll failed');
+      (mockProvider.fetchAll as jest.Mock).mockRejectedValue(error);
+
+      await expect(catalog.getAll()).rejects.toThrow('FetchAll failed');
+    });
+
+    it('should use cache even if filterFn is provided on second call', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      await catalog.getAll();
+
+      const filterFn = (_key: string, entity: TestEntity) => entity.value > 15;
+      const result = await catalog.getAll({ filterFn });
+
+      expect(result).toEqual({ entity2: entities[1].entity });
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear all cached entities', async () => {
+      const mockEntity: TestEntity = { id: '1', name: 'test', value: 100 };
+      (mockProvider.fetch as jest.Mock).mockResolvedValue(mockEntity);
+
+      await catalog.get('test-key');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(1);
+
+      catalog.clearCache();
+
+      await catalog.get('test-key');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear cache populated by getAll', async () => {
+      const entities = [
+        { key: 'entity1', entity: { id: '1', name: 'first', value: 10 } },
+        { key: 'entity2', entity: { id: '2', name: 'second', value: 20 } },
+      ];
+      (mockProvider.fetchAll as jest.Mock).mockResolvedValue(entities);
+
+      await catalog.getAll();
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(1);
+
+      catalog.clearCache();
+
+      await catalog.getAll();
+      expect(mockProvider.fetchAll).toHaveBeenCalledTimes(2);
+    });
+
+    it('should allow clearing an empty cache without errors', () => {
+      expect(() => catalog.clearCache()).not.toThrow();
+    });
+
+    it('should clear multiple cached entries', async () => {
+      const entity1: TestEntity = { id: '1', name: 'first', value: 10 };
+      const entity2: TestEntity = { id: '2', name: 'second', value: 20 };
+      const entity3: TestEntity = { id: '3', name: 'third', value: 30 };
+      (mockProvider.fetch as jest.Mock)
+        .mockResolvedValueOnce(entity1)
+        .mockResolvedValueOnce(entity2)
+        .mockResolvedValueOnce(entity3);
+
+      await catalog.get('key1');
+      await catalog.get('key2');
+      await catalog.get('key3');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(3);
+
+      catalog.clearCache();
+
+      (mockProvider.fetch as jest.Mock)
+        .mockResolvedValueOnce(entity1)
+        .mockResolvedValueOnce(entity2)
+        .mockResolvedValueOnce(entity3);
+
+      await catalog.get('key1');
+      await catalog.get('key2');
+      await catalog.get('key3');
+      expect(mockProvider.fetch).toHaveBeenCalledTimes(6);
+    });
+
+    it('should be callable multiple times', () => {
+      expect(() => {
+        catalog.clearCache();
+        catalog.clearCache();
+        catalog.clearCache();
+      }).not.toThrow();
+    });
+  });
+
+  it('should maintain cache integrity after partial failures', async () => {
+    const goodEntity: TestEntity = { id: '1', name: 'good', value: 50 };
+    (mockProvider.fetch as jest.Mock)
+      .mockResolvedValueOnce(goodEntity)
+      .mockRejectedValueOnce(new Error('Fetch failed'))
+      .mockResolvedValueOnce(goodEntity);
+
+    await catalog.get('good-key');
+
+    await expect(catalog.get('bad-key')).rejects.toThrow('Fetch failed');
+
+    const result = await catalog.get('good-key');
+    expect(result).toBe(goodEntity);
+  });
+});

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.ts
@@ -1,0 +1,56 @@
+import { isDefined } from '@kaoto/forms';
+
+import { ICatalogProvider, IDynamicCatalog } from './models';
+
+export class DynamicCatalog<T = unknown> implements IDynamicCatalog<T> {
+  protected readonly cache: Record<string, T> = {};
+
+  constructor(protected readonly provider: ICatalogProvider<T>) {}
+
+  async get(key: string, options: { forceFresh?: boolean } = {}): Promise<T | undefined> {
+    if (!options.forceFresh && isDefined(this.cache[key])) {
+      return this.cache[key];
+    }
+
+    const entity = await this.provider.fetch(key);
+    if (entity !== undefined) {
+      this.cache[key] = entity;
+    }
+
+    return entity;
+  }
+
+  async getAll(
+    options: { forceFresh?: boolean; filterFn?: (key: string, entity: T) => boolean } = {},
+  ): Promise<Record<string, T>> {
+    if (options.forceFresh || Object.keys(this.cache).length === 0) {
+      const entities = await this.provider.fetchAll();
+      if (Array.isArray(entities)) {
+        entities.forEach(({ key, entity }) => {
+          this.cache[key] = entity;
+        });
+      }
+    }
+
+    const { filterFn } = options;
+    if (typeof filterFn === 'function') {
+      return Object.entries(this.cache)
+        .filter(([key, entity]) => filterFn(key, entity))
+        .reduce(
+          (catalog, [key, entity]) => {
+            catalog[key] = entity;
+            return catalog;
+          },
+          {} as Record<string, T>,
+        );
+    }
+
+    return this.cache;
+  }
+
+  clearCache(): void {
+    Object.keys(this.cache).forEach((key) => {
+      delete this.cache[key];
+    });
+  }
+}

--- a/packages/ui/src/dynamic-catalog/index.ts
+++ b/packages/ui/src/dynamic-catalog/index.ts
@@ -1,0 +1,3 @@
+export * from './dynamic-catalog-registry';
+export * from './dynamic-catalog-registry.context';
+export * from './dynamic-catalog-registry.provider';

--- a/packages/ui/src/dynamic-catalog/models.ts
+++ b/packages/ui/src/dynamic-catalog/models.ts
@@ -1,0 +1,49 @@
+import { KaotoFunction } from '@kaoto/camel-catalog/types';
+
+import {
+  ICamelComponentDefinition,
+  ICamelDataformatDefinition,
+  ICamelLanguageDefinition,
+  ICamelProcessorDefinition,
+  IKameletDefinition,
+} from '../models';
+import { CatalogKind } from '../models/catalog-kind';
+
+export type DynamicCatalogTypeMap = {
+  [CatalogKind.Component]: ICamelComponentDefinition;
+  [CatalogKind.Processor]: ICamelProcessorDefinition;
+  [CatalogKind.Pattern]: ICamelProcessorDefinition;
+  [CatalogKind.Entity]: ICamelProcessorDefinition;
+  [CatalogKind.Language]: ICamelLanguageDefinition;
+  [CatalogKind.Dataformat]: ICamelDataformatDefinition;
+  [CatalogKind.Loadbalancer]: ICamelProcessorDefinition;
+  [CatalogKind.Kamelet]: IKameletDefinition;
+  [CatalogKind.Function]: KaotoFunction;
+};
+
+export interface ICatalogProvider<T> {
+  readonly id: string;
+  fetch(key: string): Promise<T | undefined>;
+  fetchAll(): Promise<Array<{ key: string; entity: T }>>;
+}
+
+export interface IDynamicCatalog<T> {
+  get(key: string, options?: { forceFresh?: boolean }): Promise<T | undefined>;
+  getAll(options?: {
+    forceFresh?: boolean;
+    filterFn?: (key: string, entity: T) => boolean;
+  }): Promise<Record<string, T> | undefined>;
+  clearCache(): void;
+}
+
+export interface IDynamicCatalogRegistry {
+  setCatalog<K extends CatalogKind>(kind: K, catalog: IDynamicCatalog<DynamicCatalogTypeMap[K]>): void;
+  getCatalog<K extends CatalogKind>(kind: K): IDynamicCatalog<DynamicCatalogTypeMap[K]> | undefined;
+
+  getEntity<K extends CatalogKind>(
+    kind: K,
+    key: string,
+    options?: { forceFresh?: boolean },
+  ): Promise<DynamicCatalogTypeMap[K] | undefined>;
+  clearRegistry(): void;
+}

--- a/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
+++ b/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
@@ -1,8 +1,9 @@
 import { VisualizationProvider } from '@patternfly/react-topology';
-import React, { useContext, useEffect, useLayoutEffect, useMemo } from 'react';
+import { FunctionComponent, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
 
 import { Visualization } from '../../components/Visualization';
 import { ControllerService } from '../../components/Visualization/Canvas/controller.service';
+import { DynamicCatalogRegistryProvider } from '../../dynamic-catalog';
 import {
   CatalogLoaderProvider,
   EntitiesContext,
@@ -15,7 +16,7 @@ import {
 } from '../../providers';
 import { EventNotifier } from '../../utils';
 
-const VisibleFlowsVisualization: React.FC<{ className?: string }> = ({ className = '' }) => {
+const VisibleFlowsVisualization: FunctionComponent<{ className?: string }> = ({ className = '' }) => {
   const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
   const entitiesContext = useContext(EntitiesContext);
   const visualEntities = entitiesContext?.visualEntities ?? [];
@@ -27,22 +28,24 @@ const VisibleFlowsVisualization: React.FC<{ className?: string }> = ({ className
   return <Visualization className={`canvas-page ${className}`} entities={visualEntities} />;
 };
 
-const Viz: React.FC<{ catalogUrl: string; className?: string }> = ({ catalogUrl, className = '' }) => {
+const Viz: FunctionComponent<{ catalogUrl: string; className?: string }> = ({ catalogUrl, className = '' }) => {
   const controller = useMemo(() => ControllerService.createController(), []);
 
   return (
     <ReloadProvider>
-      <RuntimeProvider catalogUrl={catalogUrl}>
-        <SchemasLoaderProvider>
-          <CatalogLoaderProvider>
-            <VisualizationProvider controller={controller}>
-              <VisibleFlowsProvider>
-                <VisibleFlowsVisualization className={`canvas-page ${className}`} />
-              </VisibleFlowsProvider>
-            </VisualizationProvider>
-          </CatalogLoaderProvider>
-        </SchemasLoaderProvider>
-      </RuntimeProvider>
+      <DynamicCatalogRegistryProvider>
+        <RuntimeProvider catalogUrl={catalogUrl}>
+          <SchemasLoaderProvider>
+            <CatalogLoaderProvider>
+              <VisualizationProvider controller={controller}>
+                <VisibleFlowsProvider>
+                  <VisibleFlowsVisualization className={`canvas-page ${className}`} />
+                </VisibleFlowsProvider>
+              </VisualizationProvider>
+            </CatalogLoaderProvider>
+          </SchemasLoaderProvider>
+        </RuntimeProvider>
+      </DynamicCatalogRegistryProvider>
     </ReloadProvider>
   );
 };

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -13,6 +13,7 @@ import { WorkspaceEdit } from '@kie-tools-core/workspace/dist/api';
 import { createRef, RefObject } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
+import { DynamicCatalogRegistryProvider } from '../dynamic-catalog';
 import { CatalogKind, StepUpdateAction } from '../models';
 import { AbstractSettingsAdapter } from '../models/settings';
 import { CatalogLoaderProvider } from '../providers/catalog.provider';
@@ -167,29 +168,31 @@ export class KaotoEditorApp implements Editor {
         <SettingsProvider adapter={this.settingsAdapter}>
           <SourceCodeProvider>
             <SourceCodeBridgeProvider ref={this.editorRef} onNewEdit={this.sendNewEdit}>
-              <RuntimeProvider catalogUrl={this.settingsAdapter.getSettings().catalogUrl}>
-                <CatalogLoaderProvider>
-                  <EntitiesProvider fileExtension={this.initArgs.fileExtension}>
-                    <KaotoBridge
-                      channelType={this.initArgs.channel}
-                      onReady={this.sendReady}
-                      setNotifications={this.sendNotifications}
-                      onStateControlCommandUpdate={this.sendStateControlCommand}
-                      getMetadata={this.getMetadata}
-                      setMetadata={this.setMetadata}
-                      getResourceContent={this.getResourceContent}
-                      saveResourceContent={this.saveResourceContent}
-                      deleteResource={this.deleteResource}
-                      askUserForFileSelection={this.askUserForFileSelection}
-                      getSuggestions={this.getSuggestions}
-                      shouldSaveSchema={false}
-                      onStepUpdated={this.onStepUpdated}
-                    >
-                      <RouterProvider router={kaotoEditorRouter} />
-                    </KaotoBridge>
-                  </EntitiesProvider>
-                </CatalogLoaderProvider>
-              </RuntimeProvider>
+              <DynamicCatalogRegistryProvider>
+                <RuntimeProvider catalogUrl={this.settingsAdapter.getSettings().catalogUrl}>
+                  <CatalogLoaderProvider>
+                    <EntitiesProvider fileExtension={this.initArgs.fileExtension}>
+                      <KaotoBridge
+                        channelType={this.initArgs.channel}
+                        onReady={this.sendReady}
+                        setNotifications={this.sendNotifications}
+                        onStateControlCommandUpdate={this.sendStateControlCommand}
+                        getMetadata={this.getMetadata}
+                        setMetadata={this.setMetadata}
+                        getResourceContent={this.getResourceContent}
+                        saveResourceContent={this.saveResourceContent}
+                        deleteResource={this.deleteResource}
+                        askUserForFileSelection={this.askUserForFileSelection}
+                        getSuggestions={this.getSuggestions}
+                        shouldSaveSchema={false}
+                        onStepUpdated={this.onStepUpdated}
+                      >
+                        <RouterProvider router={kaotoEditorRouter} />
+                      </KaotoBridge>
+                    </EntitiesProvider>
+                  </CatalogLoaderProvider>
+                </RuntimeProvider>
+              </DynamicCatalogRegistryProvider>
             </SourceCodeBridgeProvider>
           </SourceCodeProvider>
         </SettingsProvider>


### PR DESCRIPTION
### Context
Currently, our CamelCatalogService has a synchronous API and doesn't support fetching data from remote endpoints.

This commit introduces a new `DynamicCatalog` with an `async` API and featuring a pluggable providers concept.

This architectural change allows to have different catalogs from many different sources, like remote Kamelets, Camel Forage bits, etc.

relates: https://github.com/KaotoIO/kaoto/issues/2734