### PR TITLE
feat(DataMapper): Implement API to manage overrides 3/3

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -84,7 +84,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
             ctx,
             metadataId,
             metadata,
-            definition.name!,
+            definition.name,
             definition,
           );
       }
@@ -116,6 +116,14 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
     [ctx, metadata],
   );
 
+  const onUpdateNamespaceMap = useCallback(
+    (namespaceMap: Record<string, string>) => {
+      if (!metadataId || !metadata) return;
+      DataMapperMetadataService.setNamespaceMap(ctx, metadataId, metadata, namespaceMap);
+    },
+    [ctx, metadata, metadataId],
+  );
+
   if (!metadataId) {
     return <>No associated DataMapper step was provided.</>;
   }
@@ -132,6 +140,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       onRenameParameter={onRenameParameter}
       initialXsltFile={initialXsltFile}
       onUpdateMappings={onUpdateMappings}
+      onUpdateNamespaceMap={onUpdateNamespaceMap}
     >
       <DataMapperCanvasProvider>
         <DataMapperControl />

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -340,6 +340,7 @@ export class DocumentInitializationModel {
       definitionType: DocumentDefinitionType.Primitive,
       name: BODY_DOCUMENT_ID,
     },
+    public namespaceMap: Record<string, string> = {},
   ) {}
 }
 

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -76,6 +76,7 @@ type DataMapperProviderProps = PropsWithChildren & {
   onRenameParameter?: (oldName: string, newName: string) => void;
   initialXsltFile?: string;
   onUpdateMappings?: (xsltFile: string) => void;
+  onUpdateNamespaceMap?: (namespaceMap: Record<string, string>) => void;
 };
 
 export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
@@ -85,6 +86,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   onRenameParameter,
   initialXsltFile,
   onUpdateMappings,
+  onUpdateNamespaceMap,
   children,
 }) => {
   const [debug, setDebug] = useState<boolean>(false);
@@ -136,6 +138,15 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     }
     mappingTree.documentDefinitionType = latestTargetBodyDocument.definitionType;
 
+    const metadataNamespaceMap = documentInitializationModel?.namespaceMap;
+
+    if (metadataNamespaceMap) {
+      mappingTree.namespaceMap = {
+        ...initialNamespaceMap,
+        ...metadataNamespaceMap,
+      };
+    }
+
     if (initialXsltFile) {
       const loaded = MappingSerializerService.deserialize(
         initialXsltFile,
@@ -177,14 +188,22 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     newMapping.namespaceMap = mappingTree.namespaceMap;
     setMappingTree(newMapping);
     onUpdateMappings?.(MappingSerializerService.serialize(newMapping, sourceParameterMap));
-  }, [mappingTree, onUpdateMappings, sourceParameterMap, targetBodyDocument.definitionType]);
+    onUpdateNamespaceMap?.(newMapping.namespaceMap);
+  }, [mappingTree, onUpdateMappings, onUpdateNamespaceMap, sourceParameterMap, targetBodyDocument.definitionType]);
 
   const resetMappingTree = useCallback(() => {
     const newMapping = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, targetBodyDocument.definitionType);
     newMapping.namespaceMap = { ...initialNamespaceMap };
     setMappingTree(newMapping);
     onUpdateMappings?.(MappingSerializerService.serialize(newMapping, sourceParameterMap));
-  }, [initialNamespaceMap, onUpdateMappings, sourceParameterMap, targetBodyDocument.definitionType]);
+    onUpdateNamespaceMap?.(newMapping.namespaceMap);
+  }, [
+    initialNamespaceMap,
+    onUpdateMappings,
+    onUpdateNamespaceMap,
+    sourceParameterMap,
+    targetBodyDocument.definitionType,
+  ]);
 
   const renameSourceParameter = useCallback(
     (oldName: string, newName: string) => {

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -93,6 +93,9 @@ export class DataMapperMetadataService {
     return new Promise((resolve) => {
       const answer = new DocumentInitializationModel();
       const namespaceMap = metadata.namespaceMap || {};
+      if (Object.keys(namespaceMap).length > 0) {
+        answer.namespaceMap = namespaceMap;
+      }
       const sourceBodyPromise = DataMapperMetadataService.doLoadDocument(
         api,
         DocumentType.SOURCE_BODY,

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -123,7 +123,7 @@ describe('DocumentUtilService - JSON Schema', () => {
     });
   });
 
-  describe('applyFieldTypeOverrides()', () => {
+  describe('processTypeOverrides()', () => {
     it('should apply type override to top-level JSON field', () => {
       const definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'account', {
         'account.json': accountJsonSchema,
@@ -141,12 +141,7 @@ describe('DocumentUtilService - JSON Schema', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        JsonSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, JsonSchemaTypesService.parseTypeOverride);
 
       const accountIdField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'AccountId');
       expect(accountIdField?.type).toBe(Types.Numeric);
@@ -170,12 +165,7 @@ describe('DocumentUtilService - JSON Schema', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        JsonSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, JsonSchemaTypesService.parseTypeOverride);
 
       const addressField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'Address');
       const cityField = addressField?.fields.find((f) => 'key' in f && f.key === 'City');
@@ -215,12 +205,7 @@ describe('DocumentUtilService - JSON Schema', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        JsonSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, JsonSchemaTypesService.parseTypeOverride);
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.String);
@@ -264,12 +249,7 @@ describe('DocumentUtilService - JSON Schema', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        JsonSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, JsonSchemaTypesService.parseTypeOverride);
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.Boolean);

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -156,12 +156,12 @@ describe('DocumentUtilService', () => {
     });
   });
 
-  describe('applyFieldTypeOverrides()', () => {
+  describe('processTypeOverrides()', () => {
     it('should not modify document when no overrides provided', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
 
-      DocumentUtilService.applyFieldTypeOverrides(doc, [], {}, XmlSchemaTypesService.parseTypeOverride);
+      DocumentUtilService.processTypeOverrides(doc, [], {}, XmlSchemaTypesService.parseTypeOverride);
 
       expect(orderPerson?.type).toBe(Types.String);
       expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.NONE);
@@ -179,12 +179,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Integer);
@@ -203,12 +198,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo');
       const city = shipTo?.fields.find((f) => f.name === 'City');
@@ -235,12 +225,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Integer);
@@ -262,12 +247,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Container);
@@ -303,12 +283,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const companyAfterOverride = doc.fields[0].fields.find((f) => f.name === 'Company');
       expect(companyAfterOverride?.namedTypeFragmentRefs).toHaveLength(1);
@@ -340,12 +315,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const personAfterOverride = doc.fields[0].fields.find((f) => f.name === 'Person');
       expect(personAfterOverride?.namedTypeFragmentRefs).toHaveLength(0);
@@ -389,12 +359,7 @@ describe('DocumentUtilService', () => {
         },
       ];
 
-      DocumentUtilService.applyFieldTypeOverrides(
-        doc,
-        overrides,
-        namespaceMap,
-        XmlSchemaTypesService.parseTypeOverride,
-      );
+      DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
       const personAfterOverride = doc.fields[0].fields.find((f) => f.name === 'Person');
       const nameField = personAfterOverride?.fields.find((f) => f.name === 'Name');

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -4,7 +4,7 @@ import { TypeOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { XPathService } from './xpath/xpath.service';
 
-type ParseTypeOverrideFn = (
+export type ParseTypeOverrideFn = (
   typeString: string,
   namespaceMap: Record<string, string>,
   field: IField,
@@ -63,7 +63,37 @@ export class DocumentUtilService {
     return fieldStack;
   }
 
-  static applyFieldTypeOverrides(
+  /**
+   * Low level API to apply multiple field type overrides to a document.
+   * UI component should use {@link FieldTypeOverrideService.applyFieldTypeOverride()}.
+   *
+   * Iterates through all provided overrides and applies them to the document.
+   * Each override modifies both the field in the document tree and updates
+   * the DocumentDefinition to keep them in sync.
+   *
+   * @param document - The document to apply overrides to
+   * @param overrides - Array of field type overrides to apply
+   * @param namespaceMap - Namespace prefix to URI mapping for XPath resolution
+   * @param parseTypeOverride - Function to parse type override strings
+   *
+   * @example
+   * ```typescript
+   * const overrides = [
+   *   { path: '/ns0:ShipOrder/ns0:OrderPerson', type: 'xs:int', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE },
+   *   { path: '/ns0:ShipOrder/ShipTo/City', type: 'xs:boolean', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE }
+   * ];
+   * DocumentUtilService.processTypeOverrides(
+   *   document,
+   *   overrides,
+   *   namespaceMap,
+   *   XmlSchemaTypesService.parseTypeOverride
+   * );
+   * ```
+   *
+   * @see processTypeOverride
+   * @see removeTypeOverride
+   */
+  static processTypeOverrides(
     document: IDocument,
     overrides: IFieldTypeOverride[],
     namespaceMap: Record<string, string>,
@@ -77,6 +107,133 @@ export class DocumentUtilService {
     }
   }
 
+  /**
+   * Low level API to apply a field type override to a document.
+   * UI component should use {@link FieldTypeOverrideService.applyFieldTypeOverride()}.
+   *
+   * Navigates to the specified field using XPath and changes its type. Also updates
+   * the DocumentDefinition.fieldTypeOverrides to keep the definition in sync with
+   * the live document. This ensures that when the document is recreated from the
+   * definition, the override will be reapplied.
+   *
+   * @param document - The document to apply the override to
+   * @param override - The field type override to apply
+   * @param namespaceMap - Namespace prefix to URI mapping for XPath resolution
+   * @param parseTypeOverride - Function to parse type override strings (format-specific)
+   *
+   * @example
+   * ```typescript
+   * const override: IFieldTypeOverride = {
+   *   path: '/ns0:ShipOrder/ns0:OrderPerson',
+   *   type: 'xs:int',
+   *   originalType: 'xs:string',
+   *   variant: TypeOverrideVariant.FORCE,
+   * };
+   * DocumentUtilService.processTypeOverride(
+   *   document,
+   *   override,
+   *   namespaceMap,
+   *   XmlSchemaTypesService.parseTypeOverride
+   * );
+   * // Field is now type xs:int and override is stored in document.definition.fieldTypeOverrides
+   * ```
+   *
+   * @remarks
+   * This method modifies both the runtime field structure and the DocumentDefinition:
+   * 1. Runtime: Changes field.type, field.typeQName, field.typeOverride, clears field.fields
+   * 2. Definition: Adds/updates override in document.definition.fieldTypeOverrides
+   *
+   * For retrieving type override candidates, use {@link FieldTypeOverrideService.getSafeOverrideCandidates}
+   * or {@link FieldTypeOverrideService.getAllOverrideCandidates}.
+   *
+   * @see processTypeOverrides
+   * @see removeTypeOverride
+   * @see FieldTypeOverrideService.getSafeOverrideCandidates
+   * @see FieldTypeOverrideService.getAllOverrideCandidates
+   */
+  static processTypeOverride(
+    document: IDocument,
+    override: IFieldTypeOverride,
+    namespaceMap: Record<string, string>,
+    parseTypeOverride: ParseTypeOverrideFn,
+  ): void {
+    const field = DocumentUtilService.navigateToFieldByPath(document, override.path, namespaceMap);
+    if (field) {
+      DocumentUtilService.applyTypeOverrideToField(field, override.type, namespaceMap, parseTypeOverride);
+
+      document.definition.fieldTypeOverrides ??= [];
+      const existingIndex = document.definition.fieldTypeOverrides.findIndex((o) => o.path === override.path);
+      if (existingIndex >= 0) {
+        document.definition.fieldTypeOverrides[existingIndex] = override;
+      } else {
+        document.definition.fieldTypeOverrides.push(override);
+      }
+    }
+  }
+
+  /**
+   * Low level API to remove a field type override from a document.
+   * UI component should use {@link FieldTypeOverrideService.revertFieldTypeOverride()}.
+   *
+   * Removes the override for the specified field path and restores the field to its
+   * original type in the live document. Also updates the DocumentDefinition to keep
+   * the definition in sync with the live document.
+   *
+   * This method is symmetric with {@link processTypeOverride}: both update the field
+   * in the live document and keep the DocumentDefinition in sync.
+   *
+   * @param document - The document to remove the override from
+   * @param path - XPath string identifying the field (e.g., '/ns0:ShipOrder/ns0:OrderPerson')
+   * @param namespaceMap - Namespace prefix to URI mapping for XPath resolution
+   *
+   * @example
+   * ```typescript
+   * // Remove the override and restore field to original type
+   * DocumentUtilService.removeTypeOverride(
+   *   document,
+   *   '/ns0:ShipOrder/ns0:OrderPerson',
+   *   namespaceMap
+   * );
+   * // Field is now restored to its original type without recreating the document
+   * ```
+   *
+   * @remarks
+   * This method modifies both the runtime field structure and the DocumentDefinition:
+   * 1. Runtime: Restores field.type, field.typeQName, field.typeOverride, clears field.fields
+   * 2. Definition: Removes override from document.definition.fieldTypeOverrides
+   *
+   * @see processTypeOverride
+   * @see processTypeOverrides
+   */
+  static removeTypeOverride(document: IDocument, path: string, namespaceMap: Record<string, string>): void {
+    if (!document.definition.fieldTypeOverrides) {
+      return;
+    }
+
+    const override = document.definition.fieldTypeOverrides.find((o) => o.path === path);
+    if (!override) {
+      return;
+    }
+
+    const field = DocumentUtilService.navigateToFieldByPath(document, path, namespaceMap);
+    if (field) {
+      DocumentUtilService.restoreOriginalTypeToField(field);
+    }
+
+    document.definition.fieldTypeOverrides = document.definition.fieldTypeOverrides.filter((o) => o.path !== path);
+  }
+
+  /**
+   * Navigate to a field in the document tree using an XPath expression.
+   *
+   * Resolves type fragments as needed while navigating to ensure the field
+   * structure is fully expanded.
+   *
+   * @param document - The document to navigate in
+   * @param xpathString - XPath expression identifying the field
+   * @param namespaceMap - Namespace prefix to URI mapping
+   * @returns The field if found, undefined otherwise
+   */
   private static navigateToFieldByPath(
     document: IDocument,
     xpathString: string,
@@ -113,6 +270,17 @@ export class DocumentUtilService {
     return 'parent' in current ? current : undefined;
   }
 
+  /**
+   * Apply a type override to a specific field.
+   *
+   * Changes the field's type, typeQName, and typeOverride properties. Clears
+   * existing child fields and sets up namedTypeFragmentRefs for Container types.
+   *
+   * @param field - The field to apply the override to
+   * @param typeString - The type string to parse and apply
+   * @param namespaceMap - Namespace prefix to URI mapping
+   * @param parseTypeOverride - Function to parse type override strings
+   */
   private static applyTypeOverrideToField(
     field: IField,
     typeString: string,
@@ -130,6 +298,47 @@ export class DocumentUtilService {
       field.namedTypeFragmentRefs = [typeQName.toString()];
     } else {
       field.namedTypeFragmentRefs = [];
+    }
+  }
+
+  /**
+   * Restore a field to its original type.
+   *
+   * Reverses a type override by restoring the field's type, typeQName, and
+   * typeOverride properties to their original values. Clears existing child
+   * fields and sets up namedTypeFragmentRefs for Container types.
+   *
+   * @param field - The field to restore to its original type
+   */
+  private static restoreOriginalTypeToField(field: IField): void {
+    field.type = field.originalType;
+    field.typeQName = field.originalTypeQName;
+    field.typeOverride = TypeOverrideVariant.NONE;
+    field.fields = [];
+
+    if (field.originalType === Types.Container && field.originalTypeQName) {
+      field.namedTypeFragmentRefs = [field.originalTypeQName.toString()];
+    } else {
+      field.namedTypeFragmentRefs = [];
+    }
+  }
+
+  /**
+   * Generates a unique namespace prefix following sequential pattern (ns0, ns1, ns2, ...).
+   * Starts from 'ns0' and increments until an available prefix is found.
+   *
+   * This method is shared across document services and mapping service to ensure
+   * consistent namespace prefix generation throughout the application.
+   *
+   * @param namespaceMap - Map of existing prefix -> namespace URI mappings to avoid conflicts
+   * @returns Generated prefix string
+   */
+  static generateNamespacePrefix(namespaceMap: Record<string, string>): string {
+    for (let index = 0; ; index++) {
+      const prefix = `ns${index}`;
+      if (!namespaceMap[prefix]) {
+        return prefix;
+      }
     }
   }
 }

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -1,0 +1,427 @@
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+  IField,
+  PrimitiveDocument,
+  Types,
+} from '../models/datamapper';
+import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
+import { TypeOverrideVariant } from '../models/datamapper/types';
+import { importedTypesXsd, namedTypesXsd, shipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
+import { FieldTypeOverrideService } from './field-type-override.service';
+import { JsonSchemaDocument } from './json-schema-document.model';
+import { JsonSchemaDocumentService } from './json-schema-document.service';
+import { XmlSchemaDocument } from './xml-schema-document.model';
+import { XmlSchemaDocumentService } from './xml-schema-document.service';
+
+describe('FieldTypeOverrideService', () => {
+  describe('getSafeOverrideCandidates()', () => {
+    it('should return all types for xs:anyType fields', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const anyTypeField = doc.fields[0].fields[0];
+      anyTypeField.originalType = Types.AnyType;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(anyTypeField, namespaceMap);
+
+      expect(Object.keys(candidates).length).toBeGreaterThan(0);
+      expect(Object.values(candidates).some((c) => c.displayName === 'xs:string')).toBe(true);
+      expect(Object.values(candidates).some((c) => c.displayName === 'xs:int')).toBe(true);
+    });
+
+    it('should return extensions and restrictions for Container types', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const containerField = doc.fields[0];
+      containerField.originalType = Types.Container;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(containerField, namespaceMap);
+
+      expect(typeof candidates).toBe('object');
+    });
+
+    it('should return empty Record for primitive fields without inheritance', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      stringField.originalType = Types.String;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA };
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(stringField, namespaceMap);
+
+      expect(typeof candidates).toBe('object');
+    });
+  });
+
+  describe('getAllOverrideCandidates()', () => {
+    it('should return all built-in and user-defined types for XML Schema documents', async () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test-doc',
+        { 'NamedTypes.xsd': namedTypesXsd },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document as XmlSchemaDocument;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      const candidates = FieldTypeOverrideService.getAllOverrideCandidates(doc, namespaceMap);
+
+      expect(Object.keys(candidates).length).toBeGreaterThan(0);
+      const builtInTypes = Object.values(candidates).filter((c) => c.isBuiltIn);
+      const userDefinedTypes = Object.values(candidates).filter((c) => !c.isBuiltIn);
+
+      expect(builtInTypes.length).toBeGreaterThan(0);
+      expect(builtInTypes.some((c) => c.displayName === 'xs:string')).toBe(true);
+      expect(builtInTypes.some((c) => c.displayName === 'xs:int')).toBe(true);
+      expect(builtInTypes.some((c) => c.displayName === 'xs:boolean')).toBe(true);
+
+      expect(userDefinedTypes.length).toBeGreaterThan(0);
+      expect(userDefinedTypes.some((c) => c.displayName.includes('complexType1'))).toBe(true);
+      expect(userDefinedTypes.some((c) => c.displayName.includes('simpleType1'))).toBe(true);
+    });
+
+    it('should return JSON Schema types for JSON Schema documents', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        {
+          'test.json': JSON.stringify({
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          }),
+        },
+      );
+
+      const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document as JsonSchemaDocument;
+
+      const candidates = FieldTypeOverrideService.getAllOverrideCandidates(doc, {});
+
+      expect(Object.keys(candidates).length).toBeGreaterThan(0);
+      expect(Object.values(candidates).some((c) => c.displayName === 'string')).toBe(true);
+      expect(Object.values(candidates).some((c) => c.displayName === 'number')).toBe(true);
+      expect(Object.values(candidates).some((c) => c.displayName === 'boolean')).toBe(true);
+      expect(Object.values(candidates).some((c) => c.displayName === 'object')).toBe(true);
+      expect(Object.values(candidates).some((c) => c.displayName === 'array')).toBe(true);
+    });
+
+    it('should return empty array for XmlSchemaDocument with undefined collection', () => {
+      const malformedDoc = Object.create(XmlSchemaDocument.prototype);
+      malformedDoc.documentType = DocumentType.SOURCE_BODY;
+      malformedDoc.documentId = 'test';
+      malformedDoc.fields = [];
+      malformedDoc.xmlSchemaCollection = undefined;
+
+      const candidates = FieldTypeOverrideService.getAllOverrideCandidates(malformedDoc, {});
+
+      expect(typeof candidates).toBe('object');
+      expect(Object.keys(candidates).length).toBe(0);
+    });
+  });
+
+  describe('addSchemaFilesForTypeOverride', () => {
+    describe('XML Schema documents', () => {
+      it('should add schema files and return updated definition with namespace map', () => {
+        const definition = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          'test-doc',
+          { 'ShipOrder.xsd': shipOrderXsd },
+          undefined,
+          undefined,
+          { ns0: 'io.kaoto.datamapper.poc.test' },
+        );
+
+        const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+        const document = result.document as XmlSchemaDocument;
+
+        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+          'ImportedTypes.xsd': importedTypesXsd,
+        });
+
+        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('ShipOrder.xsd');
+        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('ImportedTypes.xsd');
+
+        const namespaceMap = updatedDef.namespaceMap || {};
+        expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
+        expect(namespaceMap['ns1']).toBe('http://example.com/types');
+      });
+
+      it('should preserve existing namespaces when adding new ones', () => {
+        const definition = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          'test-doc',
+          { 'ShipOrder.xsd': shipOrderXsd },
+          undefined,
+          undefined,
+          { ns0: 'io.kaoto.datamapper.poc.test', custom: 'http://example.com/custom' },
+        );
+
+        const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+        const document = result.document as XmlSchemaDocument;
+
+        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+          'ImportedTypes.xsd': importedTypesXsd,
+        });
+
+        const namespaceMap = updatedDef.namespaceMap || {};
+        expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
+        expect(namespaceMap['custom']).toBe('http://example.com/custom');
+        expect(namespaceMap['ns1']).toBe('http://example.com/types');
+      });
+    });
+
+    describe('JSON Schema documents', () => {
+      it('should add schema files and return updated definition', () => {
+        const mainSchema = { type: 'object', properties: { name: { type: 'string' } } };
+        const definition = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.JSON_SCHEMA,
+          'test-doc',
+          { 'main.json': JSON.stringify(mainSchema) },
+        );
+
+        const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+        const document = result.document as JsonSchemaDocument;
+
+        const additionalSchema = {
+          $defs: {
+            CustomType: { type: 'object', properties: { field: { type: 'string' } } },
+          },
+        };
+
+        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+          'types.json': JSON.stringify(additionalSchema),
+        });
+
+        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('main.json');
+        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('types.json');
+        expect(updatedDef.namespaceMap).toEqual({});
+      });
+    });
+
+    describe('Error handling', () => {
+      it('should throw TypeError for primitive documents', () => {
+        const definition = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.Primitive,
+          'test-doc',
+        );
+        const document = new PrimitiveDocument(definition);
+
+        expect(() => {
+          FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, { 'test.xsd': '<schema/>' });
+        }).toThrow('Cannot add schema files to primitive document');
+      });
+
+      it('should handle empty additionalFiles', () => {
+        const definition = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          'test-doc',
+          { 'ShipOrder.xsd': shipOrderXsd },
+          undefined,
+          undefined,
+          { ns0: 'io.kaoto.datamapper.poc.test' },
+        );
+
+        const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+        const document = result.document as XmlSchemaDocument;
+
+        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {});
+
+        expect(updatedDef.definitionFiles).toEqual(definition.definitionFiles);
+        expect(updatedDef.namespaceMap).toEqual(definition.namespaceMap);
+      });
+    });
+  });
+
+  describe('applyFieldTypeOverride()', () => {
+    it('should apply override to XML document field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      expect(stringField.type).toBe(Types.String);
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+
+      const candidate = {
+        displayName: 'xs:int',
+        typeString: 'xs:int',
+        type: Types.Integer,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.applyFieldTypeOverride(
+        doc,
+        stringField,
+        candidate,
+        namespaceMap,
+        TypeOverrideVariant.FORCE,
+      );
+
+      expect(stringField.type).toBe(Types.Integer);
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(doc.definition.fieldTypeOverrides).toBeDefined();
+      expect(doc.definition.fieldTypeOverrides?.length).toBeGreaterThan(0);
+    });
+
+    it('should apply override to JSON document field', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        {
+          'test.json': JSON.stringify({
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          }),
+        },
+      );
+
+      const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+      const doc = result.document as JsonSchemaDocument;
+      const root = doc.fields[0];
+      const nameField = root.fields.find((f) => f.key === 'name');
+      if (!nameField) throw new Error('Field not found');
+
+      expect(nameField.type).toBe(Types.String);
+
+      const candidate = {
+        displayName: 'number',
+        typeString: 'number',
+        type: Types.Numeric,
+        namespaceURI: '',
+        isBuiltIn: true,
+      };
+
+      FieldTypeOverrideService.applyFieldTypeOverride(doc, nameField, candidate, {}, TypeOverrideVariant.FORCE);
+
+      expect(nameField.type).toBe(Types.Numeric);
+      expect(nameField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+    });
+
+    it('should throw TypeError for PrimitiveDocument', () => {
+      const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test-doc');
+      const document = new PrimitiveDocument(definition);
+
+      const candidate = {
+        displayName: 'xs:int',
+        typeString: 'xs:int',
+        type: Types.Integer,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+
+      expect(() => {
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+      }).toThrow(TypeError);
+      expect(() => {
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+      }).toThrow('Field type override is not supported for primitive documents');
+    });
+
+    it('should throw TypeError for unsupported document type', () => {
+      const mockDoc = {
+        documentType: DocumentType.SOURCE_BODY,
+        documentId: 'test',
+        fields: [],
+        definition: new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test'),
+        constructor: { name: 'UnknownDocument' },
+      } as unknown as IDocument;
+
+      const candidate = {
+        displayName: 'xs:int',
+        typeString: 'xs:int',
+        type: Types.Integer,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+
+      expect(() => {
+        FieldTypeOverrideService.applyFieldTypeOverride(
+          mockDoc,
+          mockDoc as unknown as IField,
+          candidate,
+          {},
+          TypeOverrideVariant.FORCE,
+        );
+      }).toThrow(TypeError);
+      expect(() => {
+        FieldTypeOverrideService.applyFieldTypeOverride(
+          mockDoc,
+          mockDoc as unknown as IField,
+          candidate,
+          {},
+          TypeOverrideVariant.FORCE,
+        );
+      }).toThrow('Unsupported document type');
+    });
+  });
+
+  describe('revertFieldTypeOverride()', () => {
+    it('should remove override and restore original type', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      const originalType = stringField.type;
+
+      const candidate = {
+        displayName: 'xs:int',
+        typeString: 'xs:int',
+        type: Types.Integer,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.applyFieldTypeOverride(
+        doc,
+        stringField,
+        candidate,
+        namespaceMap,
+        TypeOverrideVariant.FORCE,
+      );
+
+      expect(stringField.type).toBe(Types.Integer);
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+
+      FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
+
+      expect(stringField.type).toBe(originalType);
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(doc.definition.fieldTypeOverrides?.length).toBe(0);
+    });
+
+    it('should be no-op if field has no override', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      const originalType = stringField.type;
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
+
+      expect(stringField.type).toBe(originalType);
+      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+    });
+  });
+});

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -1,0 +1,396 @@
+import { PathExpression, PathSegment } from '../models/datamapper';
+import { DocumentDefinition, IDocument, IField, PrimitiveDocument } from '../models/datamapper/document';
+import { IFieldTypeOverride } from '../models/datamapper/metadata';
+import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { DocumentUtilService, ParseTypeOverrideFn } from './document-util.service';
+import { JsonSchemaDocument } from './json-schema-document.model';
+import { JsonSchemaDocumentService } from './json-schema-document.service';
+import { JsonSchemaTypesService } from './json-schema-types.service';
+import { XmlSchemaDocument } from './xml-schema-document.model';
+import { XmlSchemaDocumentService } from './xml-schema-document.service';
+import { XmlSchemaTypesService } from './xml-schema-types.service';
+import { XPathService } from './xpath/xpath.service';
+
+/**
+ * Service for field type override operations.
+ * Provides high-level orchestration for applying, removing, and managing type overrides.
+ *
+ * This service consolidates all field type override functionality in one place, reducing
+ * code duplication and improving maintainability by eliminating if-XML/if-JSON patterns
+ * scattered across multiple services.
+ *
+ * @example
+ * ```typescript
+ * // Get safe type override candidates for a field
+ * const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+ *
+ * // Apply a type override
+ * FieldTypeOverrideService.applyFieldTypeOverride(
+ *   document,
+ *   field,
+ *   selectedCandidate,
+ *   namespaceMap,
+ *   TypeOverrideVariant.FORCE
+ * );
+ *
+ * // Remove a type override
+ * FieldTypeOverrideService.revertFieldTypeOverride(document, field, namespaceMap);
+ * ```
+ */
+export class FieldTypeOverrideService {
+  /**
+   * Get safe type override candidates for a field.
+   *
+   * Safe overrides are type changes that maintain schema compatibility:
+   * - For xs:anyType fields: Returns all available types (all are considered safe)
+   * - For typed XML fields: Returns extensions and restrictions of the original type
+   * - For JSON Schema fields: Returns empty Record (JSON Schema doesn't have type inheritance)
+   *
+   * This method delegates to the appropriate type service based on the document type.
+   *
+   * @param field - The field to get override candidates for
+   * @param namespaceMap - Namespace prefix to URI mapping for qualified name resolution
+   * @returns Record of type override candidates that can be safely applied to the field
+   *
+   * @example
+   * ```typescript
+   * const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+   * // For xs:anyType field, returns all built-in + user-defined types
+   * // For other XML types, returns extensions/restrictions of that type
+   * // For JSON Schema types, returns empty Record
+   * ```
+   *
+   * @see getAllOverrideCandidates
+   * @see XmlSchemaTypesService.getTypeOverrideCandidatesForField
+   * @see JsonSchemaTypesService.getTypeOverrideCandidatesForField
+   */
+  static getSafeOverrideCandidates(
+    field: IField,
+    namespaceMap: Record<string, string>,
+  ): Record<string, IFieldTypeInfo> {
+    if (field.originalType === Types.AnyType) {
+      return FieldTypeOverrideService.getAllOverrideCandidates(field.ownerDocument, namespaceMap);
+    }
+
+    if (field.ownerDocument instanceof XmlSchemaDocument) {
+      return XmlSchemaTypesService.getTypeOverrideCandidatesForField(
+        field,
+        field.ownerDocument.xmlSchemaCollection,
+        namespaceMap,
+      );
+    }
+
+    if (field.ownerDocument instanceof JsonSchemaDocument) {
+      return JsonSchemaTypesService.getTypeOverrideCandidatesForField(field);
+    }
+
+    return {};
+  }
+
+  /**
+   * Get all available type override candidates for a document.
+   *
+   * Returns all types that can be used for force overrides, including both
+   * built-in types (e.g., xs:string, xs:int for XML Schema; string, number for JSON Schema)
+   * and user-defined types from the schema. Use this when the user explicitly wants to
+   * change a field to an incompatible type that requires a force override.
+   *
+   * This method delegates to the appropriate type service based on the document type.
+   *
+   * @param document - The document to get type candidates for
+   * @param namespaceMap - Namespace prefix to URI mapping for qualified name resolution
+   * @returns Record of all available type override candidates
+   *
+   * @example
+   * ```typescript
+   * const allTypes = FieldTypeOverrideService.getAllOverrideCandidates(document, namespaceMap);
+   * // For XML Schema: Returns all xs:* types + all user-defined complexTypes and simpleTypes
+   * // For JSON Schema: Returns all built-in types (string, number, etc.) + all $defs types
+   * ```
+   *
+   * @see getSafeOverrideCandidates
+   * @see XmlSchemaTypesService.getAllXmlSchemaTypes
+   * @see JsonSchemaTypesService.getAllJsonSchemaTypes
+   */
+  static getAllOverrideCandidates(
+    document: IDocument,
+    namespaceMap: Record<string, string>,
+  ): Record<string, IFieldTypeInfo> {
+    if (document instanceof XmlSchemaDocument) {
+      return XmlSchemaTypesService.getAllXmlSchemaTypes(document, namespaceMap);
+    }
+
+    if (document instanceof JsonSchemaDocument) {
+      return JsonSchemaTypesService.getAllJsonSchemaTypes(document);
+    }
+
+    return {};
+  }
+
+  /**
+   * Create a field type override definition from field type info.
+   *
+   * Converts field type info (typically selected from the UI) into an
+   * IFieldTypeOverride object that can be applied to the document. This utility
+   * generates the XPath for the field and constructs the override definition with
+   * all required properties.
+   *
+   * @param field - The field to create the override for
+   * @param candidate - The field type info selected by the user
+   * @param namespaceMap - Namespace prefix to URI mapping for XPath generation
+   * @param variant - The override variant (SAFE or FORCE)
+   * @returns A complete IFieldTypeOverride definition ready to be applied
+   *
+   * @example
+   * ```typescript
+   * // User selects a type override from the UI
+   * const candidate: IFieldTypeInfo = {
+   *   displayName: 'xs:int',
+   *   typeString: 'xs:int',
+   *   type: Types.Integer,
+   *   namespaceURI: 'http://www.w3.org/2001/XMLSchema',
+   *   isBuiltIn: true
+   * };
+   *
+   * const override = FieldTypeOverrideService.createFieldTypeOverride(
+   *   orderPersonField,
+   *   candidate,
+   *   namespaceMap,
+   *   TypeOverrideVariant.FORCE
+   * );
+   * // Returns: {
+   * //   path: '/ns0:ShipOrder/ns0:OrderPerson',
+   * //   type: 'xs:int',
+   * //   originalType: 'xs:string',
+   * //   variant: TypeOverrideVariant.FORCE
+   * // }
+   *
+   * // Apply the override
+   * DocumentUtilService.processTypeOverride(document, override, namespaceMap, parseTypeOverrideFn);
+   * ```
+   *
+   * @see IFieldTypeInfo
+   * @see IFieldTypeOverride
+   * @see DocumentUtilService.processTypeOverride
+   * @see getSafeOverrideCandidates
+   * @see getAllOverrideCandidates
+   */
+  static createFieldTypeOverride(
+    field: IField,
+    candidate: IFieldTypeInfo,
+    namespaceMap: Record<string, string>,
+    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+  ): IFieldTypeOverride {
+    const fieldStack = DocumentUtilService.getFieldStack(field, true).reverse();
+    const pathSegments: PathSegment[] = [];
+
+    for (const f of fieldStack) {
+      const nsEntry = Object.entries(namespaceMap).find(([, uri]) => f.namespaceURI === uri);
+      const nsPrefix = nsEntry ? nsEntry[0] : '';
+      pathSegments.push(new PathSegment(f.name, f.isAttribute, nsPrefix, f.predicates));
+    }
+
+    const pathExpression = new PathExpression(undefined, false);
+    pathExpression.pathSegments = pathSegments;
+    const path = XPathService.toXPathString(pathExpression);
+
+    const originalTypeString = field.originalTypeQName?.toString() ?? field.originalType;
+
+    return {
+      path,
+      type: candidate.typeString,
+      originalType: originalTypeString,
+      variant,
+    };
+  }
+
+  /**
+   * Apply a field type override to a field in a document.
+   *
+   * This high-level orchestration method:
+   * 1. Determines the appropriate type parser based on document type
+   * 2. Creates the override definition
+   * 3. Applies the override to the document (modifies in place)
+   *
+   * The document is modified in place. After calling this method, use
+   * `dataMapperProvider.updateDocument()` to persist changes and trigger re-visualization.
+   *
+   * @param document - The document containing the field
+   * @param field - The field to override
+   * @param candidate - The type to override to
+   * @param namespaceMap - Namespace map for XPath generation
+   * @param variant - SAFE or FORCE override variant
+   * @throws Error if document type doesn't support type overrides
+   *
+   * @example
+   * ```typescript
+   * const candidate: IFieldTypeInfo = {
+   *   displayName: 'xs:int',
+   *   typeString: 'xs:int',
+   *   type: Types.Integer,
+   *   namespaceURI: NS_XML_SCHEMA,
+   *   isBuiltIn: true,
+   * };
+   *
+   * FieldTypeOverrideService.applyFieldTypeOverride(
+   *   document,
+   *   field,
+   *   candidate,
+   *   namespaceMap,
+   *   TypeOverrideVariant.FORCE
+   * );
+   *
+   * // Persist changes via provider
+   * const previousRefId = document.getReferenceId(namespaceMap);
+   * updateDocument(document, document.definition, previousRefId);
+   * ```
+   *
+   * @see revertFieldTypeOverride
+   * @see createFieldTypeOverride
+   */
+  static applyFieldTypeOverride(
+    document: IDocument,
+    field: IField,
+    candidate: IFieldTypeInfo,
+    namespaceMap: Record<string, string>,
+    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+  ): void {
+    if (document instanceof PrimitiveDocument) {
+      throw new TypeError('Field type override is not supported for primitive documents');
+    }
+
+    let parseTypeOverrideFn: ParseTypeOverrideFn;
+    if (document instanceof XmlSchemaDocument) {
+      parseTypeOverrideFn = XmlSchemaTypesService.parseTypeOverride;
+    } else if (document instanceof JsonSchemaDocument) {
+      parseTypeOverrideFn = JsonSchemaTypesService.parseTypeOverride;
+    } else {
+      throw new TypeError(`Unsupported document type: ${document.constructor.name}`);
+    }
+
+    const override = FieldTypeOverrideService.createFieldTypeOverride(field, candidate, namespaceMap, variant);
+    DocumentUtilService.processTypeOverride(document, override, namespaceMap, parseTypeOverrideFn);
+  }
+
+  /**
+   * Revert the field type override from a field in a document.
+   * Restores the field to its original type.
+   * Modifies the document in place.
+   *
+   * The document is modified in place. After calling this method, use
+   * `dataMapperProvider.updateDocument()` to persist changes and trigger re-visualization.
+   *
+   * @param document - The document containing the field
+   * @param field - The field to restore
+   * @param namespaceMap - Namespace map for XPath generation
+   *
+   * @example
+   * ```typescript
+   * FieldTypeOverrideService.revertFieldTypeOverride(document, field, namespaceMap);
+   *
+   * // Persist changes via provider
+   * const previousRefId = document.getReferenceId(namespaceMap);
+   * updateDocument(document, document.definition, previousRefId);
+   * ```
+   *
+   * @see applyFieldTypeOverride
+   */
+  static revertFieldTypeOverride(document: IDocument, field: IField, namespaceMap: Record<string, string>): void {
+    if (field.typeOverride === TypeOverrideVariant.NONE) return;
+
+    const fieldStack = DocumentUtilService.getFieldStack(field, true).reverse();
+    const pathSegments: PathSegment[] = [];
+
+    for (const f of fieldStack) {
+      const nsEntry = Object.entries(namespaceMap).find(([, uri]) => f.namespaceURI === uri);
+      const nsPrefix = nsEntry ? nsEntry[0] : '';
+      pathSegments.push(new PathSegment(f.name, f.isAttribute, nsPrefix, f.predicates));
+    }
+
+    const pathExpression = new PathExpression(undefined, false);
+    pathExpression.pathSegments = pathSegments;
+    const path = XPathService.toXPathString(pathExpression);
+
+    DocumentUtilService.removeTypeOverride(document, path, namespaceMap);
+  }
+
+  /**
+   * Adds additional schema files to a document to support field type overrides.
+   *
+   * This high-level orchestration method coordinates:
+   * 1. Adding files to the document's schema collection (via format-specific service)
+   * 2. Updating DocumentDefinition.definitionFiles with new files
+   * 3. Synchronizing namespace maps (for XML Schema documents)
+   * 4. Returning updated definition for re-visualization via provider
+   *
+   * The returned DocumentDefinition should be passed to `dataMapperProvider.updateDocument()`
+   * to trigger full synchronization across all three namespace map levels and persist changes.
+   *
+   * @param document - The document to enhance with additional schemas
+   * @param additionalFiles - Map of file paths to file contents
+   * @returns Updated DocumentDefinition with merged files and synchronized namespace map
+   * @throws Error if document is PrimitiveDocument or unsupported type
+   * @throws Error if schema parsing fails (propagated from format-specific service)
+   *
+   * @example
+   * ```typescript
+   * // User uploads additional schema file
+   * const additionalFiles = {
+   *   'CustomTypes.xsd': schemaContent,
+   * };
+   *
+   * // Create updated definition
+   * const updatedDefinition = FieldTypeOverrideService.addSchemaFilesForTypeOverride(
+   *   targetDocument,
+   *   additionalFiles
+   * );
+   *
+   * // Apply via provider - triggers full namespace synchronization
+   * dataMapperProvider.updateDocument(
+   *   targetDocument,
+   *   updatedDefinition,
+   *   previousReferenceId
+   * );
+   *
+   * // Now custom types are available for field type overrides
+   * const candidates = FieldTypeOverrideService.getAllOverrideCandidates(
+   *   targetDocument,
+   *   updatedDefinition.namespaceMap || {}
+   * );
+   * // candidates now includes types from CustomTypes.xsd
+   * ```
+   */
+  static addSchemaFilesForTypeOverride(
+    document: IDocument,
+    additionalFiles: Record<string, string>,
+  ): DocumentDefinition {
+    if (document instanceof PrimitiveDocument) {
+      throw new TypeError('Cannot add schema files to primitive document');
+    }
+
+    let updatedNamespaceMap: Record<string, string>;
+
+    if (document instanceof XmlSchemaDocument) {
+      updatedNamespaceMap = XmlSchemaDocumentService.addSchemaFiles(document, additionalFiles);
+    } else if (document instanceof JsonSchemaDocument) {
+      updatedNamespaceMap = JsonSchemaDocumentService.addSchemaFiles(document, additionalFiles);
+    } else {
+      throw new TypeError(`Unsupported document type: ${document.constructor.name}`);
+    }
+
+    const mergedDefinitionFiles = {
+      ...document.definition.definitionFiles,
+      ...additionalFiles,
+    };
+
+    return new DocumentDefinition(
+      document.definition.documentType,
+      document.definition.definitionType,
+      document.definition.name,
+      mergedDefinitionFiles,
+      document.definition.rootElementChoice,
+      document.definition.fieldTypeOverrides,
+      updatedNamespaceMap,
+    );
+  }
+}

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -812,5 +812,23 @@ describe('JsonSchemaDocumentService', () => {
       expect(collection.getJsonSchema('http://example.com/schemas/common-types.json')).toBeDefined();
       expect(collection.getJsonSchema('http://example.com/schemas/customer.json')).toBeDefined();
     });
+
+    it('should return empty namespace map when adding JSON schemas', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        { 'test.json': '{"type": "object"}' },
+      );
+
+      const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+      const document = result.document as JsonSchemaDocument;
+
+      const updatedNamespaceMap = JsonSchemaDocumentService.addSchemaFiles(document, {
+        'additional.json': '{"type": "object", "properties": {"field": {"type": "string"}}}',
+      });
+
+      expect(updatedNamespaceMap).toEqual({});
+    });
   });
 });

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -97,7 +97,7 @@ export class JsonSchemaDocumentService {
     const document = jsonDocument;
 
     if (definition.fieldTypeOverrides?.length) {
-      DocumentUtilService.applyFieldTypeOverrides(
+      DocumentUtilService.processTypeOverrides(
         document,
         definition.fieldTypeOverrides,
         definition.namespaceMap || {},
@@ -124,8 +124,9 @@ export class JsonSchemaDocumentService {
    * This is useful when field type overrides reference types defined in additional schema files.
    * @param document - The document whose schema collection will be updated
    * @param additionalFiles - Map of file paths to file contents to add
+   * @returns Empty namespace map (JSON Schema doesn't use namespaces, but this maintains API consistency)
    */
-  static addSchemaFiles(document: JsonSchemaDocument, additionalFiles: Record<string, string>): void {
+  static addSchemaFiles(document: JsonSchemaDocument, additionalFiles: Record<string, string>): Record<string, string> {
     const collection = document.schemaCollection;
 
     collection.addDefinitionFiles(additionalFiles);
@@ -139,6 +140,8 @@ export class JsonSchemaDocumentService {
         throw new Error(`Failed to add schema file "${filePath}": ${errorMessage}`);
       }
     }
+
+    return {};
   }
 
   private static populateDependencyMetadata(

--- a/packages/ui/src/services/mapping.service.ts
+++ b/packages/ui/src/services/mapping.service.ts
@@ -16,6 +16,7 @@ import {
   WhenItem,
 } from '../models/datamapper/mapping';
 import { DocumentService } from './document.service';
+import { DocumentUtilService } from './document-util.service';
 import { XPathService } from './xpath/xpath.service';
 
 export class MappingService {
@@ -369,15 +370,8 @@ export class MappingService {
       ([_prefix, uri]) => field.namespaceURI && uri === field.namespaceURI,
     );
     if (!existingns && field.namespaceURI) {
-      const prefix = field.namespacePrefix ?? MappingService.createNSPrefix(mappingTree);
+      const prefix = field.namespacePrefix ?? DocumentUtilService.generateNamespacePrefix(mappingTree.namespaceMap);
       mappingTree.namespaceMap[prefix] = field.namespaceURI;
-    }
-  }
-
-  private static createNSPrefix(mappingTree: MappingTree) {
-    for (let index = 0; ; index++) {
-      const prefix = `ns${index}`;
-      if (!mappingTree.namespaceMap[prefix]) return prefix;
     }
   }
 


### PR DESCRIPTION
#### https://github.com/KaotoIO/kaoto/pull/2931 has to be merged before this

Fixes: https://github.com/KaotoIO/kaoto/issues/2724

Step 3/3: Field type override API and namespace synchronization
Add FieldTypeOverrideService for managing field type overrides and introduce namespace map synchronization between documents and the mapping tree, enabling type overrides that reference types from additional schema files.

 - Create high level API, `FieldTypeOverrideService` with getSafeOverrideCandidates, getAllOverrideCandidates, createFieldTypeOverride, applyFieldTypeOverride, revertFieldTypeOverride, and addSchemaFilesForTypeOverride
 - Add processFieldTypeOverride and removeTypeOverride to `DocumentUtilService`, along with restoreOriginalTypeToField helper
 - Extract generateNamespacePrefix from MappingService into DocumentUtilService for reuse across services
 - Add onUpdateNamespaceMap callback to DataMapperProvider to persist namespace changes when mappings are updated or reset
 - Initialize mappingTree.namespaceMap from document definition metadata namespaces during provider setup
 - Change XmlSchemaDocumentService.addSchemaFiles to return an updated namespace map with namespaces extracted from added schemas
 - Change JsonSchemaDocumentService.addSchemaFiles to return an empty namespace map for API consistency
 - Add datamapper.provider and field-type-override.service tests