### PR TITLE
Field Type Override: UI mock up

### DIFF
--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/FieldContextMenu.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/FieldContextMenu.tsx
@@ -1,0 +1,81 @@
+import { Divider, Menu, MenuContent, MenuItem, MenuList } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+
+export interface IFieldContextMenuProps {
+  fieldName: string;
+  hasOverride?: boolean;
+  isSafeOverride?: boolean;
+  isAnyType?: boolean;
+  position?: { x: number; y: number };
+  onOverrideType?: () => void;
+  onForceOverrideType?: () => void;
+  onViewOriginalType?: () => void;
+  onResetOverride?: () => void;
+  onClose?: () => void;
+}
+
+export const FieldContextMenu: FunctionComponent<IFieldContextMenuProps> = ({
+  hasOverride = false,
+  isSafeOverride = true,
+  isAnyType = false,
+  onOverrideType,
+  onForceOverrideType,
+  onViewOriginalType,
+  onResetOverride,
+  onClose,
+}) => {
+  const handleOverrideType = () => {
+    onOverrideType?.();
+    onClose?.();
+  };
+
+  const handleForceOverrideType = () => {
+    onForceOverrideType?.();
+    onClose?.();
+  };
+
+  const handleViewOriginalType = () => {
+    onViewOriginalType?.();
+    onClose?.();
+  };
+
+  const handleResetOverride = () => {
+    onResetOverride?.();
+    onClose?.();
+  };
+
+  return (
+    <Menu
+      style={{
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+        border: '1px solid #d2d2d2',
+        borderRadius: '4px',
+        backgroundColor: '#fff',
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          {isSafeOverride && <MenuItem onClick={handleOverrideType}>Override Type...</MenuItem>}
+
+          {!isAnyType && (
+            <MenuItem
+              onClick={handleForceOverrideType}
+              icon={<span style={{ color: 'var(--pf-v6-global--warning-color--100)' }}>⚠️</span>}
+            >
+              Force Override...
+            </MenuItem>
+          )}
+
+          {hasOverride && <MenuItem onClick={handleViewOriginalType}>View Original Type</MenuItem>}
+
+          {hasOverride && (
+            <>
+              <Divider />
+              <MenuItem onClick={handleResetOverride}>Reset Override</MenuItem>
+            </>
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/OverrideBadge.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/OverrideBadge.tsx
@@ -1,0 +1,21 @@
+import { Icon } from '@patternfly/react-core';
+import { WrenchIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+export interface IOverrideBadgeProps {
+  originalType?: string;
+  overriddenType?: string;
+}
+
+export const OverrideBadge: FunctionComponent<IOverrideBadgeProps> = ({ originalType, overriddenType }) => {
+  return (
+    <Icon
+      size="sm"
+      status="warning"
+      isInline
+      style={{ marginLeft: '4px', color: 'var(--pf-v6-global--warning-color--100)' }}
+    >
+      <WrenchIcon title={`Type overridden: ${originalType} → ${overriddenType}`} />
+    </Icon>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/README.md
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/README.md
@@ -1,0 +1,5 @@
+# Field Type Override UI Mockup
+
+UI mockup for Field Type Override feature (Issue https://github.com/KaotoIO/kaoto/issues/2722)
+
+This mockup demonstrates the proposed UI for field type override functionality (Issue https://github.com/KaotoIO/kaoto/issues/2715).

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverride.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverride.stories.tsx
@@ -1,0 +1,266 @@
+import { Draggable } from '@carbon/icons-react';
+import { Meta, StoryFn } from '@storybook/react';
+import { useMemo, useState } from 'react';
+
+import { FieldContextMenu } from './FieldContextMenu';
+import { OverrideBadge } from './OverrideBadge';
+import { availableSchemaFiles, mockFields, mockFieldTypes, SchemaFile } from './type-override.stub';
+import { TypeOverrideModal } from './TypeOverrideModal';
+
+export default {
+  title: 'UI Mockups/DataMapper/Field Type Override',
+} as Meta;
+
+export const InteractiveWorkflow: StoryFn = () => {
+  const [showMenu, setShowMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+  const [showModal, setShowModal] = useState(false);
+  const [selectedField, setSelectedField] = useState<(typeof mockFields)[keyof typeof mockFields] | null>(null);
+  const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const [attachedSchemas, setAttachedSchemas] = useState<SchemaFile[]>([
+    availableSchemaFiles.find((s) => s.name === 'common-schema.xsd')!,
+    availableSchemaFiles.find((s) => s.name === 'shiporder-extended.xsd')!,
+    availableSchemaFiles.find((s) => s.name === 'customer-schema.xsd')!,
+  ]);
+  const [isForceOverride, setIsForceOverride] = useState(false);
+
+  const handleContextMenu = (event: React.MouseEvent, field: (typeof mockFields)[keyof typeof mockFields]) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setSelectedField(field);
+    setMenuPosition({ x: event.clientX, y: event.clientY });
+    setShowMenu(true);
+  };
+
+  const handleOverrideType = () => {
+    setShowMenu(false);
+    setIsForceOverride(false);
+    setShowModal(true);
+  };
+
+  const handleForceOverrideType = () => {
+    setShowMenu(false);
+    setIsForceOverride(true);
+    setShowModal(true);
+  };
+
+  const handleConfirm = (type: string) => {
+    if (selectedField) {
+      setOverrides({ ...overrides, [selectedField.path]: type });
+    }
+    setShowModal(false);
+  };
+
+  const handleReset = () => {
+    if (selectedField) {
+      const newOverrides = { ...overrides };
+      delete newOverrides[selectedField.path];
+      setOverrides(newOverrides);
+    }
+    setShowMenu(false);
+  };
+
+  const hasOverride = (field: (typeof mockFields)[keyof typeof mockFields]) => {
+    return field.path in overrides;
+  };
+
+  const getOverriddenType = (field: (typeof mockFields)[keyof typeof mockFields]) => {
+    return overrides[field.path];
+  };
+
+  const handleAttachSchema = (schema: SchemaFile) => {
+    if (!attachedSchemas.find((s) => s.path === schema.path)) {
+      setAttachedSchemas([...attachedSchemas, schema]);
+    }
+  };
+
+  const customTypes = useMemo(() => {
+    return attachedSchemas.flatMap((schema) => schema.types.map((type) => ({ ...type, schemaFile: schema.name })));
+  }, [attachedSchemas]);
+
+  const getAvailableTypes = () => {
+    if (!selectedField) return { xmlSchemaTypes: [], customTypes: [] };
+
+    const allStandardTypes = mockFieldTypes.xmlSchemaStandardTypes;
+    const allCustomTypes = customTypes;
+
+    if (isForceOverride) {
+      return { xmlSchemaTypes: allStandardTypes, customTypes: allCustomTypes };
+    }
+
+    if (selectedField.compatibleTypes === 'all') {
+      return { xmlSchemaTypes: allStandardTypes, customTypes: allCustomTypes };
+    }
+
+    const compatibleTypeValues = selectedField.compatibleTypes as string[];
+    const filteredStandardTypes = allStandardTypes.filter((type) => compatibleTypeValues.includes(type.value));
+    const filteredCustomTypes = allCustomTypes.filter((type) => compatibleTypeValues.includes(type.value));
+
+    return { xmlSchemaTypes: filteredStandardTypes, customTypes: filteredCustomTypes };
+  };
+
+  const availableTypes = useMemo(() => getAvailableTypes(), [selectedField, isForceOverride, customTypes]);
+
+  return (
+    <div style={{ padding: '20px', minHeight: '400px' }}>
+      <h3>Interactive Type Override Workflow</h3>
+      <p style={{ marginBottom: '20px', color: '#6a6e73' }}>
+        Three schemas are pre-attached for demonstration. Right-click on any field to override its type. Safe override
+        shows only compatible types, while force override shows all types:
+        <br />
+        &nbsp;&nbsp;• <strong>data</strong> (xs:anyType) - Safe override: all standard types + all attached schema types
+        <br />
+        &nbsp;&nbsp;• <strong>shipTo</strong> (ShipToType) - Safe override: only ShipToExtended; Force override: all
+        types
+        <br />
+        &nbsp;&nbsp;• <strong>name</strong> (xs:string) - Safe override: only NonEmptyString; Force override: all types
+        <br />
+        <br />
+        You can upload additional schema files from within the modal.
+      </p>
+
+      <h4 style={{ marginBottom: '10px', fontSize: '14px', fontWeight: 600 }}>Fields</h4>
+
+      <div
+        style={{
+          border: '1px solid #d2d2d2',
+          borderRadius: '8px',
+          padding: '10px',
+          backgroundColor: '#fff',
+          fontFamily: 'monospace',
+          fontSize: '14px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '8px',
+            cursor: 'pointer',
+            borderRadius: '4px',
+          }}
+          onContextMenu={(e) => handleContextMenu(e, mockFields.anyTypeField)}
+        >
+          <span style={{ marginRight: '8px' }}>
+            <Draggable />
+          </span>
+          <span style={{ fontWeight: 500 }}>{mockFields.anyTypeField.name}</span>
+          <span style={{ marginLeft: '8px', color: '#6a6e73', fontSize: '12px' }}>
+            {hasOverride(mockFields.anyTypeField)
+              ? getOverriddenType(mockFields.anyTypeField)
+              : mockFields.anyTypeField.type}
+          </span>
+          {hasOverride(mockFields.anyTypeField) && (
+            <OverrideBadge
+              originalType={mockFields.anyTypeField.type}
+              overriddenType={getOverriddenType(mockFields.anyTypeField)}
+            />
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '8px',
+            cursor: 'pointer',
+            borderRadius: '4px',
+          }}
+          onContextMenu={(e) => handleContextMenu(e, mockFields.baseTypeField)}
+        >
+          <span style={{ marginRight: '8px' }}>
+            <Draggable />
+          </span>
+          <span style={{ fontWeight: 500 }}>{mockFields.baseTypeField.name}</span>
+          <span style={{ marginLeft: '8px', color: '#6a6e73', fontSize: '12px' }}>
+            {hasOverride(mockFields.baseTypeField)
+              ? getOverriddenType(mockFields.baseTypeField)
+              : mockFields.baseTypeField.type}
+          </span>
+          {hasOverride(mockFields.baseTypeField) && (
+            <OverrideBadge
+              originalType={mockFields.baseTypeField.type}
+              overriddenType={getOverriddenType(mockFields.baseTypeField)}
+            />
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '8px',
+            cursor: 'pointer',
+            borderRadius: '4px',
+          }}
+          onContextMenu={(e) => handleContextMenu(e, mockFields.regularField)}
+        >
+          <span style={{ marginRight: '8px' }}>
+            <Draggable />
+          </span>
+          <span style={{ fontWeight: 500 }}>{mockFields.regularField.name}</span>
+          <span style={{ marginLeft: '8px', color: '#6a6e73', fontSize: '12px' }}>
+            {hasOverride(mockFields.regularField)
+              ? getOverriddenType(mockFields.regularField)
+              : mockFields.regularField.type}
+          </span>
+          {hasOverride(mockFields.regularField) && (
+            <OverrideBadge
+              originalType={mockFields.regularField.type}
+              overriddenType={getOverriddenType(mockFields.regularField)}
+            />
+          )}
+        </div>
+      </div>
+
+      {showMenu && selectedField && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 999,
+          }}
+          onClick={() => setShowMenu(false)}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              left: menuPosition.x,
+              top: menuPosition.y,
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <FieldContextMenu
+              fieldName={selectedField.name}
+              hasOverride={hasOverride(selectedField)}
+              isAnyType={selectedField.isAnyType}
+              position={{ x: 0, y: 0 }}
+              onOverrideType={handleOverrideType}
+              onForceOverrideType={handleForceOverrideType}
+              onResetOverride={handleReset}
+              onClose={() => setShowMenu(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      {showModal && selectedField && (
+        <TypeOverrideModal
+          isOpen={showModal}
+          fieldPath={selectedField.path}
+          fieldName={selectedField.name}
+          originalType={selectedField.type}
+          isForceOverride={isForceOverride}
+          xmlSchemaTypes={availableTypes.xmlSchemaTypes}
+          customTypes={availableTypes.customTypes}
+          onConfirm={handleConfirm}
+          onCancel={() => setShowModal(false)}
+          onAttachSchema={handleAttachSchema}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverrideModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverrideModal.tsx
@@ -1,0 +1,209 @@
+import { Typeahead, TypeaheadItem } from '@kaoto/forms';
+import {
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  InputGroupItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Radio,
+  TextInput,
+} from '@patternfly/react-core';
+import { FileImportIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+
+import { SchemaFile } from './type-override.stub';
+
+export interface ITypeOverrideModalProps {
+  isOpen?: boolean;
+  fieldPath: string;
+  fieldName: string;
+  originalType: string;
+  isForceOverride?: boolean;
+  xmlSchemaTypes?: Array<{ value: string; label: string }>;
+  customTypes?: Array<{ value: string; label: string; schemaFile?: string }>;
+  onConfirm?: (selectedType: string, isForceOverride: boolean) => void;
+  onCancel?: () => void;
+  onAttachSchema?: (schema: SchemaFile) => void;
+}
+
+export const TypeOverrideModal: FunctionComponent<ITypeOverrideModalProps> = ({
+  isOpen = true,
+  fieldPath,
+  originalType,
+  isForceOverride = false,
+  xmlSchemaTypes = [],
+  customTypes = [],
+  onConfirm,
+  onCancel,
+  onAttachSchema,
+}) => {
+  const initialTypeSource = xmlSchemaTypes.length > 0 ? 'standard' : customTypes.length > 0 ? 'schema' : 'standard';
+  const [typeSource, setTypeSource] = useState<'standard' | 'schema'>(initialTypeSource);
+  const [selectedStandardItem, setSelectedStandardItem] = useState<TypeaheadItem | undefined>(
+    xmlSchemaTypes.length > 0
+      ? { name: xmlSchemaTypes[0].label, value: xmlSchemaTypes[0].value, description: '' }
+      : undefined,
+  );
+  const [selectedCustomItem, setSelectedCustomItem] = useState<TypeaheadItem | undefined>(
+    customTypes.length > 0 ? { name: customTypes[0].label, value: customTypes[0].value, description: '' } : undefined,
+  );
+  const [uploadFileName, setUploadFileName] = useState<string>('');
+
+  const standardTypeItems: TypeaheadItem[] = useMemo(() => {
+    return xmlSchemaTypes.map((type) => ({
+      name: type.label,
+      value: type.value,
+      description: '',
+    }));
+  }, [xmlSchemaTypes]);
+
+  const customTypeItems: TypeaheadItem[] = useMemo(() => {
+    return customTypes.map((type) => ({
+      name: type.label,
+      value: type.value,
+      description: '',
+    }));
+  }, [customTypes]);
+
+  const handleStandardTypeChange = useCallback((item?: TypeaheadItem) => {
+    setSelectedStandardItem(item);
+  }, []);
+
+  const handleCustomTypeChange = useCallback((item?: TypeaheadItem) => {
+    setSelectedCustomItem(item);
+  }, []);
+
+  const handleConfirm = () => {
+    let selectedType = '';
+    if (typeSource === 'standard') {
+      selectedType = selectedStandardItem?.value || '';
+    } else if (typeSource === 'schema') {
+      selectedType = selectedCustomItem?.value || '';
+    }
+
+    onConfirm?.(selectedType, isForceOverride);
+  };
+
+  const handleFileUpload = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.xsd,.xml';
+    input.onchange = (e: Event) => {
+      const target = e.target as HTMLInputElement;
+      if (target.files && target.files[0]) {
+        const file = target.files[0];
+        setUploadFileName(file.name);
+
+        const mockSchema: SchemaFile = {
+          name: file.name,
+          path: `/schemas/${file.name}`,
+          types: [
+            { value: 'Type1', label: 'Type1' },
+            { value: 'Type2', label: 'Type2' },
+          ],
+        };
+        onAttachSchema?.(mockSchema);
+      }
+    };
+    input.click();
+  };
+
+  return (
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} onClose={onCancel}>
+      <ModalHeader
+        title={isForceOverride ? 'Force Override Field Type' : 'Override Field Type'}
+        titleIconVariant={isForceOverride ? 'warning' : undefined}
+      />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Field Path">
+            <p>{fieldPath}</p>
+          </FormGroup>
+
+          <FormGroup label="Original Type">
+            <p>
+              <strong>{originalType}</strong>
+            </p>
+          </FormGroup>
+
+          <FormGroup label="Select Override Type">
+            {xmlSchemaTypes.length > 0 && (
+              <Radio
+                isChecked={typeSource === 'standard'}
+                name="type-source"
+                onChange={() => setTypeSource('standard')}
+                label="XML Schema standard types"
+                id="standard-types"
+                body={
+                  typeSource === 'standard' && (
+                    <Typeahead
+                      id="standard-type-select"
+                      data-testid="standard-type-select"
+                      aria-label="Select standard type"
+                      placeholder="Select a type..."
+                      selectedItem={selectedStandardItem}
+                      onChange={handleStandardTypeChange}
+                      items={standardTypeItems}
+                    />
+                  )
+                }
+              />
+            )}
+
+            {customTypes.length > 0 && (
+              <Radio
+                isChecked={typeSource === 'schema'}
+                name="type-source"
+                onChange={() => setTypeSource('schema')}
+                label="Types from attached schemas"
+                id="schema-types"
+                body={
+                  typeSource === 'schema' && (
+                    <>
+                      <Typeahead
+                        id="custom-type-select"
+                        data-testid="custom-type-select"
+                        aria-label="Select type from attached schemas"
+                        placeholder="Select a type..."
+                        selectedItem={selectedCustomItem}
+                        onChange={handleCustomTypeChange}
+                        items={customTypeItems}
+                      />
+                      <FormGroup label="Upload Additional Schema File" style={{ marginTop: '16px' }}>
+                        <InputGroup>
+                          <InputGroupItem isFill>
+                            <TextInput type="text" readOnly value={uploadFileName} placeholder="No file selected" />
+                          </InputGroupItem>
+                          <InputGroupItem>
+                            <Button
+                              icon={<FileImportIcon />}
+                              onClick={handleFileUpload}
+                              aria-label="Upload schema file"
+                            />
+                          </InputGroupItem>
+                        </InputGroup>
+                      </FormGroup>
+                    </>
+                  )
+                }
+              />
+            )}
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="confirm" variant={isForceOverride ? 'warning' : 'primary'} onClick={handleConfirm}>
+          {isForceOverride ? 'Apply Force Override' : 'Apply Override'}
+        </Button>
+        <Button key="cancel" variant="link" onClick={onCancel}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/type-override.stub.ts
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/type-override.stub.ts
@@ -1,0 +1,84 @@
+export const mockFieldTypes = {
+  xmlSchemaStandardTypes: [
+    { value: 'string', label: 'string' },
+    { value: 'integer', label: 'integer' },
+    { value: 'decimal', label: 'decimal' },
+    { value: 'boolean', label: 'boolean' },
+    { value: 'date', label: 'date' },
+    { value: 'dateTime', label: 'dateTime' },
+    { value: 'time', label: 'time' },
+    { value: 'double', label: 'double' },
+    { value: 'float', label: 'float' },
+    { value: 'long', label: 'long' },
+    { value: 'int', label: 'int' },
+    { value: 'short', label: 'short' },
+    { value: 'byte', label: 'byte' },
+  ],
+};
+
+export interface SchemaFile {
+  name: string;
+  path: string;
+  types: Array<{ value: string; label: string }>;
+}
+
+export const availableSchemaFiles: SchemaFile[] = [
+  {
+    name: 'customer-schema.xsd',
+    path: '/schemas/customer-schema.xsd',
+    types: [
+      { value: 'CustomerData', label: 'CustomerData' },
+      { value: 'CustomerInfo', label: 'CustomerInfo' },
+    ],
+  },
+  {
+    name: 'order-schema.xsd',
+    path: '/schemas/order-schema.xsd',
+    types: [
+      { value: 'OrderInfo', label: 'OrderInfo' },
+      { value: 'OrderDetails', label: 'OrderDetails' },
+    ],
+  },
+  {
+    name: 'common-schema.xsd',
+    path: '/schemas/common-schema.xsd',
+    types: [
+      { value: 'AddressType', label: 'AddressType' },
+      { value: 'NonEmptyString', label: 'NonEmptyString (restricts xs:string)' },
+    ],
+  },
+  {
+    name: 'shiporder-extended.xsd',
+    path: '/schemas/shiporder-extended.xsd',
+    types: [{ value: 'ShipToExtended', label: 'ShipToExtended (extends ShipToType)' }],
+  },
+];
+
+export const mockFields = {
+  anyTypeField: {
+    path: '/ShipOrder/data',
+    name: 'data',
+    type: 'xs:anyType',
+    isAnyType: true,
+    isForceOverride: false,
+    compatibleTypes: 'all',
+  },
+
+  baseTypeField: {
+    path: '/ShipOrder/shipTo',
+    name: 'shipTo',
+    type: 'ShipToType',
+    isAnyType: false,
+    isForceOverride: false,
+    compatibleTypes: ['ShipToExtended'],
+  },
+
+  regularField: {
+    path: '/ShipOrder/shipTo/name',
+    name: 'name',
+    type: 'xs:string',
+    isAnyType: false,
+    isForceOverride: false,
+    compatibleTypes: ['NonEmptyString'],
+  },
+};


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2722

It automatically displays under `UI Mockups / DataMapper / Field Type Override` section.
<img width="1127" height="1510" alt="Screenshot From 2026-01-26 14-38-55" src="https://github.com/user-attachments/assets/11425f15-5fe4-4566-a1f2-913696e78858" />

# TODO:
  - [x] Verify it is removed for Chromatic deployment as expected (https://github.com/KaotoIO/kaoto/pull/2888)