### PR TITLE
Updated Poll icons EIP #2426

### DIFF
--- a/packages/ui/src/hooks/processor-icon.hook.test.tsx
+++ b/packages/ui/src/hooks/processor-icon.hook.test.tsx
@@ -1,5 +1,5 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { ArrowRightIcon, BoltIcon, DataSourceIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { ArrowRightIcon, BoltIcon, DataSourceIcon, SpinnerIcon } from '@patternfly/react-icons';
 import { renderHook } from '@testing-library/react';
 
 import { CamelCatalogService, ComponentsCatalogTypes } from '../models';
@@ -10,7 +10,7 @@ describe('useProcessorIcon', () => {
     ['from', DataSourceIcon],
     ['to', ArrowRightIcon],
     ['toD', BoltIcon],
-    ['poll', SyncAltIcon],
+    ['poll', SpinnerIcon],
   ] as const;
 
   it.each(TEST_CASES)('returns an icon and description for processorName="%s"', (name, icon) => {

--- a/packages/ui/src/hooks/processor-icon.hook.tsx
+++ b/packages/ui/src/hooks/processor-icon.hook.tsx
@@ -1,5 +1,5 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { ArrowRightIcon, BoltIcon, DataSourceIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { ArrowRightIcon, BoltIcon, DataSourceIcon, SpinnerIcon } from '@patternfly/react-icons';
 import { ElementType } from 'react';
 
 import { CamelCatalogService, CatalogKind } from '../models';
@@ -23,7 +23,7 @@ export const useProcessorIcon = (
     const toDDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'toD')?.model.description;
     description = toDDescription ? `ToD: ${toDDescription}` : '';
   } else if (processorName === 'poll') {
-    Icon = SyncAltIcon;
+    Icon = SpinnerIcon;
     const pollDescription = CamelCatalogService.getComponent(CatalogKind.Pattern, 'poll')?.model.description;
     description = pollDescription ? `Poll: ${pollDescription}` : '';
   } else {


### PR DESCRIPTION
### **Update replace & poll icons for EIP**

This PR updates the icons used for the Poll processor actions. 
The previous icons were confusing and visually similar.

### **Changes Included**
Replaced SyncAltIcon with SpinnerIcon for "Poll"
- Updated Poll icon to use SpinnerIcon (instead of SyncAltIcon)
- Updated processor-icon.hook.test.tsx to match new icons

**Before**
<img width="710" height="329" alt="Screenshot from 2025-11-21 15-16-20" src="https://github.com/user-attachments/assets/39f99ac8-10b9-4205-9586-da07fc0bbc1d" />


**After**
<img width="710" height="329" alt="Screenshot from 2025-11-21 15-15-07" src="https://github.com/user-attachments/assets/20b44082-4de0-4206-8c28-44a10f17cf89" />

fix: https://github.com/KaotoIO/kaoto/pull/2739