### PR TITLE
chore: Update Camel Catalog to 4.18

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/stepConfiguration.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/stepConfiguration.cy.ts
@@ -19,10 +19,10 @@ describe('Tests for Design page', () => {
     cy.selectFormTab('All');
     cy.interactWithConfigInputObject('topic', 'topicname');
     cy.interactWithConfigInputObject('bootstrapServers', 'bootstrap');
-    cy.interactWithConfigInputObject('securityProtocol', 'security');
-    cy.interactWithConfigInputObject('saslMechanism', 'sasl');
-    cy.interactWithConfigInputObject('user', 'user');
-    cy.interactWithConfigInputObject('password', 'password');
+    cy.interactWithConfigInputObject('oauthClientId', 'clientId');
+    cy.interactWithConfigInputObject('oauthClientSecret', 'sasl');
+    cy.interactWithConfigInputObject('saslUsername', 'user');
+    cy.interactWithConfigInputObject('saslPassword', 'password');
 
     // CHECK they are reflected in the code editor
     cy.openSourceCode();
@@ -30,9 +30,9 @@ describe('Tests for Design page', () => {
     cy.checkCodeSpanLine('message: ""', 0);
     cy.checkCodeSpanLine('topic: topicname');
     cy.checkCodeSpanLine('bootstrapServers: bootstrap');
-    cy.checkCodeSpanLine('securityProtocol: security');
-    cy.checkCodeSpanLine('saslMechanism: sasl');
-    cy.checkCodeSpanLine('user: user');
-    cy.checkCodeSpanLine('password: password');
+    cy.checkCodeSpanLine('oauthClientId: clientId');
+    cy.checkCodeSpanLine('oauthClientSecret: sasl');
+    cy.checkCodeSpanLine('saslUsername: user');
+    cy.checkCodeSpanLine('saslPassword: password');
   });
 });

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -63,7 +63,7 @@
     "vite": "^5.4.0"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.3.1",
+    "@kaoto/camel-catalog": "^0.4.0",
     "@kaoto/forms": "^1.6.0",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.4.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -80,7 +80,7 @@
     "zustand": "^4.3.9"
   },
   "peerDependencies": {
-    "@kaoto/camel-catalog": "^0.2.2 || ^0.3.0",
+    "@kaoto/camel-catalog": "^0.4.0",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.0",
@@ -98,7 +98,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
     "@eslint/js": "^9.10.0",
-    "@kaoto/camel-catalog": "^0.3.1",
+    "@kaoto/camel-catalog": "^0.4.0",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.0",

--- a/packages/ui/src/__mocks__/fileMock.ts
+++ b/packages/ui/src/__mocks__/fileMock.ts
@@ -1,1 +1,1 @@
-module.exports = '';
+module.exports = 'file-mock-data';

--- a/packages/ui/src/components/Catalog/__snapshots__/BaseCatalog.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/BaseCatalog.test.tsx.snap
@@ -274,7 +274,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -367,7 +373,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -460,7 +472,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -553,7 +571,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -646,7 +670,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -739,7 +769,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -832,7 +868,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -925,7 +967,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1018,7 +1066,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1111,7 +1165,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1204,7 +1264,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1297,7 +1363,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1390,7 +1462,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1483,7 +1561,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1576,7 +1660,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1669,7 +1759,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1762,7 +1858,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1855,7 +1957,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -1948,7 +2056,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2041,7 +2155,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2134,7 +2254,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2227,7 +2353,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2320,7 +2452,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2413,7 +2551,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2506,7 +2650,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2599,7 +2749,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2692,7 +2848,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2785,7 +2947,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2878,7 +3046,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -2971,7 +3145,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3064,7 +3244,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3157,7 +3343,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3250,7 +3442,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3343,7 +3541,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3436,7 +3640,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3529,7 +3739,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3622,7 +3838,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="component icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3715,7 +3937,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3808,7 +4036,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3901,7 +4135,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -3994,7 +4234,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4087,7 +4333,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4180,7 +4432,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4273,7 +4531,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4366,7 +4630,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4459,7 +4729,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4552,7 +4828,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="processor icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4645,7 +4927,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4738,7 +5026,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -4831,7 +5125,13 @@ exports[`BaseCatalog renders correctly with Gallery Layout 1`] = `
           >
             <div
               class="tile__header"
-            />
+            >
+              <img
+                alt="Kamelet icon"
+                class="tile__icon"
+                src="file-mock-data"
+              />
+            </div>
             <div
               class="pf-v6-c-card__title"
             >
@@ -5167,6 +5467,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5261,6 +5566,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5355,6 +5665,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5449,6 +5764,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5543,6 +5863,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5637,6 +5962,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5731,6 +6061,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5825,6 +6160,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -5919,6 +6259,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6013,6 +6358,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6107,6 +6457,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6201,6 +6556,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6295,6 +6655,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6389,6 +6754,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6483,6 +6853,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6577,6 +6952,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6671,6 +7051,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6765,6 +7150,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6859,6 +7249,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -6953,6 +7348,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7047,6 +7447,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7141,6 +7546,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7235,6 +7645,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7329,6 +7744,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7423,6 +7843,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7517,6 +7942,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7611,6 +8041,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7705,6 +8140,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7799,6 +8239,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7893,6 +8338,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -7987,6 +8437,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8081,6 +8536,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8175,6 +8635,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8269,6 +8734,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8363,6 +8833,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8457,6 +8932,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8551,6 +9031,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="component icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8645,6 +9130,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8739,6 +9229,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8833,6 +9328,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -8927,6 +9427,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9021,6 +9526,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9115,6 +9625,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9209,6 +9724,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9303,6 +9823,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9397,6 +9922,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9491,6 +10021,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="processor icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9585,6 +10120,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9679,6 +10219,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"
@@ -9773,6 +10318,11 @@ exports[`BaseCatalog renders correctly with List Layout 1`] = `
                   <div
                     class="catalog-data-list-item__title-div-left"
                   >
+                    <img
+                      alt="Kamelet icon"
+                      class="catalog-data-list-item__title-div-left__icon"
+                      src="file-mock-data"
+                    />
                     <span
                       class="catalog-data-list-item__title-div-left__title"
                       id="clickable-action-item1"

--- a/packages/ui/src/components/Catalog/__snapshots__/DataListItem.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/DataListItem.test.tsx.snap
@@ -24,6 +24,11 @@ exports[`DataListItem renders correctly 1`] = `
             <div
               class="catalog-data-list-item__title-div-left"
             >
+              <img
+                alt="component icon"
+                class="catalog-data-list-item__title-div-left__icon"
+                src="file-mock-data"
+              />
               <span
                 class="catalog-data-list-item__title-div-left__title"
                 id="clickable-action-item1"

--- a/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
+++ b/packages/ui/src/components/Catalog/__snapshots__/Tile.test.tsx.snap
@@ -33,6 +33,11 @@ exports[`Tile renders correctly 1`] = `
       <div
         class="tile__header"
       >
+        <img
+          alt="component icon"
+          class="tile__icon"
+          src="file-mock-data"
+        />
         <div
           class="pf-v6-c-label-group"
         >

--- a/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
@@ -21,6 +21,11 @@ exports[`CanvasForm should render 1`] = `
           <div
             class="pf-v6-l-grid__item pf-m-11-col form-header"
           >
+            <img
+              alt="processor icon"
+              class="form-header__icon-test|route.from.steps.1.choice.when.0.steps.0.log"
+              src="file-mock-data"
+            />
             <h2
               class="pf-v6-c-title pf-m-h2 form-header__title"
               data-ouia-component-id="OUIA-Generated-Title-1"
@@ -382,6 +387,11 @@ exports[`CanvasForm should render nothing if no schema and no definition is avai
           <div
             class="pf-v6-l-grid__item pf-m-11-col form-header"
           >
+            <img
+              alt="Entity icon"
+              class="form-header__icon-1"
+              src="file-mock-data"
+            />
             <h2
               class="pf-v6-c-title pf-m-h2 form-header__title"
               data-ouia-component-id="OUIA-Generated-Title-3"
@@ -637,6 +647,11 @@ exports[`CanvasForm should render nothing if no schema is available 1`] = `
           <div
             class="pf-v6-l-grid__item pf-m-11-col form-header"
           >
+            <img
+              alt="Entity icon"
+              class="form-header__icon-1"
+              src="file-mock-data"
+            />
             <h2
               class="pf-v6-c-title pf-m-h2 form-header__title"
               data-ouia-component-id="OUIA-Generated-Title-2"

--- a/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasFormHeader.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasFormHeader.test.tsx.snap
@@ -8,6 +8,11 @@ exports[`CanvasFormHeader renders correctly 1`] = `
     <div
       class="pf-v6-l-grid__item pf-m-11-col form-header"
     >
+      <img
+        alt="component icon"
+        class="form-header__icon-nodeId"
+        src="file-mock-data"
+      />
       <h2
         class="pf-v6-c-title pf-m-h2 form-header__title"
         data-ouia-component-id="OUIA-Generated-Title-1"

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
@@ -19,34 +19,19 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${env.name}",
   },
   {
+    "description": "Converts the message body (or expression) to a long number and return the absolute value.",
+    "group": "Simple Language",
+    "value": "\${abs(exp)}",
+  },
+  {
+    "description": "Evaluates the expression and throws an exception with the message if the condition is false",
+    "group": "Simple Language",
+    "value": "\${assert(exp,msg)}",
+  },
+  {
     "description": "The DataHandler for the given attachment.",
     "group": "Simple Language",
-    "value": "\${attachment(key)}",
-  },
-  {
-    "description": "The content of the attachment",
-    "group": "Simple Language",
-    "value": "\${attachmentContent}",
-  },
-  {
-    "description": "The content of the attachment, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAs(type)}",
-  },
-  {
-    "description": "The content of the attachment as text (ie String).",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAsText}",
-  },
-  {
-    "description": "The attachment header with the given name.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name)}",
-  },
-  {
-    "description": "The attachment header with the given name, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name,type)}",
+    "value": "\${attachment.name}",
   },
   {
     "description": "All the attachments as a Map<String,DataHandler.",
@@ -54,9 +39,54 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${attachments}",
   },
   {
+    "description": "The content of the attachment",
+    "group": "Simple Language",
+    "value": "\${attachmentsContent.name}",
+  },
+  {
+    "description": "The content of the attachment, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAs(name,type)}",
+  },
+  {
+    "description": "The content of the attachment as text (ie String).",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAsText.name}",
+  },
+  {
+    "description": "The attachment header with the given name.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeader(key,name)}",
+  },
+  {
+    "description": "The attachment header with the given name, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeaderAs(key,name,type)}",
+  },
+  {
+    "description": "All the attachment keys (filenames)",
+    "group": "Simple Language",
+    "value": "\${attachmentsKeys}",
+  },
+  {
     "description": "The number of attachments. Is 0 if there are no attachments.",
     "group": "Simple Language",
-    "value": "\${attachments.size}",
+    "value": "\${attachmentsSize}",
+  },
+  {
+    "description": "Returns the average number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${average(val...)}",
+  },
+  {
+    "description": "Base64 decodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Decode(exp)}",
+  },
+  {
+    "description": "Base64 encodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Encode(exp)}",
   },
   {
     "description": "Calls a Java bean. The name of the bean can also refer to a class name using type prefix as follows \`bean:type:com.foo.MyClass\`. If no method name is given then Camel will automatic attempt to find the best method to use.",
@@ -74,6 +104,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${bodyOneLine}",
   },
   {
+    "description": "The message body class type",
+    "group": "Simple Language",
+    "value": "\${bodyType}",
+  },
+  {
     "description": "The Camel Context",
     "group": "Simple Language",
     "value": "\${camelContext}",
@@ -84,12 +119,42 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${camelId}",
   },
   {
+    "description": "Capitalizes the message body/expression as a String value (upper case every words)",
+    "group": "Simple Language",
+    "value": "\${capitalize(exp)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the ceil value (rounded up to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${ceil(exp)}",
+  },
+  {
+    "description": "Removes all existing attachments on the message.",
+    "group": "Simple Language",
+    "value": "\${clearAttachments}",
+  },
+  {
     "description": "The collate function iterates the message body and groups the data into sub lists of specified size. This can be used with the Splitter EIP to split a message body and group/batch the split sub message into a group of N sub lists.",
     "group": "Simple Language",
     "value": "\${collate(num)}",
   },
   {
-    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
+    "description": "Performs a string concat using two expressions (message body as default) with optional separator",
+    "group": "Simple Language",
+    "value": "\${concat(exp,exp,separator)}",
+  },
+  {
+    "description": "Returns true if the message body (or expression) contains part of the text (ignore case)",
+    "group": "Simple Language",
+    "value": "\${contains(exp,text)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to the specified type.",
+    "group": "Simple Language",
+    "value": "\${convertTo(exp,type)}",
+  },
+  {
+    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`millis\` for current timestamp in millis (unix epoch), \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
     "group": "Simple Language",
     "value": "\${date(command)}",
   },
@@ -99,7 +164,12 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${date-with-timezone(command:timezone:pattern)}",
   },
   {
-    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`.",
+    "description": "Returns a set of all the values with duplicates removed",
+    "group": "Simple Language",
+    "value": "\${distinct(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
     "group": "Simple Language",
     "value": "\${empty(type)}",
   },
@@ -134,9 +204,29 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${exchangeProperty.name}",
   },
   {
+    "description": "Returns a List containing the values that satisfy the predicate function (returning true)",
+    "group": "Simple Language",
+    "value": "\${filter(exp,fun)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the floor value (rounded down to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${floor(exp)}",
+  },
+  {
+    "description": "Returns a List containing the values returned by the function when applied to each value from the input expression",
+    "group": "Simple Language",
+    "value": "\${forEach(exp,fun)}",
+  },
+  {
     "description": "The original route id where this exchange was created.",
     "group": "Simple Language",
     "value": "\${fromRouteId}",
+  },
+  {
+    "description": "Invokes a custom function with the given name using the message body (or expression) as input parameter.",
+    "group": "Simple Language",
+    "value": "\${function(name,exp)}",
   },
   {
     "description": "Returns a hashed value (string in hex decimal) of the message body/expression using JDK MessageDigest. The algorithm can be SHA-256 (default) or SHA3-256.",
@@ -169,6 +259,26 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${iif(predicate,trueExp,falseExp)}",
   },
   {
+    "description": "Whether the message body (or expression) is alphabetic value (A..Z). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlpha(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is alphanumeric value (A..Z0-9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlphaNumeric(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is null or empty (list/map types are tested if they have 0 elements).",
+    "group": "Simple Language",
+    "value": "\${isEmpty(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is numeric value (0..9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isNumeric(exp)}",
+  },
+  {
     "description": "The join function iterates the message body/expression and joins the data into a string. The separator is by default a comma. The prefix is optional. The join uses the message body as source by default. It is possible to refer to another source (simple language) such as a header via the exp parameter. For example \`join('&','id=','$\\{header.ids}')\`.",
     "group": "Simple Language",
     "value": "\${join(separator,prefix,exp)}",
@@ -184,9 +294,29 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${jsonpath(input,exp)}",
   },
   {
+    "description": "What kind of type is the value (null,number,string,boolean,array,object)",
+    "group": "Simple Language",
+    "value": "\${kindOfType(exp)}",
+  },
+  {
+    "description": "The payload length (number of bytes) of the message body (or expression).",
+    "group": "Simple Language",
+    "value": "\${length(exp)}",
+  },
+  {
     "description": "The list function creates an ArrayList with the given set of values.",
     "group": "Simple Language",
     "value": "\${list(val...)}",
+  },
+  {
+    "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
+    "group": "Simple Language",
+    "value": "\${load(file)}",
+  },
+  {
+    "description": "Lowercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${lowercase(exp)}",
   },
   {
     "description": "Converts the message body to the given type (classname). If the body is null then the function will fail with an exception",
@@ -197,6 +327,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Returns the maximum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${max(val...)}",
   },
   {
     "description": "Converts the message to the given type (classname).",
@@ -214,7 +349,27 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${messageTimestamp}",
   },
   {
-    "description": "Represents a null value",
+    "description": "Returns the minimum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${min(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
+    "group": "Simple Language",
+    "value": "\${newEmpty(type)}",
+  },
+  {
+    "description": "Normalizes the whitespace in the message body (or expression) by cleaning up excess whitespaces.",
+    "group": "Simple Language",
+    "value": "\${normalizeWhitespace(exp)}",
+  },
+  {
+    "description": "Evaluates the predicate and returns the opposite.",
+    "group": "Simple Language",
+    "value": "\${not}",
+  },
+  {
+    "description": "Returns a null value",
     "group": "Simple Language",
     "value": "\${null}",
   },
@@ -222,6 +377,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "The original incoming body (only available if allowUseOriginalMessage=true).",
     "group": "Simple Language",
     "value": "\${originalBody}",
+  },
+  {
+    "description": "Pads the expression with extra padding if necessary, according the the total width. The separator is by default a space. If the width is negative then padding to the right, otherwise to the left.",
+    "group": "Simple Language",
+    "value": "\${pad(exp,width,separator)}",
   },
   {
     "description": "Converts the expression to a String, and attempts to pretty print if JSon or XML, otherwise the expression is returned as the String value.",
@@ -244,9 +404,19 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${propertiesExist:key}",
   },
   {
-    "description": "Returns a random number between min (included) and max (excluded).",
+    "description": "Returns the message body (or expression) as a double quoted string",
+    "group": "Simple Language",
+    "value": "\${quote(exp)}",
+  },
+  {
+    "description": "Returns a random number between min and max (exclusive)",
     "group": "Simple Language",
     "value": "\${random(min,max)}",
+  },
+  {
+    "description": "Returns a list of increasing integers between the given interval (exclusive)",
+    "group": "Simple Language",
+    "value": "\${range(min,max)}",
   },
   {
     "description": "To look up a bean from the Registry with the given name.",
@@ -259,7 +429,12 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${replace(from,to,exp)}",
   },
   {
-    "description": "Returns the route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
+    "description": "Returns a list of all the values, but in reverse order",
+    "group": "Simple Language",
+    "value": "\${reverse(val...)}",
+  },
+  {
+    "description": "The route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
     "group": "Simple Language",
     "value": "\${routeGroup}",
   },
@@ -269,9 +444,44 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${routeId}",
   },
   {
+    "description": "Returns the message body (or expression) safely quoted if needed",
+    "group": "Simple Language",
+    "value": "\${safeQuote(exp)}",
+  },
+  {
+    "description": "Sets a message header with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setHeader(name,type,exp)}",
+  },
+  {
+    "description": "Sets an attachment with payload from the message body/expression.",
+    "group": "Simple Language",
+    "value": "\${setVariable(key,exp)}",
+  },
+  {
+    "description": "Sets a variable with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setVariable(name,type,exp)}",
+  },
+  {
+    "description": "Returns a list of all the values shuffled in random order",
+    "group": "Simple Language",
+    "value": "\${shuffle(val...)}",
+  },
+  {
+    "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
+    "group": "Simple Language",
+    "value": "\${size(exp)}",
+  },
+  {
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Splits the message body/expression as a String value using the separator into a String array",
+    "group": "Simple Language",
+    "value": "\${split(exp,separator)}",
   },
   {
     "description": "Returns the id of the current step the Exchange is being routed.",
@@ -282,6 +492,26 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "Returns a substring of the message body/expression. If only one positive number, then the returned string is clipped from the beginning. If only one negative number, then the returned string is clipped from the beginning. Otherwise the returned string is clipped between the head and tail positions.",
     "group": "Simple Language",
     "value": "\${substring(head,tail)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes after. Returns null if nothing comes after.",
+    "group": "Simple Language",
+    "value": "\${substringAfter(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes before. Returns null if nothing comes before.",
+    "group": "Simple Language",
+    "value": "\${substringBefore(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that are between after and before. Returns null if nothing comes between.",
+    "group": "Simple Language",
+    "value": "\${substringBetween(exp,after,before)}",
+  },
+  {
+    "description": "Sums together all the values as integral numbers. This function can also be used to subtract by using negative numbers.",
+    "group": "Simple Language",
+    "value": "\${sum(val...)}",
   },
   {
     "description": "The JVM system property with the given name",
@@ -299,12 +529,32 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${threadName}",
   },
   {
+    "description": "Deliberately throws an error. Uses IllegalArgumentException by default if no type is specified (use fully qualified classname).",
+    "group": "Simple Language",
+    "value": "\${throwException(type,msg)}",
+  },
+  {
+    "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
+    "group": "Simple Language",
+    "value": "\${trim(exp)}",
+  },
+  {
     "description": "To refer to a type or field by its classname. To refer to a field, you can append .FIELD_NAME. For example, you can refer to the constant field from Exchange as: \`org.apache.camel.Exchange.FILE_NAME\`",
     "group": "Simple Language",
     "value": "\${type:name.field}",
   },
   {
-    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the xref:manual::registry.adoc[Registry] with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
+    "description": "Returns the message body (or expression) with any leading/ending quotes removed",
+    "group": "Simple Language",
+    "value": "\${unquote(exp)}",
+  },
+  {
+    "description": "Uppercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${uppercase(exp)}",
+  },
+  {
+    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
   },
@@ -345,34 +595,19 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${env.name}",
   },
   {
+    "description": "Converts the message body (or expression) to a long number and return the absolute value.",
+    "group": "Simple Language",
+    "value": "\${abs(exp)}",
+  },
+  {
+    "description": "Evaluates the expression and throws an exception with the message if the condition is false",
+    "group": "Simple Language",
+    "value": "\${assert(exp,msg)}",
+  },
+  {
     "description": "The DataHandler for the given attachment.",
     "group": "Simple Language",
-    "value": "\${attachment(key)}",
-  },
-  {
-    "description": "The content of the attachment",
-    "group": "Simple Language",
-    "value": "\${attachmentContent}",
-  },
-  {
-    "description": "The content of the attachment, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAs(type)}",
-  },
-  {
-    "description": "The content of the attachment as text (ie String).",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAsText}",
-  },
-  {
-    "description": "The attachment header with the given name.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name)}",
-  },
-  {
-    "description": "The attachment header with the given name, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name,type)}",
+    "value": "\${attachment.name}",
   },
   {
     "description": "All the attachments as a Map<String,DataHandler.",
@@ -380,9 +615,54 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${attachments}",
   },
   {
+    "description": "The content of the attachment",
+    "group": "Simple Language",
+    "value": "\${attachmentsContent.name}",
+  },
+  {
+    "description": "The content of the attachment, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAs(name,type)}",
+  },
+  {
+    "description": "The content of the attachment as text (ie String).",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAsText.name}",
+  },
+  {
+    "description": "The attachment header with the given name.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeader(key,name)}",
+  },
+  {
+    "description": "The attachment header with the given name, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeaderAs(key,name,type)}",
+  },
+  {
+    "description": "All the attachment keys (filenames)",
+    "group": "Simple Language",
+    "value": "\${attachmentsKeys}",
+  },
+  {
     "description": "The number of attachments. Is 0 if there are no attachments.",
     "group": "Simple Language",
-    "value": "\${attachments.size}",
+    "value": "\${attachmentsSize}",
+  },
+  {
+    "description": "Returns the average number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${average(val...)}",
+  },
+  {
+    "description": "Base64 decodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Decode(exp)}",
+  },
+  {
+    "description": "Base64 encodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Encode(exp)}",
   },
   {
     "description": "Calls a Java bean. The name of the bean can also refer to a class name using type prefix as follows \`bean:type:com.foo.MyClass\`. If no method name is given then Camel will automatic attempt to find the best method to use.",
@@ -400,6 +680,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${bodyOneLine}",
   },
   {
+    "description": "The message body class type",
+    "group": "Simple Language",
+    "value": "\${bodyType}",
+  },
+  {
     "description": "The Camel Context",
     "group": "Simple Language",
     "value": "\${camelContext}",
@@ -410,12 +695,42 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${camelId}",
   },
   {
+    "description": "Capitalizes the message body/expression as a String value (upper case every words)",
+    "group": "Simple Language",
+    "value": "\${capitalize(exp)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the ceil value (rounded up to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${ceil(exp)}",
+  },
+  {
+    "description": "Removes all existing attachments on the message.",
+    "group": "Simple Language",
+    "value": "\${clearAttachments}",
+  },
+  {
     "description": "The collate function iterates the message body and groups the data into sub lists of specified size. This can be used with the Splitter EIP to split a message body and group/batch the split sub message into a group of N sub lists.",
     "group": "Simple Language",
     "value": "\${collate(num)}",
   },
   {
-    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
+    "description": "Performs a string concat using two expressions (message body as default) with optional separator",
+    "group": "Simple Language",
+    "value": "\${concat(exp,exp,separator)}",
+  },
+  {
+    "description": "Returns true if the message body (or expression) contains part of the text (ignore case)",
+    "group": "Simple Language",
+    "value": "\${contains(exp,text)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to the specified type.",
+    "group": "Simple Language",
+    "value": "\${convertTo(exp,type)}",
+  },
+  {
+    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`millis\` for current timestamp in millis (unix epoch), \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
     "group": "Simple Language",
     "value": "\${date(command)}",
   },
@@ -425,7 +740,12 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${date-with-timezone(command:timezone:pattern)}",
   },
   {
-    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`.",
+    "description": "Returns a set of all the values with duplicates removed",
+    "group": "Simple Language",
+    "value": "\${distinct(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
     "group": "Simple Language",
     "value": "\${empty(type)}",
   },
@@ -460,9 +780,29 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${exchangeProperty.name}",
   },
   {
+    "description": "Returns a List containing the values that satisfy the predicate function (returning true)",
+    "group": "Simple Language",
+    "value": "\${filter(exp,fun)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the floor value (rounded down to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${floor(exp)}",
+  },
+  {
+    "description": "Returns a List containing the values returned by the function when applied to each value from the input expression",
+    "group": "Simple Language",
+    "value": "\${forEach(exp,fun)}",
+  },
+  {
     "description": "The original route id where this exchange was created.",
     "group": "Simple Language",
     "value": "\${fromRouteId}",
+  },
+  {
+    "description": "Invokes a custom function with the given name using the message body (or expression) as input parameter.",
+    "group": "Simple Language",
+    "value": "\${function(name,exp)}",
   },
   {
     "description": "Returns a hashed value (string in hex decimal) of the message body/expression using JDK MessageDigest. The algorithm can be SHA-256 (default) or SHA3-256.",
@@ -495,6 +835,26 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${iif(predicate,trueExp,falseExp)}",
   },
   {
+    "description": "Whether the message body (or expression) is alphabetic value (A..Z). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlpha(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is alphanumeric value (A..Z0-9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlphaNumeric(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is null or empty (list/map types are tested if they have 0 elements).",
+    "group": "Simple Language",
+    "value": "\${isEmpty(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is numeric value (0..9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isNumeric(exp)}",
+  },
+  {
     "description": "The join function iterates the message body/expression and joins the data into a string. The separator is by default a comma. The prefix is optional. The join uses the message body as source by default. It is possible to refer to another source (simple language) such as a header via the exp parameter. For example \`join('&','id=','$\\{header.ids}')\`.",
     "group": "Simple Language",
     "value": "\${join(separator,prefix,exp)}",
@@ -510,9 +870,29 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${jsonpath(input,exp)}",
   },
   {
+    "description": "What kind of type is the value (null,number,string,boolean,array,object)",
+    "group": "Simple Language",
+    "value": "\${kindOfType(exp)}",
+  },
+  {
+    "description": "The payload length (number of bytes) of the message body (or expression).",
+    "group": "Simple Language",
+    "value": "\${length(exp)}",
+  },
+  {
     "description": "The list function creates an ArrayList with the given set of values.",
     "group": "Simple Language",
     "value": "\${list(val...)}",
+  },
+  {
+    "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
+    "group": "Simple Language",
+    "value": "\${load(file)}",
+  },
+  {
+    "description": "Lowercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${lowercase(exp)}",
   },
   {
     "description": "Converts the message body to the given type (classname). If the body is null then the function will fail with an exception",
@@ -523,6 +903,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Returns the maximum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${max(val...)}",
   },
   {
     "description": "Converts the message to the given type (classname).",
@@ -540,7 +925,27 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${messageTimestamp}",
   },
   {
-    "description": "Represents a null value",
+    "description": "Returns the minimum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${min(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
+    "group": "Simple Language",
+    "value": "\${newEmpty(type)}",
+  },
+  {
+    "description": "Normalizes the whitespace in the message body (or expression) by cleaning up excess whitespaces.",
+    "group": "Simple Language",
+    "value": "\${normalizeWhitespace(exp)}",
+  },
+  {
+    "description": "Evaluates the predicate and returns the opposite.",
+    "group": "Simple Language",
+    "value": "\${not}",
+  },
+  {
+    "description": "Returns a null value",
     "group": "Simple Language",
     "value": "\${null}",
   },
@@ -548,6 +953,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "The original incoming body (only available if allowUseOriginalMessage=true).",
     "group": "Simple Language",
     "value": "\${originalBody}",
+  },
+  {
+    "description": "Pads the expression with extra padding if necessary, according the the total width. The separator is by default a space. If the width is negative then padding to the right, otherwise to the left.",
+    "group": "Simple Language",
+    "value": "\${pad(exp,width,separator)}",
   },
   {
     "description": "Converts the expression to a String, and attempts to pretty print if JSon or XML, otherwise the expression is returned as the String value.",
@@ -570,9 +980,19 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${propertiesExist:key}",
   },
   {
-    "description": "Returns a random number between min (included) and max (excluded).",
+    "description": "Returns the message body (or expression) as a double quoted string",
+    "group": "Simple Language",
+    "value": "\${quote(exp)}",
+  },
+  {
+    "description": "Returns a random number between min and max (exclusive)",
     "group": "Simple Language",
     "value": "\${random(min,max)}",
+  },
+  {
+    "description": "Returns a list of increasing integers between the given interval (exclusive)",
+    "group": "Simple Language",
+    "value": "\${range(min,max)}",
   },
   {
     "description": "To look up a bean from the Registry with the given name.",
@@ -585,7 +1005,12 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${replace(from,to,exp)}",
   },
   {
-    "description": "Returns the route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
+    "description": "Returns a list of all the values, but in reverse order",
+    "group": "Simple Language",
+    "value": "\${reverse(val...)}",
+  },
+  {
+    "description": "The route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
     "group": "Simple Language",
     "value": "\${routeGroup}",
   },
@@ -595,9 +1020,44 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${routeId}",
   },
   {
+    "description": "Returns the message body (or expression) safely quoted if needed",
+    "group": "Simple Language",
+    "value": "\${safeQuote(exp)}",
+  },
+  {
+    "description": "Sets a message header with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setHeader(name,type,exp)}",
+  },
+  {
+    "description": "Sets an attachment with payload from the message body/expression.",
+    "group": "Simple Language",
+    "value": "\${setVariable(key,exp)}",
+  },
+  {
+    "description": "Sets a variable with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setVariable(name,type,exp)}",
+  },
+  {
+    "description": "Returns a list of all the values shuffled in random order",
+    "group": "Simple Language",
+    "value": "\${shuffle(val...)}",
+  },
+  {
+    "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
+    "group": "Simple Language",
+    "value": "\${size(exp)}",
+  },
+  {
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Splits the message body/expression as a String value using the separator into a String array",
+    "group": "Simple Language",
+    "value": "\${split(exp,separator)}",
   },
   {
     "description": "Returns the id of the current step the Exchange is being routed.",
@@ -608,6 +1068,26 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "Returns a substring of the message body/expression. If only one positive number, then the returned string is clipped from the beginning. If only one negative number, then the returned string is clipped from the beginning. Otherwise the returned string is clipped between the head and tail positions.",
     "group": "Simple Language",
     "value": "\${substring(head,tail)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes after. Returns null if nothing comes after.",
+    "group": "Simple Language",
+    "value": "\${substringAfter(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes before. Returns null if nothing comes before.",
+    "group": "Simple Language",
+    "value": "\${substringBefore(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that are between after and before. Returns null if nothing comes between.",
+    "group": "Simple Language",
+    "value": "\${substringBetween(exp,after,before)}",
+  },
+  {
+    "description": "Sums together all the values as integral numbers. This function can also be used to subtract by using negative numbers.",
+    "group": "Simple Language",
+    "value": "\${sum(val...)}",
   },
   {
     "description": "The JVM system property with the given name",
@@ -625,12 +1105,32 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${threadName}",
   },
   {
+    "description": "Deliberately throws an error. Uses IllegalArgumentException by default if no type is specified (use fully qualified classname).",
+    "group": "Simple Language",
+    "value": "\${throwException(type,msg)}",
+  },
+  {
+    "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
+    "group": "Simple Language",
+    "value": "\${trim(exp)}",
+  },
+  {
     "description": "To refer to a type or field by its classname. To refer to a field, you can append .FIELD_NAME. For example, you can refer to the constant field from Exchange as: \`org.apache.camel.Exchange.FILE_NAME\`",
     "group": "Simple Language",
     "value": "\${type:name.field}",
   },
   {
-    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the xref:manual::registry.adoc[Registry] with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
+    "description": "Returns the message body (or expression) with any leading/ending quotes removed",
+    "group": "Simple Language",
+    "value": "\${unquote(exp)}",
+  },
+  {
+    "description": "Uppercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${uppercase(exp)}",
+  },
+  {
+    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
   },
@@ -693,34 +1193,19 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${env.name}",
   },
   {
+    "description": "Converts the message body (or expression) to a long number and return the absolute value.",
+    "group": "Simple Language",
+    "value": "\${abs(exp)}",
+  },
+  {
+    "description": "Evaluates the expression and throws an exception with the message if the condition is false",
+    "group": "Simple Language",
+    "value": "\${assert(exp,msg)}",
+  },
+  {
     "description": "The DataHandler for the given attachment.",
     "group": "Simple Language",
-    "value": "\${attachment(key)}",
-  },
-  {
-    "description": "The content of the attachment",
-    "group": "Simple Language",
-    "value": "\${attachmentContent}",
-  },
-  {
-    "description": "The content of the attachment, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAs(type)}",
-  },
-  {
-    "description": "The content of the attachment as text (ie String).",
-    "group": "Simple Language",
-    "value": "\${attachmentContentAsText}",
-  },
-  {
-    "description": "The attachment header with the given name.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name)}",
-  },
-  {
-    "description": "The attachment header with the given name, converted to the given type.",
-    "group": "Simple Language",
-    "value": "\${attachmentHeader(key,name,type)}",
+    "value": "\${attachment.name}",
   },
   {
     "description": "All the attachments as a Map<String,DataHandler.",
@@ -728,9 +1213,54 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${attachments}",
   },
   {
+    "description": "The content of the attachment",
+    "group": "Simple Language",
+    "value": "\${attachmentsContent.name}",
+  },
+  {
+    "description": "The content of the attachment, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAs(name,type)}",
+  },
+  {
+    "description": "The content of the attachment as text (ie String).",
+    "group": "Simple Language",
+    "value": "\${attachmentsContentAsText.name}",
+  },
+  {
+    "description": "The attachment header with the given name.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeader(key,name)}",
+  },
+  {
+    "description": "The attachment header with the given name, converted to the given type.",
+    "group": "Simple Language",
+    "value": "\${attachmentsHeaderAs(key,name,type)}",
+  },
+  {
+    "description": "All the attachment keys (filenames)",
+    "group": "Simple Language",
+    "value": "\${attachmentsKeys}",
+  },
+  {
     "description": "The number of attachments. Is 0 if there are no attachments.",
     "group": "Simple Language",
-    "value": "\${attachments.size}",
+    "value": "\${attachmentsSize}",
+  },
+  {
+    "description": "Returns the average number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${average(val...)}",
+  },
+  {
+    "description": "Base64 decodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Decode(exp)}",
+  },
+  {
+    "description": "Base64 encodes the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${base64Encode(exp)}",
   },
   {
     "description": "Calls a Java bean. The name of the bean can also refer to a class name using type prefix as follows \`bean:type:com.foo.MyClass\`. If no method name is given then Camel will automatic attempt to find the best method to use.",
@@ -748,6 +1278,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${bodyOneLine}",
   },
   {
+    "description": "The message body class type",
+    "group": "Simple Language",
+    "value": "\${bodyType}",
+  },
+  {
     "description": "The Camel Context",
     "group": "Simple Language",
     "value": "\${camelContext}",
@@ -758,12 +1293,42 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${camelId}",
   },
   {
+    "description": "Capitalizes the message body/expression as a String value (upper case every words)",
+    "group": "Simple Language",
+    "value": "\${capitalize(exp)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the ceil value (rounded up to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${ceil(exp)}",
+  },
+  {
+    "description": "Removes all existing attachments on the message.",
+    "group": "Simple Language",
+    "value": "\${clearAttachments}",
+  },
+  {
     "description": "The collate function iterates the message body and groups the data into sub lists of specified size. This can be used with the Splitter EIP to split a message body and group/batch the split sub message into a group of N sub lists.",
     "group": "Simple Language",
     "value": "\${collate(num)}",
   },
   {
-    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
+    "description": "Performs a string concat using two expressions (message body as default) with optional separator",
+    "group": "Simple Language",
+    "value": "\${concat(exp,exp,separator)}",
+  },
+  {
+    "description": "Returns true if the message body (or expression) contains part of the text (ignore case)",
+    "group": "Simple Language",
+    "value": "\${contains(exp,text)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to the specified type.",
+    "group": "Simple Language",
+    "value": "\${convertTo(exp,type)}",
+  },
+  {
+    "description": "Evaluates to a java.util.Date object. Supported commands are: \`now\` for current timestamp, \`millis\` for current timestamp in millis (unix epoch), \`exchangeCreated\` for the timestamp when the current exchange was created, \`header.xxx\` to use the Long/Date object in the header with the key xxx. \`variable.xxx\` to use the Long/Date in the variable with the key xxx. \`exchangeProperty.xxx\` to use the Long/Date object in the exchange property with the key xxx. \`file\` for the last modified timestamp of the file (available with a File consumer). Command accepts offsets such as: \`now-24h\` or \`header.xxx+1h\` or even \`now+1h30m-100\`.",
     "group": "Simple Language",
     "value": "\${date(command)}",
   },
@@ -773,7 +1338,12 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${date-with-timezone(command:timezone:pattern)}",
   },
   {
-    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`.",
+    "description": "Returns a set of all the values with duplicates removed",
+    "group": "Simple Language",
+    "value": "\${distinct(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
     "group": "Simple Language",
     "value": "\${empty(type)}",
   },
@@ -808,9 +1378,29 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${exchangeProperty.name}",
   },
   {
+    "description": "Returns a List containing the values that satisfy the predicate function (returning true)",
+    "group": "Simple Language",
+    "value": "\${filter(exp,fun)}",
+  },
+  {
+    "description": "Converts the message body (or expression) to a floating number and return the floor value (rounded down to nearest integer).",
+    "group": "Simple Language",
+    "value": "\${floor(exp)}",
+  },
+  {
+    "description": "Returns a List containing the values returned by the function when applied to each value from the input expression",
+    "group": "Simple Language",
+    "value": "\${forEach(exp,fun)}",
+  },
+  {
     "description": "The original route id where this exchange was created.",
     "group": "Simple Language",
     "value": "\${fromRouteId}",
+  },
+  {
+    "description": "Invokes a custom function with the given name using the message body (or expression) as input parameter.",
+    "group": "Simple Language",
+    "value": "\${function(name,exp)}",
   },
   {
     "description": "Returns a hashed value (string in hex decimal) of the message body/expression using JDK MessageDigest. The algorithm can be SHA-256 (default) or SHA3-256.",
@@ -843,6 +1433,26 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${iif(predicate,trueExp,falseExp)}",
   },
   {
+    "description": "Whether the message body (or expression) is alphabetic value (A..Z). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlpha(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is alphanumeric value (A..Z0-9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isAlphaNumeric(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is null or empty (list/map types are tested if they have 0 elements).",
+    "group": "Simple Language",
+    "value": "\${isEmpty(exp)}",
+  },
+  {
+    "description": "Whether the message body (or expression) is numeric value (0..9). For more advanced checks use the \`regex\` operator.",
+    "group": "Simple Language",
+    "value": "\${isNumeric(exp)}",
+  },
+  {
     "description": "The join function iterates the message body/expression and joins the data into a string. The separator is by default a comma. The prefix is optional. The join uses the message body as source by default. It is possible to refer to another source (simple language) such as a header via the exp parameter. For example \`join('&','id=','$\\{header.ids}')\`.",
     "group": "Simple Language",
     "value": "\${join(separator,prefix,exp)}",
@@ -858,9 +1468,29 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${jsonpath(input,exp)}",
   },
   {
+    "description": "What kind of type is the value (null,number,string,boolean,array,object)",
+    "group": "Simple Language",
+    "value": "\${kindOfType(exp)}",
+  },
+  {
+    "description": "The payload length (number of bytes) of the message body (or expression).",
+    "group": "Simple Language",
+    "value": "\${length(exp)}",
+  },
+  {
     "description": "The list function creates an ArrayList with the given set of values.",
     "group": "Simple Language",
     "value": "\${list(val...)}",
+  },
+  {
+    "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
+    "group": "Simple Language",
+    "value": "\${load(file)}",
+  },
+  {
+    "description": "Lowercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${lowercase(exp)}",
   },
   {
     "description": "Converts the message body to the given type (classname). If the body is null then the function will fail with an exception",
@@ -871,6 +1501,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Returns the maximum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${max(val...)}",
   },
   {
     "description": "Converts the message to the given type (classname).",
@@ -888,7 +1523,27 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${messageTimestamp}",
   },
   {
-    "description": "Represents a null value",
+    "description": "Returns the minimum number from all the values (integral numbers only).",
+    "group": "Simple Language",
+    "value": "\${min(val...)}",
+  },
+  {
+    "description": "Creates a new empty object (decided by type). Use \`string\` to create an empty String. Use \`list\` to create an empty \`java.util.ArrayList\`. Use \`map\` to create an empty \`java.util.LinkedHashMap\`. Use \`set\` to create an empty \`java.util.LinkedHashSet\`.",
+    "group": "Simple Language",
+    "value": "\${newEmpty(type)}",
+  },
+  {
+    "description": "Normalizes the whitespace in the message body (or expression) by cleaning up excess whitespaces.",
+    "group": "Simple Language",
+    "value": "\${normalizeWhitespace(exp)}",
+  },
+  {
+    "description": "Evaluates the predicate and returns the opposite.",
+    "group": "Simple Language",
+    "value": "\${not}",
+  },
+  {
+    "description": "Returns a null value",
     "group": "Simple Language",
     "value": "\${null}",
   },
@@ -896,6 +1551,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "The original incoming body (only available if allowUseOriginalMessage=true).",
     "group": "Simple Language",
     "value": "\${originalBody}",
+  },
+  {
+    "description": "Pads the expression with extra padding if necessary, according the the total width. The separator is by default a space. If the width is negative then padding to the right, otherwise to the left.",
+    "group": "Simple Language",
+    "value": "\${pad(exp,width,separator)}",
   },
   {
     "description": "Converts the expression to a String, and attempts to pretty print if JSon or XML, otherwise the expression is returned as the String value.",
@@ -918,9 +1578,19 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${propertiesExist:key}",
   },
   {
-    "description": "Returns a random number between min (included) and max (excluded).",
+    "description": "Returns the message body (or expression) as a double quoted string",
+    "group": "Simple Language",
+    "value": "\${quote(exp)}",
+  },
+  {
+    "description": "Returns a random number between min and max (exclusive)",
     "group": "Simple Language",
     "value": "\${random(min,max)}",
+  },
+  {
+    "description": "Returns a list of increasing integers between the given interval (exclusive)",
+    "group": "Simple Language",
+    "value": "\${range(min,max)}",
   },
   {
     "description": "To look up a bean from the Registry with the given name.",
@@ -933,7 +1603,12 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${replace(from,to,exp)}",
   },
   {
-    "description": "Returns the route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
+    "description": "Returns a list of all the values, but in reverse order",
+    "group": "Simple Language",
+    "value": "\${reverse(val...)}",
+  },
+  {
+    "description": "The route group of the current route the Exchange is being routed. Not all routes have a group assigned, so this may be null.",
     "group": "Simple Language",
     "value": "\${routeGroup}",
   },
@@ -943,9 +1618,44 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${routeId}",
   },
   {
+    "description": "Returns the message body (or expression) safely quoted if needed",
+    "group": "Simple Language",
+    "value": "\${safeQuote(exp)}",
+  },
+  {
+    "description": "Sets a message header with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setHeader(name,type,exp)}",
+  },
+  {
+    "description": "Sets an attachment with payload from the message body/expression.",
+    "group": "Simple Language",
+    "value": "\${setVariable(key,exp)}",
+  },
+  {
+    "description": "Sets a variable with the given expression (optional converting to the given type)",
+    "group": "Simple Language",
+    "value": "\${setVariable(name,type,exp)}",
+  },
+  {
+    "description": "Returns a list of all the values shuffled in random order",
+    "group": "Simple Language",
+    "value": "\${shuffle(val...)}",
+  },
+  {
+    "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
+    "group": "Simple Language",
+    "value": "\${size(exp)}",
+  },
+  {
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Splits the message body/expression as a String value using the separator into a String array",
+    "group": "Simple Language",
+    "value": "\${split(exp,separator)}",
   },
   {
     "description": "Returns the id of the current step the Exchange is being routed.",
@@ -956,6 +1666,26 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "Returns a substring of the message body/expression. If only one positive number, then the returned string is clipped from the beginning. If only one negative number, then the returned string is clipped from the beginning. Otherwise the returned string is clipped between the head and tail positions.",
     "group": "Simple Language",
     "value": "\${substring(head,tail)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes after. Returns null if nothing comes after.",
+    "group": "Simple Language",
+    "value": "\${substringAfter(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that comes before. Returns null if nothing comes before.",
+    "group": "Simple Language",
+    "value": "\${substringBefore(exp,before)}",
+  },
+  {
+    "description": "Returns a substring of the message body/expression that are between after and before. Returns null if nothing comes between.",
+    "group": "Simple Language",
+    "value": "\${substringBetween(exp,after,before)}",
+  },
+  {
+    "description": "Sums together all the values as integral numbers. This function can also be used to subtract by using negative numbers.",
+    "group": "Simple Language",
+    "value": "\${sum(val...)}",
   },
   {
     "description": "The JVM system property with the given name",
@@ -973,12 +1703,32 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${threadName}",
   },
   {
+    "description": "Deliberately throws an error. Uses IllegalArgumentException by default if no type is specified (use fully qualified classname).",
+    "group": "Simple Language",
+    "value": "\${throwException(type,msg)}",
+  },
+  {
+    "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
+    "group": "Simple Language",
+    "value": "\${trim(exp)}",
+  },
+  {
     "description": "To refer to a type or field by its classname. To refer to a field, you can append .FIELD_NAME. For example, you can refer to the constant field from Exchange as: \`org.apache.camel.Exchange.FILE_NAME\`",
     "group": "Simple Language",
     "value": "\${type:name.field}",
   },
   {
-    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the xref:manual::registry.adoc[Registry] with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
+    "description": "Returns the message body (or expression) with any leading/ending quotes removed",
+    "group": "Simple Language",
+    "value": "\${unquote(exp)}",
+  },
+  {
+    "description": "Uppercases the message body (or expression)",
+    "group": "Simple Language",
+    "value": "\${uppercase(exp)}",
+  },
+  {
+    "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
   },

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -82,6 +82,10 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                                     class="custom-group__container__text"
                                     title="route"
                                   >
+                                    <img
+                                      alt="route"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="route-8888"
                                     >
@@ -144,6 +148,10 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                                     class="custom-group__container__text"
                                     title="choice"
                                   >
+                                    <img
+                                      alt="choice"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="choice"
                                     >
@@ -1015,6 +1023,10 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                                     class="custom-group__container__text"
                                     title="route"
                                   >
+                                    <img
+                                      alt="route"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="route-8888"
                                     >
@@ -1077,6 +1089,10 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                                     class="custom-group__container__text"
                                     title="choice"
                                   >
+                                    <img
+                                      alt="choice"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="choice"
                                     >
@@ -2835,6 +2851,10 @@ exports[`Canvas should render correctly 1`] = `
                                     class="custom-group__container__text"
                                     title="route"
                                   >
+                                    <img
+                                      alt="route"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="route-8888"
                                     >
@@ -2897,6 +2917,10 @@ exports[`Canvas should render correctly 1`] = `
                                     class="custom-group__container__text"
                                     title="choice"
                                   >
+                                    <img
+                                      alt="choice"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="choice"
                                     >
@@ -3768,6 +3792,10 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                     class="custom-group__container__text"
                                     title="route"
                                   >
+                                    <img
+                                      alt="route"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="route-8888"
                                     >
@@ -3830,6 +3858,10 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                     class="custom-group__container__text"
                                     title="choice"
                                   >
+                                    <img
+                                      alt="choice"
+                                      src="file-mock-data"
+                                    />
                                     <span
                                       title="choice"
                                     >

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`CanvasSideBar displays selected node information 1`] = `
             <div
               class="pf-v6-l-grid__item pf-m-11-col form-header"
             >
+              <img
+                alt="component icon"
+                class="form-header__icon-test|route.from"
+                src="file-mock-data"
+              />
               <h2
                 class="pf-v6-c-title pf-m-h2 form-header__title"
                 data-ouia-component-id="OUIA-Generated-Title-1"

--- a/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
@@ -52,6 +52,11 @@ export const RuntimeSelector: FunctionComponent = () => {
   const groupedRuntimes =
     runtimeContext.catalogLibrary?.definitions.reduce(
       (acc, catalog) => {
+        /** Temporary Citrus filter */
+        if (catalog.runtime.includes('Citrus')) {
+          return acc;
+        }
+
         if (acc[catalog.runtime]) {
           acc[catalog.runtime].push(catalog.name);
         } else {

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -19,6 +19,8 @@ exports[`CamelComponentSchemaService getSchema should build the appropriate sche
       "type": "string",
     },
     "parameters": {
+      "description": "The key-value pairs of the properties to configure this endpoint",
+      "title": "Endpoint Properties",
       "type": "object",
     },
     "uri": {
@@ -552,6 +554,7 @@ exports[`CamelComponentSchemaService getSchema should build the appropriate sche
   "fileName",
   "appendChars",
   "checksumFileAlgorithm",
+  "checksumWriteFile",
   "fileExist",
   "flatten",
   "jailStartingDirectory",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3173,10 +3173,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.3.1":
-  version: 0.3.5
-  resolution: "@kaoto/camel-catalog@npm:0.3.5"
-  checksum: 10/149c2f412fa1f726b37ba1e61e0396ba659587fcb884b4335daec5c38a80d8d8f2fb583922212a9132f6324946e868eb3673a83ab7447cfe56e4d9a4a5aeef1e
+"@kaoto/camel-catalog@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@kaoto/camel-catalog@npm:0.4.0"
+  checksum: 10/ded19bf56618c8ff3edc16f4193d72ff2dcd17db73c5dd020eee1e252f28b73bd09631bd68a918a73668874a1bbb36747a42bff6517bb60f7816b1af031ab330
   languageName: node
   linkType: hard
 
@@ -3204,7 +3204,7 @@ __metadata:
   dependencies:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.3.1"
+    "@kaoto/camel-catalog": "npm:^0.4.0"
     "@kaoto/forms": "npm:^1.6.0"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.4.0"
@@ -3264,7 +3264,7 @@ __metadata:
     "@carbon/icons-react": "npm:^11.67.0"
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.3.1"
+    "@kaoto/camel-catalog": "npm:^0.4.0"
     "@kaoto/forms": "npm:^1.6.0"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
@@ -3345,7 +3345,7 @@ __metadata:
     zundo: "npm:^2.3.0"
     zustand: "npm:^4.3.9"
   peerDependencies:
-    "@kaoto/camel-catalog": ^0.2.2 || ^0.3.0
+    "@kaoto/camel-catalog": ^0.4.0
     "@patternfly/patternfly": ^6.4.0
     "@patternfly/react-code-editor": ^6.4.0
     "@patternfly/react-core": ^6.4.0


### PR DESCRIPTION
### Changes
* Update Camel catalog to include 4.18
* Filter Citrus catalog from the Runtime selector (@christophd)
* Add mock content to the `fileMock.ts` file so we remove tests warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Citrus runtimes are now excluded from the runtime selector.

* **Chores**
  * Bumped camel-catalog dependency to 0.4.0 across packages.
  * Updated test mock exports used by the UI test suite.

* **Tests**
  * Updated Kafka sink test flows to use OAuth client credentials and SASL username/password fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->