### PR TITLE
fix(canvas): control container collapse state using controller

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -40,6 +40,7 @@ import { HorizontalLayoutIcon } from '../../Icons/HorizontalLayout';
 import { VerticalLayoutIcon } from '../../Icons/VerticalLayout';
 import useDeleteHotkey from '../Custom/hooks/delete-hotkey.hook';
 import { VisualizationEmptyState } from '../EmptyState';
+import { applyCollapseState } from './apply-collapse-state';
 import { CanvasDefaults } from './canvas.defaults';
 import { CanvasEdge, CanvasNode, LayoutType } from './canvas.models';
 import { CanvasSideBar } from './CanvasSideBar';
@@ -122,6 +123,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({ enti
 
     requestAnimationFrame(() => {
       controller.fromModel(model, true);
+      applyCollapseState(controller);
       controller.getGraph().layout();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -693,10 +693,10 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-7"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-8"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-19"
+                    id="pf-topology-control-bar-21"
                     style="background-color: transparent;"
                   >
                     <div
@@ -717,7 +717,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-32"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-37"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -757,7 +757,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-33"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-38"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -797,7 +797,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-34"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-39"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -836,7 +836,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-35"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-40"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -874,7 +874,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-36"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-41"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1626,10 +1626,10 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-6"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-7"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-17"
+                    id="pf-topology-control-bar-19"
                     style="background-color: transparent;"
                   >
                     <div
@@ -1650,7 +1650,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-26"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-31"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -1690,7 +1690,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-27"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-32"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -1730,7 +1730,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-28"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-33"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -1769,7 +1769,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-29"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-34"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -1807,7 +1807,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-30"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-35"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1845,7 +1845,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-31"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-36"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-catalog-button"
@@ -2072,10 +2072,10 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-9"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-10"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-23"
+                    id="pf-topology-control-bar-25"
                     style="background-color: transparent;"
                   >
                     <div
@@ -2096,7 +2096,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-42"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-47"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -2136,7 +2136,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-43"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-48"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -2176,7 +2176,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-44"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-49"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -2215,7 +2215,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-45"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-50"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -2253,7 +2253,7 @@ exports[`Canvas Empty state should render empty state when there is no visible f
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-46"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-51"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -2513,10 +2513,10 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-8"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-9"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-21"
+                    id="pf-topology-control-bar-23"
                     style="background-color: transparent;"
                   >
                     <div
@@ -2537,7 +2537,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-37"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-42"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -2577,7 +2577,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-38"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-43"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -2617,7 +2617,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-39"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-44"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -2656,7 +2656,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-40"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-45"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -2694,7 +2694,7 @@ exports[`Canvas Empty state should render empty state when there is no visual en
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-41"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-46"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"

--- a/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
@@ -1,0 +1,193 @@
+import type { Controller } from '@patternfly/react-topology';
+import { Dimensions, ModelKind } from '@patternfly/react-topology';
+
+import { applyCollapseState } from './apply-collapse-state';
+import { CanvasDefaults } from './canvas.defaults';
+import { COLLAPSE_STATE } from './collapse-handler-state';
+
+const createMockNode = (nodeId: string, setCollapsed: jest.Mock, setDimensions: jest.Mock) => ({
+  getKind: () => ModelKind.node,
+  getData: () => ({ vizNode: { getNodeDefinition: () => ({ id: nodeId }) } }),
+  setCollapsed,
+  setDimensions,
+});
+
+describe('applyCollapseState', () => {
+  it('does nothing when collapsedIds is undefined', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = createMockNode('node-1', setCollapsed, setDimensions);
+    const controller = {
+      getState: jest.fn().mockReturnValue({}),
+      getElements: jest.fn().mockReturnValue([mockNode]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    expect(controller.getState).toHaveBeenCalled();
+    expect(setCollapsed).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when collapsedIds is empty', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = createMockNode('node-1', setCollapsed, setDimensions);
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: [] }),
+      getElements: jest.fn().mockReturnValue([mockNode]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    expect(setCollapsed).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+
+  it('calls setCollapsed and setDimensions for each matching node', () => {
+    const setCollapsed1 = jest.fn();
+    const setDimensions1 = jest.fn();
+    const setCollapsed2 = jest.fn();
+    const setDimensions2 = jest.fn();
+    const setCollapsed3 = jest.fn();
+    const setDimensions3 = jest.fn();
+    const node1 = createMockNode('choice-1', setCollapsed1, setDimensions1);
+    const node2 = createMockNode('choice-2', setCollapsed2, setDimensions2);
+    const node3 = createMockNode('choice-3', setCollapsed3, setDimensions3);
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['choice-1', 'choice-3'] }),
+      getElements: jest.fn().mockReturnValue([node1, node2, node3]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    // Node 1 should be collapsed
+    expect(setCollapsed1).toHaveBeenCalledWith(true);
+    expect(setDimensions1).toHaveBeenCalledWith(
+      new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+    );
+    // Node 2 should not be collapsed
+    expect(setCollapsed2).not.toHaveBeenCalled();
+    expect(setDimensions2).not.toHaveBeenCalled();
+    // Node 3 should be collapsed
+    expect(setCollapsed3).toHaveBeenCalledWith(true);
+    expect(setDimensions3).toHaveBeenCalledWith(
+      new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+    );
+  });
+
+  it('handles nodes without vizNode data gracefully', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = {
+      getKind: () => ModelKind.node,
+      getData: () => ({ vizNode: null }),
+      setCollapsed,
+      setDimensions,
+    };
+
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['node-1'] }),
+      getElements: jest.fn().mockReturnValue([mockNode]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    expect(setCollapsed).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+
+  it('handles nodes without valid node id', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = {
+      getKind: () => ModelKind.node,
+      getData: () => ({ vizNode: { getNodeDefinition: () => ({ id: undefined }) } }),
+      setCollapsed,
+      setDimensions,
+    };
+
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['node-1'] }),
+      getElements: jest.fn().mockReturnValue([mockNode]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    expect(setCollapsed).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+
+  it('filters out non-node elements', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = createMockNode('choice-1', setCollapsed, setDimensions);
+    const mockEdge = {
+      getKind: () => ModelKind.edge,
+      getData: () => ({ vizNode: { getNodeDefinition: () => ({ id: 'edge-1' }) } }),
+    };
+
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['choice-1', 'edge-1'] }),
+      getElements: jest.fn().mockReturnValue([mockNode, mockEdge]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    // Only the node should be processed
+    expect(setCollapsed).toHaveBeenCalledWith(true);
+    expect(setDimensions).toHaveBeenCalledWith(
+      new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+    );
+  });
+
+  it('handles duplicate ids in collapsedIds array', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const node = createMockNode('choice-1', setCollapsed, setDimensions);
+
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['choice-1', 'choice-1', 'choice-1'] }),
+      getElements: jest.fn().mockReturnValue([node]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    // Should be called multiple times (once per occurrence in array)
+    expect(setCollapsed).toHaveBeenCalledTimes(3);
+    expect(setDimensions).toHaveBeenCalledTimes(3);
+    expect(setCollapsed).toHaveBeenCalledWith(true);
+  });
+
+  it('handles empty controller elements array', () => {
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['choice-1'] }),
+      getElements: jest.fn().mockReturnValue([]),
+    } as unknown as Controller;
+
+    // Should not throw
+    expect(() => applyCollapseState(controller)).not.toThrow();
+    expect(controller.getElements).toHaveBeenCalled();
+  });
+
+  it('handles null or undefined node data', () => {
+    const setCollapsed = jest.fn();
+    const setDimensions = jest.fn();
+    const mockNode = {
+      getKind: () => ModelKind.node,
+      getData: () => null,
+      setCollapsed,
+      setDimensions,
+    };
+
+    const controller = {
+      getState: jest.fn().mockReturnValue({ [COLLAPSE_STATE]: ['node-1'] }),
+      getElements: jest.fn().mockReturnValue([mockNode]),
+    } as unknown as Controller;
+
+    applyCollapseState(controller);
+
+    expect(setCollapsed).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.ts
+++ b/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.ts
@@ -1,0 +1,28 @@
+import type { Controller } from '@patternfly/react-topology';
+import { Dimensions, isNode, Node } from '@patternfly/react-topology';
+
+import { IVisualizationNode } from '../../../models';
+import { CanvasDefaults } from './canvas.defaults';
+import { COLLAPSE_STATE, CollapseHandlerState } from './collapse-handler-state';
+
+/**
+ * Re-applies collapsed state from the controller state to graph nodes.
+ * Call this after controller.fromModel() so that previously collapsed groups
+ * stay collapsed when the graph is rebuilt.
+ */
+export function applyCollapseState(controller: Controller): void {
+  const collapsedIds = controller.getState<CollapseHandlerState>()[COLLAPSE_STATE];
+  if (collapsedIds?.length) {
+    collapsedIds.forEach((id) => {
+      const node = controller
+        .getElements()
+        .find((el) => isNode(el) && (el.getData()?.vizNode as IVisualizationNode)?.getNodeDefinition()?.id === id);
+      if (node) {
+        (node as Node).setCollapsed(true);
+        (node as Node).setDimensions(
+          new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+        );
+      }
+    });
+  }
+}

--- a/packages/ui/src/components/Visualization/Canvas/collapse-handler-state.ts
+++ b/packages/ui/src/components/Visualization/Canvas/collapse-handler-state.ts
@@ -1,0 +1,11 @@
+/**
+ * Controller state for persisting which group nodes are collapsed.
+ * Mirrors the pattern used by SelectionHandlerState (selectedIds).
+ * When the controller is updated via fromModel() (e.g. empty or new nodes/edges),
+ * this state is used to re-apply collapse so expanded/collapsed state is preserved.
+ */
+export const COLLAPSE_STATE = 'collapsedIds';
+
+export interface CollapseHandlerState {
+  [COLLAPSE_STATE]?: string[];
+}

--- a/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
@@ -17,6 +17,8 @@ describe('useCollapseStep', () => {
 
     mockController = {
       getGraph: jest.fn().mockReturnValue(mockGraph),
+      getState: jest.fn().mockReturnValue({ collapsedIds: [] }),
+      setState: jest.fn(),
     } as unknown as Controller;
 
     mockElement = {
@@ -24,6 +26,12 @@ describe('useCollapseStep', () => {
       setCollapsed: jest.fn(),
       getController: jest.fn().mockReturnValue(mockController),
       getKind: jest.fn().mockReturnValue('node'),
+      getId: jest.fn().mockReturnValue('mock-node-id'),
+      getData: jest.fn().mockReturnValue({
+        vizNode: {
+          getNodeDefinition: jest.fn().mockReturnValue({ id: 'mock-node-id' }),
+        },
+      }),
     } as unknown as Node<ElementModel, unknown>;
   });
 
@@ -52,7 +60,7 @@ describe('useCollapseStep', () => {
     expect(typeof result.current.onCollapseNode).toBe('function');
   });
 
-  it('should collapse node and set dimensions when onCollapseNode is called', () => {
+  it('should collapse node, set dimensions and update the state when onCollapseNode is called', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     result.current.onCollapseNode();
@@ -62,15 +70,58 @@ describe('useCollapseStep', () => {
     );
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
     expect(mockGraph.layout).toHaveBeenCalled();
+    expect(mockElement.getController).toHaveBeenCalled();
+    expect(mockController.getState).toHaveBeenCalled();
+    expect(mockElement.getData).toHaveBeenCalled();
+    expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: ['mock-node-id'] });
   });
 
-  it('should expand node without setting dimensions when onExpandNode is called', () => {
+  it('should collapse node, set dimensions and not update the state when the node is already collapsed', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
+
+    result.current.onCollapseNode();
+
+    expect(mockElement.setDimensions).toHaveBeenCalledWith(
+      new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+    );
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
+    expect(mockGraph.layout).toHaveBeenCalled();
+    expect(mockElement.getController).toHaveBeenCalled();
+    expect(mockController.getState).toHaveBeenCalled();
+    expect(mockElement.getData).toHaveBeenCalled();
+    expect(mockController.setState).not.toHaveBeenCalled();
+  });
+
+  it('should collapse node, set dimensions and not update state when node id is not found', () => {
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+    mockElement.getData = jest.fn().mockReturnValue(undefined);
+
+    result.current.onCollapseNode();
+
+    expect(mockElement.setDimensions).toHaveBeenCalledWith(
+      new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
+    );
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
+    expect(mockGraph.layout).toHaveBeenCalled();
+    expect(mockElement.getController).toHaveBeenCalled();
+    expect(mockElement.getData).toHaveBeenCalled();
+    expect(mockController.getState).not.toHaveBeenCalled();
+    expect(mockController.setState).not.toHaveBeenCalled();
+  });
+
+  it('should expand node without setting dimensions, but updating the state when onExpandNode is called', () => {
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
 
     result.current.onExpandNode();
 
     expect(mockElement.setDimensions).not.toHaveBeenCalled();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
+    expect(mockElement.getController).toHaveBeenCalled();
+    expect(mockController.getState).toHaveBeenCalled();
+    expect(mockElement.getData).toHaveBeenCalled();
+    expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
     expect(mockGraph.layout).toHaveBeenCalled();
   });
 
@@ -101,5 +152,111 @@ describe('useCollapseStep', () => {
     rerender({ element: newMockElement });
 
     expect(result.current).not.toBe(firstResult);
+  });
+
+  it('should handle multiple collapse operations correctly', () => {
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    // Collapse the node
+    result.current.onCollapseNode();
+
+    expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: ['mock-node-id'] });
+
+    // Update mock state to reflect the change
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
+    mockController.setState = jest.fn();
+
+    // Try to collapse again - should not update state
+    result.current.onCollapseNode();
+
+    expect(mockController.setState).not.toHaveBeenCalled();
+  });
+
+  it('should handle expand of non-collapsed node', () => {
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: [] });
+
+    // Expand a node that is not collapsed
+    result.current.onExpandNode();
+
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
+    expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
+    expect(mockGraph.layout).toHaveBeenCalled();
+  });
+
+  it('should handle state with multiple collapsed nodes', () => {
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: ['other-node-1', 'other-node-2'] });
+
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    // Collapse this node - should add to existing collapsed nodes
+    result.current.onCollapseNode();
+
+    expect(mockController.setState).toHaveBeenCalledWith({
+      collapsedIds: ['other-node-1', 'other-node-2', 'mock-node-id'],
+    });
+  });
+
+  it('should remove only the target node from collapsed state on expand', () => {
+    mockController.getState = jest.fn().mockReturnValue({
+      collapsedIds: ['other-node-1', 'mock-node-id', 'other-node-2'],
+    });
+
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    // Expand this node - should remove only this node
+    result.current.onExpandNode();
+
+    expect(mockController.setState).toHaveBeenCalledWith({
+      collapsedIds: ['other-node-1', 'other-node-2'],
+    });
+  });
+
+  it('should handle rapid collapse and expand operations', () => {
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    // Rapid collapse
+    result.current.onCollapseNode();
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
+
+    // Update state to reflect collapse
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
+    mockController.setState = jest.fn();
+    (mockElement.setCollapsed as jest.Mock).mockClear();
+
+    // Rapid expand
+    result.current.onExpandNode();
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
+    expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
+  });
+
+  it('should handle elements with no node definition id', () => {
+    mockElement.getData = jest.fn().mockReturnValue({
+      vizNode: {
+        getNodeDefinition: jest.fn().mockReturnValue({}),
+      },
+    });
+
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    result.current.onCollapseNode();
+
+    expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
+    expect(mockController.setState).not.toHaveBeenCalled();
+  });
+
+  it('should preserve immutability when updating collapsed state', () => {
+    const initialState = ['node-1', 'node-2'];
+    mockController.getState = jest.fn().mockReturnValue({ collapsedIds: initialState });
+
+    const { result } = renderHook(() => useCollapseStep(mockElement));
+
+    result.current.onCollapseNode();
+
+    // Verify the original array was not mutated
+    expect(initialState).toEqual(['node-1', 'node-2']);
+    expect(mockController.setState).toHaveBeenCalledWith({
+      collapsedIds: ['node-1', 'node-2', 'mock-node-id'],
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.tsx
@@ -2,7 +2,9 @@ import type { ElementModel, GraphElement } from '@patternfly/react-topology';
 import { action, Dimensions, isNode } from '@patternfly/react-topology';
 import { useCallback, useMemo } from 'react';
 
+import { IVisualizationNode } from '../../../../models';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
+import { COLLAPSE_STATE, CollapseHandlerState } from '../../Canvas/collapse-handler-state';
 
 export const useCollapseStep = (element: GraphElement<ElementModel, unknown>) => {
   if (!isNode(element)) {
@@ -17,7 +19,26 @@ export const useCollapseStep = (element: GraphElement<ElementModel, unknown>) =>
         }
 
         element.setCollapsed(collapsed);
-        element.getController().getGraph().layout();
+
+        const controller = element.getController();
+        controller.getGraph().layout();
+
+        const id = (element.getData()?.vizNode as IVisualizationNode)?.getNodeDefinition()?.id;
+        if (!id) return;
+
+        const state = controller.getState<CollapseHandlerState>();
+        const current = state[COLLAPSE_STATE] ?? [];
+        let collapsedIds: typeof current;
+        if (collapsed) {
+          if (current.includes(id)) {
+            return;
+          } else {
+            collapsedIds = [...current, id];
+          }
+        } else {
+          collapsedIds = current.filter((cid) => cid !== id);
+        }
+        controller.setState({ [COLLAPSE_STATE]: collapsedIds });
       })();
     },
     [element],


### PR DESCRIPTION
Fixes #2913 
Canvas now restores persisted collapsed group-node state after model updates and when the canvas reloads, applying compact sizing for collapsed nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visualization now preserves and re-applies node collapsed/expanded state across model updates and initialization, keeping layout and dimensions consistent.

* **Tests**
  * Added comprehensive tests covering collapse/expand persistence, restore on init, multiple-node scenarios, edge cases (missing data, duplicates), and state immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->