### PR TITLE
fix(DataMapper): Distinguish elements with same local name but in a d…

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchemaButton.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchemaButton.tsx
@@ -417,7 +417,7 @@ const RootElementSelect: FunctionComponent<RootElementSelectProps> = ({ createDo
     return createDocumentResult.rootElementOptions.map((option) => ({
       name: option.name,
       value: option.name,
-      description: `Namespace URI: ${option.namespaceUri}`,
+      description: option.namespaceUri ? `Namespace URI: ${option.namespaceUri}` : undefined,
     }));
   }, [createDocumentResult?.rootElementOptions]);
 

--- a/packages/ui/src/services/xml-schema-document-util.service.ts
+++ b/packages/ui/src/services/xml-schema-document-util.service.ts
@@ -13,6 +13,7 @@ import {
 } from '../xml-schema-ts';
 import { QName } from '../xml-schema-ts/QName';
 import { XmlSchemaSimpleTypeRestriction } from '../xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction';
+import { QNameMap } from '../xml-schema-ts/utils/ObjectMap';
 import { DocumentUtilService } from './document-util.service';
 import { XmlSchemaDocument } from './xml-schema-document.model';
 
@@ -335,7 +336,7 @@ export class XmlSchemaDocumentUtilService {
    * @returns Array of root element options with namespace URI and name
    */
   static collectRootElementOptions(collection: XmlSchemaCollection): RootElementOption[] {
-    const allElements = new Map();
+    const allElements = new QNameMap<XmlSchemaElement>();
     for (const schema of collection.getXmlSchemas()) {
       for (const [key, value] of schema.getElements().entries()) {
         allElements.set(key, value);
@@ -345,7 +346,7 @@ export class XmlSchemaDocumentUtilService {
       .filter((key) => !!key.getLocalPart())
       .map<RootElementOption>((key) => ({
         namespaceUri: key.getNamespaceURI() || '',
-        name: key.getLocalPart(),
+        name: key.getLocalPart()!,
       }));
   }
 

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -147,6 +147,9 @@ export const lazyLoadingTestXsd = fs.readFileSync(path.resolve(__dirname, './xml
 export const adtInXsd = fs.readFileSync(path.resolve(__dirname, './xml/ADT_IN.xsd')).toString();
 export const adtOutXsd = fs.readFileSync(path.resolve(__dirname, './xml/ADT_OUT.xsd')).toString();
 export const elementRefXsd = fs.readFileSync(path.resolve(__dirname, './xml/element-ref.xsd')).toString();
+export const accountLcXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-lc.xsd')).toString();
+export const accountNsXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns.xsd')).toString();
+export const accountNs2Xsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns2.xsd')).toString();
 
 export class TestUtil {
   static createSourceOrderDoc() {

--- a/packages/ui/src/stubs/datamapper/xml/account-ns2.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/account-ns2.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="kaoto.datamapper.test.alternate">
+  <xs:element name="account">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="username" type="xs:string" />
+        <xs:element name="email" type="xs:string" />
+        <xs:element name="balance" type="xs:decimal" />
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
…ifferent namespace

Fixes: https://github.com/KaotoIO/kaoto/issues/2455

Use `QNameMap` instead of `Map`. Verify `collectRootElementOptions()` distinguishes the same local name element but in different namespace.

Skip `Namespace URI` if the element is in blank space
<img width="695" height="681" alt="Screenshot From 2026-01-30 16-57-01" src="https://github.com/user-attachments/assets/1c4c5c33-b919-45f4-a764-75a10fe3b7a2" />

vs. namespace URI defined
<img width="695" height="681" alt="Screenshot From 2026-01-30 16-57-22" src="https://github.com/user-attachments/assets/6b38c6ca-a6fe-438d-bf2f-767c62297d17" />
