### PR TITLE
Notify operator repo on stable release

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -135,7 +135,7 @@ jobs:
           repositories: kaoto-operator
 
       - name: '🔔 Notify operator repo'
-        if: ${{ github.event.inputs.stable && !contains(github.event.inputs.tag_version, '-RC') }}
+        if: ${{ github.event.inputs.stable == 'true' && !contains(github.event.inputs.tag_version, '-RC') }}
         run: |
           gh api repos/KaotoIO/kaoto-operator/dispatches \
             --field event_type=kaoto-release \


### PR DESCRIPTION
- Adds a `repository_dispatch` step at the end of the `container-image-release` job in the release pipeline
- When a stable release is published, the workflow sends a `kaoto-release` event to `KaotoIO/kaoto-operator` with the released version as payload
- Only fires when `stable` is true (same condition as the stable image push)

The operator release process depends on the Kaoto application being released first. Today this coordination is entirely manual - someone has to remember to sync the community operator forks and trigger the operator release. This change starts an automated chain: once Kaoto is released, the operator repo is notified and can prepare for its own release automatically.

Requirements:

The `KAOTO_CI_TOKEN` secret must be available in this repository with `repo` scope on `KaotoIO/kaoto-operator` (see token setup below) @lhein 

This is in the context of #815 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release pipeline now runs two new post-publish steps for stable (non-RC) releases: it obtains a release token and sends an automated release notification to the operator repository.
  * The notification is dispatched after the stable container image is pushed and includes the released tag/version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->