### PR TITLE
fix(ExpansionPanels): Fix multiple issues with panel behaviour 

### DIFF
--- a/packages/ui/src/components/ExpansionPanels/ExpansionContext.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionContext.tsx
@@ -21,6 +21,7 @@ interface ExpansionContextValue {
   unregister: (id: string) => void;
   resize: (id: string, newHeight: number, isTopHandle?: boolean) => void;
   setExpanded: (id: string, isExpanded: boolean) => void;
+  queueLayoutChange: (callback: () => void) => void;
 }
 
 export const ExpansionContext = createContext<ExpansionContextValue>({
@@ -28,4 +29,5 @@ export const ExpansionContext = createContext<ExpansionContextValue>({
   unregister: () => {},
   resize: () => {},
   setExpanded: () => {},
+  queueLayoutChange: () => {},
 });

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -8,12 +8,14 @@ describe('ExpansionPanel', () => {
   let mockUnregister: jest.Mock;
   let mockResize: jest.Mock;
   let mockSetExpanded: jest.Mock;
+  let mockQueueLayoutChange: jest.Mock;
 
   beforeEach(() => {
     mockRegister = jest.fn();
     mockUnregister = jest.fn();
     mockResize = jest.fn();
     mockSetExpanded = jest.fn();
+    mockQueueLayoutChange = jest.fn();
   });
 
   const renderPanel = (props: Partial<React.ComponentProps<typeof ExpansionPanel>> = {}) => {
@@ -30,6 +32,7 @@ describe('ExpansionPanel', () => {
           unregister: mockUnregister,
           resize: mockResize,
           setExpanded: mockSetExpanded,
+          queueLayoutChange: mockQueueLayoutChange,
         }}
       >
         <ExpansionPanel {...defaultProps} {...props} />
@@ -66,6 +69,7 @@ describe('ExpansionPanel', () => {
         unregister: mockUnregister,
         resize: mockResize,
         setExpanded: mockSetExpanded,
+        queueLayoutChange: mockQueueLayoutChange,
       };
 
       const { rerender } = render(
@@ -202,6 +206,7 @@ describe('ExpansionPanel', () => {
             unregister: mockUnregister,
             resize: mockResize,
             setExpanded: mockSetExpanded,
+            queueLayoutChange: mockQueueLayoutChange,
           }}
         >
           <ExpansionPanel id="test-panel" summary={<div>Test Summary</div>} defaultExpanded={true}>
@@ -211,6 +216,33 @@ describe('ExpansionPanel', () => {
       );
 
       expect(mockSetExpanded).toHaveBeenCalledWith('test-panel', true);
+    });
+
+    it('should queue layout change callback when onLayoutChange is provided and panel is toggled', () => {
+      const onLayoutChange = jest.fn();
+      renderPanel({ id: 'test-panel', defaultExpanded: true, onLayoutChange });
+
+      const summary = screen.getByText('Test Summary');
+
+      act(() => {
+        fireEvent.click(summary);
+      });
+
+      // Should queue a layout change callback
+      expect(mockQueueLayoutChange).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should NOT queue layout change callback when onLayoutChange is not provided', () => {
+      renderPanel({ id: 'test-panel', defaultExpanded: true });
+
+      const summary = screen.getByText('Test Summary');
+
+      act(() => {
+        fireEvent.click(summary);
+      });
+
+      // Should not queue any callback when onLayoutChange is not provided
+      expect(mockQueueLayoutChange).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -96,11 +96,12 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
     setIsExpanded(newExpanded);
     context.setExpanded(id, newExpanded);
 
-    // Notify after CSS transition completes (150ms animation + buffer)
-    // This triggers reloadNodeReferences() to update the node reference map
-    setTimeout(() => {
-      onLayoutChange?.(id);
-    }, 160);
+    // Queue layout change callback to execute after CSS transition completes
+    // The parent ExpansionPanels container listens for transitionend and flushes the queue
+    // This ensures mapping lines are recalculated when browser layout is fully settled
+    if (onLayoutChange) {
+      context.queueLayoutChange(() => onLayoutChange(id));
+    }
   };
 
   // Use refs for stable event handlers that don't change during resize


### PR DESCRIPTION
- Fix mapping lines not rendering after panel expansion (queueLayoutChange callback for deferred layout updates)
- Prevent progressive shrinking on collapse/expand cycles (equal distribution instead of proportional)
- Fix panel ordering using actual DOM order instead of React children (fixes panels inside Fragments getting wrong grid positions)
- Redistribute space when panels are dynamically added/removed
- Add unit tests for new functionality
- Add README documenting component architecture