### PR TITLE
Add "Hide rest" context menu item for flow visibility

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -694,7 +694,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                     data-ouia-component-id="OUIA-Generated-Toolbar-7"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-17"
+                    id="pf-topology-control-bar-19"
                     style="background-color: transparent;"
                   >
                     <div
@@ -1625,7 +1625,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                     data-ouia-component-id="OUIA-Generated-Toolbar-6"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-15"
+                    id="pf-topology-control-bar-17"
                     style="background-color: transparent;"
                   >
                     <div
@@ -2071,7 +2071,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                     data-ouia-component-id="OUIA-Generated-Toolbar-9"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-21"
+                    id="pf-topology-control-bar-23"
                     style="background-color: transparent;"
                   >
                     <div
@@ -2512,7 +2512,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                     data-ouia-component-id="OUIA-Generated-Toolbar-8"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-19"
+                    id="pf-topology-control-bar-21"
                     style="background-color: transparent;"
                   >
                     <div

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from '@testing-library/react';
+
+import { CatalogKind, createVisualizationNode, IVisualizationNode } from '../../../../models';
+import { EntityType } from '../../../../models/camel/entities';
+import { VisualFlowsApi } from '../../../../models/visualization/flows/support/flows-visibility';
+import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
+import { ItemHideOtherFlows } from './ItemHideOtherFlows';
+
+describe('ItemHideOtherFlows', () => {
+  let vizNode: IVisualizationNode;
+  let dispatchSpy: jest.Mock;
+  let visibleFlowsContext: VisibleFlowsContextResult;
+
+  beforeEach(() => {
+    vizNode = createVisualizationNode('test', { catalogKind: CatalogKind.Entity, name: EntityType.Route });
+    jest.spyOn(vizNode, 'getId').mockReturnValue('route-1234');
+
+    dispatchSpy = jest.fn();
+    visibleFlowsContext = {
+      allFlowsVisible: true,
+      visibleFlows: {
+        'route-1234': true,
+        'route-5678': true,
+        'route-9012': true,
+      },
+      visualFlowsApi: new VisualFlowsApi(dispatchSpy),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the "Hide rest" context menu item', () => {
+    const wrapper = render(
+      <VisibleFlowsContext.Provider value={visibleFlowsContext}>
+        <ItemHideOtherFlows data-testid="context-menu-item-hide-rest" vizNode={vizNode} />
+      </VisibleFlowsContext.Provider>,
+    );
+
+    const item = wrapper.getByText('Hide rest');
+    expect(item).toBeInTheDocument();
+  });
+
+  it('should hide other flows and keep the current flow visible on click', () => {
+    const wrapper = render(
+      <VisibleFlowsContext.Provider value={visibleFlowsContext}>
+        <ItemHideOtherFlows data-testid="context-menu-item-hide-rest" vizNode={vizNode} />
+      </VisibleFlowsContext.Provider>,
+    );
+
+    fireEvent.click(wrapper.getByText('Hide rest'));
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'hideFlows',
+      flowIds: ['route-5678', 'route-9012'],
+    });
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'showFlows',
+      flowIds: ['route-1234'],
+    });
+  });
+
+  it('should not dispatch if flowId is undefined', () => {
+    jest.spyOn(vizNode, 'getId').mockReturnValue(undefined);
+
+    const wrapper = render(
+      <VisibleFlowsContext.Provider value={visibleFlowsContext}>
+        <ItemHideOtherFlows data-testid="context-menu-item-hide-rest" vizNode={vizNode} />
+      </VisibleFlowsContext.Provider>,
+    );
+
+    fireEvent.click(wrapper.getByText('Hide rest'));
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.tsx
@@ -1,0 +1,32 @@
+import { EyeSlashIcon } from '@patternfly/react-icons';
+import { ContextMenuItem } from '@patternfly/react-topology';
+import { FunctionComponent, useContext } from 'react';
+
+import { IDataTestID } from '../../../../models';
+import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { VisibleFlowsContext } from '../../../../providers';
+
+interface ItemHideOtherFlowsProps extends IDataTestID {
+  vizNode: IVisualizationNode;
+}
+
+export const ItemHideOtherFlows: FunctionComponent<ItemHideOtherFlowsProps> = (props) => {
+  const visibleFlowsContext = useContext(VisibleFlowsContext);
+  const flowId = props.vizNode.getId();
+
+  const onClick = () => {
+    if (!flowId || !visibleFlowsContext?.visualFlowsApi) return;
+
+    const allFlowIds = Object.keys(visibleFlowsContext.visibleFlows);
+    const otherFlowIds = allFlowIds.filter((id) => id !== flowId);
+
+    visibleFlowsContext.visualFlowsApi.hideFlows(otherFlowIds);
+    visibleFlowsContext.visualFlowsApi.showFlows([flowId]);
+  };
+
+  return (
+    <ContextMenuItem onClick={onClick} data-testid={props['data-testid']}>
+      <EyeSlashIcon /> Hide rest
+    </ContextMenuItem>
+  );
+};

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -248,4 +248,13 @@ describe('NodeContextMenu', () => {
 
     expect(item).toBeInTheDocument();
   });
+
+  it('should render an ItemHideOtherFlows item if canRemoveFlow is true', () => {
+    nodeInteractions.canRemoveFlow = true;
+    const wrapper = render(<NodeContextMenu element={element} />, { wrapper: TestWrapper });
+
+    const item = wrapper.getByTestId('context-menu-item-hide-rest');
+
+    expect(item).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
@@ -23,6 +23,7 @@ import { ItemDeleteStep } from './ItemDeleteStep';
 import { ItemDisableStep } from './ItemDisableStep';
 import { ItemDuplicateStep } from './ItemDuplicateStep';
 import { ItemEnableAllSteps } from './ItemEnableAllSteps';
+import { ItemHideOtherFlows } from './ItemHideOtherFlows';
 import { ItemInsertStep } from './ItemInsertStep';
 import { ItemMoveStep } from './ItemMoveStep';
 import { ItemPasteStep } from './ItemPasteStep';
@@ -96,9 +97,6 @@ export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode
     >
       {icons.moveBefore} Move Before
     </ItemMoveStep>,
-  );
-
-  items.push(
     <ItemMoveStep
       key="context-menu-item-move-next"
       data-testid="context-menu-item-move-next"
@@ -165,6 +163,11 @@ export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode
   }
   if (nodeInteractions.canRemoveFlow) {
     items.push(
+      <ItemHideOtherFlows
+        key="context-menu-item-hide-rest"
+        data-testid="context-menu-item-hide-rest"
+        vizNode={vizNode}
+      />,
       <ItemDeleteGroup
         key="context-menu-container-remove"
         data-testid="context-menu-item-container-remove"


### PR DESCRIPTION
### Summary
This PR adds a new context menu item that allows users to hide all flows except the currently selected one, improving flow navigation and focus in the visualization.

#### Screenshot
<img width="561" height="544" alt="image" src="https://github.com/user-attachments/assets/04b4b156-4653-45b4-8627-e1134753cea4" />

#### Screencast
https://github.com/user-attachments/assets/daa7931c-45e5-4077-ab6e-9e59ddd2fce0

fix: https://github.com/KaotoIO/kaoto/issues/1095