### PR TITLE
chore(DataMapper): xs:choice: Metadata update

### DIFF
--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -58,6 +58,39 @@ export interface IDocumentMetadata {
    * Allows customization of field types beyond their schema-defined types.
    */
   fieldTypeOverrides?: IFieldTypeOverride[];
+
+  /**
+   * Array of user selections for xs:choice fields in the document.
+   * Persists which choice member is selected for each choice field.
+   */
+  choiceSelections?: IChoiceSelection[];
+}
+
+/**
+ * Represents a user selection for an xs:choice field in a document.
+ */
+export interface IChoiceSelection {
+  /**
+   * Path to the choice field in the document structure.
+   * Uses element XPath segments for elements and `{choice:N}` segments
+   * (0-based index) for choice compositors.
+   *
+   * The `{choice:N}` syntax is intentionally distinct from XPath to avoid
+   * ambiguity with XPath predicates. Therefore, `choicePath` is not directly
+   * parseable as XPath expression.
+   *
+   * Examples:
+   * - `/ns0:Root/{choice:0}` — single choice under Root
+   * - `/ns0:Root/{choice:0}` and `/ns0:Root/{choice:1}` — sibling choices
+   * - `/ns0:Root/{choice:0}/ns0:Option1/{choice:0}` — choice nested via element
+   * - `/ns0:Root/{choice:0}/{choice:0}` — choice directly nested in choice
+   */
+  choicePath: string;
+
+  /**
+   * The 0-based index of the selected choice member.
+   */
+  selectedMemberIndex: number;
 }
 
 /**

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -5,7 +5,12 @@ import {
   DocumentInitializationModel,
   DocumentType,
 } from '../models/datamapper';
-import { IDataMapperMetadata, IDocumentMetadata, IFieldTypeOverride } from '../models/datamapper/metadata';
+import {
+  IChoiceSelection,
+  IDataMapperMetadata,
+  IDocumentMetadata,
+  IFieldTypeOverride,
+} from '../models/datamapper/metadata';
 import { IMetadataApi } from '../providers';
 import { EMPTY_XSL } from './mapping-serializer.service';
 
@@ -431,6 +436,50 @@ export class DataMapperMetadataService {
   ): IFieldTypeOverride[] {
     const docMetadata = this.getDocumentMetadata(metadata, documentType, paramName);
     return docMetadata?.fieldTypeOverrides || [];
+  }
+
+  /**
+   * Sets the choice selections for the specified document.
+   * Replaces the entire choice selections array and persists the metadata.
+   * @param api The metadata API
+   * @param metadataId The metadata identifier
+   * @param metadata The DataMapper metadata
+   * @param documentType The document type (SOURCE_BODY, TARGET_BODY, or PARAM)
+   * @param paramName The parameter name (required when documentType is PARAM)
+   * @param selections The complete array of choice selections to set
+   */
+  static async setChoiceSelections(
+    api: IMetadataApi,
+    metadataId: string,
+    metadata: IDataMapperMetadata,
+    documentType: DocumentType,
+    paramName: string | undefined,
+    selections: IChoiceSelection[],
+  ) {
+    const docMetadata = this.getDocumentMetadata(metadata, documentType, paramName);
+    if (!docMetadata) {
+      return;
+    }
+
+    docMetadata.choiceSelections = selections;
+
+    await api.setMetadata(metadataId, metadata);
+  }
+
+  /**
+   * Gets the choice selections for the specified document.
+   * @param metadata The DataMapper metadata
+   * @param documentType The document type (SOURCE_BODY, TARGET_BODY, or PARAM)
+   * @param paramName The parameter name (required when documentType is PARAM)
+   * @returns The array of choice selections, or an empty array if none exist
+   */
+  static getChoiceSelections(
+    metadata: IDataMapperMetadata,
+    documentType: DocumentType,
+    paramName?: string,
+  ): IChoiceSelection[] {
+    const docMetadata = this.getDocumentMetadata(metadata, documentType, paramName);
+    return docMetadata?.choiceSelections || [];
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2811

- Added `choiceSelections?: IChoiceSelection[]` on `IDocumentMetadata`
- Added `getChoiceSelections()` and `setChoiceSelections()` on `DataMapperMetadataService`