### PR TITLE
fix: support URI formats with and without :// authority separator

### DIFF
--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -65,7 +65,7 @@ describe('CamelUriHelper', () => {
       {
         syntax: 'atmosphere-websocket:servicePath',
         uri: 'atmosphere-websocket://localhost:8080/echo',
-        result: { servicePath: '//localhost:8080/echo' },
+        result: { servicePath: 'localhost:8080/echo' },
       },
       {
         syntax: 'avro:transport:host:port/messageName',
@@ -118,6 +118,18 @@ describe('CamelUriHelper', () => {
         uri: 'ftp:localhost:21/a/nested/directory',
         requiredParameters: ['host'],
         result: { host: 'localhost', port: 21, directoryName: 'a/nested/directory' },
+      },
+      {
+        syntax: 'ftp:host:port/directoryName',
+        uri: 'ftp://localhost:21/a/nested/directory',
+        requiredParameters: ['host'],
+        result: { host: 'localhost', port: 21, directoryName: 'a/nested/directory' },
+      },
+      {
+        syntax: 'sftp:host:port/directoryName',
+        uri: 'sftp://myHost:22/upload',
+        requiredParameters: ['host'],
+        result: { host: 'myHost', port: 22, directoryName: 'upload' },
       },
       {
         syntax: 'rest-openapi:specificationUri#operationId',
@@ -215,8 +227,8 @@ describe('CamelUriHelper', () => {
       {
         uri: 'atmosphere-websocket',
         syntax: 'atmosphere-websocket:servicePath',
-        parameters: { servicePath: '//localhost:8080/echo' },
-        result: 'atmosphere-websocket://localhost:8080/echo',
+        parameters: { servicePath: 'localhost:8080/echo' },
+        result: 'atmosphere-websocket:localhost:8080/echo',
       },
       {
         uri: 'avro',

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -252,6 +252,19 @@ export class CamelUriHelper {
 
   /** Remove the scheme from the URI string: 'avro:netty:localhost:41414/foo' => 'netty:localhost:41414/foo' */
   private static getUriWithoutScheme(uriString: string, uriSyntax: string): string {
-    return uriString.substring(uriSyntax.indexOf(':') + 1);
+    const schemeEndIndex = uriSyntax.indexOf(':') + 1;
+    let result = uriString.substring(schemeEndIndex);
+
+    /**
+     * If the URI uses :// (e.g. ftp://host:port/dir) but the syntax only uses :
+     * (e.g. ftp:host:port/directoryName), strip the leading // so the URI
+     * can be correctly matched against the syntax delimiters.
+     */
+    const syntaxAfterScheme = uriSyntax.substring(schemeEndIndex);
+    if (result.startsWith('//') && !syntaxAfterScheme.startsWith('//')) {
+      result = result.substring(2);
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
### Context
Strip the leading // from URIs when the component syntax doesn't include :// (e.g. ftp://host:port/dir parsed against syntax ftp:host:port/dir). This allows Kaoto to correctly parse URIs written in the conventional URL-like form for components like ftp and sftp.

fix: #2017
