### PR TITLE
fix(DataMapper): Field type icon not shown on target field when it ha…

### DIFF
--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -7,6 +7,7 @@ import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import {
   AddMappingNodeData,
+  FieldItemNodeData,
   NodeReference,
   TargetDocumentNodeData,
   TargetNodeData,
@@ -37,6 +38,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
 
   const isExpanded = useDocumentTreeStore((state) => state.isExpanded(documentId, treeNode.path));
   const nodeData = treeNode.nodeData;
+  const iconType = nodeData instanceof FieldItemNodeData ? nodeData.field.type : nodeData.type;
 
   const isDocument = VisualizationService.isDocumentNode(nodeData);
   const isPrimitive = VisualizationService.isPrimitiveDocumentNode(nodeData);
@@ -101,7 +103,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
               isExpanded={isExpanded}
               onExpandChange={handleClickToggle}
               isDraggable={isDraggable}
-              iconType={nodeData.type}
+              iconType={iconType}
               isCollectionField={isCollectionField}
               isAttributeField={isAttributeField}
               title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}

--- a/packages/ui/src/components/Document/actions/XPathInputAction.scss
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.scss
@@ -1,5 +1,6 @@
 .input-group {
   flex-grow: 1;
+  margin-left: var(--pf-t--global--spacer--md);
 
   &__text {
     width: 100%;


### PR DESCRIPTION
…s a mapping

fixes https://github.com/KaotoIO/kaoto/issues/2940

Before:

<img width="1149" height="76" alt="Screenshot From 2026-02-12 13-42-47" src="https://github.com/user-attachments/assets/f6611cff-102f-4502-9a7a-bd9298e9f849" />


After:

<img width="1149" height="76" alt="Screenshot From 2026-02-12 13-34-51" src="https://github.com/user-attachments/assets/b1dd522c-54b6-4277-91b0-fdfb5183c5a6" />
