### PR TITLE
fix(e2e): resolve inconsistent E2E test failures

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
@@ -9,7 +9,7 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openStepConfigurationTab('timer');
 
-    cy.get('[data-testid="step-toolbar-button-replace"]').click();
+    cy.get('[data-testid="timer|step-toolbar-button-replace"]').click();
     cy.chooseFromCatalog('component', 'quartz');
 
     cy.checkNodeExist('quartz', 1);
@@ -21,7 +21,7 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openStepConfigurationTab('setHeader');
 
-    cy.get('[data-testid="step-toolbar-button-delete"]').click();
+    cy.get('[data-testid="setHeader|step-toolbar-button-delete"]').click();
 
     cy.checkNodeExist('setHeader', 0);
   });
@@ -31,7 +31,7 @@ describe('Test toolbar on hover actions', () => {
     cy.openDesignPage();
 
     cy.openStepConfigurationTab('setHeader');
-    cy.get('[data-testid="step-toolbar-button-disable"]').click();
+    cy.get('[data-testid="setHeader|step-toolbar-button-disable"]').click();
 
     cy.openStepConfigurationTab('setHeader');
 
@@ -39,7 +39,7 @@ describe('Test toolbar on hover actions', () => {
     cy.expandWrappedSection('#-Advanced');
     cy.checkConfigCheckboxObject('disabled', true);
 
-    cy.get('[data-testid="step-toolbar-button-disable"]').click();
+    cy.get('[data-testid="setHeader|step-toolbar-button-disable"]').click();
 
     cy.openStepConfigurationTab('setHeader');
 
@@ -53,7 +53,7 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openGroupConfigurationTab('camel-route');
 
-    cy.get('[data-testid="step-toolbar-button-delete-group"]').click();
+    cy.get('[data-testid="camel-route|step-toolbar-button-delete-group"]').click();
     cy.get('[data-testid="action-confirmation-modal-btn-confirm"]').click();
 
     cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
@@ -68,7 +68,7 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openGroupConfigurationTab('choice');
 
-    cy.get('[data-testid="step-toolbar-button-add-special"]').click();
+    cy.get('[data-testid="choice|step-toolbar-button-add-special"]').click();
 
     cy.chooseFromCatalog('processor', 'when');
     cy.checkNodeExist('when', 4);
@@ -81,12 +81,12 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openGroupConfigurationTab('choice');
 
-    cy.get(`[data-testid="step-toolbar-button-collapse"]`).click({ force: true });
+    cy.get(`[data-testid="choice|step-toolbar-button-collapse"]`).click({ force: true });
     cy.checkNodeExist('when', 0);
     cy.checkNodeExist('otherwise', 0);
     cy.checkNodeExist('log', 0);
 
-    cy.get(`[data-testid="step-toolbar-button-collapse"]`).click({ force: true });
+    cy.get(`[data-testid="choice|step-toolbar-button-collapse"]`).click({ force: true });
     cy.checkNodeExist('when', 3);
     cy.checkNodeExist('otherwise', 1);
     cy.checkNodeExist('log', 1);
@@ -98,7 +98,7 @@ describe('Test toolbar on hover actions', () => {
 
     cy.openGroupConfigurationTab('choice');
 
-    cy.get(`[data-testid="step-toolbar-button-collapse"]`).click({ force: true });
+    cy.get(`[data-testid="choice|step-toolbar-button-collapse"]`).click({ force: true });
     cy.checkNodeExist('when', 0);
     cy.checkNodeExist('otherwise', 0);
 

--- a/packages/ui-tests/cypress/support/next-commands/default.ts
+++ b/packages/ui-tests/cypress/support/next-commands/default.ts
@@ -218,7 +218,7 @@ Cypress.Commands.add('deleteRoute', (index: number) => {
 
 Cypress.Commands.add('deleteRouteInCanvas', (routeName: string) => {
   cy.openGroupConfigurationTab(routeName);
-  cy.get('button[data-testid="step-toolbar-button-delete-group"]').click();
+  cy.get(`button[data-testid="${routeName}|step-toolbar-button-delete-group"]`).click();
   cy.get('body').then(($body) => {
     if ($body.find('.pf-m-danger').length) {
       // Delete Confirmation Modal appeared, click on the confirm button

--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -18,7 +18,7 @@ Cypress.Commands.add('openGroupConfigurationTab', (group: string, groupIndex?: n
 
 Cypress.Commands.add('toggleExpandGroup', (groupName: string) => {
   cy.get(`span[title="${groupName}"]`).click({ force: true });
-  cy.get(`[data-testid="step-toolbar-button-collapse"]`).click({ force: true });
+  cy.get(`[data-testid="${groupName}|step-toolbar-button-collapse"]`).click({ force: true });
 });
 
 Cypress.Commands.add('closeStepConfigurationTab', () => {
@@ -270,7 +270,7 @@ Cypress.Commands.add('DnDOnNode', (sourceNodeName: string, targetNodeName: strin
   const sourceNode = cy.get(`[data-testid="${sourceNodeName}"]`);
   const targetNode = cy.get(`[data-testid="${targetNodeName}"]`);
 
-  sourceNode.realMouseDown({ button: 'left', position: 'center' }).realMouseMove(0, 0, { position: 'center' });
+  sourceNode.realMouseDown({ button: 'left', position: 'topLeft' }).realMouseMove(0, 0, { position: 'center' });
   targetNode.realMouseMove(0, 0, { position: 'center' }).realMouseUp();
 });
 
@@ -278,6 +278,6 @@ Cypress.Commands.add('DnDOnEdge', (sourceNodeName: string, targetEdgeName: strin
   const sourceNode = cy.get(`[data-testid="${sourceNodeName}"]`);
   const targetEdge = cy.get(`[data-id="${targetEdgeName}"]`);
 
-  sourceNode.realMouseDown({ button: 'left', position: 'center' }).realMouseMove(0, 0, { position: 'center' });
+  sourceNode.realMouseDown({ button: 'left', position: 'topLeft' }).realMouseMove(0, 0, { position: 'center' });
   targetEdge.realMouseMove(0, 0, { position: 'center' }).realMouseUp({ position: 'center' });
 });

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
@@ -34,6 +34,7 @@ describe('StepToolbar', () => {
   const mockGetNodeInteraction = jest.fn();
   const mockVizNode = {
     getNodeInteraction: mockGetNodeInteraction,
+    getNodeLabel: jest.fn().mockReturnValue('Test Node'),
   } as unknown as IVisualizationNode;
 
   const defaultNodeInteraction = {
@@ -80,13 +81,13 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      expect(screen.queryByTestId('step-toolbar-button-duplicate')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-add-special')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-disable')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-enable-all')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-replace')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-delete')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('step-toolbar-button-delete-group')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-duplicate')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-add-special')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-disable')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-enable-all')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-replace')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-delete')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-delete-group')).not.toBeInTheDocument();
     });
   });
 
@@ -99,7 +100,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const duplicateButton = screen.getByTestId('step-toolbar-button-duplicate');
+      const duplicateButton = screen.getByTestId('Test Node|step-toolbar-button-duplicate');
       expect(duplicateButton).toBeInTheDocument();
       expect(duplicateButton).toHaveAttribute('title', 'Duplicate');
 
@@ -119,7 +120,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const moveButton = screen.getByTestId('step-toolbar-button-move-before');
+      const moveButton = screen.getByTestId('Test Node|step-toolbar-button-move-before');
       expect(moveButton).toBeInTheDocument();
       expect(moveButton).toHaveAttribute('title', 'Move before');
 
@@ -137,7 +138,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const moveButton = screen.getByTestId('step-toolbar-button-move-after');
+      const moveButton = screen.getByTestId('Test Node|step-toolbar-button-move-after');
       expect(moveButton).toBeInTheDocument();
       expect(moveButton).toHaveAttribute('title', 'Move after');
 
@@ -161,7 +162,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const addSpecialButton = screen.getByTestId('step-toolbar-button-add-special');
+      const addSpecialButton = screen.getByTestId('Test Node|step-toolbar-button-add-special');
       expect(addSpecialButton).toBeInTheDocument();
       expect(addSpecialButton).toHaveAttribute('title', 'Add branch');
 
@@ -184,7 +185,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const disableButton = screen.getByTestId('step-toolbar-button-disable');
+      const disableButton = screen.getByTestId('Test Node|step-toolbar-button-disable');
       expect(disableButton).toHaveAttribute('title', 'Disable step');
     });
 
@@ -199,7 +200,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const disableButton = screen.getByTestId('step-toolbar-button-disable');
+      const disableButton = screen.getByTestId('Test Node|step-toolbar-button-disable');
       expect(disableButton).toHaveAttribute('title', 'Enable step');
     });
 
@@ -215,7 +216,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const disableButton = screen.getByTestId('step-toolbar-button-disable');
+      const disableButton = screen.getByTestId('Test Node|step-toolbar-button-disable');
       act(() => {
         fireEvent.click(disableButton);
       });
@@ -232,7 +233,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const enableAllButton = screen.getByTestId('step-toolbar-button-enable-all');
+      const enableAllButton = screen.getByTestId('Test Node|step-toolbar-button-enable-all');
       expect(enableAllButton).toBeInTheDocument();
       expect(enableAllButton).toHaveAttribute('title', 'Enable all');
 
@@ -256,7 +257,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const replaceButton = screen.getByTestId('step-toolbar-button-replace');
+      const replaceButton = screen.getByTestId('Test Node|step-toolbar-button-replace');
       expect(replaceButton).toBeInTheDocument();
       expect(replaceButton).toHaveAttribute('title', 'Replace step');
 
@@ -275,7 +276,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} isCollapsed={false} />);
       });
 
-      const collapseButton = screen.getByTestId('step-toolbar-button-collapse');
+      const collapseButton = screen.getByTestId('Test Node|step-toolbar-button-collapse');
       expect(collapseButton).toHaveAttribute('title', 'Collapse step');
     });
 
@@ -286,7 +287,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} isCollapsed={true} />);
       });
 
-      const collapseButton = screen.getByTestId('step-toolbar-button-collapse');
+      const collapseButton = screen.getByTestId('Test Node|step-toolbar-button-collapse');
       expect(collapseButton).toHaveAttribute('title', 'Expand step');
     });
 
@@ -297,7 +298,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} />);
       });
 
-      const collapseButton = screen.getByTestId('step-toolbar-button-collapse');
+      const collapseButton = screen.getByTestId('Test Node|step-toolbar-button-collapse');
       act(() => {
         fireEvent.click(collapseButton);
       });
@@ -309,7 +310,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      expect(screen.queryByTestId('step-toolbar-button-collapse')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('Test Node|step-toolbar-button-collapse')).not.toBeInTheDocument();
     });
   });
 
@@ -326,7 +327,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const deleteButton = screen.getByTestId('step-toolbar-button-delete');
+      const deleteButton = screen.getByTestId('Test Node|step-toolbar-button-delete');
       expect(deleteButton).toBeInTheDocument();
       expect(deleteButton).toHaveAttribute('title', 'Delete step');
 
@@ -350,7 +351,7 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} />);
       });
 
-      const deleteGroupButton = screen.getByTestId('step-toolbar-button-delete-group');
+      const deleteGroupButton = screen.getByTestId('Test Node|step-toolbar-button-delete-group');
       expect(deleteGroupButton).toBeInTheDocument();
       expect(deleteGroupButton).toHaveAttribute('title', 'Delete group');
 
@@ -382,14 +383,14 @@ describe('StepToolbar', () => {
         render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} />);
       });
 
-      expect(screen.getByTestId('step-toolbar-button-duplicate')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-add-special')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-disable')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-enable-all')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-replace')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-collapse')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-delete')).toBeInTheDocument();
-      expect(screen.getByTestId('step-toolbar-button-delete-group')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-duplicate')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-add-special')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-disable')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-enable-all')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-replace')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-collapse')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-delete')).toBeInTheDocument();
+      expect(screen.getByTestId('Test Node|step-toolbar-button-delete-group')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -15,9 +15,10 @@ import {
   TrashIcon,
 } from '@patternfly/react-icons';
 import clsx from 'clsx';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useContext } from 'react';
 
 import { AddStepMode, IDataTestID, IVisualizationNode } from '../../../../models';
+import { SettingsContext } from '../../../../providers/settings.provider';
 import { useDeleteGroup } from '../../Custom/hooks/delete-group.hook';
 import { useDeleteStep } from '../../Custom/hooks/delete-step.hook';
 import { useDisableStep } from '../../Custom/hooks/disable-step.hook';
@@ -42,8 +43,10 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
   onCollapseToggle,
   'data-testid': dataTestId,
 }) => {
+  const settingsAdapter = useContext(SettingsContext);
   const { canHaveSpecialChildren, canBeDisabled, canReplaceStep, canRemoveStep, canRemoveFlow } =
     vizNode.getNodeInteraction();
+  const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
   const { onInsertStep: onInsertSpecial } = useInsertStep(vizNode, AddStepMode.InsertSpecialChildStep);
   const { onToggleDisableNode, isDisabled } = useDisableStep(vizNode);
   const { areMultipleStepsDisabled, onEnableAllSteps } = useEnableAllSteps();
@@ -61,7 +64,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<BlueprintIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-duplicate"
+            data-testid={`${label}|step-toolbar-button-duplicate`}
             variant="control"
             title="Duplicate"
             onClick={(event) => {
@@ -75,7 +78,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<AngleDoubleUpIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-move-before"
+            data-testid={`${label}|step-toolbar-button-move-before`}
             variant="control"
             title="Move before"
             onClick={(event) => {
@@ -89,7 +92,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<AngleDoubleDownIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-move-after"
+            data-testid={`${label}|step-toolbar-button-move-after`}
             variant="control"
             title="Move after"
             onClick={(event) => {
@@ -103,7 +106,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<CodeBranchIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-add-special"
+            data-testid={`${label}|step-toolbar-button-add-special`}
             variant="control"
             title="Add branch"
             onClick={(event) => {
@@ -116,7 +119,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
         {canBeDisabled && (
           <Button
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-disable"
+            data-testid={`${label}|step-toolbar-button-disable`}
             variant="control"
             title={isDisabled ? 'Enable step' : 'Disable step'}
             onClick={(event) => {
@@ -132,7 +135,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<PowerOffIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-enable-all"
+            data-testid={`${label}|step-toolbar-button-enable-all`}
             variant="control"
             title="Enable all"
             onClick={(event) => {
@@ -146,7 +149,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<SyncAltIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-replace"
+            data-testid={`${label}|step-toolbar-button-replace`}
             variant="control"
             title="Replace step"
             onClick={(event) => {
@@ -159,7 +162,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
         {onCollapseToggle && (
           <Button
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-collapse"
+            data-testid={`${label}|step-toolbar-button-collapse`}
             variant="control"
             title={isCollapsed ? 'Expand step' : 'Collapse step'}
             onClick={(event) => {
@@ -175,7 +178,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<TrashIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-delete"
+            data-testid={`${label}|step-toolbar-button-delete`}
             variant="stateful"
             state="attention"
             title="Delete step"
@@ -190,7 +193,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
           <Button
             icon={<TrashIcon />}
             className="step-toolbar__button"
-            data-testid="step-toolbar-button-delete-group"
+            data-testid={`${label}|step-toolbar-button-delete-group`}
             variant="stateful"
             state="attention"
             title="Delete group"


### PR DESCRIPTION
For some time, a few E2E tests were failing inconsistently. We identified a scenario involving the step toolbar for containers where multiple toolbars could appear simultaneously for different containers. This caused test failures because two action buttons of the same type were being matched. The behavior was intermittent earlier, but it should no longer occur now.