### PR TITLE
fix(canvas): re-render nodes on undo and redo

### DIFF
--- a/packages/ui/src/hooks/undo-redo.hook.test.ts
+++ b/packages/ui/src/hooks/undo-redo.hook.test.ts
@@ -4,6 +4,14 @@ import { useSourceCodeStore } from '../store';
 import { EventNotifier } from '../utils';
 import { useUndoRedo } from './undo-redo.hook';
 
+const mockController = {
+  fromModel: jest.fn(),
+};
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: () => mockController,
+}));
+
 describe('useUndoRedo', () => {
   it('should return initial state', () => {
     const { result } = renderHook(() => useUndoRedo());
@@ -50,6 +58,11 @@ describe('useUndoRedo', () => {
       result.current.undo();
     });
 
+    expect(mockController.fromModel).toHaveBeenCalledTimes(1);
+    expect(mockController.fromModel).toHaveBeenCalledWith({
+      nodes: [],
+      edges: [],
+    });
     expect(eventNotifierSpy).toHaveBeenCalledWith('code:updated', { code: '', path: '' });
   });
 
@@ -70,6 +83,11 @@ describe('useUndoRedo', () => {
       result.current.redo();
     });
 
+    expect(mockController.fromModel).toHaveBeenCalledTimes(2);
+    expect(mockController.fromModel).toHaveBeenLastCalledWith({
+      nodes: [],
+      edges: [],
+    });
     expect(eventNotifierSpy).toHaveBeenCalledWith('code:updated', { code: 'new code', path: '' });
   });
 });

--- a/packages/ui/src/hooks/undo-redo.hook.ts
+++ b/packages/ui/src/hooks/undo-redo.hook.ts
@@ -1,3 +1,4 @@
+import { useVisualizationController } from '@patternfly/react-topology';
 import { useCallback } from 'react';
 import { useStore } from 'zustand';
 
@@ -6,6 +7,7 @@ import { EventNotifier } from '../utils';
 
 export const useUndoRedo = () => {
   const eventNotifier = EventNotifier.getInstance();
+  const controller = useVisualizationController();
   const {
     undo: storeUndo,
     redo: storeRedo,
@@ -24,19 +26,33 @@ export const useUndoRedo = () => {
 
   const undo = useCallback(() => {
     storeUndo();
+
+    // Set an empty model to clear the graph, Fixes an issue rendering special child nodes incorrectly
+    controller.fromModel({
+      nodes: [],
+      edges: [],
+    });
+
     eventNotifier.next('code:updated', {
       code: useSourceCodeStore.getState().sourceCode,
       path: useSourceCodeStore.getState().path,
     });
-  }, [storeUndo, eventNotifier]);
+  }, [storeUndo, controller, eventNotifier]);
 
   const redo = useCallback(() => {
     storeRedo();
+
+    // Set an empty model to clear the graph, Fixes an issue rendering special child nodes incorrectly
+    controller.fromModel({
+      nodes: [],
+      edges: [],
+    });
+
     eventNotifier.next('code:updated', {
       code: useSourceCodeStore.getState().sourceCode,
       path: useSourceCodeStore.getState().path,
     });
-  }, [storeRedo, eventNotifier]);
+  }, [storeRedo, controller, eventNotifier]);
 
   return { undo, redo, clear, canUndo, canRedo };
 };

--- a/packages/ui/src/multiplying-architecture/Bridge/editor-api.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/editor-api.test.tsx
@@ -7,6 +7,14 @@ import { useSourceCodeStore } from '../../store';
 import { EventNotifier } from '../../utils';
 import { useEditorApi } from './editor-api';
 
+const mockController = {
+  fromModel: jest.fn(),
+};
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: () => mockController,
+}));
+
 describe('useEditorApi', () => {
   const mockSetCodeAndNotify = jest.fn();
 
@@ -103,6 +111,10 @@ describe('useEditorApi', () => {
       await result.current.editorApi.undo();
     });
 
+    expect(mockController.fromModel).toHaveBeenCalledWith({
+      nodes: [],
+      edges: [],
+    });
     expect(eventNotifierSpy).toHaveBeenCalledWith('code:updated', { code: '', path: '' });
     expect(storeUndoSpy).toHaveBeenCalled();
   });
@@ -117,6 +129,10 @@ describe('useEditorApi', () => {
       await result.current.editorApi.redo();
     });
 
+    expect(mockController.fromModel).toHaveBeenCalledWith({
+      nodes: [],
+      edges: [],
+    });
     expect(eventNotifierSpy).toHaveBeenCalledWith('code:updated', { code: '', path: '' });
     expect(storeRedoSpy).toHaveBeenCalled();
   });


### PR DESCRIPTION
Fixes #2492, specially when undo or redo operation is performed.

https://github.com/user-attachments/assets/ed0d1c9f-f17f-4380-9e1b-5d54ad06027d

