### PR TITLE
fix(DataMapper): Prevent expand button on XML attributes with complexType references

### DIFF
--- a/packages/ui/src/services/document.service.ts
+++ b/packages/ui/src/services/document.service.ts
@@ -247,6 +247,8 @@ export class DocumentService {
   }
 
   static hasChildren(field: IField) {
+    // Attributes cannot have children in XML Schema
+    if (field.isAttribute) return false;
     return field.fields.length > 0 || field.namedTypeFragmentRefs.length > 0;
   }
 


### PR DESCRIPTION
XML attributes with complex type references (e.g., FHIR XSD where attributes extend from Element) were showing expand buttons because DocumentService.hasChildren() only checked for child fields or type references, without verifying if the field was an attribute. In XML Schema, attributes are always atomic and cannot have children.


Added check in DocumentService.hasChildren() to return false for attributes regardless of type references.



Fixes #2640