### PR TITLE
feat(Canvas): Place duplicated element next to the original element

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
@@ -11,6 +11,14 @@ import { VisibleFlowsContextResult } from '../../../../providers/visible-flows.p
 import { mockRandomValues, TestProvidersWrapper } from '../../../../stubs';
 import { FlowsList } from './FlowsList';
 
+const mockController = {
+  fromModel: jest.fn(),
+};
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: () => mockController,
+}));
+
 describe('FlowsList.tsx', () => {
   let camelResource: CamelRouteResource;
 
@@ -19,6 +27,7 @@ describe('FlowsList.tsx', () => {
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
     camelResource = new CamelRouteResource();
     camelResource.addNewEntity(EntityType.Route);
     camelResource.addNewEntity(EntityType.RouteConfiguration);
@@ -231,6 +240,34 @@ describe('FlowsList.tsx', () => {
     /** Eye slash icon */
     const flow2 = await wrapper.findByTestId('toggle-btn-routeConfiguration-1234-hidden');
     expect(flow2).toBeInTheDocument();
+  });
+
+  it('should call controller clear model when clicking the Eye slash icon', async () => {
+    const visibleFlowsContext: VisibleFlowsContextResult = {
+      allFlowsVisible: false,
+      visibleFlows: { ['route-1234']: false, ['routeConfiguration-1234']: true },
+      visualFlowsApi: new VisualFlowsApi(jest.fn),
+    };
+
+    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const wrapper = render(
+      <Provider>
+        <FlowsList />
+      </Provider>,
+    );
+
+    /** Eye slash icon */
+    const flow1 = await wrapper.findByTestId('toggle-btn-route-1234-hidden');
+    expect(flow1).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(flow1);
+    });
+
+    expect(mockController.fromModel).toHaveBeenCalledTimes(1);
+    expect(mockController.fromModel).toHaveBeenCalledWith({
+      nodes: [],
+      edges: [],
+    });
   });
 
   it('should rename a flow', async () => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -3,6 +3,7 @@ import './FlowsList.scss';
 import { Button, Icon, SearchInput } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon, TrashIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { useVisualizationController } from '@patternfly/react-topology';
 import { FunctionComponent, MouseEvent, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import { ValidationResult } from '../../../../models';
@@ -25,6 +26,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = ({ onClose }) => {
   const { visualEntities, camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
   const { visibleFlows, allFlowsVisible, visualFlowsApi } = useContext(VisibleFlowsContext)!;
   const deleteModalContext = useContext(ActionConfirmationModalContext);
+  const controller = useVisualizationController();
   const [searchString, setSearchString] = useState<string>('');
 
   const isListEmpty = visualEntities.length === 0;
@@ -183,6 +185,13 @@ export const FlowsList: FunctionComponent<IFlowsList> = ({ onClose }) => {
                     variant="plain"
                     onClick={(event) => {
                       visualFlowsApi.toggleFlowVisible(flow.id);
+                      /** Clear the graph if the flow is being shown to re-arrange the flows order */
+                      if (!visibleFlows[flow.id]) {
+                        controller.fromModel({
+                          nodes: [],
+                          edges: [],
+                        });
+                      }
                       /** Required to avoid closing the Dropdown after clicking in the icon */
                       event.stopPropagation();
                     }}

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -7,6 +7,7 @@ import { CamelRouteResource } from '../../../../models/camel/camel-route-resourc
 import { AddStepMode } from '../../../../models/visualization/base-visual-entity';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/camel-route-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
+import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { camelRouteJson } from '../../../../stubs/camel-route';
 import { updateIds } from '../../../../utils/update-ids';
@@ -87,12 +88,22 @@ describe('useDuplicateStep', () => {
     getRegisteredInteractionAddons: jest.fn().mockReturnValue([]),
   };
 
+  const mockVisibleFlowsContext: VisibleFlowsContextResult = {
+    visibleFlows: { route: true },
+    allFlowsVisible: true,
+    visualFlowsApi: {
+      toggleFlowVisible: jest.fn(),
+    } as never,
+  };
+
   const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
     <EntitiesContext.Provider value={mockEntitiesContext}>
       <CatalogModalContext.Provider value={mockCatalogModalContext}>
-        <NodeInteractionAddonContext.Provider value={mockNodeInteractionAddonContext}>
-          {children}
-        </NodeInteractionAddonContext.Provider>
+        <VisibleFlowsContext.Provider value={mockVisibleFlowsContext}>
+          <NodeInteractionAddonContext.Provider value={mockNodeInteractionAddonContext}>
+            {children}
+          </NodeInteractionAddonContext.Provider>
+        </VisibleFlowsContext.Provider>
       </CatalogModalContext.Provider>
     </EntitiesContext.Provider>
   );
@@ -188,15 +199,22 @@ describe('useDuplicateStep', () => {
       expect(mockEntitiesContext.updateEntitiesFromCamelResource as jest.Mock).toHaveBeenCalledTimes(1);
     });
 
-    it('should call entitiesContext.camelResource.addNewEntity() and finally updateEntitiesFromCamelResource()', async () => {
+    it('should call entitiesContext.camelResource.addNewEntity() with original entity ID and finally updateEntitiesFromCamelResource()', async () => {
       const camelResourceAddNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
       const routeVizNodeContent = updateIds(routeVizNode.getCopiedContent()!);
       const { result } = renderHook(() => useDuplicateStep(routeVizNode), { wrapper });
       await result.current.onDuplicate();
 
       expect(camelResourceAddNewEntitySpy).toHaveBeenCalledTimes(1);
-      expect(camelResourceAddNewEntitySpy).toHaveBeenCalledWith(routeVizNodeContent.name as string, {
-        [routeVizNodeContent.name]: routeVizNodeContent.definition,
+      expect(camelResourceAddNewEntitySpy).toHaveBeenCalledWith(
+        routeVizNodeContent.name as string,
+        { [routeVizNodeContent.name]: routeVizNodeContent.definition },
+        routeVizNode.getId(),
+      );
+      expect(mockVisibleFlowsContext.visualFlowsApi.toggleFlowVisible).toHaveBeenCalledTimes(1);
+      expect(mockController.fromModel).toHaveBeenCalledWith({
+        nodes: [],
+        edges: [],
       });
       expect(mockEntitiesContext.updateEntitiesFromCamelResource as jest.Mock).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
@@ -10,6 +10,7 @@ import { AddStepMode, IVisualizationNode } from '../../../../models/visualizatio
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
 import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContext } from '../../../../providers/entities.provider';
+import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 import { updateIds } from '../../../../utils/update-ids';
 import {
   IInteractionType,
@@ -23,6 +24,7 @@ export const useDuplicateStep = (vizNode: IVisualizationNode) => {
   const entitiesContext = useContext(EntitiesContext)!;
   const catalogModalContext = useContext(CatalogModalContext);
   const nodeInteractionAddonContext = useContext(NodeInteractionAddonContext);
+  const visibleFlowsContext = useContext(VisibleFlowsContext)!;
   const controller = useVisualizationController();
   let vizNodeContent = vizNode.getCopiedContent();
 
@@ -89,8 +91,16 @@ export const useDuplicateStep = (vizNode: IVisualizationNode) => {
     if (!updatedVizNodeContent) return;
 
     if (vizNodeContent.type === SourceSchemaType.Route && !isDefined(parentVizNode)) {
-      entitiesContext.camelResource.addNewEntity(updatedVizNodeContent.name as EntityType, {
-        [updatedVizNodeContent.name]: updatedVizNodeContent.definition,
+      const originalEntityId = vizNode.getId();
+      const newId = entitiesContext.camelResource.addNewEntity(
+        updatedVizNodeContent.name as EntityType,
+        { [updatedVizNodeContent.name]: updatedVizNodeContent.definition },
+        originalEntityId,
+      );
+      visibleFlowsContext.visualFlowsApi.toggleFlowVisible(newId);
+      controller.fromModel({
+        nodes: [],
+        edges: [],
       });
     } else {
       /** Append the content of the current node on the current node */
@@ -119,7 +129,15 @@ export const useDuplicateStep = (vizNode: IVisualizationNode) => {
 
     /** Update entity */
     entitiesContext.updateEntitiesFromCamelResource();
-  }, [controller, entitiesContext, nodeInteractionAddonContext, parentVizNode, vizNode, vizNodeContent]);
+  }, [
+    controller,
+    entitiesContext,
+    nodeInteractionAddonContext,
+    parentVizNode,
+    visibleFlowsContext.visualFlowsApi,
+    vizNode,
+    vizNodeContent,
+  ]);
 
   const value = useMemo(
     () => ({

--- a/packages/ui/src/models/camel/camel-resource.ts
+++ b/packages/ui/src/models/camel/camel-resource.ts
@@ -10,7 +10,7 @@ import { SourceSchemaType } from './source-schema-type';
 export interface CamelResource {
   getVisualEntities(): BaseVisualCamelEntity[];
   getEntities(): BaseCamelEntity[];
-  addNewEntity(entityType?: EntityType, entityTemplate?: unknown): string;
+  addNewEntity(entityType?: EntityType, entityTemplate?: unknown, insertAfterEntityId?: string): string;
   removeEntity(ids?: string[]): void;
   supportsMultipleVisualEntities(): boolean;
   toJSON(): unknown;

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -220,6 +220,88 @@ describe('CamelRouteResource', () => {
       expect(resource.getVisualEntities()).toHaveLength(2);
       expect(resource.getVisualEntities()[0].id).toEqual(id);
     });
+
+    describe('insertAfterEntityId', () => {
+      it('should insert a duplicated route right after the original route', () => {
+        const resource = new CamelRouteResource([
+          { from: { uri: 'direct:route1', steps: [] } },
+          { from: { uri: 'direct:route2', steps: [] } },
+          { from: { uri: 'direct:route3', steps: [] } },
+        ]);
+
+        const entities = resource.getVisualEntities();
+        expect(entities).toHaveLength(3);
+
+        const route1Id = entities[0].id;
+
+        // Duplicate route1 - should be inserted right after route1
+        const newId = resource.addNewEntity(EntityType.Route, undefined, route1Id);
+
+        const updatedEntities = resource.getVisualEntities();
+        expect(updatedEntities).toHaveLength(4);
+        expect(updatedEntities[0].id).toBe(route1Id);
+        expect(updatedEntities[1].id).toBe(newId); // Duplicate placed right after route1
+      });
+
+      it('should insert a duplicated route after the last route when duplicating the last route', () => {
+        const resource = new CamelRouteResource([
+          { from: { uri: 'direct:route1', steps: [] } },
+          { from: { uri: 'direct:route2', steps: [] } },
+        ]);
+
+        const entities = resource.getVisualEntities();
+        const route2Id = entities[1].id;
+
+        const newId = resource.addNewEntity(EntityType.Route, undefined, route2Id);
+
+        const updatedEntities = resource.getVisualEntities();
+        expect(updatedEntities).toHaveLength(3);
+        expect(updatedEntities[1].id).toBe(route2Id);
+        expect(updatedEntities[2].id).toBe(newId); // Duplicate placed right after route2
+      });
+
+      it('should insert after the specified entity among mixed entity types', () => {
+        const resource = new CamelRouteResource([
+          { routeConfiguration: { id: 'config1' } },
+          { from: { uri: 'direct:route1', steps: [] } },
+          { from: { uri: 'direct:route2', steps: [] } },
+        ]);
+
+        const entities = resource.getVisualEntities();
+        const route1Id = entities.find((e) => e.type === EntityType.Route)!.id;
+
+        const newId = resource.addNewEntity(EntityType.Route, undefined, route1Id);
+
+        const updatedEntities = resource.getVisualEntities();
+        expect(updatedEntities).toHaveLength(4);
+
+        // Find the route entities in order
+        const routeEntities = updatedEntities.filter((e) => e.type === EntityType.Route);
+        expect(routeEntities).toHaveLength(3);
+        expect(routeEntities[0].id).toBe(route1Id);
+        expect(routeEntities[1].id).toBe(newId); // Duplicate right after route1
+      });
+
+      it('should fall back to default ordering when insertAfterEntityId is not found', () => {
+        const resource = new CamelRouteResource([{ from: { uri: 'direct:route1', steps: [] } }]);
+
+        const newId = resource.addNewEntity(EntityType.Route, undefined, 'non-existing-id');
+
+        const updatedEntities = resource.getVisualEntities();
+        expect(updatedEntities).toHaveLength(2);
+        expect(updatedEntities[1].id).toBe(newId); // Falls back to end
+      });
+
+      it('should fall back to default ordering when insertAfterEntityId is not provided', () => {
+        const resource = new CamelRouteResource([{ from: { uri: 'direct:route1', steps: [] } }]);
+
+        const newId = resource.addNewEntity(EntityType.Route);
+
+        const updatedEntities = resource.getVisualEntities();
+        expect(updatedEntities).toHaveLength(2);
+        expect(updatedEntities[1].id).toBe(newId);
+      });
+    });
   });
 
   it('should return the right type', () => {


### PR DESCRIPTION
### Summary
This PR adds support for inserting new entities at a specific position relative to an existing entity, rather than always using the default XML schema ordering. This enables features like duplicating routes to appear immediately after the original route.

### Key Changes
- Added optional `insertAfterEntityId` parameter to `CamelResource.addNewEntity()` interface and `CamelRouteResource` implementation
- Introduced `getInsertionIndex()` private method that:
  - Places new entities right after the specified entity ID when provided
  - Falls back to `EntityOrderingService.findInsertionIndex()` for default XML schema ordering when the parameter is not provided or the ID is not found
- Updated `useDuplicateStep` hook to pass the original entity's ID when duplicating routes, ensuring duplicates appear immediately after the source
- Added comprehensive test coverage for the new insertion behavior:
  - Inserting after a middle route
  - Inserting after the last route
  - Inserting among mixed entity types
  - Fallback behavior when ID is not found or not provided

### Notes
The tests and the visual functionality was fixed by @shivamG640, many kudos to you my friend :muscle: 

fix: https://github.com/KaotoIO/kaoto/issues/2993
fix: https://github.com/KaotoIO/kaoto/issues/3045
