### PR TITLE
feat(Canvas): Add canvas layout direction setting

### DIFF
--- a/packages/ui/src/assets/settingsSchema.json
+++ b/packages/ui/src/assets/settingsSchema.json
@@ -32,6 +32,13 @@
       "type": "string",
       "enum": ["auto", "light", "dark"]
     },
+    "canvasLayoutDirection": {
+      "title": "Canvas layout direction",
+      "description": "Choose the canvas layout behavior. `SelectInCanvas` lets users toggle layout via canvas buttons. `Horizontal` forces horizontal layout (buttons hidden). `Vertical` forces vertical layout (buttons hidden).",
+      "default": "SelectInCanvas",
+      "type": "string",
+      "enum": ["SelectInCanvas", "Horizontal", "Vertical"]
+    },
     "rest": {
       "title": "Rest configuration",
       "description": "Rest related settings",

--- a/packages/ui/src/components/Settings/SettingsForm.scss
+++ b/packages/ui/src/components/Settings/SettingsForm.scss
@@ -1,0 +1,12 @@
+.settings-form-card {
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-card__body {
+    flex: 1;
+    overflow: hidden auto;
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-card__footer {
+    padding-block-start: var(--pf-v6-c-card--first-child--PaddingBlockStart);
+  }
+}

--- a/packages/ui/src/components/Settings/SettingsForm.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.tsx
@@ -1,3 +1,5 @@
+import './SettingsForm.scss';
+
 import { CanvasFormTabsContext, CanvasFormTabsContextResult, KaotoForm } from '@kaoto/forms';
 import { Button, Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import { FunctionComponent, useContext, useMemo, useState } from 'react';
@@ -32,7 +34,7 @@ export const SettingsForm: FunctionComponent = () => {
   };
 
   return (
-    <Card data-last-render={lastRender}>
+    <Card className="settings-form-card" data-last-render={lastRender}>
       <CardTitle>Settings</CardTitle>
 
       <CardBody>

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -572,6 +572,156 @@ exports[`SettingsForm should render 1`] = `
     </div>
   </div>
   <div
+    class="pf-v6-c-form__group"
+    data-testid="#.canvasLayoutDirection__field-wrapper"
+  >
+    <div
+      class="pf-v6-c-form__group-label"
+    >
+      <label
+        class="pf-v6-c-form__label"
+        for="#.canvasLayoutDirection"
+      >
+        <span
+          class="pf-v6-c-form__label-text"
+        >
+          Canvas layout direction
+        </span>
+      </label>
+        
+      <span
+        class="pf-v6-c-form__group-label-help"
+      >
+        <div
+          style="display: contents;"
+        >
+          <span
+            aria-label="More info for Canvas layout direction field"
+            class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+            data-ouia-component-id="OUIA-Generated-Button-plain-8"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </span>
+    </div>
+    <div
+      class="pf-v6-c-form__group-control"
+    >
+      <div
+        class="pf-v6-c-menu-toggle pf-m-full-width pf-m-typeahead"
+        id="#.canvasLayoutDirection"
+      >
+        <div
+          class="pf-v6-c-text-input-group pf-m-plain"
+        >
+          <div
+            autocomplete="off"
+            class="pf-v6-c-text-input-group__main"
+            data-testid="#.canvasLayoutDirection-typeahead-select-input"
+            id="#.canvasLayoutDirection-typeahead-select-input"
+          >
+            <span
+              class="pf-v6-c-text-input-group__text"
+            >
+              <input
+                aria-label="Type to filter"
+                class="pf-v6-c-text-input-group__text-input"
+                placeholder="SelectInCanvas"
+                type="text"
+                value="SelectInCanvas"
+              />
+            </span>
+          </div>
+          <div
+            class="pf-v6-c-text-input-group__utilities"
+          >
+            <button
+              aria-label="Clear input value"
+              class="pf-v6-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.canvasLayoutDirection__clear"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <button
+          aria-expanded="false"
+          aria-label="undefined toggle"
+          class="pf-v6-c-menu-toggle__button"
+          data-ouia-component-id="OUIA-Generated-MenuToggle-typeahead-4"
+          data-ouia-component-type="PF6/MenuToggle"
+          data-ouia-safe="true"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="pf-v6-c-menu-toggle__controls"
+          >
+            <span
+              class="pf-v6-c-menu-toggle__toggle-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
     class="pf-v6-c-card"
     data-ouia-component-id="OUIA-Generated-Card-2"
     data-ouia-component-type="PF6/Card"
@@ -588,7 +738,7 @@ exports[`SettingsForm should render 1`] = `
         <button
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-8"
+          data-ouia-component-id="OUIA-Generated-Button-plain-10"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.rest__remove"
@@ -632,7 +782,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Rest configuration field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                data-ouia-component-id="OUIA-Generated-Button-plain-11"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -693,7 +843,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Apicurio Registry URL field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                data-ouia-component-id="OUIA-Generated-Button-plain-12"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -808,7 +958,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Custom media types field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-id="OUIA-Generated-Button-plain-13"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -934,7 +1084,7 @@ exports[`SettingsForm should render 1`] = `
         <button
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-12"
+          data-ouia-component-id="OUIA-Generated-Button-plain-14"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.experimentalFeatures__remove"
@@ -978,7 +1128,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Experimental features field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -1039,7 +1189,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Enable Drag & Drop field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                data-ouia-component-id="OUIA-Generated-Button-plain-16"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -1,6 +1,6 @@
 import { LocalStorageKeys } from '../local-storage-keys';
 import { LocalStorageSettingsAdapter } from './localstorage-settings-adapter';
-import { ColorScheme, NodeLabelType, NodeToolbarTrigger, SettingsModel } from './settings.model';
+import { CanvasLayoutDirection, ColorScheme, NodeLabelType, NodeToolbarTrigger, SettingsModel } from './settings.model';
 
 describe('LocalStorageSettingsAdapter', () => {
   beforeEach(() => {
@@ -24,6 +24,7 @@ describe('LocalStorageSettingsAdapter', () => {
         apicurioRegistryUrl: '',
         customMediaTypes: [],
       },
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: true,
       },
@@ -57,6 +58,7 @@ describe('LocalStorageSettingsAdapter', () => {
         apicurioRegistryUrl: '',
         customMediaTypes: [],
       },
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: true,
       },

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.ts
@@ -1,5 +1,5 @@
 import { LocalStorageKeys } from '../local-storage-keys';
-import { AbstractSettingsAdapter, ISettingsModel, SettingsModel } from './settings.model';
+import { AbstractSettingsAdapter, CanvasLayoutDirection, ISettingsModel, SettingsModel } from './settings.model';
 
 export class LocalStorageSettingsAdapter implements AbstractSettingsAdapter {
   private settings: ISettingsModel;
@@ -11,6 +11,8 @@ export class LocalStorageSettingsAdapter implements AbstractSettingsAdapter {
       apicurioRegistryUrl: '',
       customMediaTypes: [],
     };
+
+    parsedSettings.canvasLayoutDirection ??= CanvasLayoutDirection.SelectInCanvas;
 
     this.settings = new SettingsModel(parsedSettings);
   }

--- a/packages/ui/src/models/settings/settings.model.ts
+++ b/packages/ui/src/models/settings/settings.model.ts
@@ -14,6 +14,12 @@ export const enum ColorScheme {
   Dark = 'dark',
 }
 
+export const enum CanvasLayoutDirection {
+  SelectInCanvas = 'SelectInCanvas',
+  Horizontal = 'Horizontal',
+  Vertical = 'Vertical',
+}
+
 export interface ISettingsModel {
   catalogUrl: string;
   nodeLabel: NodeLabelType;
@@ -23,6 +29,7 @@ export interface ISettingsModel {
     apicurioRegistryUrl: string;
     customMediaTypes: string[];
   };
+  canvasLayoutDirection: CanvasLayoutDirection;
   experimentalFeatures: {
     enableDragAndDrop: boolean;
   };
@@ -42,6 +49,7 @@ export class SettingsModel implements ISettingsModel {
     apicurioRegistryUrl: '',
     customMediaTypes: [] as string[],
   };
+  canvasLayoutDirection: CanvasLayoutDirection = CanvasLayoutDirection.SelectInCanvas;
   experimentalFeatures = {
     enableDragAndDrop: true,
   };

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -2,7 +2,7 @@ jest.mock('./KaotoEditorApp');
 jest.mock('react-router-dom');
 import { EditorInitArgs, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
 
-import { ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger } from '../models';
+import { CanvasLayoutDirection, ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger } from '../models';
 import { KaotoEditorApp } from './KaotoEditorApp';
 import { KaotoEditorChannelApi } from './KaotoEditorChannelApi';
 import { KaotoEditorFactory } from './KaotoEditorFactory';
@@ -22,6 +22,7 @@ describe('KaotoEditorFactory', () => {
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -55,6 +56,7 @@ describe('KaotoEditorFactory', () => {
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -113,6 +115,7 @@ describe('KaotoEditorFactory', () => {
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },
@@ -126,6 +129,7 @@ describe('KaotoEditorFactory', () => {
       nodeLabel: NodeLabelType.Id,
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
+      canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       experimentalFeatures: {
         enableDragAndDrop: false,
       },

--- a/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`SettingsProvider should render 1`] = `
 <p
   data-testid="settings"
 >
-  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"experimentalFeatures":{"enableDragAndDrop":true}}
+  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"canvasLayoutDirection":"SelectInCanvas","experimentalFeatures":{"enableDragAndDrop":true}}
 </p>
 `;

--- a/packages/ui/src/utils/get-initial-layout.test.ts
+++ b/packages/ui/src/utils/get-initial-layout.test.ts
@@ -1,0 +1,25 @@
+import { LayoutType } from '../components/Visualization/Canvas/canvas.models';
+import { CanvasLayoutDirection } from '../models';
+import { getInitialLayout } from './get-initial-layout';
+
+describe('getInitialLayout', () => {
+  it('should return DagreHorizontal for Horizontal layout direction', () => {
+    const result = getInitialLayout(CanvasLayoutDirection.Horizontal);
+    expect(result).toBe(LayoutType.DagreHorizontal);
+  });
+
+  it('should return DagreVertical for Vertical layout direction', () => {
+    const result = getInitialLayout(CanvasLayoutDirection.Vertical);
+    expect(result).toBe(LayoutType.DagreVertical);
+  });
+
+  it('should return undefined for User layout direction', () => {
+    const result = getInitialLayout(CanvasLayoutDirection.SelectInCanvas);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for any other value', () => {
+    const result = getInitialLayout('invalid' as CanvasLayoutDirection);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/ui/src/utils/get-initial-layout.ts
+++ b/packages/ui/src/utils/get-initial-layout.ts
@@ -1,0 +1,13 @@
+import { LayoutType } from '../components/Visualization/Canvas/canvas.models';
+import { CanvasLayoutDirection } from '../models/settings/settings.model';
+
+export const getInitialLayout = (canvasLayoutDirection: CanvasLayoutDirection): LayoutType | undefined => {
+  switch (canvasLayoutDirection) {
+    case CanvasLayoutDirection.Horizontal:
+      return LayoutType.DagreHorizontal;
+    case CanvasLayoutDirection.Vertical:
+      return LayoutType.DagreVertical;
+    default:
+      return undefined;
+  }
+};

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './catalog-schema-loader';
 export * from './event-notifier';
 export * from './get-array-property';
 export * from './get-custom-schema-from-kamelet';
+export * from './get-initial-layout';
 export * from './get-serialized-model';
 export * from './get-value';
 export * from './get-viznodes-from-graph';


### PR DESCRIPTION
### Context
Add a new `canvasLayoutDirection` setting that allows configuring the initial canvas layout direction at bootstrap time. The setting supports three options: `canvasControlled` (default, preserves existing behavior), `horizontal`, and `vertical`.

When selecting `horizontal` or `vertical`, the layout is fixed and the layout buttons from the canvas are removed.

#### Screenshot
<img width="1191" height="1080" alt="image" src="https://github.com/user-attachments/assets/4efc78e7-a7d7-498f-88d1-c3fc0145fdfd" />


fix: https://github.com/KaotoIO/kaoto/issues/2595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced canvas layout direction configuration in settings with three options: SelectInCanvas (default), Horizontal, and Vertical to control canvas layout behavior and toggle visibility.

## Style
* Improved settings form card component styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->