### PR TITLE
fix(DataMapper): Root element choice not persisted

### DIFF
--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -1,23 +1,93 @@
-import { DocumentDefinitionType } from './document';
+import { DocumentDefinitionType, RootElementOption } from './document';
 import { TypeOverrideVariant } from './types';
 
+/**
+ * Represents a field type override configuration for a document field.
+ * Used to override the default type of a field with a custom type.
+ */
 export interface IFieldTypeOverride {
+  /**
+   * The path to the field in the document structure.
+   */
   path: string;
+
+  /**
+   * The new type to apply to the field.
+   */
   type: string;
+
+  /**
+   * The original type of the field before the override.
+   */
   originalType: string;
+
+  /**
+   * The variant of the type override.
+   * - SAFE: The override is safe and compatible with the original type.
+   * - FORCE: The override is forced and may not be compatible with the original type.
+   */
   variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE;
 }
 
+/**
+ * Metadata for a document used in the DataMapper.
+ * Contains information about the document's schema, file paths, and field overrides.
+ */
 export interface IDocumentMetadata {
+  /**
+   * The type of document definition (e.g., XML_SCHEMA, JSON_SCHEMA, Primitive).
+   */
   type: DocumentDefinitionType;
+
+  /**
+   * Array of file paths to the schema files associated with this document.
+   */
   filePath: string[];
+
+  /**
+   * The selected root element for XML schemas with multiple root elements.
+   * When an XML schema has multiple top-level elements, this specifies which one to use.
+   * This ensures the correct document structure is restored when reopening the DataMapper.
+   */
+  rootElementChoice?: RootElementOption;
+
+  /**
+   * Array of field type overrides to apply to the document.
+   * Allows customization of field types beyond their schema-defined types.
+   */
   fieldTypeOverrides?: IFieldTypeOverride[];
 }
 
+/**
+ * Complete metadata for a DataMapper transformation.
+ * Contains all the information needed to persist and restore a DataMapper session,
+ * including source and target documents, parameters, and the XSLT transformation.
+ */
 export interface IDataMapperMetadata {
+  /**
+   * The file path to the XSLT transformation file.
+   */
   xsltPath: string;
+
+  /**
+   * Map of source parameter names to their document metadata.
+   * Parameters are additional inputs to the transformation beyond the main source body.
+   */
   sourceParameters: Record<string, IDocumentMetadata>;
+
+  /**
+   * Metadata for the main source document body.
+   */
   sourceBody: IDocumentMetadata;
+
+  /**
+   * Metadata for the target document body.
+   */
   targetBody: IDocumentMetadata;
+
+  /**
+   * Optional mapping of namespace prefixes to namespace URIs.
+   * Used for resolving XML namespaces in the transformation.
+   */
   namespaceMap?: Record<string, string>;
 }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2780


https://github.com/user-attachments/assets/8411afb2-14b1-40ca-a058-15c4067b2bb3

