### PR TITLE
fix(DataMapper): xs:choice: backend logic implementation

### DIFF
--- a/packages/ui/.claude/settings.local.json
+++ b/packages/ui/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh api repos/KaotoIO/kaoto/pulls/2982/reviews/3847791547 2>/dev/null || gh pr view 2982 --repo KaotoIO/kaoto --json reviews 2>/dev/null)",
+      "Bash(cd /home/toigaras/workspace/Kaoto/kaoto/2358-2812 && yarn workspace @kaoto/kaoto run test --testPathPattern=\"document.service\" 2>&1)",
+      "Bash(cd /home/toigaras/workspace/Kaoto/kaoto/2358-2812 && yarn workspace @kaoto/kaoto run test --testPathPattern=\"document.service.test\" 2>&1 | grep -E \"\\(PASS|FAIL|✓|✗|×|●|Tests:|Test Suites:\\)\")",
+      "Bash(cd /home/toigaras/workspace/Kaoto/kaoto/2358-2812 && yarn workspace @kaoto/kaoto run build 2>&1 | tail -20)",
+      "Bash(cd /home/toigaras/workspace/Kaoto/kaoto/2358-2812 && yarn workspace @kaoto/kaoto run test -- --testPathPattern=\"document.service.test\" --silent 2>&1)",
+      "Bash(cd /home/toigaras/workspace/Kaoto/kaoto/2358-2812 && yarn workspace @kaoto/kaoto run test --testPathPattern=\"document.service.test\" 2>&1)"
+    ]
+  }
+}

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -1,7 +1,7 @@
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { MaxOccursType } from '../../xml-schema-ts/constants';
 import { QName } from '../../xml-schema-ts/QName';
-import { IFieldTypeOverride } from './metadata';
+import { IChoiceSelection, IFieldTypeOverride } from './metadata';
 import { NodePath } from './nodepath';
 import { ReportMessage } from './schema';
 import { TypeOverrideVariant, Types } from './types';
@@ -332,6 +332,7 @@ export class DocumentDefinition {
     public definitionFiles?: Record<string, string>,
     public rootElementChoice?: RootElementOption,
     public fieldTypeOverrides?: IFieldTypeOverride[],
+    public choiceSelections?: IChoiceSelection[],
     public namespaceMap?: Record<string, string>,
   ) {
     if (!definitionFiles) this.definitionFiles = {};

--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -76,7 +76,7 @@ export interface IChoiceSelection {
    * (0-based index) for choice compositors.
    *
    * The `{choice:N}` syntax is intentionally distinct from XPath to avoid
-   * ambiguity with XPath predicates. Therefore, `choicePath` is not directly
+   * ambiguity with XPath predicates. Therefore, `schemaPath` is not directly
    * parseable as XPath expression.
    *
    * Examples:
@@ -85,7 +85,7 @@ export interface IChoiceSelection {
    * - `/ns0:Root/{choice:0}/ns0:Option1/{choice:0}` — choice nested via element
    * - `/ns0:Root/{choice:0}/{choice:0}` — choice directly nested in choice
    */
-  choicePath: string;
+  schemaPath: string;
 
   /**
    * The 0-based index of the selected choice member.

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -1277,8 +1277,8 @@ describe('DataMapperMetadataService', () => {
         namespaceMap: { ns0: 'http://example.com/source' },
       };
       const selections: IChoiceSelection[] = [
-        { choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 1 },
-        { choicePath: '/ns0:Root/{choice:1}', selectedMemberIndex: 0 },
+        { schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 1 },
+        { schemaPath: '/ns0:Root/{choice:1}', selectedMemberIndex: 0 },
       ];
 
       await DataMapperMetadataService.setChoiceSelections(
@@ -1302,7 +1302,7 @@ describe('DataMapperMetadataService', () => {
         xsltPath: 'transform.xsl',
         namespaceMap: { ns1: 'http://example.com/target' },
       };
-      const selections: IChoiceSelection[] = [{ choicePath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }];
+      const selections: IChoiceSelection[] = [{ schemaPath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }];
 
       await DataMapperMetadataService.setChoiceSelections(
         mockApi,
@@ -1327,7 +1327,7 @@ describe('DataMapperMetadataService', () => {
         xsltPath: 'transform.xsl',
         namespaceMap: { ns0: 'http://example.com/param' },
       };
-      const selections: IChoiceSelection[] = [{ choicePath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }];
+      const selections: IChoiceSelection[] = [{ schemaPath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }];
 
       await DataMapperMetadataService.setChoiceSelections(
         mockApi,
@@ -1347,7 +1347,7 @@ describe('DataMapperMetadataService', () => {
         sourceBody: {
           type: DocumentDefinitionType.XML_SCHEMA,
           filePath: ['source.xsd'],
-          choiceSelections: [{ choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 }],
+          choiceSelections: [{ schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 }],
         },
         sourceParameters: {},
         targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
@@ -1355,8 +1355,8 @@ describe('DataMapperMetadataService', () => {
         namespaceMap: { ns0: 'http://example.com/source' },
       };
       const newSelections: IChoiceSelection[] = [
-        { choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 2 },
-        { choicePath: '/ns0:Root/{choice:0}/ns0:Option1/{choice:0}', selectedMemberIndex: 1 },
+        { schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 2 },
+        { schemaPath: '/ns0:Root/{choice:0}/ns0:Option1/{choice:0}', selectedMemberIndex: 1 },
       ];
 
       await DataMapperMetadataService.setChoiceSelections(
@@ -1386,7 +1386,7 @@ describe('DataMapperMetadataService', () => {
         metadata,
         DocumentType.PARAM,
         'nonexistent',
-        [{ choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 }],
+        [{ schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 }],
       );
 
       expect(mockApi.setMetadata).not.toHaveBeenCalled();
@@ -1400,8 +1400,8 @@ describe('DataMapperMetadataService', () => {
           type: DocumentDefinitionType.XML_SCHEMA,
           filePath: ['source.xsd'],
           choiceSelections: [
-            { choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 },
-            { choicePath: '/ns0:Root/{choice:1}', selectedMemberIndex: 1 },
+            { schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 },
+            { schemaPath: '/ns0:Root/{choice:1}', selectedMemberIndex: 1 },
           ],
         },
         sourceParameters: {},
@@ -1413,8 +1413,8 @@ describe('DataMapperMetadataService', () => {
       const selections = DataMapperMetadataService.getChoiceSelections(metadata, DocumentType.SOURCE_BODY);
 
       expect(selections).toHaveLength(2);
-      expect(selections[0]).toEqual({ choicePath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 });
-      expect(selections[1]).toEqual({ choicePath: '/ns0:Root/{choice:1}', selectedMemberIndex: 1 });
+      expect(selections[0]).toEqual({ schemaPath: '/ns0:Root/{choice:0}', selectedMemberIndex: 0 });
+      expect(selections[1]).toEqual({ schemaPath: '/ns0:Root/{choice:1}', selectedMemberIndex: 1 });
     });
 
     it('should return choice selections for target body', () => {
@@ -1424,7 +1424,7 @@ describe('DataMapperMetadataService', () => {
         targetBody: {
           type: DocumentDefinitionType.XML_SCHEMA,
           filePath: ['target.xsd'],
-          choiceSelections: [{ choicePath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }],
+          choiceSelections: [{ schemaPath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }],
         },
         xsltPath: 'transform.xsl',
         namespaceMap: { ns1: 'http://example.com/target' },
@@ -1433,7 +1433,7 @@ describe('DataMapperMetadataService', () => {
       const selections = DataMapperMetadataService.getChoiceSelections(metadata, DocumentType.TARGET_BODY);
 
       expect(selections).toHaveLength(1);
-      expect(selections[0]).toEqual({ choicePath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 });
+      expect(selections[0]).toEqual({ schemaPath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 });
     });
 
     it('should return choice selections for source parameter', () => {
@@ -1443,7 +1443,7 @@ describe('DataMapperMetadataService', () => {
           param1: {
             type: DocumentDefinitionType.XML_SCHEMA,
             filePath: ['param1.xsd'],
-            choiceSelections: [{ choicePath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }],
+            choiceSelections: [{ schemaPath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }],
           },
         },
         targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
@@ -1454,7 +1454,7 @@ describe('DataMapperMetadataService', () => {
       const selections = DataMapperMetadataService.getChoiceSelections(metadata, DocumentType.PARAM, 'param1');
 
       expect(selections).toHaveLength(1);
-      expect(selections[0]).toEqual({ choicePath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 });
+      expect(selections[0]).toEqual({ schemaPath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 });
     });
 
     it('should return empty array when choiceSelections is undefined', () => {

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -158,6 +158,7 @@ export class DataMapperMetadataService {
           definitionFiles,
           documentMetadata.rootElementChoice,
           documentMetadata.fieldTypeOverrides,
+          documentMetadata.choiceSelections,
           namespaceMap,
         );
         resolve(answer);
@@ -210,6 +211,7 @@ export class DataMapperMetadataService {
       filePath: filePaths,
       rootElementChoice: definition.rootElementChoice,
       fieldTypeOverrides: existingMetadata?.fieldTypeOverrides || [],
+      choiceSelections: existingMetadata?.choiceSelections,
     };
     const metadataPromise = api.setMetadata(metadataId, metadata);
     const filePromises =

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -111,6 +111,10 @@ export class JsonSchemaDocumentService {
       );
     }
 
+    if (definition.choiceSelections?.length) {
+      DocumentUtilService.processChoiceSelections(document, definition.choiceSelections, definition.namespaceMap || {});
+    }
+
     const validationWarnings = analysisResult.warnings;
     const validationStatus = validationWarnings.length > 0 ? 'warning' : 'success';
 
@@ -169,6 +173,7 @@ export class JsonSchemaDocumentService {
       updatedFiles,
       definition.rootElementChoice,
       definition.fieldTypeOverrides,
+      definition.choiceSelections,
       definition.namespaceMap,
     );
 

--- a/packages/ui/src/services/schema-path.service.test.ts
+++ b/packages/ui/src/services/schema-path.service.test.ts
@@ -1,0 +1,193 @@
+import { Types } from '../models/datamapper';
+import { TestUtil } from '../stubs/datamapper/data-mapper';
+import { SchemaPathSegment, SchemaPathService } from './schema-path.service';
+import { XmlSchemaField } from './xml-schema-document.model';
+
+describe('SchemaPathService', () => {
+  const namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+  function makeChoiceField(parent: XmlSchemaField, memberNames: string[]) {
+    const choiceField = new XmlSchemaField(parent, 'choice', false);
+    choiceField.isChoice = true;
+    choiceField.fields = memberNames.map((n) => new XmlSchemaField(choiceField, n, false));
+    return choiceField;
+  }
+
+  describe('parse()', () => {
+    it('should parse a simple element path', () => {
+      const result = SchemaPathService.parse('/ns0:Root/ns0:Child');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'element', segment: 'ns0:Child' },
+      ]);
+    });
+
+    it('should parse a path with a choice segment', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:0}');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 0 },
+      ]);
+    });
+
+    it('should parse a path with sibling choices', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:1}');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 1 },
+      ]);
+    });
+
+    it('should parse a path with directly nested choices', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:0}/{choice:0}');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 0 },
+        { kind: 'choice', index: 0 },
+      ]);
+    });
+
+    it('should parse a path with element nested inside choice', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:0}/ns0:Option1/{choice:0}');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 0 },
+        { kind: 'element', segment: 'ns0:Option1' },
+        { kind: 'choice', index: 0 },
+      ]);
+    });
+
+    it('should return empty array for empty path', () => {
+      expect(SchemaPathService.parse('')).toEqual([]);
+    });
+
+    it('should return empty array for root-only path', () => {
+      expect(SchemaPathService.parse('/')).toEqual([]);
+    });
+  });
+
+  describe('build()', () => {
+    it('should build a basic schema path for a choice field under a namespaced element', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const choiceField = makeChoiceField(shipOrderField, ['email', 'phone']);
+      shipOrderField.fields.push(choiceField);
+
+      const path = SchemaPathService.build(choiceField, namespaceMap);
+
+      expect(path).toBe('/ns0:ShipOrder/{choice:0}');
+    });
+
+    it('should build correct path for directly nested choices', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const outerChoice = makeChoiceField(shipOrderField, []);
+      const innerChoice = makeChoiceField(outerChoice, ['optA', 'optB']);
+      outerChoice.fields = [innerChoice];
+      shipOrderField.fields.push(outerChoice);
+
+      const path = SchemaPathService.build(innerChoice, namespaceMap);
+
+      expect(path).toBe('/ns0:ShipOrder/{choice:0}/{choice:0}');
+    });
+
+    it('should build correct index when non-choice fields are interspersed between choices', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const elementA = new XmlSchemaField(shipOrderField, 'ElementA', false);
+      const choice0 = makeChoiceField(shipOrderField, ['optA', 'optB']);
+      const elementB = new XmlSchemaField(shipOrderField, 'ElementB', false);
+      const choice1 = makeChoiceField(shipOrderField, ['optX', 'optY']);
+      shipOrderField.fields.push(elementA, choice0, elementB, choice1);
+
+      expect(SchemaPathService.build(choice0, namespaceMap)).toBe('/ns0:ShipOrder/{choice:0}');
+      expect(SchemaPathService.build(choice1, namespaceMap)).toBe('/ns0:ShipOrder/{choice:1}');
+    });
+
+    it('should use bare name when element namespace URI has no matching prefix in map', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const bareParent = new XmlSchemaField(shipOrderField, 'bareParent', false);
+      const choiceField = makeChoiceField(bareParent, ['optA', 'optB']);
+      bareParent.fields = [choiceField];
+      shipOrderField.fields.push(bareParent);
+
+      const path = SchemaPathService.build(choiceField, namespaceMap);
+
+      expect(path).toBe('/ns0:ShipOrder/bareParent/{choice:0}');
+    });
+  });
+
+  describe('navigateToField()', () => {
+    it('should navigate to a choice field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const choiceField = makeChoiceField(shipOrderField, ['email', 'phone']);
+      shipOrderField.fields.push(choiceField);
+
+      const result = SchemaPathService.navigateToField(doc, '/ns0:ShipOrder/{choice:0}', namespaceMap);
+
+      expect(result?.isChoice).toBe(true);
+    });
+
+    it('should return undefined for empty path', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+
+      const result = SchemaPathService.navigateToField(doc, '', namespaceMap);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when terminal field is not a choice', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+
+      const result = SchemaPathService.navigateToField(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should resolve namedTypeFragmentRefs in findChoiceChildByIndex', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const intermediateField = new XmlSchemaField(shipOrderField, 'intermediate', false);
+      const choiceField = new XmlSchemaField(intermediateField, 'choice', false);
+      choiceField.isChoice = true;
+      doc.namedTypeFragments['fragId'] = {
+        type: Types.Container,
+        fields: [choiceField],
+        namedTypeFragmentRefs: [],
+      };
+      intermediateField.namedTypeFragmentRefs = ['fragId'];
+      shipOrderField.fields.push(intermediateField);
+
+      const result = SchemaPathService.navigateToField(doc, '/ns0:ShipOrder/intermediate/{choice:0}', namespaceMap);
+
+      expect(result?.isChoice).toBe(true);
+    });
+
+    it('should resolve namedTypeFragmentRefs in findElementChild', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+      const intermediateField = new XmlSchemaField(shipOrderField, 'intermediate', false);
+      const innerField = new XmlSchemaField(intermediateField, 'innerField', false);
+      const choiceField = new XmlSchemaField(innerField, 'choice', false);
+      choiceField.isChoice = true;
+      innerField.fields = [choiceField];
+      doc.namedTypeFragments['fragId'] = {
+        type: Types.Container,
+        fields: [innerField],
+        namedTypeFragmentRefs: [],
+      };
+      intermediateField.namedTypeFragmentRefs = ['fragId'];
+      shipOrderField.fields.push(intermediateField);
+
+      const result = SchemaPathService.navigateToField(
+        doc,
+        '/ns0:ShipOrder/intermediate/innerField/{choice:0}',
+        namespaceMap,
+      );
+
+      expect(result?.isChoice).toBe(true);
+    });
+  });
+});

--- a/packages/ui/src/services/schema-path.service.ts
+++ b/packages/ui/src/services/schema-path.service.ts
@@ -1,0 +1,146 @@
+import { IDocument, IField } from '../models/datamapper/document';
+import { DocumentUtilService } from './document-util.service';
+import { XPathService } from './xpath/xpath.service';
+
+export type SchemaPathSegment = { kind: 'element'; segment: string } | { kind: 'choice'; index: number };
+
+/**
+ * Service for schema path string operations: parsing, building, and navigation.
+ *
+ * A schema path (e.g. `/ns0:Root/{choice:0}`) is a serializable path format mixing
+ * XPath-style element segments and `{choice:N}` compositor indices. It is intentionally
+ * distinct from XPath to avoid ambiguity with XPath predicates.
+ *
+ * Examples:
+ * - `/ns0:Root/{choice:0}` — single choice under Root
+ * - `/ns0:Root/{choice:0}` and `/ns0:Root/{choice:1}` — sibling choices
+ * - `/ns0:Root/{choice:0}/ns0:Option1/{choice:0}` — choice nested via element
+ * - `/ns0:Root/{choice:0}/{choice:0}` — choice directly nested in choice
+ *
+ * @see DocumentUtilService for choice selection processing and mutation
+ * @see FieldTypeOverrideService for high-level orchestration
+ * @see IChoiceSelection holds schema path to persist choice selection into DataMapper Metadata
+ */
+export class SchemaPathService {
+  /**
+   * Parses a schema path string into an array of typed segments.
+   *
+   * @param schemaPath - The schema path string (e.g. `/ns0:Root/{choice:0}`)
+   * @returns Array of segments, each either `{ kind: 'element', segment }` or `{ kind: 'choice', index }`
+   */
+  static parse(schemaPath: string): SchemaPathSegment[] {
+    const parts = schemaPath.split('/').filter((p) => p.length > 0);
+    const segments: SchemaPathSegment[] = [];
+    for (const part of parts) {
+      const choiceMatch = /^\{choice:(\d+)}$/.exec(part);
+      if (choiceMatch) {
+        segments.push({ kind: 'choice', index: Number.parseInt(choiceMatch[1], 10) });
+      } else {
+        segments.push({ kind: 'element', segment: part });
+      }
+    }
+    return segments;
+  }
+
+  /**
+   * Builds a schema path string from a choice compositor field and its ancestor chain.
+   *
+   * @param field - The choice compositor field to build the path for
+   * @param namespaceMap - Namespace prefix to URI mapping for segment generation
+   * @returns Schema path string (e.g. `/ns0:Root/{choice:0}`)
+   */
+  static build(field: IField, namespaceMap: Record<string, string>): string {
+    const fieldStack = DocumentUtilService.getFieldStack(field, true).reverse();
+    const segments: string[] = [];
+    for (const f of fieldStack) {
+      segments.push(
+        f.isChoice
+          ? `{choice:${SchemaPathService.getChoiceSiblingIndex(f)}}`
+          : SchemaPathService.buildElementSegment(f, namespaceMap),
+      );
+    }
+    return '/' + segments.join('/');
+  }
+
+  private static getChoiceSiblingIndex(field: IField): number {
+    let index = 0;
+    for (const sibling of field.parent.fields) {
+      if (sibling === field) break;
+      if (sibling.isChoice) index++;
+    }
+    return index;
+  }
+
+  private static buildElementSegment(field: IField, namespaceMap: Record<string, string>): string {
+    const nsEntry = Object.entries(namespaceMap).find(([, uri]) => field.namespaceURI === uri);
+    const nsPrefix = nsEntry ? nsEntry[0] : '';
+    return nsPrefix ? `${nsPrefix}:${field.name}` : field.name;
+  }
+
+  /**
+   * Navigates to a choice compositor field in a document tree using a schema path.
+   *
+   * @param document - The document to navigate in
+   * @param schemaPath - The schema path string identifying the choice field
+   * @param namespaceMap - Namespace prefix to URI mapping for element segment resolution
+   * @returns The choice field if found, undefined otherwise
+   */
+  static navigateToField(
+    document: IDocument,
+    schemaPath: string,
+    namespaceMap: Record<string, string>,
+  ): IField | undefined {
+    const segments = SchemaPathService.parse(schemaPath);
+    if (segments.length === 0) return undefined;
+
+    let current: IDocument | IField = document;
+
+    for (const segment of segments) {
+      if (segment.kind === 'element') {
+        const found = SchemaPathService.findElementChild(current, segment.segment, namespaceMap);
+        if (!found) return undefined;
+        current = found;
+      } else {
+        const found = SchemaPathService.findChoiceChildByIndex(current, segment.index);
+        if (!found) return undefined;
+        current = found;
+      }
+    }
+
+    if (!('parent' in current)) return undefined;
+    return current.isChoice ? current : undefined;
+  }
+
+  private static findElementChild(
+    parent: IDocument | IField,
+    elementSegment: string,
+    namespaceMap: Record<string, string>,
+  ): IField | undefined {
+    if ('parent' in parent && parent.namedTypeFragmentRefs.length > 0) {
+      DocumentUtilService.resolveTypeFragment(parent);
+    }
+
+    const pathExpressions = XPathService.extractFieldPaths(`/${elementSegment}`);
+    if (pathExpressions.length === 0 || pathExpressions[0].pathSegments.length === 0) return undefined;
+
+    const segment = pathExpressions[0].pathSegments[0];
+
+    return parent.fields.find((f) => XPathService.matchSegment(namespaceMap, f, segment));
+  }
+
+  private static findChoiceChildByIndex(parent: IDocument | IField, choiceIndex: number): IField | undefined {
+    if ('parent' in parent && parent.namedTypeFragmentRefs.length > 0) {
+      DocumentUtilService.resolveTypeFragment(parent);
+    }
+
+    let count = 0;
+    for (const field of parent.fields) {
+      if (field.isChoice) {
+        if (count === choiceIndex) return field;
+        count++;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -1117,6 +1117,7 @@ describe('XmlSchemaDocumentService', () => {
         { 'main.xsd': mainSchema },
         undefined,
         undefined,
+        undefined,
         { ns0: 'http://example.com/main' },
       );
 
@@ -1218,6 +1219,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         { 'main.xsd': mainSchema },
+        undefined,
         undefined,
         undefined,
         { ns0: 'http://example.com/main' },


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2812

Update: field-type-override.service.ts: High level API supposed to be used directly by UI components
- applyChoiceSelection()
- revertChoiceSelection()

Update: document-util.service.ts: Low level API supposed to be used for initialization sequence and high level APIs
- processChoiceSelections()
- processChoiceSelection()
- removeChoiceSelection()

New: schema-path.service.ts: A collection of utilities to handle `schema path`, which is used to identify the logical path in the schema. It uses `{choice:N}` special notation to represent the `xs:choice` node. This lays a foundation for the next task https://github.com/KaotoIO/kaoto/issues/2973
- build()
- parse()
- navigateToField()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist and apply/remove choice selections across documents; schema-path parsing/building and navigation for choice-targeting; readable choice display names.

* **Refactor**
  * Field lookup and navigation now traverse nested choice members, fragments and choice-indexed paths; choice selection handling integrated into document creation, update and removal flows; added owner-document, field-ancestry and root-element utilities; document rename propagation.

* **Tests**
  * Extensive new/updated tests covering choice scenarios, schema paths, nested-choice navigation and selection apply/revert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->