### PR TITLE
feat(DataMapper): xs:import: S.1: Implement FileMap URI Resolver

### DIFF
--- a/packages/ui/src/services/xml-schema-document-util.service.ts
+++ b/packages/ui/src/services/xml-schema-document-util.service.ts
@@ -300,7 +300,7 @@ export class XmlSchemaDocumentUtilService {
     const filePaths = Object.keys(definitionFiles);
     for (const path of filePaths) {
       const fileContent = definitionFiles[path];
-      collection.read(fileContent, () => {});
+      collection.read(fileContent, () => {}, path);
     }
   }
 

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -63,6 +63,7 @@ export class XmlSchemaDocumentService {
     const docId = definition.documentType === DocumentType.PARAM ? definition.name! : 'Body';
 
     const collection = new XmlSchemaCollection();
+    definition.definitionFiles && collection.getSchemaResolver().addFiles(definition.definitionFiles);
 
     try {
       XmlSchemaDocumentUtilService.loadXmlSchemaFiles(collection, definition.definitionFiles || {});
@@ -123,6 +124,22 @@ export class XmlSchemaDocumentService {
       document,
       rootElementOptions,
     };
+  }
+
+  /**
+   * Adds additional schema files to an existing document's schema collection.
+   * This is useful when field type overrides reference types defined in additional schema files.
+   * @param document - The document whose schema collection will be updated
+   * @param additionalFiles - Map of file paths to file contents to add
+   */
+  static addSchemaFiles(document: XmlSchemaDocument, additionalFiles: Record<string, string>): void {
+    const collection = document.xmlSchemaCollection;
+    const resolver = collection.getSchemaResolver();
+
+    resolver.addFiles(additionalFiles);
+
+    XmlSchemaDocumentUtilService.loadXmlSchemaFiles(collection, additionalFiles);
+    XmlSchemaDocumentService.populateNamedTypeFragments(document);
   }
 
   /**

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -150,6 +150,10 @@ export const elementRefXsd = fs.readFileSync(path.resolve(__dirname, './xml/elem
 export const accountLcXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-lc.xsd')).toString();
 export const accountNsXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns.xsd')).toString();
 export const accountNs2Xsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns2.xsd')).toString();
+export const mainWithIncludeXsd = fs.readFileSync(path.resolve(__dirname, './xml/MainWithInclude.xsd')).toString();
+export const commonTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/CommonTypes.xsd')).toString();
+export const mainWithImportXsd = fs.readFileSync(path.resolve(__dirname, './xml/MainWithImport.xsd')).toString();
+export const importedTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/ImportedTypes.xsd')).toString();
 
 export class TestUtil {
   static createSourceOrderDoc() {

--- a/packages/ui/src/stubs/datamapper/xml/CommonTypes.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/CommonTypes.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="CommonType">
+    <xs:sequence>
+      <xs:element name="field1" type="xs:string"/>
+      <xs:element name="field2" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/ImportedTypes.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/ImportedTypes.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/types">
+  <xs:complexType name="ImportedType">
+    <xs:sequence>
+      <xs:element name="field" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/MainWithImport.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/MainWithImport.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/main"
+           xmlns:types="http://example.com/types">
+  <xs:import namespace="http://example.com/types" schemaLocation="ImportedTypes.xsd"/>
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="imported" type="types:ImportedType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/MainWithInclude.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/MainWithInclude.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="./CommonTypes.xsd"/>
+  <xs:element name="Main" type="CommonType"/>
+</xs:schema>

--- a/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
@@ -375,4 +375,16 @@ describe('XmlSchemaCollection', () => {
       expect(xsdSchema).toBeUndefined();
     });
   });
+
+  describe('setBaseUri', () => {
+    it('should set base URI on collection and resolver', () => {
+      const collection = new XmlSchemaCollection();
+      const testUri = 'http://example.com/schemas';
+
+      collection.setBaseUri(testUri);
+
+      expect(collection.baseUri).toBe(testUri);
+      expect(collection.getSchemaResolver().getCollectionBaseURI()).toBe(testUri);
+    });
+  });
 });

--- a/packages/ui/src/xml-schema-ts/index.ts
+++ b/packages/ui/src/xml-schema-ts/index.ts
@@ -17,6 +17,7 @@ export { XmlSchemaGroupRef } from './particle/XmlSchemaGroupRef';
 export { XmlSchemaParticle } from './particle/XmlSchemaParticle';
 export { XmlSchemaSequence } from './particle/XmlSchemaSequence';
 export type { XmlSchemaSequenceMember } from './particle/XmlSchemaSequenceMember';
+export { DefaultURIResolver } from './resolver/DefaultURIResolver';
 export { XmlSchemaSimpleContentExtension } from './simple/XmlSchemaSimpleContentExtension';
 export { XmlSchemaSimpleContentRestriction } from './simple/XmlSchemaSimpleContentRestriction';
 export { XmlSchemaSimpleType } from './simple/XmlSchemaSimpleType';

--- a/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
@@ -1,0 +1,289 @@
+import { DefaultURIResolver } from './DefaultURIResolver';
+
+describe('DefaultURIResolver', () => {
+  describe('without file map', () => {
+    it('should throw error when resolving entity without file map', () => {
+      const resolver = new DefaultURIResolver();
+
+      expect(() => {
+        resolver.resolveEntity(null, 'schema.xsd', null);
+      }).toThrow('XML schema External entity resolution is not yet supported');
+    });
+
+    it('should allow adding files after construction', () => {
+      const resolver = new DefaultURIResolver();
+
+      resolver.addFiles({ 'schema.xsd': '<schema>schema</schema>' });
+
+      expect(resolver.resolveEntity(null, 'schema.xsd', null)).toBe('<schema>schema</schema>');
+    });
+  });
+
+  describe('with file map', () => {
+    describe('resolveEntity', () => {
+      it('should resolve exact filename match', () => {
+        const definitionFiles = {
+          'main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, 'common.xsd', null);
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should resolve relative path with ./ prefix', () => {
+        const definitionFiles = {
+          'schemas/main.xsd': '<schema>main</schema>',
+          'schemas/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, './common.xsd', 'schemas/main.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should resolve relative path with baseUri', () => {
+        const definitionFiles = {
+          'schemas/main.xsd': '<schema>main</schema>',
+          'schemas/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, 'common.xsd', 'schemas/main.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should normalize ./ in schemaLocation', () => {
+        const definitionFiles = {
+          'schemas/types/base.xsd': '<schema>base</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, './types/./base.xsd', 'schemas/main.xsd');
+
+        expect(result).toBe('<schema>base</schema>');
+      });
+
+      it('should resolve ../ in schemaLocation', () => {
+        const definitionFiles = {
+          'schemas/main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, '../common.xsd', 'schemas/main.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should resolve nested relative paths (../../common.xsd)', () => {
+        const definitionFiles = {
+          'schemas/types/nested/specific.xsd': '<schema>specific</schema>',
+          'schemas/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, '../../common.xsd', 'schemas/types/nested/specific.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should fallback to filename-only match when unique', () => {
+        const definitionFiles = {
+          'schemas/main.xsd': '<schema>main</schema>',
+          'schemas/types/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, 'common.xsd', null);
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should throw error when filename match is ambiguous', () => {
+        const definitionFiles = {
+          'schemas/common.xsd': '<schema>common1</schema>',
+          'types/common.xsd': '<schema>common2</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        expect(() => {
+          resolver.resolveEntity(null, 'common.xsd', null);
+        }).toThrow('Ambiguous filename match for "common.xsd"');
+      });
+
+      it('should throw error when schema not found', () => {
+        const definitionFiles = {
+          'main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        expect(() => {
+          resolver.resolveEntity(null, 'missing.xsd', null);
+        }).toThrow('Schema not found: schemaLocation="missing.xsd"');
+      });
+
+      it('should include available files in error message', () => {
+        const definitionFiles = {
+          'main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        expect(() => {
+          resolver.resolveEntity(null, 'missing.xsd', null);
+        }).toThrow('Available files: [main.xsd, common.xsd]');
+      });
+
+      it('should handle absolute paths', () => {
+        const definitionFiles = {
+          '/schemas/main.xsd': '<schema>main</schema>',
+          '/schemas/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, '/schemas/common.xsd', null);
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should resolve with absolute schemaLocation ignoring baseUri', () => {
+        const definitionFiles = {
+          'schemas/main.xsd': '<schema>main</schema>',
+          '/absolute/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, '/absolute/common.xsd', 'schemas/main.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should resolve with normalized path when it differs from original', () => {
+        const definitionFiles = {
+          'schemas/types/common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, 'schemas/./types/./common.xsd', null);
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should handle baseUri without directory separator when no exact match', () => {
+        const definitionFiles = {
+          'main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, './common.xsd', 'main.xsd');
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+
+      it('should handle ../ at the beginning of path', () => {
+        const definitionFiles = {
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const result = resolver.resolveEntity(null, '../common.xsd', null);
+
+        expect(result).toBe('<schema>common</schema>');
+      });
+    });
+
+    describe('CollectionURIResolver interface', () => {
+      it('should get and set collection base URI', () => {
+        const resolver = new DefaultURIResolver({});
+
+        expect(resolver.getCollectionBaseURI()).toBeUndefined();
+
+        resolver.setCollectionBaseURI('http://example.com/schemas');
+
+        expect(resolver.getCollectionBaseURI()).toBe('http://example.com/schemas');
+      });
+
+      it('should store collectionBaseUri independently', () => {
+        const resolver = new DefaultURIResolver({});
+
+        resolver.setCollectionBaseURI('http://example.com/schemas');
+
+        expect(resolver.getCollectionBaseURI()).toBe('http://example.com/schemas');
+
+        resolver.setCollectionBaseURI('http://example.com/types');
+
+        expect(resolver.getCollectionBaseURI()).toBe('http://example.com/types');
+      });
+    });
+
+    describe('addFiles', () => {
+      it('should add new files to existing definition files', () => {
+        const initialFiles = {
+          'main.xsd': '<schema>main</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(initialFiles);
+
+        const additionalFiles = {
+          'types.xsd': '<schema>types</schema>',
+          'enums.xsd': '<schema>enums</schema>',
+        };
+        resolver.addFiles(additionalFiles);
+
+        expect(resolver.resolveEntity(null, 'types.xsd', null)).toBe('<schema>types</schema>');
+        expect(resolver.resolveEntity(null, 'enums.xsd', null)).toBe('<schema>enums</schema>');
+        expect(resolver.resolveEntity(null, 'common.xsd', null)).toBe('<schema>common</schema>');
+      });
+
+      it('should overwrite existing files with same path', () => {
+        const initialFiles = {
+          'main.xsd': '<schema>main original</schema>',
+          'common.xsd': '<schema>common</schema>',
+        };
+        const resolver = new DefaultURIResolver(initialFiles);
+
+        const updatedFiles = {
+          'main.xsd': '<schema>main updated</schema>',
+        };
+        resolver.addFiles(updatedFiles);
+
+        expect(resolver.resolveEntity(null, 'main.xsd', null)).toBe('<schema>main updated</schema>');
+        expect(resolver.resolveEntity(null, 'common.xsd', null)).toBe('<schema>common</schema>');
+      });
+
+      it('should handle adding files to initially empty resolver', () => {
+        const resolver = new DefaultURIResolver({});
+
+        const newFiles = {
+          'schema.xsd': '<schema>schema</schema>',
+        };
+        resolver.addFiles(newFiles);
+
+        expect(resolver.resolveEntity(null, 'schema.xsd', null)).toBe('<schema>schema</schema>');
+      });
+
+      it('should allow resolution of newly added file imports', () => {
+        const initialFiles = {
+          'main.xsd': '<schema>main</schema>',
+        };
+        const resolver = new DefaultURIResolver(initialFiles);
+
+        const additionalFiles = {
+          'imported.xsd': '<schema>imported</schema>',
+        };
+        resolver.addFiles(additionalFiles);
+
+        const result = resolver.resolveEntity(null, 'imported.xsd', 'main.xsd');
+
+        expect(result).toBe('<schema>imported</schema>');
+      });
+    });
+  });
+});

--- a/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.ts
@@ -2,18 +2,135 @@ import { CollectionURIResolver } from './CollectionURIResolver';
 
 export class DefaultURIResolver implements CollectionURIResolver {
   private collectionBaseUri?: string;
+  private definitionFiles?: Record<string, string>;
+
+  constructor(definitionFiles?: Record<string, string>) {
+    this.definitionFiles = definitionFiles;
+  }
 
   getCollectionBaseURI(): string | undefined {
     return this.collectionBaseUri;
   }
 
+  setCollectionBaseURI(uri: string): void {
+    this.collectionBaseUri = uri;
+  }
+
+  addFiles(newFiles: Record<string, string>): void {
+    this.definitionFiles ??= {};
+    Object.assign(this.definitionFiles, newFiles);
+  }
+
   resolveEntity(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): string {
+    if (this.definitionFiles) {
+      return this.resolveFromFileMap(targetNamespace, schemaLocation, baseUri);
+    }
+
     throw new Error(
       `XML schema External entity resolution is not yet supported: [namespace:${targetNamespace}, schemaLocation:${schemaLocation}, baseUri:${baseUri}]`,
     );
   }
 
-  setCollectionBaseURI(uri: string): void {
-    this.collectionBaseUri = uri;
+  private resolveFromFileMap(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): string {
+    if (this.definitionFiles![schemaLocation]) {
+      return this.definitionFiles![schemaLocation];
+    }
+
+    if (baseUri) {
+      const resolvedPath = this.resolvePath(schemaLocation, baseUri);
+      if (this.definitionFiles![resolvedPath]) {
+        return this.definitionFiles![resolvedPath];
+      }
+    }
+
+    const normalizedPath = this.normalizePath(schemaLocation);
+    if (normalizedPath !== schemaLocation && this.definitionFiles![normalizedPath]) {
+      return this.definitionFiles![normalizedPath];
+    }
+
+    const filename = this.extractFilename(schemaLocation);
+    const matchByFilename = this.findByFilename(filename);
+    if (matchByFilename) {
+      return matchByFilename;
+    }
+
+    const availableFiles = Object.keys(this.definitionFiles!).join(', ');
+    throw new Error(
+      `Schema not found: schemaLocation="${schemaLocation}", ` +
+        `targetNamespace="${targetNamespace}", baseUri="${baseUri}". ` +
+        `Available files: [${availableFiles}]`,
+    );
+  }
+
+  private resolvePath(schemaLocation: string, baseUri: string): string {
+    if (this.isAbsolutePath(schemaLocation)) {
+      return schemaLocation;
+    }
+
+    const baseDir = this.extractDirectory(baseUri);
+    if (!baseDir) {
+      return schemaLocation;
+    }
+
+    const combined = `${baseDir}/${schemaLocation}`;
+    return this.normalizePath(combined);
+  }
+
+  private normalizePath(path: string): string {
+    const parts = path.split('/').filter((part) => part !== '.');
+
+    const normalized: string[] = [];
+    for (const part of parts) {
+      if (part === '..') {
+        if (normalized.length > 0 && normalized.at(-1) !== '..') {
+          normalized.pop();
+        } else {
+          normalized.push(part);
+        }
+      } else {
+        normalized.push(part);
+      }
+    }
+
+    return normalized.join('/');
+  }
+
+  private extractDirectory(path: string): string | null {
+    const lastSlash = path.lastIndexOf('/');
+    if (lastSlash === -1) {
+      return null;
+    }
+    return path.substring(0, lastSlash);
+  }
+
+  private extractFilename(path: string): string {
+    const lastSlash = path.lastIndexOf('/');
+    return lastSlash === -1 ? path : path.substring(lastSlash + 1);
+  }
+
+  private findByFilename(filename: string): string | null {
+    const matches: string[] = [];
+
+    for (const [path, content] of Object.entries(this.definitionFiles!)) {
+      if (this.extractFilename(path) === filename) {
+        matches.push(content);
+      }
+    }
+
+    if (matches.length === 0) {
+      return null;
+    }
+
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous filename match for "${filename}". ` + `Multiple files with this name found in definitionFiles.`,
+      );
+    }
+
+    return matches[0];
+  }
+
+  private isAbsolutePath(path: string): boolean {
+    return path.startsWith('/');
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2879

Instead of introducing `FileMapURIResolver`, directly enhanced DefaultURIResolver to support resolving XML schema locations by holding file map. We don't have a plan to switch schema resolver in foreseeable future.

#### API Additions:
  - XmlSchemaDocumentService.addSchemaFiles() - Add schemas to existing documents
  - DefaultURIResolver.addFiles() - Dynamically add files to resolver