### PR TITLE
feat(DataMapper): Add UI mockup for comments

### DIFF
--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsMockup.tsx
@@ -1,0 +1,314 @@
+import '../choice/ConditionalMappingView.scss';
+
+import { DocumentComment } from '@carbon/icons-react';
+import { BaseNode, Types } from '@kaoto/kaoto/testing';
+import {
+  ActionListGroup,
+  ActionListItem,
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  TextInput,
+  Tooltip,
+} from '@patternfly/react-core';
+import { EllipsisVIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent, MouseEvent, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { CommentsModal } from './CommentsModal';
+
+export const CommentsMockup: FunctionComponent = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [comment, setComment] = useState<string>('');
+
+  const onToggleMenu = useCallback(
+    (event: MouseEvent | undefined) => {
+      event?.stopPropagation();
+      setIsMenuOpen(!isMenuOpen);
+    },
+    [isMenuOpen],
+  );
+
+  const onSelectAction = useCallback((event: MouseEvent | undefined, value: string | number | undefined) => {
+    event?.stopPropagation();
+    if (value === 'create-comment') {
+      setIsModalOpen(true);
+    }
+    setIsMenuOpen(false);
+  }, []);
+
+  const handleCreateComment = useCallback((newComment: string) => {
+    setComment(newComment);
+    setIsModalOpen(false);
+    console.log('Comment created:', newComment);
+  }, []);
+
+  const handleDeleteComment = useCallback(() => {
+    setComment('');
+    setIsModalOpen(false);
+    console.log('Comment deleted');
+  }, []);
+
+  const handleUpdateComment = useCallback((newComment: string) => {
+    setComment(newComment);
+    setIsModalOpen(false);
+    console.log('Comment updated:', newComment);
+  }, []);
+
+  const handleCancelComment = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(
+    new Set(['source-root', 'source-choice', 'source-address', 'target-root', 'target-email']),
+  );
+  interface MappingLine {
+    sourceId: string;
+    targetId: string;
+    color?: string;
+  }
+
+  const mappingLines: MappingLine[] = useMemo(
+    () => [{ sourceId: 'source-email', targetId: 'target-email', color: '#06c' }],
+    [],
+  );
+  const [nodeRefs, setNodeRefs] = useState<Record<string, DOMRect>>({});
+
+  useEffect(() => {
+    const updatePositions = () => {
+      const refs: Record<string, DOMRect> = {};
+      for (const line of mappingLines) {
+        const sourceEl = document.getElementById(line.sourceId);
+        const targetEl = document.getElementById(line.targetId);
+        if (sourceEl) refs[line.sourceId] = sourceEl.getBoundingClientRect();
+        if (targetEl) refs[line.targetId] = targetEl.getBoundingClientRect();
+      }
+      setNodeRefs(refs);
+    };
+
+    updatePositions();
+    window.addEventListener('resize', updatePositions);
+    return () => window.removeEventListener('resize', updatePositions);
+  }, [expandedNodes, mappingLines]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const containerRect = containerRef.current?.getBoundingClientRect();
+
+  const toggleNode = (nodeId: string) => {
+    setExpandedNodes((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(nodeId)) {
+        newSet.delete(nodeId);
+      } else {
+        newSet.add(nodeId);
+      }
+      return newSet;
+    });
+  };
+
+  return (
+    <div ref={containerRef} className="conditional-mapping-view">
+      <div className="conditional-mapping-view__panels">
+        <div className="conditional-mapping-view__source">
+          <h3>Source</h3>
+          <div className="node__container">
+            <div className="node__header">
+              <BaseNode
+                isExpandable
+                isExpanded={expandedNodes.has('source-root')}
+                onExpandChange={() => toggleNode('source-root')}
+                isDraggable={false}
+                iconType={Types.Container}
+                title={
+                  <span className="node__spacer" id="source-root">
+                    customer
+                  </span>
+                }
+                rank={0}
+              />
+            </div>
+            {expandedNodes.has('source-root') && (
+              <div className="node__children">
+                <div className="choice-node" style={{ '--node-rank': 1 } as React.CSSProperties}>
+                  {expandedNodes.has('source-choice') && (
+                    <div className="node__children">
+                      {/* email */}
+                      <div className="node__container" style={{ marginLeft: 'calc(2 * 0.85rem)' }}>
+                        <div className="node__header" id="source-email">
+                          <BaseNode
+                            isExpandable={false}
+                            isDraggable={false}
+                            iconType={Types.String}
+                            title={<span className="node__spacer">email</span>}
+                            rank={2}
+                          />
+                        </div>
+                      </div>
+
+                      {/* phone */}
+                      <div className="node__container" style={{ marginLeft: 'calc(2 * 0.85rem)' }}>
+                        <div className="node__header" id="source-phone">
+                          <BaseNode
+                            isExpandable={false}
+                            isDraggable={false}
+                            iconType={Types.String}
+                            title={<span className="node__spacer">phone</span>}
+                            rank={2}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="conditional-mapping-view__target">
+          <h3>Target</h3>
+          <div className="node__container">
+            <div className="node__header">
+              <BaseNode
+                isExpandable
+                isExpanded={expandedNodes.has('target-root')}
+                onExpandChange={() => toggleNode('target-root')}
+                isDraggable={false}
+                iconType={Types.Container}
+                title={
+                  <span className="node__spacer" id="target-root">
+                    output
+                  </span>
+                }
+                rank={0}
+              />
+            </div>
+
+            {expandedNodes.has('target-root') && (
+              <div className="node__children">
+                {/* email node */}
+                <div className="node__container" style={{ marginLeft: 'calc(1 * 0.85rem)' }}>
+                  <div className="node__header">
+                    <div style={{ display: 'flex', alignItems: 'center', height: '2rem' }} id="target-email">
+                      <BaseNode
+                        isExpandable={false}
+                        isDraggable={false}
+                        title={
+                          <span
+                            className="node__spacer"
+                            style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}
+                          >
+                            email
+                            <TextInput
+                              value="/customer/email"
+                              aria-label="XPath test expression"
+                              style={{ marginLeft: '0.5rem', width: '150px', height: '1.75rem' }}
+                            />
+                          </span>
+                        }
+                        rank={2}
+                      />
+                      <span className="node__spacer" style={{ flex: 1 }} />
+                      <ActionListGroup className="node__target__actions">
+                        <ActionListItem>
+                          <Tooltip content="Edit XPath">
+                            <Button variant="plain" icon={<PencilAltIcon />} />
+                          </Tooltip>
+                        </ActionListItem>
+                        {comment && (
+                          <ActionListItem>
+                            <Tooltip content={'Comment : ' + (comment ? comment : 'No comment')}>
+                              <Button variant="plain" icon={<DocumentComment />} onClick={() => setIsModalOpen(true)} />
+                            </Tooltip>
+                          </ActionListItem>
+                        )}
+                        <ActionListItem>
+                          <Dropdown
+                            onSelect={onSelectAction}
+                            toggle={(toggleRef: Ref<MenuToggleElement>) => (
+                              <MenuToggle
+                                icon={<EllipsisVIcon />}
+                                ref={toggleRef}
+                                onClick={onToggleMenu}
+                                variant="plain"
+                                isExpanded={isMenuOpen}
+                                aria-label="Target element actions"
+                                data-testid="target-actions-menu-toggle"
+                              />
+                            )}
+                            isOpen={isMenuOpen}
+                            onOpenChange={(isOpen: boolean) => setIsMenuOpen(isOpen)}
+                          >
+                            <DropdownList>
+                              <DropdownItem>Add selector expression</DropdownItem>
+                              <DropdownItem>Wrap with &quot;if&quot;</DropdownItem>
+                              <DropdownItem>Wrap with &quot;choose-when-otherwise&quot;</DropdownItem>
+                              <DropdownItem
+                                key="create-comment"
+                                value="create-comment"
+                                data-testid="create-comment-action"
+                              >
+                                {comment ? 'Edit comment' : 'Add comment'}
+                              </DropdownItem>
+                            </DropdownList>
+                          </Dropdown>
+                        </ActionListItem>
+                        <ActionListItem>
+                          <Tooltip content="Delete">
+                            <Button variant="plain" icon={<TrashIcon />} />
+                          </Tooltip>
+                        </ActionListItem>
+                      </ActionListGroup>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Mapping Lines SVG */}
+        {containerRect && (
+          <svg className="conditional-mapping-view__lines" data-testid="mapping-lines">
+            {mappingLines.map((line) => {
+              const sourceRect = nodeRefs[line.sourceId];
+              const targetRect = nodeRefs[line.targetId];
+
+              if (!sourceRect || !targetRect) return null;
+
+              const x1 = sourceRect.right - containerRect.left;
+              const y1 = sourceRect.top + sourceRect.height / 2 - containerRect.top;
+              const x2 = targetRect.left - containerRect.left;
+              const y2 = targetRect.top + targetRect.height / 2 - containerRect.top;
+
+              return (
+                <line
+                  key={`${line.sourceId}-${line.targetId}`}
+                  x1={x1}
+                  y1={y1}
+                  x2={x2}
+                  y2={y2}
+                  stroke={line.color || '#0066cc'}
+                  strokeWidth="2"
+                  opacity="0.6"
+                />
+              );
+            })}
+          </svg>
+        )}
+      </div>
+
+      {/* Comments Modal */}
+      <CommentsModal
+        isOpen={isModalOpen}
+        initialComment={comment}
+        onCreateComment={handleCreateComment}
+        onCancel={handleCancelComment}
+        onDeleteComment={handleDeleteComment}
+        onUpdateComment={handleUpdateComment}
+      />
+    </div>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
@@ -1,0 +1,70 @@
+import { Button } from '@patternfly/react-core';
+import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+
+import { CommentsMockup } from './CommentsMockup';
+import { CommentsModal } from './CommentsModal';
+
+export default {
+  title: 'UI Mockups/DataMapper/CommentsModal',
+
+  component: CommentsModal,
+} as Meta<typeof CommentsModal>;
+
+const Template: StoryFn<typeof CommentsModal> = (args) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <Button variant="primary" onClick={() => setIsOpen(true)} style={{ marginBottom: '1rem' }}>
+        Open Modal
+      </Button>
+      <CommentsModal
+        {...args}
+        isOpen={isOpen}
+        onCreateComment={(comment) => {
+          console.log('Comment created:', comment);
+          setIsOpen(false);
+        }}
+        onCancel={() => {
+          console.log('Comment creation cancelled');
+          setIsOpen(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export const EmptyModal = Template.bind({});
+EmptyModal.args = {
+  initialComment: '',
+};
+
+export const ModalWithComment = Template.bind({});
+ModalWithComment.args = {
+  initialComment: 'This is a pre-filled comment',
+};
+
+// Story showcasing the full DataMapper mockup with source/target elements and comments functionality
+export const DataMapperWithComments: StoryFn = () => {
+  return (
+    <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+      <h2 style={{ marginBottom: '0.5rem' }}>Comments visualization</h2>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        When a comment is added to a mapping, it should be visible as an icon next to the mapped field. Hovering over
+        the icon will display the comment content in a tooltip. This allows users to easily see and manage comments
+        associated with their mappings without needing to open the comment modal each time.
+      </p>
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '1.5rem',
+          borderRadius: '4px',
+          border: '1px solid #ccc',
+        }}
+      >
+        <CommentsMockup />;{' '}
+      </div>
+    </div>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.tsx
@@ -1,0 +1,94 @@
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant, TextArea } from '@patternfly/react-core';
+import { FunctionComponent, useState } from 'react';
+
+export type CommentsModalProps = {
+  isOpen: boolean;
+  initialComment?: string;
+  onCreateComment: (comment: string) => void;
+  onUpdateComment?: (comment: string) => void;
+  onDeleteComment?: () => void;
+  onCancel: () => void;
+};
+
+export const CommentsModal: FunctionComponent<CommentsModalProps> = ({
+  isOpen,
+  initialComment = '',
+  onCreateComment,
+  onUpdateComment,
+  onDeleteComment,
+  onCancel,
+}) => {
+  const [comment, setComment] = useState<string>(initialComment);
+  const isEditMode = Boolean(initialComment);
+
+  const handleCreate = () => {
+    onCreateComment(comment);
+  };
+
+  const handleUpdate = () => {
+    if (onUpdateComment) {
+      onUpdateComment(comment);
+    }
+  };
+
+  const handleDelete = () => {
+    if (onDeleteComment) {
+      onDeleteComment();
+    }
+  };
+
+  const handleCancel = () => {
+    setComment(initialComment);
+    onCancel();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      variant={ModalVariant.small}
+      data-testid="comments-modal"
+      onClose={handleCancel}
+      ouiaId="CommentsModal"
+    >
+      <ModalHeader title={isEditMode ? 'Edit Comment' : 'Add Comment'} />
+
+      <ModalBody>
+        <TextArea
+          type="text"
+          id="comment-area"
+          name="comment-area"
+          aria-label="Comment input area"
+          value={comment}
+          onChange={(_event, value) => setComment(value)}
+          placeholder="Enter your comment..."
+          data-testid="comment-area"
+        />
+      </ModalBody>
+
+      <ModalFooter>
+        {isEditMode ? (
+          <>
+            <Button key="update" variant="primary" onClick={handleUpdate} data-testid="update-comment-btn">
+              Update
+            </Button>
+            <Button key="delete" variant="danger" onClick={handleDelete} data-testid="delete-comment-btn">
+              Delete
+            </Button>
+            <Button key="cancel" variant="link" onClick={handleCancel} data-testid="cancel-comment-btn">
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button key="create" variant="primary" onClick={handleCreate} data-testid="create-comment-btn">
+              Create
+            </Button>
+            <Button key="cancel" variant="link" onClick={handleCancel} data-testid="cancel-comment-btn">
+              Cancel
+            </Button>
+          </>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+};


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/2869


---

# UI Mockup for  comments within XSLT

## Overview

This PR provides UI mockup for writing comments within XSLT (#2869). The Storybook story provides complete user experience for the comment creation workflow in the DataMapper. 

---
## Main Story


Complete Interactive Workflow.

**Purpose:** Demonstration of the comment creation workflow. 

####  Interactive workflow
* Select option: select the three dot dropdown, select the "Add comment" option: 

<img width="361" height="257" alt="Screenshot From 2026-02-10 15-58-41" src="https://github.com/user-attachments/assets/86817b6b-9633-43f8-b9ce-1c618db40421" />

* Write the required comment for the mapping in the comment modal:

<img width="574" height="223" alt="Screenshot From 2026-02-10 16-25-35" src="https://github.com/user-attachments/assets/9b579a7d-33ad-4370-8d66-aa7c5c517f1c" />

* In the newly appeared `Comment` icon, the user can see the added comment:

<img width="294" height="149" alt="Screenshot From 2026-02-10 15-59-06" src="https://github.com/user-attachments/assets/ad164056-4ffe-468e-ae4e-b6a39feea8ff" />

* Clicking the `Comment` icon, or using the `Edit comment` from the dropdown, the user can edit or delete the comment.

<img width="574" height="223" alt="Screenshot From 2026-02-10 15-59-21" src="https://github.com/user-attachments/assets/6161f5f0-0c4d-4f43-8aa8-c8a9b1bcdc53" />

The complete workflow:


https://github.com/user-attachments/assets/8d9afa8b-1c8f-4164-b158-0cdb9d0a54b9

---



