### PR TITLE
e2e(DataMapper): add e2e tests for multiple schemas support

### DIFF
--- a/packages/ui-tests/cypress/e2e/datamapper/multischema.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/multischema.ts
@@ -1,0 +1,56 @@
+describe('Test for DataMapper : multiple schemas', () => {
+  beforeEach(() => {
+    cy.openHomePage();
+  });
+
+  it('Datamapper - multiple schema', () => {
+    cy.openDataMapper();
+    cy.attachTargetBodySchema([
+      'datamapper/xsd/MultiIncludeMain.xsd',
+      'datamapper/xsd/MultiIncludeComponentA.xsd',
+      'datamapper/xsd/MultiIncludeComponentB.xsd',
+    ]);
+
+    cy.attachSourceBodySchema('datamapper/xsd/Cart.xsd');
+
+    cy.engageMapping(
+      ['document-doc-sourceBody-Body', 'node-source-fx-Title'],
+      ['document-doc-targetBody-Body', 'node-target-fx-fieldA1'],
+      '/ns0:Cart/Item/Title',
+    );
+    cy.engageMapping(
+      ['document-doc-sourceBody-Body', 'node-source-fx-Note'],
+      ['document-doc-targetBody-Body', 'node-target-fx-fieldA2'],
+      '/ns0:Cart/Item/Note',
+    );
+    cy.engageMapping(
+      ['document-doc-sourceBody-Body', 'node-source-fx-Quantity'],
+      ['document-doc-targetBody-Body', 'node-target-fx-fieldB1'],
+      '/ns0:Cart/Item/Quantity',
+    );
+    cy.engageMapping(
+      ['document-doc-sourceBody-Body', 'node-source-fx-Price'],
+      ['document-doc-targetBody-Body', 'node-target-fx-fieldB2'],
+      '/ns0:Cart/Item/Price',
+    );
+    cy.countMappingLines(4);
+  });
+
+  it('Datamapper - multiple schema, missing required schemas', () => {
+    cy.openDataMapper();
+    cy.addTargetBodySchema(['datamapper/xsd/MultiIncludeMain.xsd']);
+
+    cy.get('[data-testid="attach-schema-modal"]')
+      .should('be.visible')
+      .and(
+        'contain.text',
+        'Missing required schema: "MultiIncludeComponentA.xsd" referenced by "MultiIncludeMain.xsd" via xs:include',
+      );
+    cy.get('[data-testid="attach-schema-modal"]')
+      .should('be.visible')
+      .and(
+        'contain.text',
+        'Missing required schema: "MultiIncludeComponentB.xsd" referenced by "MultiIncludeMain.xsd" via xs:include',
+      );
+  });
+});

--- a/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentA.xsd
+++ b/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentA.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/multi-include"
+           xmlns:mi="http://example.com/multi-include"
+           elementFormDefault="qualified">
+  <xs:complexType name="TypeA">
+    <xs:sequence>
+      <xs:element name="fieldA1" type="xs:string"/>
+      <xs:element name="fieldA2" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentB.xsd
+++ b/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentB.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/multi-include"
+           xmlns:mi="http://example.com/multi-include"
+           elementFormDefault="qualified">
+  <xs:complexType name="TypeB">
+    <xs:sequence>
+      <xs:element name="fieldB1" type="xs:string"/>
+      <xs:element name="fieldB2" type="xs:boolean"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeMain.xsd
+++ b/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeMain.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/multi-include"
+           xmlns:mi="http://example.com/multi-include"
+           elementFormDefault="qualified">
+  <xs:include schemaLocation="MultiIncludeComponentA.xsd"/>
+  <xs:include schemaLocation="MultiIncludeComponentB.xsd"/>
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="partA" type="mi:TypeA"/>
+        <xs:element name="partB" type="mi:TypeB"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -155,7 +155,8 @@ declare global {
       compareFileWithMonacoEditor(filePath: string): Chainable<JQuery<Element>>;
       // DataMapper
       attachSourceBodySchema(filePath: string): Chainable<JQuery<Element>>;
-      attachTargetBodySchema(filePath: string): Chainable<JQuery<Element>>;
+      attachTargetBodySchema(filePath: string | string[]): Chainable<JQuery<Element>>;
+      addTargetBodySchema(filePath: string | string[]): Chainable<JQuery<Element>>;
       addParameter(name: string): Chainable<JQuery<Element>>;
       deleteParameter(name: string): Chainable<JQuery<Element>>;
       attachParameterSchema(name: string, filePath: string): Chainable<JQuery<Element>>;

--- a/packages/ui-tests/cypress/support/next-commands/datamapper.ts
+++ b/packages/ui-tests/cypress/support/next-commands/datamapper.ts
@@ -13,19 +13,8 @@ Cypress.Commands.add('attachSourceBodySchema', (filePath: string) => {
   cy.wait(100);
 });
 
-Cypress.Commands.add('attachTargetBodySchema', (filePath: string) => {
-  cy.get('[data-testid="attach-schema-targetBody-Body-button"]').click();
-  cy.get('[data-testid="attach-schema-modal-btn-file"]').click();
-  cy.get('[data-testid="attach-schema-file-input"]').attachFile(filePath);
-
-  cy.get('[data-testid="attach-schema-file-list"]').should('exist');
-  if (filePath.endsWith('json')) {
-    cy.get('[data-testid="attach-schema-modal-option-json"]').should('be.checked');
-    cy.get('[data-testid="attach-schema-modal-option-xml"]').should('not.be.checked');
-  } else {
-    cy.get('[data-testid="attach-schema-modal-option-json"]').should('not.be.checked');
-    cy.get('[data-testid="attach-schema-modal-option-xml"]').should('be.checked');
-  }
+Cypress.Commands.add('attachTargetBodySchema', (filePath: string | string[]) => {
+  cy.addTargetBodySchema(filePath);
 
   cy.get('[data-testid="attach-schema-modal-btn-attach"]').click();
 
@@ -33,6 +22,29 @@ Cypress.Commands.add('attachTargetBodySchema', (filePath: string) => {
   cy.get('.target-panel').find('[data-testid^="node-target-"]').should('exist');
   // Wait for panel heights to stabilize after schema attachment
   cy.wait(100);
+});
+
+Cypress.Commands.add('addTargetBodySchema', (filePath: string | string[]) => {
+  // Normalize input to array for consistent processing
+  const filePaths = Array.isArray(filePath) ? filePath : [filePath];
+
+  cy.get('[data-testid="attach-schema-targetBody-Body-button"]').click();
+  cy.get('[data-testid="attach-schema-modal-btn-file"]').click();
+
+  // Attach each file
+  cy.get('[data-testid="attach-schema-file-input"]').attachFile(filePaths);
+
+  cy.get('[data-testid="attach-schema-file-list"]').should('exist');
+
+  // Check file type based on the first file
+  const firstFile = filePaths[0];
+  if (firstFile.endsWith('json')) {
+    cy.get('[data-testid="attach-schema-modal-option-json"]').should('be.checked');
+    cy.get('[data-testid="attach-schema-modal-option-xml"]').should('not.be.checked');
+  } else {
+    cy.get('[data-testid="attach-schema-modal-option-json"]').should('not.be.checked');
+    cy.get('[data-testid="attach-schema-modal-option-xml"]').should('be.checked');
+  }
 });
 
 Cypress.Commands.add('addParameter', (name: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for DataMapper with multiple schema handling, including mapping verification between source and target schemas.
  * Added tests to verify proper error messaging when required schemas are missing from the setup.
  * Enhanced test infrastructure to support attaching multiple schema files simultaneously in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->