### PR TITLE
#1613 - feat(visualization): add robust direct route navigation

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.direct-navigation.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.direct-navigation.test.tsx
@@ -1,0 +1,207 @@
+import { BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CatalogKind, IVisualizationNode } from '../../../../models';
+import { DirectRouteNavigationService } from '../../../../models/camel/direct-route-navigation.service';
+import { TestProvidersWrapper } from '../../../../stubs';
+import { ControllerService } from '../../Canvas/controller.service';
+import { DirectRouteNavigationAnchor } from './DirectRouteNavigationAnchor';
+
+describe('DirectRouteNavigationAnchor', () => {
+  const createMockVizNode = (processorName: string): IVisualizationNode =>
+    ({
+      id: 'route-target',
+      lastUpdate: 1,
+      data: {
+        catalogKind: CatalogKind.Component,
+        name: 'to',
+        path: 'route.from.steps.0.to',
+        processorName,
+        componentName: 'direct',
+      },
+      getId: () => 'route-target',
+      getNodeLabel: () => 'Label',
+      getTooltipContent: () => undefined,
+      getNodeValidationText: () => undefined,
+      canDragNode: () => false,
+      getNodeDefinition: () => ({ uri: 'direct:addPet' }),
+      getNodeInteraction: () => ({
+        canBeDisabled: false,
+        canHaveChildren: false,
+        canHaveNextStep: false,
+        canHavePreviousStep: false,
+        canHaveSpecialChildren: false,
+        canRemoveFlow: false,
+        canRemoveStep: false,
+        canReplaceStep: false,
+      }),
+    }) as unknown as IVisualizationNode;
+
+  const renderNode = (
+    vizNode: IVisualizationNode,
+    visibleFlowsContext?: {
+      visibleFlows: Record<string, boolean>;
+      visualFlowsApi: { showFlows: (flowIds?: string[]) => void };
+    },
+  ) => {
+    const parentElement = new BaseGraph();
+    const element = new BaseNode();
+    const controller = ControllerService.createController();
+    parentElement.setController(controller);
+    element.setController(controller);
+    element.setParent(parentElement);
+    element.setData({ vizNode });
+
+    const { Provider } = TestProvidersWrapper(
+      visibleFlowsContext
+        ? {
+            visibleFlowsContext: {
+              allFlowsVisible: false,
+              visibleFlows: visibleFlowsContext.visibleFlows,
+              visualFlowsApi: visibleFlowsContext.visualFlowsApi,
+            } as never,
+          }
+        : {},
+    );
+
+    render(
+      <Provider>
+        <VisualizationProvider controller={controller}>
+          <ElementContext.Provider value={element}>
+            <DirectRouteNavigationAnchor vizNode={vizNode} />
+          </ElementContext.Provider>
+        </VisualizationProvider>
+      </Provider>,
+    );
+
+    return { controller };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback): number => {
+      callback(0);
+      return 0;
+    });
+    jest.spyOn(DirectRouteNavigationService.prototype, 'getDirectEndpointNameFromDefinition').mockReturnValue('addPet');
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerRouteId').mockReturnValue(undefined);
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerNodeId').mockReturnValue(undefined);
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectCallerRouteIds').mockReturnValue([]);
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectCallerNodeId').mockReturnValue(undefined);
+  });
+
+  it('should provide single-route navigation for direct to nodes', () => {
+    const showFlows = jest.fn();
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerRouteId').mockReturnValue('route-1');
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerNodeId').mockReturnValue('target-node-1');
+
+    const { controller } = renderNode(createMockVizNode('to'), {
+      visibleFlows: { 'route-1': true },
+      visualFlowsApi: { showFlows },
+    });
+    jest
+      .spyOn(controller, 'getNodeById')
+      .mockImplementation((id) => (id === 'route-1|target-node-1' ? ({} as never) : undefined));
+    const fireEventSpy = jest.spyOn(controller, 'fireEvent');
+
+    fireEvent.click(screen.getByTestId('goto-route-btn'));
+
+    expect(showFlows).not.toHaveBeenCalled();
+    expect(fireEventSpy).toHaveBeenCalledWith('selection', ['route-1|target-node-1']);
+  });
+
+  it('should provide route options for direct from nodes with multiple callers', async () => {
+    const showFlows = jest.fn();
+    jest
+      .spyOn(DirectRouteNavigationService.prototype, 'findDirectCallerRouteIds')
+      .mockReturnValue(['route-1', 'route-2']);
+    jest
+      .spyOn(DirectRouteNavigationService.prototype, 'findDirectCallerNodeId')
+      .mockImplementation((routeId) => `target-node-${routeId}`);
+
+    const { controller } = renderNode(createMockVizNode('from'), {
+      visibleFlows: { 'route-1': true, 'route-2': false },
+      visualFlowsApi: { showFlows },
+    });
+    jest
+      .spyOn(controller, 'getNodeById')
+      .mockImplementation((id) => (id === 'route-2|target-node-route-2' ? ({} as never) : undefined));
+    const fireEventSpy = jest.spyOn(controller, 'fireEvent');
+
+    fireEvent.click(screen.getByTestId('goto-route-btn'));
+    fireEvent.click(await screen.findByTestId('goto-route-option-route-2'));
+
+    expect(showFlows).toHaveBeenCalledWith(['route-2']);
+    expect(fireEventSpy).toHaveBeenCalledWith('selection', ['route-2|target-node-route-2']);
+  });
+
+  it('should skip navigation when direct endpoint name is not resolved', () => {
+    jest
+      .spyOn(DirectRouteNavigationService.prototype, 'getDirectEndpointNameFromDefinition')
+      .mockReturnValue(undefined);
+
+    renderNode(createMockVizNode('to'));
+
+    expect(screen.queryByTestId('goto-route-btn')).not.toBeInTheDocument();
+    expect(DirectRouteNavigationService.prototype.findDirectConsumerRouteId).not.toHaveBeenCalled();
+    expect(DirectRouteNavigationService.prototype.findDirectCallerRouteIds).not.toHaveBeenCalled();
+  });
+
+  it('should fallback to canvas node discovery when precomputed target id is stale', () => {
+    const showFlows = jest.fn();
+    const raised = jest.fn();
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerRouteId').mockReturnValue('route-1');
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerNodeId').mockReturnValue('route-1');
+
+    const { controller } = renderNode(createMockVizNode('to'), {
+      visibleFlows: { 'route-1': true },
+      visualFlowsApi: { showFlows },
+    });
+
+    const fallbackTargetNode = new BaseNode();
+    fallbackTargetNode.setController(controller);
+    fallbackTargetNode.setId('route-1|fallback-target');
+    fallbackTargetNode.setData({
+      vizNode: {
+        data: { processorName: 'from', componentName: 'direct' },
+        getNodeDefinition: () => ({ uri: 'direct:addPet' }),
+      },
+    });
+    (fallbackTargetNode as unknown as { raise: () => void }).raise = raised;
+
+    jest.spyOn(controller, 'getElements').mockReturnValue([fallbackTargetNode]);
+    jest.spyOn(controller, 'getNodeById').mockImplementation((id) => {
+      if (id === 'route-1|fallback-target') {
+        return fallbackTargetNode as never;
+      }
+      return undefined;
+    });
+    const fireEventSpy = jest.spyOn(controller, 'fireEvent');
+
+    fireEvent.click(screen.getByTestId('goto-route-btn'));
+
+    expect(raised).toHaveBeenCalledTimes(1);
+    expect(showFlows).not.toHaveBeenCalled();
+    expect(fireEventSpy).toHaveBeenCalledWith('selection', ['route-1|fallback-target']);
+  });
+
+  it('should not fire selection when no target node can be resolved', () => {
+    const showFlows = jest.fn();
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerRouteId').mockReturnValue('route-1');
+    jest.spyOn(DirectRouteNavigationService.prototype, 'findDirectConsumerNodeId').mockReturnValue('route-1');
+
+    const { controller } = renderNode(createMockVizNode('to'), {
+      visibleFlows: { 'route-1': false },
+      visualFlowsApi: { showFlows },
+    });
+    jest.spyOn(controller, 'getElements').mockReturnValue([]);
+    jest.spyOn(controller, 'getNodeById').mockReturnValue(undefined);
+    const fireEventSpy = jest.spyOn(controller, 'fireEvent');
+
+    fireEvent.click(screen.getByTestId('goto-route-btn'));
+
+    expect(showFlows).toHaveBeenCalledWith(['route-1']);
+    expect(fireEventSpy).not.toHaveBeenCalledWith('selection', expect.anything());
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -89,4 +89,22 @@
     overflow: visible;
     text-align: center;
   }
+
+  &__navigate-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  &__navigate-option {
+    width: 100%;
+    justify-content: flex-start;
+    font-weight: var(--pf-t--global--font--weight--heading--bold);
+  }
 }

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContent.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContent.test.tsx
@@ -9,6 +9,12 @@ jest.mock('../../../IconResolver', () => ({
   ),
 }));
 
+jest.mock('../../../RenderingAnchor/RenderingAnchor', () => ({
+  RenderingAnchor: ({ anchorTag }: { anchorTag: string }) => (
+    <div data-testid="rendering-anchor" data-anchor={anchorTag} />
+  ),
+}));
+
 describe('NodeContent', () => {
   const createMockVizNode = (): IVisualizationNode => {
     return {
@@ -192,5 +198,6 @@ describe('NodeContent', () => {
     expect(screen.getByTitle('3')).toBeInTheDocument();
     expect(screen.getByTestId('processor-icon')).toBeInTheDocument();
     expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+    expect(screen.getByTestId('rendering-anchor')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContent.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContent.tsx
@@ -4,6 +4,8 @@ import { ElementType, FunctionComponent } from 'react';
 
 import { IVisualizationNode } from '../../../../models';
 import { IconResolver } from '../../../IconResolver';
+import { Anchors } from '../../../registers/anchors';
+import { RenderingAnchor } from '../../../RenderingAnchor/RenderingAnchor';
 import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
 
 export interface CustomNodeContentProps {
@@ -46,6 +48,7 @@ export const CustomNodeContent: FunctionComponent<CustomNodeContentProps> = ({
           </Icon>
         </FloatingCircle>
       )}
+      <RenderingAnchor anchorTag={Anchors.CanvasNodeBottomRight} vizNode={vizNode} />
     </div>
   );
 };

--- a/packages/ui/src/components/Visualization/Custom/Node/DirectRouteNavigationAnchor.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/DirectRouteNavigationAnchor.tsx
@@ -1,0 +1,255 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { Button, Icon, List, ListItem, Popover } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { ElementContext, isNode, SELECTION_EVENT } from '@patternfly/react-topology';
+import { FunctionComponent, useContext, useMemo, useState } from 'react';
+
+import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
+import { IVisualizationNode } from '../../../../models';
+import { DirectRouteNavigationService } from '../../../../models/camel/direct-route-navigation.service';
+import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
+import { SourceCodeContext } from '../../../../providers/source-code.provider';
+import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
+import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
+
+interface DirectRouteNavigationAnchorProps {
+  vizNode?: IVisualizationNode;
+}
+
+export const DirectRouteNavigationAnchor: FunctionComponent<DirectRouteNavigationAnchorProps> = ({ vizNode }) => {
+  const [isPopoverVisible, setIsPopoverVisible] = useState(false);
+  const element = useContext(ElementContext);
+  const entitiesContext = useEntityContext();
+  const visibleFlowsContext = useContext(VisibleFlowsContext);
+  const sourceCode = useContext(SourceCodeContext);
+
+  const directNavigation = useMemo(() => {
+    if (!vizNode || !entitiesContext) {
+      return {
+        directEndpointName: undefined,
+        targetProcessorName: undefined as 'from' | 'to' | undefined,
+        singleTargetId: undefined,
+        targetOptions: [] as string[],
+        targetNodeIds: {} as Record<string, string>,
+      };
+    }
+    // Recompute direct navigation targets when source changes without recreating entities context.
+    void sourceCode;
+
+    const nodeData = vizNode.data as CamelRouteVisualEntityData;
+    const isDirectToNode = nodeData.processorName === 'to' && nodeData.componentName === 'direct';
+    const isDirectFromNode =
+      nodeData.processorName === ('from' as keyof ProcessorDefinition) && nodeData.componentName === 'direct';
+    if (!isDirectToNode && !isDirectFromNode) {
+      return {
+        directEndpointName: undefined,
+        targetProcessorName: undefined as 'from' | 'to' | undefined,
+        singleTargetId: undefined,
+        targetOptions: [] as string[],
+        targetNodeIds: {} as Record<string, string>,
+      };
+    }
+
+    const navigationService = new DirectRouteNavigationService(entitiesContext.visualEntities);
+    const directEndpointName = navigationService.getDirectEndpointNameFromDefinition(vizNode.getNodeDefinition());
+    if (!directEndpointName) {
+      return {
+        directEndpointName: undefined,
+        targetProcessorName: undefined as 'from' | 'to' | undefined,
+        singleTargetId: undefined,
+        targetOptions: [] as string[],
+        targetNodeIds: {} as Record<string, string>,
+      };
+    }
+
+    if (isDirectFromNode) {
+      const callerRouteIds = navigationService.findDirectCallerRouteIds(directEndpointName, vizNode.getId());
+      const callerNodeIds = callerRouteIds.reduce(
+        (acc, routeId) => {
+          const targetNodeId = navigationService.findDirectCallerNodeId(routeId, directEndpointName);
+          if (targetNodeId) {
+            acc[routeId] = targetNodeId;
+          }
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+
+      return {
+        directEndpointName,
+        targetProcessorName: 'to' as const,
+        singleTargetId: callerRouteIds.length === 1 ? callerRouteIds[0] : undefined,
+        targetOptions: callerRouteIds.length > 1 ? callerRouteIds : [],
+        targetNodeIds: callerNodeIds,
+      };
+    }
+
+    const singleTargetId = navigationService.findDirectConsumerRouteId(directEndpointName);
+    const targetNodeIds =
+      singleTargetId === undefined
+        ? {}
+        : (() => {
+            const targetNodeId = navigationService.findDirectConsumerNodeId(singleTargetId, directEndpointName);
+            return targetNodeId ? { [singleTargetId]: targetNodeId } : {};
+          })();
+
+    return {
+      directEndpointName,
+      targetProcessorName: 'from' as const,
+      singleTargetId,
+      targetOptions: [],
+      targetNodeIds,
+    };
+  }, [entitiesContext, sourceCode, vizNode]);
+
+  const onNavigateToRouteSelect = (routeId: string) => {
+    if (!isNode(element) || !visibleFlowsContext) {
+      return;
+    }
+    if (!directNavigation.directEndpointName || !directNavigation.targetProcessorName) {
+      return;
+    }
+
+    if (!visibleFlowsContext.visibleFlows[routeId]) {
+      visibleFlowsContext.visualFlowsApi.showFlows([routeId]);
+    }
+
+    const controller = element.getController();
+    const applySelection = (canvasTargetNodeId: string) => {
+      const targetNode = controller.getNodeById(canvasTargetNodeId);
+      if (!targetNode) {
+        return false;
+      }
+
+      if (typeof targetNode.raise === 'function') {
+        targetNode.raise();
+      }
+      controller.setState({ selectedIds: [canvasTargetNodeId] });
+      controller.fireEvent(SELECTION_EVENT, [canvasTargetNodeId]);
+      return true;
+    };
+
+    const resolveCanvasTargetNodeId = () => {
+      const mappedTargetNodeId = directNavigation.targetNodeIds[routeId];
+      if (mappedTargetNodeId) {
+        const mappedCanvasNodeId = `${routeId}|${mappedTargetNodeId}`;
+        if (controller.getNodeById(mappedCanvasNodeId)) {
+          return mappedCanvasNodeId;
+        }
+      }
+
+      const routeNodePrefix = `${routeId}|`;
+      const targetNode = controller.getElements().find((graphElement) => {
+        if (!isNode(graphElement) || !graphElement.getId().startsWith(routeNodePrefix)) {
+          return false;
+        }
+
+        const targetVizNode = graphElement.getData()?.vizNode as IVisualizationNode | undefined;
+        if (!targetVizNode) {
+          return false;
+        }
+
+        const targetNodeData = targetVizNode.data as CamelRouteVisualEntityData;
+        return (
+          targetNodeData.processorName === directNavigation.targetProcessorName &&
+          targetNodeData.componentName === 'direct' &&
+          DirectRouteNavigationService.getDirectEndpointNameFromDefinition(targetVizNode.getNodeDefinition()) ===
+            directNavigation.directEndpointName
+        );
+      });
+
+      return targetNode?.getId();
+    };
+
+    const selectNode = (attempt = 0) => {
+      const canvasTargetNodeId = resolveCanvasTargetNodeId();
+      if (!canvasTargetNodeId) {
+        if (attempt < 10) {
+          requestAnimationFrame(() => selectNode(attempt + 1));
+        }
+        return;
+      }
+
+      if (applySelection(canvasTargetNodeId)) {
+        return;
+      }
+
+      if (attempt < 10) {
+        requestAnimationFrame(() => selectNode(attempt + 1));
+      }
+    };
+
+    selectNode();
+  };
+
+  const singleTargetId = directNavigation.singleTargetId;
+  const navigateToRouteTitle = singleTargetId
+    ? `Go to route ${singleTargetId}`
+    : directNavigation.targetOptions.length > 1
+      ? 'Go to caller route'
+      : undefined;
+  const hasNavigateOptions = directNavigation.targetOptions.length > 1;
+
+  if (!navigateToRouteTitle) {
+    return null;
+  }
+
+  const navigateButton = (
+    <Button
+      variant="plain"
+      aria-label={navigateToRouteTitle}
+      title={navigateToRouteTitle}
+      data-testid="goto-route-btn"
+      className="custom-node__navigate-btn"
+      onClick={(event) => {
+        event.stopPropagation();
+        if (singleTargetId) {
+          onNavigateToRouteSelect(singleTargetId);
+        }
+      }}
+    >
+      <Icon status="info" size="lg">
+        <ExternalLinkAltIcon />
+      </Icon>
+    </Button>
+  );
+
+  return (
+    <FloatingCircle className="step-icon step-icon__navigation">
+      {hasNavigateOptions ? (
+        <Popover
+          triggerAction="click"
+          isVisible={isPopoverVisible}
+          shouldOpen={() => setIsPopoverVisible(true)}
+          shouldClose={() => setIsPopoverVisible(false)}
+          showClose={false}
+          bodyContent={
+            <List isPlain>
+              {directNavigation.targetOptions.map((routeId) => (
+                <ListItem key={routeId}>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="custom-node__navigate-option"
+                    data-testid={`goto-route-option-${routeId}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIsPopoverVisible(false);
+                      onNavigateToRouteSelect(routeId);
+                    }}
+                  >
+                    {routeId}
+                  </Button>
+                </ListItem>
+              ))}
+            </List>
+          }
+        >
+          {navigateButton}
+        </Popover>
+      ) : (
+        navigateButton
+      )}
+    </FloatingCircle>
+  );
+};

--- a/packages/ui/src/components/Visualization/Custom/_custom.scss
+++ b/packages/ui/src/components/Visualization/Custom/_custom.scss
@@ -10,6 +10,12 @@
   &__processor {
     left: -12px;
   }
+
+  &__navigation {
+    top: auto;
+    bottom: -12px;
+    right: -12px;
+  }
 }
 
 @mixin highligth {

--- a/packages/ui/src/components/registers/RegisterComponents.tsx
+++ b/packages/ui/src/components/registers/RegisterComponents.tsx
@@ -5,6 +5,7 @@ import { IRegisteredComponent } from '../RenderingAnchor/rendering.provider.mode
 import { Anchors } from './anchors';
 import { componentModeActivationFn } from './component-mode.activationfn';
 import { datamapperActivationFn } from './datamapper.activationfn';
+import { directRouteNavigationActivationFn } from './direct-route-navigation.activationfn';
 
 export const RegisterComponents: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { registerComponent } = useContext(RenderingAnchorContext);
@@ -19,6 +20,15 @@ export const RegisterComponents: FunctionComponent<PropsWithChildren> = ({ child
       anchor: Anchors.CanvasFormHeader,
       activationFn: componentModeActivationFn,
       component: lazy(() => import('../ComponentMode/ComponentMode')),
+    },
+    {
+      anchor: Anchors.CanvasNodeBottomRight,
+      activationFn: directRouteNavigationActivationFn,
+      component: lazy(() =>
+        import('../Visualization/Custom/Node/DirectRouteNavigationAnchor').then((module) => ({
+          default: module.DirectRouteNavigationAnchor,
+        })),
+      ),
     },
   ]);
 

--- a/packages/ui/src/components/registers/anchors.ts
+++ b/packages/ui/src/components/registers/anchors.ts
@@ -1,3 +1,4 @@
 export const enum Anchors {
   CanvasFormHeader = 'CanvasFormHeader',
+  CanvasNodeBottomRight = 'CanvasNodeBottomRight',
 }

--- a/packages/ui/src/components/registers/direct-route-navigation.activationfn.test.ts
+++ b/packages/ui/src/components/registers/direct-route-navigation.activationfn.test.ts
@@ -1,0 +1,131 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { IVisualizationNode } from '../../models';
+import { DirectRouteNavigationService } from '../../models/camel/direct-route-navigation.service';
+import { CamelRouteVisualEntityData } from '../../models/visualization/flows/support/camel-component-types';
+import { directRouteNavigationActivationFn } from './direct-route-navigation.activationfn';
+
+jest.mock('../../models/camel/direct-route-navigation.service');
+
+describe('directRouteNavigationActivationFn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return false if vizNode data is not a direct component', () => {
+    const vizNode = {
+      data: {
+        processorName: 'to',
+        componentName: 'http',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue({}),
+    } as unknown as IVisualizationNode;
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(false);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).not.toHaveBeenCalled();
+  });
+
+  it('should return false if processorName is not "to" or "from"', () => {
+    const vizNode = {
+      data: {
+        processorName: 'log',
+        componentName: 'direct',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue({}),
+    } as unknown as IVisualizationNode;
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(false);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).not.toHaveBeenCalled();
+  });
+
+  it('should return true for direct "to" node with valid endpoint name', () => {
+    const nodeDefinition = { uri: 'direct:myEndpoint' };
+    const vizNode = {
+      data: {
+        processorName: 'to',
+        componentName: 'direct',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue(nodeDefinition),
+    } as unknown as IVisualizationNode;
+
+    jest.spyOn(DirectRouteNavigationService, 'getDirectEndpointNameFromDefinition').mockReturnValue('myEndpoint');
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(true);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).toHaveBeenCalledWith(nodeDefinition);
+  });
+
+  it('should return true for direct "from" node with valid endpoint name', () => {
+    const nodeDefinition = { uri: 'direct:anotherEndpoint' };
+    const vizNode = {
+      data: {
+        processorName: 'from' as keyof ProcessorDefinition,
+        componentName: 'direct',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue(nodeDefinition),
+    } as unknown as IVisualizationNode;
+
+    jest.spyOn(DirectRouteNavigationService, 'getDirectEndpointNameFromDefinition').mockReturnValue('anotherEndpoint');
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(true);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).toHaveBeenCalledWith(nodeDefinition);
+  });
+
+  it('should return false for direct "to" node without endpoint name', () => {
+    const nodeDefinition = { uri: 'direct:' };
+    const vizNode = {
+      data: {
+        processorName: 'to',
+        componentName: 'direct',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue(nodeDefinition),
+    } as unknown as IVisualizationNode;
+
+    jest.spyOn(DirectRouteNavigationService, 'getDirectEndpointNameFromDefinition').mockReturnValue(undefined);
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(false);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).toHaveBeenCalledWith(nodeDefinition);
+  });
+
+  it('should return false for direct "from" node without endpoint name', () => {
+    const nodeDefinition = { uri: 'direct:' };
+    const vizNode = {
+      data: {
+        processorName: 'from' as keyof ProcessorDefinition,
+        componentName: 'direct',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue(nodeDefinition),
+    } as unknown as IVisualizationNode;
+
+    jest.spyOn(DirectRouteNavigationService, 'getDirectEndpointNameFromDefinition').mockReturnValue(undefined);
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(false);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).toHaveBeenCalledWith(nodeDefinition);
+  });
+
+  it('should handle edge case with empty componentName', () => {
+    const vizNode = {
+      data: {
+        processorName: 'to',
+        componentName: '',
+      } as CamelRouteVisualEntityData,
+      getNodeDefinition: jest.fn().mockReturnValue({}),
+    } as unknown as IVisualizationNode;
+
+    const result = directRouteNavigationActivationFn(vizNode);
+
+    expect(result).toBe(false);
+    expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/registers/direct-route-navigation.activationfn.ts
+++ b/packages/ui/src/components/registers/direct-route-navigation.activationfn.ts
@@ -1,0 +1,18 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { IVisualizationNode } from '../../models';
+import { DirectRouteNavigationService } from '../../models/camel/direct-route-navigation.service';
+import { CamelRouteVisualEntityData } from '../../models/visualization/flows/support/camel-component-types';
+
+export const directRouteNavigationActivationFn = (vizNode: IVisualizationNode): boolean => {
+  const nodeData = vizNode.data as CamelRouteVisualEntityData;
+  const isDirectToNode = nodeData.processorName === 'to' && nodeData.componentName === 'direct';
+  const isDirectFromNode =
+    nodeData.processorName === ('from' as keyof ProcessorDefinition) && nodeData.componentName === 'direct';
+
+  if (!isDirectToNode && !isDirectFromNode) {
+    return false;
+  }
+
+  return DirectRouteNavigationService.getDirectEndpointNameFromDefinition(vizNode.getNodeDefinition()) !== undefined;
+};

--- a/packages/ui/src/models/camel/direct-route-navigation.service.test.ts
+++ b/packages/ui/src/models/camel/direct-route-navigation.service.test.ts
@@ -1,0 +1,293 @@
+import { BaseVisualCamelEntity } from '..';
+import { DirectRouteNavigationService } from './direct-route-navigation.service';
+import { EntityType } from './entities';
+
+describe('DirectRouteNavigationService', () => {
+  describe('getDirectEndpointNameFromDefinition', () => {
+    it.each([
+      [{ uri: 'direct:addPet' }, 'addPet'],
+      [{ uri: 'direct:addPet?block=true' }, 'addPet'],
+      [{ uri: 'direct', parameters: { name: 'addPet' } }, 'addPet'],
+      ['direct:addPet', 'addPet'],
+      [{ uri: 'seda:addPet' }, undefined],
+      [{ uri: 'direct' }, undefined],
+    ])('should return `%s` for `%s`', (definition, expected) => {
+      expect(DirectRouteNavigationService.getDirectEndpointNameFromDefinition(definition)).toBe(expected);
+    });
+  });
+
+  describe('findDirectConsumerRouteId', () => {
+    const createMockEntity = (options: {
+      id: string;
+      type?: EntityType;
+      fromDefinition?: unknown;
+      routeDefinition?: unknown;
+    }): BaseVisualCamelEntity => {
+      return {
+        id: options.id,
+        type: options.type ?? EntityType.Route,
+        getRootPath: () => 'route',
+        getNodeDefinition: (_path?: string) => options.fromDefinition,
+        toJSON: () => ({ route: options.routeDefinition }),
+      } as unknown as BaseVisualCamelEntity;
+    };
+
+    it('should resolve a route when matching from uri is direct:name', () => {
+      const entities = [
+        createMockEntity({ id: 'route-1', fromDefinition: { uri: 'direct:addPet' }, routeDefinition: {} }),
+        createMockEntity({ id: 'route-2', fromDefinition: { uri: 'direct:other' }, routeDefinition: {} }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerRouteId('addPet')).toBe('route-1');
+    });
+
+    it('should resolve a route when matching from uri uses parameters.name', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-1',
+          fromDefinition: { uri: 'direct', parameters: { name: 'addPet' } },
+          routeDefinition: {},
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerRouteId('addPet')).toBe('route-1');
+    });
+
+    it('should return undefined when there is no match', () => {
+      const entities = [
+        createMockEntity({ id: 'route-1', fromDefinition: { uri: 'direct:addPet' }, routeDefinition: {} }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerRouteId('deletePet')).toBeUndefined();
+    });
+
+    it('should return undefined when more than one route matches', () => {
+      const entities = [
+        createMockEntity({ id: 'route-1', fromDefinition: { uri: 'direct:addPet' }, routeDefinition: {} }),
+        createMockEntity({
+          id: 'route-2',
+          fromDefinition: { uri: 'direct', parameters: { name: 'addPet' } },
+          routeDefinition: {},
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerRouteId('addPet')).toBeUndefined();
+    });
+
+    it('should ignore non-route entities', () => {
+      const entities = [
+        createMockEntity({ id: 'route-1', fromDefinition: { uri: 'direct:addPet' }, routeDefinition: {} }),
+        createMockEntity({
+          id: 'rest-1',
+          type: EntityType.Rest,
+          fromDefinition: { uri: 'direct:addPet' },
+          routeDefinition: {},
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerRouteId('addPet')).toBe('route-1');
+    });
+  });
+
+  describe('findDirectCallerRouteId', () => {
+    const createMockEntity = (options: {
+      id: string;
+      type?: EntityType;
+      routeDefinition?: unknown;
+      restDefinition?: unknown;
+    }): BaseVisualCamelEntity => {
+      return {
+        id: options.id,
+        type: options.type ?? EntityType.Route,
+        toJSON: () => ({ route: options.routeDefinition, rest: options.restDefinition }),
+      } as unknown as BaseVisualCamelEntity;
+    };
+
+    it('should resolve caller route for direct:addPet string notation', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-caller',
+          routeDefinition: { from: { uri: 'direct:start', steps: [{ to: 'direct:addPet' }] } },
+        }),
+        createMockEntity({ id: 'route-target', routeDefinition: { from: { uri: 'direct:addPet', steps: [] } } }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('addPet', 'route-target')).toBe('route-caller');
+    });
+
+    it('should resolve caller route for uri: direct + parameters.name notation', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-caller',
+          routeDefinition: {
+            from: { uri: 'direct:start', steps: [{ to: { uri: 'direct', parameters: { name: 'addPet' } } }] },
+          },
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('addPet')).toBe('route-caller');
+    });
+
+    it('should return undefined when there is no caller route', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-caller',
+          routeDefinition: { from: { uri: 'direct:start', steps: [{ to: 'direct:deletePet' }] } },
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('addPet')).toBeUndefined();
+    });
+
+    it('should return undefined when more than one caller route exists', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-caller-1',
+          routeDefinition: { from: { uri: 'direct:start', steps: [{ to: 'direct:addPet' }] } },
+        }),
+        createMockEntity({
+          id: 'route-caller-2',
+          routeDefinition: { from: { uri: 'direct:start2', steps: [{ to: { uri: 'direct:addPet' } }] } },
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('addPet')).toBeUndefined();
+      expect(navigationService.findDirectCallerRouteIds('addPet')).toEqual(['route-caller-1', 'route-caller-2']);
+    });
+
+    it('should resolve caller when the caller is a rest operation', () => {
+      const entities = [
+        createMockEntity({
+          id: 'rest-1',
+          type: EntityType.Rest,
+          restDefinition: {
+            get: [{ path: '/pets', to: { uri: 'direct:addPet' } }],
+          },
+        }),
+        createMockEntity({ id: 'route-target', routeDefinition: { from: { uri: 'direct:addPet', steps: [] } } }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('addPet', 'route-target')).toBe('rest-1');
+    });
+
+    it('should return undefined when direct endpoint name is empty', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-caller',
+          routeDefinition: { from: { uri: 'direct:start', steps: [{ to: 'direct:addPet' }] } },
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteId('')).toBeUndefined();
+      expect(navigationService.findDirectCallerRouteIds('')).toEqual([]);
+    });
+
+    it('should exclude target route id from caller matches', () => {
+      const entities = [
+        createMockEntity({
+          id: 'route-target',
+          routeDefinition: { from: { uri: 'direct:start', steps: [{ to: 'direct:addPet' }] } },
+        }),
+        createMockEntity({
+          id: 'route-caller',
+          routeDefinition: { from: { uri: 'direct:start-2', steps: [{ to: 'direct:addPet' }] } },
+        }),
+      ];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerRouteIds('addPet', 'route-target')).toEqual(['route-caller']);
+    });
+  });
+
+  describe('findDirectNodeIds', () => {
+    type MockVizNode = {
+      data: {
+        processorName: string;
+        componentName?: string;
+      };
+      getId: () => string;
+      getNodeDefinition: () => unknown;
+      getChildren: () => MockVizNode[] | undefined;
+    };
+
+    const createMockVizNode = (options: {
+      id: string;
+      processorName: string;
+      componentName?: string;
+      definition?: unknown;
+      children?: MockVizNode[];
+    }): MockVizNode => {
+      return {
+        data: {
+          processorName: options.processorName,
+          componentName: options.componentName,
+        },
+        getId: () => options.id,
+        getNodeDefinition: () => options.definition,
+        getChildren: () => options.children,
+      } as never;
+    };
+
+    const createMockEntity = (id: string, rootNode: MockVizNode): BaseVisualCamelEntity => {
+      return {
+        id,
+        type: EntityType.Route,
+        toVizNode: () => rootNode as never,
+      } as unknown as BaseVisualCamelEntity;
+    };
+
+    it('should resolve direct consumer node id inside the target route', () => {
+      const consumerNode = createMockVizNode({
+        id: 'from-direct-node',
+        processorName: 'from',
+        componentName: 'direct',
+        definition: { uri: 'direct:addPet' },
+      });
+      const root = createMockVizNode({
+        id: 'root-node',
+        processorName: 'route',
+        children: [consumerNode],
+      });
+      const entities = [createMockEntity('route-target', root)];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerNodeId('route-target', 'addPet')).toBe('from-direct-node');
+    });
+
+    it('should resolve direct caller node id inside the target route', () => {
+      const callerNode = createMockVizNode({
+        id: 'to-direct-node',
+        processorName: 'to',
+        componentName: 'direct',
+        definition: { uri: 'direct:addPet' },
+      });
+      const root = createMockVizNode({
+        id: 'root-node',
+        processorName: 'route',
+        children: [callerNode],
+      });
+      const entities = [createMockEntity('route-caller', root)];
+
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectCallerNodeId('route-caller', 'addPet')).toBe('to-direct-node');
+    });
+
+    it('should return undefined when route does not exist', () => {
+      const entities: BaseVisualCamelEntity[] = [];
+      const navigationService = new DirectRouteNavigationService(entities);
+      expect(navigationService.findDirectConsumerNodeId('missing-route', 'addPet')).toBeUndefined();
+      expect(navigationService.findDirectCallerNodeId('missing-route', 'addPet')).toBeUndefined();
+    });
+  });
+});

--- a/packages/ui/src/models/camel/direct-route-navigation.service.ts
+++ b/packages/ui/src/models/camel/direct-route-navigation.service.ts
@@ -1,0 +1,131 @@
+import { CamelUriHelper } from '../../utils/camel-uri-helper';
+import { BaseVisualCamelEntity } from '..';
+import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
+import { EntityType } from './entities';
+
+export class DirectRouteNavigationService {
+  constructor(private readonly visualEntities: BaseVisualCamelEntity[]) {}
+
+  static getDirectEndpointNameFromDefinition(definition: unknown): string | undefined {
+    return CamelUriHelper.getDirectEndpointName(definition);
+  }
+
+  getDirectEndpointNameFromDefinition(definition: unknown): string | undefined {
+    return DirectRouteNavigationService.getDirectEndpointNameFromDefinition(definition);
+  }
+
+  findDirectConsumerRouteId(directEndpointName: string): string | undefined {
+    if (!directEndpointName) {
+      return undefined;
+    }
+
+    const matchingRouteIds = this.visualEntities
+      .filter((entity) => entity.type === EntityType.Route)
+      .filter((entity) => {
+        const fromDefinition = entity.getNodeDefinition(`${entity.getRootPath()}.from`);
+        return DirectRouteNavigationService.getDirectEndpointNameFromDefinition(fromDefinition) === directEndpointName;
+      })
+      .map((entity) => entity.id);
+
+    if (matchingRouteIds.length !== 1) {
+      return undefined;
+    }
+
+    return matchingRouteIds[0];
+  }
+
+  findDirectCallerRouteId(directEndpointName: string, targetRouteId?: string): string | undefined {
+    const matchingCallerRouteIds = this.findDirectCallerRouteIds(directEndpointName, targetRouteId);
+    if (matchingCallerRouteIds.length !== 1) {
+      return undefined;
+    }
+
+    return matchingCallerRouteIds[0];
+  }
+
+  findDirectCallerRouteIds(directEndpointName: string, targetRouteId?: string): string[] {
+    if (!directEndpointName) {
+      return [];
+    }
+
+    return this.visualEntities
+      .filter((entity) => entity.type === EntityType.Route || entity.type === EntityType.Rest)
+      .filter((entity) => entity.id !== targetRouteId)
+      .filter((entity) => {
+        const entityDefinition = entity.toJSON() as { route?: unknown; rest?: unknown };
+        return (
+          DirectRouteNavigationService.includesDirectToEndpoint(entityDefinition?.route, directEndpointName) ||
+          DirectRouteNavigationService.includesDirectToEndpoint(entityDefinition?.rest, directEndpointName)
+        );
+      })
+      .map((entity) => entity.id);
+  }
+
+  findDirectConsumerNodeId(routeId: string, directEndpointName: string): string | undefined {
+    return this.findDirectNodeIdByRouteAndDirection(routeId, directEndpointName, 'from');
+  }
+
+  findDirectCallerNodeId(routeId: string, directEndpointName: string): string | undefined {
+    return this.findDirectNodeIdByRouteAndDirection(routeId, directEndpointName, 'to');
+  }
+
+  private findDirectNodeIdByRouteAndDirection(
+    routeId: string,
+    directEndpointName: string,
+    processorName: 'from' | 'to',
+  ): string | undefined {
+    if (!directEndpointName || !routeId) {
+      return undefined;
+    }
+
+    const targetEntity = this.visualEntities.find((entity) => entity.id === routeId);
+    if (!targetEntity) {
+      return undefined;
+    }
+
+    const rootNode = targetEntity.toVizNode();
+    const stack = [rootNode];
+
+    while (stack.length > 0) {
+      const currentNode = stack.pop();
+      if (!currentNode) {
+        continue;
+      }
+
+      const nodeData = currentNode.data as CamelRouteVisualEntityData;
+      if (
+        nodeData.processorName === processorName &&
+        nodeData.componentName === 'direct' &&
+        DirectRouteNavigationService.getDirectEndpointNameFromDefinition(currentNode.getNodeDefinition()) ===
+          directEndpointName
+      ) {
+        return currentNode.getId();
+      }
+
+      const children = currentNode.getChildren();
+      if (children) {
+        children.forEach((child) => stack.push(child));
+      }
+    }
+
+    return undefined;
+  }
+
+  private static includesDirectToEndpoint(value: unknown, directEndpointName: string): boolean {
+    if (Array.isArray(value)) {
+      return value.some((item) => this.includesDirectToEndpoint(item, directEndpointName));
+    }
+
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    return Object.entries(value).some(([key, entryValue]) => {
+      if (key === 'to') {
+        return this.getDirectEndpointNameFromDefinition(entryValue) === directEndpointName;
+      }
+
+      return this.includesDirectToEndpoint(entryValue, directEndpointName);
+    });
+  }
+}

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -411,7 +411,7 @@ describe('Camel Route', () => {
       /** toDirect */
       const toDirectNode = choiceNode.getNextNode()!;
       expect(toDirectNode.data.path).toEqual('route.from.steps.2.to');
-      expect(toDirectNode.getNodeLabel()).toEqual('direct');
+      expect(toDirectNode.getNodeLabel()).toEqual('my-route');
       expect(toDirectNode.getPreviousNode()).toBe(choiceNode);
       expect(toDirectNode.getNextNode()?.data.isPlaceholder).toBe(true);
 

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -343,7 +343,7 @@ describe('VisualizationNode', () => {
 
       expect(node.getChildren()?.[0].getNodeLabel()).toEqual('timer');
       expect(node.getChildren()?.[1].getNodeLabel()).toEqual('choice');
-      expect(node.getChildren()?.[2].getNodeLabel()).toEqual('direct');
+      expect(node.getChildren()?.[2].getNodeLabel()).toEqual('my-route');
       expect(node.getChildren()).toHaveLength(4);
       expect(node.getChildren()?.[3].data.isPlaceholder).toBe(true);
       expect(fromNode!.getChildren()).toHaveLength(0);
@@ -466,7 +466,7 @@ describe('VisualizationNode', () => {
       expect(node.getChildren()?.[1].getNodeLabel()).toEqual('set-header');
       expect(node.getChildren()?.[2].getNodeLabel()).toEqual('log');
       expect(node.getChildren()?.[3].getNodeLabel()).toEqual('choice');
-      expect(node.getChildren()?.[4].getNodeLabel()).toEqual('direct');
+      expect(node.getChildren()?.[4].getNodeLabel()).toEqual('my-route');
       expect(node.getChildren()).toHaveLength(6);
       expect(node.getChildren()?.[5].data.isPlaceholder).toBe(true);
       expect(fromNode!.getChildren()).toHaveLength(0);

--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -26,12 +26,34 @@ describe('CamelUriHelper', () => {
     it.each([
       [{}, {}, undefined],
       [{ processorName: 'to', componentName: 'direct' }, { parameters: { name: 'anotherWorld' } }, 'anotherWorld'],
+      [{ processorName: 'to', componentName: 'direct' }, { uri: 'direct:anotherWorld' }, 'anotherWorld'],
+      [
+        { processorName: 'to', componentName: 'direct' },
+        { uri: 'direct', parameters: { name: 'anotherWorld' } },
+        'anotherWorld',
+      ],
+      [{ processorName: 'to', componentName: 'direct' }, 'direct:anotherWorld', 'anotherWorld'],
     ] as Array<[ICamelElementLookupResult, unknown, string | undefined]>)(
       'for `%s` with `%s` value, it should return %s',
       (camelElementLookup, value, expected) => {
         expect(CamelUriHelper.getSemanticString(camelElementLookup, value)).toBe(expected);
       },
     );
+  });
+
+  describe('getDirectEndpointName', () => {
+    it.each([
+      [undefined, undefined],
+      [null, undefined],
+      [{}, undefined],
+      ['direct:addPet', 'addPet'],
+      [{ uri: 'direct:addPet' }, 'addPet'],
+      [{ uri: 'direct:addPet?block=true' }, 'addPet'],
+      [{ uri: 'direct', parameters: { name: 'addPet' } }, 'addPet'],
+      [{ uri: 'seda:addPet', parameters: { name: 'addPet' } }, 'addPet'],
+    ])('should return `%s` for `%s`', (value, expected) => {
+      expect(CamelUriHelper.getDirectEndpointName(value)).toBe(expected);
+    });
   });
 
   describe('getParametersFromPathString', () => {


### PR DESCRIPTION
Added an icon button to direct endpoints on the canvas which acts as a "Go To" functionality. When clicking the button on a To node the selection changes to the referenced direct from endpoint. If the route containing this element is not visible, it will be made visible. There is also the reverse functionality where you can jump from a direct from endpoint to the caller. If there are multiple callers then a popover is shown which lets the user select the right route. 

- Add direct endpoint normalization for both URI notations:
  - `uri: direct` + `parameters.name`
  - `uri: direct:<name>` (including query params)
- Resolve direct links from both route and REST callers
- Add reverse navigation from `from(direct:...)` back to caller(s)
- Show a route chooser popover when multiple callers exist
- Keep single-caller behavior as one-click navigation
- Hide popover close icon and improve chooser UX (button-style entries, plain list)
- Fix stale navigation icon updates after source changes
- Extend unit tests for URI parsing and direct route navigation flows

Fixes #1613
Fixes #1487