### PR TITLE
chore(test): Set longer timeout for FlowExportImage.test.tsx

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
@@ -108,9 +108,12 @@ describe('FlowExportImage', () => {
     // Button should be disabled while exporting
     expect(button).toBeDisabled();
 
-    await waitFor(() => {
-      expect(toBlob).toHaveBeenCalled();
-    });
+    await waitFor(
+      () => {
+        expect(toBlob).toHaveBeenCalled();
+      },
+      { timeout: 5000 },
+    );
 
     // After export completes, button should be enabled again
     await waitFor(() => {


### PR DESCRIPTION
Some failures like this has been observed
https://github.com/KaotoIO/kaoto/actions/runs/20788014886/job/59702822031