### PR TITLE
Added disable option for datamapper step

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -758,4 +758,24 @@ describe('CamelComponentSchemaService', () => {
       });
     });
   });
+
+  describe('canBeDisabled', () => {
+    it('should allow disabling DataMapper', () => {
+      const result = CamelComponentSchemaService.canBeDisabled(DATAMAPPER_ID_PREFIX);
+
+      expect(result).toBe(true);
+    });
+
+    it('should allow disabling processors that define disabled in schema', () => {
+      const result = CamelComponentSchemaService.canBeDisabled('log' as keyof ProcessorDefinition);
+
+      expect(result).toBe(true);
+    });
+
+    it('should not allow disabling processors without disabled property', () => {
+      const result = CamelComponentSchemaService.canBeDisabled('from' as keyof ProcessorDefinition);
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -396,6 +396,10 @@ export class CamelComponentSchemaService {
   }
 
   static canBeDisabled(processorName: keyof ProcessorDefinition): boolean {
+    if (processorName == DATAMAPPER_ID_PREFIX) {
+      return true;
+    }
+
     const processorDefinition = CamelCatalogService.getComponent(CatalogKind.Processor, processorName);
 
     return Object.keys(processorDefinition?.properties ?? {}).includes('disabled');


### PR DESCRIPTION

This change enables the Disable action for DataMapper steps in the node context menu. DataMapper is a synthetic Kaoto construct and is not backed by the Camel processor schema, so it previously could not expose the Disable capability, which is derived from schema metadata for standard EIPs.

To address this, the Disable capability is explicitly enabled for DataMapper in the capability check, aligning its behavior with other single-step processors. 

FIxes: https://github.com/KaotoIO/kaoto/issues/2546
