### PR TITLE
feat(DataMapper): Implement XML/JSON schema file dependency analysis

### DIFF
--- a/packages/ui/src/models/datamapper/index.ts
+++ b/packages/ui/src/models/datamapper/index.ts
@@ -1,6 +1,7 @@
 export * from './document';
 export * from './mapping';
 export * from './nodepath';
+export * from './schema';
 export { NS_XSL } from './standard-namespaces';
 export * from './types';
 export * from './view';

--- a/packages/ui/src/models/datamapper/schema.ts
+++ b/packages/ui/src/models/datamapper/schema.ts
@@ -1,0 +1,13 @@
+/**
+ * Common report produced by schema analysis services, consumed by UI components
+ * in a format-agnostic way. Extended by {@link XmlSchemaAnalysisReport} and
+ * {@link JsonSchemaAnalysisReport} with format-specific details.
+ */
+export interface SchemaAnalysisReport {
+  /** Topologically sorted file identifiers — dependencies come before dependents. */
+  loadOrder: string[];
+  /** Errors that prevent schema loading (missing dependencies, circular includes). */
+  errors: string[];
+  /** Non-fatal issues such as circular imports that are allowed but noteworthy. */
+  warnings: string[];
+}

--- a/packages/ui/src/services/json-schema-analysis.service.test.ts
+++ b/packages/ui/src/services/json-schema-analysis.service.test.ts
@@ -1,0 +1,604 @@
+import { JSONSchema7 } from 'json-schema';
+
+import {
+  commonTypesJsonSchema,
+  customerJsonSchema,
+  mainWithRefJsonSchema,
+  orderJsonSchema,
+  productJsonSchema,
+} from '../stubs/datamapper/data-mapper';
+import { JsonSchemaAnalysisService } from './json-schema-analysis.service';
+import { JsonSchemaMetadata } from './json-schema-document.model';
+import { JsonSchemaDocumentUtilService } from './json-schema-document-util.service';
+
+function createMetadata(identifier: string, filePath: string, schema: JSONSchema7): JsonSchemaMetadata {
+  return { ...schema, identifier, filePath, path: '#' };
+}
+
+function parseMetadata(filePath: string, content: string): JsonSchemaMetadata {
+  return JsonSchemaDocumentUtilService.parseJsonSchema(content, filePath);
+}
+
+describe('JsonSchemaAnalysisService', () => {
+  describe('extractRefs', () => {
+    it('should return empty array for schema with no $ref', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual([]);
+    });
+
+    it('should extract top-level $ref', () => {
+      const schema: JSONSchema7 = {
+        $ref: '#/definitions/MyType',
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/MyType']);
+    });
+
+    it('should extract $ref from properties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          address: { $ref: './CommonTypes.json#/definitions/Address' },
+          name: { type: 'string' },
+        },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['./CommonTypes.json#/definitions/Address']);
+    });
+
+    it('should extract $ref from items', () => {
+      const schema: JSONSchema7 = {
+        type: 'array',
+        items: { $ref: '#/definitions/Item' },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Item']);
+    });
+
+    it('should extract $ref from items array', () => {
+      const schema: JSONSchema7 = {
+        type: 'array',
+        items: [{ $ref: '#/definitions/First' }, { $ref: '#/definitions/Second' }],
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/First', '#/definitions/Second']);
+    });
+
+    it('should extract $ref from definitions', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        definitions: {
+          SubType: { $ref: './Other.json#/definitions/Base' },
+        },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['./Other.json#/definitions/Base']);
+    });
+
+    it('should extract $ref from allOf', () => {
+      const schema: JSONSchema7 = {
+        allOf: [{ $ref: '#/definitions/Base' }, { type: 'object', properties: { extra: { type: 'string' } } }],
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Base']);
+    });
+
+    it('should extract $ref from anyOf', () => {
+      const schema: JSONSchema7 = {
+        anyOf: [{ $ref: '#/definitions/TypeA' }, { $ref: '#/definitions/TypeB' }],
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/TypeA', '#/definitions/TypeB']);
+    });
+
+    it('should extract $ref from oneOf', () => {
+      const schema: JSONSchema7 = {
+        oneOf: [{ $ref: '#/definitions/Option1' }, { $ref: '#/definitions/Option2' }],
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Option1', '#/definitions/Option2']);
+    });
+
+    it('should extract $ref from not', () => {
+      const schema: JSONSchema7 = {
+        not: { $ref: '#/definitions/Excluded' },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Excluded']);
+    });
+
+    it('should extract $ref from additionalProperties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        additionalProperties: { $ref: '#/definitions/Extra' },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Extra']);
+    });
+
+    it('should not extract from boolean additionalProperties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        additionalProperties: true,
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual([]);
+    });
+
+    it('should extract $ref from patternProperties', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        patternProperties: {
+          '^S_': { $ref: '#/definitions/StringProp' },
+        },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/StringProp']);
+    });
+
+    it('should extract $ref from if/then/else', () => {
+      const schema: JSONSchema7 = {
+        if: { $ref: '#/definitions/Condition' },
+        then: { $ref: '#/definitions/ThenResult' },
+        else: { $ref: '#/definitions/ElseResult' },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Condition', '#/definitions/ThenResult', '#/definitions/ElseResult']);
+    });
+
+    it('should extract $ref from contains', () => {
+      const schema: JSONSchema7 = {
+        type: 'array',
+        contains: { $ref: '#/definitions/Required' },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toEqual(['#/definitions/Required']);
+    });
+
+    it('should extract multiple nested $ref', () => {
+      const schema: JSONSchema7 = {
+        type: 'object',
+        properties: {
+          address: { $ref: './CommonTypes.json#/definitions/Address' },
+          contact: { $ref: './CommonTypes.json#/definitions/ContactInfo' },
+        },
+        definitions: {
+          LocalType: {
+            type: 'object',
+            properties: {
+              nested: { $ref: '#/definitions/OtherLocal' },
+            },
+          },
+          OtherLocal: { type: 'string' },
+        },
+      };
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toHaveLength(3);
+      expect(refs).toContain('./CommonTypes.json#/definitions/Address');
+      expect(refs).toContain('./CommonTypes.json#/definitions/ContactInfo');
+      expect(refs).toContain('#/definitions/OtherLocal');
+    });
+
+    it('should extract refs from real Order schema', () => {
+      const schema = JSON.parse(orderJsonSchema) as JSONSchema7;
+
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      expect(refs).toContain('./Customer.schema.json');
+      expect(refs).toContain('./CommonTypes.schema.json#/definitions/Money');
+      expect(refs).toContain('http://example.com/schemas/common-types.json#/definitions/Money');
+    });
+  });
+
+  describe('analyze', () => {
+    describe('single schema', () => {
+      it('should handle single schema with no refs', () => {
+        const schema = createMetadata('simple', 'simple.json', {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schema]);
+
+        expect(result.nodes.size).toBe(1);
+        expect(result.edges).toHaveLength(0);
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.missingReferences).toHaveLength(0);
+        expect(result.loadOrder).toEqual(['simple']);
+        expect(result.warnings).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+      });
+
+      it('should skip internal self-references', () => {
+        const schema = createMetadata('self', 'self.json', {
+          type: 'object',
+          definitions: {
+            Node: {
+              type: 'object',
+              properties: {
+                child: { $ref: '#/definitions/Node' },
+              },
+            },
+          },
+          properties: {
+            root: { $ref: '#/definitions/Node' },
+          },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schema]);
+
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.edges).toHaveLength(0);
+        expect(result.missingReferences).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+      });
+    });
+
+    describe('two schemas', () => {
+      it('should detect A depends on B', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: {
+            b: { $ref: './B.json#/definitions/TypeB' },
+          },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          definitions: {
+            TypeB: { type: 'string' },
+          },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB]);
+
+        expect(result.edges).toHaveLength(1);
+        expect(result.edges[0].from).toBe('A');
+        expect(result.edges[0].to).toBe('B');
+
+        const nodeA = result.nodes.get('A')!;
+        expect(nodeA.outbound).toHaveLength(1);
+        expect(nodeA.inbound).toHaveLength(0);
+
+        const nodeB = result.nodes.get('B')!;
+        expect(nodeB.outbound).toHaveLength(0);
+        expect(nodeB.inbound).toHaveLength(1);
+      });
+
+      it('should produce loading order with dependency first', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: {
+            b: { $ref: './B.json' },
+          },
+        });
+        const schemaB = createMetadata('B', 'B.json', { type: 'object' });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB]);
+
+        expect(result.loadOrder).toEqual(['B', 'A']);
+      });
+    });
+
+    describe('chain A -> B -> C', () => {
+      it('should produce correct loading order', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: { b: { $ref: './B.json' } },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          properties: { c: { $ref: './C.json' } },
+        });
+        const schemaC = createMetadata('C', 'C.json', { type: 'object' });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB, schemaC]);
+
+        expect(result.loadOrder).toEqual(['C', 'B', 'A']);
+        expect(result.circularDependencies).toHaveLength(0);
+      });
+    });
+
+    describe('diamond dependency', () => {
+      it('should handle diamond A->B, A->C, B->D, C->D', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: {
+            b: { $ref: './B.json' },
+            c: { $ref: './C.json' },
+          },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          properties: { d: { $ref: './D.json' } },
+        });
+        const schemaC = createMetadata('C', 'C.json', {
+          type: 'object',
+          properties: { d: { $ref: './D.json' } },
+        });
+        const schemaD = createMetadata('D', 'D.json', { type: 'object' });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB, schemaC, schemaD]);
+
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.loadOrder[0]).toBe('D');
+        expect(result.loadOrder[result.loadOrder.length - 1]).toBe('A');
+        expect(result.loadOrder).toHaveLength(4);
+      });
+    });
+
+    describe('circular dependencies', () => {
+      it('should detect simple A -> B -> A cycle', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: { b: { $ref: './B.json' } },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          properties: { a: { $ref: './A.json' } },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB]);
+
+        expect(result.circularDependencies).toHaveLength(1);
+        expect(result.circularDependencies[0].chain).toContain('A');
+        expect(result.circularDependencies[0].chain).toContain('B');
+        expect(result.warnings.length).toBeGreaterThan(0);
+        expect(result.warnings[0]).toContain('Circular dependency');
+        expect(result.loadOrder).toHaveLength(2);
+      });
+
+      it('should detect three-node cycle A -> B -> C -> A', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: { b: { $ref: './B.json' } },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          properties: { c: { $ref: './C.json' } },
+        });
+        const schemaC = createMetadata('C', 'C.json', {
+          type: 'object',
+          properties: { a: { $ref: './A.json' } },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB, schemaC]);
+
+        expect(result.circularDependencies).toHaveLength(1);
+        expect(result.circularDependencies[0].chain).toHaveLength(4);
+        expect(result.loadOrder).toHaveLength(3);
+      });
+
+      it('should still produce complete loading order with circular dependencies', () => {
+        const schemaA = createMetadata('A', 'A.json', {
+          type: 'object',
+          properties: { b: { $ref: './B.json' } },
+        });
+        const schemaB = createMetadata('B', 'B.json', {
+          type: 'object',
+          properties: { a: { $ref: './A.json' } },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB]);
+
+        expect(result.loadOrder).toHaveLength(2);
+        expect(result.loadOrder).toContain('A');
+        expect(result.loadOrder).toContain('B');
+      });
+    });
+
+    describe('missing references', () => {
+      it('should detect missing schema reference', () => {
+        const schema = createMetadata('main', 'main.json', {
+          type: 'object',
+          properties: {
+            ext: { $ref: './Missing.json#/definitions/Type' },
+          },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schema]);
+
+        expect(result.missingReferences).toHaveLength(1);
+        expect(result.missingReferences[0].from).toBe('main');
+        expect(result.missingReferences[0].ref).toBe('./Missing.json#/definitions/Type');
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0]).toContain('Missing schema reference');
+      });
+
+      it('should not report missing when ref exists in definitionFiles', () => {
+        const schema = createMetadata('main', 'main.json', {
+          type: 'object',
+          properties: {
+            ext: { $ref: './Extra.json#/definitions/Type' },
+          },
+        });
+        const definitionFiles = {
+          'Extra.json': '{"type": "object", "definitions": {"Type": {"type": "string"}}}',
+        };
+
+        const result = JsonSchemaAnalysisService.analyze([schema], definitionFiles);
+
+        expect(result.missingReferences).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+      });
+    });
+
+    describe('real schemas', () => {
+      it('should analyze Order -> Customer -> CommonTypes correctly', () => {
+        const order = parseMetadata('Order.schema.json', orderJsonSchema);
+        const customer = parseMetadata('Customer.schema.json', customerJsonSchema);
+        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+
+        const result = JsonSchemaAnalysisService.analyze([order, customer, common]);
+
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.missingReferences).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+
+        const orderNode = result.nodes.get(order.identifier)!;
+        expect(orderNode.outbound.length).toBeGreaterThan(0);
+
+        const commonNode = result.nodes.get(common.identifier)!;
+        expect(commonNode.outbound).toHaveLength(0);
+        expect(commonNode.inbound.length).toBeGreaterThan(0);
+
+        const commonIdx = result.loadOrder.indexOf(common.identifier);
+        const orderIdx = result.loadOrder.indexOf(order.identifier);
+        expect(commonIdx).toBeLessThan(orderIdx);
+      });
+
+      it('should analyze MainWithRef -> CommonTypes correctly', () => {
+        const main = parseMetadata('MainWithRef.schema.json', mainWithRefJsonSchema);
+        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+
+        const result = JsonSchemaAnalysisService.analyze([main, common]);
+
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.missingReferences).toHaveLength(0);
+
+        const mainNode = result.nodes.get(main.identifier)!;
+        expect(mainNode.outbound.length).toBeGreaterThan(0);
+
+        const commonIdx = result.loadOrder.indexOf(common.identifier);
+        const mainIdx = result.loadOrder.indexOf(main.identifier);
+        expect(commonIdx).toBeLessThan(mainIdx);
+      });
+
+      it('should analyze nested/Product -> CommonTypes with ../ path', () => {
+        const product = parseMetadata('nested/Product.schema.json', productJsonSchema);
+        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+
+        const result = JsonSchemaAnalysisService.analyze([product, common]);
+
+        expect(result.circularDependencies).toHaveLength(0);
+        expect(result.missingReferences).toHaveLength(0);
+
+        const productNode = result.nodes.get(product.identifier)!;
+        expect(productNode.outbound.length).toBeGreaterThan(0);
+
+        const commonIdx = result.loadOrder.indexOf(common.identifier);
+        const productIdx = result.loadOrder.indexOf(product.identifier);
+        expect(commonIdx).toBeLessThan(productIdx);
+      });
+
+      it('should detect missing schema when CommonTypes is not provided', () => {
+        const main = parseMetadata('MainWithRef.schema.json', mainWithRefJsonSchema);
+
+        const result = JsonSchemaAnalysisService.analyze([main]);
+
+        expect(result.missingReferences.length).toBeGreaterThan(0);
+        expect(result.errors.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('$id-based resolution', () => {
+      it('should resolve ref by $id identifier', () => {
+        const schemaA = createMetadata('http://example.com/a.json', 'a.json', {
+          type: 'object',
+          properties: {
+            b: { $ref: 'http://example.com/b.json#/definitions/Type' },
+          },
+        });
+        const schemaB = createMetadata('http://example.com/b.json', 'b.json', {
+          type: 'object',
+          definitions: { Type: { type: 'string' } },
+        });
+
+        const result = JsonSchemaAnalysisService.analyze([schemaA, schemaB]);
+
+        expect(result.edges).toHaveLength(1);
+        expect(result.edges[0].from).toBe('http://example.com/a.json');
+        expect(result.edges[0].to).toBe('http://example.com/b.json');
+        expect(result.missingReferences).toHaveLength(0);
+      });
+    });
+
+    describe('empty schemas', () => {
+      it('should handle empty schema list', () => {
+        const result = JsonSchemaAnalysisService.analyze([]);
+
+        expect(result.nodes.size).toBe(0);
+        expect(result.edges).toHaveLength(0);
+        expect(result.loadOrder).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('analyzeFromDefinitionFiles', () => {
+    it('should parse and analyze definition files', () => {
+      const definitionFiles = {
+        'MainWithRef.schema.json': mainWithRefJsonSchema,
+        'CommonTypes.schema.json': commonTypesJsonSchema,
+      };
+
+      const result = JsonSchemaAnalysisService.analyzeFromDefinitionFiles(definitionFiles);
+
+      expect(result.missingReferences).toHaveLength(0);
+      expect(result.circularDependencies).toHaveLength(0);
+      expect(result.nodes.size).toBe(2);
+    });
+
+    it('should throw error for invalid JSON', () => {
+      const definitionFiles = {
+        'invalid.json': 'not valid json',
+      };
+
+      expect(() => {
+        JsonSchemaAnalysisService.analyzeFromDefinitionFiles(definitionFiles);
+      }).toThrow('Failed to parse JSON schema');
+    });
+
+    it('should analyze multi-file scenario', () => {
+      const definitionFiles = {
+        'Order.schema.json': orderJsonSchema,
+        'Customer.schema.json': customerJsonSchema,
+        'CommonTypes.schema.json': commonTypesJsonSchema,
+      };
+
+      const result = JsonSchemaAnalysisService.analyzeFromDefinitionFiles(definitionFiles);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.circularDependencies).toHaveLength(0);
+      expect(result.nodes.size).toBe(3);
+      expect(result.loadOrder).toHaveLength(3);
+    });
+  });
+});

--- a/packages/ui/src/services/json-schema-analysis.service.ts
+++ b/packages/ui/src/services/json-schema-analysis.service.ts
@@ -1,0 +1,560 @@
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+
+import { SchemaAnalysisReport } from '../models/datamapper/schema';
+import { JsonSchemaMetadata } from './json-schema-document.model';
+import { JsonSchemaDocumentUtilService } from './json-schema-document-util.service';
+import { PathUtil } from './path-util';
+
+/**
+ * Represents a directed edge in the JSON Schema dependency graph.
+ * Captures a `$ref` relationship from one schema to another.
+ */
+interface JsonSchemaDependencyEdge {
+  /** Identifier of the schema containing the `$ref` */
+  from: string;
+  /** Identifier of the schema being referenced */
+  to: string;
+  /** The raw `$ref` string as it appears in the schema */
+  ref: string;
+  /** The JSON Pointer fragment after `#` (empty string if none) */
+  localPart: string;
+}
+
+/**
+ * A node in the JSON Schema dependency graph, representing a single schema file.
+ * Tracks both outgoing (`$ref` this schema makes) and incoming (other schemas referencing this one) edges.
+ */
+interface JsonSchemaDependencyNode {
+  /** Schema identifier (typically `$id` or file path) */
+  identifier: string;
+  /** File path of the schema */
+  filePath: string;
+  /** Edges for `$ref` values pointing from this schema to others */
+  outbound: JsonSchemaDependencyEdge[];
+  /** Edges for `$ref` values in other schemas pointing to this one */
+  inbound: JsonSchemaDependencyEdge[];
+}
+
+/**
+ * Describes a circular dependency cycle found among JSON Schema files.
+ */
+interface CircularChain {
+  /** Ordered list of schema identifiers forming the cycle, with the first identifier repeated at the end */
+  chain: string[];
+}
+
+/**
+ * Three-color marking for DFS (Depth First Search) based cycle detection.
+ * @see JsonSchemaAnalysisService.detectCircularDependencies
+ */
+enum DfsMarker {
+  /** Not yet visited */
+  White,
+  /** Currently on the DFS stack (descendants not fully processed) */
+  Gray,
+  /** Fully processed (all descendants visited) */
+  Black,
+}
+
+/**
+ * JSON-specific analysis report extending the common {@link SchemaAnalysisReport}.
+ * Includes the full dependency graph, detected cycles, and categorized reference edges.
+ */
+export interface JsonSchemaAnalysisReport extends SchemaAnalysisReport {
+  /** Dependency graph nodes keyed by schema identifier */
+  nodes: Map<string, JsonSchemaDependencyNode>;
+  /** All cross-schema dependency edges (excludes self-references) */
+  edges: JsonSchemaDependencyEdge[];
+  /** Circular dependency cycles detected via DFS */
+  circularDependencies: CircularChain[];
+  /** `$ref` values that could not be resolved to any known schema */
+  missingReferences: JsonSchemaDependencyEdge[];
+}
+
+/**
+ * Analyzes JSON Schema files to determine inter-file `$ref` dependencies,
+ * detect circular references, and compute a valid loading order.
+ *
+ * @see JsonSchemaDocumentService.createJsonSchemaDocument
+ */
+export class JsonSchemaAnalysisService {
+  /**
+   * Analyzes dependency relationships among the provided JSON Schema metadata.
+   * Builds a dependency graph from `$ref` values, detects circular dependencies,
+   * identifies missing references, and produces a topologically sorted load order.
+   * @param schemas - Parsed schema metadata objects to analyze
+   * @param definitionFiles - Optional raw definition files for fallback resolution
+   * @returns Analysis report with dependency graph, load order, and any errors/warnings
+   */
+  static analyze(schemas: JsonSchemaMetadata[], definitionFiles?: Record<string, string>): JsonSchemaAnalysisReport {
+    const { nodes, edges, missingReferences } = JsonSchemaAnalysisService.buildDependencyGraph(
+      schemas,
+      definitionFiles,
+    );
+    const circularDependencies = JsonSchemaAnalysisService.detectCircularDependencies(nodes);
+    const loadOrder = JsonSchemaAnalysisService.computeLoadingOrder(nodes, circularDependencies);
+
+    const warnings: string[] = [];
+    for (const cycle of circularDependencies) {
+      warnings.push(`Circular dependency detected: ${cycle.chain.join(' → ')}`);
+    }
+
+    const errors: string[] = [];
+    for (const missing of missingReferences) {
+      errors.push(`Missing schema reference: '${missing.ref}' referenced from '${missing.from}' could not be resolved`);
+    }
+
+    return {
+      nodes,
+      edges,
+      loadOrder,
+      circularDependencies,
+      missingReferences,
+      warnings,
+      errors,
+    };
+  }
+
+  /**
+   * Convenience method that parses raw JSON Schema file contents and then analyzes their dependencies.
+   * @param definitionFiles - Map of file paths to JSON Schema content strings
+   * @returns Analysis report with dependency graph, load order, and any errors/warnings
+   */
+  static analyzeFromDefinitionFiles(definitionFiles: Record<string, string>): JsonSchemaAnalysisReport {
+    const schemas: JsonSchemaMetadata[] = [];
+    for (const [filePath, content] of Object.entries(definitionFiles)) {
+      schemas.push(JsonSchemaDocumentUtilService.parseJsonSchema(content, filePath));
+    }
+    return JsonSchemaAnalysisService.analyze(schemas, definitionFiles);
+  }
+
+  /**
+   * Recursively extracts all `$ref` strings from a JSON Schema object.
+   * Traverses properties, items, definitions, composition keywords, and conditionals.
+   * @param schema - The JSON Schema to extract `$ref` values from
+   * @returns Array of raw `$ref` strings found in the schema
+   */
+  static extractRefs(schema: JSONSchema7): string[] {
+    const result: string[] = [];
+    const visited = new Set<object>();
+    JsonSchemaAnalysisService.collectRefs(schema, visited, result);
+    return result;
+  }
+
+  private static collectRefs(
+    node: JSONSchema7 | JSONSchema7Definition | undefined,
+    visited: Set<object>,
+    result: string[],
+  ): void {
+    if (node === undefined || node === null || typeof node === 'boolean') {
+      return;
+    }
+
+    if (visited.has(node)) {
+      return;
+    }
+    visited.add(node);
+
+    if (node.$ref) {
+      result.push(node.$ref);
+    }
+
+    JsonSchemaAnalysisService.collectRefsFromProperties(node, visited, result);
+    JsonSchemaAnalysisService.collectRefsFromItems(node, visited, result);
+    JsonSchemaAnalysisService.collectRefsFromCompositions(node, visited, result);
+    JsonSchemaAnalysisService.collectRefsFromSubSchemas(node, visited, result);
+    JsonSchemaAnalysisService.collectRefsFromGuarded(node, visited, result);
+  }
+
+  private static collectRefsFromProperties(node: JSONSchema7, visited: Set<object>, result: string[]): void {
+    const maps = [
+      node.properties,
+      node.definitions,
+      node.$defs as Record<string, JSONSchema7Definition>,
+      node.patternProperties,
+    ];
+    for (const map of maps) {
+      if (map) {
+        for (const value of Object.values(map)) {
+          JsonSchemaAnalysisService.collectRefs(value, visited, result);
+        }
+      }
+    }
+  }
+
+  private static collectRefsFromItems(node: JSONSchema7, visited: Set<object>, result: string[]): void {
+    if (!node.items) {
+      return;
+    }
+    if (Array.isArray(node.items)) {
+      for (const item of node.items) {
+        JsonSchemaAnalysisService.collectRefs(item, visited, result);
+      }
+    } else {
+      JsonSchemaAnalysisService.collectRefs(node.items, visited, result);
+    }
+  }
+
+  private static collectRefsFromCompositions(node: JSONSchema7, visited: Set<object>, result: string[]): void {
+    const arrays = [node.allOf, node.anyOf, node.oneOf];
+    for (const arr of arrays) {
+      if (arr) {
+        for (const sub of arr) {
+          JsonSchemaAnalysisService.collectRefs(sub, visited, result);
+        }
+      }
+    }
+  }
+
+  private static collectRefsFromSubSchemas(node: JSONSchema7, visited: Set<object>, result: string[]): void {
+    const subSchemas = [node.not, node.if, node.then, node.else, node.contains];
+    for (const sub of subSchemas) {
+      if (sub) {
+        JsonSchemaAnalysisService.collectRefs(sub, visited, result);
+      }
+    }
+  }
+
+  private static collectRefsFromGuarded(node: JSONSchema7, visited: Set<object>, result: string[]): void {
+    if (node.additionalProperties && typeof node.additionalProperties !== 'boolean') {
+      JsonSchemaAnalysisService.collectRefs(node.additionalProperties, visited, result);
+    }
+    if (node.additionalItems && typeof node.additionalItems !== 'boolean') {
+      JsonSchemaAnalysisService.collectRefs(node.additionalItems, visited, result);
+    }
+  }
+
+  private static buildDependencyGraph(
+    schemas: JsonSchemaMetadata[],
+    definitionFiles?: Record<string, string>,
+  ): {
+    nodes: Map<string, JsonSchemaDependencyNode>;
+    edges: JsonSchemaDependencyEdge[];
+    missingReferences: JsonSchemaDependencyEdge[];
+  } {
+    const nodes = new Map<string, JsonSchemaDependencyNode>();
+    const edges: JsonSchemaDependencyEdge[] = [];
+    const missingReferences: JsonSchemaDependencyEdge[] = [];
+
+    const schemasByIdentifier = new Map<string, JsonSchemaMetadata>();
+    const schemasByFilePath = new Map<string, JsonSchemaMetadata>();
+
+    for (const schema of schemas) {
+      schemasByIdentifier.set(schema.identifier, schema);
+      schemasByFilePath.set(schema.filePath, schema);
+
+      nodes.set(schema.identifier, {
+        identifier: schema.identifier,
+        filePath: schema.filePath,
+        outbound: [],
+        inbound: [],
+      });
+    }
+
+    for (const schema of schemas) {
+      const refs = JsonSchemaAnalysisService.extractRefs(schema);
+
+      for (const ref of refs) {
+        const [schemaPart, fragment] = ref.split('#');
+        const localPart = fragment || '';
+
+        if (!schemaPart || schemaPart === '') {
+          continue;
+        }
+
+        const targetId = JsonSchemaAnalysisService.resolveRefTarget(
+          schemaPart,
+          schema,
+          schemasByIdentifier,
+          schemasByFilePath,
+          definitionFiles,
+        );
+
+        if (targetId === null) {
+          missingReferences.push({ from: schema.identifier, to: schemaPart, ref, localPart });
+          continue;
+        }
+
+        if (targetId === schema.identifier) {
+          continue;
+        }
+
+        JsonSchemaAnalysisService.registerEdge({ from: schema.identifier, to: targetId, ref, localPart }, nodes, edges);
+      }
+    }
+
+    return { nodes, edges, missingReferences };
+  }
+
+  private static registerEdge(
+    edge: JsonSchemaDependencyEdge,
+    nodes: Map<string, JsonSchemaDependencyNode>,
+    edges: JsonSchemaDependencyEdge[],
+  ): void {
+    edges.push(edge);
+    const sourceNode = nodes.get(edge.from);
+    if (sourceNode) {
+      sourceNode.outbound.push(edge);
+    }
+    const targetNode = nodes.get(edge.to);
+    if (targetNode) {
+      targetNode.inbound.push(edge);
+    }
+  }
+
+  private static resolveRefTarget(
+    schemaPart: string,
+    sourceSchema: JsonSchemaMetadata,
+    schemasByIdentifier: Map<string, JsonSchemaMetadata>,
+    schemasByFilePath: Map<string, JsonSchemaMetadata>,
+    definitionFiles?: Record<string, string>,
+  ): string | null {
+    const direct = JsonSchemaAnalysisService.lookupSchemaIdentifier(schemaPart, schemasByIdentifier, schemasByFilePath);
+    if (direct) return direct;
+
+    const resolvedPath = JsonSchemaAnalysisService.resolvePath(schemaPart, sourceSchema.filePath);
+    if (resolvedPath !== schemaPart) {
+      const resolved = JsonSchemaAnalysisService.lookupSchemaIdentifier(
+        resolvedPath,
+        schemasByIdentifier,
+        schemasByFilePath,
+      );
+      if (resolved) return resolved;
+    }
+
+    const normalizedPath = PathUtil.normalizePath(schemaPart);
+    if (normalizedPath !== schemaPart) {
+      const normalized = JsonSchemaAnalysisService.lookupSchemaIdentifier(
+        normalizedPath,
+        schemasByIdentifier,
+        schemasByFilePath,
+      );
+      if (normalized) return normalized;
+    }
+
+    const filename = PathUtil.extractFilename(schemaPart);
+    const byFilename = JsonSchemaAnalysisService.lookupByFilename(filename, schemasByFilePath);
+    if (byFilename) return byFilename;
+
+    return JsonSchemaAnalysisService.lookupInDefinitionFiles(
+      schemaPart,
+      resolvedPath,
+      normalizedPath,
+      filename,
+      definitionFiles,
+    );
+  }
+
+  private static lookupSchemaIdentifier(
+    candidate: string,
+    schemasByIdentifier: Map<string, JsonSchemaMetadata>,
+    schemasByFilePath: Map<string, JsonSchemaMetadata>,
+  ): string | null {
+    if (schemasByIdentifier.has(candidate)) {
+      return schemasByIdentifier.get(candidate)!.identifier;
+    }
+    if (schemasByFilePath.has(candidate)) {
+      return schemasByFilePath.get(candidate)!.identifier;
+    }
+    return null;
+  }
+
+  private static lookupByFilename(filename: string, schemasByFilePath: Map<string, JsonSchemaMetadata>): string | null {
+    for (const schema of schemasByFilePath.values()) {
+      if (PathUtil.extractFilename(schema.filePath) === filename) {
+        return schema.identifier;
+      }
+    }
+    return null;
+  }
+
+  private static lookupInDefinitionFiles(
+    schemaPart: string,
+    resolvedPath: string,
+    normalizedPath: string,
+    filename: string,
+    definitionFiles?: Record<string, string>,
+  ): string | null {
+    if (!definitionFiles) return null;
+
+    if (definitionFiles[schemaPart] !== undefined) return schemaPart;
+    if (resolvedPath !== schemaPart && definitionFiles[resolvedPath] !== undefined) return resolvedPath;
+    if (normalizedPath !== schemaPart && definitionFiles[normalizedPath] !== undefined) return normalizedPath;
+
+    for (const path of Object.keys(definitionFiles)) {
+      if (PathUtil.extractFilename(path) === filename) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  private static detectCircularDependencies(nodes: Map<string, JsonSchemaDependencyNode>): CircularChain[] {
+    const color = new Map<string, DfsMarker>();
+    for (const id of nodes.keys()) {
+      color.set(id, DfsMarker.White);
+    }
+
+    const cycles: CircularChain[] = [];
+    const path: string[] = [];
+
+    for (const id of nodes.keys()) {
+      if (color.get(id) === DfsMarker.White) {
+        JsonSchemaAnalysisService.dfsVisit(id, nodes, color, path, cycles);
+      }
+    }
+
+    return cycles;
+  }
+
+  private static dfsVisit(
+    nodeId: string,
+    nodes: Map<string, JsonSchemaDependencyNode>,
+    color: Map<string, DfsMarker>,
+    path: string[],
+    cycles: CircularChain[],
+  ): void {
+    color.set(nodeId, DfsMarker.Gray);
+    path.push(nodeId);
+
+    const node = nodes.get(nodeId);
+    if (node) {
+      const visitedNeighbors = new Set<string>();
+      for (const edge of node.outbound) {
+        if (visitedNeighbors.has(edge.to)) {
+          continue;
+        }
+        visitedNeighbors.add(edge.to);
+
+        const neighborColor = color.get(edge.to);
+        if (neighborColor === DfsMarker.Gray) {
+          const cycleStart = path.indexOf(edge.to);
+          const chain = [...path.slice(cycleStart), edge.to];
+          cycles.push({ chain });
+        } else if (neighborColor === DfsMarker.White) {
+          JsonSchemaAnalysisService.dfsVisit(edge.to, nodes, color, path, cycles);
+        }
+      }
+    }
+
+    path.pop();
+    color.set(nodeId, DfsMarker.Black);
+  }
+
+  private static computeLoadingOrder(
+    nodes: Map<string, JsonSchemaDependencyNode>,
+    circularDependencies: CircularChain[],
+  ): string[] {
+    if (nodes.size === 0) {
+      return [];
+    }
+
+    const dependencyCount = JsonSchemaAnalysisService.initializeDependencyCounts(nodes);
+    const queue = JsonSchemaAnalysisService.collectInitialQueue(dependencyCount);
+    const result: string[] = [];
+    const processed = new Set<string>();
+
+    while (result.length < nodes.size) {
+      if (queue.length === 0) {
+        JsonSchemaAnalysisService.breakDeadlock(queue, processed, circularDependencies, nodes);
+      }
+
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (!processed.has(current)) {
+          JsonSchemaAnalysisService.processQueuedNode(current, nodes, processed, dependencyCount, queue, result);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private static initializeDependencyCounts(nodes: Map<string, JsonSchemaDependencyNode>): Map<string, number> {
+    const dependencyCount = new Map<string, number>();
+    for (const node of nodes.values()) {
+      const countedTargets = new Set<string>();
+      for (const edge of node.outbound) {
+        if (!countedTargets.has(edge.to) && nodes.has(edge.to)) {
+          countedTargets.add(edge.to);
+        }
+      }
+      dependencyCount.set(node.identifier, countedTargets.size);
+    }
+    return dependencyCount;
+  }
+
+  private static collectInitialQueue(dependencyCount: Map<string, number>): string[] {
+    const queue: string[] = [];
+    for (const [id, count] of dependencyCount.entries()) {
+      if (count === 0) {
+        queue.push(id);
+      }
+    }
+    return queue;
+  }
+
+  private static breakDeadlock(
+    queue: string[],
+    processed: Set<string>,
+    circularDependencies: CircularChain[],
+    nodes: Map<string, JsonSchemaDependencyNode>,
+  ): void {
+    for (const cycle of circularDependencies) {
+      for (const nodeId of cycle.chain) {
+        if (!processed.has(nodeId)) {
+          queue.push(nodeId);
+          return;
+        }
+      }
+    }
+
+    for (const id of nodes.keys()) {
+      if (!processed.has(id)) {
+        queue.push(id);
+        return;
+      }
+    }
+  }
+
+  private static processQueuedNode(
+    current: string,
+    nodes: Map<string, JsonSchemaDependencyNode>,
+    processed: Set<string>,
+    dependencyCount: Map<string, number>,
+    queue: string[],
+    result: string[],
+  ): void {
+    processed.add(current);
+    result.push(current);
+
+    const node = nodes.get(current);
+    if (!node) return;
+
+    const decrementedSources = new Set<string>();
+    for (const edge of node.inbound) {
+      if (!decrementedSources.has(edge.from) && !processed.has(edge.from) && nodes.has(edge.from)) {
+        decrementedSources.add(edge.from);
+        const newCount = (dependencyCount.get(edge.from) || 1) - 1;
+        dependencyCount.set(edge.from, newCount);
+        if (newCount === 0) {
+          queue.push(edge.from);
+        }
+      }
+    }
+  }
+
+  private static resolvePath(schemaLocation: string, baseUri: string): string {
+    if (PathUtil.isAbsolutePath(schemaLocation)) {
+      return schemaLocation;
+    }
+
+    const baseDir = PathUtil.extractDirectory(baseUri);
+    if (!baseDir) {
+      return schemaLocation;
+    }
+
+    const combined = `${baseDir}/${schemaLocation}`;
+    return PathUtil.normalizePath(combined);
+  }
+}

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -73,6 +73,10 @@ export interface JsonSchemaMetadata extends JSONSchema7 {
    * Updated as the schema is navigated during $ref resolution.
    */
   path: string;
+
+  schemaDependencies?: string[];
+
+  schemaDependents?: string[];
 }
 
 /**

--- a/packages/ui/src/services/path-util.ts
+++ b/packages/ui/src/services/path-util.ts
@@ -1,0 +1,35 @@
+export class PathUtil {
+  static normalizePath(path: string): string {
+    const parts = path.split('/').filter((part) => part !== '.');
+    const normalized: string[] = [];
+    for (const part of parts) {
+      if (part === '..') {
+        if (normalized.length > 0 && normalized.at(-1) !== '..') {
+          normalized.pop();
+        } else {
+          normalized.push(part);
+        }
+      } else {
+        normalized.push(part);
+      }
+    }
+    return normalized.join('/');
+  }
+
+  static extractDirectory(path: string): string | null {
+    const lastSlash = path.lastIndexOf('/');
+    if (lastSlash === -1) {
+      return null;
+    }
+    return path.substring(0, lastSlash);
+  }
+
+  static extractFilename(path: string): string {
+    const lastSlash = path.lastIndexOf('/');
+    return lastSlash === -1 ? path : path.substring(lastSlash + 1);
+  }
+
+  static isAbsolutePath(path: string): boolean {
+    return path.startsWith('/');
+  }
+}

--- a/packages/ui/src/services/xml-schema-analysis.service.test.ts
+++ b/packages/ui/src/services/xml-schema-analysis.service.test.ts
@@ -1,0 +1,225 @@
+import { XmlSchemaAnalysisService } from './xml-schema-analysis.service';
+
+describe('XmlSchemaAnalysisService', () => {
+  const makeSchema = (opts?: {
+    targetNamespace?: string;
+    includes?: string[];
+    imports?: { ns: string; loc: string }[];
+    elements?: string;
+  }) => {
+    const ns = opts?.targetNamespace ? ` targetNamespace="${opts.targetNamespace}"` : '';
+    const includes = (opts?.includes ?? []).map((loc) => `  <xs:include schemaLocation="${loc}"/>`).join('\n');
+    const imports = (opts?.imports ?? [])
+      .map((imp) => `  <xs:import namespace="${imp.ns}" schemaLocation="${imp.loc}"/>`)
+      .join('\n');
+    const elements = opts?.elements ?? '  <xs:element name="Root" type="xs:string"/>';
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"${ns}>
+${includes}
+${imports}
+${elements}
+</xs:schema>`;
+  };
+
+  it('should handle single schema with no dependencies', () => {
+    const files = { 'schema.xsd': makeSchema() };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.loadOrder).toEqual(['schema.xsd']);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('should detect include dependency and produce correct load order', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['B.xsd'] }),
+      'B.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].from).toBe('A.xsd');
+    expect(result.edges[0].to).toBe('B.xsd');
+    const aIndex = result.loadOrder.indexOf('A.xsd');
+    const bIndex = result.loadOrder.indexOf('B.xsd');
+    expect(bIndex).toBeLessThan(aIndex);
+  });
+
+  it('should report missing included schema', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['B.xsd'] }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Missing required schema');
+    expect(result.errors[0]).toContain('B.xsd');
+    expect(result.errors[0]).toContain('A.xsd');
+    expect(result.errors[0]).toContain('xs:include');
+  });
+
+  it('should report missing imported schema', () => {
+    const files = {
+      'A.xsd': makeSchema({ imports: [{ ns: 'http://example.com/types', loc: 'types.xsd' }] }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Missing required schema');
+    expect(result.errors[0]).toContain('types.xsd');
+    expect(result.errors[0]).toContain('A.xsd');
+    expect(result.errors[0]).toContain('xs:import');
+  });
+
+  it('should detect circular includes', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['B.xsd'] }),
+      'B.xsd': makeSchema({ includes: ['A.xsd'] }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    const circularErrors = result.errors.filter((e) => e.includes('Circular'));
+    expect(circularErrors.length).toBeGreaterThan(0);
+    expect(circularErrors[0]).toContain('A.xsd');
+    expect(circularErrors[0]).toContain('B.xsd');
+  });
+
+  it('should allow circular imports (different namespaces)', () => {
+    const files = {
+      'A.xsd': makeSchema({
+        targetNamespace: 'http://example.com/a',
+        imports: [{ ns: 'http://example.com/b', loc: 'B.xsd' }],
+      }),
+      'B.xsd': makeSchema({
+        targetNamespace: 'http://example.com/b',
+        imports: [{ ns: 'http://example.com/a', loc: 'A.xsd' }],
+      }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('Circular xs:import');
+    expect(result.loadOrder).toContain('A.xsd');
+    expect(result.loadOrder).toContain('B.xsd');
+  });
+
+  it('should handle deep chain: A includes B, B includes C', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['B.xsd'] }),
+      'B.xsd': makeSchema({ includes: ['C.xsd'] }),
+      'C.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    const aIdx = result.loadOrder.indexOf('A.xsd');
+    const bIdx = result.loadOrder.indexOf('B.xsd');
+    const cIdx = result.loadOrder.indexOf('C.xsd');
+    expect(cIdx).toBeLessThan(bIdx);
+    expect(bIdx).toBeLessThan(aIdx);
+  });
+
+  it('should report missing leaf in deep chain', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['B.xsd'] }),
+      'B.xsd': makeSchema({ includes: ['C.xsd'] }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('C.xsd');
+    expect(result.errors[0]).toContain('B.xsd');
+  });
+
+  it('should handle mixed include/import scenarios', () => {
+    const files = {
+      'main.xsd': makeSchema({
+        targetNamespace: 'http://example.com/main',
+        includes: ['common.xsd'],
+        imports: [{ ns: 'http://example.com/types', loc: 'types.xsd' }],
+      }),
+      'common.xsd': makeSchema({ targetNamespace: 'http://example.com/main' }),
+      'types.xsd': makeSchema({ targetNamespace: 'http://example.com/types' }),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.edges).toHaveLength(2);
+    const mainIdx = result.loadOrder.indexOf('main.xsd');
+    const commonIdx = result.loadOrder.indexOf('common.xsd');
+    const typesIdx = result.loadOrder.indexOf('types.xsd');
+    expect(commonIdx).toBeLessThan(mainIdx);
+    expect(typesIdx).toBeLessThan(mainIdx);
+  });
+
+  it('should resolve relative path with subdirectory', () => {
+    const files = {
+      'schemas/main.xsd': makeSchema({ includes: ['common.xsd'] }),
+      'schemas/common.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].to).toBe('schemas/common.xsd');
+  });
+
+  it('should resolve filename-only match as fallback', () => {
+    const files = {
+      'main.xsd': makeSchema({ includes: ['common.xsd'] }),
+      'types/common.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.edges[0].to).toBe('types/common.xsd');
+  });
+
+  it('should handle multiple files referencing the same dependency', () => {
+    const files = {
+      'A.xsd': makeSchema({ includes: ['common.xsd'] }),
+      'B.xsd': makeSchema({ includes: ['common.xsd'] }),
+      'common.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.edges).toHaveLength(2);
+    const commonIdx = result.loadOrder.indexOf('common.xsd');
+    const aIdx = result.loadOrder.indexOf('A.xsd');
+    const bIdx = result.loadOrder.indexOf('B.xsd');
+    expect(commonIdx).toBeLessThan(aIdx);
+    expect(commonIdx).toBeLessThan(bIdx);
+  });
+
+  it('should handle schema with invalid XML gracefully', () => {
+    const files = {
+      'bad.xsd': 'this is not xml',
+      'good.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.loadOrder).toContain('bad.xsd');
+    expect(result.loadOrder).toContain('good.xsd');
+  });
+
+  it('should handle empty definitionFiles', () => {
+    const result = XmlSchemaAnalysisService.analyze({});
+    expect(result.errors).toHaveLength(0);
+    expect(result.loadOrder).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('should report XML parse errors', () => {
+    const files = {
+      'valid.xsd': makeSchema(),
+      'invalid.xsd': 'this is not valid XML',
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('XML parse error');
+    expect(result.errors[0]).toContain('invalid.xsd');
+  });
+
+  it('should resolve path with parent directory references', () => {
+    const files = {
+      'schemas/sub/main.xsd': makeSchema({ includes: ['../common.xsd'] }),
+      'schemas/common.xsd': makeSchema(),
+    };
+    const result = XmlSchemaAnalysisService.analyze(files);
+    expect(result.errors).toHaveLength(0);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].to).toBe('schemas/common.xsd');
+  });
+});

--- a/packages/ui/src/services/xml-schema-analysis.service.ts
+++ b/packages/ui/src/services/xml-schema-analysis.service.ts
@@ -1,0 +1,305 @@
+import { SchemaAnalysisReport } from '../models/datamapper/schema';
+import { PathUtil } from './path-util';
+
+interface SchemaDirective {
+  type: 'include' | 'import';
+  schemaLocation: string;
+  namespace: string | null;
+}
+
+interface SchemaFileInfo {
+  filePath: string;
+  targetNamespace: string | null;
+  directives: SchemaDirective[];
+}
+
+interface DependencyEdge {
+  from: string;
+  to: string;
+  directive: SchemaDirective;
+}
+
+/**
+ * XML-specific analysis report extending the common {@link SchemaAnalysisReport}.
+ * Includes parsed schema file metadata and dependency edges for internal use.
+ */
+export interface XmlSchemaAnalysisReport extends SchemaAnalysisReport {
+  fileInfos: Map<string, SchemaFileInfo>;
+  edges: DependencyEdge[];
+}
+
+/**
+ * Analyzes XML Schema (XSD) files to determine inter-file dependencies,
+ * detect circular includes, and compute a valid loading order.
+ *
+ * @see XmlSchemaDocumentService.createXmlSchemaDocument
+ */
+export class XmlSchemaAnalysisService {
+  /**
+   * Analyzes dependency relationships among the provided XML Schema files.
+   * Parses `xs:include` and `xs:import` directives, resolves schema locations,
+   * detects circular `xs:include` chains, and produces a topologically sorted load order.
+   * @param definitionFiles - Map of file paths to XML Schema content strings
+   * @returns Analysis report with load order, dependency edges, and any errors
+   */
+  static analyze(definitionFiles: Record<string, string>): XmlSchemaAnalysisReport {
+    const fileInfos = new Map<string, SchemaFileInfo>();
+    const edges: DependencyEdge[] = [];
+    const errors: string[] = [];
+
+    for (const [filePath, content] of Object.entries(definitionFiles)) {
+      const { info, parseError } = XmlSchemaAnalysisService.parseSchemaFileInfo(filePath, content);
+      fileInfos.set(filePath, info);
+      if (parseError) {
+        errors.push(parseError);
+      }
+    }
+
+    for (const [filePath, info] of fileInfos) {
+      for (const directive of info.directives) {
+        const resolvedPath = XmlSchemaAnalysisService.resolveSchemaLocation(
+          directive.schemaLocation,
+          filePath,
+          definitionFiles,
+        );
+        if (resolvedPath) {
+          edges.push({ from: filePath, to: resolvedPath, directive });
+        } else {
+          errors.push(
+            `Missing required schema: "${directive.schemaLocation}" referenced by "${filePath}" via xs:${directive.type}`,
+          );
+        }
+      }
+    }
+
+    const circularErrors = XmlSchemaAnalysisService.detectCircularIncludes(fileInfos, edges);
+    errors.push(...circularErrors);
+
+    const warnings = XmlSchemaAnalysisService.detectCircularImports(fileInfos, edges);
+
+    const loadOrder = XmlSchemaAnalysisService.topologicalSort(Object.keys(definitionFiles), edges);
+
+    return { fileInfos, edges, errors, warnings, loadOrder };
+  }
+
+  private static parseSchemaFileInfo(
+    filePath: string,
+    content: string,
+  ): { info: SchemaFileInfo; parseError: string | null } {
+    const directives: SchemaDirective[] = [];
+    let targetNamespace: string | null = null;
+
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(content, 'text/xml');
+      const root = doc.documentElement;
+
+      if (root.nodeName === 'parsererror' || root.getElementsByTagName('parsererror').length > 0) {
+        const message = root.textContent?.trim() || 'Unknown XML parse error';
+        return {
+          info: { filePath, targetNamespace, directives },
+          parseError: `XML parse error in "${filePath}": ${message}`,
+        };
+      }
+
+      targetNamespace = root.getAttribute('targetNamespace') || null;
+
+      for (const child of Array.from(root.children)) {
+        const localName = child.localName;
+        if (localName === 'include') {
+          const schemaLocation = child.getAttribute('schemaLocation');
+          if (schemaLocation) {
+            directives.push({ type: 'include', schemaLocation, namespace: null });
+          }
+        } else if (localName === 'import') {
+          const schemaLocation = child.getAttribute('schemaLocation');
+          if (schemaLocation) {
+            const ns = child.getAttribute('namespace') || null;
+            directives.push({ type: 'import', schemaLocation, namespace: ns });
+          }
+        }
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        info: { filePath, targetNamespace, directives },
+        parseError: `XML parse error in "${filePath}": ${message}`,
+      };
+    }
+
+    return { info: { filePath, targetNamespace, directives }, parseError: null };
+  }
+
+  private static resolveSchemaLocation(
+    schemaLocation: string,
+    sourceFilePath: string,
+    definitionFiles: Record<string, string>,
+  ): string | null {
+    if (schemaLocation in definitionFiles) {
+      return schemaLocation;
+    }
+
+    const baseDir = PathUtil.extractDirectory(sourceFilePath);
+    if (baseDir) {
+      const resolvedPath = PathUtil.normalizePath(`${baseDir}/${schemaLocation}`);
+      if (resolvedPath in definitionFiles) {
+        return resolvedPath;
+      }
+    }
+
+    const normalizedPath = PathUtil.normalizePath(schemaLocation);
+    if (normalizedPath !== schemaLocation && normalizedPath in definitionFiles) {
+      return normalizedPath;
+    }
+
+    const filename = PathUtil.extractFilename(schemaLocation);
+    const matches: string[] = [];
+    for (const path of Object.keys(definitionFiles)) {
+      if (PathUtil.extractFilename(path) === filename) {
+        matches.push(path);
+      }
+    }
+    if (matches.length === 1) {
+      return matches[0];
+    }
+
+    return null;
+  }
+
+  private static detectCircularIncludes(fileInfos: Map<string, SchemaFileInfo>, edges: DependencyEdge[]): string[] {
+    const includeAdj = new Map<string, string[]>();
+    for (const edge of edges) {
+      if (edge.directive.type === 'include') {
+        const neighbors = includeAdj.get(edge.from) ?? [];
+        neighbors.push(edge.to);
+        includeAdj.set(edge.from, neighbors);
+      }
+    }
+
+    const errors: string[] = [];
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+    const stack: string[] = [];
+
+    const dfs = (node: string) => {
+      visited.add(node);
+      inStack.add(node);
+      stack.push(node);
+
+      for (const neighbor of includeAdj.get(node) ?? []) {
+        if (inStack.has(neighbor)) {
+          const cycleStart = stack.indexOf(neighbor);
+          const cycle = stack.slice(cycleStart);
+          cycle.push(neighbor);
+          const circularInclude = cycle.map((p) => `"${p}"`).join(' -> ');
+          errors.push(`Circular xs:include detected: ${circularInclude}`);
+        } else if (!visited.has(neighbor)) {
+          dfs(neighbor);
+        }
+      }
+
+      stack.pop();
+      inStack.delete(node);
+    };
+
+    for (const filePath of fileInfos.keys()) {
+      if (!visited.has(filePath)) {
+        dfs(filePath);
+      }
+    }
+
+    return errors;
+  }
+
+  private static detectCircularImports(fileInfos: Map<string, SchemaFileInfo>, edges: DependencyEdge[]): string[] {
+    const importAdj = new Map<string, string[]>();
+    for (const edge of edges) {
+      if (edge.directive.type === 'import') {
+        const neighbors = importAdj.get(edge.from) ?? [];
+        neighbors.push(edge.to);
+        importAdj.set(edge.from, neighbors);
+      }
+    }
+
+    const warnings: string[] = [];
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+    const stack: string[] = [];
+
+    const dfs = (node: string) => {
+      visited.add(node);
+      inStack.add(node);
+      stack.push(node);
+
+      for (const neighbor of importAdj.get(node) ?? []) {
+        if (inStack.has(neighbor)) {
+          const cycleStart = stack.indexOf(neighbor);
+          const cycle = stack.slice(cycleStart);
+          cycle.push(neighbor);
+          const circularImport = cycle.map((p) => `"${p}"`).join(' -> ');
+          warnings.push(`Circular xs:import detected: ${circularImport}`);
+        } else if (!visited.has(neighbor)) {
+          dfs(neighbor);
+        }
+      }
+
+      stack.pop();
+      inStack.delete(node);
+    };
+
+    for (const filePath of fileInfos.keys()) {
+      if (!visited.has(filePath)) {
+        dfs(filePath);
+      }
+    }
+
+    return warnings;
+  }
+
+  private static buildAdjacency(
+    filePaths: string[],
+    edges: DependencyEdge[],
+  ): { inDegree: Map<string, number>; adj: Map<string, string[]> } {
+    const inDegree = new Map<string, number>();
+    const adj = new Map<string, string[]>();
+
+    for (const path of filePaths) {
+      inDegree.set(path, 0);
+      adj.set(path, []);
+    }
+
+    for (const edge of edges) {
+      if (inDegree.has(edge.from) && inDegree.has(edge.to)) {
+        adj.get(edge.to)!.push(edge.from);
+        inDegree.set(edge.from, (inDegree.get(edge.from) ?? 0) + 1);
+      }
+    }
+
+    return { inDegree, adj };
+  }
+
+  private static topologicalSort(filePaths: string[], edges: DependencyEdge[]): string[] {
+    const { inDegree, adj } = XmlSchemaAnalysisService.buildAdjacency(filePaths, edges);
+
+    const queue = Array.from(inDegree.entries())
+      .filter(([_path, degree]) => degree === 0)
+      .map(([path]) => path);
+
+    const result: string[] = [];
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      result.push(node);
+      for (const neighbor of adj.get(node) ?? []) {
+        const newDegree = (inDegree.get(neighbor) ?? 1) - 1;
+        inDegree.set(neighbor, newDegree);
+        if (newDegree === 0) {
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    filePaths.filter((path) => !result.includes(path)).forEach((path) => result.push(path));
+
+    return result;
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2880
Fixes: https://github.com/KaotoIO/kaoto/issues/2911

 - Add JsonSchemaAnalysisService and XmlSchemaAnalysisService to analyze inter-file $ref/xs:include/xs:import dependencies, detect circular references, and compute topological load order
 - Add SchemaAnalysisReport base interface in models/datamapper/schema.ts.
 - The next sub-issues https://github.com/KaotoIO/kaoto/issues/2881 and https://github.com/KaotoIO/kaoto/issues/2912 should integrate into XmlSchemaAnalysisService, JsonSchemaAnalysisService and SchemaAnalysisReport
 - Extract shared path utilities (normalizePath, extractDirectory, extractFilename, isAbsolutePath) into PathUtil class in path-util.ts
 - Integrate analysis into JsonSchemaDocumentService.createJsonSchemaDocument() and XmlSchemaDocumentService.createXmlSchemaDocument()