### PR TITLE
Fix:XML - Using placeholders {{}} in parameters make the route to fail 

### DIFF
--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -351,6 +351,32 @@ describe('CamelUriHelper', () => {
     );
   });
 
+  describe('expression handling in query parameters', () => {
+    it('should not encode {{ }} expression placeholders', () => {
+      const result = CamelUriHelper['getUriStringFromParameters']('timer', 'timer:timerName', {
+        period: '{{demo.period}}',
+      });
+
+      expect(result).toBe('timer?period={{demo.period}}');
+    });
+
+    it('should not encode ${ } expression placeholders', () => {
+      const result = CamelUriHelper['getUriStringFromParameters']('direct', 'direct:channel', {
+        headerValue: '${header.foo}',
+      });
+
+      expect(result).toBe('direct?headerValue=${header.foo}');
+    });
+
+    it('should still encode literal values when needed', () => {
+      const result = CamelUriHelper['getUriStringFromParameters']('timer', 'timer:timerName', {
+        custom: 'value with space',
+      });
+
+      expect(result).toBe('timer?custom=value%20with%20space');
+    });
+  });
+
   describe('getParametersFromQueryString', () => {
     it.each([
       { queryString: undefined, result: {} },

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -63,6 +63,12 @@ export class CamelUriHelper {
     }, {} as ParsedParameters);
   }
 
+  private static readonly REGEX_EXPRESSION = /^\s*(\{\{.*\}\}|\$\{.*\})\s*$/;
+
+  private static isExpression(value: string): boolean {
+    return this.REGEX_EXPRESSION.test(value);
+  }
+
   private static createQueryString(parameters: ParsedParameters): string {
     if (!parameters || Object.keys(parameters).length === 0) {
       return '';
@@ -70,7 +76,11 @@ export class CamelUriHelper {
 
     return Object.keys(parameters)
       .filter((key) => parameters[key] !== undefined)
-      .map((key) => `${key}=${encodeURIComponent(parameters[key].toString())}`)
+      .map((key) => {
+        const rawValue = parameters[key].toString();
+        const value = this.isExpression(rawValue) ? rawValue : encodeURIComponent(rawValue);
+        return `${key}=${value}`;
+      })
       .join('&');
   }
 


### PR DESCRIPTION
**Preserve Camel Expression Placeholders During URI Serialization**

This PR fixes an issue where expression-based parameter values (e.g. {{demo.period}} or ${header.foo}) were being URL-encoded during Camel URI serialization. This caused placeholder values to be converted into their encoded forms (e.g. %7B%7Bdemo.period%7D%7D), leading to broken behavior when switching between Form and Source views or after refreshing the editor.

**Changes Made**

- Introduced a new expression detection utility
- Updated URI query parameter serialization logic to skip URL encoding for expressions
- Ensured literal values (e.g. those containing spaces) continue to be properly encoded


[Screencast from 2025-12-06 19-01-17.webm](https://github.com/user-attachments/assets/833acb8b-de59-4fdf-935c-b08d91af3d00)

Fix: https://github.com/KaotoIO/kaoto/issues/2719