### PR TITLE
feat(DataMapper): Implement API to manage overrides 1/3

### DIFF
--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -2,7 +2,13 @@ import { render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect, useState } from 'react';
 
 import { useCanvas } from '../../hooks/useCanvas';
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
 import { MappingTree } from '../../models/datamapper/mapping';
 import { TargetDocumentNodeData } from '../../models/datamapper/visualization';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
@@ -20,7 +26,9 @@ describe('DocumentHeader', () => {
   );
 
   it('should render with enableDnD=false (default)', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
 
     render(
       <DocumentHeader
@@ -38,7 +46,9 @@ describe('DocumentHeader', () => {
   });
 
   it('should render with enableDnD=true', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
 
     const { container } = render(
       <DocumentHeader
@@ -58,7 +68,9 @@ describe('DocumentHeader', () => {
   });
 
   it('should render attach/detach schema buttons when not read-only', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
 
     render(
       <DocumentHeader
@@ -75,7 +87,9 @@ describe('DocumentHeader', () => {
   });
 
   it('should register node reference with accessible containerRef', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     let capturedContainerRef: HTMLDivElement | null = null;
 
     // Helper component to access canvas context

--- a/packages/ui/src/components/Document/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import {
   BODY_DOCUMENT_ID,
+  DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
   PrimitiveDocument,
@@ -24,7 +25,9 @@ describe('NodeTitle', () => {
   };
 
   it('should render document title with Title component when isDocument is true', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={documentNodeData} isDocument={true} rank={0} />);
@@ -47,7 +50,9 @@ describe('NodeTitle', () => {
   });
 
   it('should render with truncate class by default for document node', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={documentNodeData} isDocument={false} rank={0} />);
@@ -57,7 +62,9 @@ describe('NodeTitle', () => {
   });
 
   it('should render content correctly with custom className', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
     const customClass = 'custom-test-class';
 
@@ -69,7 +76,9 @@ describe('NodeTitle', () => {
   });
 
   it('should handle PrimitiveDocument node data', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, 'primitive-doc');
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'primitive-doc'),
+    );
     const primitiveNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={primitiveNodeData} isDocument={true} rank={0} />);
@@ -81,7 +90,9 @@ describe('NodeTitle', () => {
 
   it('should handle long titles with truncation', () => {
     const longTitle = 'This is a very long document title that should be truncated properly when rendered';
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, longTitle);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, longTitle),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={documentNodeData} isDocument={true} rank={0} />);
@@ -92,7 +103,9 @@ describe('NodeTitle', () => {
   });
 
   it('should render with truncate class by default', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={documentNodeData} isDocument={false} rank={0} />);
@@ -102,7 +115,9 @@ describe('NodeTitle', () => {
   });
 
   it('should handle undefined className gracefully', () => {
-    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const primitiveDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
     render(<NodeTitle nodeData={documentNodeData} isDocument={false} className={undefined} rank={0} />);

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -1,7 +1,13 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
@@ -72,7 +78,9 @@ describe('SourceDocumentNode', () => {
   });
 
   it('should render a primitive document node', () => {
-    const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -174,7 +182,9 @@ describe('SourceDocumentNode', () => {
   });
 
   it('should render with draggable indicator for primitive document nodes', () => {
-    const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -206,7 +216,9 @@ describe('SourceDocumentNode', () => {
   });
 
   it('should render correct test-id when selected', () => {
-    const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -395,7 +407,9 @@ describe('SourceDocumentNode', () => {
 
   describe('Selection', () => {
     it('should render as selected when node is in selected mapping', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -419,7 +433,9 @@ describe('SourceDocumentNode', () => {
     });
 
     it('should apply selected-container class when selected', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -445,7 +461,9 @@ describe('SourceDocumentNode', () => {
     });
 
     it('should call toggleSelectedNodeReference when clicking field', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -504,7 +522,9 @@ describe('SourceDocumentNode', () => {
 
   describe('Node Reference', () => {
     it('should register node reference with correct path', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -521,7 +541,9 @@ describe('SourceDocumentNode', () => {
     });
 
     it('should update node reference when changed', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -706,7 +728,9 @@ describe('SourceDocumentNode', () => {
     });
 
     it('should stop propagation on field click', () => {
-      const document = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -1,7 +1,13 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
@@ -72,7 +78,9 @@ describe('TargetDocumentNode', () => {
   });
 
   it('should render a primitive document node', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -164,7 +172,9 @@ describe('TargetDocumentNode', () => {
   });
 
   it('should render with draggable indicator for primitive document nodes', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -196,7 +206,9 @@ describe('TargetDocumentNode', () => {
   });
 
   it('should render correct test-id when selected', () => {
-    const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+    const document = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    );
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
 
@@ -367,7 +379,9 @@ describe('TargetDocumentNode', () => {
 
   describe('Selection', () => {
     it('should render as selected when node is in selected mapping', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -388,7 +402,9 @@ describe('TargetDocumentNode', () => {
     });
 
     it('should apply selected-container class when selected', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -411,7 +427,9 @@ describe('TargetDocumentNode', () => {
     });
 
     it('should call toggleSelectedNodeReference when clicking field', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -467,7 +485,9 @@ describe('TargetDocumentNode', () => {
 
   describe('Node Reference', () => {
     it('should register node reference with correct path', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -484,7 +504,9 @@ describe('TargetDocumentNode', () => {
     });
 
     it('should update node reference when changed', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -529,7 +551,9 @@ describe('TargetDocumentNode', () => {
     });
 
     it('should show TargetNodeActions for primitive document nodes', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
@@ -716,7 +740,9 @@ describe('TargetDocumentNode', () => {
     });
 
     it('should stop propagation on field click', () => {
-      const document = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 

--- a/packages/ui/src/components/Document/actions/DeleteParameterButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteParameterButton.test.tsx
@@ -2,7 +2,13 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
-import { DocumentType, IDocument, PrimitiveDocument } from '../../../models/datamapper/document';
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+  PrimitiveDocument,
+} from '../../../models/datamapper/document';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../../providers/datamapper-canvas.provider';
 import { DeleteParameterButton } from './DeleteParameterButton';
@@ -13,7 +19,12 @@ describe('DeleteParameterButton', () => {
     const ParamTest: FunctionComponent<PropsWithChildren> = ({ children }) => {
       const { sourceParameterMap } = useDataMapper();
       useEffect(() => {
-        sourceParameterMap.set('testparam1', new PrimitiveDocument(DocumentType.PARAM, 'testparam1'));
+        sourceParameterMap.set(
+          'testparam1',
+          new PrimitiveDocument(
+            new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'testparam1'),
+          ),
+        );
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       useEffect(() => {

--- a/packages/ui/src/components/Document/actions/RenameParameterButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/RenameParameterButton.test.tsx
@@ -2,7 +2,13 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
-import { DocumentType, IDocument, PrimitiveDocument } from '../../../models/datamapper/document';
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+  PrimitiveDocument,
+} from '../../../models/datamapper/document';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../../providers/datamapper-canvas.provider';
 import { RenameParameterButton } from './RenameParameterButton';
@@ -15,7 +21,12 @@ describe('RenameParameterButton', () => {
     const ParamTest: FunctionComponent<PropsWithChildren> = ({ children }) => {
       const { sourceParameterMap } = useDataMapper();
       useEffect(() => {
-        sourceParameterMap.set('testparam1', new PrimitiveDocument(DocumentType.PARAM, 'testparam1'));
+        sourceParameterMap.set(
+          'testparam1',
+          new PrimitiveDocument(
+            new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'testparam1'),
+          ),
+        );
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       useEffect(() => {

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -21,6 +21,7 @@ import { SendAlertProps } from '../models/datamapper';
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,
+  DocumentDefinitionType,
   DocumentInitializationModel,
   DocumentType,
   IDocument,
@@ -93,10 +94,14 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   const [sourceParameterMap, setSourceParameterMap] = useState<Map<string, IDocument>>(new Map<string, IDocument>());
   const [isSourceParametersExpanded, setSourceParametersExpanded] = useState<boolean>(true);
   const [sourceBodyDocument, setSourceBodyDocument] = useState<IDocument>(
-    new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID),
+    new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    ),
   );
   const [targetBodyDocument, setTargetBodyDocument] = useState<IDocument>(
-    new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID),
+    new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+    ),
   );
 
   /**

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -443,7 +443,7 @@ describe('DataMapperMetadataService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         {
           'Order.schema.json': orderJsonSchema,
           'Customer.schema.json': customerJsonSchema,

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -10,7 +10,9 @@ import { JsonSchemaDocumentUtilService } from './json-schema-document-util.servi
 describe('DocumentUtilService - JSON Schema', () => {
   describe('adoptTypeFragment()', () => {
     it('should adopt type when fragment has type defined', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const fragment = {
@@ -25,7 +27,9 @@ describe('DocumentUtilService - JSON Schema', () => {
     });
 
     it('should adopt minOccurs when fragment has it defined', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.String);
 
       const fragment = {
@@ -40,7 +44,9 @@ describe('DocumentUtilService - JSON Schema', () => {
     });
 
     it('should adopt maxOccurs when fragment has it defined', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.String);
 
       const fragment = {
@@ -55,7 +61,9 @@ describe('DocumentUtilService - JSON Schema', () => {
     });
 
     it('should adopt all fields from fragment using JSON Schema adopt logic', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.Container);
 
       const fragmentField1 = new JsonSchemaField(doc, 'child1', Types.String);

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -69,7 +69,7 @@ describe('DocumentUtilService', () => {
       const definition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'camel-spring.xsd': camelSpringXsd },
         { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
       );

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -1,4 +1,5 @@
 import {
+  DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
   IField,
@@ -157,7 +158,7 @@ describe('DocumentService', () => {
       );
       expect(result.validationStatus).toBe('success');
       expect(result.document instanceof PrimitiveDocument).toBeTruthy();
-      expect(result.document?.documentId).toEqual('Body');
+      expect(result.document?.documentId).toEqual('test');
       expect(result.documentDefinition).toBeDefined();
       expect(result.documentDefinition?.documentType).toBe(DocumentType.SOURCE_BODY);
       expect(result.documentDefinition?.definitionType).toBe(DocumentDefinitionType.Primitive);
@@ -388,7 +389,9 @@ describe('DocumentService', () => {
 
   describe('getRootElementQName()', () => {
     it('should return null for non-XML schema documents', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, 'test');
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test'),
+      );
       const qName = DocumentService.getRootElementQName(primitiveDoc);
       expect(qName).toBeNull();
     });
@@ -421,7 +424,9 @@ describe('DocumentService', () => {
 
   describe('updateRootElement()', () => {
     it('should return original document for non-XML schema documents', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, 'test');
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test'),
+      );
       const rootElementOption: RootElementOption = {
         name: 'Test',
         namespaceUri: 'http://test.com',
@@ -475,14 +480,14 @@ describe('DocumentService', () => {
         DocumentDefinitionType.Primitive,
         'sourceTest',
       );
-      expect(sourceResult.document?.documentId).toEqual('Body');
+      expect(sourceResult.document?.documentId).toEqual('sourceTest');
 
       const targetResult = DocumentService.createPrimitiveDocument(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.Primitive,
         'targetTest',
       );
-      expect(targetResult.document?.documentId).toEqual('Body');
+      expect(targetResult.document?.documentId).toEqual('targetTest');
 
       const paramResult = DocumentService.createPrimitiveDocument(
         DocumentType.PARAM,
@@ -517,7 +522,9 @@ describe('DocumentService', () => {
     };
 
     it('should rename a primitive document', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, 'test');
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test'),
+      );
 
       DocumentService.renameDocument(primitiveDoc, 'renamedTest');
       expect(primitiveDoc).toBeDefined();

--- a/packages/ui/src/services/document.service.ts
+++ b/packages/ui/src/services/document.service.ts
@@ -89,8 +89,7 @@ export class DocumentService {
     documentId: string,
   ): CreateDocumentResult {
     const definition = new DocumentDefinition(documentType, schemaType, documentId);
-    const docId = documentType === DocumentType.PARAM ? definition.name! : BODY_DOCUMENT_ID;
-    const doc = new PrimitiveDocument(definition.documentType, docId);
+    const doc = new PrimitiveDocument(definition);
     return { validationStatus: 'success', documentDefinition: definition, document: doc };
   }
 
@@ -117,10 +116,7 @@ export class DocumentService {
   private static doCreateDocumentFromDefinition(definition: DocumentDefinition): CreateDocumentResult {
     switch (definition.definitionType) {
       case DocumentDefinitionType.Primitive: {
-        const document = new PrimitiveDocument(
-          definition.documentType,
-          DocumentType.PARAM ? definition.name! : BODY_DOCUMENT_ID,
-        );
+        const document = new PrimitiveDocument(definition);
         return {
           validationStatus: 'success',
           validationMessage: 'Schema validation successful',
@@ -159,17 +155,17 @@ export class DocumentService {
     };
     if (initModel.sourceBody) {
       const result = DocumentService.doCreateDocumentFromDefinition(initModel.sourceBody);
-      if (document) answer.sourceBodyDocument = result.document;
+      if (result.document) answer.sourceBodyDocument = result.document;
     }
     if (initModel.sourceParameters) {
       Object.entries(initModel.sourceParameters).forEach(([key, value]) => {
         const result = DocumentService.doCreateDocumentFromDefinition(value);
-        answer.sourceParameterMap.set(key, result.document ?? new PrimitiveDocument(DocumentType.PARAM, key));
+        answer.sourceParameterMap.set(key, result.document ?? new PrimitiveDocument(value));
       });
     }
     if (initModel.targetBody) {
       const result = DocumentService.doCreateDocumentFromDefinition(initModel.targetBody);
-      if (document) answer.targetBodyDocument = result.document;
+      if (result.document) answer.targetBodyDocument = result.document;
     }
     return answer;
   }

--- a/packages/ui/src/services/json-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/json-schema-document-util.service.test.ts
@@ -1,4 +1,4 @@
-import { DocumentType } from '../models/datamapper';
+import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
 import { TypeOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
@@ -13,7 +13,9 @@ import { JsonSchemaDocumentUtilService } from './json-schema-document-util.servi
 describe('JsonSchemaDocumentUtilService', () => {
   describe('getChildField()', () => {
     it('should find child field by key', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const parent = new JsonSchemaField(doc, 'parent', Types.Container);
       const child1 = new JsonSchemaField(doc, 'child1', Types.String);
       const child2 = new JsonSchemaField(doc, 'child2', Types.Integer);
@@ -26,7 +28,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should return undefined when key does not match', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const parent = new JsonSchemaField(doc, 'parent', Types.Container);
       const child1 = new JsonSchemaField(doc, 'child1', Types.String);
       parent.fields.push(child1);
@@ -42,7 +46,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should return undefined when type does not match', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const parent = new JsonSchemaField(doc, 'parent', Types.Container);
       const child1 = new JsonSchemaField(doc, 'child1', Types.String);
       parent.fields.push(child1);
@@ -85,7 +91,9 @@ describe('JsonSchemaDocumentUtilService', () => {
 
   describe('parseTypeOverride()', () => {
     it('should parse primitive type override', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('string', {}, field);
@@ -96,7 +104,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should parse number type override', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('number', {}, field);
@@ -107,7 +117,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should parse boolean type override', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('boolean', {}, field);
@@ -118,7 +130,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should parse array type override', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('array', {}, field);
@@ -129,7 +143,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should parse object type override', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('object', {}, field);
@@ -140,7 +156,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should parse type reference with #/ prefix as Container', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.AnyType);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('#/definitions/MyType', {}, field);
@@ -151,7 +169,9 @@ describe('JsonSchemaDocumentUtilService', () => {
     });
 
     it('should return FORCE variant when overriding non-AnyType field', () => {
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, 'test-doc');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'test-doc'),
+      );
       const field = new JsonSchemaField(doc, 'testField', Types.String);
 
       const result = JsonSchemaDocumentUtilService.parseTypeOverride('number', {}, field);

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -5,6 +5,7 @@ import {
   BaseDocument,
   BaseField,
   CreateDocumentResult,
+  DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
   IField,
@@ -389,9 +390,9 @@ export class JsonSchemaDocument extends BaseDocument {
   definitionType: DocumentDefinitionType;
   schemaCollection = new JsonSchemaCollection();
 
-  constructor(documentType: DocumentType, documentId: string) {
-    super(documentType, documentId);
-    this.name = documentId;
+  constructor(definition: DocumentDefinition) {
+    super(definition);
+    this.name = definition.name;
     this.definitionType = DocumentDefinitionType.JSON_SCHEMA;
   }
 

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -1,7 +1,7 @@
 import { JSONSchema7 } from 'json-schema';
 
 import { DocumentDefinition, DocumentDefinitionType, PathExpression, Types } from '../models/datamapper';
-import { DocumentType } from '../models/datamapper/document';
+import { BODY_DOCUMENT_ID, DocumentType } from '../models/datamapper/document';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
 import {
   accountJsonSchema,
@@ -20,7 +20,7 @@ function createTestJsonDocument(documentType: DocumentType, documentId: string, 
   const definition = new DocumentDefinition(
     documentType,
     DocumentDefinitionType.JSON_SCHEMA,
-    documentType === DocumentType.PARAM ? documentId : undefined,
+    documentType === DocumentType.PARAM ? documentId : BODY_DOCUMENT_ID,
     { [`${documentId}.json`]: content },
   );
   const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
@@ -515,7 +515,7 @@ describe('JsonSchemaDocumentService', () => {
   describe('Cross-schema reference resolution', () => {
     const createMultiSchemaDocument = (
       documentType: DocumentType,
-      documentId: string | undefined,
+      documentId: string,
       schemas: Record<string, string>,
       rootElementChoice?: { namespaceUri: string; name: string },
     ): JsonSchemaDocument => {
@@ -677,7 +677,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'MainWithRef.schema.json': mainWithRefJsonSchema,
           'CommonTypes.schema.json': commonTypesJsonSchema,
@@ -706,7 +706,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'nested/Product.schema.json': productJsonSchema,
           'CommonTypes.schema.json': commonTypesJsonSchema,
@@ -735,7 +735,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'MainWithRef.schema.json': mainWithRefJsonSchema,
         },
@@ -752,7 +752,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'test.json': '{"type": "object", "properties": {"name": {"type": "string"}}}',
         },
@@ -780,7 +780,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'test.json': '{"type": "object"}',
         },
@@ -800,7 +800,7 @@ describe('JsonSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'test.json': '{"type": "object"}',
         },

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -1,7 +1,6 @@
 import { JSONSchema7Definition } from 'json-schema';
 
-import { BODY_DOCUMENT_ID, DocumentDefinition } from '../models/datamapper';
-import { DocumentType } from '../models/datamapper/document';
+import { DocumentDefinition } from '../models/datamapper';
 import { Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { DocumentUtilService } from './document-util.service';
@@ -39,9 +38,6 @@ export class JsonSchemaDocumentService {
    * @returns CreateJsonSchemaDocumentResult with document and validation status
    */
   static createJsonSchemaDocument(definition: DocumentDefinition): CreateJsonSchemaDocumentResult {
-    const documentType = definition.documentType;
-    const docId = definition.documentType === DocumentType.PARAM ? definition.name! : BODY_DOCUMENT_ID;
-
     const filePaths = Object.keys(definition.definitionFiles || {});
     if (filePaths.length === 0) {
       return {
@@ -72,7 +68,7 @@ export class JsonSchemaDocumentService {
       primarySchema = found;
     }
 
-    const jsonDocument = new JsonSchemaDocument(documentType, docId);
+    const jsonDocument = new JsonSchemaDocument(definition);
     jsonDocument.schemaCollection.setDefinitionFiles(definition.definitionFiles || {});
 
     for (const schema of schemas) {

--- a/packages/ui/src/services/mapping-links.service.json.test.ts
+++ b/packages/ui/src/services/mapping-links.service.json.test.ts
@@ -29,7 +29,9 @@ describe('MappingLinksService : JSON', () => {
   let targetDoc: JsonSchemaDocument;
   let paramsMap: Map<string, IDocument>;
   let mappingTree: MappingTree;
-  const dummySourceBodyDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+  const dummySourceBodyDoc = new PrimitiveDocument(
+    new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+  );
 
   beforeAll(() => {
     mockRandomValues();
@@ -51,7 +53,9 @@ describe('MappingLinksService : JSON', () => {
     const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
     expect(cartResult.validationStatus).toBe('success');
     cartParamDoc = cartResult.document as JsonSchemaDocument;
-    const orderSequenceParamDoc = new PrimitiveDocument(DocumentType.PARAM, 'OrderSequence');
+    const orderSequenceParamDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
+    );
     paramsMap = new Map<string, IDocument>([
       ['OrderSequence', orderSequenceParamDoc],
       ['Account', accountParamDoc],
@@ -60,7 +64,7 @@ describe('MappingLinksService : JSON', () => {
     const targetDefinition = new DocumentDefinition(
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.JSON_SCHEMA,
-      undefined,
+      BODY_DOCUMENT_ID,
       { 'ShipOrder.json': shipOrderJsonSchema },
     );
     const targetResult = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
@@ -75,7 +79,9 @@ describe('MappingLinksService : JSON', () => {
       const links = MappingLinksService.extractMappingLinks(
         mappingTree,
         paramsMap,
-        new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID),
+        new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        ),
       );
       expect(links.length).toEqual(13);
       expect(links[0].sourceNodePath).toMatch('fj-string-AccountId');

--- a/packages/ui/src/services/mapping-links.service.test.ts
+++ b/packages/ui/src/services/mapping-links.service.test.ts
@@ -1,7 +1,13 @@
 import { renderHook } from '@testing-library/react';
 import { RefObject, useRef } from 'react';
 
-import { DocumentDefinition, DocumentDefinitionType, DocumentType, IDocument } from '../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+} from '../models/datamapper/document';
 import { MappingTree } from '../models/datamapper/mapping';
 import { NodeReference } from '../models/datamapper/visualization';
 import { mockRandomValues } from '../stubs';
@@ -100,14 +106,14 @@ describe('MappingLinksService', () => {
       const sourceDefinition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'x12837PDfdl.xsd': x12837PDfdlXsd },
       );
       sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(sourceDefinition).document!;
       const targetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'message837.xsd': message837Xsd },
       );
       targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
@@ -149,14 +155,14 @@ describe('MappingLinksService', () => {
       const sourceDefinition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'x12850Dfdl.xsd': x12850DfdlXsd },
       );
       sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(sourceDefinition).document!;
       const targetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'invoice850.xsd': invoice850Xsd },
       );
       targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
@@ -182,7 +188,7 @@ describe('MappingLinksService', () => {
       const jsonTargetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'shipOrder.json': shipOrderJsonSchema },
       );
       const jsonTargetDoc = JsonSchemaDocumentService.createJsonSchemaDocument(jsonTargetDefinition).document!;
@@ -194,7 +200,7 @@ describe('MappingLinksService', () => {
       const orgSourceDefinition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'org.xsd': orgXsd },
       );
       const orgSourceResult = XmlSchemaDocumentService.createXmlSchemaDocument(orgSourceDefinition);
@@ -203,7 +209,7 @@ describe('MappingLinksService', () => {
       const contactsTargetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'contacts.xsd': contactsXsd },
       );
       const contactsResult = XmlSchemaDocumentService.createXmlSchemaDocument(contactsTargetDefinition);

--- a/packages/ui/src/services/mapping-serializer-json-addon.test.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.test.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinitionType, FieldItem, MappingTree, NS_XSL, PrimitiveDocument, Types } from '../models/datamapper';
-import { DocumentDefinition, DocumentType } from '../models/datamapper/document';
+import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentType } from '../models/datamapper/document';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
 import { cartToShipOrderJsonXslt, shipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
@@ -88,7 +88,9 @@ describe('mappingSerializerJsonAddon', () => {
       const xsltDocument = MappingSerializerService.createNew();
       const stylesheet = xsltDocument.children[0];
       const paramName = 'testParam';
-      const doc = new JsonSchemaDocument(DocumentType.PARAM, paramName);
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, paramName),
+      );
       MappingSerializerJsonAddon.populateJsonToXmlVariable(doc, stylesheet, paramName);
 
       expect(stylesheet.children.length).toBe(2);
@@ -101,7 +103,9 @@ describe('mappingSerializerJsonAddon', () => {
       const xsltDocument = MappingSerializerService.createNew();
       const stylesheet = xsltDocument.children[0];
       const paramName = 'testParam';
-      const doc = new PrimitiveDocument(DocumentType.PARAM, paramName);
+      const doc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, paramName),
+      );
       MappingSerializerJsonAddon.populateJsonToXmlVariable(doc, stylesheet, paramName);
       expect(stylesheet.children.length).toBe(1);
     });
@@ -123,7 +127,9 @@ describe('mappingSerializerJsonAddon', () => {
         TestUtil.createParameterMap(),
       );
       const root = MappingSerializerJsonAddon.populateJsonTargetBase(mappings, template);
-      const doc = new JsonSchemaDocument(DocumentType.TARGET_BODY, 'Body');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, 'Body'),
+      );
 
       let mapField = new JsonSchemaField(doc, '', Types.Container);
       let fieldItem = new FieldItem(mappings, mapField);
@@ -179,7 +185,7 @@ describe('mappingSerializerJsonAddon', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'shipOrder.xsd': shipOrderXsd },
       );
       const doc = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
@@ -194,7 +200,9 @@ describe('mappingSerializerJsonAddon', () => {
 
   describe('getOrCreateJsonField()', () => {
     it('should create a JsonSchemaField', () => {
-      const doc = new JsonSchemaDocument(DocumentType.TARGET_BODY, 'Body');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, 'Body'),
+      );
       const mapElement = document.createElementNS(NS_XPATH_FUNCTIONS, 'map');
       const mapField = MappingSerializerJsonAddon.getOrCreateJsonField(mapElement, doc);
       expect(mapField instanceof JsonSchemaField).toBeTruthy();
@@ -244,7 +252,9 @@ describe('mappingSerializerJsonAddon', () => {
     });
 
     it('should not create a field if not lossless element', () => {
-      const doc = new JsonSchemaDocument(DocumentType.TARGET_BODY, 'Body');
+      const doc = new JsonSchemaDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, 'Body'),
+      );
       const testElement = document.createElementNS('test', 'Test');
       const testField = MappingSerializerJsonAddon.getOrCreateJsonField(testElement, doc);
       expect(testField).toBeNull();

--- a/packages/ui/src/services/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping-serializer.service.json.test.ts
@@ -37,7 +37,9 @@ describe('MappingSerializerService / JSON', () => {
   const cartDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
   expect(cartDocResult.validationStatus).toBe('success');
   const cartParamDoc = cartDocResult.document!;
-  const orderSequenceParamDoc = new PrimitiveDocument(DocumentType.PARAM, 'OrderSequence');
+  const orderSequenceParamDoc = new PrimitiveDocument(
+    new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
+  );
   const sourceParameterMap = new Map<string, IDocument>([
     ['OrderSequence', orderSequenceParamDoc],
     ['Account', accountParamDoc],
@@ -46,7 +48,7 @@ describe('MappingSerializerService / JSON', () => {
   const targetDefinition = new DocumentDefinition(
     DocumentType.TARGET_BODY,
     DocumentDefinitionType.JSON_SCHEMA,
-    undefined,
+    BODY_DOCUMENT_ID,
     { 'ShipOrder.json': shipOrderJsonSchema },
   );
   const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);

--- a/packages/ui/src/services/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping-serializer.service.ts
@@ -2,6 +2,8 @@ import xmlFormat from 'xml-formatter';
 
 import {
   BaseField,
+  DocumentDefinition,
+  DocumentDefinitionType,
   DocumentType,
   IDocument,
   IField,
@@ -273,7 +275,10 @@ export class MappingSerializerService {
       const paramEl = param as Element;
       const name = paramEl.getAttribute('name');
       if (!name || sourceParameterMap.has(name)) continue;
-      sourceParameterMap.set(name, new PrimitiveDocument(DocumentType.PARAM, name));
+      sourceParameterMap.set(
+        name,
+        new PrimitiveDocument(new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, name)),
+      );
     }
   }
 

--- a/packages/ui/src/services/tree-parsing.service.test.ts
+++ b/packages/ui/src/services/tree-parsing.service.test.ts
@@ -1,4 +1,11 @@
-import { BODY_DOCUMENT_ID, DocumentType, IDocument, PrimitiveDocument } from '../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+  PrimitiveDocument,
+} from '../models/datamapper/document';
 import { DocumentTree, INITIAL_PARSE_DEPTH } from '../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../models/datamapper/document-tree-node';
 import { DocumentNodeData, FieldNodeData } from '../models/datamapper/visualization';
@@ -40,7 +47,9 @@ describe('TreeParsingService', () => {
     });
 
     it('should stop parsing at primitive nodes regardless of depth', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const primitiveDocNode = new DocumentNodeData(primitiveDoc);
       const primitiveTree = new DocumentTree(primitiveDocNode);
 

--- a/packages/ui/src/services/tree-ui.service.test.ts
+++ b/packages/ui/src/services/tree-ui.service.test.ts
@@ -1,4 +1,10 @@
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../models/datamapper/document';
 import { DocumentTree } from '../models/datamapper/document-tree';
 import { DocumentNodeData } from '../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../store/document-tree.store';
@@ -71,7 +77,9 @@ describe('TreeUIService', () => {
     });
 
     it('should create tree for primitive document', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const primitiveDocNode = new DocumentNodeData(primitiveDoc);
 
       const tree = TreeUIService.createTree(primitiveDocNode);
@@ -382,7 +390,9 @@ describe('TreeUIService', () => {
     });
 
     it('should handle primitive document tree', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const primitiveDocNode = new DocumentNodeData(primitiveDoc);
       const tree = TreeUIService.createTree(primitiveDocNode);
 

--- a/packages/ui/src/services/visualization.service.json.test.ts
+++ b/packages/ui/src/services/visualization.service.json.test.ts
@@ -41,11 +41,13 @@ describe('VisualizationService / JSON', () => {
   const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
   expect(cartResult.validationStatus).toBe('success');
   const cartDoc = cartResult.document!;
-  const orderSequenceDoc = new PrimitiveDocument(DocumentType.PARAM, 'OrderSequence');
+  const orderSequenceDoc = new PrimitiveDocument(
+    new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
+  );
   const targetDefinition = new DocumentDefinition(
     DocumentType.TARGET_BODY,
     DocumentDefinitionType.JSON_SCHEMA,
-    undefined,
+    BODY_DOCUMENT_ID,
     { 'ShipOrder.json': shipOrderJsonSchema },
   );
   const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
@@ -198,7 +200,7 @@ describe('VisualizationService / JSON', () => {
     const camelYamlDefinition = new DocumentDefinition(
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.JSON_SCHEMA,
-      undefined,
+      BODY_DOCUMENT_ID,
       { 'CamelYamlDsl.json': camelYamlDslJsonSchema },
     );
     const result = JsonSchemaDocumentService.createJsonSchemaDocument(camelYamlDefinition);

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -139,7 +139,9 @@ describe('VisualizationService', () => {
       });
 
       it('should add If on primitive target body', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -197,7 +199,9 @@ describe('VisualizationService', () => {
       });
 
       it('should add Choose-When-Otherwise on primitive target body', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -258,7 +262,9 @@ describe('VisualizationService', () => {
       });
 
       it('should add When in primitive target body choose', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -320,7 +326,9 @@ describe('VisualizationService', () => {
       });
 
       it('should add Otherwise in primitive target body choose', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -380,7 +388,9 @@ describe('VisualizationService', () => {
       });
 
       it('should apply value selector on primitive target body', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -397,7 +407,9 @@ describe('VisualizationService', () => {
 
     describe('getExpressionItemForNode()', () => {
       it('should return ValueSelector for primitive target body', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -415,7 +427,9 @@ describe('VisualizationService', () => {
 
     describe('deleteMappingItem()', () => {
       it('should delete primitive target body mapping', () => {
-        const primitiveTargetDoc = new PrimitiveDocument(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID);
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
         tree = new MappingTree(
           primitiveTargetDoc.documentType,
           primitiveTargetDoc.documentId,
@@ -608,7 +622,7 @@ describe('VisualizationService', () => {
         const extensionSimpleDef = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
-          undefined,
+          BODY_DOCUMENT_ID,
           { 'ExtensionSimple.xsd': extensionSimpleXsd },
         );
         const sourceDocResult = XmlSchemaDocumentService.createXmlSchemaDocument(extensionSimpleDef);
@@ -651,7 +665,7 @@ describe('VisualizationService', () => {
       const contactsDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'Contacts.xsd': contactsXsd },
       );
       const contactsResult = XmlSchemaDocumentService.createXmlSchemaDocument(contactsDefinition);
@@ -737,7 +751,7 @@ describe('VisualizationService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'extensionSimple.xsd': extensionSimpleXsd },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -779,7 +793,7 @@ describe('VisualizationService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'extensionComplex.xsd': extensionComplexXsd },
         { namespaceUri: 'http://www.example.com/TEST', name: 'Request' },
       );
@@ -810,7 +824,7 @@ describe('VisualizationService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'schemaTest.xsd': schemaTestXsd },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);

--- a/packages/ui/src/services/xml-schema-document.model.ts
+++ b/packages/ui/src/services/xml-schema-document.model.ts
@@ -3,8 +3,8 @@ import {
   BaseDocument,
   BaseField,
   CreateDocumentResult,
+  DocumentDefinition,
   DocumentDefinitionType,
-  DocumentType,
   IField,
   ITypeFragment,
 } from '../models/datamapper/document';
@@ -38,13 +38,12 @@ export class XmlSchemaDocument extends BaseDocument {
   definitionType: DocumentDefinitionType;
 
   constructor(
+    definition: DocumentDefinition,
     public xmlSchemaCollection: XmlSchemaCollection,
-    documentType: DocumentType,
-    documentId: string,
     public rootElement?: XmlSchemaElement,
   ) {
-    super(documentType, documentId);
-    this.name = documentId;
+    super(definition);
+    this.name = definition.name;
     this.definitionType = DocumentDefinitionType.XML_SCHEMA;
   }
 }

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -1,4 +1,9 @@
-import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+} from '../models/datamapper/document';
 import { Types } from '../models/datamapper/types';
 import {
   camelSpringXsd,
@@ -26,9 +31,14 @@ import { XmlSchemaDocumentUtilService } from './xml-schema-document-util.service
 
 describe('XmlSchemaDocumentService', () => {
   it('should parse ShipOrder XML schema', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'shipOrder.xsd': shipOrderXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'shipOrder.xsd': shipOrderXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -45,9 +55,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse TestDocument XML schema', () => {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'testDocument.xsd': testDocumentXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'testDocument.xsd': testDocumentXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -59,9 +74,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse camel-spring.xsd XML schema', () => {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'camel-spring.xsd': camelSpringXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'camel-spring.xsd': camelSpringXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -92,9 +112,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse ExtensionSimple.xsd', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'extensionSimple.xsd': extensionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'extensionSimple.xsd': extensionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -151,7 +176,7 @@ describe('XmlSchemaDocumentService', () => {
     const definition = new DocumentDefinition(
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
-      undefined,
+      BODY_DOCUMENT_ID,
       { 'extensionComplex.xsd': extensionComplexXsd },
       { namespaceUri: 'http://www.example.com/TEST', name: 'Request' },
     );
@@ -184,7 +209,7 @@ describe('XmlSchemaDocumentService', () => {
     const definition = new DocumentDefinition(
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.XML_SCHEMA,
-      undefined,
+      BODY_DOCUMENT_ID,
       { 'camel-spring.xsd': camelSpringXsd },
       { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
     );
@@ -209,9 +234,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should create XML Schema Document', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'shipOrder.xsd': shipOrderXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'shipOrder.xsd': shipOrderXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const doc = result.document as XmlSchemaDocument;
@@ -234,9 +264,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse SchemaTest.xsd with advanced features', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'schemaTest.xsd': schemaTestXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'schemaTest.xsd': schemaTestXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -302,9 +337,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle XmlSchemaField getExpression with namespaceMap', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'extensionSimple.xsd': extensionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'extensionSimple.xsd': extensionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -333,9 +373,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse RestrictionSimple.xsd', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'restrictionSimple.xsd': restrictionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'restrictionSimple.xsd': restrictionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -370,9 +415,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse RestrictionComplex.xsd', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'restrictionComplex.xsd': restrictionComplexXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'restrictionComplex.xsd': restrictionComplexXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -424,9 +474,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should parse RestrictionInheritance.xsd with nested content models', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'restrictionInheritance.xsd': restrictionInheritanceXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'restrictionInheritance.xsd': restrictionInheritanceXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -478,9 +533,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle multi-level extension inheritance', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'multiLevelExtension.xsd': multiLevelExtensionXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'multiLevelExtension.xsd': multiLevelExtensionXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -526,9 +586,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle multi-level restriction inheritance', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'multiLevelRestriction.xsd': multiLevelRestrictionXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'multiLevelRestriction.xsd': multiLevelRestrictionXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -571,9 +636,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle XmlSchemaField isIdentical method correctly', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'extensionSimple.xsd': extensionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'extensionSimple.xsd': extensionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -597,9 +667,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should merge attributes from base type in restrictions', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'restrictionSimple.xsd': restrictionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'restrictionSimple.xsd': restrictionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -621,9 +696,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should support getChildField with namespace matching', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'extensionSimple.xsd': extensionSimpleXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'extensionSimple.xsd': extensionSimpleXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -649,9 +729,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle extension that attempts to redefine base elements', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'invalidComplexExtension.xsd': invalidComplexExtensionXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'invalidComplexExtension.xsd': invalidComplexExtensionXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -696,9 +781,14 @@ describe('XmlSchemaDocumentService', () => {
   });
 
   it('should handle simpleType inheritance with extension and restriction', () => {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'simpleTypeInheritance.xsd': simpleTypeInheritanceXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'simpleTypeInheritance.xsd': simpleTypeInheritanceXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('success');
     const document = result.document as XmlSchemaDocument;
@@ -732,7 +822,7 @@ describe('XmlSchemaDocumentService', () => {
     const definition = new DocumentDefinition(
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
-      undefined,
+      BODY_DOCUMENT_ID,
       { 'element-ref.xsd': elementRefXsd },
       { namespaceUri: '', name: 'CSV' },
     );
@@ -760,7 +850,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'MainWithInclude.xsd': mainSchema,
           'CommonTypes.xsd': commonTypesXsd,
@@ -793,7 +883,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'schemas/main.xsd': mainSchema,
           'schemas/common.xsd': commonTypesXsd,
@@ -815,7 +905,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'MainWithInclude.xsd': mainSchema,
         },
@@ -846,7 +936,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'MainWithImport.xsd': mainSchema,
           'ImportedTypes.xsd': importedTypesXsd,
@@ -883,7 +973,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'schemas/main.xsd': mainSchema,
           'schemas/types.xsd': importedTypesXsd,
@@ -907,7 +997,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'schema1.xsd': schema1,
           'ImportedTypes.xsd': importedTypesXsd,
@@ -936,7 +1026,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'main.xsd': mainSchema,
         },
@@ -971,7 +1061,7 @@ describe('XmlSchemaDocumentService', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        'test-doc',
         {
           'main.xsd': mainSchema,
         },

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -1,4 +1,4 @@
-import { DocumentDefinition, DocumentType, RootElementOption } from '../models/datamapper/document';
+import { DocumentDefinition, RootElementOption } from '../models/datamapper/document';
 import { Types } from '../models/datamapper/types';
 import { capitalize } from '../serializers/xml/utils/xml-utils';
 import {
@@ -59,9 +59,6 @@ export class XmlSchemaDocumentService {
    * @returns {@link CreateXmlSchemaDocumentResult} with document, root element options, and validation status
    */
   static createXmlSchemaDocument(definition: DocumentDefinition): CreateXmlSchemaDocumentResult {
-    const documentType = definition.documentType;
-    const docId = definition.documentType === DocumentType.PARAM ? definition.name! : 'Body';
-
     const collection = new XmlSchemaCollection();
     definition.definitionFiles && collection.getSchemaResolver().addFiles(definition.definitionFiles);
 
@@ -101,7 +98,7 @@ export class XmlSchemaDocumentService {
       };
     }
 
-    const document = new XmlSchemaDocument(collection, documentType, docId, rootElement);
+    const document = new XmlSchemaDocument(definition, collection, rootElement);
 
     XmlSchemaDocumentService.populateNamedTypeFragments(document);
     XmlSchemaDocumentService.populateElement(document, document.fields, document.rootElement!);
@@ -156,12 +153,7 @@ export class XmlSchemaDocumentService {
       throw new Error(`Unable to find a root element ${newRootQName.toString()}`);
     }
 
-    const newDocument = new XmlSchemaDocument(
-      document.xmlSchemaCollection,
-      document.documentType,
-      document.documentId,
-      newRootElement,
-    );
+    const newDocument = new XmlSchemaDocument(document.definition, document.xmlSchemaCollection, newRootElement);
 
     XmlSchemaDocumentService.populateNamedTypeFragments(newDocument);
     XmlSchemaDocumentService.populateElement(newDocument, newDocument.fields, newDocument.rootElement!);

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -1,5 +1,11 @@
 import { PathExpression, PathSegment } from '../../models/datamapper';
-import { DocumentDefinition, DocumentDefinitionType, DocumentType, IDocument } from '../../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+} from '../../models/datamapper/document';
 import { Predicate, PredicateOperator } from '../../models/datamapper/xpath';
 import { cartXsd, shipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaDocumentService } from '../xml-schema-document.service';
@@ -750,7 +756,7 @@ describe('XPathService', () => {
       const bodyDefinition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
-        undefined,
+        BODY_DOCUMENT_ID,
         { 'shipOrder.xsd': shipOrderXsd },
       );
       bodyDoc = XmlSchemaDocumentService.createXmlSchemaDocument(bodyDefinition).document!;

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -1,4 +1,10 @@
-import { BODY_DOCUMENT_ID, DocumentType, PrimitiveDocument } from '../models/datamapper/document';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../models/datamapper/document';
 import { DocumentTree } from '../models/datamapper/document-tree';
 import { DocumentNodeData } from '../models/datamapper/visualization';
 import { TreeParsingService } from '../services/tree-parsing.service';
@@ -76,7 +82,9 @@ describe('useDocumentTreeStore', () => {
     });
 
     it('should not include primitive nodes in expansion state', () => {
-      const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
       const primitiveDocNode = new DocumentNodeData(primitiveDoc);
       const primitiveTree = new DocumentTree(primitiveDocNode);
 

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -4,6 +4,7 @@ import { parse } from 'yaml';
 
 import {
   BaseDocument,
+  BODY_DOCUMENT_ID,
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
@@ -163,9 +164,14 @@ export const importedTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/I
 
 export class TestUtil {
   static createSourceOrderDoc() {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'shipOrder.xsd': shipOrderXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'shipOrder.xsd': shipOrderXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
       throw new Error(result.validationMessage || 'Failed to create document');
@@ -174,9 +180,14 @@ export class TestUtil {
   }
 
   static createCamelSpringXsdSourceDoc() {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'camelSpring.xsd': camelSpringXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'camelSpring.xsd': camelSpringXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
       throw new Error(result.validationMessage || 'Failed to create document');
@@ -185,9 +196,14 @@ export class TestUtil {
   }
 
   static createTargetOrderDoc() {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'shipOrder.xsd': shipOrderXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'shipOrder.xsd': shipOrderXsd,
+      },
+    );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
       throw new Error(result.validationMessage || 'Failed to create document');
@@ -196,9 +212,14 @@ export class TestUtil {
   }
 
   static createJSONTargetOrderDoc() {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, undefined, {
-      'shipOrder.json': shipOrderJsonSchema,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.JSON_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'shipOrder.json': shipOrderJsonSchema,
+      },
+    );
     const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
       throw new Error(result.validationMessage || 'Failed to create document');
@@ -225,7 +246,9 @@ export class TestUtil {
 
   static createParameterMap() {
     const sourceParamDoc = TestUtil.createParamOrderDoc('sourceParam1');
-    const sourcePrimitiveParamDoc = new PrimitiveDocument(DocumentType.PARAM, 'primitive');
+    const sourcePrimitiveParamDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'primitive'),
+    );
     const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.XML_SCHEMA, cartXsd);
     return new Map<string, IDocument>([
       ['sourceParam1', sourceParamDoc],
@@ -235,7 +258,9 @@ export class TestUtil {
   }
 
   static createJSONParameterMap() {
-    const sourcePrimitiveParamDoc = new PrimitiveDocument(DocumentType.PARAM, 'primitive');
+    const sourcePrimitiveParamDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'primitive'),
+    );
     const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.JSON_SCHEMA, cartJsonSchema);
     const cart2ParamDoc = TestUtil.createParamOrderDoc('cart2', DocumentDefinitionType.JSON_SCHEMA, cartJsonSchema);
     return new Map<string, IDocument>([
@@ -246,16 +271,26 @@ export class TestUtil {
   }
 
   static createAdtInDoc() {
-    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'ADT_IN.xsd': adtInXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'ADT_IN.xsd': adtInXsd,
+      },
+    );
     return XmlSchemaDocumentService.createXmlSchemaDocument(definition);
   }
 
   static createAdtOutDoc() {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, undefined, {
-      'ADT_OUT.xsd': adtOutXsd,
-    });
+    const definition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'ADT_OUT.xsd': adtOutXsd,
+      },
+    );
     return XmlSchemaDocumentService.createXmlSchemaDocument(definition);
   }
 }


### PR DESCRIPTION
https://github.com/KaotoIO/kaoto/issues/2724

Step 1/3: Store DocumentDefinition on IDocument and simplify document construction

While implementing Field Type Override API, it was found that more parameters held in DocumentDefinition are needed to be delivered. Refactor document model to accept and retain the full DocumentDefinition in constructors instead of individual documentType/documentId parameters and keep holding it. This makes DocumentDefinition the single source of truth for document creation as well as dynamic modification like Field Type Override, and allows downstream code to access the original definition.

  - Add `definition` property to IDocument/BaseDocument
  - Change BaseDocument, PrimitiveDocument, JsonSchemaDocument, and XmlSchemaDocument constructors to accept DocumentDefinition
  - Make DocumentDefinition.name required (was optional)
  - Remove redundant document ID derivation logic from services
  - Fix bug in DocumentService where `if (document)` should be `if (result.document)`
  - Update all tests and stubs to match new constructor API