### PR TITLE
chore(DataMapper): xs:choice: choice field visualization and selection handling

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -130,6 +130,16 @@ describe('BaseNode', () => {
       expect(screen.queryByTestId('collection-field-icon')).not.toBeInTheDocument();
     });
 
+    it('should render choice icon when isChoiceField is true', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isChoiceField={true} />);
+      expect(screen.getByTestId('choice-field-icon')).toBeInTheDocument();
+    });
+
+    it('should not render choice icon when isChoiceField is false', () => {
+      render(<BaseNode title="Title" data-testid="test-node" isChoiceField={false} />);
+      expect(screen.queryByTestId('choice-field-icon')).not.toBeInTheDocument();
+    });
+
     it('should render attribute icon when isAttributeField is true', () => {
       render(<BaseNode title="Title" data-testid="test-node" isAttributeField={true} />);
       expect(screen.getByTestId('attribute-field-icon')).toBeInTheDocument();

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -1,6 +1,6 @@
 import './BaseNode.scss';
 
-import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
+import { At, ChevronDown, ChevronRight, Choices, Draggable } from '@carbon/icons-react';
 import { Icon } from '@patternfly/react-core';
 import { LayerGroupIcon } from '@patternfly/react-icons';
 import { FunctionComponent, MouseEventHandler, PropsWithChildren, ReactNode } from 'react';
@@ -21,6 +21,7 @@ interface BaseNodeProps extends IDataTestID {
   isDraggable?: boolean;
   iconType?: Types;
   isCollectionField?: boolean;
+  isChoiceField?: boolean;
   isAttributeField?: boolean;
 
   /** Title node */
@@ -40,6 +41,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
   isDraggable,
   iconType,
   isCollectionField,
+  isChoiceField,
   isAttributeField,
   title,
   rank,
@@ -71,6 +73,11 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
       {isCollectionField && (
         <Icon className="node__spacer" data-testid="collection-field-icon">
           <LayerGroupIcon />
+        </Icon>
+      )}
+      {isChoiceField && (
+        <Icon className="node__spacer" data-testid="choice-field-icon">
+          <Choices />
         </Icon>
       )}
       <FieldIcon className="node__spacer" type={iconType} />

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -6,13 +6,15 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
+  IField,
   PrimitiveDocument,
 } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
-import { DocumentNodeData } from '../../models/datamapper/visualization';
+import { ChoiceFieldNodeData, DocumentNodeData } from '../../models/datamapper/visualization';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
+import { DocumentUtilService } from '../../services/document-util.service';
 import { TreeParsingService } from '../../services/tree-parsing.service';
 import { TreeUIService } from '../../services/tree-ui.service';
 import { VisualizationService } from '../../services/visualization.service';
@@ -161,6 +163,34 @@ describe('SourceDocumentNode', () => {
     });
 
     expect(screen.getByTestId('attribute-field-icon')).toBeInTheDocument();
+  });
+
+  it('should render a choice field with choice icon', () => {
+    const document = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(document);
+    const baseField = document.fields[0];
+    const memberFields = [
+      { ...baseField, name: 'email', displayName: 'email', fields: [] },
+      { ...baseField, name: 'phone', displayName: 'phone', fields: [] },
+    ];
+    const choiceField = {
+      ...baseField,
+      name: 'choice',
+      displayName: DocumentUtilService.formatChoiceDisplayName(memberFields as unknown as IField[]),
+      isChoice: true,
+      fields: memberFields,
+    } as unknown as typeof baseField;
+    const choiceNodeData = new ChoiceFieldNodeData(documentNodeData, choiceField);
+    const choiceTreeNode = new DocumentTreeNode(choiceNodeData);
+
+    act(() => {
+      render(
+        <SourceDocumentNode treeNode={choiceTreeNode} documentId={documentNodeData.id} isReadOnly={false} rank={1} />,
+        { wrapper },
+      );
+    });
+
+    expect(screen.getByTestId('choice-field-icon')).toBeInTheDocument();
   });
 
   it('should render with draggable indicator for non-document nodes', () => {

--- a/packages/ui/src/components/Document/SourceDocumentNode.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.tsx
@@ -50,6 +50,7 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
   );
 
   const isCollectionField = VisualizationService.isCollectionField(nodeData);
+  const isChoiceField = VisualizationService.isChoiceField(nodeData);
   const isAttributeField = VisualizationService.isAttributeField(nodeData);
   const isDraggable = !isDocument || VisualizationService.isPrimitiveDocumentNode(nodeData);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -94,6 +95,7 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = ({
               isDraggable={isDraggable}
               iconType={nodeData.type}
               isCollectionField={isCollectionField}
+              isChoiceField={isChoiceField}
               isAttributeField={isAttributeField}
               title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
               rank={rank}

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -6,13 +6,20 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
+  IField,
   PrimitiveDocument,
 } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
-import { DocumentNodeData } from '../../models/datamapper/visualization';
+import { MappingTree } from '../../models/datamapper/mapping';
+import {
+  DocumentNodeData,
+  TargetChoiceFieldNodeData,
+  TargetDocumentNodeData,
+} from '../../models/datamapper/visualization';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
+import { DocumentUtilService } from '../../services/document-util.service';
 import { TreeParsingService } from '../../services/tree-parsing.service';
 import { TreeUIService } from '../../services/tree-ui.service';
 import { VisualizationService } from '../../services/visualization.service';
@@ -151,6 +158,34 @@ describe('TargetDocumentNode', () => {
 
     const icons = screen.getAllByRole('img', { hidden: true });
     expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('should render a choice field with choice icon', () => {
+    const document = TestUtil.createTargetOrderDoc();
+    const tree = new MappingTree(document.documentType, document.documentId, DocumentDefinitionType.XML_SCHEMA);
+    const documentNodeData = new TargetDocumentNodeData(document, tree);
+    const baseField = document.fields[0];
+    const memberFields = [
+      { ...baseField, name: 'email', displayName: 'email', fields: [] },
+      { ...baseField, name: 'phone', displayName: 'phone', fields: [] },
+    ];
+    const choiceField = {
+      ...baseField,
+      name: 'choice',
+      displayName: DocumentUtilService.formatChoiceDisplayName(memberFields as unknown as IField[]),
+      isChoice: true,
+      fields: memberFields,
+    } as unknown as typeof baseField;
+    const choiceNodeData = new TargetChoiceFieldNodeData(documentNodeData, choiceField);
+    const choiceTreeNode = new DocumentTreeNode(choiceNodeData);
+
+    act(() => {
+      render(<TargetDocumentNode treeNode={choiceTreeNode} documentId={documentNodeData.id} rank={1} />, {
+        wrapper,
+      });
+    });
+
+    expect(screen.getByTestId('choice-field-icon')).toBeInTheDocument();
   });
 
   it('should render with draggable indicator for non-document nodes', () => {

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -55,6 +55,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
     [hasChildren, documentId, treeNode.path, reloadNodeReferences],
   );
   const isCollectionField = VisualizationService.isCollectionField(nodeData);
+  const isChoiceField = VisualizationService.isChoiceField(nodeData);
   const isAttributeField = VisualizationService.isAttributeField(nodeData);
   const isDraggable = !isDocument || VisualizationService.isPrimitiveDocumentNode(nodeData);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -105,6 +106,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({ treeN
               isDraggable={isDraggable}
               iconType={iconType}
               isCollectionField={isCollectionField}
+              isChoiceField={isChoiceField}
               isAttributeField={isAttributeField}
               title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
               rank={rank}

--- a/packages/ui/src/models/datamapper/document.test.ts
+++ b/packages/ui/src/models/datamapper/document.test.ts
@@ -7,23 +7,27 @@ describe('BaseField.adopt()', () => {
   const collection = new XmlSchemaCollection();
   const doc = new XmlSchemaDocument(definition, collection);
 
-  it('should copy choice metadata when creating a new adopted field', () => {
+  it('should copy choice metadata and member fields when creating a new adopted field', () => {
     const parent = new XmlSchemaField(doc, 'root', false);
     doc.fields.push(parent);
 
     const field = new BaseField(parent, doc, 'child');
     field.isChoice = true;
-    field.choiceMembers = [];
     field.selectedMemberIndex = 1;
+    const memberA = new BaseField(field, doc, 'memberA');
+    const memberB = new BaseField(field, doc, 'memberB');
+    field.fields = [memberA, memberB];
 
     const adopted = field.adopt(parent);
 
     expect(adopted.isChoice).toBe(true);
-    expect(adopted.choiceMembers).toEqual([]);
     expect(adopted.selectedMemberIndex).toBe(1);
+    expect(adopted.fields.length).toBe(2);
+    expect(adopted.fields[0].name).toBe('memberA');
+    expect(adopted.fields[1].name).toBe('memberB');
   });
 
-  it('should merge choice metadata into an existing identical field', () => {
+  it('should merge choice metadata and member fields into an existing identical field', () => {
     const parent = new XmlSchemaField(doc, 'parent', false);
     doc.fields.push(parent);
 
@@ -32,32 +36,36 @@ describe('BaseField.adopt()', () => {
 
     const second = new BaseField(parent, doc, 'same');
     second.isChoice = true;
-    second.choiceMembers = [];
     second.selectedMemberIndex = 2;
+    const memberX = new BaseField(second, doc, 'memberX');
+    second.fields = [memberX];
 
     const merged = second.adopt(parent);
 
     expect(merged.isChoice).toBe(true);
-    expect(merged.choiceMembers).toEqual([]);
     expect(merged.selectedMemberIndex).toBe(2);
+    expect(merged.fields.length).toBe(1);
+    expect(merged.fields[0].name).toBe('memberX');
   });
 
-  it('should leave choice metadata untouched when source has none', () => {
+  it('should leave choice metadata and fields untouched when source has none', () => {
     const parent = new XmlSchemaField(doc, 'parent2', false);
     doc.fields.push(parent);
 
     const first = new BaseField(parent, doc, 'noChoice');
     first.isChoice = true;
-    first.choiceMembers = [];
     first.selectedMemberIndex = 0;
+    const memberKeep = new BaseField(first, doc, 'memberKeep');
+    first.fields = [memberKeep];
     first.adopt(parent);
 
     const second = new BaseField(parent, doc, 'noChoice');
     const merged = second.adopt(parent);
 
     expect(merged.isChoice).toBe(true);
-    expect(merged.choiceMembers).toEqual([]);
     expect(merged.selectedMemberIndex).toBe(0);
+    expect(merged.fields.length).toBe(1);
+    expect(merged.fields[0].name).toBe('memberKeep');
   });
 });
 
@@ -66,19 +74,23 @@ describe('XmlSchemaField.adopt()', () => {
   const collection = new XmlSchemaCollection();
   const doc = new XmlSchemaDocument(definition, collection);
 
-  it('should copy choice metadata when adopting into a new field', () => {
+  it('should copy choice metadata and member fields when adopting into a new field', () => {
     const parent = new XmlSchemaField(doc, 'root', false);
     doc.fields.push(parent);
 
     const field = new XmlSchemaField(parent, 'element', false);
     field.isChoice = true;
-    field.choiceMembers = [];
     field.selectedMemberIndex = 1;
+    const memberA = new XmlSchemaField(field, 'memberA', false);
+    const memberB = new XmlSchemaField(field, 'memberB', false);
+    field.fields = [memberA, memberB];
 
     const adopted = field.adopt(parent);
 
     expect(adopted.isChoice).toBe(true);
-    expect(adopted.choiceMembers).toEqual([]);
     expect(adopted.selectedMemberIndex).toBe(1);
+    expect(adopted.fields.length).toBe(2);
+    expect(adopted.fields[0].name).toBe('memberA');
+    expect(adopted.fields[1].name).toBe('memberB');
   });
 });

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -65,8 +65,6 @@ export interface IField {
   predicates: Predicate[];
   /** Whether this field represents a choice compositor */
   isChoice?: boolean;
-  /** Array of choice option fields */
-  choiceMembers?: IField[];
   /** Index of selected member (0-based), undefined = show all */
   selectedMemberIndex?: number;
 
@@ -263,7 +261,6 @@ export class BaseField implements IField {
   namedTypeFragmentRefs: string[] = [];
   predicates: Predicate[] = [];
   isChoice?: boolean;
-  choiceMembers?: IField[];
   selectedMemberIndex?: number;
 
   protected mergeInto(existing: IField): void {
@@ -273,7 +270,6 @@ export class BaseField implements IField {
       !existing.namedTypeFragmentRefs.includes(ref) && existing.namedTypeFragmentRefs.push(ref);
     }
     if (this.isChoice !== undefined) existing.isChoice = this.isChoice;
-    if (this.choiceMembers !== undefined) existing.choiceMembers = this.choiceMembers;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
     for (const child of this.fields) child.adopt(existing);
   }
@@ -299,7 +295,6 @@ export class BaseField implements IField {
     adopted.namespaceURI = this.namespaceURI;
     adopted.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     adopted.isChoice = this.isChoice;
-    adopted.choiceMembers = this.choiceMembers;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
     adopted.fields = this.fields.map((child) => child.adopt(adopted));
     parent.fields.push(adopted);

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -21,8 +21,8 @@ export interface TargetNodeData extends NodeData {
   mapping?: MappingParentType;
 }
 
-export type SourceNodeDataType = DocumentNodeData | FieldNodeData;
-export type TargetNodeDataType = TargetDocumentNodeData | TargetFieldNodeData;
+export type SourceNodeDataType = DocumentNodeData | FieldNodeData | ChoiceFieldNodeData;
+export type TargetNodeDataType = TargetDocumentNodeData | TargetFieldNodeData | TargetChoiceFieldNodeData;
 
 export class DocumentNodeData implements NodeData {
   constructor(document: IDocument) {
@@ -83,6 +83,14 @@ export class TargetFieldNodeData extends FieldNodeData implements TargetNodeData
     this.mappingTree = parent.mappingTree;
   }
   mappingTree: MappingTree;
+}
+
+export class ChoiceFieldNodeData extends FieldNodeData {
+  choiceField?: IField;
+}
+
+export class TargetChoiceFieldNodeData extends TargetFieldNodeData {
+  choiceField?: IField;
 }
 
 export class MappingNodeData implements TargetNodeData {

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -5,6 +5,7 @@ import {
   DocumentType,
   Types,
 } from '../models/datamapper';
+import { IField } from '../models/datamapper/document';
 import { IFieldTypeOverride } from '../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { TypeOverrideVariant } from '../models/datamapper/types';
@@ -382,6 +383,29 @@ describe('DocumentUtilService', () => {
       expect(companyAddressField?.fields).toHaveLength(0);
       expect(companyContactField?.namedTypeFragmentRefs).toHaveLength(1);
       expect(companyContactField?.fields).toHaveLength(0);
+    });
+  });
+
+  describe('formatChoiceDisplayName()', () => {
+    it('should format with member names', () => {
+      expect(DocumentUtilService.formatChoiceDisplayName([{ name: 'email' }, { name: 'phone' }] as IField[])).toEqual(
+        'choice (email | phone)',
+      );
+    });
+
+    it('should return "choice (empty)" when members array is empty', () => {
+      expect(DocumentUtilService.formatChoiceDisplayName([])).toEqual('choice (empty)');
+    });
+
+    it('should return "choice (empty)" when members is undefined', () => {
+      expect(DocumentUtilService.formatChoiceDisplayName()).toEqual('choice (empty)');
+    });
+
+    it('should truncate long member lists', () => {
+      const longMembers = Array.from({ length: 20 }, (_, i) => ({ name: `VeryLongMemberName${i}` })) as IField[];
+      const result = DocumentUtilService.formatChoiceDisplayName(longMembers);
+      expect(result).toContain('...');
+      expect(result).toMatch(/^choice \(.+\.\.\.\)$/);
     });
   });
 });

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -341,4 +341,16 @@ export class DocumentUtilService {
       }
     }
   }
+
+  static formatChoiceDisplayName(choiceMembers?: IField[]): string {
+    if (!choiceMembers || choiceMembers.length === 0) {
+      return 'choice (empty)';
+    }
+    const memberNames = choiceMembers.map((m) => m.name).join(' | ');
+    const maxLength = 40;
+    if (memberNames.length > maxLength) {
+      return `choice (${memberNames.substring(0, maxLength - 3)}...)`;
+    }
+    return `choice (${memberNames})`;
+  }
 }

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -507,7 +507,6 @@ export class JsonSchemaField extends BaseField {
       !existing.namedTypeFragmentRefs.includes(ref) && existing.namedTypeFragmentRefs.push(ref);
     }
     if (this.isChoice !== undefined) existing.isChoice = this.isChoice;
-    if (this.choiceMembers !== undefined) existing.choiceMembers = this.choiceMembers;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
     for (const child of this.fields) child.adopt(existing);
     return existing;
@@ -525,7 +524,6 @@ export class JsonSchemaField extends BaseField {
     to.typeOverride = this.typeOverride;
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     to.isChoice = this.isChoice;
-    to.choiceMembers = this.choiceMembers;
     to.selectedMemberIndex = this.selectedMemberIndex;
     to.fields = this.fields.map((child) => child.adopt(to) as JsonSchemaField);
     return to;

--- a/packages/ui/src/services/xml-schema-document.model.ts
+++ b/packages/ui/src/services/xml-schema-document.model.ts
@@ -94,7 +94,6 @@ export class XmlSchemaField extends BaseField {
     adopted.namespaceURI = this.namespaceURI;
     adopted.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     adopted.isChoice = this.isChoice;
-    adopted.choiceMembers = this.choiceMembers;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
     adopted.fields = this.fields.map((child) => child.adopt(adopted) as XmlSchemaField);
     parent.fields.push(adopted);


### PR DESCRIPTION
### Context
 - Turns out `IField.choiceMembers` is redundant where `IField.fields` could be used. `IField.isChoice` is enough to distinguish from a regular field
 - ChoiceFieldNodeData / TargetChoiceFieldNodeData to represent choice node, both selected and not selected
 - When a choice member is selected, show the selected field directly
 - Add choiceField reference on ChoiceFieldNodeData / TargetChoiceFieldNodeData to support reverting choice selection
 - Handle nested choices correctly: selections resolve level by level, each with its own choiceField reference for independent revert
 - DocumentUtilService.formatChoiceDisplayName() to generate display name of the choice node

Fixes: https://github.com/KaotoIO/kaoto/issues/2813