### PR TITLE
fix(DataMapper): Draw mapping lines for XPath if-else expressions

### DIFF
--- a/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
@@ -171,4 +171,21 @@ describe('Test for DataMapper : XML to XML', () => {
     cy.deleteParameter('Account');
     cy.countMappingLines(0);
   });
+
+  it('import mappings with XPath if-else expression', () => {
+    cy.openDataMapper();
+    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.importMappings('datamapper/xslt/ShipOrderWithIfElse.xsl');
+
+    cy.get('[data-testid^="node-source-fx-OrderPerson"]').should('exist');
+    cy.get('[data-testid^="node-target-fx-OrderPerson"]').should('exist');
+
+    cy.countMappingLines(8);
+
+    cy.get('[data-testid^="node-source-fx-OrderPerson"]').first().click({ force: true });
+    cy.checkFieldSelected('source', 'fx', 'OrderPerson', true);
+    cy.checkFieldSelected('target', 'fx', 'OrderPerson', true);
+    cy.checkMappingLineSelected(true);
+  });
 });

--- a/packages/ui-tests/cypress/fixtures/datamapper/xslt/ShipOrderWithIfElse.xsl
+++ b/packages/ui-tests/cypress/fixtures/datamapper/xslt/ShipOrderWithIfElse.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:attribute name="OrderId">
+                <xsl:value-of select="/ns0:ShipOrder/@OrderId"/>
+            </xsl:attribute>
+            <OrderPerson>
+                <xsl:value-of select="if (/ns0:ShipOrder/ns0:OrderPerson = 'VIP') then /ns0:ShipOrder/ns0:OrderPerson else /ns0:ShipOrder/@OrderId"/>
+            </OrderPerson>
+            <ShipTo xmlns="">
+                <Name>
+                    <xsl:value-of select="/ns0:ShipOrder/ShipTo/Name"/>
+                </Name>
+            </ShipTo>
+            <xsl:for-each select="/ns0:ShipOrder/Item">
+                <Item xmlns="">
+                    <Title>
+                        <xsl:value-of select="Title"/>
+                    </Title>
+                    <Quantity>
+                        <xsl:value-of select="Quantity"/>
+                    </Quantity>
+                    <Price>
+                        <xsl:value-of select="Price"/>
+                    </Price>
+                </Item>
+            </xsl:for-each>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-model.ts
+++ b/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-model.ts
@@ -35,6 +35,7 @@ export enum XPathNodeType {
   ReverseStep = 'ReverseStep',
   ParenthesizedExpr = 'ParenthesizedExpr',
   Expr = 'Expr',
+  IfExpr = 'IfExpr',
 }
 
 /**
@@ -127,6 +128,18 @@ export interface FilterExprNode extends XPathNode {
 export type PrimaryExprNode = LiteralNode | VarRefNode | ParenthesizedExprNode | ContextItemExprNode | FunctionCallNode;
 
 /**
+ * Union type for single expression nodes that can be returned by ExprSingle.
+ * Represents individual XPath expressions including paths, comparisons, literals, function calls, variables, and if-else expressions.
+ */
+export type ExprSingleNode =
+  | PathExprNode
+  | ComparisonExprNode
+  | LiteralNode
+  | FunctionCallNode
+  | VarRefNode
+  | IfExprNode;
+
+/**
  * Literal value in an XPath expression.
  * Examples:
  * - `"hello"` (string literal)
@@ -190,6 +203,13 @@ export interface ParenthesizedExprNode extends XPathNode {
   expr?: ExprNode;
 }
 
+export interface IfExprNode extends XPathNode {
+  type: XPathNodeType.IfExpr;
+  condition: ExprNode;
+  thenExpr: ExprSingleNode;
+  elseExpr: ExprSingleNode;
+}
+
 /**
  * Top-level expression container, can hold one or more sub-expressions.
  * Examples:
@@ -199,7 +219,7 @@ export interface ParenthesizedExprNode extends XPathNode {
  */
 export interface ExprNode extends XPathNode {
   type: XPathNodeType.Expr;
-  expressions: (PathExprNode | ComparisonExprNode | LiteralNode | FunctionCallNode | VarRefNode)[];
+  expressions: ExprSingleNode[];
 }
 
 /**

--- a/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-util.ts
+++ b/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-util.ts
@@ -3,6 +3,7 @@ import {
   ExprNode,
   FilterExprNode,
   FunctionCallNode,
+  IfExprNode,
   ParenthesizedExprNode,
   PathExprNode,
   PredicateNode,
@@ -95,6 +96,12 @@ export class XPathUtil {
     if (node.nodeTest) this.traverseNode(node.nodeTest, callback);
   }
 
+  private static traverseIfExpr(node: IfExprNode, callback: (node: XPathNode) => void): void {
+    if (node.condition) this.traverseNode(node.condition, callback);
+    if (node.thenExpr) this.traverseNode(node.thenExpr, callback);
+    if (node.elseExpr) this.traverseNode(node.elseExpr, callback);
+  }
+
   private static traverseNode(node: XPathNode, callback: (node: XPathNode) => void): void {
     callback(node);
 
@@ -122,6 +129,9 @@ export class XPathUtil {
         break;
       case XPathNodeType.ParenthesizedExpr:
         this.traverseParenthesizedExpr(node as ParenthesizedExprNode, callback);
+        break;
+      case XPathNodeType.IfExpr:
+        this.traverseIfExpr(node as IfExprNode, callback);
         break;
       case XPathNodeType.ReverseStep:
         this.traverseReverseStep(node as ReverseStepNode, callback);

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -575,6 +575,40 @@ describe('XPathService', () => {
         expect(paths[0].pathSegments[2].name).toEqual('node');
       });
     });
+
+    describe('if-else expressions (issue #2917)', () => {
+      it('should extract fields from condition and branches', () => {
+        const paths = XPathService.extractFieldPaths(
+          'if ($order/status = "VIP") then $order/totalPrice * 0.8 else $order/totalPrice',
+        );
+        expect(paths.length).toEqual(2);
+
+        // First path: order/status (used in condition)
+        expect(paths[0].documentReferenceName).toEqual('order');
+        expect(paths[0].pathSegments.length).toEqual(1);
+        expect(paths[0].pathSegments[0].name).toEqual('status');
+
+        // Second path: order/totalPrice (used in both then and else branches)
+        expect(paths[1].documentReferenceName).toEqual('order');
+        expect(paths[1].pathSegments.length).toEqual(1);
+        expect(paths[1].pathSegments[0].name).toEqual('totalPrice');
+      });
+
+      it('should extract fields from nested if-else', () => {
+        const paths = XPathService.extractFieldPaths(
+          'if ($price > 100) then (if ($vip) then $price * 0.8 else $price * 0.9) else $price',
+        );
+        expect(paths.length).toEqual(2);
+
+        // price field
+        expect(paths[0].documentReferenceName).toEqual('price');
+        expect(paths[0].pathSegments.length).toEqual(0);
+
+        // vip field
+        expect(paths[1].documentReferenceName).toEqual('vip');
+        expect(paths[1].pathSegments.length).toEqual(0);
+      });
+    });
   });
 
   describe('toXPathString()', () => {


### PR DESCRIPTION
closes #2917 


DataMapper failed to draw mapping lines when source fields were referenced
inside XPath if-else expressions. The XPath AST visitor was missing support
for IfExpr nodes, causing field extraction to skip these expressions.

  - Add IfExpr node type and interface to XPath syntax tree model
  - Implement visitIfExpr() in CST-to-AST visitor
  - Add traverseIfExpr() to syntax tree traversal utility
  - Extract ExprSingleNode type alias 

<img width="1490" height="872" alt="Screenshot 2026-02-10 at 16 41 28" src="https://github.com/user-attachments/assets/08e686b8-bd01-420c-ad44-b75fd8152034" />