### PR TITLE
feat(Canvas): Allowing to create routes from direct component

### DIFF
--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@kaoto/camel-catalog": "^0.3.1",
-    "@kaoto/forms": "^1.5.9",
+    "@kaoto/forms": "^1.6.0",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@carbon/icons-react": "^11.67.0",
     "@dnd-kit/core": "^6.1.0",
-    "@kaoto/forms": "^1.5.9",
+    "@kaoto/forms": "^1.6.0",
     "@kie-tools-core/editor": "^10.0.0",
     "@kie-tools-core/notifications": "^10.0.0",
     "@visx/shape": "^3.12.0",

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { EntitiesContextResult } from '../../../../../providers/entities.provider';
+import { VisibleFlowsContextResult } from '../../../../../providers/visible-flows.provider';
+import {
+  getDirectNameFromUri,
+  useCreateDirectRoute,
+  useDirectEndpointNameOptions,
+} from './DirectEndpointNameField.hooks';
+
+describe('DirectEndpointNameField hooks', () => {
+  describe('getDirectNameFromUri', () => {
+    it('extracts a direct endpoint name', () => {
+      expect(getDirectNameFromUri('direct:orders')).toBe('orders');
+      expect(getDirectNameFromUri('direct:orders?lazyStartProducer=true')).toBe('orders');
+    });
+
+    it('returns undefined for non-direct URIs', () => {
+      expect(getDirectNameFromUri('timer:test')).toBeUndefined();
+    });
+  });
+
+  describe('useDirectEndpointNameOptions', () => {
+    const visualEntities = [
+      {
+        getId: () => 'route-start',
+        toJSON: () => ({ route: { from: { uri: 'direct:start', steps: [{ to: { uri: 'direct:orders' } }] } } }),
+      },
+      {
+        getId: () => 'route-billing',
+        toJSON: () => ({ route: { from: { uri: 'direct', parameters: { name: 'billing' }, steps: [] } } }),
+      },
+    ];
+
+    it('lists and sorts direct endpoint names from entities', () => {
+      const onChange = jest.fn();
+
+      const { result } = renderHook(() =>
+        useDirectEndpointNameOptions({
+          value: '',
+          onChange,
+          visualEntities,
+        }),
+      );
+
+      expect(result.current.items.map((item) => item.name)).toEqual(['billing', 'orders', 'start']);
+      expect(result.current.existingDirectRouteNames).toEqual(['billing', 'start']);
+      expect(result.current.items.find((item) => item.name === 'billing')?.description).toContain('route-billing');
+      expect(result.current.items.find((item) => item.name === 'start')?.description).toContain('route-start');
+    });
+
+    it('handles typeahead callbacks', () => {
+      const onChange = jest.fn();
+      const { result } = renderHook(() =>
+        useDirectEndpointNameOptions({
+          value: 'start',
+          onChange,
+          visualEntities,
+        }),
+      );
+
+      act(() => result.current.onTypeaheadChange({ name: 'orders', value: 'orders' }));
+      act(() => result.current.onCleanInput());
+      act(() => result.current.onCreateOption(undefined, 'new-route'));
+
+      expect(onChange).toHaveBeenNthCalledWith(1, 'orders');
+      expect(onChange).toHaveBeenNthCalledWith(2, undefined);
+      expect(onChange).toHaveBeenNthCalledWith(3, 'new-route');
+      expect(result.current.typedName).toBe('start');
+    });
+  });
+
+  describe('useCreateDirectRoute', () => {
+    it('creates a route for a new direct name', () => {
+      const onChange = jest.fn();
+      const addNewEntity = jest.fn().mockReturnValue('new-route-id');
+      const toggleFlowVisible = jest.fn();
+      const updateEntitiesFromCamelResource = jest.fn();
+      const entitiesContext = {
+        camelResource: { addNewEntity },
+        updateEntitiesFromCamelResource,
+      } as unknown as EntitiesContextResult;
+      const visibleFlowsContext = {
+        visualFlowsApi: { toggleFlowVisible },
+      } as unknown as VisibleFlowsContextResult;
+
+      const { result } = renderHook(() =>
+        useCreateDirectRoute({
+          disabled: false,
+          typedName: 'new-route',
+          existingDirectRouteNames: ['start'],
+          onChange,
+          entitiesContext,
+          visibleFlowsContext,
+        }),
+      );
+
+      expect(result.current.canCreateRoute).toBe(true);
+
+      act(() => result.current.onCreateRoute());
+
+      expect(addNewEntity).toHaveBeenCalledWith('route', {
+        from: { uri: 'direct', parameters: { name: 'new-route' }, steps: [] },
+      });
+      expect(toggleFlowVisible).toHaveBeenCalledWith('new-route-id');
+      expect(updateEntitiesFromCamelResource).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith('new-route');
+    });
+
+    it('disables route creation for existing names', () => {
+      const onChange = jest.fn();
+      const { result } = renderHook(() =>
+        useCreateDirectRoute({
+          disabled: false,
+          typedName: 'start',
+          existingDirectRouteNames: ['start'],
+          onChange,
+          entitiesContext: null,
+          visibleFlowsContext: undefined,
+        }),
+      );
+
+      expect(result.current.canCreateRoute).toBe(false);
+    });
+
+    it('allows route creation when the name is only referenced but has no direct from route', () => {
+      const onChange = jest.fn();
+      const { result } = renderHook(() =>
+        useCreateDirectRoute({
+          disabled: false,
+          typedName: 'orders',
+          existingDirectRouteNames: ['start'],
+          onChange,
+          entitiesContext: null,
+          visibleFlowsContext: undefined,
+        }),
+      );
+
+      expect(result.current.canCreateRoute).toBe(true);
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.ts
@@ -1,0 +1,234 @@
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
+import { TypeaheadItem } from '@kaoto/forms';
+import { useCallback, useMemo } from 'react';
+
+import { EntityType } from '../../../../../models/camel/entities';
+import { EntitiesContextResult } from '../../../../../providers/entities.provider';
+import { VisibleFlowsContextResult } from '../../../../../providers/visible-flows.provider';
+
+const DIRECT_URI = 'direct';
+const DIRECT_URI_PREFIX = `${DIRECT_URI}:`;
+
+interface DirectEndpointEntityLike {
+  getId: () => string | undefined;
+  toJSON: () => unknown;
+}
+
+interface UseDirectEndpointNameOptionsParams {
+  value: string;
+  onChange: (value: string | undefined) => void;
+  visualEntities?: DirectEndpointEntityLike[];
+}
+
+interface UseCreateDirectRouteParams {
+  disabled: boolean;
+  typedName: string;
+  existingDirectRouteNames: string[];
+  onChange: (value: string | undefined) => void;
+  entitiesContext: EntitiesContextResult | null;
+  visibleFlowsContext: VisibleFlowsContextResult | undefined;
+}
+
+export const getDirectNameFromUri = (uri: string): string | undefined => {
+  if (!uri.startsWith(DIRECT_URI_PREFIX)) {
+    return undefined;
+  }
+
+  const [name] = uri.substring(DIRECT_URI_PREFIX.length).split('?');
+  const normalizedName = name.trim();
+  return normalizedName === '' ? undefined : normalizedName;
+};
+
+const getDirectNameFromEndpointDefinition = (endpointDefinition: unknown): string | undefined => {
+  if (typeof endpointDefinition === 'string') {
+    return getDirectNameFromUri(endpointDefinition);
+  }
+
+  if (!endpointDefinition || typeof endpointDefinition !== 'object' || Array.isArray(endpointDefinition)) {
+    return undefined;
+  }
+
+  const endpoint = endpointDefinition as Record<string, unknown>;
+  const uri = endpoint.uri;
+  if (typeof uri !== 'string') {
+    return undefined;
+  }
+
+  const directNameFromUri = getDirectNameFromUri(uri);
+  if (directNameFromUri) {
+    return directNameFromUri;
+  }
+
+  if (uri !== DIRECT_URI) {
+    return undefined;
+  }
+
+  const name = (endpoint.parameters as Record<string, unknown> | undefined)?.name;
+  return typeof name === 'string' && name.trim() !== '' ? name.trim() : undefined;
+};
+
+export const collectDirectEndpointNames = (value: unknown, names: Set<string>) => {
+  if (typeof value === 'string') {
+    const directName = getDirectNameFromUri(value);
+    if (directName) {
+      names.add(directName);
+    }
+    return;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectDirectEndpointNames(item, names));
+    return;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  const uri = objectValue.uri;
+
+  if (typeof uri === 'string') {
+    const directNameFromUri = getDirectNameFromUri(uri);
+    if (directNameFromUri) {
+      names.add(directNameFromUri);
+    }
+
+    if (uri === DIRECT_URI) {
+      const name = (objectValue.parameters as Record<string, unknown> | undefined)?.name;
+      if (typeof name === 'string' && name.trim() !== '') {
+        names.add(name.trim());
+      }
+    }
+  }
+
+  Object.values(objectValue).forEach((item) => collectDirectEndpointNames(item, names));
+};
+
+const getRouteIdsByDirectName = (visualEntities?: DirectEndpointEntityLike[]) => {
+  const routeIdsMap = new Map<string, string[]>();
+
+  visualEntities?.forEach((entity) => {
+    const entityDefinition = entity.toJSON() as Record<string, unknown>;
+    const routeDefinition = entityDefinition.route as Record<string, unknown> | undefined;
+    if (!routeDefinition) {
+      return;
+    }
+
+    const directName = getDirectNameFromEndpointDefinition(routeDefinition.from);
+    if (!directName) {
+      return;
+    }
+
+    const routeId = entity.getId();
+    if (!routeId) {
+      return;
+    }
+
+    const routeIds = routeIdsMap.get(directName) ?? [];
+    if (!routeIds.includes(routeId)) {
+      routeIds.push(routeId);
+      routeIdsMap.set(directName, routeIds);
+    }
+  });
+
+  return routeIdsMap;
+};
+
+export const useDirectEndpointNameOptions = ({
+  value,
+  onChange,
+  visualEntities,
+}: UseDirectEndpointNameOptionsParams) => {
+  const existingDirectNames = useMemo(() => {
+    const names = new Set<string>();
+    visualEntities?.forEach((entity) => collectDirectEndpointNames(entity.toJSON(), names));
+    return [...names].sort((first, second) => first.localeCompare(second));
+  }, [visualEntities]);
+
+  const routeIdsByDirectName = useMemo(() => getRouteIdsByDirectName(visualEntities), [visualEntities]);
+  const existingDirectRouteNames = useMemo(
+    () => [...routeIdsByDirectName.keys()].sort((first, second) => first.localeCompare(second)),
+    [routeIdsByDirectName],
+  );
+
+  const items = useMemo<TypeaheadItem<string>[]>(() => {
+    return existingDirectNames.map((name) => {
+      const routeIds = routeIdsByDirectName.get(name) ?? [];
+      return {
+        name,
+        value: name,
+        description: routeIds.length > 0 ? routeIds.join(', ') : '',
+      };
+    });
+  }, [existingDirectNames, routeIdsByDirectName]);
+
+  const selectedItem = useMemo(() => {
+    if (!value) {
+      return undefined;
+    }
+
+    return items.find((item) => item.name === value) ?? { name: value, value, description: '' };
+  }, [items, value]);
+
+  const typedName = value.trim();
+
+  const onTypeaheadChange = useCallback(
+    (item?: TypeaheadItem<string>) => {
+      onChange(item?.name?.trim() ? item.name : undefined);
+    },
+    [onChange],
+  );
+
+  const onCleanInput = useCallback(() => onChange(undefined), [onChange]);
+
+  const onCreateOption = useCallback(
+    (_value?: string, filterValue?: string) => {
+      onChange(filterValue?.trim() ? filterValue : undefined);
+    },
+    [onChange],
+  );
+
+  return {
+    existingDirectNames,
+    existingDirectRouteNames,
+    items,
+    selectedItem,
+    typedName,
+    onTypeaheadChange,
+    onCleanInput,
+    onCreateOption,
+  };
+};
+
+export const useCreateDirectRoute = ({
+  disabled,
+  typedName,
+  existingDirectRouteNames,
+  onChange,
+  entitiesContext,
+  visibleFlowsContext,
+}: UseCreateDirectRouteParams) => {
+  const canCreateRoute = !disabled && typedName !== '' && !existingDirectRouteNames.includes(typedName);
+
+  const onCreateRoute = useCallback(() => {
+    if (!entitiesContext || !canCreateRoute) {
+      return;
+    }
+
+    const routeTemplate: RouteDefinition = {
+      from: {
+        uri: DIRECT_URI,
+        parameters: { name: typedName },
+        steps: [],
+      },
+    };
+
+    const newRouteId = entitiesContext.camelResource.addNewEntity(EntityType.Route, routeTemplate);
+    visibleFlowsContext?.visualFlowsApi.toggleFlowVisible(newRouteId);
+    entitiesContext.updateEntitiesFromCamelResource();
+    onChange(typedName);
+  }, [canCreateRoute, entitiesContext, onChange, typedName, visibleFlowsContext]);
+
+  return { canCreateRoute, onCreateRoute };
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
@@ -1,0 +1,104 @@
+import { CamelYamlDsl, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { JSONSchema4 } from 'json-schema';
+
+import { CamelRouteResource } from '../../../../../models/camel/camel-route-resource';
+import { EntityType } from '../../../../../models/camel/entities';
+import { VisibleFlowsContextResult } from '../../../../../providers';
+import { TestProvidersWrapper } from '../../../../../stubs';
+import { DirectEndpointNameField } from './DirectEndpointNameField';
+
+describe('DirectEndpointNameField', () => {
+  const PROP_NAME = 'parameters.name';
+  const schema: JSONSchema4 = {
+    title: 'Name',
+    type: 'string',
+    description: 'Sets the endpoint name',
+  };
+
+  const renderField = (
+    model: string | undefined,
+    routes: RouteDefinition[],
+    visibleFlowsContext?: VisibleFlowsContextResult,
+  ) => {
+    const camelResource = new CamelRouteResource(routes as unknown as CamelYamlDsl);
+    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext,
+    });
+
+    render(
+      <Provider>
+        <SchemaProvider schema={schema}>
+          <ModelContextProvider model={model} onPropertyChange={jest.fn()}>
+            <DirectEndpointNameField propName={PROP_NAME} />
+          </ModelContextProvider>
+        </SchemaProvider>
+      </Provider>,
+    );
+
+    return { camelResource, updateEntitiesFromCamelResourceSpy };
+  };
+
+  it('renders known direct endpoint names as suggestions', () => {
+    renderField(undefined, [
+      { from: { uri: 'direct:start', steps: [] } },
+      { from: { uri: 'timer:test', steps: [{ to: { uri: 'direct:orders' } }] } },
+      { from: { uri: 'direct', parameters: { name: 'billing' }, steps: [] } },
+    ]);
+
+    const toggle = screen.getByLabelText('Name toggle');
+    fireEvent.click(toggle);
+
+    const options = screen.getAllByRole('option').map((option) => option.textContent);
+
+    expect(options.some((option) => option?.includes('billing'))).toBeTruthy();
+    expect(options.some((option) => option?.includes('orders'))).toBeTruthy();
+    expect(options.some((option) => option?.includes('start'))).toBeTruthy();
+  });
+
+  it('enables create button only for new names', async () => {
+    renderField(undefined, [{ from: { uri: 'direct:start', steps: [] } }]);
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+    const button = screen.getByRole('button', { name: 'Create Route' });
+
+    expect(button).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'start' } });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'new-endpoint' } });
+    await waitFor(() => expect(button).toBeEnabled());
+  });
+
+  it('creates a new route with direct from and typed name', async () => {
+    const toggleFlowVisibleSpy = jest.fn();
+    const visibleFlowsContext = {
+      allFlowsVisible: true,
+      visibleFlows: {},
+      visualFlowsApi: { toggleFlowVisible: toggleFlowVisibleSpy },
+    } as unknown as VisibleFlowsContextResult;
+
+    const { camelResource, updateEntitiesFromCamelResourceSpy } = renderField(
+      undefined,
+      [{ from: { uri: 'direct:start', steps: [] } }],
+      visibleFlowsContext,
+    );
+    const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+    const button = screen.getByRole('button', { name: 'Create Route' });
+
+    fireEvent.change(input, { target: { value: 'new-route' } });
+    await waitFor(() => expect(button).toBeEnabled());
+    fireEvent.click(button);
+
+    expect(addNewEntitySpy).toHaveBeenCalledWith(EntityType.Route, {
+      from: { uri: 'direct', parameters: { name: 'new-route' }, steps: [] },
+    });
+    expect(toggleFlowVisibleSpy).toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.tsx
@@ -1,0 +1,75 @@
+import { FieldProps, FieldWrapper, SchemaContext, Typeahead, useFieldValue } from '@kaoto/forms';
+import { Button, InputGroup, InputGroupItem } from '@patternfly/react-core';
+import { FunctionComponent, useContext, useEffect, useState } from 'react';
+
+import { EntitiesContext } from '../../../../../providers/entities.provider';
+import { VisibleFlowsContext } from '../../../../../providers/visible-flows.provider';
+import { useCreateDirectRoute, useDirectEndpointNameOptions } from './DirectEndpointNameField.hooks';
+
+export const DirectEndpointNameField: FunctionComponent<FieldProps> = ({ propName, required }) => {
+  const { schema } = useContext(SchemaContext);
+  const { value = '', onChange, disabled } = useFieldValue<string | undefined>(propName);
+  const entitiesContext = useContext(EntitiesContext);
+  const visibleFlowsContext = useContext(VisibleFlowsContext);
+  const [typedInputValue, setTypedInputValue] = useState(value);
+
+  useEffect(() => {
+    setTypedInputValue(value);
+  }, [value]);
+
+  const { existingDirectRouteNames, items, selectedItem, typedName, onTypeaheadChange, onCleanInput } =
+    useDirectEndpointNameOptions({
+      value,
+      onChange,
+      visualEntities: entitiesContext?.visualEntities,
+    });
+  const typedCandidateName = typedInputValue.trim() || typedName;
+  const { canCreateRoute, onCreateRoute } = useCreateDirectRoute({
+    disabled: !!disabled,
+    typedName: typedCandidateName,
+    existingDirectRouteNames,
+    onChange,
+    entitiesContext,
+    visibleFlowsContext,
+  });
+
+  return (
+    <FieldWrapper
+      propName={propName}
+      required={required}
+      title={schema.title}
+      type="string"
+      description={schema.description}
+      defaultValue={schema.default?.toString()}
+    >
+      <InputGroup>
+        <InputGroupItem isFill>
+          <Typeahead
+            aria-label={schema.title ?? propName}
+            data-testid={propName}
+            selectedItem={selectedItem}
+            items={items}
+            placeholder={schema.default?.toString()}
+            id={propName}
+            onChange={(item) => {
+              onTypeaheadChange(item);
+              setTypedInputValue(item?.name ?? '');
+            }}
+            onCleanInput={() => {
+              onCleanInput();
+              setTypedInputValue('');
+            }}
+            onInputValueChange={setTypedInputValue}
+            disabled={disabled}
+            allowCustomInput
+          />
+        </InputGroupItem>
+        <InputGroupItem>
+          <Button variant="secondary" onClick={onCreateRoute} isDisabled={!canCreateRoute}>
+            Create Route
+          </Button>
+        </InputGroupItem>
+      </InputGroup>
+    </FieldWrapper>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -1,12 +1,19 @@
 import { CustomFieldsFactory, EnumField } from '@kaoto/forms';
 
 import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
+import { DirectEndpointNameField } from './DirectEndpointNameField';
 import { ExpressionField } from './ExpressionField/ExpressionField';
 
 export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
   if (Array.isArray(schema.enum) && schema.enum.length > 0) {
     /* Workaround for https://github.com/KaotoIO/kaoto/issues/2565 since the SNMP component has the wrong type */
     return EnumField;
+  } else if (
+    schema.type === 'string' &&
+    schema.title === 'Name' &&
+    schema.description?.toLowerCase().includes('direct endpoint')
+  ) {
+    return DirectEndpointNameField;
   } else if (schema.type === 'string' && schema.format?.startsWith('bean:')) {
     return PrefixedBeanField;
   } else if (schema.type === 'string' && schema.title === 'Ref') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,9 +3180,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/forms@npm:^1.5.9":
-  version: 1.5.9
-  resolution: "@kaoto/forms@npm:1.5.9"
+"@kaoto/forms@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@kaoto/forms@npm:1.6.0"
   dependencies:
     ajv: "npm:^8.12.0"
     clsx: "npm:^2.1.0"
@@ -3194,7 +3194,7 @@ __metadata:
     "@patternfly/react-icons": 6.4.0
     react: ^18.3.1
     react-dom: ^18.3.1
-  checksum: 10/ff3234f89153d84c6b6a71da2e594d185049a09769e4c381f4ab121da12b75fc556cf80e8b3bccb6065cb35cd3eabab78be26419fede272bd8a53f0a25c718fb
+  checksum: 10/8c8b30daca3bb4b59b314805eb2c5ddb7835119370eb9e4e616bfb8da8470e930c003cd25a610bb223a3b5c48ecc9259dffc8d11a810b249ad2b77cdeac0c175
   languageName: node
   linkType: hard
 
@@ -3205,7 +3205,7 @@ __metadata:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.3.1"
-    "@kaoto/forms": "npm:^1.5.9"
+    "@kaoto/forms": "npm:^1.6.0"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.4.0"
     "@patternfly/react-code-editor": "npm:^6.4.0"
@@ -3265,7 +3265,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.3.1"
-    "@kaoto/forms": "npm:^1.5.9"
+    "@kaoto/forms": "npm:^1.6.0"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
     "@patternfly/patternfly": "npm:^6.4.0"


### PR DESCRIPTION
### Changes

Creating new routes from the `direct` component in the Canvas or to selecting existing direct endpoints from a dropdown

fixes #909 