### PR TITLE
fix(Canvas): Avoid asking clipboard permissions upon loading

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.test.tsx
@@ -79,34 +79,13 @@ describe('GraphContextMenuFn', () => {
     expect(defaultOptions.entityContextMenuFn).toHaveBeenCalledTimes(1);
   });
 
-  it('Paste menu item is disabled when canPasteEntity is false', () => {
-    const items = GraphContextMenuFn({ ...defaultOptions, canPasteEntity: false });
+  it('Paste menu item is present', () => {
+    const items = GraphContextMenuFn({ ...defaultOptions });
 
     renderWithContext(<>{items}</>);
 
     const pasteItem = screen.getByTestId('context-menu-item-paste');
-    expect(pasteItem).toHaveClass('pf-m-disabled');
-  });
-
-  it('Paste menu item is enabled when canPasteEntity is true', () => {
-    const items = GraphContextMenuFn({ ...defaultOptions, canPasteEntity: true });
-
-    renderWithContext(<>{items}</>);
-
-    const pasteItem = screen.getByTestId('context-menu-item-paste');
-    expect(pasteItem).not.toHaveClass('pf-m-disabled');
-  });
-
-  it('Paste menu item calls pasteEntity on click', () => {
-    const pasteEntity = jest.fn();
-    const items = GraphContextMenuFn({ ...defaultOptions, canPasteEntity: true, pasteEntity });
-
-    renderWithContext(<>{items}</>);
-
-    const pasteButton = screen.getByText('Paste').closest('button')!;
-    fireEvent.click(pasteButton);
-
-    expect(pasteEntity).toHaveBeenCalledTimes(1);
+    expect(pasteItem).toBeInTheDocument();
   });
 
   it('Show all menu item calls showFlows on click', () => {

--- a/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.tsx
@@ -1,7 +1,6 @@
 import { Divider } from '@patternfly/react-core';
-import { EyeIcon, EyeSlashIcon, PasteIcon, PlusIcon } from '@patternfly/react-icons';
+import { EyeIcon, EyeSlashIcon, PlusIcon } from '@patternfly/react-icons';
 import {
-  ContextMenuItem,
   ContextSubMenuItem,
   ElementContext,
   GraphComponent,
@@ -11,19 +10,16 @@ import {
 import { FunctionComponent, PropsWithChildren, ReactElement, useContext } from 'react';
 
 import { IDataTestID } from '../../../../models';
+import { ItemPasteEntity } from './ItemPasteEntity';
 import { ShowOrHideAllFlows } from './ShowOrHideAllFlows';
 import { withEntityContextMenu, WithEntityContextMenuProps } from './withEntityContextMenu';
 
 interface GraphContextMenuOptions {
   entityContextMenuFn: () => ReactElement[];
-  canPasteEntity: boolean;
-  pasteEntity: () => Promise<void>;
 }
 
 export const GraphContextMenuFn = ({
   entityContextMenuFn,
-  canPasteEntity,
-  pasteEntity,
 }: GraphContextMenuOptions): ReactElement<PropsWithChildren<IDataTestID>>[] => {
   const items: ReactElement<PropsWithChildren<IDataTestID>>[] = [
     <ShowOrHideAllFlows key="showAll" data-testid="context-menu-item-show-all" mode="showAll">
@@ -34,16 +30,7 @@ export const GraphContextMenuFn = ({
       <EyeSlashIcon />
       <span className="pf-v6-u-m-sm">Hide all</span>
     </ShowOrHideAllFlows>,
-    <Divider key="paste-divider" />,
-    <ContextMenuItem
-      key="paste-entity"
-      data-testid="context-menu-item-paste"
-      isDisabled={!canPasteEntity}
-      onClick={pasteEntity}
-    >
-      <PasteIcon />
-      <span className="pf-v6-u-m-sm">Paste</span>
-    </ContextMenuItem>,
+    <ItemPasteEntity key="paste-entity" data-testid="context-menu-item-paste" />,
   ];
 
   const entities = entityContextMenuFn();
@@ -69,13 +56,8 @@ export const GraphContextMenuFn = ({
   return items;
 };
 
-const BaseCustomGraph: FunctionComponent<WithEntityContextMenuProps> = ({
-  entityContextMenuFn,
-  canPasteEntity,
-  pasteEntity,
-  ...rest
-}) => {
-  const contextMenuFn = () => GraphContextMenuFn({ entityContextMenuFn, canPasteEntity, pasteEntity });
+const BaseCustomGraph: FunctionComponent<WithEntityContextMenuProps> = ({ entityContextMenuFn, ...rest }) => {
+  const contextMenuFn = () => GraphContextMenuFn({ entityContextMenuFn });
   const element = useContext(ElementContext);
   const EnhancedGraphComponent = withPanZoom()(withContextMenu(contextMenuFn)(GraphComponent));
 

--- a/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { usePasteEntity } from '../../../../hooks/usePasteEntity';
+import { ItemPasteEntity } from './ItemPasteEntity';
+
+jest.mock('../../../../hooks/usePasteEntity');
+
+describe('ItemPasteEntity', () => {
+  const mockUsePasteEntity = usePasteEntity as jest.MockedFunction<typeof usePasteEntity>;
+  const mockOnPasteEntity = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the paste menu item with icon and text', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    expect(screen.getByTestId('paste-item')).toBeInTheDocument();
+    expect(screen.getByText('Paste')).toBeInTheDocument();
+  });
+
+  it('is enabled when isCompatible is true', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).not.toHaveAttribute('disabled', 'true');
+  });
+
+  it('is disabled when isCompatible is false', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: false,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).toHaveAttribute('disabled');
+  });
+
+  it('calls onPasteEntity when clicked and enabled', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    const menuItem = screen.getByRole('menuitem');
+    fireEvent.click(menuItem);
+
+    expect(mockOnPasteEntity).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onPasteEntity when clicked and disabled', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: false,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    const menuItem = screen.getByTestId('paste-item');
+    fireEvent.click(menuItem);
+
+    expect(mockOnPasteEntity).not.toHaveBeenCalled();
+  });
+
+  it('renders with custom data-testid', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="custom-test-id" />);
+
+    expect(screen.getByTestId('custom-test-id')).toBeInTheDocument();
+  });
+
+  it('renders without data-testid when not provided', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    const { container } = render(<ItemPasteEntity />);
+
+    expect(screen.getByText('Paste')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid]')).not.toBeInTheDocument();
+  });
+
+  it('maintains correct structure with icon and text', () => {
+    mockUsePasteEntity.mockReturnValue({
+      isCompatible: true,
+      onPasteEntity: mockOnPasteEntity,
+    });
+
+    render(<ItemPasteEntity data-testid="paste-item" />);
+
+    const menuItem = screen.getByTestId('paste-item');
+    const icon = menuItem.querySelector('svg');
+    const text = screen.getByText('Paste');
+
+    expect(icon).toBeInTheDocument();
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveClass('pf-v6-u-m-sm');
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.tsx
@@ -1,0 +1,17 @@
+import { PasteIcon } from '@patternfly/react-icons';
+import { ContextMenuItem } from '@patternfly/react-topology';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { usePasteEntity } from '../../../../hooks/usePasteEntity';
+import { IDataTestID } from '../../../../models';
+
+export const ItemPasteEntity: FunctionComponent<PropsWithChildren<IDataTestID>> = ({ 'data-testid': dataTestId }) => {
+  const { isCompatible, onPasteEntity } = usePasteEntity();
+
+  return (
+    <ContextMenuItem data-testid={dataTestId} onClick={onPasteEntity} isDisabled={!isCompatible}>
+      <PasteIcon />
+      <span className="pf-v6-u-m-sm">Paste</span>
+    </ContextMenuItem>
+  );
+};

--- a/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.test.tsx
@@ -15,8 +15,6 @@ jest.mock('@patternfly/react-topology', () => ({
 
 describe('generateEntityContextMenu', () => {
   const createEntity = jest.fn();
-  const canPasteEntity = false;
-  const pasteEntity = jest.fn();
 
   const commonEntities = [
     {
@@ -62,8 +60,6 @@ describe('generateEntityContextMenu', () => {
       commonEntities,
       groupedEntities: {},
       createEntity,
-      canPasteEntity,
-      pasteEntity,
     });
 
     const { getByTestId } = render(<>{items}</>);
@@ -80,8 +76,6 @@ describe('generateEntityContextMenu', () => {
       commonEntities,
       groupedEntities: {},
       createEntity,
-      canPasteEntity,
-      pasteEntity,
     });
 
     const { getByTestId } = render(<>{items}</>);
@@ -98,8 +92,6 @@ describe('generateEntityContextMenu', () => {
       commonEntities: [],
       groupedEntities,
       createEntity,
-      canPasteEntity,
-      pasteEntity,
     });
 
     const { getByText, getByTestId } = render(<>{items}</>);
@@ -119,8 +111,6 @@ describe('generateEntityContextMenu', () => {
       commonEntities: [],
       groupedEntities,
       createEntity,
-      canPasteEntity,
-      pasteEntity,
     });
 
     const { getByTestId } = render(<>{items}</>);
@@ -139,8 +129,6 @@ describe('generateEntityContextMenu', () => {
       commonEntities: [],
       groupedEntities: {},
       createEntity,
-      canPasteEntity,
-      pasteEntity,
     });
     expect(items).toEqual([]);
   });

--- a/packages/ui/src/components/Visualization/Custom/Graph/withEntityContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/withEntityContextMenu.tsx
@@ -6,8 +6,6 @@ import { generateEntityContextMenu } from './generateEntityContextMenu';
 
 export interface WithEntityContextMenuProps {
   entityContextMenuFn: () => React.ReactElement[];
-  canPasteEntity: boolean;
-  pasteEntity: () => Promise<void>;
 }
 export const withEntityContextMenu = (
   WrappedComponent: ComponentType<WithEntityContextMenuProps>,
@@ -15,14 +13,7 @@ export const withEntityContextMenu = (
   const Component: FunctionComponent<WithContextMenuProps> = (props) => {
     const entityData = useCanvasEntities();
     const entityContextMenuFn = useMemo(() => () => generateEntityContextMenu(entityData), [entityData]);
-    return (
-      <WrappedComponent
-        {...props}
-        entityContextMenuFn={entityContextMenuFn}
-        canPasteEntity={entityData.canPasteEntity}
-        pasteEntity={entityData.pasteEntity}
-      />
-    );
+    return <WrappedComponent {...props} entityContextMenuFn={entityContextMenuFn} />;
   };
   return Component;
 };

--- a/packages/ui/src/hooks/useCanvasEntities.ts
+++ b/packages/ui/src/hooks/useCanvasEntities.ts
@@ -4,21 +4,17 @@ import { BaseVisualCamelEntityDefinition, BaseVisualCamelEntityDefinitionItem } 
 import { EntityType } from '../models/camel/entities';
 import { EntitiesContext } from '../providers/entities.provider';
 import { VisibleFlowsContext } from '../providers/visible-flows.provider';
-import { usePasteEntity } from './usePasteEntity';
 
 export interface CanvasEntities {
   commonEntities: BaseVisualCamelEntityDefinitionItem[];
   groupedEntities: Record<string, BaseVisualCamelEntityDefinitionItem[]>;
   createEntity: (entityType: EntityType) => void;
-  canPasteEntity: boolean;
-  pasteEntity: () => Promise<void>;
 }
 
 export const useCanvasEntities = (): CanvasEntities => {
   const { camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
   const visibleFlowsContext = useContext(VisibleFlowsContext)!;
   const groupedEntities = useRef<BaseVisualCamelEntityDefinition>(camelResource.getCanvasEntityList());
-  const { canPaste, pasteEntity } = usePasteEntity();
 
   const createEntity = useCallback(
     (entityType: EntityType) => {
@@ -34,10 +30,8 @@ export const useCanvasEntities = (): CanvasEntities => {
       commonEntities: groupedEntities.current.common,
       groupedEntities: groupedEntities.current.groups,
       createEntity,
-      canPasteEntity: canPaste,
-      pasteEntity,
     }),
-    [canPaste, createEntity, pasteEntity],
+    [createEntity],
   );
 
   return result;


### PR DESCRIPTION
### Context
Currently, copy & paste functionality for Canvas entities, requires allowing access to the clipboard right away when loading Kaoto. In addition to that, since this process happens too early in the chain, the result is always false, blocking the functionality.

The fix is to delay accessing the clipboard until the context menu is opened, this way, we get fresh results every time.