### PR TITLE
chore(DataMapper): xs:choice: Model update

### DIFF
--- a/packages/ui/src/models/datamapper/document.test.ts
+++ b/packages/ui/src/models/datamapper/document.test.ts
@@ -1,0 +1,84 @@
+import { XmlSchemaDocument, XmlSchemaField } from '../../services/xml-schema-document.model';
+import { XmlSchemaCollection } from '../../xml-schema-ts';
+import { BaseField, DocumentDefinition, DocumentDefinitionType, DocumentType } from './document';
+
+describe('BaseField.adopt()', () => {
+  const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'doc');
+  const collection = new XmlSchemaCollection();
+  const doc = new XmlSchemaDocument(definition, collection);
+
+  it('should copy choice metadata when creating a new adopted field', () => {
+    const parent = new XmlSchemaField(doc, 'root', false);
+    doc.fields.push(parent);
+
+    const field = new BaseField(parent, doc, 'child');
+    field.isChoice = true;
+    field.choiceMembers = [];
+    field.selectedMemberIndex = 1;
+
+    const adopted = field.adopt(parent);
+
+    expect(adopted.isChoice).toBe(true);
+    expect(adopted.choiceMembers).toEqual([]);
+    expect(adopted.selectedMemberIndex).toBe(1);
+  });
+
+  it('should merge choice metadata into an existing identical field', () => {
+    const parent = new XmlSchemaField(doc, 'parent', false);
+    doc.fields.push(parent);
+
+    const first = new BaseField(parent, doc, 'same');
+    first.adopt(parent);
+
+    const second = new BaseField(parent, doc, 'same');
+    second.isChoice = true;
+    second.choiceMembers = [];
+    second.selectedMemberIndex = 2;
+
+    const merged = second.adopt(parent);
+
+    expect(merged.isChoice).toBe(true);
+    expect(merged.choiceMembers).toEqual([]);
+    expect(merged.selectedMemberIndex).toBe(2);
+  });
+
+  it('should leave choice metadata untouched when source has none', () => {
+    const parent = new XmlSchemaField(doc, 'parent2', false);
+    doc.fields.push(parent);
+
+    const first = new BaseField(parent, doc, 'noChoice');
+    first.isChoice = true;
+    first.choiceMembers = [];
+    first.selectedMemberIndex = 0;
+    first.adopt(parent);
+
+    const second = new BaseField(parent, doc, 'noChoice');
+    const merged = second.adopt(parent);
+
+    expect(merged.isChoice).toBe(true);
+    expect(merged.choiceMembers).toEqual([]);
+    expect(merged.selectedMemberIndex).toBe(0);
+  });
+});
+
+describe('XmlSchemaField.adopt()', () => {
+  const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'doc');
+  const collection = new XmlSchemaCollection();
+  const doc = new XmlSchemaDocument(definition, collection);
+
+  it('should copy choice metadata when adopting into a new field', () => {
+    const parent = new XmlSchemaField(doc, 'root', false);
+    doc.fields.push(parent);
+
+    const field = new XmlSchemaField(parent, 'element', false);
+    field.isChoice = true;
+    field.choiceMembers = [];
+    field.selectedMemberIndex = 1;
+
+    const adopted = field.adopt(parent);
+
+    expect(adopted.isChoice).toBe(true);
+    expect(adopted.choiceMembers).toEqual([]);
+    expect(adopted.selectedMemberIndex).toBe(1);
+  });
+});

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -484,7 +484,7 @@ export class JsonSchemaField extends BaseField {
     return created;
   }
 
-  adopt(parent: IField): BaseField {
+  adopt(parent: IField): IField {
     if (!(parent instanceof JsonSchemaField)) return super.adopt(parent);
 
     const existing = parent.fields.find((f) => f.isIdentical(this));
@@ -506,6 +506,9 @@ export class JsonSchemaField extends BaseField {
     for (const ref of this.namedTypeFragmentRefs) {
       !existing.namedTypeFragmentRefs.includes(ref) && existing.namedTypeFragmentRefs.push(ref);
     }
+    if (this.isChoice !== undefined) existing.isChoice = this.isChoice;
+    if (this.choiceMembers !== undefined) existing.choiceMembers = this.choiceMembers;
+    if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
     for (const child of this.fields) child.adopt(existing);
     return existing;
   }
@@ -521,6 +524,9 @@ export class JsonSchemaField extends BaseField {
     to.originalTypeQName = this.originalTypeQName;
     to.typeOverride = this.typeOverride;
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
+    to.isChoice = this.isChoice;
+    to.choiceMembers = this.choiceMembers;
+    to.selectedMemberIndex = this.selectedMemberIndex;
     to.fields = this.fields.map((child) => child.adopt(to) as JsonSchemaField);
     return to;
   }

--- a/packages/ui/src/services/xml-schema-document.model.ts
+++ b/packages/ui/src/services/xml-schema-document.model.ts
@@ -93,6 +93,9 @@ export class XmlSchemaField extends BaseField {
     adopted.namespacePrefix = this.namespacePrefix;
     adopted.namespaceURI = this.namespaceURI;
     adopted.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
+    adopted.isChoice = this.isChoice;
+    adopted.choiceMembers = this.choiceMembers;
+    adopted.selectedMemberIndex = this.selectedMemberIndex;
     adopted.fields = this.fields.map((child) => child.adopt(adopted) as XmlSchemaField);
     parent.fields.push(adopted);
     parent.ownerDocument.totalFieldCount++;


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2729

Had a 2nd thought on splitting `IField` interface and couldn't find much benefit for that. Added choice related properties directly to the `IField` instead.