### PR TITLE
feat(datamapper): add asterisks to required fields

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle.scss
@@ -18,3 +18,7 @@
     display: table-cell;
   }
 }
+
+span.required-information {
+  color: #b1380b;
+}

--- a/packages/ui/src/components/Document/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.test.tsx
@@ -129,6 +129,32 @@ describe('NodeTitle', () => {
     });
   });
 
+  it('should display an asterisk when the field information is required', async () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const mockField = createMockField();
+    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
+    fieldNodeData.field.minOccurs = 1;
+
+    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
+
+    const element = screen.getByText('*');
+    expect(element).toBeVisible();
+  });
+
+  it('should not display an asterisk when the field information is optional', async () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const mockField = createMockField();
+    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
+    fieldNodeData.field.minOccurs = 0;
+
+    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
+
+    const element = screen.queryByText('*');
+    expect(element).not.toBeInTheDocument();
+  });
+
   it('should not display popover for MappingNodeData', async () => {
     const user = userEvent.setup();
     const targetDoc = TestUtil.createTargetOrderDoc();

--- a/packages/ui/src/components/Document/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.tsx
@@ -41,6 +41,13 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, node
     nodeData instanceof FieldItemNodeData ||
     nodeData instanceof AddMappingNodeData
   ) {
+    const requiredField = nodeData.field.minOccurs === 0 ? false : true;
+    const updatedContent = (
+      <span className={clsx('node-title__text', className)} data-rank={rank}>
+        {title} {requiredField && <span className="required-information">*</span>}
+      </span>
+    );
+
     return (
       <Popover
         triggerAction="hover"
@@ -59,7 +66,7 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, node
           </div>
         }
       >
-        {content}
+        {updatedContent}
       </Popover>
     );
   }


### PR DESCRIPTION
Adding asterisks next to the field name to mark it as required.

<img width="803" height="848" alt="Screenshot 2026-01-26 at 12 55 22" src="https://github.com/user-attachments/assets/6231b645-7053-411b-9018-1dff05384b46" />

Fix: https://github.com/KaotoIO/kaoto/issues/2359