### PR TITLE
fix(sonarqubecloud): fixed 2 issues

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.tsx
@@ -41,7 +41,7 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, node
     nodeData instanceof FieldItemNodeData ||
     nodeData instanceof AddMappingNodeData
   ) {
-    const requiredField = nodeData.field.minOccurs === 0 ? false : true;
+    const requiredField = nodeData.field.minOccurs !== 0;
     const updatedContent = (
       <span className={clsx('node-title__text', className)} data-rank={rank}>
         {title} {requiredField && <span className="required-information">*</span>}

--- a/packages/ui/src/dynamic-catalog/catalog-modal.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-modal.provider.tsx
@@ -85,7 +85,7 @@ export const CatalogModalProvider: FunctionComponent<PropsWithChildren> = (props
       }
 
       if (isDefined(catalogFilter)) {
-        const localFilteredTiles = tiles.filter(catalogFilter);
+        const localFilteredTiles = tiles.filter((element) => catalogFilter(element));
         setFilteredTiles(localFilteredTiles);
       } else {
         setFilteredTiles(tiles);


### PR DESCRIPTION
Fixed two issues from SonarQubeReport:
1. [Unnecessary use of boolean literals in conditional expression](https://sonarcloud.io/project/issues?pullRequest=2890&open=AZvr6ztuhUIQ4SgLeamF&id=KaotoIO_kaoto)
2. [Do not pass function `catalogFilter` directly to `.filter(…)`](https://sonarcloud.io/project/issues?open=AZv6ysW943HClOmbmi0_&id=KaotoIO_kaoto)

fix: https://github.com/KaotoIO/kaoto/issues/2359