### PR TITLE
Revert "fix(settings): enable drag-and-drop feature by default"

### DIFF
--- a/packages/ui/src/assets/settingsSchema.json
+++ b/packages/ui/src/assets/settingsSchema.json
@@ -61,6 +61,20 @@
           }
         }
       }
+    },
+    "experimentalFeatures": {
+      "title": "Experimental features",
+      "description": "Enable / disable experimental features",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enableDragAndDrop": {
+          "title": "Enable Drag & Drop",
+          "description": "Control whether to enable drag and drop feature",
+          "type": "boolean",
+          "default": false
+        }
+      }
     }
   }
 }

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -1067,5 +1067,201 @@ exports[`SettingsForm should render 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="pf-v6-c-card"
+    data-ouia-component-id="OUIA-Generated-Card-3"
+    data-ouia-component-type="PF6/Card"
+    data-ouia-safe="true"
+    data-testid="#.experimentalFeatures__field-wrapper"
+    id=""
+  >
+    <div
+      class="pf-v6-c-card__header"
+    >
+      <div
+        class="pf-v6-c-card__actions"
+      >
+        <button
+          aria-label="Remove object"
+          class="pf-v6-c-button pf-m-plain"
+          data-ouia-component-id="OUIA-Generated-Button-plain-14"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe="true"
+          data-testid="#.experimentalFeatures__remove"
+          title="Remove object"
+          type="button"
+        >
+          <span
+            class="pf-v6-c-button__icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="pf-v6-c-card__header-main"
+      >
+        <div
+          class="pf-v6-c-card__title"
+        >
+          <div
+            class="pf-v6-c-card__title-text"
+          >
+             
+            Experimental features
+             
+            <div
+              style="display: contents;"
+            >
+              <span
+                aria-label="More info for Experimental features field"
+                class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                role="button"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-v6-c-card__body pf-v6-c-form kaoto-form__label"
+      data-testid="#.experimentalFeatures__children"
+    >
+      <div
+        class="pf-v6-c-form__group kaoto-form__wrapper--row"
+        data-testid="#.experimentalFeatures.enableDragAndDrop__field-wrapper"
+      >
+        <div
+          class="pf-v6-c-form__group-label"
+        >
+          <label
+            class="pf-v6-c-form__label"
+            for="#.experimentalFeatures.enableDragAndDrop"
+          >
+            <span
+              class="pf-v6-c-form__label-text"
+            >
+              Enable Drag & Drop
+            </span>
+          </label>
+            
+          <span
+            class="pf-v6-c-form__group-label-help"
+          >
+            <div
+              style="display: contents;"
+            >
+              <span
+                aria-label="More info for Enable Drag & Drop field"
+                class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+                data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                role="button"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+          </span>
+        </div>
+        <div
+          class="pf-v6-c-form__group-control"
+        >
+          <label
+            class="pf-v6-c-switch"
+            data-ouia-component-id="OUIA-Generated-Switch-1"
+            data-ouia-component-type="PF6/Switch"
+            data-ouia-safe="true"
+            for="#.experimentalFeatures.enableDragAndDrop"
+          >
+            <input
+              aria-describedby="#.experimentalFeatures.enableDragAndDrop-popover"
+              aria-label="Enable Drag & Drop"
+              checked=""
+              class="pf-v6-c-switch__input"
+              id="#.experimentalFeatures.enableDragAndDrop"
+              name="#.experimentalFeatures.enableDragAndDrop"
+              role="checkbox"
+              type="checkbox"
+            />
+            <span
+              class="pf-v6-c-switch__toggle"
+            >
+              <div
+                class="pf-v6-c-switch__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                  />
+                </svg>
+              </div>
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
 </form>
 `;

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -71,6 +71,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
       CanvasDefaults.HOVER_DELAY_IN,
       CanvasDefaults.HOVER_DELAY_OUT,
     );
+    const dndSettingsEnabled = settingsAdapter.getSettings().experimentalFeatures.enableDragAndDrop;
     const boxRef = useRef<Rect | null>(null);
     const shouldShowToolbar =
       settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
@@ -95,7 +96,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
       () => ({
         item: { type: GROUP_DRAG_TYPE },
         canDrag: () => {
-          return canDragGroup(groupVizNode);
+          return dndSettingsEnabled && canDragGroup(groupVizNode);
         },
         end(dropResult, monitor) {
           if (monitor.didDrop() && dropResult) {
@@ -110,7 +111,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
           dragEvent: monitor.getDragEvent(),
         }),
       }),
-      [element, entitiesContext, groupVizNode, nodeInteractionAddonContext],
+      [dndSettingsEnabled, element, entitiesContext, groupVizNode, nodeInteractionAddonContext],
     );
 
     const customGroupExpandedDropTargetSpec: DropTargetSpec<

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -129,6 +129,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       settingsAdapter.getSettings().nodeToolbarTrigger === NodeToolbarTrigger.onHover
         ? isGHover || isToolbarHover || selected
         : selected;
+    const dndSettingsEnabled = settingsAdapter.getSettings().experimentalFeatures.enableDragAndDrop;
     const canDragNode = vizNode?.canDragNode() ?? false;
 
     const hasSomeInteractions = useMemo(
@@ -164,7 +165,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       () => ({
         item: { type: NODE_DRAG_TYPE },
         canDrag: () => {
-          return canDragNode;
+          return dndSettingsEnabled && canDragNode;
         },
         end(dropResult, monitor) {
           if (monitor.didDrop() && dropResult) {
@@ -178,7 +179,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
           node: monitor.getItem(),
         }),
       }),
-      [canDragNode, element, entitiesContext, nodeInteractionAddonContext],
+      [canDragNode, dndSettingsEnabled, element, entitiesContext, nodeInteractionAddonContext],
     );
 
     const customNodeDropTargetSpec: DropTargetSpec<
@@ -278,7 +279,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
                   dndDropProps.droppable && dndDropProps.canDrop && dndDropProps.hover,
                 'custom-node__container__possibleDropTargets':
                   dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
-                'custom-node__container__draggable': canDragNode,
+                'custom-node__container__draggable': dndSettingsEnabled && canDragNode,
                 'custom-node__container__draggedNode': isDraggedNode,
               }}
               vizNode={vizNode}

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -25,6 +25,9 @@ describe('LocalStorageSettingsAdapter', () => {
         customMediaTypes: [],
       },
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: true,
+      },
     };
 
     adapter.saveSettings(newSettings);
@@ -56,6 +59,9 @@ describe('LocalStorageSettingsAdapter', () => {
         customMediaTypes: [],
       },
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: true,
+      },
     };
 
     adapter.saveSettings(newSettings);

--- a/packages/ui/src/models/settings/settings.model.ts
+++ b/packages/ui/src/models/settings/settings.model.ts
@@ -30,6 +30,9 @@ export interface ISettingsModel {
     customMediaTypes: string[];
   };
   canvasLayoutDirection: CanvasLayoutDirection;
+  experimentalFeatures: {
+    enableDragAndDrop: boolean;
+  };
 }
 
 export interface AbstractSettingsAdapter {
@@ -47,10 +50,13 @@ export class SettingsModel implements ISettingsModel {
     customMediaTypes: [] as string[],
   };
   canvasLayoutDirection: CanvasLayoutDirection = CanvasLayoutDirection.SelectInCanvas;
+  experimentalFeatures = {
+    enableDragAndDrop: true,
+  };
 
   constructor(options: Partial<ISettingsModel> = {}) {
     // Extract nested objects before Object.assign
-    const { rest, ...topLevel } = options;
+    const { rest, experimentalFeatures, ...topLevel } = options;
 
     // Assign top-level properties
     Object.assign(this, topLevel);
@@ -58,6 +64,9 @@ export class SettingsModel implements ISettingsModel {
     // Deep merge nested objects to preserve defaults
     if (rest) {
       this.rest = { ...this.rest, ...rest };
+    }
+    if (experimentalFeatures) {
+      this.experimentalFeatures = { ...this.experimentalFeatures, ...experimentalFeatures };
     }
   }
 }

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -23,6 +23,9 @@ describe('KaotoEditorFactory', () => {
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const envelopeContext = {
@@ -54,6 +57,9 @@ describe('KaotoEditorFactory', () => {
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const getVSCodeKaotoSettingsSpy = jest.fn().mockResolvedValue(settingsModel);
@@ -110,6 +116,9 @@ describe('KaotoEditorFactory', () => {
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
     const expectedSettings: ISettingsModel = {
       catalogUrl: 'path-prefix/camel-catalog/index.json',
@@ -121,6 +130,9 @@ describe('KaotoEditorFactory', () => {
       nodeToolbarTrigger: NodeToolbarTrigger.onHover,
       colorScheme: ColorScheme.Auto,
       canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
+      experimentalFeatures: {
+        enableDragAndDrop: false,
+      },
     };
 
     const getVSCodeKaotoSettingsSpy = jest.fn().mockResolvedValue(settingsModel);

--- a/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`SettingsProvider should render 1`] = `
 <p
   data-testid="settings"
 >
-  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"canvasLayoutDirection":"SelectInCanvas"}
+  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"canvasLayoutDirection":"SelectInCanvas","experimentalFeatures":{"enableDragAndDrop":true}}
 </p>
 `;


### PR DESCRIPTION
### Context
Reverting this change as we need to handle the VS Code side of it.

Reverts KaotoIO/kaoto#2981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an experimental drag-and-drop feature flag in settings. Users can now control whether drag-and-drop functionality is enabled for visualization interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->