### PR TITLE
feat(datamapper): field indicators icons added

### DIFF
--- a/packages/ui/src/assets/data-mapper/field-icons/optional-icon.svg
+++ b/packages/ui/src/assets/data-mapper/field-icons/optional-icon.svg
@@ -1,0 +1,45 @@
+<svg width="26" height="14" viewBox="0 0 26 14" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .marker-container {
+      cursor: pointer;
+      transition: all 0.2s ease-in-out;
+    }
+
+    .marker-container:hover .outline {
+      stroke-width: 1.2px;
+    }
+    
+    .marker-container:hover .label {
+      opacity: 0.7;
+    }
+  </style>
+
+  <g class="marker-container">
+    <rect 
+      class="outline"
+      x="0.5" 
+      y="0.5" 
+      width="25" 
+      height="13" 
+      rx="4" 
+      ry="4" 
+      fill="none" 
+      stroke="currentColor" 
+      stroke-width="0.8"
+    />
+    
+    <text 
+      class="label"
+      x="50%" 
+      y="55%" 
+      dominant-baseline="middle" 
+      text-anchor="middle" 
+      font-family="monospace" 
+      font-size="7.84" 
+      font-weight="700" 
+      fill="currentColor"
+    >
+      Opt
+    </text>
+  </g>
+</svg>

--- a/packages/ui/src/assets/data-mapper/field-icons/repeat0-icon.svg
+++ b/packages/ui/src/assets/data-mapper/field-icons/repeat0-icon.svg
@@ -1,0 +1,45 @@
+<svg width="26" height="14" viewBox="0 0 26 14" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .marker-container {
+      cursor: pointer;
+      transition: all 0.2s ease-in-out;
+    }
+
+    .marker-container:hover .outline {
+      stroke-width: 1.2px;
+    }
+    
+    .marker-container:hover .label {
+      opacity: 0.7;
+    }
+  </style>
+
+  <g class="marker-container">
+    <rect 
+      class="outline"
+      x="0.5" 
+      y="0.5" 
+      width="25" 
+      height="13" 
+      rx="4" 
+      ry="4" 
+      fill="none" 
+      stroke="currentColor" 
+      stroke-width="0.8"
+    />
+    
+    <text 
+      class="label"
+      x="50%" 
+      y="55%" 
+      dominant-baseline="middle" 
+      text-anchor="middle" 
+      font-family="monospace" 
+      font-size="7.84" 
+      font-weight="700" 
+      fill="currentColor"
+    >
+      0+
+    </text>
+  </g>
+</svg>

--- a/packages/ui/src/assets/data-mapper/field-icons/repeat1-icon.svg
+++ b/packages/ui/src/assets/data-mapper/field-icons/repeat1-icon.svg
@@ -1,0 +1,45 @@
+<svg width="26" height="14" viewBox="0 0 26 14" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .marker-container {
+      cursor: pointer;
+      transition: all 0.2s ease-in-out;
+    }
+
+    .marker-container:hover .outline {
+      stroke-width: 1.2px;
+    }
+    
+    .marker-container:hover .label {
+      opacity: 0.7;
+    }
+  </style>
+
+  <g class="marker-container">
+    <rect 
+      class="outline"
+      x="0.5" 
+      y="0.5" 
+      width="25" 
+      height="13" 
+      rx="4" 
+      ry="4" 
+      fill="none" 
+      stroke="currentColor" 
+      stroke-width="0.8"
+    />
+    
+    <text 
+      class="label"
+      x="50%" 
+      y="55%" 
+      dominant-baseline="middle" 
+      text-anchor="middle" 
+      font-family="monospace" 
+      font-size="7.84" 
+      font-weight="700" 
+      fill="currentColor"
+    >
+      1+
+    </text>
+  </g>
+</svg>

--- a/packages/ui/src/components/Document/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle.scss
@@ -19,6 +19,10 @@
   }
 }
 
-span.required-information {
-  color: #b1380b;
+div.node-title-container {
+  display: flex;
+}
+
+img.datamapper-marker-field {
+  margin: 2px;
 }

--- a/packages/ui/src/components/Document/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.test.tsx
@@ -144,20 +144,7 @@ describe('NodeTitle', () => {
     });
   });
 
-  it('should display an asterisk when the field information is required', async () => {
-    const shipOrderDoc = TestUtil.createSourceOrderDoc();
-    const documentNodeData = new DocumentNodeData(shipOrderDoc);
-    const mockField = createMockField();
-    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
-    fieldNodeData.field.minOccurs = 1;
-
-    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
-
-    const element = screen.getByText('*');
-    expect(element).toBeVisible();
-  });
-
-  it('should not display an asterisk when the field information is optional', async () => {
+  it('should display an optional icon when the field information is optional', async () => {
     const shipOrderDoc = TestUtil.createSourceOrderDoc();
     const documentNodeData = new DocumentNodeData(shipOrderDoc);
     const mockField = createMockField();
@@ -166,8 +153,36 @@ describe('NodeTitle', () => {
 
     render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
 
-    const element = screen.queryByText('*');
-    expect(element).not.toBeInTheDocument();
+    const element = screen.getByAltText('Optional');
+    expect(element).toBeVisible();
+  });
+
+  it('should display an repeat 0+ icon when the field information can be repeated 0+ times', async () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const mockField = createMockField();
+    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
+    fieldNodeData.field.minOccurs = 0;
+    fieldNodeData.field.maxOccurs = 'unbounded';
+
+    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
+
+    const element = screen.getByAltText('Repeat0');
+    expect(element).toBeVisible();
+  });
+
+  it('should display an repeat 1+ icon when the field information can be repeated 1+ times', async () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const mockField = createMockField();
+    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
+    fieldNodeData.field.minOccurs = 1;
+    fieldNodeData.field.maxOccurs = 'unbounded';
+
+    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
+
+    const element = screen.getByAltText('Repeat1');
+    expect(element).toBeVisible();
   });
 
   it('should not display popover for MappingNodeData', async () => {

--- a/packages/ui/src/components/Document/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.tsx
@@ -4,6 +4,9 @@ import { Label, Popover, Title } from '@patternfly/react-core';
 import clsx from 'clsx';
 import { FunctionComponent } from 'react';
 
+import optionalIcon from '../../assets/data-mapper/field-icons/optional-icon.svg';
+import repeat0Icon from '../../assets/data-mapper/field-icons/repeat0-icon.svg';
+import repeat1Icon from '../../assets/data-mapper/field-icons/repeat1-icon.svg';
 import {
   AddMappingNodeData,
   FieldItemNodeData,
@@ -41,12 +44,9 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, node
     nodeData instanceof FieldItemNodeData ||
     nodeData instanceof AddMappingNodeData
   ) {
-    const requiredField = nodeData.field.minOccurs !== 0;
-    const updatedContent = (
-      <span className={clsx('node-title__text', className)} data-rank={rank}>
-        {title} {requiredField && <span className="required-information">*</span>}
-      </span>
-    );
+    const optionalField = nodeData.field.minOccurs === 0;
+    const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
+    const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
 
     return (
       <Popover
@@ -66,7 +66,18 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, node
           </div>
         }
       >
-        {updatedContent}
+        <div className="node-title-container">
+          <span className={clsx('node-title__text', className)} data-rank={rank}>
+            {title}
+          </span>
+          {optionalField && !repeatingField0 && (
+            <img className="datamapper-marker-field" src={optionalIcon} alt="Optional" />
+          )}
+          {repeatingField0 && !repeatingField1 && (
+            <img className="datamapper-marker-field" src={repeat0Icon} alt="Repeat0" />
+          )}
+          {repeatingField1 && <img className="datamapper-marker-field" src={repeat1Icon} alt="Repeat1" />}
+        </div>
       </Popover>
     );
   }


### PR DESCRIPTION
Added new icons and new field indicators for optional and repeatable (minOccurs >= 0 || minOccurs >= 1)

<img width="400" height="683" alt="image" src="https://github.com/user-attachments/assets/aeef9e98-5d74-4ada-9189-20bd496d99f4" />

Deleted field indicators for required.


fix: #2359 