### PR TITLE
feat(design): show/hide uri in forms

### DIFF
--- a/packages/ui/src/components/InlineEdit/InlineEdit.scss
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.scss
@@ -1,3 +1,8 @@
 span[data-clickable='true'] {
   cursor: pointer;
 }
+
+.inline-edit-placeholder {
+  color: var(--pf-t--global--text--color--placeholder);
+  font-style: italic;
+}

--- a/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
@@ -254,24 +254,6 @@ describe('InlineEdit', () => {
       expect(stopPropagationSpy).toHaveBeenCalled();
     });
 
-    it('should prevent the form submission', () => {
-      const submitEvent = new Event('submit', { bubbles: true });
-      const preventDefaultSpy = jest.spyOn(submitEvent, 'preventDefault');
-      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
-
-      act(() => {
-        const editButton = wrapper.getByTestId('inline--edit');
-        fireEvent.click(editButton);
-      });
-
-      act(() => {
-        const form = wrapper.getByTestId('inline--form');
-        fireEvent(form, submitEvent);
-      });
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
-    });
-
     it('should set the edit icon title', () => {
       const wrapper = render(<InlineEdit data-testid={DATA_TESTID} editTitle="Edit" />);
 
@@ -284,6 +266,30 @@ describe('InlineEdit', () => {
 
       const textSpan = wrapper.getByTestId(DATA_TESTID);
       expect(textSpan).toHaveAttribute('title', 'Edit');
+    });
+  });
+
+  describe('Placeholder', () => {
+    it('should display placeholder text when value is empty and placeholder is provided', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} placeholder="Enter value" />);
+
+      const textSpan = wrapper.getByTestId(DATA_TESTID);
+      expect(textSpan).toHaveTextContent('Enter value');
+    });
+
+    it('should display value instead of placeholder when value is provided', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} value="My value" placeholder="Enter value" />);
+
+      const textSpan = wrapper.getByTestId(DATA_TESTID);
+      expect(textSpan).toHaveTextContent('My value');
+      expect(textSpan).not.toHaveTextContent('Enter value');
+    });
+
+    it('should not display placeholder when no placeholder prop is provided', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      const textSpan = wrapper.getByTestId(DATA_TESTID);
+      expect(textSpan).toHaveTextContent('');
     });
   });
 });

--- a/packages/ui/src/components/InlineEdit/InlineEdit.tsx
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.tsx
@@ -2,7 +2,6 @@ import './InlineEdit.scss';
 
 import {
   Button,
-  Form,
   FormGroup,
   FormHelperText,
   HelperText,
@@ -12,14 +11,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { CheckIcon, ExclamationCircleIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
-import {
-  FormEventHandler,
-  FunctionComponent,
-  KeyboardEventHandler,
-  MouseEventHandler,
-  useCallback,
-  useState,
-} from 'react';
+import { FunctionComponent, KeyboardEventHandler, MouseEventHandler, useCallback, useState } from 'react';
 
 import { IDataTestID, ValidationResult, ValidationStatus } from '../../models';
 
@@ -30,6 +22,8 @@ interface IInlineEdit extends IDataTestID {
   validator?: (value: string) => ValidationResult;
   onChange?: (value: string) => void;
   onClick?: () => void;
+  placeholder?: string;
+  className?: string;
 }
 
 export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
@@ -111,10 +105,6 @@ export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
     [cancelValue],
   );
 
-  const noop: FormEventHandler<HTMLFormElement> = useCallback((event) => {
-    event.preventDefault();
-  }, []);
-
   return (
     <>
       {isReadOnly ? (
@@ -125,8 +115,9 @@ export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
             data-clickable={typeof props.onClick === 'function'}
             data-testid={props['data-testid']}
             onClick={props.onClick}
+            className={props.className ? props.className : undefined}
           >
-            {props.value}
+            {props.value || props.placeholder}
           </span>
           &nbsp;&nbsp;
           <Button
@@ -138,8 +129,8 @@ export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
           />
         </>
       ) : (
-        <Form onSubmit={noop} data-testid={props['data-testid'] + '--form'}>
-          <FormGroup type="text" fieldId="edit-value">
+        <FormGroup data-testid={props['data-testid'] + '--form'}>
+          <FormGroup type="text" fieldId="edit-value" className={props.className ? props.className : undefined}>
             <InputGroup>
               <InputGroupItem isFill>
                 <TextInput
@@ -189,7 +180,7 @@ export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
               </InputGroupItem>
             </InputGroup>
           </FormGroup>
-        </Form>
+        </FormGroup>
       )}
     </>
   );

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.scss
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.scss
@@ -1,0 +1,3 @@
+.uri-group {
+  text-transform: none;
+}

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.test.tsx
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom';
+
+import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { JSONSchema4 } from 'json-schema';
+
+import { UriField } from './UriField';
+
+describe('UriField', () => {
+  const PROP_NAME = 'uri';
+  const schema: JSONSchema4 = {
+    title: 'Uri',
+    type: 'string',
+    description: 'Sets the URI of the endpoint to use',
+  };
+
+  const renderField = (model: Record<string, unknown> = {}, onChange = jest.fn()) => {
+    render(
+      <SchemaProvider schema={schema}>
+        <ModelContextProvider model={model} onPropertyChange={onChange}>
+          <UriField propName={PROP_NAME} />
+        </ModelContextProvider>
+      </SchemaProvider>,
+    );
+  };
+
+  it('should render with existing URI value', () => {
+    renderField({ uri: 'timer:test' });
+
+    const valueElement = screen.getByTestId('uri');
+    expect(valueElement).toHaveTextContent('timer:test');
+    expect(screen.queryByText("Click to add 'uri'")).not.toBeInTheDocument();
+
+    const editButton = screen.getByTestId('uri--edit');
+    expect(editButton).toBeInTheDocument();
+  });
+
+  it('should render with empty value', () => {
+    renderField({});
+
+    const placeholder = screen.getByText("Click to add 'uri'");
+    expect(placeholder).toBeInTheDocument();
+
+    const editButton = screen.getByTestId('uri--edit');
+    expect(editButton).toBeInTheDocument();
+  });
+
+  it('should display placeholder when URI is empty string', () => {
+    renderField({ uri: '' });
+
+    const placeholder = screen.getByText("Click to add 'uri'");
+    expect(placeholder).toBeInTheDocument();
+  });
+
+  it('should call onChange when editing URI value', () => {
+    const onChangeMock = jest.fn();
+    renderField({ uri: 'timer:test' }, onChangeMock);
+
+    const editButton = screen.getByTestId('uri--edit');
+    act(() => {
+      fireEvent.click(editButton);
+    });
+
+    const input = screen.getByTestId('uri--text-input');
+    act(() => {
+      fireEvent.change(input, { target: { value: 'timer:newtest' } });
+    });
+
+    const saveButton = screen.getByTestId('uri--save');
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    expect(onChangeMock).toHaveBeenCalledWith('uri', 'timer:newtest');
+  });
+
+  it('should call onChange with undefined when clearing URI value', () => {
+    const onChangeMock = jest.fn();
+    renderField({ uri: 'timer:test' }, onChangeMock);
+
+    const editButton = screen.getByTestId('uri--edit');
+    act(() => {
+      fireEvent.click(editButton);
+    });
+
+    const input = screen.getByTestId('uri--text-input');
+    act(() => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    const saveButton = screen.getByTestId('uri--save');
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    expect(onChangeMock).toHaveBeenCalledWith('uri', undefined);
+  });
+
+  it('should not call onChange when canceling edit', () => {
+    const onChangeMock = jest.fn();
+    renderField({ uri: 'timer:test' }, onChangeMock);
+
+    const editButton = screen.getByTestId('uri--edit');
+    act(() => {
+      fireEvent.click(editButton);
+    });
+
+    const input = screen.getByTestId('uri--text-input');
+    act(() => {
+      fireEvent.change(input, { target: { value: 'timer:newtest' } });
+    });
+
+    const cancelButton = screen.getByTestId('uri--cancel');
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.tsx
@@ -1,0 +1,34 @@
+import './UriField.scss';
+
+import { FieldProps, FieldWrapper, SchemaContext, useFieldValue } from '@kaoto/forms';
+import { FunctionComponent, useContext } from 'react';
+
+import { InlineEdit } from '../../../../../InlineEdit';
+
+export const UriField: FunctionComponent<FieldProps> = ({ propName, required }) => {
+  const { schema } = useContext(SchemaContext);
+  const { value = '', onChange } = useFieldValue<string | undefined>(propName);
+
+  return (
+    <FieldWrapper
+      propName={propName}
+      required={required}
+      title={schema.title}
+      type="string"
+      description={schema.description}
+      defaultValue={schema.default?.toString()}
+    >
+      <InlineEdit
+        editTitle={`Edit ${schema.title ?? 'URI'}`}
+        textTitle={schema.title ?? 'URI'}
+        data-testid={propName}
+        value={value}
+        placeholder="Click to add 'uri'"
+        className="uri-group"
+        onChange={(newValue: string) => {
+          onChange(newValue || undefined);
+        }}
+      />
+    </FieldWrapper>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
@@ -12,6 +12,7 @@ import { customFieldsFactoryfactory } from './custom-fields-factory';
 import { DirectEndpointNameField } from './DirectEndpointNameField';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 import { MediaTypeField } from './MediaTypeField/MediaTypeField';
+import { UriField } from './UriField/UriField';
 
 describe('customFieldsFactoryfactory', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
@@ -126,6 +127,18 @@ describe('customFieldsFactoryfactory', () => {
 
   it('returns undefined if schema is empty', () => {
     const result = customFieldsFactoryfactory({});
+    expect(result).toBeUndefined();
+  });
+
+  it('returns UriField for string type with title "Uri"', () => {
+    const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'Uri' };
+    const result = customFieldsFactoryfactory(schema);
+    expect(result).toBe(UriField);
+  });
+
+  it('returns undefined for string type with case-sensitive title mismatch for Uri', () => {
+    const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'uri' };
+    const result = customFieldsFactoryfactory(schema);
     expect(result).toBeUndefined();
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -5,29 +5,56 @@ import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './B
 import { DirectEndpointNameField } from './DirectEndpointNameField';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 import { MediaTypeField } from './MediaTypeField/MediaTypeField';
+import { UriField } from './UriField/UriField';
 
-export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
-  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
-    /* Workaround for https://github.com/KaotoIO/kaoto/issues/2565 since the SNMP component has the wrong type */
-    return EnumField;
-  } else if (
+const isDirectEndpointName = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {
+  return (
     schema.type === 'string' &&
     schema.title === 'Name' &&
-    schema.description?.toLowerCase().includes('direct endpoint')
-  ) {
+    schema.description?.toLowerCase().includes('direct endpoint') === true
+  );
+};
+
+const isMediaTypeField = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {
+  return schema.type === 'string' && (schema.title === 'Consumes' || schema.title === 'Produces');
+};
+
+export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
+  /* Workaround for https://github.com/KaotoIO/kaoto/issues/2565 since the SNMP component has the wrong type */
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return EnumField;
+  }
+
+  if (isDirectEndpointName(schema)) {
     return DirectEndpointNameField;
-  } else if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
+  }
+
+  if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
     return PrefixedBeanField;
-  } else if (schema.type === 'string' && schema.title === 'Ref') {
+  }
+
+  if (schema.type === 'string' && schema.title === 'Ref') {
     return UnprefixedBeanField;
-  } else if (schema.type === 'string' && schema.title?.includes('Data Source')) {
+  }
+
+  if (schema.type === 'string' && schema.title?.includes('Data Source')) {
     return DataSourceBeanField;
-  } else if (schema.type === 'string' && (schema.title === 'Consumes' || schema.title === 'Produces')) {
+  }
+
+  if (isMediaTypeField(schema)) {
     return MediaTypeField;
-  } else if (schema.format === 'expression' || schema.format === 'expressionProperty') {
+  }
+
+  if (schema.format === 'expression' || schema.format === 'expressionProperty') {
     return ExpressionField;
-  } else if (schema.type === 'array' && schema.title === 'Custom media types') {
+  }
+
+  if (schema.type === 'array' && schema.title === 'Custom media types') {
     return CustomMediaTypes;
+  }
+
+  if (schema.type === 'string' && schema.title === 'Uri') {
+    return UriField;
   }
 
   return undefined;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -199,6 +199,12 @@ describe('AbstractCamelVisualEntity', () => {
     });
   });
 
+  it('should return the list of fields to omit from forms', () => {
+    const result = abstractVisualEntity.getOmitFormFields();
+
+    expect(result).toEqual(['from', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally']);
+  });
+
   describe('updateModel', () => {
     it('should update the model with the new value', () => {
       const newUri = 'timer';

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -109,7 +109,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   }
 
   getOmitFormFields(): string[] {
-    return ['from', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally', 'uri'];
+    return ['from', 'outputs', 'steps', 'when', 'otherwise', 'doCatch', 'doFinally'];
   }
 
   updateModel(path: string | undefined, value: unknown): void {


### PR DESCRIPTION
This PR allows to update the uri field in the forms. The changes are the following:

- Uri is not filtered in getOmitFormFields
- A custom field component, UriField, is added specifically for uri fields that allow to edit
- InlineEdit is modified to show a placeholder that helps the user know that they need to add a URI
- Tests are added

Some examples of the implementation:

<img width="504" height="699" alt="image" src="https://github.com/user-attachments/assets/7da6e45b-8975-42ad-8dd8-d3e8152ebed6" />

<img width="504" height="699" alt="image" src="https://github.com/user-attachments/assets/5524f508-3923-48db-a545-1cd46bb1b786" />

<img width="504" height="699" alt="image" src="https://github.com/user-attachments/assets/223fbac1-a965-4414-a199-ac70fb0f8c54" />

<img width="504" height="699" alt="image" src="https://github.com/user-attachments/assets/311776c0-1c4a-4719-a179-ce747c0ac795" />


fix: https://github.com/KaotoIO/kaoto/issues/2777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline edit shows placeholder when empty.
  * New URI field with inline editing, save/clear behavior, and schema-based labels.

* **Bug Fixes / Improvements**
  * Placeholder and URI label styling refinements.
  * Edit containers accept external styling hooks for easier customization.

* **Tests**
  * Expanded tests for inline placeholder behavior.
  * Comprehensive tests added for the new URI field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->