### PR TITLE
chore: Address SonarCloud container issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi8/nginx-122
 RUN set -x \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
-    
-ADD nginx/nginx.conf /etc/nginx/nginx.conf
-ADD packages/ui/dist .
+
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY packages/ui/dist .
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Replace `ADD` with `COPY` in `Dockerfile`

From SonarCloud:
> Using the ADD instruction instead of COPY for local resources in Dockerfiles can lead to several issues, including unexpected behavior, increased complexity, and security risks. The ADD instruction has additional features that can introduce unintended side effects, such as automatically extracting compressed files and fetching remote resources. This can make the behavior of the instruction less predictable and harder to understand or even lead to security issues, if, for example, due to a typo in the source path, the ADD instruction could fetch a remote resource instead of copying a local file.

> If you only need to copy local files or directories into your Docker image, it is recommended to use the COPY instruction instead. Only use the ADD instruction when you need its additional features, such as fetching remote resources or extracting compressed files. See also the rule S7026 for more information on using the ADD instruction to fetch remote resources.