### PR TITLE
feat(Rest): Import OpenAPI Spec

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -117,6 +117,7 @@
     "@types/json-schema": "^7.0.15",
     "@types/lodash": "^4",
     "@types/node": "^22.0.0",
+    "@types/openapi-v3": "^3.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^10.0.0",

--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -25,6 +25,16 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
         ],
       },
       {
+        title: 'Rest DSL',
+        hidden: () => !NAVIGATION_ELEMENTS.RestDsl.includes(currentSchemaType),
+        children: [
+          {
+            title: 'Import',
+            to: Links.RestImport,
+          },
+        ],
+      },
+      {
         title: 'Beans',
         to: Links.Beans,
         hidden: () => !NAVIGATION_ELEMENTS.Beans.includes(currentSchemaType),
@@ -112,6 +122,7 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
 
 const NAVIGATION_ELEMENTS = {
   Beans: [SourceSchemaType.Route, SourceSchemaType.Kamelet],
+  RestDsl: [SourceSchemaType.Route, SourceSchemaType.Integration],
   Metadata: [
     SourceSchemaType.Integration,
     SourceSchemaType.Kamelet,

--- a/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
+++ b/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
         >
           <li
             class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
-            data-ouia-component-id="OUIA-Generated-NavExpandable-5"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-9"
             data-ouia-component-type="PF6/NavExpandable"
             data-ouia-safe="true"
             data-testid="Visualization"
@@ -66,7 +66,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-29"
+                  data-ouia-component-id="OUIA-Generated-NavItem-33"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -81,7 +81,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-30"
+                  data-ouia-component-id="OUIA-Generated-NavItem-34"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -97,8 +97,68 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
             </section>
           </li>
           <li
+            class="pf-v6-c-nav__item pf-m-expanded"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-10"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Rest DSL"
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Rest DSL"
+            >
+              Rest DSL
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Rest DSL"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-35"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Import"
+                    href="/rest/import"
+                  >
+                    Import
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-31"
+            data-ouia-component-id="OUIA-Generated-NavItem-36"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -112,7 +172,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-32"
+            data-ouia-component-id="OUIA-Generated-NavItem-37"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -126,7 +186,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-33"
+            data-ouia-component-id="OUIA-Generated-NavItem-38"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -140,7 +200,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-34"
+            data-ouia-component-id="OUIA-Generated-NavItem-39"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -154,7 +214,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-35"
+            data-ouia-component-id="OUIA-Generated-NavItem-40"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -187,352 +247,6 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
         aria-label="Default global nav"
         class="pf-v6-c-nav"
         data-ouia-component-id="OUIA-Generated-Nav-2"
-        data-ouia-component-type="PF6/Nav"
-        data-ouia-safe="true"
-      >
-        <ul
-          class="pf-v6-c-nav__list"
-          role="list"
-        >
-          <li
-            class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
-            data-ouia-component-id="OUIA-Generated-NavExpandable-2"
-            data-ouia-component-type="PF6/NavExpandable"
-            data-ouia-safe="true"
-            data-testid="Visualization"
-          >
-            <button
-              aria-expanded="true"
-              class="pf-v6-c-nav__link"
-              id="Visualization"
-            >
-              Visualization
-              <span
-                class="pf-v6-c-nav__toggle"
-              >
-                <span
-                  class="pf-v6-c-nav__toggle-icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </button>
-            <section
-              aria-labelledby="Visualization"
-              class="pf-v6-c-nav__subnav"
-            >
-              <ul
-                class="pf-v6-c-nav__list"
-                role="list"
-              >
-                <li
-                  class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-8"
-                  data-ouia-component-type="PF6/NavItem"
-                  data-ouia-safe="true"
-                >
-                  <a
-                    aria-current="page"
-                    class="pf-v6-c-nav__link pf-m-current"
-                    data-testid="Design"
-                    href="/"
-                  >
-                    Design
-                  </a>
-                </li>
-                <li
-                  class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-9"
-                  data-ouia-component-type="PF6/NavItem"
-                  data-ouia-safe="true"
-                >
-                  <a
-                    class="pf-v6-c-nav__link"
-                    data-testid="Source Code"
-                    href="/code"
-                  >
-                    Source Code
-                  </a>
-                </li>
-              </ul>
-            </section>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-10"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Beans"
-              href="/beans"
-            >
-              Beans
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-11"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Metadata"
-              href="/metadata"
-            >
-              Metadata
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-12"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Pipe ErrorHandler"
-              href="/pipe-error-handler"
-            >
-              Pipe ErrorHandler
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-13"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="DataMapper"
-              href="/datamapper"
-            >
-              DataMapper
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-14"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Catalog"
-              href="/catalog"
-            >
-              Catalog
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
-<DocumentFragment>
-  <div
-    aria-hidden="false"
-    class="pf-v6-c-page__sidebar pf-m-expanded"
-    id="vertical-sidebar"
-  >
-    <div
-      class="pf-v6-c-page__sidebar-body"
-    >
-      <nav
-        aria-label="Default global nav"
-        class="pf-v6-c-nav"
-        data-ouia-component-id="OUIA-Generated-Nav-4"
-        data-ouia-component-type="PF6/Nav"
-        data-ouia-safe="true"
-      >
-        <ul
-          class="pf-v6-c-nav__list"
-          role="list"
-        >
-          <li
-            class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
-            data-ouia-component-id="OUIA-Generated-NavExpandable-4"
-            data-ouia-component-type="PF6/NavExpandable"
-            data-ouia-safe="true"
-            data-testid="Visualization"
-          >
-            <button
-              aria-expanded="true"
-              class="pf-v6-c-nav__link"
-              id="Visualization"
-            >
-              Visualization
-              <span
-                class="pf-v6-c-nav__toggle"
-              >
-                <span
-                  class="pf-v6-c-nav__toggle-icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </button>
-            <section
-              aria-labelledby="Visualization"
-              class="pf-v6-c-nav__subnav"
-            >
-              <ul
-                class="pf-v6-c-nav__list"
-                role="list"
-              >
-                <li
-                  class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-22"
-                  data-ouia-component-type="PF6/NavItem"
-                  data-ouia-safe="true"
-                >
-                  <a
-                    aria-current="page"
-                    class="pf-v6-c-nav__link pf-m-current"
-                    data-testid="Design"
-                    href="/"
-                  >
-                    Design
-                  </a>
-                </li>
-                <li
-                  class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-23"
-                  data-ouia-component-type="PF6/NavItem"
-                  data-ouia-safe="true"
-                >
-                  <a
-                    class="pf-v6-c-nav__link"
-                    data-testid="Source Code"
-                    href="/code"
-                  >
-                    Source Code
-                  </a>
-                </li>
-              </ul>
-            </section>
-          </li>
-          <li
-            class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-24"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Beans"
-              href="/beans"
-            >
-              Beans
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-25"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Metadata"
-              href="/metadata"
-            >
-              Metadata
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-26"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Pipe ErrorHandler"
-              href="/pipe-error-handler"
-            >
-              Pipe ErrorHandler
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-27"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="DataMapper"
-              href="/datamapper"
-            >
-              DataMapper
-            </a>
-          </li>
-          <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-28"
-            data-ouia-component-type="PF6/NavItem"
-            data-ouia-safe="true"
-          >
-            <a
-              class="pf-v6-c-nav__link"
-              data-testid="Catalog"
-              href="/catalog"
-            >
-              Catalog
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
-<DocumentFragment>
-  <div
-    aria-hidden="false"
-    class="pf-v6-c-page__sidebar pf-m-expanded"
-    id="vertical-sidebar"
-  >
-    <div
-      class="pf-v6-c-page__sidebar-body"
-    >
-      <nav
-        aria-label="Default global nav"
-        class="pf-v6-c-nav"
-        data-ouia-component-id="OUIA-Generated-Nav-3"
         data-ouia-component-type="PF6/Nav"
         data-ouia-safe="true"
       >
@@ -585,7 +299,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-15"
+                  data-ouia-component-id="OUIA-Generated-NavItem-9"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -600,7 +314,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-16"
+                  data-ouia-component-id="OUIA-Generated-NavItem-10"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -616,8 +330,69 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
             </section>
           </li>
           <li
-            class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-17"
+            class="pf-v6-c-nav__item pf-m-expanded pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-4"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Rest DSL"
+            hidden=""
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Rest DSL"
+            >
+              Rest DSL
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Rest DSL"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-11"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Import"
+                    href="/rest/import"
+                  >
+                    Import
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-12"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -631,7 +406,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-18"
+            data-ouia-component-id="OUIA-Generated-NavItem-13"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -644,8 +419,8 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
             </a>
           </li>
           <li
-            class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-19"
+            class="pf-v6-c-nav__item pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavItem-14"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -658,8 +433,8 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
             </a>
           </li>
           <li
-            class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-20"
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-15"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -673,7 +448,475 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-16"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Catalog"
+              href="/catalog"
+            >
+              Catalog
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
+<DocumentFragment>
+  <div
+    aria-hidden="false"
+    class="pf-v6-c-page__sidebar pf-m-expanded"
+    id="vertical-sidebar"
+  >
+    <div
+      class="pf-v6-c-page__sidebar-body"
+    >
+      <nav
+        aria-label="Default global nav"
+        class="pf-v6-c-nav"
+        data-ouia-component-id="OUIA-Generated-Nav-4"
+        data-ouia-component-type="PF6/Nav"
+        data-ouia-safe="true"
+      >
+        <ul
+          class="pf-v6-c-nav__list"
+          role="list"
+        >
+          <li
+            class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-7"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Visualization"
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Visualization"
+            >
+              Visualization
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Visualization"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-25"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    aria-current="page"
+                    class="pf-v6-c-nav__link pf-m-current"
+                    data-testid="Design"
+                    href="/"
+                  >
+                    Design
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-26"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Source Code"
+                    href="/code"
+                  >
+                    Source Code
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-m-expanded pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-8"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Rest DSL"
+            hidden=""
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Rest DSL"
+            >
+              Rest DSL
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Rest DSL"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-27"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Import"
+                    href="/rest/import"
+                  >
+                    Import
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavItem-28"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Beans"
+              href="/beans"
+            >
+              Beans
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-29"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Metadata"
+              href="/metadata"
+            >
+              Metadata
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-30"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Pipe ErrorHandler"
+              href="/pipe-error-handler"
+            >
+              Pipe ErrorHandler
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavItem-31"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="DataMapper"
+              href="/datamapper"
+            >
+              DataMapper
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-32"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Catalog"
+              href="/catalog"
+            >
+              Catalog
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
+<DocumentFragment>
+  <div
+    aria-hidden="false"
+    class="pf-v6-c-page__sidebar pf-m-expanded"
+    id="vertical-sidebar"
+  >
+    <div
+      class="pf-v6-c-page__sidebar-body"
+    >
+      <nav
+        aria-label="Default global nav"
+        class="pf-v6-c-nav"
+        data-ouia-component-id="OUIA-Generated-Nav-3"
+        data-ouia-component-type="PF6/Nav"
+        data-ouia-safe="true"
+      >
+        <ul
+          class="pf-v6-c-nav__list"
+          role="list"
+        >
+          <li
+            class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-5"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Visualization"
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Visualization"
+            >
+              Visualization
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Visualization"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-17"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    aria-current="page"
+                    class="pf-v6-c-nav__link pf-m-current"
+                    data-testid="Design"
+                    href="/"
+                  >
+                    Design
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-18"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Source Code"
+                    href="/code"
+                  >
+                    Source Code
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-m-expanded pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-6"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Rest DSL"
+            hidden=""
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Rest DSL"
+            >
+              Rest DSL
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Rest DSL"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-19"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Import"
+                    href="/rest/import"
+                  >
+                    Import
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavItem-20"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Beans"
+              href="/beans"
+            >
+              Beans
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
             data-ouia-component-id="OUIA-Generated-NavItem-21"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Metadata"
+              href="/metadata"
+            >
+              Metadata
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-22"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="Pipe ErrorHandler"
+              href="/pipe-error-handler"
+            >
+              Pipe ErrorHandler
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item pf-v6-u-hidden"
+            data-ouia-component-id="OUIA-Generated-NavItem-23"
+            data-ouia-component-type="PF6/NavItem"
+            data-ouia-safe="true"
+          >
+            <a
+              class="pf-v6-c-nav__link"
+              data-testid="DataMapper"
+              href="/datamapper"
+            >
+              DataMapper
+            </a>
+          </li>
+          <li
+            class="pf-v6-c-nav__item"
+            data-ouia-component-id="OUIA-Generated-NavItem-24"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -789,8 +1032,68 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
             </section>
           </li>
           <li
+            class="pf-v6-c-nav__item pf-m-expanded"
+            data-ouia-component-id="OUIA-Generated-NavExpandable-2"
+            data-ouia-component-type="PF6/NavExpandable"
+            data-ouia-safe="true"
+            data-testid="Rest DSL"
+          >
+            <button
+              aria-expanded="true"
+              class="pf-v6-c-nav__link"
+              id="Rest DSL"
+            >
+              Rest DSL
+              <span
+                class="pf-v6-c-nav__toggle"
+              >
+                <span
+                  class="pf-v6-c-nav__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+            <section
+              aria-labelledby="Rest DSL"
+              class="pf-v6-c-nav__subnav"
+            >
+              <ul
+                class="pf-v6-c-nav__list"
+                role="list"
+              >
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-3"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-testid="Import"
+                    href="/rest/import"
+                  >
+                    Import
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </li>
+          <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-3"
+            data-ouia-component-id="OUIA-Generated-NavItem-4"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -804,7 +1107,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-4"
+            data-ouia-component-id="OUIA-Generated-NavItem-5"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -818,7 +1121,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-5"
+            data-ouia-component-id="OUIA-Generated-NavItem-6"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -832,7 +1135,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-6"
+            data-ouia-component-id="OUIA-Generated-NavItem-7"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -846,7 +1149,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-7"
+            data-ouia-component-id="OUIA-Generated-NavItem-8"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
@@ -1,0 +1,71 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { Links } from '../../router/links.models';
+import { RestDslImportPage } from './RestDslImportPage';
+
+describe('RestDslImportPage', () => {
+  it('renders the page title', () => {
+    render(
+      <MemoryRouter>
+        <RestDslImportPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Import OpenAPI')).toBeInTheDocument();
+  });
+
+  it('renders the import wizard', () => {
+    render(
+      <MemoryRouter>
+        <RestDslImportPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('Upload file')).toBeInTheDocument();
+  });
+
+  it('navigates back to the Home page when closing the wizard', async () => {
+    render(
+      <MemoryRouter initialEntries={[Links.RestImport]}>
+        <Routes>
+          <Route path={Links.Home} element={<p>Home page</p>} />
+          <Route path={Links.RestImport} element={<RestDslImportPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const resultsButton = screen.getByRole('button', { name: 'Result' });
+    act(() => {
+      fireEvent.click(resultsButton);
+    });
+
+    const goToRestEditorButton = screen.getByRole('button', { name: 'Go to Rest Editor' });
+    act(() => {
+      fireEvent.click(goToRestEditorButton);
+    });
+
+    expect(screen.getByText('Home page')).toBeInTheDocument();
+  });
+
+  it('navigates back to the Home page when closing the wizard', async () => {
+    render(
+      <MemoryRouter initialEntries={[Links.RestImport]}>
+        <Routes>
+          <Route path={Links.Home} element={<p>Home page</p>} />
+          <Route path={Links.RestImport} element={<RestDslImportPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const resultsButton = screen.getByRole('button', { name: 'Result' });
+    act(() => {
+      fireEvent.click(resultsButton);
+    });
+
+    const goToDesignerButton = screen.getByRole('button', { name: 'Go to Designer' });
+    act(() => {
+      fireEvent.click(goToDesignerButton);
+    });
+
+    expect(screen.getByText('Home page')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
@@ -1,0 +1,25 @@
+import { Title } from '@patternfly/react-core';
+import { FunctionComponent, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Links } from '../../router/links.models';
+import { RestDslImportWizard } from './RestDslImportWizard';
+
+export const RestDslImportPage: FunctionComponent = () => {
+  const navigate = useNavigate();
+
+  const handleClose = useCallback(() => {
+    navigate(Links.Home);
+  }, [navigate]);
+
+  const handleGoToDesigner = useCallback(() => {
+    navigate(Links.Home);
+  }, [navigate]);
+
+  return (
+    <>
+      <Title headingLevel="h1">Import OpenAPI</Title>
+      <RestDslImportWizard onClose={handleClose} onGoToDesigner={handleGoToDesigner} />
+    </>
+  );
+};

--- a/packages/ui/src/pages/RestDslImport/RestDslImportTypes.ts
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportTypes.ts
@@ -1,0 +1,34 @@
+export type ImportLoadSource = 'uri' | 'file' | 'apicurio' | 'manual' | undefined;
+
+export type ImportSourceOption = 'uri' | 'file' | 'apicurio';
+
+export type SchemaLoadedResult = {
+  schema: string;
+  source: ImportLoadSource;
+  sourceIdentifier: string;
+};
+
+export type ImportOperation = {
+  operationId: string;
+  method: string;
+  path: string;
+  description?: string;
+  consumes?: string;
+  produces?: string;
+  param?: Record<string, unknown>[];
+  responseMessage?: Record<string, unknown>[];
+  security?: Record<string, unknown>[];
+  deprecated?: boolean;
+  selected: boolean;
+  routeExists: boolean;
+};
+
+export type ApicurioArtifact = {
+  id: string;
+  name: string;
+  type: string;
+};
+
+export type ApicurioArtifactSearchResult = {
+  artifacts: ApicurioArtifact[];
+};

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.scss
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.scss
@@ -1,0 +1,145 @@
+.rest-dsl-import-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.rest-dsl-import-footer {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 12px;
+}
+
+.rest-dsl-import-modal [class*='pf-v6-c-wizard__footer'] {
+  justify-content: flex-end;
+}
+
+.rest-dsl-import-toast {
+  inset: 0 auto auto;
+  right: 24px;
+  top: 24px;
+}
+
+.rest-dsl-import-source {
+  margin: 8px 0 16px 24px;
+  display: grid;
+  gap: 8px;
+}
+
+.rest-dsl-import-uri-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rest-dsl-import-uri-row > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.rest-dsl-import-file-input {
+  display: none;
+}
+
+.rest-dsl-import-error {
+  color: var(--pf-v6-global--danger-color--100);
+  font-size: var(--pf-v6-global--FontSize--sm);
+}
+
+.rest-dsl-import-success {
+  align-items: center;
+  color: var(--pf-v6-global--success-color--100);
+  display: inline-flex;
+  font-size: var(--pf-v6-global--FontSize--sm);
+  gap: 6px;
+}
+
+.rest-dsl-import-success-block {
+  margin-top: 8px;
+}
+
+.rest-dsl-import-options {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.rest-dsl-import-apicurio {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.rest-dsl-import-apicurio-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rest-dsl-import-apicurio-toolbar > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.rest-dsl-import-apicurio-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rest-dsl-import-apicurio-list {
+  border: 1px solid var(--pf-v6-global--BorderColor--100);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.rest-dsl-import-list {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  align-content: start;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+}
+
+.rest-dsl-import-list-scroll {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
+  overflow: auto;
+  padding-right: 4px;
+  padding-bottom: 12px;
+}
+
+.rest-dsl-import-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rest-dsl-import-note {
+  font-size: var(--pf-v6-global--FontSize--xs);
+  color: var(--pf-v6-global--Color--200);
+  font-style: italic;
+}
+
+/* stylelint-disable selector-class-pattern */
+.rest-dsl-import-wizard .pf-v6-c-wizard__main-body,
+.rest-dsl-import-wizard .pf-v6-c-wizard__main {
+  height: 100%;
+}
+
+.rest-dsl-import-wizard .pf-v6-c-wizard__main-body {
+  padding-bottom: 16px;
+}
+
+.rest-dsl-import-wizard .pf-v6-c-wizard__main-body > form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+/* stylelint-enable selector-class-pattern */

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.test.tsx
@@ -1,0 +1,361 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { RestDslImportWizard } from './RestDslImportWizard';
+import { useRestDslImportWizard } from './useRestDslImportWizard';
+
+jest.mock('./useRestDslImportWizard');
+
+describe('RestDslImportWizard', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch');
+  const mockOnClose = jest.fn();
+  const mockOnGoToDesigner = jest.fn();
+
+  const mockWizard = {
+    importSource: 'file' as const,
+    isOpenApiParsed: false,
+    openApiSpecText: '',
+    openApiLoadSource: undefined,
+    sourceIdentifier: '',
+    importCreateRest: false,
+    importCreateRoutes: true,
+    importSelectAll: true,
+    importOperations: [],
+    importStatus: null,
+    apicurioRegistryUrl: 'http://registry.example.com',
+    handleSchemaLoaded: jest.fn(),
+    handleImportSourceChange: jest.fn(),
+    setOpenApiSpecText: jest.fn(),
+    handleParseOpenApiSpec: jest.fn(),
+    setImportCreateRest: jest.fn(),
+    setImportCreateRoutes: jest.fn(),
+    handleToggleSelectAllOperations: jest.fn(),
+    handleToggleOperation: jest.fn(),
+    handleImportOpenApi: jest.fn(),
+    resetImportWizard: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useRestDslImportWizard as jest.Mock).mockReturnValue(mockWizard);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('Import source step', () => {
+    it('renders all import source options', () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      expect(screen.getByLabelText('Upload file')).toBeInTheDocument();
+      expect(screen.getByLabelText('Import from URI')).toBeInTheDocument();
+      expect(screen.getByLabelText('Import from Apicurio')).toBeInTheDocument();
+    });
+
+    it('calls handleImportSourceChange when changing source', () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const uriRadio = screen.getByLabelText('Import from URI');
+      fireEvent.click(uriRadio);
+      expect(mockWizard.handleImportSourceChange).toHaveBeenCalledWith('uri');
+    });
+
+    it('shows FileImportSource when file source is selected', () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      // FileImportSource renders a file upload component with the ID
+      const fileUpload = document.querySelector('#openapi-file-upload');
+      expect(fileUpload).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument();
+    });
+
+    it('shows UriImportSource when URI source is selected', () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, importSource: 'uri' });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      // UriImportSource renders a text input and Fetch button
+      expect(screen.getByPlaceholderText('https://example.com/openapi.yaml')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /fetch/i })).toBeInTheDocument();
+    });
+
+    it('shows ApicurioImportSource when Apicurio source is selected', async () => {
+      // Mock the Apicurio fetch call
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ artifacts: [] }),
+      } as unknown as Response);
+
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, importSource: 'apicurio' });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      // ApicurioImportSource renders search input and refresh button
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search OpenAPI artifacts')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Operations step', () => {
+    it('renders OpenAPI specification textarea', async () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      // Click on the Operations step in the nav
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /rest-openapi-spec/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls setOpenApiSpecText when textarea changes', async () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        const textarea = screen.getByRole('textbox', { name: /rest-openapi-spec/i });
+        fireEvent.change(textarea, { target: { value: 'openapi: 3.0.0' } });
+        expect(mockWizard.setOpenApiSpecText).toHaveBeenCalledWith('openapi: 3.0.0');
+      });
+    });
+
+    it('calls handleParseOpenApiSpec when Parse button is clicked', async () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        const parseButton = screen.getByRole('button', { name: /parse specification/i });
+        fireEvent.click(parseButton);
+        expect(mockWizard.handleParseOpenApiSpec).toHaveBeenCalled();
+      });
+    });
+
+    it('shows error message in operations step', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        importStatus: { type: 'error', message: 'Invalid specification' },
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        expect(screen.getByText('Invalid specification')).toBeInTheDocument();
+      });
+    });
+
+    it('renders import options checkboxes', async () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Create Rest DSL operations')).toBeInTheDocument();
+        expect(screen.getByLabelText('Create routes with direct endpoints')).toBeInTheDocument();
+      });
+    });
+
+    it('calls setImportCreateRest when checkbox is toggled', async () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        const checkbox = screen.getByLabelText('Create Rest DSL operations');
+        fireEvent.click(checkbox);
+        expect(mockWizard.setImportCreateRest).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('renders operations list when operations are available', async () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet/{id}',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, importOperations: operations });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        expect(screen.getByText('Select all operations')).toBeInTheDocument();
+        expect(screen.getByLabelText(/GET \/pet\/{id}/)).toBeInTheDocument();
+      });
+    });
+
+    it('calls handleToggleOperation when individual operation is toggled', async () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, importOperations: operations });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+      await waitFor(() => {
+        const checkbox = screen.getByLabelText(/GET \/pet/);
+        fireEvent.click(checkbox);
+        expect(mockWizard.handleToggleOperation).toHaveBeenCalledWith('getPet', 'get', '/pet', false);
+      });
+    });
+  });
+
+  describe('Result step', () => {
+    it('shows success alert when import succeeds', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        isOpenApiParsed: true,
+        importStatus: { type: 'success', message: 'Import succeeded. 2 operations added.' },
+        handleImportOpenApi: jest.fn().mockReturnValue(true),
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      // Navigate to Operations step
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+
+      // Find and click the Import button
+      await waitFor(() => {
+        const importButton = screen.getByRole('button', { name: /^Import$/i });
+        expect(importButton).toBeInTheDocument();
+        fireEvent.click(importButton);
+      });
+
+      // Navigate to Result step
+      await waitFor(() => {
+        const resultNav = screen.getByRole('button', { name: /^Result$/i });
+        fireEvent.click(resultNav);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Import succeeded. 2 operations added.')).toBeInTheDocument();
+      });
+    });
+
+    it('calls onGoToDesigner when Go to Designer button is clicked', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        isOpenApiParsed: true,
+        importStatus: { type: 'success', message: 'Import succeeded.' },
+        handleImportOpenApi: jest.fn().mockReturnValue(true),
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      // Navigate to Result step
+      const resultNav = screen.getByRole('button', { name: /^Result$/i });
+      fireEvent.click(resultNav);
+
+      await waitFor(() => {
+        const designerButton = screen.getByRole('button', { name: /go to designer/i });
+        fireEvent.click(designerButton);
+        expect(mockWizard.resetImportWizard).toHaveBeenCalled();
+        expect(mockOnGoToDesigner).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Wizard footer', () => {
+    it('disables Back button on first step', () => {
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+      const backButton = screen.getByRole('button', { name: /back/i });
+      expect(backButton).toBeDisabled();
+    });
+
+    it('disables Import button when spec is not parsed', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, isOpenApiParsed: false });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      // Navigate to Operations step
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+
+      await waitFor(() => {
+        const importButton = screen.getByRole('button', { name: /^Import$/i });
+        expect(importButton).toBeDisabled();
+      });
+    });
+
+    it('disables Import button when neither REST nor routes are selected', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        isOpenApiParsed: true,
+        importCreateRest: false,
+        importCreateRoutes: false,
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      // Navigate to Operations step
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+
+      await waitFor(() => {
+        const importButton = screen.getByRole('button', { name: /^Import$/i });
+        expect(importButton).toBeDisabled();
+      });
+    });
+
+    it('calls resetImportWizard and onClose when Go to Rest Editor is clicked on result step', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        isOpenApiParsed: true,
+        importStatus: { type: 'success', message: 'Import succeeded.' },
+        handleImportOpenApi: jest.fn().mockReturnValue(true),
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      const resultNav = screen.getByRole('button', { name: /^Result$/i });
+      fireEvent.click(resultNav);
+
+      await waitFor(() => {
+        const restEditorButton = screen.getByRole('button', { name: /go to rest editor/i });
+        fireEvent.click(restEditorButton);
+        expect(mockWizard.resetImportWizard).toHaveBeenCalled();
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+    });
+
+    it('shows operation as disabled with "Route exists" label when routeExists is true', async () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: true,
+        },
+      ];
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({ ...mockWizard, importOperations: operations });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+
+      await waitFor(() => {
+        const checkbox = screen.getByLabelText(/GET \/pet - Route exists/);
+        expect(checkbox).toBeInTheDocument();
+        expect(checkbox).toBeDisabled();
+      });
+    });
+
+    it('does not advance to result when import fails', async () => {
+      (useRestDslImportWizard as jest.Mock).mockReturnValue({
+        ...mockWizard,
+        isOpenApiParsed: true,
+        importCreateRoutes: true,
+        handleImportOpenApi: jest.fn().mockReturnValue(false),
+      });
+      render(<RestDslImportWizard onClose={mockOnClose} onGoToDesigner={mockOnGoToDesigner} />);
+
+      const operationsNav = screen.getByRole('button', { name: /^Operations$/i });
+      fireEvent.click(operationsNav);
+
+      await waitFor(() => {
+        const importButton = screen.getByRole('button', { name: /^Import$/i });
+        fireEvent.click(importButton);
+      });
+
+      // Should still be on Operations step, not Result
+      expect(screen.getByRole('textbox', { name: /rest-openapi-spec/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
@@ -1,0 +1,295 @@
+import './RestDslImportWizard.scss';
+
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Form,
+  FormGroup,
+  Radio,
+  TextArea,
+  Wizard,
+  WizardFooterWrapper,
+  WizardStep,
+} from '@patternfly/react-core';
+import { FunctionComponent, MouseEvent, useCallback } from 'react';
+
+import { ApicurioImportSource, FileImportSource, UriImportSource } from './components';
+import { ImportOperation } from './RestDslImportTypes';
+import { useRestDslImportWizard } from './useRestDslImportWizard';
+
+type ImportWizardFooterProps = {
+  isSourceStep: boolean;
+  isOperationsStep: boolean;
+  isResultStep: boolean;
+  isOpenApiParsed: boolean;
+  importCreateRest: boolean;
+  importCreateRoutes: boolean;
+  onBack: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  onNext: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  onFinish: () => boolean;
+  onFinishSuccess: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  onClose: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  onGoToDesigner: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+};
+
+type WizardFooterRenderParams = {
+  activeStep: { id?: string | number };
+  goToNextStep: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  goToPrevStep: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  close: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+};
+
+const ImportWizardFooter: FunctionComponent<ImportWizardFooterProps> = ({
+  isSourceStep,
+  isOperationsStep,
+  isResultStep,
+  isOpenApiParsed,
+  importCreateRest,
+  importCreateRoutes,
+  onBack,
+  onNext,
+  onFinish,
+  onFinishSuccess,
+  onClose,
+  onGoToDesigner,
+}) => {
+  const handleNextClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    if (isOperationsStep) {
+      const ok = onFinish();
+      if (ok) {
+        await onFinishSuccess(event);
+      }
+      return;
+    }
+    await onNext(event);
+  };
+
+  const isNextDisabled =
+    (isSourceStep && !isOpenApiParsed) ||
+    (isOperationsStep && (!isOpenApiParsed || (!importCreateRest && !importCreateRoutes)));
+
+  return (
+    <WizardFooterWrapper className="rest-dsl-import-footer">
+      {!isResultStep && (
+        <Button variant="secondary" onClick={onBack} isDisabled={isSourceStep}>
+          Back
+        </Button>
+      )}
+      {isResultStep ? (
+        <>
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={(event) => {
+              event.preventDefault();
+              onGoToDesigner(event);
+            }}
+          >
+            Go to Designer
+          </Button>
+          <Button variant="primary" onClick={onClose}>
+            Go to Rest Editor
+          </Button>
+        </>
+      ) : (
+        <Button variant="primary" onClick={handleNextClick} isDisabled={isNextDisabled}>
+          {isOperationsStep ? 'Import' : 'Next'}
+        </Button>
+      )}
+    </WizardFooterWrapper>
+  );
+};
+
+const renderImportWizardFooter = (
+  params: WizardFooterRenderParams,
+  footerState: Omit<
+    ImportWizardFooterProps,
+    | 'isSourceStep'
+    | 'isOperationsStep'
+    | 'isResultStep'
+    | 'onBack'
+    | 'onNext'
+    | 'onFinish'
+    | 'onClose'
+    | 'onFinishSuccess'
+  > & {
+    onFinish: () => boolean;
+    onClose: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+    onGoToDesigner: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  },
+) => {
+  const isSourceStep = params.activeStep.id === 'source';
+  const isOperationsStep = params.activeStep.id === 'operations';
+  const isResultStep = params.activeStep.id === 'result';
+
+  return (
+    <ImportWizardFooter
+      isSourceStep={isSourceStep}
+      isOperationsStep={isOperationsStep}
+      isResultStep={isResultStep}
+      isOpenApiParsed={footerState.isOpenApiParsed}
+      importCreateRest={footerState.importCreateRest}
+      importCreateRoutes={footerState.importCreateRoutes}
+      onBack={params.goToPrevStep}
+      onFinish={footerState.onFinish}
+      onFinishSuccess={params.goToNextStep}
+      onClose={footerState.onClose}
+      onGoToDesigner={footerState.onGoToDesigner}
+      onNext={params.goToNextStep}
+    />
+  );
+};
+
+type RestDslImportWizardProps = {
+  onClose: () => void;
+  onGoToDesigner: () => void;
+};
+
+export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = ({ onClose, onGoToDesigner }) => {
+  const wizard = useRestDslImportWizard();
+
+  const handleClose = useCallback(() => {
+    wizard.resetImportWizard();
+    onClose();
+  }, [wizard, onClose]);
+
+  const handleGoToDesigner = useCallback(() => {
+    wizard.resetImportWizard();
+    onGoToDesigner();
+  }, [wizard, onGoToDesigner]);
+
+  const renderOperationCheckbox = (operation: ImportOperation) => (
+    <Checkbox
+      key={`${operation.operationId}-${operation.method}-${operation.path}`}
+      id={`rest-openapi-${operation.operationId}-${operation.method}`}
+      label={`${operation.method.toUpperCase()} ${operation.path}${operation.routeExists ? ' - Route exists' : ''}`}
+      isChecked={operation.routeExists ? false : operation.selected}
+      isDisabled={operation.routeExists}
+      onChange={(_event, checked) =>
+        wizard.handleToggleOperation(operation.operationId, operation.method, operation.path, checked)
+      }
+    />
+  );
+
+  return (
+    <Wizard
+      onClose={handleClose}
+      className="rest-dsl-import-wizard"
+      footer={(activeStep, goToNextStep, goToPrevStep, close) =>
+        renderImportWizardFooter(
+          { activeStep, goToNextStep, goToPrevStep, close },
+          {
+            isOpenApiParsed: wizard.isOpenApiParsed,
+            importCreateRest: wizard.importCreateRest,
+            importCreateRoutes: wizard.importCreateRoutes,
+            onFinish: wizard.handleImportOpenApi,
+            onClose: handleClose,
+            onGoToDesigner: handleGoToDesigner,
+          },
+        )
+      }
+    >
+      <WizardStep name="Import source" id="source">
+        <Form>
+          <FormGroup label="Choose import source" fieldId="rest-openapi-import-source">
+            <Radio
+              id="rest-openapi-import-file"
+              name="rest-openapi-import-source"
+              label="Upload file"
+              isChecked={wizard.importSource === 'file'}
+              onChange={() => wizard.handleImportSourceChange('file')}
+            />
+            {wizard.importSource === 'file' && <FileImportSource onSchemaLoaded={wizard.handleSchemaLoaded} />}
+
+            <Radio
+              id="rest-openapi-import-uri"
+              name="rest-openapi-import-source"
+              label="Import from URI"
+              isChecked={wizard.importSource === 'uri'}
+              onChange={() => wizard.handleImportSourceChange('uri')}
+            />
+            {wizard.importSource === 'uri' && <UriImportSource onSchemaLoaded={wizard.handleSchemaLoaded} />}
+
+            <Radio
+              id="rest-openapi-import-apicurio"
+              name="rest-openapi-import-source"
+              label="Import from Apicurio"
+              isChecked={wizard.importSource === 'apicurio'}
+              onChange={() => wizard.handleImportSourceChange('apicurio')}
+            />
+            {wizard.importSource === 'apicurio' && (
+              <ApicurioImportSource
+                registryUrl={wizard.apicurioRegistryUrl}
+                onSchemaLoaded={wizard.handleSchemaLoaded}
+              />
+            )}
+          </FormGroup>
+        </Form>
+      </WizardStep>
+      <WizardStep name="Operations" id="operations">
+        <Form>
+          <FormGroup label="OpenAPI Specification" fieldId="rest-openapi-spec">
+            <TextArea
+              id="rest-openapi-spec"
+              aria-label="rest-openapi-spec"
+              value={wizard.openApiSpecText}
+              onChange={(_event, value) => wizard.setOpenApiSpecText(value)}
+              resizeOrientation="vertical"
+              rows={6}
+            />
+          </FormGroup>
+          <div className="rest-dsl-import-actions">
+            <Button variant="secondary" onClick={wizard.handleParseOpenApiSpec}>
+              Parse Specification
+            </Button>
+            {wizard.importStatus?.type === 'error' && (
+              <span className="rest-dsl-import-error">{wizard.importStatus.message}</span>
+            )}
+          </div>
+          <div className="rest-dsl-import-options">
+            <Checkbox
+              id="rest-openapi-create-rest"
+              label="Create Rest DSL operations"
+              isChecked={wizard.importCreateRest}
+              onChange={(_event, checked) => wizard.setImportCreateRest(checked)}
+            />
+            <Checkbox
+              id="rest-openapi-create-routes"
+              label="Create routes with direct endpoints"
+              isChecked={wizard.importCreateRoutes}
+              onChange={(_event, checked) => wizard.setImportCreateRoutes(checked)}
+            />
+          </div>
+          {wizard.importOperations.length > 0 && (
+            <div className="rest-dsl-import-list">
+              <Checkbox
+                id="rest-openapi-select-all"
+                label="Select all operations"
+                isChecked={wizard.importSelectAll}
+                onChange={(_event, checked) => wizard.handleToggleSelectAllOperations(checked)}
+              />
+              <div className="rest-dsl-import-list-scroll">
+                {wizard.importOperations.map((operation) => (
+                  <div
+                    key={`${operation.operationId}-${operation.method}-${operation.path}`}
+                    className="rest-dsl-import-row"
+                  >
+                    {renderOperationCheckbox(operation)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </Form>
+      </WizardStep>
+      <WizardStep name="Result" id="result">
+        <Alert
+          variant={wizard.importStatus?.type === 'success' ? 'success' : 'danger'}
+          title={wizard.importStatus?.message ?? 'No import results yet.'}
+          isInline
+        />
+      </WizardStep>
+    </Wizard>
+  );
+};

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
@@ -1,0 +1,245 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { ApicurioImportSource } from './ApicurioImportSource';
+
+describe('ApicurioImportSource', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch');
+  const mockOnSchemaLoaded = jest.fn();
+  const registryUrl = 'http://registry.example.com';
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('shows message when registry URL is not configured', () => {
+    render(<ApicurioImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    expect(screen.getByText(/Configure the Apicurio Registry URL in Settings/)).toBeInTheDocument();
+  });
+
+  it('fetches artifacts on mount when registry URL is provided', async () => {
+    const mockArtifacts = {
+      artifacts: [
+        { id: 'artifact-1', name: 'API Spec 1', type: 'OPENAPI' },
+        { id: 'artifact-2', name: 'API Spec 2', type: 'OPENAPI' },
+        { id: 'artifact-3', name: 'Schema', type: 'AVRO' },
+      ],
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockArtifacts),
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(`${registryUrl}/apis/registry/v2/search/artifacts`);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec 1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('API Spec 2')).toBeInTheDocument();
+    expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+  });
+
+  it('filters artifacts based on search term', async () => {
+    const mockArtifacts = {
+      artifacts: [
+        { id: 'artifact-1', name: 'User API', type: 'OPENAPI' },
+        { id: 'artifact-2', name: 'Product API', type: 'OPENAPI' },
+      ],
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockArtifacts),
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('User API')).toBeInTheDocument();
+      expect(screen.getByText('Product API')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search OpenAPI artifacts');
+    fireEvent.change(searchInput, { target: { value: 'user' } });
+
+    expect(screen.getByText('User API')).toBeInTheDocument();
+    expect(screen.queryByText('Product API')).not.toBeInTheDocument();
+  });
+
+  it('loads artifact when selected', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-1', name: 'API Spec', type: 'OPENAPI' }],
+    };
+
+    const artifactContent = 'openapi: 3.0.0';
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockArtifacts),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(artifactContent),
+      } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec')).toBeInTheDocument();
+    });
+
+    const radio = screen.getByLabelText(/API Spec/);
+    fireEvent.click(radio);
+
+    await waitFor(() => {
+      expect(mockOnSchemaLoaded).toHaveBeenCalledWith({
+        schema: artifactContent,
+        source: 'apicurio',
+        sourceIdentifier: `${registryUrl}/apis/registry/v2/groups/default/artifacts/artifact-1`,
+      });
+    });
+
+    expect(screen.getByText('Loaded')).toBeInTheDocument();
+  });
+
+  it('shows error when artifact fetch fails', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-1', name: 'API Spec', type: 'OPENAPI' }],
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockArtifacts),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec')).toBeInTheDocument();
+    });
+
+    const radio = screen.getByLabelText(/API Spec/);
+    fireEvent.click(radio);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch artifact \(500\)/)).toBeInTheDocument();
+    });
+  });
+
+  it('refreshes artifacts when refresh button is clicked', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-1', name: 'API Spec', type: 'OPENAPI' }],
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockArtifacts),
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec')).toBeInTheDocument();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows "no artifacts" message when list is empty', async () => {
+    const mockArtifacts = {
+      artifacts: [],
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockArtifacts),
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No OpenAPI artifacts found.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when initial artifact fetch fails', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when initial fetch throws a non-Error value', async () => {
+    fetchSpy.mockRejectedValue('non-error rejection');
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to fetch artifacts from Apicurio Registry.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when artifact load throws a non-Error value', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-1', name: 'API Spec', type: 'OPENAPI' }],
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockArtifacts),
+      } as unknown as Response)
+      .mockRejectedValueOnce('non-error rejection');
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec')).toBeInTheDocument();
+    });
+
+    const radio = screen.getByLabelText(/API Spec/);
+    fireEvent.click(radio);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to download the selected artifact.')).toBeInTheDocument();
+    });
+  });
+
+  it('displays artifact id when name is missing', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-no-name', name: '', type: 'OPENAPI' }],
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockArtifacts),
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('artifact-no-name')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
@@ -1,0 +1,159 @@
+import { Button, List, ListItem, Radio, SearchInput } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
+
+import { ApicurioArtifact, ApicurioArtifactSearchResult, SchemaLoadedResult } from '../RestDslImportTypes';
+
+type ApicurioImportSourceProps = {
+  registryUrl?: string;
+  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+};
+
+export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> = ({ registryUrl, onSchemaLoaded }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [artifacts, setArtifacts] = useState<ApicurioArtifact[]>([]);
+  const [filteredArtifacts, setFilteredArtifacts] = useState<ApicurioArtifact[]>([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchArtifacts = useCallback(async () => {
+    if (!registryUrl) {
+      setError('Apicurio Registry URL is missing.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const response = await fetch(`${registryUrl}/apis/registry/v2/search/artifacts`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch artifacts (${response.status})`);
+      }
+      const result = (await response.json()) as ApicurioArtifactSearchResult;
+      const openapiArtifacts = (result.artifacts ?? []).filter((artifact) => artifact.type === 'OPENAPI');
+      setArtifacts(openapiArtifacts);
+      setFilteredArtifacts(openapiArtifacts);
+      setError('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to fetch artifacts from Apicurio Registry.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [registryUrl]);
+
+  useEffect(() => {
+    if (registryUrl) {
+      fetchArtifacts();
+    }
+  }, [fetchArtifacts, registryUrl]);
+
+  useEffect(() => {
+    if (!searchTerm.trim()) {
+      setFilteredArtifacts(artifacts);
+      return;
+    }
+    const lowered = searchTerm.toLowerCase();
+    setFilteredArtifacts(
+      artifacts.filter((artifact) => (artifact.name ?? artifact.id ?? '').toLowerCase().includes(lowered)),
+    );
+  }, [artifacts, searchTerm]);
+
+  const handleLoadArtifact = useCallback(
+    async (artifactId: string) => {
+      if (!registryUrl) return;
+
+      setIsLoading(true);
+      setError('');
+      setIsLoaded(false);
+
+      try {
+        const artifactUrl = `${registryUrl}/apis/registry/v2/groups/default/artifacts/${artifactId}`;
+        const response = await fetch(artifactUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch artifact (${response.status})`);
+        }
+        const specText = await response.text();
+
+        onSchemaLoaded({
+          schema: specText,
+          source: 'apicurio',
+          sourceIdentifier: artifactUrl,
+        });
+
+        setIsLoaded(true);
+        setError('');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unable to download the selected artifact.';
+        setError(message);
+        setIsLoaded(false);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [registryUrl, onSchemaLoaded],
+  );
+
+  const handleSelectArtifact = useCallback(
+    (artifactId: string) => {
+      setSelectedId(artifactId);
+      handleLoadArtifact(artifactId);
+    },
+    [handleLoadArtifact],
+  );
+
+  if (!registryUrl) {
+    return (
+      <div className="rest-dsl-import-source rest-dsl-import-apicurio">
+        <span className="rest-dsl-import-note">
+          Configure the Apicurio Registry URL in Settings to enable this option.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rest-dsl-import-source rest-dsl-import-apicurio">
+      <div className="rest-dsl-import-apicurio-toolbar">
+        <SearchInput
+          aria-label="Search Apicurio artifacts"
+          placeholder="Search OpenAPI artifacts"
+          value={searchTerm}
+          onChange={(_event, value) => setSearchTerm(value)}
+        />
+        <Button variant="secondary" onClick={fetchArtifacts} isDisabled={isLoading}>
+          Refresh
+        </Button>
+      </div>
+      {error && <span className="rest-dsl-import-error">{error}</span>}
+      <div className="rest-dsl-import-list-scroll rest-dsl-import-apicurio-list">
+        <List isPlain>
+          {filteredArtifacts.map((artifact) => (
+            <ListItem key={artifact.id}>
+              <Radio
+                id={`rest-openapi-apicurio-${artifact.id}`}
+                name="rest-openapi-apicurio-artifact"
+                label={
+                  <span>
+                    {artifact.name || artifact.id} <span className="rest-dsl-import-note">(id: {artifact.id})</span>
+                  </span>
+                }
+                isChecked={selectedId === artifact.id}
+                onChange={() => handleSelectArtifact(artifact.id)}
+              />
+            </ListItem>
+          ))}
+          {filteredArtifacts.length === 0 && !isLoading && <ListItem>No OpenAPI artifacts found.</ListItem>}
+        </List>
+      </div>
+      {isLoaded && (
+        <span className="rest-dsl-import-success">
+          <CheckCircleIcon /> Loaded
+        </span>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
@@ -1,0 +1,204 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { FileImportSource } from './FileImportSource';
+
+describe('FileImportSource', () => {
+  const mockOnSchemaLoaded = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders file upload component', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const fileUpload = container.querySelector('#openapi-file-upload');
+    expect(fileUpload).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Drag and drop a file or upload one')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument();
+  });
+
+  it('renders without errors', () => {
+    expect(() => render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />)).not.toThrow();
+  });
+
+  it('accepts required props', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders clear button in disabled state initially', () => {
+    render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    expect(clearButton).toBeDisabled();
+  });
+
+  it('renders textarea for file content', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const textarea = container.querySelector('#openapi-file-upload') as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
+  it('does not show success message initially', () => {
+    render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    expect(screen.queryByText('Schema loaded successfully')).not.toBeInTheDocument();
+  });
+
+  it('does not show error message initially', () => {
+    render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it('configures file upload to accept JSON and YAML files', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const hiddenFileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    expect(hiddenFileInput).toBeInTheDocument();
+    expect(hiddenFileInput).toHaveAttribute('accept');
+
+    const acceptAttr = hiddenFileInput.getAttribute('accept');
+    expect(acceptAttr).toContain('.json');
+    expect(acceptAttr).toContain('.yaml');
+    expect(acceptAttr).toContain('.yml');
+  });
+
+  it('renders with correct component structure', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    // Check for main file upload container
+    const fileUploadContainer = container.querySelector('.pf-v6-c-file-upload');
+    expect(fileUploadContainer).toBeInTheDocument();
+
+    // Check for file select section
+    const fileSelect = container.querySelector('.pf-v6-c-file-upload__file-select');
+    expect(fileSelect).toBeInTheDocument();
+
+    // Check for file details section (textarea)
+    const fileDetails = container.querySelector('.pf-v6-c-file-upload__file-details');
+    expect(fileDetails).toBeInTheDocument();
+  });
+
+  it('has proper accessibility attributes', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    const textarea = container.querySelector('#openapi-file-upload');
+    expect(textarea).toHaveAttribute('aria-label', 'File upload');
+    expect(textarea).toHaveAttribute('aria-invalid', 'false');
+
+    const filenameInput = container.querySelector('#openapi-file-upload-filename');
+    expect(filenameInput).toHaveAttribute('aria-label', 'Drag and drop a file or upload one');
+  });
+
+  it('renders upload button with correct text', () => {
+    render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const uploadButton = screen.getByRole('button', { name: /upload/i });
+    expect(uploadButton).toHaveTextContent('Upload');
+  });
+
+  it('renders clear button with correct text', () => {
+    render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    expect(clearButton).toHaveTextContent('Clear');
+  });
+
+  it('calls onSchemaLoaded and shows success when a file is uploaded', async () => {
+    const fileContent = '{"openapi": "3.0.0"}';
+    const file = new File([fileContent], 'spec.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockOnSchemaLoaded).toHaveBeenCalledWith({
+        schema: fileContent,
+        source: 'file',
+        sourceIdentifier: 'spec.json',
+      });
+    });
+
+    expect(screen.getByText('Schema loaded successfully')).toBeInTheDocument();
+  });
+
+  it('shows error when onSchemaLoaded throws', async () => {
+    mockOnSchemaLoaded.mockImplementation(() => {
+      throw new Error('Parse failed');
+    });
+
+    const file = new File(['invalid content'], 'bad.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Parse failed')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Schema loaded successfully')).not.toBeInTheDocument();
+  });
+
+  it('clears file state when clear button is clicked', async () => {
+    const fileContent = '{"openapi": "3.0.0"}';
+    const file = new File([fileContent], 'spec.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = container.querySelector('#openapi-file-upload') as HTMLTextAreaElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockOnSchemaLoaded).toHaveBeenCalled();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    expect(textarea).toHaveValue('');
+    expect(screen.queryByText('Schema loaded successfully')).not.toBeInTheDocument();
+  });
+
+  it('allows manual text input in the textarea', () => {
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const textarea = container.querySelector('#openapi-file-upload') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'openapi: 3.0.0' } });
+
+    expect(textarea.value).toBe('openapi: 3.0.0');
+  });
+
+  it('shows error when file content is empty', async () => {
+    const file = new File([''], 'empty.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('No file content to load')).toBeInTheDocument();
+    });
+
+    expect(mockOnSchemaLoaded).not.toHaveBeenCalled();
+  });
+
+  it('shows generic error message when onSchemaLoaded throws non-Error', async () => {
+    mockOnSchemaLoaded.mockImplementation(() => {
+      throw 'string error';
+    });
+
+    const file = new File(['some content'], 'spec.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to read the uploaded specification.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/components/FileImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/FileImportSource.tsx
@@ -1,0 +1,115 @@
+import { DropEvent, FileUpload, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useCallback, useRef, useState } from 'react';
+
+import { SchemaLoadedResult } from '../RestDslImportTypes';
+
+type FileImportSourceProps = {
+  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+};
+
+export const FileImportSource: FunctionComponent<FileImportSourceProps> = ({ onSchemaLoaded }) => {
+  const [value, setValue] = useState('');
+  const [filename, setFilename] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState('');
+  const filenameRef = useRef('');
+
+  const handleFileInputChange = useCallback((_: DropEvent, file: File) => {
+    setFilename(file.name);
+    filenameRef.current = file.name;
+    setError('');
+  }, []);
+
+  const handleDataChange = useCallback(
+    (_event: DropEvent, fileContent: string) => {
+      setValue(fileContent);
+
+      if (!fileContent) {
+        setError('No file content to load');
+        setIsLoaded(false);
+        return;
+      }
+
+      try {
+        onSchemaLoaded({
+          schema: fileContent,
+          source: 'file',
+          sourceIdentifier: filenameRef.current || 'uploaded-file',
+        });
+        setIsLoaded(true);
+        setError('');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unable to read the uploaded specification.';
+        setError(message);
+        setIsLoaded(false);
+      }
+    },
+    [onSchemaLoaded],
+  );
+
+  const handleTextChange = useCallback((_event: React.ChangeEvent<HTMLTextAreaElement>, textValue: string) => {
+    setValue(textValue);
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setFilename('');
+    filenameRef.current = '';
+    setValue('');
+    setIsLoaded(false);
+    setError('');
+  }, []);
+
+  const handleFileReadStarted = useCallback(() => {
+    setIsLoading(true);
+    setError('');
+  }, []);
+
+  const handleFileReadFinished = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <>
+      <FileUpload
+        id="openapi-file-upload"
+        type="text"
+        value={value}
+        filename={filename}
+        filenamePlaceholder="Drag and drop a file or upload one"
+        onFileInputChange={handleFileInputChange}
+        onDataChange={handleDataChange}
+        onTextChange={handleTextChange}
+        onReadStarted={handleFileReadStarted}
+        onReadFinished={handleFileReadFinished}
+        onClearClick={handleClear}
+        isLoading={isLoading}
+        browseButtonText="Upload"
+        dropzoneProps={{
+          accept: {
+            'application/json': ['.json'],
+            'application/x-yaml': ['.yaml', '.yml'],
+            'text/yaml': ['.yaml', '.yml'],
+          },
+        }}
+      />
+      {isLoaded && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant="success" icon={<CheckCircleIcon />}>
+              Schema loaded successfully
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+      {error && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant="error">{error}</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+    </>
+  );
+};

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { UriImportSource } from './UriImportSource';
+
+describe('UriImportSource', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch');
+  const mockOnSchemaLoaded = jest.fn();
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('renders URI input and fetch button', () => {
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /fetch/i })).toBeInTheDocument();
+  });
+
+  it('fetch button is disabled when URI is empty', () => {
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    expect(fetchButton).toBeDisabled();
+  });
+
+  it('fetch button is enabled when URI is entered', () => {
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'http://example.com/spec.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    expect(fetchButton).not.toBeDisabled();
+  });
+
+  it('calls onSchemaLoaded when fetch is successful', async () => {
+    const specContent = 'openapi: 3.0.0';
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(specContent),
+    } as unknown as Response);
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+    const uri = 'http://example.com/spec.yaml';
+
+    fireEvent.change(input, { target: { value: uri } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    await waitFor(() => {
+      expect(mockOnSchemaLoaded).toHaveBeenCalledWith({
+        schema: specContent,
+        source: 'uri',
+        sourceIdentifier: uri,
+      });
+    });
+
+    expect(screen.getByText('Loaded')).toBeInTheDocument();
+  });
+
+  it('shows error message when fetch fails', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as unknown as Response);
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'http://example.com/notfound.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch specification \(404\)/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when network error occurs', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'http://example.com/spec.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when URI is empty and fetch is attempted', () => {
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockOnSchemaLoaded).not.toHaveBeenCalled();
+  });
+
+  it('disables fetch button while loading', async () => {
+    fetchSpy.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                text: jest.fn().mockResolvedValue('openapi: 3.0.0'),
+              } as unknown as Response),
+            100,
+          ),
+        ),
+    );
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'http://example.com/spec.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    expect(fetchButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(mockOnSchemaLoaded).toHaveBeenCalled();
+    });
+  });
+
+  it('shows generic error when fetch throws a non-Error value', async () => {
+    fetchSpy.mockRejectedValue('non-error rejection');
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'http://example.com/spec.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch the specification.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
@@ -1,0 +1,80 @@
+import { Button, FormHelperText, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useCallback, useState } from 'react';
+
+import { SchemaLoadedResult } from '../RestDslImportTypes';
+
+type UriImportSourceProps = {
+  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+};
+
+export const UriImportSource: FunctionComponent<UriImportSourceProps> = ({ onSchemaLoaded }) => {
+  const [uri, setUri] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleFetch = useCallback(async () => {
+    const trimmed = uri.trim();
+    if (!trimmed) {
+      setError('Provide a specification URI to fetch.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    setIsLoaded(false);
+
+    try {
+      const response = await fetch(trimmed);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch specification (${response.status})`);
+      }
+      const specText = await response.text();
+
+      onSchemaLoaded({
+        schema: specText,
+        source: 'uri',
+        sourceIdentifier: trimmed,
+      });
+
+      setIsLoaded(true);
+      setError('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch the specification.';
+      setError(message);
+      setIsLoaded(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [uri, onSchemaLoaded]);
+
+  return (
+    <div className="rest-dsl-import-source">
+      <div className="rest-dsl-import-uri-row">
+        <TextInput
+          id="rest-openapi-spec-uri"
+          aria-label="Open API specification URI"
+          value={uri}
+          onChange={(_event, value) => setUri(value)}
+          placeholder="https://example.com/openapi.yaml"
+        />
+        <Button variant="secondary" onClick={handleFetch} isDisabled={!uri.trim() || isLoading} isLoading={isLoading}>
+          Fetch
+        </Button>
+      </div>
+      {isLoaded && (
+        <span className="rest-dsl-import-success rest-dsl-import-success-block">
+          <CheckCircleIcon /> Loaded
+        </span>
+      )}
+      {error && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant="error">{error}</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/pages/RestDslImport/components/index.ts
+++ b/packages/ui/src/pages/RestDslImport/components/index.ts
@@ -1,0 +1,3 @@
+export { ApicurioImportSource } from './ApicurioImportSource';
+export { FileImportSource } from './FileImportSource';
+export { UriImportSource } from './UriImportSource';

--- a/packages/ui/src/pages/RestDslImport/index.ts
+++ b/packages/ui/src/pages/RestDslImport/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/packages/ui/src/pages/RestDslImport/router-exports.tsx
+++ b/packages/ui/src/pages/RestDslImport/router-exports.tsx
@@ -1,0 +1,3 @@
+import { RestDslImportPage } from './RestDslImportPage';
+
+export const element = <RestDslImportPage />;

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -1,0 +1,679 @@
+import { act, renderHook } from '@testing-library/react';
+import { OpenApi } from 'openapi-v3';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { CamelResource } from '../../models/camel/camel-resource';
+import { CamelRouteResource } from '../../models/camel/camel-route-resource';
+import { EntitiesContextResult, SettingsContext } from '../../providers';
+import { TestProvidersWrapper } from '../../stubs/TestProvidersWrapper';
+import { useRestDslImportWizard } from './useRestDslImportWizard';
+
+describe('useRestDslImportWizard', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch');
+  let wrapper: FunctionComponent<PropsWithChildren>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy.mockClear();
+
+    const { Provider } = TestProvidersWrapper();
+    wrapper = ({ children }) => (
+      <SettingsContext.Provider value={mockSettingsContext}>
+        <Provider>{children}</Provider>
+      </SettingsContext.Provider>
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const mockSettingsContext = {
+    getSettings: () => ({ rest: { apicurioRegistryUrl: '', customMediaTypes: [] } }),
+  } as never;
+
+  describe('handleSchemaLoaded', () => {
+    it('parses valid OpenAPI spec and updates state', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPet',
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'openapi.json',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(true);
+      expect(result.current.openApiLoadSource).toBe('file');
+      expect(result.current.sourceIdentifier).toBe('openapi.json');
+      expect(result.current.importOperations).toHaveLength(1);
+      expect(result.current.importOperations[0].operationId).toBe('getPet');
+    });
+
+    it('updates state for URI source', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/user': {
+            post: {
+              operationId: 'createUser',
+              responses: { '201': { description: 'created' } },
+            },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'uri',
+          sourceIdentifier: 'https://example.com/openapi.yaml',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(true);
+      expect(result.current.openApiLoadSource).toBe('uri');
+      expect(result.current.sourceIdentifier).toBe('https://example.com/openapi.yaml');
+      expect(result.current.importOperations).toHaveLength(1);
+    });
+
+    it('updates state for Apicurio source', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/order': {
+            delete: {
+              operationId: 'deleteOrder',
+              responses: { '204': { description: 'deleted' } },
+            },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'apicurio',
+          sourceIdentifier: 'https://registry/artifacts/my-api',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(true);
+      expect(result.current.openApiLoadSource).toBe('apicurio');
+      expect(result.current.sourceIdentifier).toBe('https://registry/artifacts/my-api');
+      expect(result.current.importOperations).toHaveLength(1);
+    });
+
+    it('handles invalid OpenAPI spec gracefully', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: 'invalid json {{{',
+          source: 'file',
+          sourceIdentifier: 'invalid.json',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(false);
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: expect.stringMatching(/Invalid spec/),
+      });
+    });
+
+    it('handles spec with no paths', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const noPaths = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: noPaths,
+          source: 'file',
+          sourceIdentifier: 'empty.json',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(false);
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: 'No operations were found in the specification.',
+      });
+    });
+  });
+
+  it('does not create duplicate route when operation direct route already exists', () => {
+    const camelResource = new CamelRouteResource([
+      {
+        route: {
+          from: {
+            uri: 'direct:addPet',
+            steps: [],
+          },
+        },
+      },
+    ]);
+
+    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
+    const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
+
+    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <SettingsContext.Provider value={mockSettingsContext}>
+        <Provider>{children}</Provider>
+      </SettingsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+    const spec: OpenApi = {
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/pet': {
+          post: {
+            operationId: 'addPet',
+            responses: {
+              '200': { description: 'ok' },
+            },
+          },
+        },
+      },
+    };
+
+    act(() => {
+      result.current.setOpenApiSpecText(JSON.stringify(spec));
+    });
+
+    act(() => {
+      result.current.handleParseOpenApiSpec();
+    });
+
+    let imported = false;
+    act(() => {
+      imported = result.current.handleImportOpenApi();
+    });
+
+    expect(imported).toBe(false);
+    expect(addNewEntitySpy).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
+  });
+
+  describe('resetImportWizard', () => {
+    it('resets all state to defaults after loading a spec', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'uri',
+          sourceIdentifier: 'https://example.com/openapi.yaml',
+        });
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(true);
+      expect(result.current.importOperations).toHaveLength(1);
+
+      act(() => {
+        result.current.resetImportWizard();
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(false);
+      expect(result.current.openApiSpecText).toBe('');
+      expect(result.current.sourceIdentifier).toBe('');
+      expect(result.current.openApiLoadSource).toBeUndefined();
+      expect(result.current.importSource).toBe('file');
+      expect(result.current.importCreateRest).toBe(false);
+      expect(result.current.importCreateRoutes).toBe(true);
+      expect(result.current.importSelectAll).toBe(true);
+      expect(result.current.importOperations).toHaveLength(0);
+      expect(result.current.importStatus).toBeNull();
+    });
+  });
+
+  describe('handleImportSourceChange', () => {
+    it('changes import source and resets relevant state', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      expect(result.current.importSource).toBe('file');
+      expect(result.current.isOpenApiParsed).toBe(true);
+
+      act(() => {
+        result.current.handleImportSourceChange('uri');
+      });
+
+      expect(result.current.importSource).toBe('uri');
+      expect(result.current.isOpenApiParsed).toBe(false);
+      expect(result.current.openApiLoadSource).toBeUndefined();
+      expect(result.current.sourceIdentifier).toBe('');
+      expect(result.current.importOperations).toHaveLength(0);
+    });
+  });
+
+  describe('handleParseOpenApiSpec', () => {
+    it('sets error status when spec text is empty', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      act(() => {
+        result.current.handleParseOpenApiSpec();
+      });
+
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: 'Provide an OpenAPI specification to import.',
+      });
+      expect(result.current.isOpenApiParsed).toBe(false);
+    });
+
+    it('parses valid spec text that was previously set', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.setOpenApiSpecText(validSpec);
+      });
+
+      act(() => {
+        result.current.handleParseOpenApiSpec();
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(true);
+      expect(result.current.importStatus).toBeNull();
+      expect(result.current.importOperations).toHaveLength(1);
+    });
+
+    it('sets error when spec text is invalid', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      act(() => {
+        result.current.setOpenApiSpecText('not valid yaml {{{');
+      });
+
+      act(() => {
+        result.current.handleParseOpenApiSpec();
+      });
+
+      expect(result.current.isOpenApiParsed).toBe(false);
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: expect.any(String),
+      });
+    });
+  });
+
+  describe('handleToggleSelectAllOperations', () => {
+    it('deselects all operations and then selects all', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+            post: { operationId: 'addPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      expect(result.current.importOperations).toHaveLength(2);
+      expect(result.current.importSelectAll).toBe(true);
+
+      act(() => {
+        result.current.handleToggleSelectAllOperations(false);
+      });
+
+      expect(result.current.importOperations.every((op) => !op.selected)).toBe(true);
+      expect(result.current.importSelectAll).toBe(false);
+
+      act(() => {
+        result.current.handleToggleSelectAllOperations(true);
+      });
+
+      expect(result.current.importOperations.every((op) => op.selected)).toBe(true);
+      expect(result.current.importSelectAll).toBe(true);
+    });
+  });
+
+  describe('handleToggleOperation', () => {
+    it('toggles selection of a specific operation', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      const validSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+            post: { operationId: 'addPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      expect(result.current.importOperations).toHaveLength(2);
+      expect(result.current.importOperations.every((op) => op.selected)).toBe(true);
+
+      act(() => {
+        result.current.handleToggleOperation('getPet', 'get', '/pet', false);
+      });
+
+      const getPetOp = result.current.importOperations.find((op) => op.operationId === 'getPet');
+      const addPetOp = result.current.importOperations.find((op) => op.operationId === 'addPet');
+      expect(getPetOp?.selected).toBe(false);
+      expect(addPetOp?.selected).toBe(true);
+      expect(result.current.importSelectAll).toBe(false);
+    });
+  });
+
+  describe('handleImportOpenApi', () => {
+    const validSpec = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/pet': {
+          get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+        },
+      },
+    });
+    let routeWrapper: FunctionComponent<PropsWithChildren>;
+    let camelResource: CamelResource;
+    let updateEntitiesFromCamelResourceSpy: EntitiesContextResult['updateEntitiesFromCamelResource'];
+
+    beforeEach(() => {
+      const testProvider = TestProvidersWrapper();
+      const Provider = testProvider.Provider;
+      camelResource = testProvider.camelResource;
+      updateEntitiesFromCamelResourceSpy = testProvider.updateEntitiesFromCamelResourceSpy;
+
+      routeWrapper = ({ children }) => (
+        <SettingsContext.Provider value={mockSettingsContext}>
+          <Provider>{children}</Provider>
+        </SettingsContext.Provider>
+      );
+    });
+
+    it('returns false when neither REST nor routes are selected', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      act(() => {
+        result.current.setImportCreateRest(false);
+        result.current.setImportCreateRoutes(false);
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(false);
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: 'Import failed. Choose at least one option to generate.',
+      });
+    });
+
+    it('returns false when no operations are selected', () => {
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      act(() => {
+        result.current.handleToggleSelectAllOperations(false);
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(false);
+      expect(result.current.importStatus).toEqual({
+        type: 'error',
+        message: 'Import failed. Select at least one operation.',
+      });
+    });
+
+    it('creates routes when importCreateRoutes is enabled', () => {
+      const mockRouteEntity = {
+        id: 'new-route-1',
+        type: 'route',
+        updateModel: jest.fn(),
+      };
+      camelResource.addNewEntity = jest.fn().mockReturnValue('new-route-1');
+      camelResource.getVisualEntities = jest.fn().mockReturnValue([mockRouteEntity]);
+
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper: routeWrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(true);
+      expect(camelResource.addNewEntity).toHaveBeenCalledWith('route');
+      expect(mockRouteEntity.updateModel).toHaveBeenCalledWith('route.from.uri', 'direct:getPet');
+      expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+      expect(result.current.importStatus).toEqual({
+        type: 'success',
+        message: 'Import succeeded. 1 operation added.',
+      });
+    });
+
+    it('creates REST definition when importCreateRest is enabled', () => {
+      const mockRestEntity = {
+        id: 'new-rest-1',
+        type: 'rest',
+        updateModel: jest.fn(),
+        getRootPath: jest.fn().mockReturnValue('rest'),
+      };
+      camelResource.addNewEntity = jest.fn().mockReturnValue('new-rest-1');
+      camelResource.getVisualEntities = jest.fn().mockReturnValue([mockRestEntity]);
+
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper: routeWrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      act(() => {
+        result.current.setImportCreateRest(true);
+        result.current.setImportCreateRoutes(false);
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(true);
+      expect(camelResource.addNewEntity).toHaveBeenCalledWith('rest');
+      expect(mockRestEntity.updateModel).toHaveBeenCalled();
+      expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+    });
+
+    it('creates both routes and REST definitions when both are enabled', () => {
+      const mockRouteEntity = { id: 'new-route-1', type: 'route', updateModel: jest.fn() };
+      const mockRestEntity = {
+        id: 'new-rest-1',
+        type: 'rest',
+        updateModel: jest.fn(),
+        getRootPath: jest.fn().mockReturnValue('rest'),
+      };
+      camelResource.addNewEntity = jest.fn().mockImplementation((type) => {
+        return type === 'rest' ? 'new-rest-1' : 'new-route-1';
+      });
+      camelResource.getVisualEntities = jest.fn().mockReturnValue([mockRouteEntity, mockRestEntity]);
+
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper: routeWrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: validSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      act(() => {
+        result.current.setImportCreateRest(true);
+        result.current.setImportCreateRoutes(true);
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(true);
+      expect(camelResource.addNewEntity).toHaveBeenCalledWith('route');
+      expect(camelResource.addNewEntity).toHaveBeenCalledWith('rest');
+      expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+    });
+
+    it('reports plural message for multiple operations', () => {
+      const mockRouteEntity1 = { id: 'new-route-1', type: 'route', updateModel: jest.fn() };
+      const mockRouteEntity2 = { id: 'new-route-2', type: 'route', updateModel: jest.fn() };
+      let routeCount = 0;
+      camelResource.addNewEntity = jest.fn().mockImplementation(() => {
+        routeCount++;
+        return `new-route-${routeCount}`;
+      });
+      camelResource.getVisualEntities = jest.fn().mockReturnValue([mockRouteEntity1, mockRouteEntity2]);
+
+      const multiOpSpec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+            post: { operationId: 'addPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      });
+
+      const { result } = renderHook(() => useRestDslImportWizard(), { wrapper: routeWrapper });
+
+      act(() => {
+        result.current.handleSchemaLoaded({
+          schema: multiOpSpec,
+          source: 'file',
+          sourceIdentifier: 'spec.json',
+        });
+      });
+
+      let imported = false;
+      act(() => {
+        imported = result.current.handleImportOpenApi();
+      });
+
+      expect(imported).toBe(true);
+      expect(result.current.importStatus?.message).toBe('Import succeeded. 2 operations added.');
+    });
+  });
+});

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
@@ -1,0 +1,253 @@
+import { OpenApi } from 'openapi-v3';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import { parse as parseYaml } from 'yaml';
+
+import { EntityType } from '../../models/camel/entities';
+import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
+import { CamelRouteVisualEntity } from '../../models/visualization/flows/camel-route-visual-entity';
+import { EntitiesContext, SettingsContext } from '../../providers';
+import { OpenApiProcessingService } from '../../services/openapi-processing.service';
+import { ImportLoadSource, ImportOperation, ImportSourceOption, SchemaLoadedResult } from './RestDslImportTypes';
+
+export const useRestDslImportWizard = () => {
+  const entitiesContext = useContext(EntitiesContext);
+  const settingsAdapter = useContext(SettingsContext);
+  const apicurioRegistryUrl = settingsAdapter.getSettings().rest.apicurioRegistryUrl;
+
+  const [importOperations, setImportOperations] = useState<ImportOperation[]>([]);
+  const [openApiLoadSource, setOpenApiLoadSource] = useState<ImportLoadSource>(undefined);
+  const [importSource, setImportSource] = useState<ImportSourceOption>('file');
+  const [importCreateRest, setImportCreateRest] = useState(false);
+  const [importCreateRoutes, setImportCreateRoutes] = useState(true);
+  const [importSelectAll, setImportSelectAll] = useState(true);
+  const [isOpenApiParsed, setIsOpenApiParsed] = useState(false);
+  const [openApiSpecText, setOpenApiSpecText] = useState('');
+  const [sourceIdentifier, setSourceIdentifier] = useState('');
+  const [importStatus, setImportStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const resetImportWizard = useCallback(() => {
+    setImportOperations([]);
+    setIsOpenApiParsed(false);
+    setOpenApiSpecText('');
+    setSourceIdentifier('');
+    setOpenApiLoadSource(undefined);
+    setImportSource('file');
+    setImportCreateRest(false);
+    setImportCreateRoutes(true);
+    setImportSelectAll(true);
+    setImportStatus(null);
+  }, []);
+
+  const parseOpenApiSpec = useCallback((specText: string): { success: boolean; error?: string } => {
+    if (!specText.trim()) {
+      setImportOperations([]);
+      setIsOpenApiParsed(false);
+      return { success: false, error: 'Provide an OpenAPI specification to import.' };
+    }
+
+    try {
+      const spec = parseYaml(specText) as OpenApi;
+      if (!spec || typeof spec !== 'object' || !('paths' in spec)) {
+        throw new Error('Invalid spec');
+      }
+      setOpenApiSpecText(JSON.stringify(spec, null, 2));
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      if (operations.length === 0) {
+        setImportOperations([]);
+        setIsOpenApiParsed(false);
+        return { success: false, error: 'No operations were found in the specification.' };
+      }
+
+      setImportOperations(operations);
+      setImportSelectAll(true);
+      setIsOpenApiParsed(true);
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid OpenAPI specification.';
+      setImportOperations([]);
+      setIsOpenApiParsed(false);
+      return { success: false, error: message };
+    }
+  }, []);
+
+  const handleSchemaLoaded = useCallback(
+    (result: SchemaLoadedResult) => {
+      const parsed = parseOpenApiSpec(result.schema);
+      if (parsed.success) {
+        setOpenApiLoadSource(result.source);
+        setSourceIdentifier(result.sourceIdentifier);
+        setImportStatus(null);
+      } else if (parsed.error) {
+        setImportStatus({ type: 'error', message: parsed.error });
+      }
+    },
+    [parseOpenApiSpec],
+  );
+
+  const importOperationsWithRouteExists = useMemo(() => {
+    const routeNames = new Set<string>();
+    const visualRoutes = entitiesContext?.visualEntities?.filter((entity) => entity.type === EntityType.Route) ?? [];
+    if (visualRoutes.length > 0) {
+      visualRoutes.forEach((entity) => {
+        const routeEntity = entity as CamelRouteVisualEntity;
+        const uri = routeEntity.entityDef?.route?.from?.uri ?? '';
+        if (uri.startsWith('direct:')) {
+          routeNames.add(uri.slice('direct:'.length).split('?')[0]);
+        }
+      });
+    }
+
+    return OpenApiProcessingService.applyRouteExistsToOperations(importOperations, routeNames).map((operation) => ({
+      ...operation,
+      selected: operation.routeExists ? false : operation.selected,
+    }));
+  }, [entitiesContext?.visualEntities, importOperations]);
+
+  const handleToggleSelectAllOperations = useCallback(
+    (checked: boolean) => {
+      const routeExistsByKey = new Map(
+        importOperationsWithRouteExists.map((operation) => [
+          OpenApiProcessingService.getOperationKey(operation),
+          operation.routeExists,
+        ]),
+      );
+      setImportOperations((prev) => {
+        const withRouteExists = prev.map((operation) => ({
+          ...operation,
+          routeExists: routeExistsByKey.get(OpenApiProcessingService.getOperationKey(operation)) ?? false,
+        }));
+        const next = OpenApiProcessingService.toggleSelectAllOperations(withRouteExists, checked);
+        const selectable = next.filter((operation) => !operation.routeExists);
+        const allSelected = selectable.length > 0 && selectable.every((operation) => operation.selected);
+        setImportSelectAll(allSelected);
+        return next;
+      });
+    },
+    [importOperationsWithRouteExists],
+  );
+
+  const handleToggleOperation = useCallback((operationId: string, method: string, path: string, checked: boolean) => {
+    setImportOperations((prev) => {
+      const next = prev.map((operation) =>
+        operation.operationId === operationId && operation.method === method && operation.path === path
+          ? { ...operation, selected: checked }
+          : operation,
+      );
+      setImportSelectAll(next.every((operation) => operation.selected));
+      return next;
+    });
+  }, []);
+
+  const handleImportOpenApi = useCallback((): boolean => {
+    if (!entitiesContext || (!importCreateRest && !importCreateRoutes)) {
+      setImportStatus({
+        type: 'error',
+        message: 'Import failed. Choose at least one option to generate.',
+      });
+      return false;
+    }
+    const selectedOperations = importOperationsWithRouteExists.filter((operation) => operation.selected);
+    if (selectedOperations.length === 0) {
+      setImportStatus({
+        type: 'error',
+        message: 'Import failed. Select at least one operation.',
+      });
+      return false;
+    }
+
+    const camelResource = entitiesContext.camelResource as {
+      addNewEntity: (type?: EntityType) => string;
+      getVisualEntities: () => Array<{ id: string; type: EntityType }>;
+    };
+
+    if (importCreateRoutes) {
+      selectedOperations.forEach((operation) => {
+        if (operation.routeExists) return;
+        const newId = camelResource.addNewEntity(EntityType.Route);
+        const routeEntity = camelResource
+          .getVisualEntities()
+          .find((entity) => entity.type === EntityType.Route && entity.id === newId) as
+          | CamelRouteVisualEntity
+          | undefined;
+
+        routeEntity?.updateModel('route.id', `route-${operation.operationId}`);
+        routeEntity?.updateModel('route.from.id', `direct-from-${operation.operationId}`);
+        routeEntity?.updateModel('route.from.uri', `direct:${operation.operationId}`);
+        routeEntity?.updateModel('route.from.steps', [
+          {
+            setBody: {
+              constant: `Operation ${operation.operationId} not yet implemented`,
+            },
+          },
+        ]);
+      });
+    }
+
+    if (importCreateRest) {
+      const newRestId = camelResource.addNewEntity(EntityType.Rest);
+      const restEntity = camelResource
+        .getVisualEntities()
+        .find((entity) => entity.type === EntityType.Rest && entity.id === newRestId) as
+        | CamelRestVisualEntity
+        | undefined;
+
+      if (restEntity) {
+        const restDefinition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+          selectedOperations,
+          newRestId,
+          sourceIdentifier,
+        );
+        restEntity.updateModel(restEntity.getRootPath(), restDefinition);
+      }
+    }
+
+    entitiesContext.updateEntitiesFromCamelResource();
+    setImportStatus({
+      type: 'success',
+      message: `Import succeeded. ${selectedOperations.length} operation${selectedOperations.length === 1 ? '' : 's'} added.`,
+    });
+    return true;
+  }, [entitiesContext, importCreateRest, importCreateRoutes, importOperationsWithRouteExists, sourceIdentifier]);
+
+  const handleImportSourceChange = useCallback((nextSource: ImportSourceOption) => {
+    setImportSource(nextSource);
+    setImportOperations([]);
+    setIsOpenApiParsed(false);
+    setOpenApiLoadSource(undefined);
+    setImportSelectAll(true);
+    setSourceIdentifier('');
+  }, []);
+
+  const handleParseOpenApiSpec = useCallback(() => {
+    const result = parseOpenApiSpec(openApiSpecText);
+    if (!result.success && result.error) {
+      setImportStatus({ type: 'error', message: result.error });
+    } else {
+      setImportStatus(null);
+    }
+  }, [openApiSpecText, parseOpenApiSpec]);
+
+  return {
+    importSource,
+    isOpenApiParsed,
+    openApiSpecText,
+    openApiLoadSource,
+    sourceIdentifier,
+    importCreateRest,
+    importCreateRoutes,
+    importSelectAll,
+    importOperations: importOperationsWithRouteExists,
+    importStatus,
+    apicurioRegistryUrl,
+    handleSchemaLoaded,
+    handleImportSourceChange,
+    setOpenApiSpecText,
+    handleParseOpenApiSpec,
+    setImportCreateRest,
+    setImportCreateRoutes,
+    handleToggleSelectAllOperations,
+    handleToggleOperation,
+    handleImportOpenApi,
+    resetImportWizard,
+  };
+};

--- a/packages/ui/src/router.tsx
+++ b/packages/ui/src/router.tsx
@@ -24,6 +24,10 @@ export const router = createHashRouter([
         lazy: async () => import('./pages/SourceCode'),
       },
       {
+        path: Links.RestImport,
+        lazy: async () => import('./pages/RestDslImport'),
+      },
+      {
         path: Links.Catalog,
         lazy: async () => import('./pages/Catalog'),
       },

--- a/packages/ui/src/router/links.models.ts
+++ b/packages/ui/src/router/links.models.ts
@@ -5,6 +5,7 @@ export const enum Links {
   About = '/about',
   Beans = '/beans',
   Rest = '/rest',
+  RestImport = '/rest/import',
   Metadata = '/metadata',
   PipeErrorHandler = '/pipe-error-handler',
   Catalog = '/catalog',

--- a/packages/ui/src/services/openapi-processing.service.test.ts
+++ b/packages/ui/src/services/openapi-processing.service.test.ts
@@ -1,0 +1,909 @@
+import { OpenApi, OpenApiParameter } from 'openapi-v3';
+
+import { OpenApiProcessingService } from './openapi-processing.service';
+
+describe('OpenApiProcessingService', () => {
+  describe('buildOperationsFromSpec()', () => {
+    it('maps consumes/produces from request and response content types', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            post: {
+              operationId: 'addPet',
+              requestBody: {
+                content: {
+                  'application/json': {},
+                  'application/xml': {},
+                  'application/x-www-form-urlencoded': {},
+                },
+              },
+              responses: {
+                '200': {
+                  description: 'Success',
+                  content: {
+                    'application/json': {},
+                    'application/xml': {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].consumes).toBe('application/json,application/xml,application/x-www-form-urlencoded');
+      expect(operations[0].produces).toBe('application/json,application/xml');
+    });
+
+    it('maps responseMessage from OpenAPI responses', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            post: {
+              operationId: 'addPet',
+              responses: {
+                '200': { description: 'Successful operation' },
+                '400': { description: 'Invalid input' },
+                default: { description: 'Unexpected error' },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].responseMessage).toEqual([
+        { code: '200', message: 'Successful operation' },
+        { code: '400', message: 'Invalid input' },
+        { code: 'default', message: 'Unexpected error' },
+      ]);
+    });
+
+    it('maps response headers with allowable values', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPet',
+              responses: {
+                '200': {
+                  description: 'Success',
+                  headers: {
+                    'X-Rate-Limit': {
+                      description: 'Rate limit',
+                      schema: {
+                        type: 'string',
+                        enum: ['low', 'medium', 'high'],
+                      },
+                      content: {},
+                    },
+                    'X-Request-Id': {
+                      description: 'Request ID',
+                      content: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].responseMessage).toEqual([
+        {
+          code: '200',
+          message: 'Success',
+          header: [
+            {
+              name: 'X-Rate-Limit',
+              description: 'Rate limit',
+              allowableValues: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
+            },
+            {
+              name: 'X-Request-Id',
+              description: 'Request ID',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('maps response headers without descriptions', () => {
+      const spec: OpenApi = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPet',
+              responses: {
+                '200': {
+                  description: 'Success',
+                  headers: {
+                    'X-Correlation-Id': {
+                      schema: { type: 'string' },
+                      content: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].responseMessage).toEqual([
+        {
+          code: '200',
+          message: 'Success',
+          header: [{ name: 'X-Correlation-Id' }],
+        },
+      ]);
+    });
+
+    it('maps security requirements and scopes from OpenAPI operation security', () => {
+      const spec: OpenApi = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            post: {
+              operationId: 'addPet',
+              security: [{ petstore_auth: ['write:pets', 'read:pets'] }, { api_key: [] }],
+              responses: {
+                '200': { description: 'Success' },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].security).toEqual([
+        { key: 'petstore_auth', scopes: 'write:pets,read:pets' },
+        { key: 'api_key' },
+      ]);
+    });
+
+    it('maps params from OpenAPI operation/path parameters', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet/{id}': {
+            parameters: [
+              {
+                name: 'id',
+                in: 'path' as const,
+                required: true,
+                description: 'Pet id',
+                schema: { type: 'string' },
+              },
+            ],
+            get: {
+              operationId: 'getPet',
+              parameters: [
+                {
+                  name: 'status',
+                  in: 'query' as const,
+                  required: false,
+                  schema: { type: 'string', default: 'available', enum: ['available', 'sold'] },
+                },
+              ],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].param).toEqual([
+        {
+          name: 'id',
+          type: 'path',
+          required: true,
+          description: 'Pet id',
+          dataType: 'string',
+        },
+        {
+          name: 'status',
+          type: 'query',
+          required: false,
+          dataType: 'string',
+          defaultValue: 'available',
+          allowableValues: [{ value: 'available' }, { value: 'sold' }],
+        },
+      ]);
+    });
+
+    it('merges path and operation parameters with operation taking precedence', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet/{id}': {
+            parameters: [
+              {
+                name: 'id',
+                in: 'path' as const,
+                required: true,
+                description: 'Path level description',
+                schema: { type: 'string' },
+              },
+            ],
+            get: {
+              operationId: 'getPet',
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path' as const,
+                  required: true,
+                  description: 'Operation level description',
+                  schema: { type: 'integer' },
+                },
+              ],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].param).toEqual([
+        {
+          name: 'id',
+          type: 'path',
+          required: true,
+          description: 'Operation level description',
+          dataType: 'integer',
+        },
+      ]);
+    });
+
+    it('filters out invalid parameters without name or location', () => {
+      const spec: OpenApi = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            parameters: [
+              { name: 'valid', in: 'query' } as OpenApiParameter,
+              { name: 'no-location' } as OpenApiParameter,
+              { in: 'query' } as OpenApiParameter,
+              null as unknown as OpenApiParameter,
+              'invalid' as unknown as OpenApiParameter,
+            ],
+            get: {
+              operationId: 'getPet',
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].param).toEqual([
+        {
+          name: 'valid',
+          type: 'query',
+        },
+      ]);
+    });
+
+    it('uses summary when description is missing and maps deprecated flag', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            put: {
+              operationId: 'updatePet',
+              summary: 'Update pet summary',
+              deprecated: true,
+              responses: {
+                '200': {
+                  description: 'Success',
+                  content: {
+                    'application/json': {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].description).toBe('Update pet summary');
+      expect(operations[0].deprecated).toBe(true);
+    });
+
+    it('falls back to first response content type when no 2xx response exists', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            post: {
+              operationId: 'addPet',
+              responses: {
+                '400': {
+                  description: 'Error',
+                  content: {
+                    'application/problem+json': {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].produces).toBe('application/problem+json');
+    });
+
+    it('uses generated operationId when OpenAPI operationId is missing', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            delete: {
+              responses: {
+                '200': { description: 'ok' },
+              },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].operationId).toBe('delete-/pet');
+    });
+
+    it('returns empty array when spec has no paths', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      };
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toEqual([]);
+    });
+
+    it('returns empty array when spec paths is undefined', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+      } as OpenApi;
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toEqual([]);
+    });
+
+    it('handles all REST verbs', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+            post: { operationId: 'addPet', responses: { '200': { description: 'ok' } } },
+            put: { operationId: 'updatePet', responses: { '200': { description: 'ok' } } },
+            delete: { operationId: 'deletePet', responses: { '200': { description: 'ok' } } },
+            patch: { operationId: 'patchPet', responses: { '200': { description: 'ok' } } },
+            head: { operationId: 'headPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(6);
+      expect(operations.map((op) => op.method)).toEqual(['get', 'post', 'put', 'delete', 'patch', 'head']);
+    });
+
+    it('sets all operations as selected by default', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: { operationId: 'getPet', responses: { '200': { description: 'ok' } } },
+            post: { operationId: 'addPet', responses: { '200': { description: 'ok' } } },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations.every((op) => op.selected)).toBe(true);
+      expect(operations.every((op) => !op.routeExists)).toBe(true);
+    });
+
+    it('handles operations with no optional fields', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/pet': {
+            get: {
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
+      expect(operations).toHaveLength(1);
+      expect(operations[0].operationId).toBe('get-/pet');
+      expect(operations[0].description).toBeUndefined();
+      expect(operations[0].consumes).toBeUndefined();
+      expect(operations[0].produces).toBeUndefined();
+      expect(operations[0].deprecated).toBeUndefined();
+      expect(operations[0].param).toEqual([]);
+      expect(operations[0].security).toEqual([]);
+      expect(operations[0].responseMessage).toHaveLength(1);
+    });
+  });
+
+  describe('buildRestDefinitionFromOperations()', () => {
+    it('builds rest operation entries with mapped import fields', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+        [
+          {
+            operationId: 'updatePet',
+            method: 'put',
+            path: '/pet',
+            description: 'Update an existing pet',
+            consumes: 'application/json,application/xml',
+            produces: 'application/json',
+            param: [{ name: 'id', type: 'path' }],
+            responseMessage: [{ code: '200', message: 'ok' }],
+            security: [{ key: 'petstore_auth', scopes: 'write:pets,read:pets' }],
+            deprecated: true,
+            selected: true,
+            routeExists: false,
+          },
+        ],
+        'rest-1',
+        'petstore.json',
+      );
+
+      expect(definition).toEqual({
+        id: 'rest-1',
+        openApi: { specification: 'petstore.json' },
+        put: [
+          {
+            id: 'updatePet',
+            path: '/pet',
+            routeId: 'route-updatePet',
+            to: 'direct:updatePet',
+            description: 'Update an existing pet',
+            consumes: 'application/json,application/xml',
+            produces: 'application/json',
+            param: [{ name: 'id', type: 'path' }],
+            responseMessage: [{ code: '200', message: 'ok' }],
+            security: [{ key: 'petstore_auth', scopes: 'write:pets,read:pets' }],
+            deprecated: true,
+          },
+        ],
+      });
+    });
+
+    it('omits openApi specification when URI is empty', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+        [
+          {
+            operationId: 'getPet',
+            method: 'get',
+            path: '/pet',
+            selected: true,
+            routeExists: false,
+          },
+        ],
+        'rest-1',
+        '',
+      );
+
+      expect(definition).toEqual({
+        id: 'rest-1',
+        get: [
+          {
+            id: 'getPet',
+            path: '/pet',
+            routeId: 'route-getPet',
+            to: 'direct:getPet',
+          },
+        ],
+      });
+    });
+
+    it('omits openApi specification when URI is whitespace', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+        [
+          {
+            operationId: 'getPet',
+            method: 'get',
+            path: '/pet',
+            selected: true,
+            routeExists: false,
+          },
+        ],
+        'rest-1',
+        '   ',
+      );
+
+      expect(definition).toEqual({
+        id: 'rest-1',
+        get: [
+          {
+            id: 'getPet',
+            path: '/pet',
+            routeId: 'route-getPet',
+            to: 'direct:getPet',
+          },
+        ],
+      });
+    });
+
+    it('groups multiple operations by method', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+        [
+          {
+            operationId: 'getPet',
+            method: 'get',
+            path: '/pet/{id}',
+            selected: true,
+            routeExists: false,
+          },
+          {
+            operationId: 'listPets',
+            method: 'get',
+            path: '/pet',
+            selected: true,
+            routeExists: false,
+          },
+          {
+            operationId: 'addPet',
+            method: 'post',
+            path: '/pet',
+            selected: true,
+            routeExists: false,
+          },
+        ],
+        'rest-1',
+        '',
+      );
+
+      expect(definition.get).toHaveLength(2);
+      expect(definition.post).toHaveLength(1);
+    });
+
+    it('omits optional fields when not provided', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations(
+        [
+          {
+            operationId: 'getPet',
+            method: 'get',
+            path: '/pet',
+            description: '',
+            consumes: '',
+            produces: '',
+            param: [],
+            responseMessage: [],
+            security: [],
+            selected: true,
+            routeExists: false,
+          },
+        ],
+        'rest-1',
+        '',
+      );
+
+      expect(definition.get).toBeDefined();
+      expect(Array.isArray(definition.get)).toBe(true);
+      expect((definition.get as Array<unknown>)[0]).toEqual({
+        id: 'getPet',
+        path: '/pet',
+        routeId: 'route-getPet',
+        to: 'direct:getPet',
+      });
+    });
+
+    it('handles empty operations array', () => {
+      const definition = OpenApiProcessingService.buildRestDefinitionFromOperations([], 'rest-1', 'spec.json');
+
+      expect(definition).toEqual({
+        id: 'rest-1',
+        openApi: { specification: 'spec.json' },
+      });
+    });
+  });
+
+  describe('getOperationKey()', () => {
+    it('generates unique key from operationId, method, and path', () => {
+      const key = OpenApiProcessingService.getOperationKey({
+        operationId: 'getPet',
+        method: 'get',
+        path: '/pet/{id}',
+      });
+
+      expect(key).toBe('getPet-get-/pet/{id}');
+    });
+
+    it('handles special characters in path', () => {
+      const key = OpenApiProcessingService.getOperationKey({
+        operationId: 'searchPets',
+        method: 'get',
+        path: '/pets?filter=active&sort=name',
+      });
+
+      expect(key).toBe('searchPets-get-/pets?filter=active&sort=name');
+    });
+
+    it('handles unicode characters in path', () => {
+      const key = OpenApiProcessingService.getOperationKey({
+        operationId: 'getUser',
+        method: 'get',
+        path: '/users/José',
+      });
+
+      expect(key).toBe('getUser-get-/users/José');
+    });
+
+    it('handles very long operation keys', () => {
+      const longPath = '/api/v1/' + 'segment/'.repeat(50) + 'endpoint';
+      const key = OpenApiProcessingService.getOperationKey({
+        operationId: 'veryLongOperationId',
+        method: 'post',
+        path: longPath,
+      });
+
+      expect(key).toBe(`veryLongOperationId-post-${longPath}`);
+      expect(key.length).toBeGreaterThan(100);
+    });
+  });
+
+  describe('applyRouteExistsToOperations()', () => {
+    it('marks operations with existing routes', () => {
+      const operations = [
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+
+      const result = OpenApiProcessingService.applyRouteExistsToOperations(operations, new Set(['addPet']));
+
+      expect(result).toEqual([
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: true,
+          routeExists: true,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ]);
+    });
+
+    it('handles empty route set', () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: true,
+        },
+      ];
+
+      const result = OpenApiProcessingService.applyRouteExistsToOperations(operations, new Set());
+
+      expect(result).toEqual([
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ]);
+    });
+
+    it('handles empty operations array', () => {
+      const result = OpenApiProcessingService.applyRouteExistsToOperations([], new Set(['someRoute']));
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles operations where routeNames partially match', () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+        {
+          operationId: 'getPets',
+          method: 'get',
+          path: '/pets',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+
+      const result = OpenApiProcessingService.applyRouteExistsToOperations(operations, new Set(['getPet']));
+
+      expect(result[0].routeExists).toBe(true);
+      expect(result[1].routeExists).toBe(false);
+    });
+  });
+
+  describe('toggleSelectAllOperations()', () => {
+    it('keeps route-existing operations unselected when selecting all', () => {
+      const operations = [
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: false,
+          routeExists: true,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: false,
+          routeExists: false,
+        },
+      ];
+
+      const toggled = OpenApiProcessingService.toggleSelectAllOperations(operations, true);
+
+      expect(toggled).toEqual([
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: false,
+          routeExists: true,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ]);
+    });
+
+    it('keeps route-existing operations unselected when deselecting all', () => {
+      const operations = [
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: true,
+          routeExists: true,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+
+      const toggled = OpenApiProcessingService.toggleSelectAllOperations(operations, false);
+
+      expect(toggled).toEqual([
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: false,
+          routeExists: true,
+        },
+        {
+          operationId: 'updatePet',
+          method: 'put',
+          path: '/pet',
+          selected: false,
+          routeExists: false,
+        },
+      ]);
+    });
+
+    it('handles empty operations array', () => {
+      const toggled = OpenApiProcessingService.toggleSelectAllOperations([], true);
+
+      expect(toggled).toEqual([]);
+    });
+
+    it('selects all operations when none have existing routes', () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: false,
+          routeExists: false,
+        },
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: false,
+          routeExists: false,
+        },
+      ];
+
+      const toggled = OpenApiProcessingService.toggleSelectAllOperations(operations, true);
+
+      expect(toggled.every((op) => op.selected)).toBe(true);
+    });
+
+    it('deselects all operations when none have existing routes', () => {
+      const operations = [
+        {
+          operationId: 'getPet',
+          method: 'get',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+        {
+          operationId: 'addPet',
+          method: 'post',
+          path: '/pet',
+          selected: true,
+          routeExists: false,
+        },
+      ];
+
+      const toggled = OpenApiProcessingService.toggleSelectAllOperations(operations, false);
+
+      expect(toggled.every((op) => !op.selected)).toBe(true);
+    });
+  });
+});

--- a/packages/ui/src/services/openapi-processing.service.ts
+++ b/packages/ui/src/services/openapi-processing.service.ts
@@ -1,0 +1,329 @@
+import { OpenApi, OpenApiOperation, OpenApiPath } from 'openapi-v3';
+
+import { REST_DSL_VERBS } from '../models/special-processors.constants';
+import { ImportOperation } from '../pages/RestDslImport/RestDslImportTypes';
+
+/**
+ * Service for processing OpenAPI specifications and converting them to Camel REST DSL format.
+ *
+ * This service provides utilities for:
+ * - Parsing OpenAPI specs into ImportOperation objects
+ * - Building Camel REST definitions from operations
+ * - Managing operation selection state
+ * - Tracking which operations have existing routes
+ */
+export class OpenApiProcessingService {
+  private static readonly SUCCESS_STATUS_CODE_REGEX = /^2\d\d$/;
+
+  /**
+   * Builds a list of ImportOperation objects from an OpenAPI specification.
+   *
+   * Iterates through all paths and REST verbs (GET, POST, PUT, DELETE, PATCH, HEAD),
+   * extracting operation details including parameters, security, and response information.
+   *
+   * @param spec - The OpenAPI specification object
+   * @returns Array of ImportOperation objects, empty if spec has no paths
+   */
+  static buildOperationsFromSpec(spec: OpenApi): ImportOperation[] {
+    const operations: ImportOperation[] = [];
+    const paths = spec.paths;
+    if (!paths) return operations;
+
+    /**
+     * Each path contains a set of get, post, etc operations
+     * {
+     *   "/hello": {
+     *     "get": {}
+     *     "post": {}
+     *   }
+     * }
+     */
+    Object.entries(paths).forEach(([pathKey, definition]) => {
+      if (!definition || typeof definition !== 'object') return;
+      REST_DSL_VERBS.forEach((method) => {
+        const op = definition[method as keyof Pick<OpenApiPath, 'get' | 'put' | 'post' | 'delete' | 'patch' | 'head'>];
+        if (!op) return;
+
+        const operationId = op.operationId ?? `${method}-${pathKey}`;
+        const description = op.description ?? op.summary;
+        const requestBodyContent = (op.requestBody as { content?: Record<string, unknown> } | undefined)?.content;
+        const consumes = requestBodyContent ? Object.keys(requestBodyContent).join(',') : undefined;
+
+        const responseEntries = Object.entries((op.responses as Record<string, unknown> | undefined) ?? {});
+        const successResponse = responseEntries.find(([statusCode]) =>
+          OpenApiProcessingService.SUCCESS_STATUS_CODE_REGEX.test(statusCode),
+        )?.[1] as { content?: Record<string, unknown> } | undefined;
+        const fallbackResponse = responseEntries[0]?.[1] as { content?: Record<string, unknown> } | undefined;
+        const responseContent = successResponse?.content ?? fallbackResponse?.content;
+        const produces = responseContent ? Object.keys(responseContent).join(',') : undefined;
+        const param = OpenApiProcessingService.buildCamelParamList(definition, op);
+        const security = OpenApiProcessingService.buildCamelSecurityList(op);
+        const responseMessage = OpenApiProcessingService.buildCamelResponseMessageList(op);
+        const deprecated = typeof op.deprecated === 'boolean' ? op.deprecated : undefined;
+
+        operations.push({
+          operationId,
+          method,
+          path: pathKey,
+          description,
+          consumes,
+          produces,
+          param,
+          security,
+          responseMessage,
+          deprecated,
+          selected: true,
+          routeExists: false,
+        });
+      });
+    });
+
+    return operations;
+  }
+
+  /**
+   * Builds a Camel REST definition from a list of operations.
+   *
+   * Groups operations by HTTP method and formats them according to Camel REST DSL schema.
+   * Includes optional OpenAPI specification reference if sourceIdentifier is provided.
+   *
+   * @param operations - Array of ImportOperation objects to include in the REST definition
+   * @param restId - Unique identifier for the REST definition
+   * @param sourceIdentifier - Optional source identifier (file path or URI) for the OpenAPI spec
+   * @returns Camel REST definition object with operations grouped by HTTP method
+   */
+  static buildRestDefinitionFromOperations(
+    operations: ImportOperation[],
+    restId: string,
+    sourceIdentifier: string,
+  ): Record<string, unknown> {
+    const restDefinition: Record<string, unknown> = { id: restId };
+    const trimmedIdentifier = sourceIdentifier.trim();
+    if (trimmedIdentifier) {
+      restDefinition.openApi = { specification: trimmedIdentifier };
+    }
+
+    operations.forEach((operation) => {
+      const methodKey = operation.method;
+      const list = (restDefinition[methodKey] as Record<string, unknown>[] | undefined) ?? [];
+      const operationDefinition: Record<string, unknown> = {
+        id: operation.operationId,
+        path: operation.path,
+        routeId: `route-${operation.operationId}`,
+        to: `direct:${operation.operationId}`,
+      };
+      const operationDescription = operation.description?.trim();
+      if (operationDescription) {
+        operationDefinition.description = operationDescription;
+      }
+      const operationConsumes = operation.consumes?.trim();
+      if (operationConsumes) {
+        operationDefinition.consumes = operationConsumes;
+      }
+      const operationProduces = operation.produces?.trim();
+      if (operationProduces) {
+        operationDefinition.produces = operationProduces;
+      }
+      if (operation.param && operation.param.length > 0) {
+        operationDefinition.param = operation.param;
+      }
+      if (operation.responseMessage && operation.responseMessage.length > 0) {
+        operationDefinition.responseMessage = operation.responseMessage;
+      }
+      if (operation.security && operation.security.length > 0) {
+        operationDefinition.security = operation.security;
+      }
+      if (typeof operation.deprecated === 'boolean') {
+        operationDefinition.deprecated = operation.deprecated;
+      }
+      list.push(operationDefinition);
+      restDefinition[methodKey] = list;
+    });
+
+    return restDefinition;
+  }
+
+  /**
+   * Generates a unique key for an operation based on operationId, method, and path.
+   *
+   * @param operation - Operation object with operationId, method, and path properties
+   * @returns Unique operation key in format "operationId-method-path"
+   */
+  static getOperationKey(operation: Pick<ImportOperation, 'operationId' | 'method' | 'path'>): string {
+    return `${operation.operationId}-${operation.method}-${operation.path}`;
+  }
+
+  /**
+   * Marks operations that have existing routes based on route names.
+   *
+   * An operation is considered to have an existing route if its operationId matches
+   * a route name in the provided set.
+   *
+   * @param operations - Array of operations to check
+   * @param routeNames - Set of existing route names (extracted from direct: URIs)
+   * @returns New array with routeExists flag updated for each operation
+   */
+  static applyRouteExistsToOperations(operations: ImportOperation[], routeNames: Set<string>): ImportOperation[] {
+    return operations.map((operation) => ({
+      ...operation,
+      routeExists: routeNames.has(operation.operationId),
+    }));
+  }
+
+  /**
+   * Updates the selected state for all operations based on the checked flag.
+   *
+   * Operations with existing routes (routeExists: true) remain unselected regardless
+   * of the checked value to prevent duplicate route creation.
+   *
+   * @param operations - Array of operations to update
+   * @param checked - Whether to select (true) or deselect (false) operations
+   * @returns New array with updated selection state
+   */
+  static toggleSelectAllOperations(operations: ImportOperation[], checked: boolean): ImportOperation[] {
+    return operations.map((operation) => ({
+      ...operation,
+      selected: operation.routeExists ? false : checked,
+    }));
+  }
+
+  /**
+   * Maps an OpenAPI parameter to Camel REST DSL parameter format.
+   *
+   * @param parameter - OpenAPI parameter object
+   * @returns Camel parameter object or undefined if parameter is invalid
+   */
+  private static mapOpenApiParameterToCamelParam(
+    parameter: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    const name = typeof parameter.name === 'string' ? parameter.name : undefined;
+    const location = typeof parameter.in === 'string' ? parameter.in : undefined;
+    if (!name || !location) return undefined;
+
+    const schema = (parameter.schema as Record<string, unknown> | undefined) ?? {};
+    const mapped: Record<string, unknown> = {
+      name,
+      type: location,
+    };
+
+    if (typeof parameter.required === 'boolean') {
+      mapped.required = parameter.required;
+    }
+    if (typeof parameter.description === 'string' && parameter.description.trim()) {
+      mapped.description = parameter.description;
+    }
+    if (typeof schema.type === 'string') {
+      mapped.dataType = schema.type;
+    }
+    if ('default' in schema) {
+      mapped.defaultValue = schema.default;
+    }
+
+    const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+    if (enumValues?.length) {
+      mapped.allowableValues = enumValues.map((value) => ({ value: String(value) }));
+    }
+
+    return mapped;
+  }
+
+  /**
+   * Builds a merged list of Camel parameters from path-level and operation-level parameters.
+   *
+   * Operation-level parameters override path-level parameters with the same name and location.
+   *
+   * @param pathItem - OpenAPI path item containing path-level parameters
+   * @param operation - OpenAPI operation containing operation-level parameters
+   * @returns Array of Camel parameter objects
+   */
+  private static buildCamelParamList(pathItem: OpenApiPath, operation: OpenApiOperation): Record<string, unknown>[] {
+    const merged = new Map<string, Record<string, unknown>>();
+    const addParameters = (parameters: unknown) => {
+      if (!Array.isArray(parameters)) return;
+      parameters.forEach((parameter) => {
+        if (!parameter || typeof parameter !== 'object') return;
+        const asRecord = parameter as Record<string, unknown>;
+        const name = typeof asRecord.name === 'string' ? asRecord.name : '';
+        const location = typeof asRecord.in === 'string' ? asRecord.in : '';
+        if (!name || !location) return;
+        merged.set(`${location}:${name}`, asRecord);
+      });
+    };
+
+    addParameters(pathItem.parameters);
+    addParameters(operation.parameters);
+
+    return Array.from(merged.values())
+      .map(OpenApiProcessingService.mapOpenApiParameterToCamelParam)
+      .filter((item): item is Record<string, unknown> => Boolean(item));
+  }
+
+  /**
+   * Builds a list of Camel security requirements from OpenAPI operation security.
+   *
+   * @param operation - OpenAPI operation containing security requirements
+   * @returns Array of Camel security objects with key and optional scopes
+   */
+  private static buildCamelSecurityList(operation: OpenApiOperation): Record<string, unknown>[] {
+    const security = operation.security;
+    if (!Array.isArray(security)) return [];
+
+    const mapped: Record<string, unknown>[] = [];
+    security.forEach((securityRequirement) => {
+      if (!securityRequirement || typeof securityRequirement !== 'object') return;
+      Object.entries(securityRequirement as Record<string, unknown>).forEach(([key, value]) => {
+        const scopes = Array.isArray(value) ? value.map(String).join(',') : '';
+        mapped.push(scopes ? { key, scopes } : { key });
+      });
+    });
+
+    return mapped;
+  }
+
+  /**
+   * Builds a list of Camel response messages from OpenAPI operation responses.
+   *
+   * Includes response code, message (description), and optional headers with allowable values.
+   *
+   * @param operation - OpenAPI operation containing response definitions
+   * @returns Array of Camel response message objects
+   */
+  private static buildCamelResponseMessageList(operation: OpenApiOperation): Record<string, unknown>[] {
+    const responses = operation.responses as Record<string, unknown> | undefined;
+    if (!responses || typeof responses !== 'object') return [];
+
+    return Object.entries(responses).map(([code, response]) => {
+      const responseRecord = (response as Record<string, unknown> | undefined) ?? {};
+      const mapped: Record<string, unknown> = { code: String(code) };
+
+      if (typeof responseRecord.description === 'string' && responseRecord.description.trim()) {
+        mapped.message = responseRecord.description;
+      }
+
+      const headers = responseRecord.headers as Record<string, unknown> | undefined;
+      if (headers && typeof headers === 'object') {
+        const mappedHeaders = Object.entries(headers)
+          .map(([name, headerValue]) => {
+            const headerRecord = (headerValue as Record<string, unknown> | undefined) ?? {};
+            const schema = (headerRecord.schema as Record<string, unknown> | undefined) ?? {};
+            const mappedHeader: Record<string, unknown> = { name };
+            if (typeof headerRecord.description === 'string' && headerRecord.description.trim()) {
+              mappedHeader.description = headerRecord.description;
+            }
+            const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+            if (enumValues?.length) {
+              mappedHeader.allowableValues = enumValues.map((value) => ({ value: String(value) }));
+            }
+            return mappedHeader;
+          })
+          .filter((header) => Boolean(header.name));
+
+        if (mappedHeaders.length > 0) {
+          mapped.header = mappedHeaders;
+        }
+      }
+
+      return mapped;
+    });
+  }
+}

--- a/packages/ui/src/stubs/index.ts
+++ b/packages/ui/src/stubs/index.ts
@@ -3,6 +3,7 @@ export * from './kamelet-binding-route';
 export * from './kamelet-route';
 export * from './mock-random-values';
 export * from './pipe';
+export * from './rest-visual-entity';
 export * from './TestProvidersWrapper';
 export * from './TestRuntimeProviderWrapper';
 export * from './tiles';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,7 @@ __metadata:
     "@types/json-schema": "npm:^7.0.15"
     "@types/lodash": "npm:^4"
     "@types/node": "npm:^22.0.0"
+    "@types/openapi-v3": "npm:^3.0.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/uuid": "npm:^10.0.0"
@@ -6483,6 +6484,13 @@ __metadata:
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
   checksum: 10/65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
+  languageName: node
+  linkType: hard
+
+"@types/openapi-v3@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/openapi-v3@npm:3.0.0"
+  checksum: 10/a793fb3edfa511bfd3f370ebcc813277cd5e7b886c60a45bbd9777c78620bd47cc651f38e22f952a97d91a8920af46917755a131a3907091c8df7e2e89b1617a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
This commit adds the needed functionality to import a OpenAPI spec like `https://petstore3.swagger.io/api/v3/openapi.json` and create Rest DSL entities out of it.

### Note
This functionality was extracted from https://github.com/KaotoIO/kaoto/pull/2914 to make the changeset more manageable

fix: https://github.com/KaotoIO/kaoto/issues/1490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added OpenAPI import wizard with support for multiple import sources (file upload, URI, and Apicurio Registry)
  * Added ability to parse OpenAPI specifications and selectively import operations as REST DSL routes
  * Added new "Rest DSL" navigation menu with quick access to import functionality

* **Tests**
  * Added comprehensive test coverage for import workflow and components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->