### PR TITLE
chore: Define `getResourcesContentByType` API

### DIFF
--- a/packages/ui/src/models/file-types.ts
+++ b/packages/ui/src/models/file-types.ts
@@ -1,0 +1,3 @@
+export const enum FileTypes {
+  Kamelets = 'kamelets',
+}

--- a/packages/ui/src/models/index.ts
+++ b/packages/ui/src/models/index.ts
@@ -6,6 +6,7 @@ export * from './camel-loadbalancers-catalog';
 export * from './camel-processors-catalog';
 export * from './camel-properties-common';
 export * from './catalog-kind';
+export * from './file-types';
 export * from './kamelets-catalog';
 export * from './kaoto-schema';
 export * from './loading-status';

--- a/packages/ui/src/multiplying-architecture/KaotoEditorChannelApi.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorChannelApi.ts
@@ -1,7 +1,7 @@
 import { Suggestion, SuggestionRequestContext } from '@kaoto/forms';
 import { KogitoEditorChannelApi } from '@kie-tools-core/editor/dist/api';
 
-import { CatalogKind, StepUpdateAction } from '../models';
+import { CatalogKind, FileTypes, StepUpdateAction } from '../models';
 import {
   CamelMainMavenInformation,
   CamelQuarkusMavenInformation,
@@ -33,6 +33,12 @@ export interface KaotoEditorChannelApi extends KogitoEditorChannelApi {
    * @param metadata The metadata to be saved
    */
   setMetadata<T>(key: string, metadata: T): Promise<void>;
+
+  /**
+   * Retrieve resources content based on the filetype filter
+   * @param filetype The file filter to use, f.i. `kamelets`, `schemas`, etc.
+   */
+  getResourcesContentByType(filetype: FileTypes): Promise<Array<{ filename: string; content: string }>>;
 
   /**
    * Retrieve resource content


### PR DESCRIPTION
### Context
As a prerequisite of consuming local Kamelets from the host application, we need to define the API to be used as the request mechanism.

### Notes
1. To be merged after: https://github.com/KaotoIO/vscode-kaoto/pull/1175
2. Relates: KaotoIO/kaoto/issues/1432
3. Relates: https://github.com/KaotoIO/kaoto/issues/2734