### PR TITLE
feat(Rest): form-based Rest DSL editor for `code-first` approach

### DIFF
--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -28,6 +28,7 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
         title: 'Rest DSL',
         hidden: () => !NAVIGATION_ELEMENTS.RestDsl.includes(currentSchemaType),
         children: [
+          { title: 'Editor', to: Links.Rest },
           {
             title: 'Import',
             to: Links.RestImport,

--- a/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
+++ b/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-33"
+                  data-ouia-component-id="OUIA-Generated-NavItem-37"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -81,7 +81,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-34"
+                  data-ouia-component-id="OUIA-Generated-NavItem-38"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -141,7 +141,21 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-35"
+                  data-ouia-component-id="OUIA-Generated-NavItem-39"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Editor"
+                    href="/rest"
+                  >
+                    Editor
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-40"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -158,7 +172,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-36"
+            data-ouia-component-id="OUIA-Generated-NavItem-41"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -172,7 +186,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-37"
+            data-ouia-component-id="OUIA-Generated-NavItem-42"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -186,7 +200,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-38"
+            data-ouia-component-id="OUIA-Generated-NavItem-43"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -200,7 +214,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-39"
+            data-ouia-component-id="OUIA-Generated-NavItem-44"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -214,7 +228,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-40"
+            data-ouia-component-id="OUIA-Generated-NavItem-45"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -299,7 +313,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-9"
+                  data-ouia-component-id="OUIA-Generated-NavItem-10"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -314,7 +328,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-10"
+                  data-ouia-component-id="OUIA-Generated-NavItem-11"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -375,7 +389,21 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-11"
+                  data-ouia-component-id="OUIA-Generated-NavItem-12"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Editor"
+                    href="/rest"
+                  >
+                    Editor
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-13"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -392,7 +420,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-12"
+            data-ouia-component-id="OUIA-Generated-NavItem-14"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -406,7 +434,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-13"
+            data-ouia-component-id="OUIA-Generated-NavItem-15"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -420,7 +448,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-14"
+            data-ouia-component-id="OUIA-Generated-NavItem-16"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -434,7 +462,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-15"
+            data-ouia-component-id="OUIA-Generated-NavItem-17"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -448,7 +476,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-16"
+            data-ouia-component-id="OUIA-Generated-NavItem-18"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -533,7 +561,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-25"
+                  data-ouia-component-id="OUIA-Generated-NavItem-28"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -548,7 +576,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-26"
+                  data-ouia-component-id="OUIA-Generated-NavItem-29"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -609,7 +637,21 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-27"
+                  data-ouia-component-id="OUIA-Generated-NavItem-30"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Editor"
+                    href="/rest"
+                  >
+                    Editor
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-31"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -626,7 +668,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-28"
+            data-ouia-component-id="OUIA-Generated-NavItem-32"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -640,7 +682,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-29"
+            data-ouia-component-id="OUIA-Generated-NavItem-33"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -654,7 +696,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-30"
+            data-ouia-component-id="OUIA-Generated-NavItem-34"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -668,7 +710,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-31"
+            data-ouia-component-id="OUIA-Generated-NavItem-35"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -682,7 +724,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-32"
+            data-ouia-component-id="OUIA-Generated-NavItem-36"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -767,7 +809,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-17"
+                  data-ouia-component-id="OUIA-Generated-NavItem-19"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -782,7 +824,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-18"
+                  data-ouia-component-id="OUIA-Generated-NavItem-20"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -843,7 +885,21 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-19"
+                  data-ouia-component-id="OUIA-Generated-NavItem-21"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Editor"
+                    href="/rest"
+                  >
+                    Editor
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-22"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -860,7 +916,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-20"
+            data-ouia-component-id="OUIA-Generated-NavItem-23"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -874,7 +930,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-21"
+            data-ouia-component-id="OUIA-Generated-NavItem-24"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -888,7 +944,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-22"
+            data-ouia-component-id="OUIA-Generated-NavItem-25"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -902,7 +958,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-23"
+            data-ouia-component-id="OUIA-Generated-NavItem-26"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -916,7 +972,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-24"
+            data-ouia-component-id="OUIA-Generated-NavItem-27"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1082,6 +1138,20 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
                 >
                   <a
                     class="pf-v6-c-nav__link"
+                    data-testid="Editor"
+                    href="/rest"
+                  >
+                    Editor
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-4"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
                     data-testid="Import"
                     href="/rest/import"
                   >
@@ -1093,7 +1163,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-4"
+            data-ouia-component-id="OUIA-Generated-NavItem-5"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1107,7 +1177,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-5"
+            data-ouia-component-id="OUIA-Generated-NavItem-6"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1121,7 +1191,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-6"
+            data-ouia-component-id="OUIA-Generated-NavItem-7"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1135,7 +1205,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-7"
+            data-ouia-component-id="OUIA-Generated-NavItem-8"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1149,7 +1219,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-8"
+            data-ouia-component-id="OUIA-Generated-NavItem-9"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >

--- a/packages/ui/src/pages/RestDsl/RestDslDetails.scss
+++ b/packages/ui/src/pages/RestDsl/RestDslDetails.scss
@@ -1,0 +1,45 @@
+.rest-dsl-details-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.rest-dsl-details-panel-header {
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.rest-dsl-details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.rest-dsl-details-panel-title {
+  margin: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.rest-dsl-details-panel-body {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rest-dsl-details-to-uri-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rest-dsl-details-to-uri-row > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}

--- a/packages/ui/src/pages/RestDsl/RestDslDetails.test.tsx
+++ b/packages/ui/src/pages/RestDsl/RestDslDetails.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('@kaoto/forms', () => ({
+  CanvasFormTabsContext: React.createContext({}),
+  FieldWrapper: ({ children }: { children: React.ReactNode }) => <div data-testid="field-wrapper">{children}</div>,
+  KaotoForm: jest.fn((props) => (
+    <div data-testid="kaoto-form" data-schema={JSON.stringify(props.schema)} data-model={JSON.stringify(props.model)} />
+  )),
+  Typeahead: (props: { 'data-testid'?: string }) => <div data-testid={props['data-testid'] ?? 'typeahead'} />,
+}));
+
+import { RestDslDetails } from './RestDslDetails';
+import { RestEditorSelection } from './restDslTypes';
+
+jest.mock('../../components/Visualization/Canvas/Form/suggestions/SuggestionsProvider', () => ({
+  SuggestionRegistrar: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../../components/Visualization/Canvas/Form/fields/custom-fields-factory', () => ({
+  customFieldsFactoryfactory: jest.fn(),
+}));
+
+const baseProps = {
+  formKey: 'form-1',
+  selection: undefined as RestEditorSelection | undefined,
+  formTabsValue: {} as never,
+  toUriFieldRef: { current: null },
+  directEndpointItems: [],
+  toUriValue: '',
+  directRouteExists: false,
+  onToUriChange: jest.fn(),
+  onToUriClear: jest.fn(),
+  onCreateDirectRoute: jest.fn(),
+  onChangeProp: jest.fn(),
+};
+
+describe('RestDslDetails', () => {
+  it('renders empty state when nothing is selected', () => {
+    render(<RestDslDetails {...baseProps} />);
+
+    expect(screen.getByText('Nothing selected')).toBeInTheDocument();
+    expect(screen.getByText('Select a Rest element to start editing.')).toBeInTheDocument();
+  });
+
+  it('renders form and operation controls when selection is an operation', () => {
+    const selectedFormState = {
+      title: 'Rest Operation',
+      path: 'rest.get.0',
+      omitFields: [],
+      entity: {
+        getNodeSchema: jest.fn(() => ({ title: 'schema' })),
+        getNodeDefinition: jest.fn(() => ({ id: 'op-1' })),
+        getRootPath: jest.fn(() => 'rest.get.0'),
+        updateModel: jest.fn(),
+      },
+    };
+
+    render(
+      <RestDslDetails
+        {...baseProps}
+        selectedFormState={selectedFormState}
+        selection={{ kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 }}
+        toUriValue=""
+        directRouteExists={false}
+      />,
+    );
+
+    expect(screen.getByText('Rest Operation')).toBeInTheDocument();
+    expect(screen.getByTestId('rest-operation-to-uri')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Route' })).toBeDisabled();
+    expect(screen.getByTestId('kaoto-form')).toBeInTheDocument();
+  });
+
+  it('enables Create Route when a to-uri is set and no route exists', () => {
+    const selectedFormState = {
+      title: 'Rest Operation',
+      path: 'rest.get.0',
+      omitFields: [],
+      entity: {
+        getNodeSchema: jest.fn(() => ({})),
+        getNodeDefinition: jest.fn(() => ({})),
+        getRootPath: jest.fn(() => 'rest.get.0'),
+        updateModel: jest.fn(),
+      },
+    };
+
+    render(
+      <RestDslDetails
+        {...baseProps}
+        selectedFormState={selectedFormState}
+        selection={{ kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 }}
+        toUriValue="direct:test"
+        directRouteExists={false}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Create Route' })).toBeEnabled();
+  });
+});

--- a/packages/ui/src/pages/RestDsl/RestDslDetails.tsx
+++ b/packages/ui/src/pages/RestDsl/RestDslDetails.tsx
@@ -1,0 +1,184 @@
+import './RestDslDetails.scss';
+
+import {
+  CanvasFormTabsContext,
+  CanvasFormTabsContextResult,
+  FieldWrapper,
+  KaotoForm,
+  Typeahead,
+  TypeaheadItem,
+} from '@kaoto/forms';
+import {
+  Bullseye,
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  EmptyState,
+  EmptyStateBody,
+  Popover,
+  SplitItem,
+  Title,
+} from '@patternfly/react-core';
+import { CodeIcon, HelpIcon } from '@patternfly/react-icons';
+import { FunctionComponent, RefObject } from 'react';
+
+import { customFieldsFactoryfactory } from '../../components/Visualization/Canvas/Form/fields/custom-fields-factory';
+import { SuggestionRegistrar } from '../../components/Visualization/Canvas/Form/suggestions/SuggestionsProvider';
+import { CatalogKind } from '../../models/catalog-kind';
+import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
+import { RestEditorSelection, RestVerb, SelectedFormState, ToUriSchema } from './restDslTypes';
+
+export const getOperationFieldHelp = (verb: RestVerb, fieldName: string, fallbackTitle?: string) => {
+  const operationSchema = CamelCatalogService.getComponent(CatalogKind.Processor, verb)?.propertiesSchema;
+  const schemaProperty = operationSchema?.properties?.[fieldName] as
+    | { title?: string; description?: string; default?: unknown; type?: string; enum?: unknown[] }
+    | undefined;
+  const description = schemaProperty?.description;
+  const defaultValue = schemaProperty?.default;
+  const title = schemaProperty?.title ?? fallbackTitle ?? fieldName;
+  const type = schemaProperty?.type ?? (Array.isArray(schemaProperty?.enum) ? 'enum' : undefined);
+
+  if (!description && defaultValue === undefined) return undefined;
+
+  return (
+    <Popover
+      bodyContent={
+        <div>
+          <strong>
+            {title}
+            {type ? ` <${type}>` : ''}
+          </strong>
+          {description && <p>{description}</p>}
+          {defaultValue !== undefined && (
+            <p>
+              Default:{' '}
+              {typeof defaultValue === 'string' || typeof defaultValue === 'number' || typeof defaultValue === 'boolean'
+                ? String(defaultValue)
+                : JSON.stringify(defaultValue)}
+            </p>
+          )}
+        </div>
+      }
+      triggerAction="hover"
+      withFocusTrap={false}
+    >
+      <Button variant="plain" aria-label={`More info about ${title}`} icon={<HelpIcon />} />
+    </Popover>
+  );
+};
+
+export { OperationTypeHelp } from './components/RestDslOperationVerbSelect';
+
+type RestDslDetailsProps = {
+  formKey: string;
+  selectedFormState?: SelectedFormState;
+  selection: RestEditorSelection | undefined;
+  formTabsValue: CanvasFormTabsContextResult;
+  toUriSchema?: ToUriSchema;
+  toUriFieldRef: RefObject<HTMLDivElement | null>;
+  selectedToUriItem?: TypeaheadItem<string>;
+  directEndpointItems: TypeaheadItem<string>[];
+  toUriValue: string;
+  directRouteExists: boolean;
+  onToUriChange: (item?: TypeaheadItem<string>) => void;
+  onToUriClear: () => void;
+  onCreateDirectRoute: () => void;
+  onChangeProp: (path: string, value: unknown) => void;
+};
+
+export const RestDslDetails: FunctionComponent<RestDslDetailsProps> = ({
+  formKey,
+  selectedFormState,
+  selection,
+  formTabsValue,
+  toUriSchema,
+  toUriFieldRef,
+  selectedToUriItem,
+  directEndpointItems,
+  toUriValue,
+  directRouteExists,
+  onToUriChange,
+  onToUriClear,
+  onCreateDirectRoute,
+  onChangeProp,
+}) => {
+  return (
+    <SplitItem className="rest-dsl-page-pane rest-dsl-page-pane-form" isFilled>
+      <Card className="rest-dsl-details-panel">
+        <CardHeader className="rest-dsl-details-panel-header">
+          <div className="rest-dsl-details-header">
+            <Title headingLevel="h2" size="md" className="rest-dsl-details-panel-title">
+              {selectedFormState?.title ?? 'Details'}
+            </Title>
+          </div>
+        </CardHeader>
+        <CardBody className="rest-dsl-details-panel-body">
+          {selectedFormState ? (
+            <CanvasFormTabsContext.Provider value={formTabsValue}>
+              <SuggestionRegistrar>
+                {selection?.kind === 'operation' && (
+                  <FieldWrapper
+                    propName="to.uri"
+                    required={toUriSchema?.required ?? false}
+                    title={toUriSchema?.title ?? 'To URI'}
+                    type="string"
+                    description={toUriSchema?.description}
+                    defaultValue={toUriSchema?.defaultValue?.toString()}
+                  >
+                    <div className="rest-dsl-details-to-uri-row" ref={toUriFieldRef}>
+                      <Typeahead
+                        aria-label={toUriSchema?.title ?? 'To URI'}
+                        data-testid="rest-operation-to-uri"
+                        selectedItem={selectedToUriItem}
+                        items={directEndpointItems}
+                        placeholder="Select or write a direct endpoint"
+                        id="rest-operation-to-uri"
+                        onChange={onToUriChange}
+                        onCleanInput={onToUriClear}
+                        allowCustomInput
+                      />
+                      <Popover
+                        bodyContent={
+                          directRouteExists
+                            ? 'A route with this direct endpoint already exists.'
+                            : 'Create a new route that uses this direct endpoint as its input.'
+                        }
+                        triggerAction="hover"
+                        withFocusTrap={false}
+                      >
+                        <span>
+                          <Button
+                            variant="secondary"
+                            onClick={onCreateDirectRoute}
+                            isDisabled={!toUriValue || directRouteExists}
+                          >
+                            Create Route
+                          </Button>
+                        </span>
+                      </Popover>
+                    </div>
+                  </FieldWrapper>
+                )}
+                <KaotoForm
+                  key={formKey}
+                  schema={selectedFormState.entity.getNodeSchema(selectedFormState.path) ?? {}}
+                  model={selectedFormState.entity.getNodeDefinition(selectedFormState.path) ?? {}}
+                  onChangeProp={onChangeProp}
+                  omitFields={selectedFormState.omitFields}
+                  customFieldsFactory={customFieldsFactoryfactory}
+                />
+              </SuggestionRegistrar>
+            </CanvasFormTabsContext.Provider>
+          ) : (
+            <Bullseye>
+              <EmptyState headingLevel="h3" icon={CodeIcon} titleText="Nothing selected">
+                <EmptyStateBody>Select a Rest element to start editing.</EmptyStateBody>
+              </EmptyState>
+            </Bullseye>
+          )}
+        </CardBody>
+      </Card>
+    </SplitItem>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/RestDslNav.scss
+++ b/packages/ui/src/pages/RestDsl/RestDslNav.scss
@@ -1,0 +1,130 @@
+.rest-dsl-nav-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.rest-dsl-nav-panel-header {
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.rest-dsl-nav-panel-title {
+  margin: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.rest-dsl-nav-panel-body {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rest-dsl-nav-section-title {
+  margin-top: 8px;
+  margin-bottom: 6px;
+  font-size: var(--pf-v6-global--FontSize--md) !important;
+  font-weight: 700 !important;
+  font-variation-settings: 'wght' 700;
+  font-synthesis: weight;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--pf-v6-global--Color--100);
+}
+
+.rest-dsl-nav-section-title * {
+  font-weight: 700 !important;
+  font-variation-settings: 'wght' 700;
+  font-synthesis: weight;
+}
+
+.rest-dsl-nav-section-title-text {
+  font-size: var(--pf-v6-global--FontSize--md) !important;
+  font-weight: 700 !important;
+  font-variation-settings: 'wght' 700;
+  font-synthesis: weight;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--pf-v6-global--Color--100);
+}
+
+.rest-dsl-nav-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rest-dsl-nav-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rest-dsl-nav-empty-text {
+  margin: 0;
+  color: var(--pf-v6-global--Color--200);
+  font-size: var(--pf-v6-global--FontSize--sm);
+}
+
+.rest-dsl-nav-rest-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rest-dsl-nav-rest-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rest-dsl-nav-rest-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.rest-dsl-nav-list {
+  margin: 0;
+  padding-left: 0;
+}
+
+.rest-dsl-nav-list-nested {
+  padding-left: 16px;
+}
+
+.rest-dsl-nav-item {
+  border: none;
+  background: transparent;
+  padding: 4px 8px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rest-dsl-nav-item.pf-v6-c-button {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.rest-dsl-nav-item:hover {
+  background: var(--pf-v6-global--BackgroundColor--200);
+}
+
+.rest-dsl-nav-item-selected {
+  background: var(--pf-v6-global--BackgroundColor--100);
+  font-weight: 600;
+}

--- a/packages/ui/src/pages/RestDsl/RestDslNav.tsx
+++ b/packages/ui/src/pages/RestDsl/RestDslNav.tsx
@@ -1,0 +1,172 @@
+import './RestDslNav.scss';
+
+import { Button, Card, CardBody, CardHeader, List, ListItem, SplitItem, Title } from '@patternfly/react-core';
+import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
+import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
+import { RestDslOperationList } from './components/RestDslOperationList';
+import { RestEditorSelection, RestVerb } from './restDslTypes';
+
+type RestDslNavProps = {
+  navWidth: number | string;
+  restConfiguration?: CamelRestConfigurationVisualEntity;
+  restEntities: CamelRestVisualEntity[];
+  restMethods: RestVerb[];
+  selection: RestEditorSelection | undefined;
+  canAddRestEntities: boolean;
+  canDeleteRestEntities: boolean;
+  onCreateRestConfiguration: () => void;
+  onDeleteRestConfiguration: () => void;
+  onSelectRestConfiguration: () => void;
+  onCreateRest: () => void;
+  onDeleteRest: (restEntity: CamelRestVisualEntity) => void;
+  onSelectRest: (restId: string) => void;
+  onAddOperation: (restId: string) => void;
+  onSelectOperation: (restId: string, verb: RestVerb, index: number) => void;
+  onDeleteOperation: (restEntity: CamelRestVisualEntity, verb: RestVerb, index: number) => void;
+  getListItemClass: (selection: RestEditorSelection | undefined, target: RestEditorSelection) => string;
+};
+
+export const RestDslNav: FunctionComponent<RestDslNavProps> = ({
+  navWidth,
+  restConfiguration,
+  restEntities,
+  restMethods,
+  selection,
+  canAddRestEntities,
+  canDeleteRestEntities,
+  onCreateRestConfiguration,
+  onDeleteRestConfiguration,
+  onSelectRestConfiguration,
+  onCreateRest,
+  onDeleteRest,
+  onSelectRest,
+  onAddOperation,
+  onSelectOperation,
+  onDeleteOperation,
+  getListItemClass,
+}) => {
+  return (
+    <SplitItem className="rest-dsl-page-pane rest-dsl-page-pane-nav" style={{ flexBasis: navWidth }}>
+      <Card className="rest-dsl-nav-panel">
+        <CardHeader className="rest-dsl-nav-panel-header">
+          <div className="rest-dsl-nav-header">
+            <Title headingLevel="h2" size="md" className="rest-dsl-nav-panel-title">
+              Rest DSL
+            </Title>
+          </div>
+        </CardHeader>
+        <CardBody className="rest-dsl-nav-panel-body">
+          <div className="rest-dsl-nav-section-header">
+            <Title headingLevel="h3" className="rest-dsl-nav-section-title">
+              <span className="rest-dsl-nav-section-title-text">Rest Configuration</span>
+            </Title>
+            <div className="rest-dsl-nav-section-actions">
+              <Button
+                variant="secondary"
+                icon={<PlusIcon />}
+                onClick={onCreateRestConfiguration}
+                isDisabled={!canAddRestEntities || Boolean(restConfiguration)}
+              >
+                Add
+              </Button>
+            </div>
+          </div>
+          {restConfiguration ? (
+            <List className="rest-dsl-nav-list">
+              <ListItem>
+                <div className="rest-dsl-nav-rest-header">
+                  <Button
+                    variant="plain"
+                    className={getListItemClass(selection, { kind: 'restConfiguration' })}
+                    onClick={onSelectRestConfiguration}
+                    aria-label="Select Rest Configuration"
+                    aria-pressed={selection?.kind === 'restConfiguration'}
+                  >
+                    Rest Configuration
+                  </Button>
+                  <div className="rest-dsl-nav-rest-actions">
+                    <Button
+                      variant="plain"
+                      icon={<TrashIcon />}
+                      aria-label="Delete Rest Configuration"
+                      onClick={onDeleteRestConfiguration}
+                      isDisabled={!canDeleteRestEntities}
+                    />
+                  </div>
+                </div>
+              </ListItem>
+            </List>
+          ) : (
+            <p className="rest-dsl-nav-empty-text">No rest configuration found.</p>
+          )}
+
+          <div className="rest-dsl-nav-section-header">
+            <Title headingLevel="h3" className="rest-dsl-nav-section-title">
+              <span className="rest-dsl-nav-section-title-text">Rest Services</span>
+            </Title>
+            <div className="rest-dsl-nav-section-actions">
+              <Button variant="secondary" icon={<PlusIcon />} onClick={onCreateRest} isDisabled={!canAddRestEntities}>
+                Add
+              </Button>
+            </div>
+          </div>
+          {restEntities.length === 0 ? (
+            <p className="rest-dsl-nav-empty-text">No rest elements found.</p>
+          ) : (
+            <List className="rest-dsl-nav-list">
+              {restEntities.map((restEntity) => {
+                const restDefinition = restEntity.restDef?.rest ?? {};
+                const restLabel =
+                  (typeof restDefinition.id === 'string' && restDefinition.id.trim()) ||
+                  (typeof restDefinition.path === 'string' && restDefinition.path.trim()) ||
+                  restEntity.id ||
+                  'rest';
+                return (
+                  <ListItem key={restEntity.id}>
+                    <div className="rest-dsl-nav-rest-group">
+                      <div className="rest-dsl-nav-rest-header">
+                        <Button
+                          variant="plain"
+                          className={getListItemClass(selection, { kind: 'rest', restId: restEntity.id })}
+                          onClick={() => onSelectRest(restEntity.id)}
+                          aria-label={`Select REST service ${restLabel}`}
+                          aria-pressed={selection?.kind === 'rest' && selection.restId === restEntity.id}
+                        >
+                          {restLabel}
+                        </Button>
+                        <div className="rest-dsl-nav-rest-actions">
+                          <Button variant="link" icon={<PlusIcon />} onClick={() => onAddOperation(restEntity.id)}>
+                            Add Operation
+                          </Button>
+                          <Button
+                            variant="plain"
+                            icon={<TrashIcon />}
+                            aria-label="Delete Rest Element"
+                            onClick={() => onDeleteRest(restEntity)}
+                            isDisabled={!canDeleteRestEntities}
+                          />
+                        </div>
+                      </div>
+                      <RestDslOperationList
+                        restEntity={restEntity}
+                        restDefinition={restDefinition as Record<string, unknown>}
+                        restMethods={restMethods}
+                        selection={selection}
+                        onSelectOperation={onSelectOperation}
+                        onDeleteOperation={onDeleteOperation}
+                        getListItemClass={getListItemClass}
+                      />
+                    </div>
+                  </ListItem>
+                );
+              })}
+            </List>
+          )}
+        </CardBody>
+      </Card>
+    </SplitItem>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/RestDslPage.scss
+++ b/packages/ui/src/pages/RestDsl/RestDslPage.scss
@@ -1,0 +1,77 @@
+.rest-dsl-page {
+  height: 100%;
+  padding: 16px;
+}
+
+.rest-dsl-page-split {
+  height: 100%;
+  align-items: stretch;
+}
+
+.rest-dsl-page-pane {
+  min-height: 0;
+}
+
+.rest-dsl-page-pane-nav {
+  flex: 0 0 18rem;
+}
+
+.rest-dsl-page-pane-form {
+  flex: 1 1 0;
+}
+
+.rest-dsl-page-resize-handle {
+  width: 22px;
+  height: 100%;
+  min-height: 100%;
+  cursor: col-resize;
+  background: var(--pf-v6-global--BackgroundColor--200);
+  border-left: 1px solid var(--pf-v6-global--BorderColor--200);
+  border-right: 1px solid var(--pf-v6-global--BorderColor--200);
+  border: 0;
+  border-radius: 3px;
+  padding: 0;
+  align-self: stretch;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rest-dsl-page-resize-handle:hover,
+.rest-dsl-page-resize-handle:active {
+  background: var(--pf-v6-global--BackgroundColor--300);
+}
+
+.rest-dsl-page-resize-handle-line {
+  width: 6px;
+  height: 100%;
+  margin: 0;
+  border: 0;
+  background: var(--pf-v6-global--BorderColor--200);
+  border-radius: 3px;
+}
+
+.rest-dsl-page-resize-grip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--pf-v6-global--Color--100);
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: 3px;
+  font-weight: 700;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+@media (width <= 1200px) {
+  .rest-dsl-page-split {
+    flex-wrap: wrap;
+  }
+
+  .rest-dsl-page-pane-nav {
+    flex: 1 1 100%;
+  }
+}

--- a/packages/ui/src/pages/RestDsl/RestDslPage.tsx
+++ b/packages/ui/src/pages/RestDsl/RestDslPage.tsx
@@ -1,0 +1,213 @@
+import './RestDslPage.scss';
+
+import { CanvasFormTabsContextResult } from '@kaoto/forms';
+import { Split } from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+
+import { useRuntimeContext } from '../../hooks/useRuntimeContext/useRuntimeContext';
+import { EntityType } from '../../models/camel/entities';
+import { REST_DSL_VERBS } from '../../models/special-processors.constants';
+import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
+import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
+import { EntitiesContext } from '../../providers';
+import { ActionConfirmationModalContextProvider } from '../../providers/action-confirmation-modal.provider';
+import { setValue } from '../../utils';
+import { RestDslAddOperationModal } from './components/RestDslAddOperationModal';
+import { RestDslResizeHandle } from './components/RestDslResizeHandle';
+import { useRestDslOperations } from './hooks/useRestDslOperations';
+import { useRestDslResize } from './hooks/useRestDslResize';
+import { useRestDslSelection } from './hooks/useRestDslSelection';
+import { useRestDslToUri } from './hooks/useRestDslToUri';
+import { RestDslDetails } from './RestDslDetails';
+import { RestDslNav } from './RestDslNav';
+import { RestVerb } from './restDslTypes';
+import { collectDirectEndpoints, collectDirectRouteInputs, getListItemClass } from './utils/rest-dsl-helpers';
+
+const REST_METHODS = REST_DSL_VERBS;
+
+export const RestDslPage: FunctionComponent = () => {
+  const entitiesContext = useContext(EntitiesContext);
+  const { selectedCatalog } = useRuntimeContext();
+  const catalogKey = selectedCatalog?.version ?? selectedCatalog?.name ?? 'default';
+
+  const restConfiguration = useMemo(() => {
+    return entitiesContext?.visualEntities.find((entity) => entity.type === EntityType.RestConfiguration) as
+      | CamelRestConfigurationVisualEntity
+      | undefined;
+  }, [entitiesContext?.visualEntities]);
+
+  const restEntities = useMemo(() => {
+    return (entitiesContext?.visualEntities ?? []).filter(
+      (entity) => entity.type === EntityType.Rest,
+    ) as CamelRestVisualEntity[];
+  }, [entitiesContext?.visualEntities]);
+
+  const directRouteInputs = useMemo(
+    () => collectDirectRouteInputs(entitiesContext?.visualEntities ?? []),
+    [entitiesContext?.visualEntities],
+  );
+
+  const directEndpointItems = useMemo(
+    () => collectDirectEndpoints(entitiesContext?.visualEntities ?? []),
+    [entitiesContext?.visualEntities],
+  );
+
+  const canAddRestEntities = useMemo(() => {
+    return Boolean(entitiesContext?.camelResource && 'addNewEntity' in entitiesContext.camelResource);
+  }, [entitiesContext?.camelResource]);
+
+  const canDeleteRestEntities = useMemo(() => {
+    return Boolean(entitiesContext?.camelResource && 'removeEntity' in entitiesContext.camelResource);
+  }, [entitiesContext?.camelResource]);
+
+  const { selection, setSelection, selectedFormState } = useRestDslSelection({
+    restConfiguration,
+    restEntities,
+  });
+
+  const { navWidth, handleResizeStart } = useRestDslResize();
+
+  const formTabsValue: CanvasFormTabsContextResult = useMemo(
+    () => ({
+      selectedTab: 'All',
+      setSelectedTab: () => {},
+    }),
+    [],
+  );
+
+  const handleOnChangeProp = useCallback(
+    (path: string, value: unknown) => {
+      if (!selectedFormState || !entitiesContext) return;
+
+      let updatedValue = value;
+      if (typeof value === 'string' && value.trim() === '') {
+        updatedValue = undefined;
+      }
+
+      const newModel = selectedFormState.entity.getNodeDefinition(selectedFormState.path) ?? {};
+      setValue(newModel, path, updatedValue);
+      selectedFormState.entity.updateModel(selectedFormState.path, newModel);
+      entitiesContext.updateSourceCodeFromEntities();
+
+      // Force a lightweight rerender so nav labels based on editable model IDs update on blur/input.
+      if (path === 'id' || path === 'path') {
+        setSelection((current) => (current ? { ...current } : current));
+      }
+    },
+    [entitiesContext, selectedFormState, setSelection],
+  );
+
+  const {
+    toUriValue,
+    toUriFieldRef,
+    toUriSchema,
+    selectedToUriItem,
+    directRouteExists,
+    handleToUriChange,
+    handleToUriClear,
+    handleCreateDirectRoute,
+  } = useRestDslToUri({
+    selection,
+    selectedFormState,
+    restEntities,
+    directEndpointItems,
+    directRouteInputs,
+    canAddRestEntities,
+    onChangeProp: handleOnChangeProp,
+  });
+
+  const {
+    isAddOperationOpen,
+    addOperationRestId,
+    openAddOperationModal,
+    closeAddOperationModal,
+    handleCreateOperation,
+    handleCreateRestConfiguration,
+    handleCreateRest,
+    handleDeleteRestConfiguration,
+    handleDeleteRest,
+    handleDeleteOperation,
+  } = useRestDslOperations({
+    restEntities,
+    restConfiguration,
+    canAddRestEntities,
+    canDeleteRestEntities,
+    setSelection,
+  });
+
+  const handleSelectOperation = useCallback(
+    (restId: string, verb: RestVerb, index: number) => {
+      setSelection({ kind: 'operation', restId, verb, index });
+    },
+    [setSelection],
+  );
+
+  const handleSelectRestConfiguration = useCallback(() => {
+    setSelection({ kind: 'restConfiguration' });
+  }, [setSelection]);
+
+  const handleSelectRest = useCallback(
+    (restId: string) => {
+      setSelection({ kind: 'rest', restId });
+    },
+    [setSelection],
+  );
+
+  const formKey = useMemo(() => {
+    if (!selection) return `rest-form-${catalogKey}-none`;
+    if (selection.kind === 'restConfiguration') return `rest-form-${catalogKey}-config`;
+    if (selection.kind === 'rest') return `rest-form-${catalogKey}-rest-${selection.restId}`;
+    return `rest-form-${catalogKey}-op-${selection.restId}-${selection.verb}-${selection.index}`;
+  }, [catalogKey, selection]);
+
+  return (
+    <ActionConfirmationModalContextProvider>
+      <div className="rest-dsl-page">
+        <Split className="rest-dsl-page-split" hasGutter>
+          <RestDslNav
+            navWidth={navWidth}
+            restConfiguration={restConfiguration}
+            restEntities={restEntities}
+            restMethods={REST_METHODS}
+            selection={selection}
+            canAddRestEntities={canAddRestEntities}
+            canDeleteRestEntities={canDeleteRestEntities}
+            onCreateRestConfiguration={handleCreateRestConfiguration}
+            onDeleteRestConfiguration={handleDeleteRestConfiguration}
+            onSelectRestConfiguration={handleSelectRestConfiguration}
+            onCreateRest={handleCreateRest}
+            onDeleteRest={handleDeleteRest}
+            onSelectRest={handleSelectRest}
+            onAddOperation={openAddOperationModal}
+            onSelectOperation={handleSelectOperation}
+            onDeleteOperation={handleDeleteOperation}
+            getListItemClass={getListItemClass}
+          />
+          <RestDslResizeHandle onResizeStart={handleResizeStart} />
+          <RestDslDetails
+            formKey={formKey}
+            selectedFormState={selectedFormState}
+            selection={selection}
+            formTabsValue={formTabsValue}
+            toUriSchema={toUriSchema}
+            toUriFieldRef={toUriFieldRef}
+            selectedToUriItem={selectedToUriItem}
+            directEndpointItems={directEndpointItems}
+            toUriValue={toUriValue}
+            directRouteExists={directRouteExists}
+            onToUriChange={handleToUriChange}
+            onToUriClear={handleToUriClear}
+            onCreateDirectRoute={handleCreateDirectRoute}
+            onChangeProp={handleOnChangeProp}
+          />
+        </Split>
+        <RestDslAddOperationModal
+          isOpen={isAddOperationOpen}
+          restId={addOperationRestId}
+          onClose={closeAddOperationModal}
+          onCreateOperation={handleCreateOperation}
+        />
+      </div>
+    </ActionConfirmationModalContextProvider>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/components/RestDslAddOperationModal.test.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslAddOperationModal.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RestDslAddOperationModal } from './RestDslAddOperationModal';
+
+jest.mock('../RestDslDetails', () => ({
+  getOperationFieldHelp: jest.fn(() => null),
+  OperationTypeHelp: () => <div>Operation Type Help</div>,
+}));
+
+describe('RestDslAddOperationModal', () => {
+  const baseProps = {
+    isOpen: true,
+    restId: 'rest-1',
+    onClose: jest.fn(),
+    onCreateOperation: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal when isOpen is true', () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    expect(screen.getByText('Add REST Operation')).toBeInTheDocument();
+  });
+
+  it('does not render modal when isOpen is false', () => {
+    render(<RestDslAddOperationModal {...baseProps} isOpen={false} />);
+
+    expect(screen.queryByText('Add REST Operation')).not.toBeInTheDocument();
+  });
+
+  it('renders form fields', () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    expect(screen.getByLabelText(/operation id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/uri/i)).toBeInTheDocument();
+  });
+
+  it('generates random operation ID on open', () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    const operationIdInput = screen.getByLabelText(/operation id/i) as HTMLInputElement;
+    expect(operationIdInput.value).toMatch(/^rest-/);
+  });
+
+  it('focuses URI input on open', async () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    await waitFor(() => {
+      const uriInput = screen.getByLabelText(/uri/i);
+      expect(uriInput).toHaveFocus();
+    });
+  });
+
+  it('disables Add Operation button when URI is empty', () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    const addButton = screen.getByRole('button', { name: /add operation/i });
+    expect(addButton).toBeDisabled();
+  });
+
+  it('enables Add Operation button when URI is provided', async () => {
+    const user = userEvent.setup();
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    const uriInput = screen.getByLabelText(/uri/i);
+    await user.type(uriInput, '/users');
+
+    const addButton = screen.getByRole('button', { name: /add operation/i });
+    expect(addButton).toBeEnabled();
+  });
+
+  it('calls onCreateOperation with correct parameters', async () => {
+    const user = userEvent.setup();
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    const uriInput = screen.getByLabelText(/uri/i);
+    await user.type(uriInput, '/users');
+
+    const addButton = screen.getByRole('button', { name: /add operation/i });
+    fireEvent.click(addButton);
+
+    expect(baseProps.onCreateOperation).toHaveBeenCalledWith('rest-1', 'get', expect.any(String), '/users');
+  });
+
+  it('calls onClose when Cancel button is clicked', () => {
+    render(<RestDslAddOperationModal {...baseProps} />);
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelButton);
+
+    expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCreateOperation when restId is undefined', async () => {
+    const user = userEvent.setup();
+    render(<RestDslAddOperationModal {...baseProps} restId={undefined} />);
+
+    const uriInput = screen.getByLabelText(/uri/i);
+    await user.type(uriInput, '/users');
+
+    const addButton = screen.getByRole('button', { name: /add operation/i });
+    fireEvent.click(addButton);
+
+    expect(baseProps.onCreateOperation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/RestDsl/components/RestDslAddOperationModal.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslAddOperationModal.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { REST_DSL_VERBS } from '../../../models/special-processors.constants';
+import { getOperationFieldHelp, OperationTypeHelp } from '../RestDslDetails';
+import { RestVerb } from '../restDslTypes';
+import { RestDslOperationVerbSelect } from './RestDslOperationVerbSelect';
+
+const REST_METHODS = REST_DSL_VERBS;
+
+interface RestDslAddOperationModalProps {
+  isOpen: boolean;
+  restId: string | undefined;
+  onClose: () => void;
+  onCreateOperation: (restId: string, verb: RestVerb, operationId: string, operationPath: string) => void;
+}
+
+export const RestDslAddOperationModal: FunctionComponent<RestDslAddOperationModalProps> = ({
+  isOpen,
+  restId,
+  onClose,
+  onCreateOperation,
+}) => {
+  const [operationId, setOperationId] = useState('');
+  const [operationPath, setOperationPath] = useState('');
+  const [operationVerb, setOperationVerb] = useState<RestVerb>('get');
+  const [isVerbSelectOpen, setIsVerbSelectOpen] = useState(false);
+  const uriInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setOperationVerb('get');
+      setOperationId(getCamelRandomId('rest'));
+      setOperationPath('');
+      requestAnimationFrame(() => {
+        uriInputRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  const handleVerbToggle = useCallback(() => {
+    setIsVerbSelectOpen((prev) => !prev);
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    if (!restId || !operationPath.trim()) return;
+    onCreateOperation(restId, operationVerb, operationId, operationPath);
+  }, [restId, operationVerb, operationId, operationPath, onCreateOperation]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      variant={ModalVariant.small}
+      onClose={onClose}
+      aria-label="Add REST Operation"
+      className="rest-dsl-add-operation-modal"
+    >
+      <ModalHeader title="Add REST Operation" />
+      <ModalBody>
+        <Form>
+          <FormGroup
+            label="Operation Id"
+            fieldId="rest-operation-id"
+            labelHelp={getOperationFieldHelp(operationVerb, 'id', 'Id')}
+          >
+            <TextInput id="rest-operation-id" value={operationId} onChange={(_event, value) => setOperationId(value)} />
+          </FormGroup>
+          <FormGroup
+            label="URI"
+            fieldId="rest-operation-uri"
+            isRequired
+            labelHelp={getOperationFieldHelp(operationVerb, 'path', 'Path')}
+          >
+            <TextInput
+              id="rest-operation-uri"
+              value={operationPath}
+              onChange={(_event, value) => setOperationPath(value)}
+              isRequired
+              ref={uriInputRef}
+            />
+          </FormGroup>
+          <FormGroup label="Operation Type" fieldId="rest-operation-type" isRequired labelHelp={<OperationTypeHelp />}>
+            <RestDslOperationVerbSelect
+              isOpen={isVerbSelectOpen}
+              selected={operationVerb}
+              verbs={REST_METHODS}
+              onSelect={(value) => {
+                setOperationVerb(value);
+                setIsVerbSelectOpen(false);
+              }}
+              onOpenChange={setIsVerbSelectOpen}
+              onToggle={handleVerbToggle}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="primary" onClick={handleCreate} isDisabled={!operationPath.trim()}>
+          Add Operation
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/components/RestDslOperationList.scss
+++ b/packages/ui/src/pages/RestDsl/components/RestDslOperationList.scss
@@ -1,0 +1,52 @@
+.rest-dsl-operation-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+}
+
+.rest-dsl-operation-path {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rest-dsl-operation-verb {
+  font-size: var(--pf-v6-global--FontSize--xs);
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--pf-v6-global--BackgroundColor--200);
+  min-width: 44px;
+  text-align: center;
+}
+
+.rest-dsl-operation-verb-get {
+  background: #e6f4ff;
+  color: #004080;
+}
+
+.rest-dsl-operation-verb-post {
+  background: #f3f0ff;
+  color: #3f1b8b;
+}
+
+.rest-dsl-operation-verb-put {
+  background: #e8fff5;
+  color: #0a6b4f;
+}
+
+.rest-dsl-operation-verb-delete {
+  background: #fff0f0;
+  color: #8a0000;
+}
+
+.rest-dsl-operation-verb-patch {
+  background: #fff8e5;
+  color: #7a4b00;
+}
+
+.rest-dsl-operation-verb-head {
+  background: #f0f4f8;
+  color: #47515c;
+}

--- a/packages/ui/src/pages/RestDsl/components/RestDslOperationList.test.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslOperationList.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { createSimpleRestVisualEntity } from '../../../stubs';
+import { RestVerb } from '../restDslTypes';
+import { RestDslOperationList } from './RestDslOperationList';
+
+describe('RestDslOperationList', () => {
+  const mockRestEntity = createSimpleRestVisualEntity('rest-1');
+
+  const mockRestDefinition = {
+    get: [
+      { id: 'op1', path: '/users' },
+      { id: 'op2', path: '/posts' },
+    ],
+  };
+
+  const baseProps = {
+    restEntity: mockRestEntity,
+    restDefinition: mockRestDefinition,
+    restMethods: ['get', 'post', 'put', 'delete'] as RestVerb[],
+    selection: undefined,
+    onSelectOperation: jest.fn(),
+    onDeleteOperation: jest.fn(),
+    getListItemClass: jest.fn(() => 'rest-dsl-nav-item'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders operations for specified verb', () => {
+    render(<RestDslOperationList {...baseProps} />);
+
+    expect(screen.getByText('/users')).toBeInTheDocument();
+    expect(screen.getByText('/posts')).toBeInTheDocument();
+  });
+
+  it('renders verb badge', () => {
+    render(<RestDslOperationList {...baseProps} />);
+
+    expect(screen.getAllByText('GET').length).toBeGreaterThan(0);
+  });
+
+  it('calls onSelectOperation when operation is clicked', () => {
+    render(<RestDslOperationList {...baseProps} />);
+
+    const firstOperation = screen.getByText('/users');
+    fireEvent.click(firstOperation);
+
+    expect(baseProps.onSelectOperation).toHaveBeenCalledWith('rest-1', 'get', 0);
+  });
+
+  it('calls onDeleteOperation when delete button is clicked', () => {
+    render(<RestDslOperationList {...baseProps} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(baseProps.onDeleteOperation).toHaveBeenCalledWith(mockRestEntity, 'get', 0);
+  });
+
+  it('does not render operations for verbs without operations', () => {
+    render(<RestDslOperationList {...baseProps} />);
+
+    expect(screen.queryByText('POST')).not.toBeInTheDocument();
+    expect(screen.queryByText('PUT')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/RestDsl/components/RestDslOperationList.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslOperationList.tsx
@@ -1,0 +1,73 @@
+import './RestDslOperationList.scss';
+
+import { Button, List, ListItem } from '@patternfly/react-core';
+import { TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEditorSelection, RestVerb } from '../restDslTypes';
+
+type RestOperationListProps = {
+  restEntity: CamelRestVisualEntity;
+  restDefinition: Record<string, unknown>;
+  restMethods: RestVerb[];
+  selection: RestEditorSelection | undefined;
+  onSelectOperation: (restId: string, verb: RestVerb, index: number) => void;
+  onDeleteOperation: (restEntity: CamelRestVisualEntity, verb: RestVerb, index: number) => void;
+  getListItemClass: (selection: RestEditorSelection | undefined, target: RestEditorSelection) => string;
+};
+
+export const RestDslOperationList: FunctionComponent<RestOperationListProps> = ({
+  restEntity,
+  restDefinition,
+  restMethods,
+  selection,
+  onSelectOperation,
+  onDeleteOperation,
+  getListItemClass,
+}) => {
+  const items = restMethods.flatMap((verb) => {
+    const operations = restDefinition[verb] as Array<{ path?: string; id?: string }> | undefined;
+    if (!operations || operations.length === 0) return [];
+
+    return operations.map((operation, index) => {
+      const operationPath = operation?.path || operation?.id || '/';
+      const isSelected =
+        selection?.kind === 'operation' &&
+        selection.restId === restEntity.id &&
+        selection.verb === verb &&
+        selection.index === index;
+
+      return (
+        <ListItem key={`${restEntity.id}-${verb}-${index}`}>
+          <div className="rest-dsl-operation-row">
+            <Button
+              variant="plain"
+              className={getListItemClass(selection, {
+                kind: 'operation',
+                restId: restEntity.id,
+                verb,
+                index,
+              })}
+              onClick={() => onSelectOperation(restEntity.id, verb, index)}
+              aria-label={`Select ${verb.toUpperCase()} operation ${operationPath}`}
+              aria-pressed={isSelected}
+            >
+              <span className={`rest-dsl-operation-verb rest-dsl-operation-verb-${verb}`}>{verb.toUpperCase()}</span>
+              <span className="rest-dsl-operation-path">{operationPath}</span>
+            </Button>
+            <Button
+              variant="plain"
+              size="sm"
+              icon={<TrashIcon />}
+              aria-label="Delete Operation"
+              onClick={() => onDeleteOperation(restEntity, verb, index)}
+            />
+          </div>
+        </ListItem>
+      );
+    });
+  });
+
+  return <List className="rest-dsl-nav-list rest-dsl-nav-list-nested">{items}</List>;
+};

--- a/packages/ui/src/pages/RestDsl/components/RestDslOperationVerbSelect.test.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslOperationVerbSelect.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RestVerb } from '../restDslTypes';
+import { OperationTypeHelp, RestDslOperationVerbSelect } from './RestDslOperationVerbSelect';
+
+describe('RestDslOperationVerbSelect', () => {
+  const verbs: RestVerb[] = ['get', 'post', 'put', 'delete'];
+
+  const baseProps = {
+    isOpen: false,
+    selected: 'get' as const,
+    verbs,
+    onSelect: jest.fn(),
+    onOpenChange: jest.fn(),
+    onToggle: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with selected verb', () => {
+    render(<RestDslOperationVerbSelect {...baseProps} />);
+
+    expect(screen.getByText('GET')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when toggle is clicked', () => {
+    render(<RestDslOperationVerbSelect {...baseProps} />);
+
+    const toggle = screen.getByRole('button', { name: /get/i });
+    fireEvent.click(toggle);
+
+    expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows options when isOpen is true', () => {
+    render(<RestDslOperationVerbSelect {...baseProps} isOpen={true} />);
+
+    expect(screen.getAllByText('GET').length).toBeGreaterThan(0);
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getByText('PUT')).toBeInTheDocument();
+    expect(screen.getByText('DELETE')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when an option is clicked', () => {
+    render(<RestDslOperationVerbSelect {...baseProps} isOpen={true} />);
+
+    const options = screen.getAllByRole('option');
+    const postOption = options.find((opt) => opt.textContent === 'POST');
+    if (postOption) {
+      fireEvent.click(postOption);
+    }
+
+    expect(baseProps.onSelect).toHaveBeenCalledWith('post');
+  });
+
+  it('renders help popover trigger and shows content on hover', async () => {
+    const user = userEvent.setup();
+    render(<OperationTypeHelp />);
+
+    const helpButton = screen.getByRole('button', { name: /more info about operation type/i });
+    expect(helpButton).toBeInTheDocument();
+
+    // Hover over the help button to trigger the popover
+    await user.hover(helpButton);
+
+    // Wait for and verify the popover content appears
+    await waitFor(() => {
+      expect(screen.getByText('Select the HTTP method to create for this REST operation.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDsl/components/RestDslOperationVerbSelect.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslOperationVerbSelect.tsx
@@ -1,0 +1,72 @@
+import { Button, MenuToggle, Popover, Select, SelectList, SelectOption } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useMemo } from 'react';
+
+import { RestVerb } from '../restDslTypes';
+
+type OperationVerbToggleProps = {
+  toggleRef: React.Ref<HTMLButtonElement>;
+  operationVerb: RestVerb;
+  onToggle: () => void;
+};
+
+const OperationVerbToggle: FunctionComponent<OperationVerbToggleProps> = ({ toggleRef, operationVerb, onToggle }) => {
+  return (
+    <MenuToggle ref={toggleRef} onClick={onToggle}>
+      {operationVerb.toUpperCase()}
+    </MenuToggle>
+  );
+};
+
+const createOperationVerbToggleRenderer =
+  (operationVerb: RestVerb, onToggle: () => void) => (toggleRef: React.Ref<HTMLButtonElement>) => (
+    <OperationVerbToggle toggleRef={toggleRef} operationVerb={operationVerb} onToggle={onToggle} />
+  );
+
+export const OperationTypeHelp: FunctionComponent = () => (
+  <Popover
+    bodyContent="Select the HTTP method to create for this REST operation."
+    triggerAction="hover"
+    withFocusTrap={false}
+  >
+    <Button variant="plain" aria-label="More info about Operation Type" icon={<HelpIcon />} />
+  </Popover>
+);
+
+type RestDslOperationVerbSelectProps = {
+  isOpen: boolean;
+  selected: RestVerb;
+  verbs: RestVerb[];
+  onSelect: (value: RestVerb) => void;
+  onOpenChange: (isOpen: boolean) => void;
+  onToggle: () => void;
+};
+
+export const RestDslOperationVerbSelect: FunctionComponent<RestDslOperationVerbSelectProps> = ({
+  isOpen,
+  selected,
+  verbs,
+  onSelect,
+  onOpenChange,
+  onToggle,
+}) => {
+  const toggleRenderer = useMemo(() => createOperationVerbToggleRenderer(selected, onToggle), [selected, onToggle]);
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={(_event, value) => onSelect(value as RestVerb)}
+      onOpenChange={onOpenChange}
+      toggle={toggleRenderer}
+    >
+      <SelectList>
+        {verbs.map((verb) => (
+          <SelectOption key={verb} itemId={verb}>
+            {verb.toUpperCase()}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/components/RestDslResizeHandle.test.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslResizeHandle.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { RestDslResizeHandle } from './RestDslResizeHandle';
+
+describe('RestDslResizeHandle', () => {
+  it('renders resize handle button', () => {
+    const onResizeStart = jest.fn();
+    render(<RestDslResizeHandle onResizeStart={onResizeStart} />);
+
+    const button = screen.getByRole('button', { name: /resize/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('calls onResizeStart when mouse down on handle', () => {
+    const onResizeStart = jest.fn();
+    render(<RestDslResizeHandle onResizeStart={onResizeStart} />);
+
+    const button = screen.getByRole('button', { name: /resize/i });
+    fireEvent.mouseDown(button);
+
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it('has correct CSS class', () => {
+    const onResizeStart = jest.fn();
+    const { container } = render(<RestDslResizeHandle onResizeStart={onResizeStart} />);
+
+    const splitItem = container.querySelector('.rest-dsl-page-resize-handle');
+    expect(splitItem).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/RestDsl/components/RestDslResizeHandle.tsx
+++ b/packages/ui/src/pages/RestDsl/components/RestDslResizeHandle.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@patternfly/react-core';
+import { FunctionComponent, MouseEvent } from 'react';
+
+type RestDslResizeHandleProps = {
+  onResizeStart: (event: MouseEvent<HTMLButtonElement>) => void;
+};
+
+export const RestDslResizeHandle: FunctionComponent<RestDslResizeHandleProps> = ({ onResizeStart }) => {
+  return (
+    <Button
+      variant="plain"
+      className="rest-dsl-page-resize-handle"
+      onMouseDown={onResizeStart}
+      aria-label="Resize panels"
+    >
+      <hr className="rest-dsl-page-resize-handle-line" />
+      <span className="rest-dsl-page-resize-grip" aria-hidden="true">
+        ||
+      </span>
+    </Button>
+  );
+};

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslOperations.test.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslOperations.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from '@testing-library/react';
+import { createElement, ReactNode } from 'react';
+
+import { EntitiesContext } from '../../../providers';
+import { ActionConfirmationModalContext } from '../../../providers/action-confirmation-modal.provider';
+import { createSimpleRestVisualEntity } from '../../../stubs';
+import { useRestDslOperations } from './useRestDslOperations';
+
+describe('useRestDslOperations', () => {
+  const mockSetSelection = jest.fn();
+  const mockUpdateEntitiesFromCamelResource = jest.fn();
+  const mockAddNewEntity = jest.fn();
+  const mockRemoveEntity = jest.fn();
+
+  const baseProps = {
+    restEntities: [createSimpleRestVisualEntity('rest-1')],
+    restConfiguration: undefined,
+    canAddRestEntities: true,
+    canDeleteRestEntities: true,
+    setSelection: mockSetSelection,
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(
+      ActionConfirmationModalContext.Provider,
+      { value: undefined },
+      createElement(
+        EntitiesContext.Provider,
+        {
+          value: {
+            camelResource: {
+              addNewEntity: mockAddNewEntity,
+              removeEntity: mockRemoveEntity,
+            },
+            updateEntitiesFromCamelResource: mockUpdateEntitiesFromCamelResource,
+          } as never,
+        },
+        children,
+      ),
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes with closed add operation modal', () => {
+    const { result } = renderHook(() => useRestDslOperations(baseProps), { wrapper });
+
+    expect(result.current.isAddOperationOpen).toBe(false);
+    expect(result.current.addOperationRestId).toBeUndefined();
+  });
+
+  it('opens add operation modal for specific rest entity', () => {
+    const { result } = renderHook(() => useRestDslOperations(baseProps), { wrapper });
+
+    act(() => {
+      result.current.openAddOperationModal('rest-1');
+    });
+
+    expect(result.current.isAddOperationOpen).toBe(true);
+    expect(result.current.addOperationRestId).toBe('rest-1');
+  });
+
+  it('closes add operation modal', () => {
+    const { result } = renderHook(() => useRestDslOperations(baseProps), { wrapper });
+
+    act(() => {
+      result.current.openAddOperationModal('rest-1');
+    });
+
+    act(() => {
+      result.current.closeAddOperationModal();
+    });
+
+    expect(result.current.isAddOperationOpen).toBe(false);
+    expect(result.current.addOperationRestId).toBeUndefined();
+  });
+
+  it('creates a new operation', () => {
+    const { result } = renderHook(() => useRestDslOperations(baseProps), { wrapper });
+
+    act(() => {
+      result.current.handleCreateOperation('rest-1', 'get', 'newOp', '/new-path');
+    });
+
+    expect(mockUpdateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(mockSetSelection).toHaveBeenCalledWith({
+      kind: 'operation',
+      restId: 'rest-1',
+      verb: 'get',
+      index: 2,
+    });
+  });
+
+  it('creates a new rest entity', () => {
+    mockAddNewEntity.mockReturnValue('rest-2');
+    const { result } = renderHook(() => useRestDslOperations(baseProps), { wrapper });
+
+    act(() => {
+      result.current.handleCreateRest();
+    });
+
+    expect(mockAddNewEntity).toHaveBeenCalledWith('rest');
+    expect(mockUpdateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(mockSetSelection).toHaveBeenCalledWith({
+      kind: 'rest',
+      restId: 'rest-2',
+    });
+  });
+
+  it('does not create rest when canAddRestEntities is false', () => {
+    const { result } = renderHook(
+      () =>
+        useRestDslOperations({
+          ...baseProps,
+          canAddRestEntities: false,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.handleCreateRest();
+    });
+
+    expect(mockAddNewEntity).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslOperations.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslOperations.ts
@@ -1,0 +1,179 @@
+import { useCallback, useContext, useState } from 'react';
+
+import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { EntityType } from '../../../models/camel/entities';
+import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
+import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { EntitiesContext } from '../../../providers';
+import {
+  ACTION_ID_CONFIRM,
+  ActionConfirmationModalContext,
+} from '../../../providers/action-confirmation-modal.provider';
+import { RestEditorSelection, RestVerb } from '../restDslTypes';
+
+interface UseRestDslOperationsProps {
+  restEntities: CamelRestVisualEntity[];
+  restConfiguration: CamelRestConfigurationVisualEntity | undefined;
+  canAddRestEntities: boolean;
+  canDeleteRestEntities: boolean;
+  setSelection: (selection: RestEditorSelection | undefined) => void;
+}
+
+export const useRestDslOperations = ({
+  restEntities,
+  restConfiguration,
+  canAddRestEntities,
+  canDeleteRestEntities,
+  setSelection,
+}: UseRestDslOperationsProps) => {
+  const entitiesContext = useContext(EntitiesContext);
+  const actionConfirmation = useContext(ActionConfirmationModalContext);
+
+  const [isAddOperationOpen, setIsAddOperationOpen] = useState(false);
+  const [addOperationRestId, setAddOperationRestId] = useState<string | undefined>(undefined);
+
+  const confirmDelete = useCallback(
+    async (title: string, text: string) => {
+      if (!actionConfirmation) {
+        return globalThis.confirm(text);
+      }
+
+      const result = await actionConfirmation.actionConfirmation({
+        title,
+        text,
+      });
+      return result === ACTION_ID_CONFIRM;
+    },
+    [actionConfirmation],
+  );
+
+  const handleCreateRestConfiguration = useCallback(() => {
+    if (!entitiesContext || !canAddRestEntities || restConfiguration) return;
+
+    const camelResource = entitiesContext.camelResource as { addNewEntity: (type?: EntityType) => string };
+    camelResource.addNewEntity(EntityType.RestConfiguration);
+    entitiesContext.updateEntitiesFromCamelResource();
+    setSelection({ kind: 'restConfiguration' });
+  }, [canAddRestEntities, entitiesContext, restConfiguration, setSelection]);
+
+  const handleCreateRest = useCallback(() => {
+    if (!entitiesContext || !canAddRestEntities) return;
+
+    const camelResource = entitiesContext.camelResource as { addNewEntity: (type?: EntityType) => string };
+    const newId = camelResource.addNewEntity(EntityType.Rest);
+    entitiesContext.updateEntitiesFromCamelResource();
+    if (newId) {
+      setSelection({ kind: 'rest', restId: newId });
+    }
+  }, [canAddRestEntities, entitiesContext, setSelection]);
+
+  const openAddOperationModal = useCallback((restId: string) => {
+    setAddOperationRestId(restId);
+    setIsAddOperationOpen(true);
+  }, []);
+
+  const closeAddOperationModal = useCallback(() => {
+    setIsAddOperationOpen(false);
+    setAddOperationRestId(undefined);
+  }, []);
+
+  const handleCreateOperation = useCallback(
+    (restId: string, verb: RestVerb, operationId: string, operationPath: string) => {
+      if (!entitiesContext) return;
+      const restEntity = restEntities.find((entity) => entity.id === restId);
+      if (!restEntity) return;
+
+      const restDefinition = restEntity.restDef.rest ?? {};
+      const operations = (restDefinition as Record<string, unknown>)[verb] as Record<string, unknown>[] | undefined;
+      const normalizedOperations = operations ? [...operations] : [];
+      const resolvedId = operationId.trim() || getCamelRandomId(verb);
+
+      normalizedOperations.push({
+        id: resolvedId,
+        path: operationPath.trim() || '/',
+        to: {
+          uri: `direct:${resolvedId}`,
+        },
+      });
+
+      (restDefinition as Record<string, unknown>)[verb] = normalizedOperations;
+      restEntity.updateModel(restEntity.getRootPath(), restDefinition);
+      entitiesContext.updateEntitiesFromCamelResource();
+
+      setSelection({
+        kind: 'operation',
+        restId,
+        verb,
+        index: normalizedOperations.length - 1,
+      });
+      closeAddOperationModal();
+    },
+    [closeAddOperationModal, entitiesContext, restEntities, setSelection],
+  );
+
+  const handleDeleteRestConfiguration = useCallback(async () => {
+    if (!entitiesContext || !restConfiguration || !canDeleteRestEntities) return;
+    const shouldDelete = await confirmDelete('Delete Rest Configuration', 'This will remove the Rest Configuration.');
+    if (!shouldDelete) return;
+
+    const camelResource = entitiesContext.camelResource as { removeEntity: (ids?: string[]) => void };
+    camelResource.removeEntity([restConfiguration.id]);
+    entitiesContext.updateEntitiesFromCamelResource();
+    setSelection(undefined);
+  }, [canDeleteRestEntities, confirmDelete, entitiesContext, restConfiguration, setSelection]);
+
+  const handleDeleteRest = useCallback(
+    async (restEntity: CamelRestVisualEntity) => {
+      if (!entitiesContext || !canDeleteRestEntities) return;
+      const label = restEntity.restDef?.rest?.path || restEntity.id;
+      const shouldDelete = await confirmDelete('Delete Rest Element', `This will remove ${label}.`);
+      if (!shouldDelete) return;
+
+      const camelResource = entitiesContext.camelResource as { removeEntity: (ids?: string[]) => void };
+      camelResource.removeEntity([restEntity.id]);
+      entitiesContext.updateEntitiesFromCamelResource();
+      setSelection(undefined);
+    },
+    [canDeleteRestEntities, confirmDelete, entitiesContext, setSelection],
+  );
+
+  const handleDeleteOperation = useCallback(
+    async (restEntity: CamelRestVisualEntity, verb: RestVerb, index: number) => {
+      if (!entitiesContext) return;
+      const restDefinition = restEntity.restDef.rest ?? {};
+      const operations = (restDefinition as Record<string, unknown>)[verb] as Record<string, unknown>[] | undefined;
+      if (!operations?.[index]) return;
+      const pathLabel = (operations[index] as { path?: string }).path ?? '';
+      const shouldDelete = await confirmDelete(
+        'Delete Operation',
+        `This will remove ${verb.toUpperCase()} ${pathLabel || ''}.`,
+      );
+      if (!shouldDelete) return;
+
+      const updated = operations.filter((_operation, idx) => idx !== index);
+      if (updated.length === 0) {
+        delete (restDefinition as Record<string, unknown>)[verb];
+      } else {
+        (restDefinition as Record<string, unknown>)[verb] = updated;
+      }
+
+      restEntity.updateModel(restEntity.getRootPath(), restDefinition);
+      entitiesContext.updateEntitiesFromCamelResource();
+      setSelection(undefined);
+    },
+    [confirmDelete, entitiesContext, setSelection],
+  );
+
+  return {
+    isAddOperationOpen,
+    addOperationRestId,
+    openAddOperationModal,
+    closeAddOperationModal,
+    handleCreateOperation,
+    handleCreateRestConfiguration,
+    handleCreateRest,
+    handleDeleteRestConfiguration,
+    handleDeleteRest,
+    handleDeleteOperation,
+  };
+};

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslResize.test.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslResize.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useRestDslResize } from './useRestDslResize';
+
+describe('useRestDslResize', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('initializes with default width from localStorage', () => {
+    const { result } = renderHook(() => useRestDslResize());
+
+    expect(result.current.navWidth).toBe(288);
+  });
+
+  it('attaches mouse event listeners on resize start', () => {
+    const { result } = renderHook(() => useRestDslResize());
+
+    act(() => {
+      result.current.handleResizeStart({
+        preventDefault: jest.fn(),
+        clientX: 300,
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(addEventListenerSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+  });
+
+  it('updates width during resize', () => {
+    const { result } = renderHook(() => useRestDslResize());
+
+    act(() => {
+      result.current.handleResizeStart({
+        preventDefault: jest.fn(),
+        clientX: 288,
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      const mouseMoveHandler = addEventListenerSpy.mock.calls.find((call) => call[0] === 'mousemove')?.[1];
+      mouseMoveHandler(new MouseEvent('mousemove', { clientX: 400 }));
+    });
+
+    expect(result.current.navWidth).toBe(400);
+  });
+
+  it('enforces minimum width constraint', () => {
+    const { result } = renderHook(() => useRestDslResize());
+
+    act(() => {
+      result.current.handleResizeStart({
+        preventDefault: jest.fn(),
+        clientX: 288,
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      const mouseMoveHandler = addEventListenerSpy.mock.calls.find((call) => call[0] === 'mousemove')?.[1];
+      mouseMoveHandler(new MouseEvent('mousemove', { clientX: 100 }));
+    });
+
+    expect(result.current.navWidth).toBe(220);
+  });
+
+  it('removes event listeners on mouseup', () => {
+    const { result } = renderHook(() => useRestDslResize());
+
+    act(() => {
+      result.current.handleResizeStart({
+        preventDefault: jest.fn(),
+        clientX: 288,
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      const mouseUpHandler = addEventListenerSpy.mock.calls.find((call) => call[0] === 'mouseup')?.[1];
+      mouseUpHandler(new MouseEvent('mouseup'));
+    });
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+  });
+});

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslResize.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslResize.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from 'react';
+
+import { useLocalStorage } from '../../../hooks';
+import { LocalStorageKeys } from '../../../models/local-storage-keys';
+
+const NAV_MIN_WIDTH = 220;
+const DETAILS_MIN_WIDTH = 420;
+
+export const useRestDslResize = () => {
+  const [navWidth, setNavWidth] = useLocalStorage(LocalStorageKeys.RestDslNavWidth, 288);
+  const resizeRef = useRef<{ startX: number; startWidth: number; isDragging: boolean } | null>(null);
+
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      resizeRef.current = {
+        startX: event.clientX,
+        startWidth: navWidth,
+        isDragging: true,
+      };
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!resizeRef.current?.isDragging) return;
+        const delta = e.clientX - resizeRef.current.startX;
+        const newWidth = Math.max(NAV_MIN_WIDTH, resizeRef.current.startWidth + delta);
+        const maxWidth = window.innerWidth - DETAILS_MIN_WIDTH;
+        setNavWidth(Math.min(newWidth, maxWidth));
+      };
+
+      const handleMouseUp = () => {
+        if (resizeRef.current) {
+          resizeRef.current.isDragging = false;
+        }
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [navWidth, setNavWidth],
+  );
+
+  return {
+    navWidth,
+    handleResizeStart,
+  };
+};

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslSelection.test.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslSelection.test.ts
@@ -1,0 +1,103 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { createRestConfigurationVisualEntity, createSimpleRestVisualEntity } from '../../../stubs';
+import { useRestDslSelection } from './useRestDslSelection';
+
+describe('useRestDslSelection', () => {
+  const mockRestEntity = createSimpleRestVisualEntity('rest-1');
+
+  it('initializes with undefined selection when no data', () => {
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: undefined,
+        restEntities: [],
+      }),
+    );
+
+    expect(result.current.selection).toBeUndefined();
+  });
+
+  it('initializes with rest configuration when available', () => {
+    const mockRestConfiguration = createRestConfigurationVisualEntity();
+
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: mockRestConfiguration,
+        restEntities: [],
+      }),
+    );
+
+    expect(result.current.selection).toEqual({ kind: 'restConfiguration' });
+  });
+
+  it('initializes with first rest entity when no configuration', () => {
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: undefined,
+        restEntities: [mockRestEntity],
+      }),
+    );
+
+    expect(result.current.selection).toEqual({
+      kind: 'rest',
+      restId: 'rest-1',
+    });
+  });
+
+  it('updates selection when set', () => {
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: undefined,
+        restEntities: [mockRestEntity],
+      }),
+    );
+
+    act(() => {
+      result.current.setSelection({
+        kind: 'operation',
+        restId: 'rest-1',
+        verb: 'get',
+        index: 0,
+      });
+    });
+
+    expect(result.current.selection).toEqual({
+      kind: 'operation',
+      restId: 'rest-1',
+      verb: 'get',
+      index: 0,
+    });
+  });
+
+  it('returns selectedFormState for rest configuration', () => {
+    const mockRestConfiguration = createRestConfigurationVisualEntity();
+
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: mockRestConfiguration,
+        restEntities: [],
+      }),
+    );
+
+    expect(result.current.selectedFormState).toMatchObject({
+      title: 'Rest Configuration',
+      entity: mockRestConfiguration,
+      path: 'restConfiguration',
+    });
+  });
+
+  it('returns selectedFormState for rest entity', () => {
+    const { result } = renderHook(() =>
+      useRestDslSelection({
+        restConfiguration: undefined,
+        restEntities: [mockRestEntity],
+      }),
+    );
+
+    expect(result.current.selectedFormState).toMatchObject({
+      title: 'Rest',
+      entity: mockRestEntity,
+      path: 'rest',
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslSelection.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslSelection.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
+import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEditorSelection, SelectedFormState } from '../restDslTypes';
+
+interface UseRestDslSelectionProps {
+  restConfiguration: CamelRestConfigurationVisualEntity | undefined;
+  restEntities: CamelRestVisualEntity[];
+}
+
+export const useRestDslSelection = ({ restConfiguration, restEntities }: UseRestDslSelectionProps) => {
+  const defaultSelection = useMemo<RestEditorSelection | undefined>(() => {
+    if (restConfiguration) return { kind: 'restConfiguration' };
+    const firstRest = restEntities[0];
+    if (firstRest) return { kind: 'rest', restId: firstRest.id };
+    return undefined;
+  }, [restConfiguration, restEntities]);
+
+  const [selection, setSelection] = useState<RestEditorSelection | undefined>(defaultSelection);
+
+  useEffect(() => {
+    if (!selection) {
+      setSelection(defaultSelection);
+      return;
+    }
+
+    if (selection.kind === 'restConfiguration' && !restConfiguration) {
+      setSelection(defaultSelection);
+      return;
+    }
+
+    if (selection.kind !== 'restConfiguration') {
+      const restEntity = restEntities.find((entity) => entity.id === selection.restId);
+      if (!restEntity) {
+        setSelection(defaultSelection);
+      }
+    }
+  }, [defaultSelection, restConfiguration, restEntities, selection]);
+
+  const selectedFormState = useMemo<SelectedFormState | undefined>(() => {
+    if (!selection) return undefined;
+
+    if (selection.kind === 'restConfiguration') {
+      if (!restConfiguration) return undefined;
+      return {
+        title: 'Rest Configuration',
+        entity: restConfiguration,
+        path: restConfiguration.getRootPath(),
+        omitFields: restConfiguration.getOmitFormFields(),
+      };
+    }
+
+    const restEntity = restEntities.find((entity) => entity.id === selection.restId);
+    if (!restEntity) return undefined;
+
+    if (selection.kind === 'rest') {
+      return {
+        title: 'Rest',
+        entity: restEntity,
+        path: restEntity.getRootPath(),
+        omitFields: restEntity.getOmitFormFields(),
+      };
+    }
+
+    const operationPath = `${restEntity.getRootPath()}.${selection.verb}.${selection.index}`;
+    return {
+      title: `${selection.verb.toUpperCase()} Operation`,
+      entity: restEntity,
+      path: operationPath,
+      omitFields: ['to'],
+    };
+  }, [restConfiguration, restEntities, selection]);
+
+  return {
+    selection,
+    setSelection,
+    selectedFormState,
+  };
+};

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslToUri.test.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslToUri.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+
+import {
+  createRestEntityWithDirectRouteNotFound,
+  createRestEntityWithNonDirectUri,
+  createRestEntityWithoutTo,
+  createSimpleRestVisualEntity,
+} from '../../../stubs';
+import { useRestDslToUri } from './useRestDslToUri';
+
+describe('useRestDslToUri', () => {
+  const mockDirectEndpointItems = [
+    { name: 'direct:users', value: 'direct:users' },
+    { name: 'direct:posts', value: 'direct:posts' },
+  ];
+
+  const mockDirectRouteInputs = new Set(['direct:users']);
+
+  const defaultProps = {
+    selection: undefined,
+    selectedFormState: undefined,
+    restEntities: [],
+    directEndpointItems: mockDirectEndpointItems,
+    directRouteInputs: mockDirectRouteInputs,
+    entitiesContext: null,
+    canAddRestEntities: false,
+    onChangeProp: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes with empty toUri value when no selection', () => {
+    const { result } = renderHook(() => useRestDslToUri(defaultProps));
+
+    expect(result.current.toUriValue).toBe('');
+    expect(result.current.directRouteExists).toBe(false);
+  });
+
+  it('returns toUri value for selected operation', () => {
+    const restEntities = [createSimpleRestVisualEntity('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.toUriValue).toBe('direct:users');
+  });
+
+  it('detects when direct route exists', () => {
+    const restEntities = [createSimpleRestVisualEntity('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.directRouteExists).toBe(true);
+  });
+
+  it('detects when direct route does not exist', () => {
+    const restEntities = [createRestEntityWithDirectRouteNotFound('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.directRouteExists).toBe(false);
+  });
+
+  it('returns empty toUri for rest entity selection', () => {
+    const restEntities = [createSimpleRestVisualEntity('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'rest', restId: 'rest-1' },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.toUriValue).toBe('');
+    expect(result.current.directRouteExists).toBe(false);
+  });
+
+  it('handles operation without to field', () => {
+    const restEntities = [createRestEntityWithoutTo('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.toUriValue).toBe('');
+  });
+
+  it('handles non-direct URI', () => {
+    const restEntities = [createRestEntityWithNonDirectUri('rest-1')];
+
+    const { result } = renderHook(() =>
+      useRestDslToUri({
+        ...defaultProps,
+        selection: { kind: 'operation', restId: 'rest-1', verb: 'get', index: 0 },
+        restEntities,
+      }),
+    );
+
+    expect(result.current.toUriValue).toBe('log:info');
+    expect(result.current.directRouteExists).toBe(false);
+  });
+});

--- a/packages/ui/src/pages/RestDsl/hooks/useRestDslToUri.ts
+++ b/packages/ui/src/pages/RestDsl/hooks/useRestDslToUri.ts
@@ -1,0 +1,182 @@
+import { TypeaheadItem } from '@kaoto/forms';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+import { EntityType } from '../../../models/camel/entities';
+import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { CamelRouteVisualEntity } from '../../../models/visualization/flows/camel-route-visual-entity';
+import { EntitiesContext } from '../../../providers';
+import { RestEditorSelection, SelectedFormState, ToUriSchema } from '../restDslTypes';
+
+interface UseRestDslToUriProps {
+  selection: RestEditorSelection | undefined;
+  selectedFormState: SelectedFormState | undefined;
+  restEntities: CamelRestVisualEntity[];
+  directEndpointItems: TypeaheadItem<string>[];
+  directRouteInputs: Set<string>;
+  canAddRestEntities: boolean;
+  onChangeProp: (path: string, value: unknown) => void;
+}
+
+export const useRestDslToUri = ({
+  selection,
+  selectedFormState,
+  restEntities,
+  directEndpointItems,
+  directRouteInputs,
+  canAddRestEntities,
+  onChangeProp,
+}: UseRestDslToUriProps) => {
+  const entitiesContext = useContext(EntitiesContext);
+
+  const [toUriValue, setToUriValue] = useState('');
+  const toUriFieldRef = useRef<HTMLDivElement | null>(null);
+
+  const getOperationToUri = useCallback(
+    (selectionValue: RestEditorSelection | undefined) => {
+      if (selectionValue?.kind !== 'operation') return '';
+      const restEntity = restEntities.find((entity) => entity.id === selectionValue.restId);
+      if (!restEntity) return '';
+      const restDefinition = restEntity.restDef?.rest ?? {};
+      const operations = (restDefinition as Record<string, unknown>)[selectionValue.verb] as
+        | Record<string, unknown>[]
+        | undefined;
+      const selectedOperation = operations?.[selectionValue.index];
+      if (!selectedOperation) return '';
+      const toValue = (selectedOperation as { to?: unknown }).to;
+      if (typeof toValue === 'string') return toValue;
+      if (toValue && typeof toValue === 'object') {
+        return String((toValue as { uri?: string })?.uri ?? '');
+      }
+      return '';
+    },
+    [restEntities],
+  );
+
+  const toUriSchema = useMemo<ToUriSchema | undefined>(() => {
+    if (selection?.kind !== 'operation' || !selectedFormState) return undefined;
+    const schema = selectedFormState.entity.getNodeSchema(selectedFormState.path) as
+      | { properties?: Record<string, unknown>; required?: string[] }
+      | undefined;
+    const toSchema = schema?.properties?.to as
+      | { properties?: Record<string, unknown>; required?: string[] }
+      | undefined;
+    const uriSchema = toSchema?.properties?.uri as
+      | { title?: string; description?: string; default?: unknown; type?: string }
+      | undefined;
+    const isRequired =
+      (Array.isArray(schema?.required) && schema?.required.includes('to')) ||
+      (Array.isArray(toSchema?.required) && toSchema?.required.includes('uri'));
+
+    return {
+      title: uriSchema?.title ?? (toSchema as { title?: string } | undefined)?.title ?? 'To URI',
+      description: uriSchema?.description ?? (toSchema as { description?: string } | undefined)?.description,
+      defaultValue: uriSchema?.default ?? (toSchema as { default?: unknown } | undefined)?.default,
+      required: isRequired,
+    };
+  }, [selectedFormState, selection]);
+
+  const selectionKey = useMemo(() => {
+    if (!selection) return 'none';
+    if (selection.kind === 'restConfiguration') return 'restConfiguration';
+    if (selection.kind === 'rest') return `rest-${selection.restId}`;
+    return `op-${selection.restId}-${selection.verb}-${selection.index}`;
+  }, [selection]);
+
+  const lastSelectionKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (lastSelectionKeyRef.current === selectionKey) return;
+    lastSelectionKeyRef.current = selectionKey;
+    setToUriValue(getOperationToUri(selection));
+  }, [getOperationToUri, selection, selectionKey]);
+
+  const selectedToUriItem = useMemo<TypeaheadItem<string> | undefined>(() => {
+    if (!toUriValue) return undefined;
+    return (
+      directEndpointItems.find((item) => item.value === toUriValue) ?? {
+        name: toUriValue,
+        value: toUriValue,
+      }
+    );
+  }, [directEndpointItems, toUriValue]);
+
+  const handleToUriChange = useCallback(
+    (item?: TypeaheadItem<string>) => {
+      const nextValue = item?.value ?? '';
+      setToUriValue(nextValue);
+      onChangeProp('to', nextValue || undefined);
+    },
+    [onChangeProp],
+  );
+
+  const handleToUriClear = useCallback(() => {
+    setToUriValue('');
+    onChangeProp('to', undefined);
+  }, [onChangeProp]);
+
+  useEffect(() => {
+    if (selection?.kind !== 'operation') return;
+    const container = toUriFieldRef.current;
+    if (!container) return;
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="rest-operation-to-uri-typeahead-select-input"]',
+    );
+    if (!input) return;
+
+    const handleInput = (event: Event) => {
+      const target = event.target as HTMLInputElement | null;
+      const nextValue = target?.value ?? '';
+      setToUriValue(nextValue);
+    };
+
+    input.addEventListener('input', handleInput);
+    return () => {
+      input.removeEventListener('input', handleInput);
+    };
+  }, [selection]);
+
+  const normalizeRestTargetEndpoint = useCallback((value: string) => {
+    if (value.startsWith('direct:')) return value;
+    return `direct:${value}`;
+  }, []);
+
+  const directRouteExists = useMemo(() => {
+    if (!toUriValue) return false;
+    const normalized = normalizeRestTargetEndpoint(toUriValue.trim());
+    return directRouteInputs.has(normalized);
+  }, [directRouteInputs, normalizeRestTargetEndpoint, toUriValue]);
+
+  const handleCreateDirectRoute = useCallback(() => {
+    if (!entitiesContext || !canAddRestEntities) return;
+    const rawValue = toUriValue?.trim();
+    if (!rawValue) return;
+
+    const normalized = normalizeRestTargetEndpoint(rawValue);
+    if (!normalized.startsWith('direct:')) return;
+
+    const camelResource = entitiesContext.camelResource as unknown as {
+      addNewEntity: (type?: EntityType) => string;
+      getVisualEntities: () => Array<{ id: string; type: EntityType }>;
+    };
+
+    const newId = camelResource.addNewEntity(EntityType.Route);
+    const routeEntity = camelResource
+      .getVisualEntities()
+      .find((entity) => entity.type === EntityType.Route && entity.id === newId) as CamelRouteVisualEntity | undefined;
+
+    routeEntity?.updateModel('route.from.uri', normalized);
+    entitiesContext.updateEntitiesFromCamelResource();
+  }, [canAddRestEntities, entitiesContext, normalizeRestTargetEndpoint, toUriValue]);
+
+  return {
+    toUriValue,
+    setToUriValue,
+    toUriFieldRef,
+    toUriSchema,
+    selectedToUriItem,
+    directRouteExists,
+    handleToUriChange,
+    handleToUriClear,
+    handleCreateDirectRoute,
+  };
+};

--- a/packages/ui/src/pages/RestDsl/index.ts
+++ b/packages/ui/src/pages/RestDsl/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/packages/ui/src/pages/RestDsl/restDslTypes.ts
+++ b/packages/ui/src/pages/RestDsl/restDslTypes.ts
@@ -1,0 +1,29 @@
+import { REST_DSL_VERBS } from '../../models/special-processors.constants';
+
+export type RestVerb = (typeof REST_DSL_VERBS)[number];
+
+export type RestEditorSelection =
+  | { kind: 'restConfiguration' }
+  | { kind: 'rest'; restId: string }
+  | { kind: 'operation'; restId: string; verb: RestVerb; index: number };
+
+export type FormEntity = {
+  getNodeSchema: (path: string) => unknown;
+  getNodeDefinition: (path: string) => unknown;
+  getRootPath: () => string;
+  updateModel: (path: string | undefined, value: unknown) => void;
+};
+
+export type SelectedFormState = {
+  title?: string;
+  entity: FormEntity;
+  path: string;
+  omitFields?: string[];
+};
+
+export type ToUriSchema = {
+  required: boolean;
+  title?: string;
+  description?: string;
+  defaultValue?: unknown;
+};

--- a/packages/ui/src/pages/RestDsl/router-exports.tsx
+++ b/packages/ui/src/pages/RestDsl/router-exports.tsx
@@ -1,0 +1,3 @@
+import { RestDslPage } from './RestDslPage';
+
+export const element = <RestDslPage />;

--- a/packages/ui/src/pages/RestDsl/utils/rest-dsl-helpers.test.ts
+++ b/packages/ui/src/pages/RestDsl/utils/rest-dsl-helpers.test.ts
@@ -1,0 +1,46 @@
+import { getListItemClass } from './rest-dsl-helpers';
+
+describe('rest-dsl-helpers', () => {
+  describe('getListItemClass', () => {
+    it('returns selected class for matching rest selection', () => {
+      const selection = { kind: 'rest' as const, restId: 'rest-1' };
+      const target = { kind: 'rest' as const, restId: 'rest-1' };
+
+      expect(getListItemClass(selection, target)).toBe('rest-dsl-nav-item rest-dsl-nav-item-selected');
+    });
+
+    it('returns base class for non-matching rest selection', () => {
+      const selection = { kind: 'rest' as const, restId: 'rest-1' };
+      const target = { kind: 'rest' as const, restId: 'rest-2' };
+
+      expect(getListItemClass(selection, target)).toBe('rest-dsl-nav-item');
+    });
+
+    it('returns selected class for matching operation selection', () => {
+      const selection = { kind: 'operation' as const, restId: 'rest-1', verb: 'get' as const, index: 0 };
+      const target = { kind: 'operation' as const, restId: 'rest-1', verb: 'get' as const, index: 0 };
+
+      expect(getListItemClass(selection, target)).toBe('rest-dsl-nav-item rest-dsl-nav-item-selected');
+    });
+
+    it('returns base class for operation with different index', () => {
+      const selection = { kind: 'operation' as const, restId: 'rest-1', verb: 'get' as const, index: 0 };
+      const target = { kind: 'operation' as const, restId: 'rest-1', verb: 'get' as const, index: 1 };
+
+      expect(getListItemClass(selection, target)).toBe('rest-dsl-nav-item');
+    });
+
+    it('returns base class when selection is undefined', () => {
+      const target = { kind: 'rest' as const, restId: 'rest-1' };
+
+      expect(getListItemClass(undefined, target)).toBe('rest-dsl-nav-item');
+    });
+
+    it('returns base class for mismatched kinds', () => {
+      const selection = { kind: 'rest' as const, restId: 'rest-1' };
+      const target = { kind: 'operation' as const, restId: 'rest-1', verb: 'get' as const, index: 0 };
+
+      expect(getListItemClass(selection, target)).toBe('rest-dsl-nav-item');
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDsl/utils/rest-dsl-helpers.ts
+++ b/packages/ui/src/pages/RestDsl/utils/rest-dsl-helpers.ts
@@ -1,0 +1,123 @@
+import { TypeaheadItem } from '@kaoto/forms';
+
+import { EntityType } from '../../../models/camel/entities';
+import { BaseVisualCamelEntity } from '../../../models/visualization/base-visual-entity';
+import { CamelRouteVisualEntity } from '../../../models/visualization/flows/camel-route-visual-entity';
+import { getValue } from '../../../utils';
+import { RestEditorSelection } from '../restDslTypes';
+
+/**
+ * Checks if a URI is an allowed REST target endpoint
+ */
+export const isAllowedRestTargetEndpoint = (uri: string): boolean => {
+  return uri.startsWith('direct:');
+};
+
+/**
+ * Collects direct endpoint URIs from visual entities
+ */
+export const collectDirectEndpoints = (visualEntities: BaseVisualCamelEntity[]): TypeaheadItem<string>[] => {
+  const endpoints = new Set<string>();
+  const visited = new WeakSet<Record<string, unknown>>();
+
+  const collectDirectEndpoint = (value: Record<string, unknown>) => {
+    const idValue = getValue(value, 'id');
+    if (typeof idValue === 'string') {
+      endpoints.add(`direct:${idValue}`);
+    }
+  };
+
+  const addEndpointIfAllowed = (value: string) => {
+    if (isAllowedRestTargetEndpoint(value)) {
+      endpoints.add(value);
+    }
+  };
+
+  const collectUriValue = (value: Record<string, unknown>) => {
+    const uriValue = getValue(value, 'uri');
+    if (typeof uriValue !== 'string') return;
+    if (isAllowedRestTargetEndpoint(uriValue)) {
+      endpoints.add(uriValue);
+      return;
+    }
+    if (uriValue === 'direct') {
+      collectDirectEndpoint(value);
+    }
+  };
+
+  const collectObject = (value: Record<string, unknown>) => {
+    if (visited.has(value)) return;
+    visited.add(value);
+    collectUriValue(value);
+    Object.values(value).forEach((item) => collect(item));
+  };
+
+  const collect = (value: unknown) => {
+    if (!value) return;
+    if (typeof value === 'string') {
+      addEndpointIfAllowed(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item) => collect(item));
+      return;
+    }
+    if (typeof value === 'object') {
+      collectObject(value as Record<string, unknown>);
+    }
+  };
+
+  visualEntities.forEach((entity) => {
+    if (entity.type === EntityType.Route) {
+      const routeEntity = entity as CamelRouteVisualEntity;
+      collect(routeEntity.entityDef);
+      return;
+    }
+    collect((entity as unknown as { entityDef?: unknown }).entityDef ?? entity);
+  });
+
+  return Array.from(endpoints)
+    .sort((a, b) => a.localeCompare(b))
+    .map((uri) => ({ name: uri, value: uri }));
+};
+
+/**
+ * Collects direct route input URIs from route entities
+ */
+export const collectDirectRouteInputs = (visualEntities: BaseVisualCamelEntity[]): Set<string> => {
+  const inputs = new Set<string>();
+
+  visualEntities.forEach((entity) => {
+    if (entity.type !== EntityType.Route) return;
+    const routeEntity = entity as CamelRouteVisualEntity;
+    const fromUri = getValue(routeEntity.entityDef, 'route.from.uri');
+    if (typeof fromUri === 'string' && fromUri.startsWith('direct:')) {
+      inputs.add(fromUri);
+    }
+  });
+
+  return inputs;
+};
+
+/**
+ * Generates a CSS class name for a navigation list item based on selection state
+ */
+export const getListItemClass = (selection: RestEditorSelection | undefined, target: RestEditorSelection): string => {
+  const isSelected =
+    selection?.kind === target.kind &&
+    (target.kind === 'restConfiguration' ||
+      (selection?.kind !== 'restConfiguration' &&
+        selection?.restId === (target as { restId?: string }).restId &&
+        (target.kind !== 'operation' ||
+          (selection?.kind === 'operation' && selection.verb === target.verb && selection.index === target.index))));
+
+  return `rest-dsl-nav-item${isSelected ? ' rest-dsl-nav-item-selected' : ''}`;
+};
+
+/**
+ * Normalizes a REST target endpoint to ensure it has the 'direct:' prefix
+ */
+export const normalizeRestTargetEndpoint = (value: string): string => {
+  if (value.startsWith('direct:')) return value;
+  return `direct:${value}`;
+};

--- a/packages/ui/src/pages/RestDsl/utils/rest-dsl-validators.test.ts
+++ b/packages/ui/src/pages/RestDsl/utils/rest-dsl-validators.test.ts
@@ -1,0 +1,33 @@
+import { isValidOperationId } from './rest-dsl-validators';
+
+describe('rest-dsl-validators', () => {
+  describe('isValidOperationId', () => {
+    it('returns true for valid alphanumeric IDs', () => {
+      expect(isValidOperationId('getUsers')).toBe(true);
+      expect(isValidOperationId('createUser123')).toBe(true);
+      expect(isValidOperationId('DELETE_USER')).toBe(true);
+    });
+
+    it('returns true for IDs with hyphens and underscores', () => {
+      expect(isValidOperationId('get-users')).toBe(true);
+      expect(isValidOperationId('get_users')).toBe(true);
+      expect(isValidOperationId('get-users_v2')).toBe(true);
+    });
+
+    it('returns false for empty or whitespace-only strings', () => {
+      expect(isValidOperationId('')).toBe(false);
+      expect(isValidOperationId('   ')).toBe(false);
+    });
+
+    it('returns false for IDs with invalid characters', () => {
+      expect(isValidOperationId('get users')).toBe(false);
+      expect(isValidOperationId('get@users')).toBe(false);
+      expect(isValidOperationId('get.users')).toBe(false);
+      expect(isValidOperationId('get/users')).toBe(false);
+    });
+
+    it('trims whitespace before validation', () => {
+      expect(isValidOperationId('  getUsers  ')).toBe(true);
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDsl/utils/rest-dsl-validators.ts
+++ b/packages/ui/src/pages/RestDsl/utils/rest-dsl-validators.ts
@@ -1,0 +1,93 @@
+import { REST_DSL_VERBS } from '../../../models/special-processors.constants';
+import { RestVerb } from '../restDslTypes';
+
+/**
+ * Validates if a REST operation path is valid
+ */
+export const isValidOperationPath = (path: string): boolean => {
+  if (!path || typeof path !== 'string') return false;
+  const trimmed = path.trim();
+  return trimmed.length > 0;
+};
+
+/**
+ * Validates if a REST operation ID is valid
+ */
+export const isValidOperationId = (id: string): boolean => {
+  if (!id || typeof id !== 'string') return false;
+  const trimmed = id.trim();
+  // IDs should not contain spaces or special characters that could cause issues
+  return trimmed.length > 0 && /^[a-zA-Z0-9_-]+$/.test(trimmed);
+};
+
+/**
+ * Validates if a REST verb is valid
+ */
+export const isValidRestVerb = (verb: string): verb is RestVerb => {
+  return REST_DSL_VERBS.includes(verb);
+};
+
+/**
+ * Validates if a direct endpoint URI is properly formatted
+ */
+export const isValidDirectEndpoint = (uri: string): boolean => {
+  if (!uri || typeof uri !== 'string') return false;
+  const trimmed = uri.trim();
+  if (!trimmed.startsWith('direct:')) return false;
+  const endpointName = trimmed.substring(7); // Remove 'direct:' prefix
+  return endpointName.length > 0;
+};
+
+/**
+ * Sanitizes a string to be used as a REST operation ID
+ */
+export const sanitizeOperationId = (input: string): string => {
+  if (!input || typeof input !== 'string') return '';
+  return input
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, '-') // Replace invalid chars with dash
+    .replace(/-+/g, '-') // Replace multiple dashes with single dash
+    .replace(/^-|-$/g, ''); // Remove leading/trailing dashes
+};
+
+/**
+ * Validates REST configuration properties
+ */
+export const validateRestConfiguration = (config: Record<string, unknown>): string[] => {
+  const errors: string[] = [];
+
+  if (config.host && typeof config.host !== 'string') {
+    errors.push('Host must be a string');
+  }
+
+  if (config.port && typeof config.port !== 'number') {
+    errors.push('Port must be a number');
+  }
+
+  if (config.contextPath && typeof config.contextPath !== 'string') {
+    errors.push('Context path must be a string');
+  }
+
+  return errors;
+};
+
+/**
+ * Validates REST element properties
+ */
+export const validateRestElement = (rest: Record<string, unknown>): string[] => {
+  const errors: string[] = [];
+
+  if (rest.path && typeof rest.path !== 'string') {
+    errors.push('Path must be a string');
+  }
+
+  if (rest.consumes && typeof rest.consumes !== 'string') {
+    errors.push('Consumes must be a string');
+  }
+
+  if (rest.produces && typeof rest.produces !== 'string') {
+    errors.push('Produces must be a string');
+  }
+
+  return errors;
+};

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
@@ -23,11 +23,11 @@ describe('RestDslImportPage', () => {
     expect(screen.getByLabelText('Upload file')).toBeInTheDocument();
   });
 
-  it('navigates back to the Home page when closing the wizard', async () => {
+  it('navigates back to the Rest editor page when closing the wizard', async () => {
     render(
       <MemoryRouter initialEntries={[Links.RestImport]}>
         <Routes>
-          <Route path={Links.Home} element={<p>Home page</p>} />
+          <Route path={Links.Rest} element={<p>Rest editor</p>} />
           <Route path={Links.RestImport} element={<RestDslImportPage />} />
         </Routes>
       </MemoryRouter>,
@@ -43,7 +43,7 @@ describe('RestDslImportPage', () => {
       fireEvent.click(goToRestEditorButton);
     });
 
-    expect(screen.getByText('Home page')).toBeInTheDocument();
+    expect(screen.getByText('Rest editor')).toBeInTheDocument();
   });
 
   it('navigates back to the Home page when closing the wizard', async () => {

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
@@ -9,7 +9,7 @@ export const RestDslImportPage: FunctionComponent = () => {
   const navigate = useNavigate();
 
   const handleClose = useCallback(() => {
-    navigate(Links.Home);
+    navigate(Links.Rest);
   }, [navigate]);
 
   const handleGoToDesigner = useCallback(() => {

--- a/packages/ui/src/router.tsx
+++ b/packages/ui/src/router.tsx
@@ -24,6 +24,10 @@ export const router = createHashRouter([
         lazy: async () => import('./pages/SourceCode'),
       },
       {
+        path: Links.Rest,
+        lazy: async () => import('./pages/RestDsl'),
+      },
+      {
         path: Links.RestImport,
         lazy: async () => import('./pages/RestDslImport'),
       },


### PR DESCRIPTION
### Context
Implement a form-based editor for the code-first Rest DSL.

fix: https://github.com/KaotoIO/kaoto/issues/756
relates to https://github.com/KaotoIO/kaoto/issues/909