### PR TITLE
fix(StepToolbar): Calculate toolbar width dynamically based on visible buttons

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.scss
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.scss
@@ -1,8 +1,18 @@
 @use '../../Custom/custom';
 
+.step-toolbar-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .step-toolbar {
   @include custom.highligth {
-    display: inline-block;
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
     position: relative;
     border: 1px solid var(--custom-node-BorderColor);
     border-radius: var(--custom-node-BorderRadius);
@@ -11,6 +21,7 @@
     padding: var(--pf-t--global--spacer--sm);
 
     &__button {
+      flex-shrink: 0;
       margin-right: 1rem;
     }
 

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -55,150 +55,152 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
   const { canBeMoved: canMoveAfter, onMoveStep: onMoveAfter } = useMoveStep(vizNode, AddStepMode.AppendStep);
 
   return (
-    <div className={clsx(className, 'step-toolbar')} data-testid={dataTestId}>
-      {canDuplicate && (
-        <Button
-          icon={<BlueprintIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-duplicate"
-          variant="control"
-          title="Duplicate"
-          onClick={(event) => {
-            onDuplicate();
-            event.stopPropagation();
-          }}
-        />
-      )}
+    <div className="step-toolbar-wrapper">
+      <div className={clsx(className, 'step-toolbar')} data-testid={dataTestId}>
+        {canDuplicate && (
+          <Button
+            icon={<BlueprintIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-duplicate"
+            variant="control"
+            title="Duplicate"
+            onClick={(event) => {
+              onDuplicate();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canMoveBefore && (
-        <Button
-          icon={<AngleDoubleUpIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-move-before"
-          variant="control"
-          title="Move before"
-          onClick={(event) => {
-            onMoveBefore();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canMoveBefore && (
+          <Button
+            icon={<AngleDoubleUpIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-move-before"
+            variant="control"
+            title="Move before"
+            onClick={(event) => {
+              onMoveBefore();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canMoveAfter && (
-        <Button
-          icon={<AngleDoubleDownIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-move-after"
-          variant="control"
-          title="Move after"
-          onClick={(event) => {
-            onMoveAfter();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canMoveAfter && (
+          <Button
+            icon={<AngleDoubleDownIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-move-after"
+            variant="control"
+            title="Move after"
+            onClick={(event) => {
+              onMoveAfter();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canHaveSpecialChildren && (
-        <Button
-          icon={<CodeBranchIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-add-special"
-          variant="control"
-          title="Add branch"
-          onClick={(event) => {
-            onInsertSpecial();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canHaveSpecialChildren && (
+          <Button
+            icon={<CodeBranchIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-add-special"
+            variant="control"
+            title="Add branch"
+            onClick={(event) => {
+              onInsertSpecial();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canBeDisabled && (
-        <Button
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-disable"
-          variant="control"
-          title={isDisabled ? 'Enable step' : 'Disable step'}
-          onClick={(event) => {
-            onToggleDisableNode();
-            event.stopPropagation();
-          }}
-        >
-          {isDisabled ? <CheckIcon /> : <BanIcon />}
-        </Button>
-      )}
+        {canBeDisabled && (
+          <Button
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-disable"
+            variant="control"
+            title={isDisabled ? 'Enable step' : 'Disable step'}
+            onClick={(event) => {
+              onToggleDisableNode();
+              event.stopPropagation();
+            }}
+          >
+            {isDisabled ? <CheckIcon /> : <BanIcon />}
+          </Button>
+        )}
 
-      {areMultipleStepsDisabled && (
-        <Button
-          icon={<PowerOffIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-enable-all"
-          variant="control"
-          title="Enable all"
-          onClick={(event) => {
-            onEnableAllSteps();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {areMultipleStepsDisabled && (
+          <Button
+            icon={<PowerOffIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-enable-all"
+            variant="control"
+            title="Enable all"
+            onClick={(event) => {
+              onEnableAllSteps();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canReplaceStep && (
-        <Button
-          icon={<SyncAltIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-replace"
-          variant="control"
-          title="Replace step"
-          onClick={(event) => {
-            onReplaceNode();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canReplaceStep && (
+          <Button
+            icon={<SyncAltIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-replace"
+            variant="control"
+            title="Replace step"
+            onClick={(event) => {
+              onReplaceNode();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {onCollapseToggle && (
-        <Button
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-collapse"
-          variant="control"
-          title={isCollapsed ? 'Expand step' : 'Collapse step'}
-          onClick={(event) => {
-            onCollapseToggle();
-            event.stopPropagation();
-          }}
-        >
-          {isCollapsed ? <ExpandArrowsAltIcon /> : <CompressArrowsAltIcon />}
-        </Button>
-      )}
+        {onCollapseToggle && (
+          <Button
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-collapse"
+            variant="control"
+            title={isCollapsed ? 'Expand step' : 'Collapse step'}
+            onClick={(event) => {
+              onCollapseToggle();
+              event.stopPropagation();
+            }}
+          >
+            {isCollapsed ? <ExpandArrowsAltIcon /> : <CompressArrowsAltIcon />}
+          </Button>
+        )}
 
-      {canRemoveStep && (
-        <Button
-          icon={<TrashIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-delete"
-          variant="stateful"
-          state="attention"
-          title="Delete step"
-          onClick={(event) => {
-            onDeleteStep();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canRemoveStep && (
+          <Button
+            icon={<TrashIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-delete"
+            variant="stateful"
+            state="attention"
+            title="Delete step"
+            onClick={(event) => {
+              onDeleteStep();
+              event.stopPropagation();
+            }}
+          />
+        )}
 
-      {canRemoveFlow && (
-        <Button
-          icon={<TrashIcon />}
-          className="step-toolbar__button"
-          data-testid="step-toolbar-button-delete-group"
-          variant="stateful"
-          state="attention"
-          title="Delete group"
-          onClick={(event) => {
-            onDeleteGroup();
-            event.stopPropagation();
-          }}
-        />
-      )}
+        {canRemoveFlow && (
+          <Button
+            icon={<TrashIcon />}
+            className="step-toolbar__button"
+            data-testid="step-toolbar-button-delete-group"
+            variant="stateful"
+            state="attention"
+            title="Delete group"
+            onClick={(event) => {
+              onDeleteGroup();
+              event.stopPropagation();
+            }}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.defaults.ts
@@ -17,7 +17,8 @@ export class CanvasDefaults {
 
   static readonly DEFAULT_GROUP_PADDING = 40;
 
-  static readonly STEP_TOOLBAR_WIDTH = 350;
+  /* Making the step toolbar narrower and center it via CSS */
+  static readonly STEP_TOOLBAR_WIDTH = 60;
   static readonly STEP_TOOLBAR_HEIGHT = 60;
 
   static readonly HOVER_DELAY_IN = 200;

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -76,8 +76,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
       boxRef.current = element.getBounds();
     }
 
-    const toolbarWidth = Math.max(CanvasDefaults.STEP_TOOLBAR_WIDTH, boxRef.current.width);
-    const toolbarX = boxRef.current.x + (boxRef.current.width - toolbarWidth) / 2;
+    const toolbarX = boxRef.current.x + (boxRef.current.width - CanvasDefaults.STEP_TOOLBAR_WIDTH) / 2;
     const toolbarY = boxRef.current.y - CanvasDefaults.STEP_TOOLBAR_HEIGHT;
     const addStepX = isHorizontal
       ? boxRef.current.x + boxRef.current.width
@@ -153,7 +152,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
                 className="custom-group__toolbar"
                 x={toolbarX}
                 y={toolbarY}
-                width={toolbarWidth}
+                width={CanvasDefaults.STEP_TOOLBAR_WIDTH}
                 height={CanvasDefaults.STEP_TOOLBAR_HEIGHT}
               >
                 <StepToolbar


### PR DESCRIPTION
### Context
The StepToolbar was overflowing horizontally when nodes had multiple available actions, causing buttons to wrap to multiple rows instead of displaying in a single row.

### Changes
- Reduce the toolbar width to be the same size as a node
- Updates CustomGroupExpanded to use the static toolbar width
- Updates StepToolbar.scss to add a step-toolbar-wrapper class to center the toolbar within the foreignObject and use flexbox with nowrap to prevent button wrapping

Since the `foreignObject` is narrower, it helps when transitioning between nested containers like `choice` and `when`

| Before | After |
| --- | --- |
| <img width="371" height="490" alt="image" src="https://github.com/user-attachments/assets/4c2b869c-b235-4f52-a57d-fd6d2b764e7a" /> | <img width="392" height="491" alt="image" src="https://github.com/user-attachments/assets/2f146fff-7544-4471-ad6d-5977c2e1b272" /> }


fix: https://github.com/KaotoIO/kaoto/issues/2425

Co-authored with Claude Code