### PR TITLE
Fixed expand button on attributes

### DIFF
--- a/packages/ui/src/components/Document/SourceDocumentNode.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.tsx
@@ -36,12 +36,13 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
   const nodeData = treeNode.nodeData;
 
   const isDocument = VisualizationService.isDocumentNode(nodeData);
-  const hasChildren = VisualizationService.hasChildren(nodeData);
+  const isAttributeField = VisualizationService.isAttributeField(nodeData);
+  const hasChildren = !isAttributeField && VisualizationService.hasChildren(nodeData);
 
   const handleClickToggle = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation();
-      if (!hasChildren) return;
+      if (isAttributeField || !hasChildren) return;
 
       TreeUIService.toggleNode(documentId, treeNode.path);
       reloadNodeReferences();
@@ -50,7 +51,6 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
   );
 
   const isCollectionField = VisualizationService.isCollectionField(nodeData);
-  const isAttributeField = VisualizationService.isAttributeField(nodeData);
   const isDraggable = !isDocument || VisualizationService.isPrimitiveDocumentNode(nodeData);
   const headerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -40,12 +40,13 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
 
   const isDocument = VisualizationService.isDocumentNode(nodeData);
   const isPrimitive = VisualizationService.isPrimitiveDocumentNode(nodeData);
-  const hasChildren = VisualizationService.hasChildren(nodeData);
+  const isAttributeField = VisualizationService.isAttributeField(nodeData);
+  const hasChildren = !isAttributeField && VisualizationService.hasChildren(nodeData);
 
   const handleClickToggle = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation();
-      if (!hasChildren) return;
+      if (isAttributeField || !hasChildren) return;
 
       TreeUIService.toggleNode(documentId, treeNode.path);
       reloadNodeReferences();
@@ -53,7 +54,6 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
     [hasChildren, documentId, treeNode.path, reloadNodeReferences],
   );
   const isCollectionField = VisualizationService.isCollectionField(nodeData);
-  const isAttributeField = VisualizationService.isAttributeField(nodeData);
   const isDraggable = !isDocument || VisualizationService.isPrimitiveDocumentNode(nodeData);
   const headerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
### Fixed incorrect expand icon shown for XML attribute fields in DataMapper tree

This PR fixes an issue where XML attribute fields (for example, @value) were incorrectly rendered with an expand/collapse icon in the DataMapper document tree, primarily on the target side when using certain XSDs.

The root cause was that expandability was derived solely from hasChildren, which in some cases was temporarily true for attribute nodes during schema initialization.

Closes : https://github.com/KaotoIO/kaoto/issues/2640 