### PR TITLE
fix(DataMapper): Replace useState + useRef with useRef

### DIFF
--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -1,7 +1,7 @@
 import './SourceTargetView.scss';
 
 import { Split, SplitItem } from '@patternfly/react-core';
-import { FunctionComponent, useEffect, useRef } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 
 import { useCanvas } from '../../hooks/useCanvas';
 import { useMappingLinks } from '../../hooks/useMappingLinks';
@@ -12,13 +12,7 @@ import { TargetPanel } from './TargetPanel';
 
 export const SourceTargetView: FunctionComponent = () => {
   const { reloadNodeReferences, setDefaultHandler } = useCanvas();
-  const { setMappingLinkCanvasRef } = useMappingLinks();
-  const mappingLinkCanvasRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setMappingLinkCanvasRef(mappingLinkCanvasRef);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { mappingLinkCanvasRef } = useMappingLinks();
 
   useEffect(() => {
     setDefaultHandler(new SourceTargetDnDHandler());

--- a/packages/ui/src/providers/data-mapping-links.provider.tsx
+++ b/packages/ui/src/providers/data-mapping-links.provider.tsx
@@ -3,10 +3,10 @@ import {
   FunctionComponent,
   MutableRefObject,
   PropsWithChildren,
-  RefObject,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -15,8 +15,7 @@ import { IMappingLink, NodeReference } from '../models/datamapper';
 import { MappingLinksService } from '../services/mapping-links.service';
 
 export interface IMappingLinksContext {
-  mappingLinkCanvasRef: RefObject<HTMLDivElement> | null;
-  setMappingLinkCanvasRef: (ref: RefObject<HTMLDivElement>) => void;
+  mappingLinkCanvasRef: MutableRefObject<HTMLDivElement | null>;
   getMappingLinks: () => IMappingLink[];
   getSelectedNodeReference: () => MutableRefObject<NodeReference> | null;
   setSelectedNodeReference: (ref: MutableRefObject<NodeReference> | null) => void;
@@ -28,9 +27,9 @@ export const MappingLinksContext = createContext<IMappingLinksContext | undefine
 
 export const MappingLinksProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { mappingTree, sourceParameterMap, sourceBodyDocument } = useDataMapper();
-  const [mappingLinkCanvasRef, setMappingLinkCanvasRef] = useState<RefObject<HTMLDivElement> | null>(null);
   const [mappingLinks, setMappingLinks] = useState<IMappingLink[]>([]);
   const [selectedNodeRef, setSelectedNodeRef] = useState<MutableRefObject<NodeReference> | null>(null);
+  const mappingLinkCanvasRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const links = MappingLinksService.extractMappingLinks(
@@ -44,7 +43,7 @@ export const MappingLinksProvider: FunctionComponent<PropsWithChildren> = ({ chi
 
   const toggleSelectedNodeReference = useCallback(
     (ref: MutableRefObject<NodeReference> | null) => {
-      setSelectedNodeRef(ref !== selectedNodeRef ? ref : null);
+      setSelectedNodeRef(ref === selectedNodeRef ? null : ref);
     },
     [selectedNodeRef],
   );
@@ -58,7 +57,6 @@ export const MappingLinksProvider: FunctionComponent<PropsWithChildren> = ({ chi
   const value = useMemo(() => {
     return {
       mappingLinkCanvasRef,
-      setMappingLinkCanvasRef,
       getMappingLinks: () => mappingLinks,
       getSelectedNodeReference: () => selectedNodeRef,
       setSelectedNodeReference: setSelectedNodeRef,


### PR DESCRIPTION
### Context
Currently, we're setting the reference to the mapping links area using a `useState` hook to store it.

### Changes
Since this rerender is not necessary, we can skip the `useState` hook and use a `useRef` directly instead. This simplifies the `MappingLinksContext`'s API.

This is also a prerequisite of updating React to v19.