### PR TITLE
fix(DataMapper): xs:choice: Handle mutual interference with Field Typ…

### DIFF
--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -2,15 +2,26 @@ import { DocumentDefinitionType, RootElementOption } from './document';
 import { TypeOverrideVariant } from './types';
 
 /**
+ * Shared base for overrides and selections that are addressed by schema path.
+ */
+export interface IBaseOverride {
+  /**
+   * Path to the field in the document structure.
+   * Uses element XPath segments for elements and `{choice:N}` segments
+   * (0-based index) for choice compositors.
+   *
+   * The `{choice:N}` syntax is intentionally distinct from XPath to avoid
+   * ambiguity with XPath predicates. Therefore, `schemaPath` is not directly
+   * parseable as XPath expression.
+   */
+  schemaPath: string;
+}
+
+/**
  * Represents a field type override configuration for a document field.
  * Used to override the default type of a field with a custom type.
  */
-export interface IFieldTypeOverride {
-  /**
-   * The path to the field in the document structure.
-   */
-  path: string;
-
+export interface IFieldTypeOverride extends IBaseOverride {
   /**
    * The new type to apply to the field.
    */
@@ -68,25 +79,14 @@ export interface IDocumentMetadata {
 
 /**
  * Represents a user selection for an xs:choice field in a document.
+ *
+ * Examples of `schemaPath`:
+ * - `/ns0:Root/{choice:0}` — single choice under Root
+ * - `/ns0:Root/{choice:0}` and `/ns0:Root/{choice:1}` — sibling choices
+ * - `/ns0:Root/{choice:0}/ns0:Option1/{choice:0}` — choice nested via element
+ * - `/ns0:Root/{choice:0}/{choice:0}` — choice directly nested in choice
  */
-export interface IChoiceSelection {
-  /**
-   * Path to the choice field in the document structure.
-   * Uses element XPath segments for elements and `{choice:N}` segments
-   * (0-based index) for choice compositors.
-   *
-   * The `{choice:N}` syntax is intentionally distinct from XPath to avoid
-   * ambiguity with XPath predicates. Therefore, `schemaPath` is not directly
-   * parseable as XPath expression.
-   *
-   * Examples:
-   * - `/ns0:Root/{choice:0}` — single choice under Root
-   * - `/ns0:Root/{choice:0}` and `/ns0:Root/{choice:1}` — sibling choices
-   * - `/ns0:Root/{choice:0}/ns0:Option1/{choice:0}` — choice nested via element
-   * - `/ns0:Root/{choice:0}/{choice:0}` — choice directly nested in choice
-   */
-  schemaPath: string;
-
+export interface IChoiceSelection extends IBaseOverride {
   /**
    * The 0-based index of the selected choice member.
    */

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -134,7 +134,7 @@ describe('DocumentUtilService - JSON Schema', () => {
       const namespaceMap = { fn: 'http://www.w3.org/2005/xpath-functions' };
       const overrides: IFieldTypeOverride[] = [
         {
-          path: '/fn:map/fn:string[@key="AccountId"]',
+          schemaPath: '/fn:map/fn:string[@key="AccountId"]',
           type: 'number',
           originalType: 'string',
           variant: TypeOverrideVariant.FORCE,
@@ -158,7 +158,7 @@ describe('DocumentUtilService - JSON Schema', () => {
       const namespaceMap = { fn: 'http://www.w3.org/2005/xpath-functions' };
       const overrides: IFieldTypeOverride[] = [
         {
-          path: '/fn:map/fn:map[@key="Address"]/fn:string[@key="City"]',
+          schemaPath: '/fn:map/fn:map[@key="Address"]/fn:string[@key="City"]',
           type: 'number',
           originalType: 'string',
           variant: TypeOverrideVariant.FORCE,
@@ -198,7 +198,7 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const overrides: IFieldTypeOverride[] = [
         {
-          path: '/fn:map/fn:map[@key="map"]/fn:string[@key="foo"]',
+          schemaPath: '/fn:map/fn:map[@key="map"]/fn:string[@key="foo"]',
           type: 'number',
           originalType: 'string',
           variant: TypeOverrideVariant.FORCE,
@@ -242,7 +242,7 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const overrides: IFieldTypeOverride[] = [
         {
-          path: '/fn:map/fn:string[@key="foo"]',
+          schemaPath: '/fn:map/fn:string[@key="foo"]',
           type: 'boolean',
           originalType: 'string',
           variant: TypeOverrideVariant.FORCE,

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -661,7 +661,12 @@ describe('DocumentService', () => {
       const originalDocument = result.document as XmlSchemaDocument;
 
       originalDocument.definition.fieldTypeOverrides = [
-        { path: '/old:Order/field', type: 'xs:int', originalType: 'xs:string', variant: TypeOverrideVariant.SAFE },
+        {
+          schemaPath: '/old:Order/field',
+          type: 'xs:int',
+          originalType: 'xs:string',
+          variant: TypeOverrideVariant.SAFE,
+        },
       ];
       originalDocument.definition.choiceSelections = [{ schemaPath: '/old:Order/{choice:0}', selectedMemberIndex: 1 }];
 

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -102,18 +102,13 @@ export class JsonSchemaDocumentService {
 
     const document = jsonDocument;
 
-    if (definition.fieldTypeOverrides?.length) {
-      DocumentUtilService.processTypeOverrides(
-        document,
-        definition.fieldTypeOverrides,
-        definition.namespaceMap || {},
-        JsonSchemaTypesService.parseTypeOverride,
-      );
-    }
-
-    if (definition.choiceSelections?.length) {
-      DocumentUtilService.processChoiceSelections(document, definition.choiceSelections, definition.namespaceMap || {});
-    }
+    DocumentUtilService.processOverrides(
+      document,
+      definition.fieldTypeOverrides ?? [],
+      definition.choiceSelections ?? [],
+      definition.namespaceMap || {},
+      JsonSchemaTypesService.parseTypeOverride,
+    );
 
     const validationWarnings = analysisResult.warnings;
     const validationStatus = validationWarnings.length > 0 ? 'warning' : 'success';

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -130,17 +130,12 @@ export class XmlSchemaDocumentService {
     XmlSchemaDocumentService.populateNamedTypeFragments(document);
     XmlSchemaDocumentService.populateElement(document, document.fields, document.rootElement!);
 
-    DocumentUtilService.processTypeOverrides(
+    DocumentUtilService.processOverrides(
       document,
       definition.fieldTypeOverrides ?? [],
-      definition.namespaceMap || {},
-      XmlSchemaTypesService.parseTypeOverride,
-    );
-
-    DocumentUtilService.processChoiceSelections(
-      document,
       definition.choiceSelections ?? [],
       definition.namespaceMap || {},
+      XmlSchemaTypesService.parseTypeOverride,
     );
 
     const rootElementOptions = XmlSchemaDocumentUtilService.collectRootElementOptions(collection);


### PR DESCRIPTION
…e Override

Fixes: https://github.com/KaotoIO/kaoto/issues/2973

- Establishes a shared IBaseOverride interface with a schemaPath field (renaming the old path) used by both IFieldTypeOverride and IChoiceSelection. The {choice:N} segment syntax in schema paths allows overrides and selections to address fields through xs:choice compositors unambiguously.
- Field navigation is consolidated into SchemaPathService.navigateToField(), removing duplicated traversal logic scattered across DocumentUtilService and FieldTypeOverrideService. The previously separate processTypeOverrides() and processChoiceSelections() calls are replaced by a unified processOverrides() that applies them in depth order — type overrides before choice selections at the same depth — which is necessary for correct xs:choice resolution.
- A new invalidateDescendants() ensures that when a type override or choice selection changes, stale descendant overrides and selections are automatically removed, preventing inconsistent document state.
- Individual setFieldTypeOverride/removeFieldTypeOverride methods are replaced by bulk setFieldTypeOverrides() and setChoiceSelections(), which replace the entire array atomically, matching the pattern used for persistence.
- Finally, a bug is fixed where fieldTypeOverrides and choiceSelections were silently discarded on every document definition update because doCreateDocumentMetadata read them from a dead existingMetadata parameter that no caller ever passed — they are now correctly read from the DocumentDefinition itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Switched public model to use schema-paths (schemaPath) instead of XPath-style path for addressing fields and choices.
  * Unified processing of type overrides and choice selections into a single, depth-ordered workflow that invalidates descendant entries and applies schema-path navigation.
  * Changed metadata persistence to replace override/selection sets in bulk for consistent updates and added a consolidated metadata shape.

* **Tests**
  * Expanded coverage for persistence, retrieval, replacement semantics, invalidation, and choice/navigation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->