### PR TITLE
fix(Build): Restore Chromatic token

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -54,7 +54,7 @@ jobs:
         uses: chromaui/action@v13.3.5
         # Chromatic GitHub Action options
         with:
-          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          # This token needs to be specified directly here so forks of the repository can push their changes to the chromatic UI
+          projectToken: chpt_7d9db951361ed23
           buildScriptName: build:storybook
           workingDir: packages/ui-tests


### PR DESCRIPTION
### Context
Per the docs:

> Run Chromatic on external forks of open source projects You can enable PR checks for external forks by sharing your project token where you configured the Chromatic command (often in package.json or in the pipeline step).

> Sharing project tokens allows contributors and others to run Chromatic builds on your project, consuming your snapshot quota. They cannot access your account, settings, or accept baselines. This can be an acceptable tradeoff for open source projects that value community contributions.