### PR TITLE
feat(DataMapper): Multiple schema files support: add removeSchemaFile…

### DIFF
--- a/packages/ui/src/components/Document/ParameterInputPlaceholder.test.tsx
+++ b/packages/ui/src/components/Document/ParameterInputPlaceholder.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { useDataMapper } from '../../hooks/useDataMapper';
+import { DataMapperProvider } from '../../providers/datamapper.provider';
+import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
+import { DocumentService } from '../../services/document.service';
+import { ParameterInputPlaceholder } from './ParameterInputPlaceholder';
+
+describe('ParameterInputPlaceholder', () => {
+  let mockSendAlert: jest.Mock;
+  let mockOnComplete: jest.Mock;
+  let mockCreatePrimitiveDocument: jest.SpyInstance;
+
+  const AlertCapture: FunctionComponent<PropsWithChildren> = ({ children }) => {
+    const dataMapper = useDataMapper();
+    dataMapper.sendAlert = mockSendAlert;
+    return <>{children}</>;
+  };
+
+  beforeEach(() => {
+    mockSendAlert = jest.fn();
+    mockOnComplete = jest.fn();
+  });
+
+  afterEach(() => {
+    mockCreatePrimitiveDocument?.mockRestore();
+  });
+
+  function renderAndSubmit() {
+    render(
+      <DataMapperProvider>
+        <DataMapperCanvasProvider>
+          <AlertCapture>
+            <ParameterInputPlaceholder onComplete={mockOnComplete} />
+          </AlertCapture>
+        </DataMapperCanvasProvider>
+      </DataMapperProvider>,
+    );
+
+    const paramNameInput = screen.getByTestId('new-parameter-name-input');
+    act(() => {
+      fireEvent.change(paramNameInput, { target: { value: 'testparam' } });
+    });
+
+    const submitButton = screen.getByTestId('new-parameter-submit-btn');
+    act(() => {
+      fireEvent.click(submitButton);
+    });
+  }
+
+  it('should send error alert when createPrimitiveDocument returns error', () => {
+    mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
+    mockCreatePrimitiveDocument.mockReturnValue({
+      validationStatus: 'error',
+      errors: ['Failed to create primitive document'],
+    });
+
+    renderAndSubmit();
+
+    expect(mockSendAlert).toHaveBeenCalledWith({
+      variant: 'danger',
+      title: 'Failed to create primitive document',
+    });
+    expect(mockOnComplete).toHaveBeenCalled();
+  });
+
+  it('should send warning alert when createPrimitiveDocument returns warning', () => {
+    mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
+    mockCreatePrimitiveDocument.mockReturnValue({
+      validationStatus: 'warning',
+      warnings: ['Warning during document creation'],
+    });
+
+    renderAndSubmit();
+
+    expect(mockSendAlert).toHaveBeenCalledWith({
+      variant: 'warning',
+      title: 'Warning during document creation',
+    });
+    expect(mockOnComplete).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Document/ParameterInputPlaceholder.tsx
+++ b/packages/ui/src/components/Document/ParameterInputPlaceholder.tsx
@@ -40,7 +40,8 @@ export const ParameterInputPlaceholder: FunctionComponent<ParameterInputPlacehol
 
       if (result.validationStatus !== 'success') {
         const variant = result.validationStatus === 'warning' ? AlertVariant.warning : AlertVariant.danger;
-        sendAlert({ variant: variant, title: result.validationMessage });
+        const messages = result.errors ?? result.warnings ?? [];
+        sendAlert({ variant: variant, title: messages.join('; ') });
       } else if (!result.documentDefinition || !result.document) {
         sendAlert({ variant: AlertVariant.danger, title: 'Could not create a parameter' });
       } else {

--- a/packages/ui/src/components/Document/actions/AttachSchemaButton.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchemaButton.tsx
@@ -119,22 +119,25 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
         if (!DataMapperStepService.supportsJsonBody()) {
           setCreateDocumentResult({
             validationStatus: 'error',
-            validationMessage:
+            errors: [
               'JSON source body is not supported. The xslt-saxon component requires the useJsonBody parameter which is not available in this Camel version. Please use parameter for JSON source.',
+            ],
           });
           return;
         }
       } else if (!['.xml', '.xsd'].includes(fileExtension)) {
         setCreateDocumentResult({
           validationStatus: 'error',
-          validationMessage: `Unknown file extension '${fileExtension}'. Only XML schema file (.xml, .xsd) is supported.`,
+          errors: [`Unknown file extension '${fileExtension}'. Only XML schema file (.xml, .xsd) is supported.`],
         });
         return;
       }
     } else if (!['.json', '.xsd', '.xml'].includes(fileExtension)) {
       setCreateDocumentResult({
         validationStatus: 'error',
-        validationMessage: `Unknown file extension '${fileExtension}'. Either XML schema (.xsd, .xml) or JSON schema (.json) file is supported.`,
+        errors: [
+          `Unknown file extension '${fileExtension}'. Either XML schema (.xsd, .xml) or JSON schema (.json) file is supported.`,
+        ],
       });
       return;
     }
@@ -167,7 +170,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
 
   const onCommit = useCallback(async () => {
     if (!createDocumentResult?.document || !createDocumentResult.documentDefinition) {
-      setCreateDocumentResult({ validationStatus: 'error', validationMessage: 'Please select a schema file first' });
+      setCreateDocumentResult({ validationStatus: 'error', errors: ['Please select a schema file first'] });
       return;
     }
 
@@ -179,7 +182,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (error: any) {
       const cause = error['message'] ? ': ' + error['message'] : '';
-      setCreateDocumentResult({ validationStatus: 'error', validationMessage: `Cannot attach the schema ${cause}` });
+      setCreateDocumentResult({ validationStatus: 'error', errors: [`Cannot attach the schema ${cause}`] });
     } finally {
       setIsLoading(false);
     }
@@ -224,6 +227,10 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
       filePaths.length > 0 && createDocumentResult?.validationStatus === 'success' && createDocumentResult?.document
     );
   }, [filePaths.length, createDocumentResult]);
+
+  const validationMessage = useMemo(() => {
+    return (createDocumentResult?.errors ?? createDocumentResult?.warnings ?? []).join('; ');
+  }, [createDocumentResult]);
 
   return (
     <>
@@ -273,7 +280,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
                       data-testid="attach-schema-modal-text-helper"
                       variant={createDocumentResult.validationStatus}
                     >
-                      {createDocumentResult.validationMessage}
+                      {validationMessage}
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
@@ -168,7 +168,7 @@ describe('DetachSchemaButton', () => {
     const mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
     mockCreatePrimitiveDocument.mockReturnValue({
       validationStatus: 'error',
-      validationMessage: 'Failed to create primitive document',
+      errors: ['Failed to create primitive document'],
     });
 
     const mockSendAlert = jest.fn();
@@ -216,7 +216,7 @@ describe('DetachSchemaButton', () => {
     const mockCreatePrimitiveDocument = jest.spyOn(DocumentService, 'createPrimitiveDocument');
     mockCreatePrimitiveDocument.mockReturnValue({
       validationStatus: 'warning',
-      validationMessage: 'Warning during document creation',
+      warnings: ['Warning during document creation'],
     });
 
     const mockSendAlert = jest.fn();

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.tsx
@@ -44,7 +44,8 @@ export const DetachSchemaButton: FunctionComponent<DeleteSchemaProps> = ({
 
     if (result.validationStatus !== 'success') {
       const variant = result.validationStatus === 'warning' ? AlertVariant.warning : AlertVariant.danger;
-      sendAlert({ variant: variant, title: result.validationMessage });
+      const messages = result.errors ?? result.warnings ?? [];
+      sendAlert({ variant: variant, title: messages.join('; ') });
     } else if (!result.documentDefinition || !result.document) {
       sendAlert({ variant: AlertVariant.danger, title: 'Could not detach schema' });
     } else {

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -359,7 +359,8 @@ export type RootElementOption = {
  */
 export interface CreateDocumentResult {
   validationStatus: 'success' | 'warning' | 'error';
-  validationMessage?: string;
+  errors?: string[];
+  warnings?: string[];
   documentDefinition?: DocumentDefinition;
   document?: IDocument;
   rootElementOptions?: RootElementOption[];

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -250,7 +250,7 @@ describe('DataMapperMetadataService', () => {
 
       const docResult = JsonSchemaDocumentService.createJsonSchemaDocument(result.sourceBody);
       if (docResult.validationStatus !== 'success') {
-        throw new Error(`Validation failed: ${docResult.validationMessage}`);
+        throw new Error(`Validation failed: ${docResult.errors?.join('; ')}`);
       }
       const root = docResult.document!.fields[0];
       const customerId = root.fields.find((f) => f.key === 'customerId');

--- a/packages/ui/src/services/document.service.ts
+++ b/packages/ui/src/services/document.service.ts
@@ -64,14 +64,14 @@ export class DocumentService {
         schemaFilePaths,
       );
       if (!documentDefinition) {
-        return { validationStatus: 'error', validationMessage: 'Could not read schema file(s)' };
+        return { validationStatus: 'error', errors: ['Could not read schema file(s)'] };
       }
 
       return DocumentService.doCreateDocumentFromDefinition(documentDefinition);
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (error: any) {
       const errorMessage = error?.message || 'Unknown validation error';
-      return { validationStatus: 'error', validationMessage: errorMessage };
+      return { validationStatus: 'error', errors: [errorMessage] };
     }
   }
 
@@ -119,7 +119,6 @@ export class DocumentService {
         const document = new PrimitiveDocument(definition);
         return {
           validationStatus: 'success',
-          validationMessage: 'Schema validation successful',
           documentDefinition: definition,
           document,
           rootElementOptions: [],
@@ -132,7 +131,30 @@ export class DocumentService {
       default:
         return {
           validationStatus: 'error',
-          validationMessage: `Unsupported definition type: ${definition.definitionType}`,
+          errors: [`Unsupported definition type: ${definition.definitionType}`],
+        };
+    }
+  }
+
+  /**
+   * Removes a schema file from the definition and re-creates the document with updated analysis.
+   * Delegates to {@link XmlSchemaDocumentService.removeSchemaFile} or
+   * {@link JsonSchemaDocumentService.removeSchemaFile} based on the definition type.
+   *
+   * @param definition - The current document definition containing schema files
+   * @param filePath - The key of the schema file to remove from {@link DocumentDefinition.definitionFiles}
+   * @returns A {@link CreateDocumentResult} with updated validation status, errors/warnings, and definition
+   */
+  static removeSchemaFile(definition: DocumentDefinition, filePath: string): CreateDocumentResult {
+    switch (definition.definitionType) {
+      case DocumentDefinitionType.XML_SCHEMA:
+        return XmlSchemaDocumentService.removeSchemaFile(definition, filePath);
+      case DocumentDefinitionType.JSON_SCHEMA:
+        return JsonSchemaDocumentService.removeSchemaFile(definition, filePath);
+      default:
+        return {
+          validationStatus: 'error',
+          errors: [`removeSchemaFile is not supported for definition type: ${definition.definitionType}`],
         };
     }
   }

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -174,7 +174,7 @@ export class TestUtil {
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
-      throw new Error(result.validationMessage || 'Failed to create document');
+      throw new Error(result.errors?.join('; ') || 'Failed to create document');
     }
     return result.document;
   }
@@ -190,7 +190,7 @@ export class TestUtil {
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
-      throw new Error(result.validationMessage || 'Failed to create document');
+      throw new Error(result.errors?.join('; ') || 'Failed to create document');
     }
     return result.document;
   }
@@ -206,7 +206,7 @@ export class TestUtil {
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
-      throw new Error(result.validationMessage || 'Failed to create document');
+      throw new Error(result.errors?.join('; ') || 'Failed to create document');
     }
     return result.document;
   }
@@ -222,7 +222,7 @@ export class TestUtil {
     );
     const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
     if (result.validationStatus !== 'success' || !result.document) {
-      throw new Error(result.validationMessage || 'Failed to create document');
+      throw new Error(result.errors?.join('; ') || 'Failed to create document');
     }
     return result.document;
   }


### PR DESCRIPTION
…s API and clean up errors/warnings propagation

Fixes: https://github.com/KaotoIO/kaoto/issues/2946

 - Add `removeSchemaFile()` API to `XmlSchemaDocumentService`, `JsonSchemaDocumentService`, and `DocumentService` — clones the definition, removes the file, and re-runs full analysis
 - Replace `validationMessage: string` with structured `errors: string[]` and `warnings: string[]` arrays in CreateDocumentResult, allowing to hold multiple errors and warnings, as well as giving consumers (i.e. UI components) full control over how to display validation diagnostics
 - Surface `analysis.warnings` in `XmlSchemaDocumentService` (previously only errors were returned; warnings like circular xs:import were silently dropped)
 - Always include warnings alongside errors in both XML and JSON schema services, even when the status is error, so the UI gets the complete picture
 - Always return documentDefinition in error paths, so callers can continue working with the definition