### PR TITLE
[WIP] fix(DataMapper): substitution: S.1: Field Override model update

### DIFF
--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -1,10 +1,10 @@
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { MaxOccursType } from '../../xml-schema-ts/constants';
 import { QName } from '../../xml-schema-ts/QName';
-import { IChoiceSelection, IFieldTypeOverride } from './metadata';
+import { IChoiceSelection, IFieldSubstitution, IFieldTypeOverride } from './metadata';
 import { NodePath } from './nodepath';
 import { ReportMessage } from './schema';
-import { TypeOverrideVariant, Types } from './types';
+import { FieldOverrideVariant, Types } from './types';
 import { Predicate } from './xpath';
 
 /**
@@ -12,6 +12,50 @@ import { Predicate } from './xpath';
  * A field can be a child of either a document or another field.
  */
 export type IParentType = IDocument | IField;
+
+/**
+ * Immutable snapshot of a field's identity and structure taken **before** the first type override
+ * or substitution is applied. Stored on {@link IField.originalField} and cleared on revert.
+ *
+ * ## Restoration strategy
+ *
+ * On revert, `restoreOriginalTypeToField` restores `fields` and `namedTypeFragmentRefs`
+ * independently to cover all schema variants:
+ *
+ * | Schema variant | Snapshot | Restored state |
+ * |---|---|---|
+ * | XML named type | `refs=[T]`, `fields=undefined` | `fields=[]`, `refs=[T]` — re-expandable via `resolveTypeFragment` |
+ * | XML inline anonymous type | `refs=[]`, `fields=[c1,c2]` | `fields=[c1,c2]`, `refs=[]` — inline children restored directly |
+ * | JSON `$ref` + `properties` | `refs=[R]`, `fields=[inline]` | `fields=[inline]`, `refs=[R]` — pre-expansion state restored |
+ * | Simple / primitive type | `refs=[]`, `fields=undefined` | `fields=[]`, `refs=[]` (or derived from type) |
+ *
+ * ## Snapshot safety
+ *
+ * The snapshot is always taken in a **pre-adoption** context via `??=` guards in
+ * `resolveTypeFragment` (before `adoptTypeFragment` runs) and `applyTypeOverrideToField` (only
+ * fires when `originalField` is still `undefined`, which means `resolveTypeFragment` has not yet
+ * expanded the field). Post-adoption children therefore can never appear in `fields`.
+ *
+ * `fields` is captured as a **shallow-copied array** of field references (not a deep copy).
+ * This preserves pre-override membership while keeping object identity for existing child nodes.
+ * `applyTypeOverrideToField` replaces `field.fields` with a new empty array rather than mutating
+ * existing elements, so the snapshot remains unaffected by subsequent adoptions.
+ */
+export interface IOriginalFieldState {
+  name: string;
+  namespaceURI: string | null;
+  namespacePrefix: string | null;
+  type: Types;
+  typeQName: QName | null;
+  /** Original `namedTypeFragmentRefs` at snapshot time. Set at field expansion for named types; empty for inline types. */
+  namedTypeFragmentRefs: string[];
+  /**
+   * Original `fields` at snapshot time. Present when the field held inline children at capture
+   * time (XML anonymous complex type, or JSON `$ref` + `properties` mixed node). Absent (`undefined`)
+   * for named-type fields whose children are re-derived from `namedTypeFragmentRefs` on expansion.
+   */
+  fields?: IField[];
+}
 
 /**
  * Document ID constant for the main body document.
@@ -39,12 +83,14 @@ export interface IField {
   type: Types;
   /** The data format specific, qualified name of the current type of this field, if applicable */
   typeQName: QName | null;
-  /** Original data type of this field before any overrides, in DataMapper common style */
-  originalType: Types;
-  /** The data format specific, qualified name of the original type of this field before any overrides, if applicable */
-  originalTypeQName: QName | null;
+  /**
+   * Snapshot of the original field state. Set lazily on field expansion or just before the first override or substitution,
+   * whichever comes first. Cleared when the override is reverted.
+   * @see IOriginalFieldState for the restoration strategy covering all schema variants.
+   */
+  originalField?: IOriginalFieldState;
   /** Indicates whether and how the type has been overridden */
-  typeOverride: TypeOverrideVariant;
+  typeOverride: FieldOverrideVariant;
   /** Child fields for complex types */
   fields: IField[];
   /** Whether this field represents an attribute (vs element) */
@@ -208,9 +254,7 @@ export class PrimitiveDocument extends BaseDocument implements IField {
   parent: IParentType = this;
   type = Types.AnyType;
   typeQName: QName | null = null;
-  originalType = Types.AnyType;
-  originalTypeQName: QName | null = null;
-  typeOverride = TypeOverrideVariant.NONE;
+  typeOverride = FieldOverrideVariant.NONE;
   path: NodePath;
   id: string;
   displayName: string;
@@ -250,9 +294,7 @@ export class BaseField implements IField {
   isAttribute: boolean = false;
   type = Types.AnyType;
   typeQName: QName | null = null;
-  originalType = Types.AnyType;
-  originalTypeQName: QName | null = null;
-  typeOverride = TypeOverrideVariant.NONE;
+  typeOverride = FieldOverrideVariant.NONE;
   minOccurs: number = 0;
   maxOccurs: MaxOccursType = 1;
   defaultValue: string | null = null;
@@ -262,6 +304,7 @@ export class BaseField implements IField {
   predicates: Predicate[] = [];
   isChoice?: boolean;
   selectedMemberIndex?: number;
+  originalField?: IOriginalFieldState;
 
   protected mergeInto(existing: IField): void {
     if (this.type && this.type !== Types.AnyType) existing.type = this.type;
@@ -285,8 +328,6 @@ export class BaseField implements IField {
     adopted.isAttribute = this.isAttribute;
     adopted.type = this.type;
     adopted.typeQName = this.typeQName;
-    adopted.originalType = this.originalType;
-    adopted.originalTypeQName = this.originalTypeQName;
     adopted.typeOverride = this.typeOverride;
     adopted.minOccurs = this.minOccurs;
     adopted.maxOccurs = this.maxOccurs;
@@ -331,9 +372,10 @@ export class DocumentDefinition {
     public name: string,
     public definitionFiles?: Record<string, string>,
     public rootElementChoice?: RootElementOption,
+    public namespaceMap?: Record<string, string>,
     public fieldTypeOverrides?: IFieldTypeOverride[],
     public choiceSelections?: IChoiceSelection[],
-    public namespaceMap?: Record<string, string>,
+    public fieldSubstitutions?: IFieldSubstitution[],
   ) {
     if (!definitionFiles) this.definitionFiles = {};
   }

--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinitionType, RootElementOption } from './document';
-import { TypeOverrideVariant } from './types';
+import { FieldOverrideVariant } from './types';
 
 /**
  * Shared base for overrides and selections that are addressed by schema path.
@@ -23,12 +23,16 @@ export interface IBaseOverride {
  */
 export interface IFieldTypeOverride extends IBaseOverride {
   /**
-   * The new type to apply to the field.
+   * The new type to apply to the field, in `<prefix>:<localName>` form
+   * (e.g. `xs:string`, `ns0:MyType`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
    */
   type: string;
 
   /**
-   * The original type of the field before the override.
+   * The original type of the field before the override, in `<prefix>:<localName>` form
+   * (e.g. `xs:string`, `ns0:MyType`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
    */
   originalType: string;
 
@@ -37,7 +41,27 @@ export interface IFieldTypeOverride extends IBaseOverride {
    * - SAFE: The override is safe and compatible with the original type.
    * - FORCE: The override is forced and may not be compatible with the original type.
    */
-  variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE;
+  variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE;
+}
+
+/**
+ * Represents an element substitution for a field in a document.
+ * Used to substitute an element with another element from the same substitution group.
+ */
+export interface IFieldSubstitution extends IBaseOverride {
+  /**
+   * The substitute element name in `<prefix>:<localName>` form
+   * (e.g. `ns0:AlrtMetaDtaReq`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
+   */
+  name: string;
+
+  /**
+   * The original element name in `<prefix>:<localName>` form
+   * (e.g. `ns0:Message`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
+   */
+  originalName: string;
 }
 
 /**
@@ -75,6 +99,12 @@ export interface IDocumentMetadata {
    * Persists which choice member is selected for each choice field.
    */
   choiceSelections?: IChoiceSelection[];
+
+  /**
+   * Array of element substitutions for fields in the document.
+   * Allows substituting an element with another from the same substitution group.
+   */
+  fieldSubstitutions?: IFieldSubstitution[];
 }
 
 /**

--- a/packages/ui/src/models/datamapper/types.ts
+++ b/packages/ui/src/models/datamapper/types.ts
@@ -30,10 +30,11 @@ export enum Types {
   Array = 'Array',
 }
 
-export enum TypeOverrideVariant {
+export enum FieldOverrideVariant {
   NONE = 'NONE',
   SAFE = 'SAFE',
   FORCE = 'FORCE',
+  SUBSTITUTION = 'SUBSTITUTION',
 }
 
 /**

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -1,6 +1,11 @@
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
-import { IChoiceSelection, IDataMapperMetadata, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import {
+  IChoiceSelection,
+  IDataMapperMetadata,
+  IFieldSubstitution,
+  IFieldTypeOverride,
+} from '../models/datamapper/metadata';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
 import { getCommonTypesJsonSchema, getCustomerJsonSchema, getOrderJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DataMapperMetadataService } from './datamapper-metadata.service';
@@ -465,7 +470,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Root/Field1',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       const definition = new DocumentDefinition(
@@ -473,6 +478,7 @@ describe('DataMapperMetadataService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         { 'source.xsd': '<schema/>' },
+        undefined,
         undefined,
         fieldTypeOverrides,
       );
@@ -490,6 +496,7 @@ describe('DataMapperMetadataService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         { 'source.xsd': '<schema/>' },
+        undefined,
         undefined,
         undefined,
         choiceSelections,
@@ -512,6 +519,32 @@ describe('DataMapperMetadataService', () => {
       await DataMapperMetadataService.updateSourceBodyMetadata(mockApi, 'test-id', metadata, definition);
 
       expect(metadata.sourceBody.fieldTypeOverrides).toBeUndefined();
+    });
+
+    it('should persist fieldSubstitutions from DocumentDefinition', async () => {
+      const metadata = DataMapperMetadataService.createMetadata('test.xsl');
+      const fieldSubstitutions: IFieldSubstitution[] = [
+        {
+          schemaPath: '/ns0:Root/ns0:Message',
+          name: 'ns0:AlrtMetaDtaReq',
+          originalName: 'ns0:Message',
+        },
+      ];
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'source.xsd': '<schema/>' },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        fieldSubstitutions,
+      );
+
+      await DataMapperMetadataService.updateSourceBodyMetadata(mockApi, 'test-id', metadata, definition);
+
+      expect(metadata.sourceBody.fieldSubstitutions).toEqual(fieldSubstitutions);
     });
   });
 
@@ -544,7 +577,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns1:Order/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [{ schemaPath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }];
@@ -553,6 +586,7 @@ describe('DataMapperMetadataService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         { 'target.xsd': '<schema/>' },
+        undefined,
         undefined,
         fieldTypeOverrides,
         choiceSelections,
@@ -616,7 +650,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Config/Setting',
           type: 'xs:string',
           originalType: 'xs:anyType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [{ schemaPath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }];
@@ -625,6 +659,7 @@ describe('DataMapperMetadataService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'param1',
         { 'param1.xsd': '<schema/>' },
+        undefined,
         undefined,
         fieldTypeOverrides,
         choiceSelections,
@@ -905,13 +940,13 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/Field1',
               type: 'ns0:Type1',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
             {
               schemaPath: '/ns0:Root/Field2',
               type: 'ns0:Type2',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
           ],
         },
@@ -927,13 +962,13 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns0:Root/Field1',
         type: 'ns0:Type1',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
       expect(overrides[1]).toEqual({
         schemaPath: '/ns0:Root/Field2',
         type: 'ns0:Type2',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -949,7 +984,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns1:Order/ShipTo',
               type: 'ns1:ExtendedShipTo',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
           ],
         },
@@ -963,7 +998,7 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns1:Order/ShipTo',
         type: 'ns1:ExtendedShipTo',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -979,7 +1014,7 @@ describe('DataMapperMetadataService', () => {
                 schemaPath: '/ns0:Config/Setting',
                 type: 'xs:string',
                 originalType: 'xs:anyType',
-                variant: TypeOverrideVariant.SAFE,
+                variant: FieldOverrideVariant.SAFE,
               },
             ],
           },
@@ -995,7 +1030,7 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns0:Config/Setting',
         type: 'xs:string',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -1041,6 +1076,32 @@ describe('DataMapperMetadataService', () => {
 
       expect(overrides).toEqual([]);
     });
+
+    it('should return empty array for PARAM document type without paramName', () => {
+      const metadata: IDataMapperMetadata = {
+        sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        sourceParameters: {},
+        targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        xsltPath: 'transform.xsl',
+      };
+
+      const overrides = DataMapperMetadataService.getFieldTypeOverrides(metadata, DocumentType.PARAM);
+
+      expect(overrides).toEqual([]);
+    });
+
+    it('should return empty array for unknown DocumentType', () => {
+      const metadata: IDataMapperMetadata = {
+        sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        sourceParameters: {},
+        targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        xsltPath: 'transform.xsl',
+      };
+
+      const overrides = DataMapperMetadataService.getFieldTypeOverrides(metadata, 99 as unknown as DocumentType);
+
+      expect(overrides).toEqual([]);
+    });
   });
 
   describe('setFieldTypeOverrides()', () => {
@@ -1054,7 +1115,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/OldField',
               type: 'xs:int',
               originalType: 'xs:string',
-              variant: TypeOverrideVariant.FORCE,
+              variant: FieldOverrideVariant.FORCE,
             },
           ],
         },
@@ -1068,13 +1129,13 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Root/Field1',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
         {
           schemaPath: '/ns0:Root/Field2',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -1103,7 +1164,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns1:Order/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -1134,7 +1195,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Config/Setting',
           type: 'xs:string',
           originalType: 'xs:anyType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
 
@@ -1161,7 +1222,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/Field',
               type: 'xs:int',
               originalType: 'xs:string',
-              variant: TypeOverrideVariant.FORCE,
+              variant: FieldOverrideVariant.FORCE,
             },
           ],
         },

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -157,9 +157,10 @@ export class DataMapperMetadataService {
           name,
           definitionFiles,
           documentMetadata.rootElementChoice,
+          namespaceMap,
           documentMetadata.fieldTypeOverrides,
           documentMetadata.choiceSelections,
-          namespaceMap,
+          documentMetadata.fieldSubstitutions,
         );
         resolve(answer);
       });
@@ -204,6 +205,7 @@ export class DataMapperMetadataService {
       rootElementChoice: definition.rootElementChoice,
       fieldTypeOverrides: definition.fieldTypeOverrides,
       choiceSelections: definition.choiceSelections,
+      fieldSubstitutions: definition.fieldSubstitutions,
     };
     const filePromises =
       api.shouldSaveSchema && definition.definitionFiles

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType, Types } from '../models/datamapper';
 import { IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { getAccountJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
@@ -137,7 +137,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:string[@key="AccountId"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -145,7 +145,7 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const accountIdField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'AccountId');
       expect(accountIdField?.type).toBe(Types.Numeric);
-      expect(accountIdField?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(accountIdField?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply type override to nested JSON field', () => {
@@ -161,7 +161,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:map[@key="Address"]/fn:string[@key="City"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -170,7 +170,7 @@ describe('DocumentUtilService - JSON Schema', () => {
       const addressField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'Address');
       const cityField = addressField?.fields.find((f) => 'key' in f && f.key === 'City');
       expect(cityField?.type).toBe(Types.Numeric);
-      expect(cityField?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(cityField?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should distinguish between fields with same key at different levels', () => {
@@ -201,7 +201,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:map[@key="map"]/fn:string[@key="foo"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -209,12 +209,12 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.String);
-      expect(topLevelFoo?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(topLevelFoo?.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const mapField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'map');
       const nestedFoo = mapField?.fields.find((f) => 'key' in f && f.key === 'foo');
       expect(nestedFoo?.type).toBe(Types.Numeric);
-      expect(nestedFoo?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(nestedFoo?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply override to /fn:map/fn:string[@key=foo] but not /fn:map[@key=map]/fn:string[@key=foo]', () => {
@@ -245,7 +245,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:string[@key="foo"]',
           type: 'boolean',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -253,12 +253,12 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.Boolean);
-      expect(topLevelFoo?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(topLevelFoo?.typeOverride).toBe(FieldOverrideVariant.FORCE);
 
       const mapField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'map');
       const nestedFoo = mapField?.fields.find((f) => 'key' in f && f.key === 'foo');
       expect(nestedFoo?.type).toBe(Types.String);
-      expect(nestedFoo?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(nestedFoo?.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
   });
 });

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -3,12 +3,13 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
+  PrimitiveDocument,
   Types,
 } from '../models/datamapper';
 import { IField } from '../models/datamapper/document';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { getCamelSpringXsd, getLazyLoadingTestXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { XmlSchemaField } from './xml-schema-document.model';
@@ -35,6 +36,13 @@ describe('DocumentUtilService', () => {
       const stackWithSelf = DocumentUtilService.getFieldStack(sourceDoc.fields[0].fields[1], true);
       expect(stackWithSelf.length).toEqual(2);
       expect(stackWithSelf[0].name).toEqual('OrderPerson');
+    });
+
+    it('should return empty array for PrimitiveDocument', () => {
+      const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test-doc');
+      const primitiveDoc = new PrimitiveDocument(definition);
+      const stack = DocumentUtilService.getFieldStack(primitiveDoc);
+      expect(stack).toEqual([]);
     });
   });
 
@@ -84,6 +92,47 @@ describe('DocumentUtilService', () => {
       // occurrences must be taken from the referrer as opposed to the other attributes
       expect(route?.minOccurs).toEqual(0);
       expect(route?.maxOccurs).toEqual('unbounded');
+    });
+
+    it('should not overwrite originalField if already set', () => {
+      const testDoc = TestUtil.createSourceOrderDoc();
+      const testChildField = new XmlSchemaField(testDoc, 'testField', false);
+      testChildField.type = Types.String;
+      testDoc.namedTypeFragments['testFragment'] = {
+        type: Types.Container,
+        minOccurs: 1,
+        maxOccurs: 1,
+        namedTypeFragmentRefs: [],
+        fields: [testChildField],
+      };
+
+      const refField = new XmlSchemaField(testDoc.fields[0], 'testRefField', false);
+      refField.namedTypeFragmentRefs.push('testFragment');
+      testDoc.fields[0].fields.push(refField);
+
+      const existingOriginalField = {
+        name: 'testRefField',
+        namespaceURI: null,
+        namespacePrefix: null,
+        type: Types.String,
+        typeQName: null,
+        namedTypeFragmentRefs: ['testFragment'],
+      };
+      refField.originalField = existingOriginalField;
+
+      DocumentUtilService.resolveTypeFragment(refField);
+
+      expect(refField.originalField).toBe(existingOriginalField);
+    });
+
+    it('should not throw and preserve unresolved refs when a namedTypeFragmentRef does not exist in namedTypeFragments', () => {
+      const testDoc = TestUtil.createSourceOrderDoc();
+      const refField = new XmlSchemaField(testDoc.fields[0], 'missingRefField', false);
+      refField.namedTypeFragmentRefs = ['nonExistentRef'];
+      testDoc.fields[0].fields.push(refField);
+
+      expect(() => DocumentUtilService.resolveTypeFragment(refField)).not.toThrow();
+      expect(refField.namedTypeFragmentRefs).toEqual(['nonExistentRef']);
     });
   });
 
@@ -155,6 +204,19 @@ describe('DocumentUtilService', () => {
 
       expect(field.fields.length).toBe(2);
     });
+
+    it('should not throw when a namedTypeFragmentRef inside a fragment does not exist in namedTypeFragments', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const field = new XmlSchemaField(doc, 'testField', false);
+
+      const fragment = {
+        fields: [],
+        namedTypeFragmentRefs: ['nonExistentChildRef'],
+      };
+
+      expect(() => DocumentUtilService.adoptTypeFragment(field, fragment)).not.toThrow();
+      expect(field.fields).toHaveLength(0);
+    });
   });
 
   describe('processTypeOverrides()', () => {
@@ -165,7 +227,7 @@ describe('DocumentUtilService', () => {
       DocumentUtilService.processTypeOverrides(doc, [], {}, XmlSchemaTypesService.parseTypeOverride);
 
       expect(orderPerson?.type).toBe(Types.String);
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
 
     it('should apply type override to top-level field', () => {
@@ -176,7 +238,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -184,7 +246,7 @@ describe('DocumentUtilService', () => {
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Integer);
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply type override to nested field', () => {
@@ -195,7 +257,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -204,7 +266,7 @@ describe('DocumentUtilService', () => {
       const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo');
       const city = shipTo?.fields.find((f) => f.name === 'City');
       expect(city?.type).toBe(Types.Integer);
-      expect(city?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(city?.typeOverride).toBe(FieldOverrideVariant.FORCE);
       expect(city?.fields).toEqual([]);
     });
 
@@ -216,13 +278,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -244,7 +306,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'ns0:CustomType',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
 
@@ -280,7 +342,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Name',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -312,7 +374,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Address/tns:City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -344,7 +406,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -372,7 +434,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/{choice:0}/targetField',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -405,13 +467,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Name',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/tns:Root/tns:Company/tns:CompanyName',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -450,7 +512,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
 
       const result = DocumentUtilService.processTypeOverride(
@@ -473,7 +535,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:NonExistent',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
 
       const result = DocumentUtilService.processTypeOverride(
@@ -493,7 +555,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, first, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -501,7 +563,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:boolean',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, second, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -519,7 +581,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -527,7 +589,7 @@ describe('DocumentUtilService', () => {
 
       expect(result).toBe(true);
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.NONE);
       expect(doc.definition.fieldTypeOverrides).toHaveLength(0);
     });
 
@@ -546,6 +608,187 @@ describe('DocumentUtilService', () => {
       const result = DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap);
 
       expect(result).toBe(false);
+    });
+
+    it('should return false when schemaPath is not present in fieldTypeOverrides', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      doc.definition.fieldTypeOverrides = [
+        {
+          schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+          type: 'xs:int',
+          originalType: 'xs:string',
+          variant: FieldOverrideVariant.FORCE,
+        },
+      ];
+
+      const result = DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/NonExistent', namespaceMap);
+
+      expect(result).toBe(false);
+    });
+
+    it('should restore fields=[] and refs=[] when reverting override on a simple-type field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+        type: 'xs:int',
+        originalType: 'xs:string',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson')!;
+      expect(orderPerson.originalField?.fields).toBeUndefined();
+      expect(orderPerson.originalField?.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap);
+
+      expect(orderPerson.fields).toHaveLength(0);
+      expect(orderPerson.namedTypeFragmentRefs).toHaveLength(0);
+      expect(orderPerson.originalField).toBeUndefined();
+    });
+
+    it('should restore namedTypeFragmentRefs when reverting override on a named-type field', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'lazy.xsd': getLazyLoadingTestXsd() },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const lazyNamespaceMap = { tns: 'http://www.example.com/LAZYTEST', xs: NS_XML_SCHEMA };
+
+      const person = doc.fields[0].fields.find((f) => f.name === 'Person')!;
+      expect(person.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/tns:Root/tns:Person',
+        type: 'xs:string',
+        originalType: 'tns:PersonType',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, lazyNamespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(person.originalField?.fields).toBeUndefined();
+      expect(person.originalField?.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+      expect(person.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/tns:Root/tns:Person', lazyNamespaceMap);
+
+      expect(person.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+      expect(person.originalField).toBeUndefined();
+    });
+
+    it('should restore inline children when reverting override on an XML anonymous-type field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo')!;
+      const originalChildren = shipTo.fields;
+      expect(originalChildren).toHaveLength(4);
+      expect(shipTo.namedTypeFragmentRefs).toHaveLength(0);
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ShipTo',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(shipTo.fields).toHaveLength(0);
+      expect(shipTo.originalField?.fields).toEqual(originalChildren);
+      expect(shipTo.originalField?.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ShipTo', namespaceMap);
+
+      expect(shipTo.fields).toEqual(originalChildren);
+      expect(shipTo.fields.map((f) => f.name)).toEqual(['Name', 'Address', 'City', 'Country']);
+      expect(shipTo.namedTypeFragmentRefs).toHaveLength(0);
+      expect(shipTo.originalField).toBeUndefined();
+    });
+
+    it('should preserve namespace values across apply and revert of a type override', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const namespaceMap2 = { ns0: 'io.kaoto.datamapper.poc.test', xs: NS_XML_SCHEMA };
+      const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson')!;
+      const originalNamespaceURI = orderPerson.namespaceURI;
+      const originalNamespacePrefix = orderPerson.namespacePrefix;
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+        type: 'xs:int',
+        originalType: 'xs:string',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap2, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(orderPerson.originalField!.namespaceURI).toBe(originalNamespaceURI);
+      expect(orderPerson.originalField!.namespacePrefix).toBe(originalNamespacePrefix);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap2);
+
+      expect(orderPerson.namespaceURI).toBe(originalNamespaceURI);
+      expect(orderPerson.namespacePrefix).toBe(originalNamespacePrefix);
+    });
+
+    it('should capture and restore null namespace values without coercing to empty string', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const namespaceMap2 = { ns0: 'io.kaoto.datamapper.poc.test', xs: NS_XML_SCHEMA };
+      const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo')!;
+      shipTo.namespaceURI = null;
+      shipTo.namespacePrefix = null;
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ShipTo',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap2, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(shipTo.originalField!.namespaceURI).toBeNull();
+      expect(shipTo.originalField!.namespacePrefix).toBeNull();
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ShipTo', namespaceMap2);
+
+      expect(shipTo.namespaceURI).toBeNull();
+      expect(shipTo.namespacePrefix).toBeNull();
+    });
+
+    it('should restore both inline children and refs when reverting override on a field with both set', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+
+      const mixedField = new XmlSchemaField(shipOrderField, 'mixedField', false);
+      mixedField.type = Types.Container;
+      mixedField.namedTypeFragmentRefs = ['someRef'];
+      const childField = new XmlSchemaField(mixedField, 'child', false);
+      childField.type = Types.String;
+      mixedField.fields.push(childField);
+      shipOrderField.fields.push(mixedField);
+
+      const originalChildren = mixedField.fields;
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/mixedField',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(mixedField.fields).toHaveLength(0);
+      expect(mixedField.namedTypeFragmentRefs).toHaveLength(0);
+      expect(mixedField.originalField?.fields).toEqual(originalChildren);
+      expect(mixedField.originalField?.namedTypeFragmentRefs).toEqual(['someRef']);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/mixedField', namespaceMap);
+
+      expect(mixedField.fields).toEqual(originalChildren);
+      expect(mixedField.namedTypeFragmentRefs).toEqual(['someRef']);
+      expect(mixedField.originalField).toBeUndefined();
     });
   });
 
@@ -570,7 +813,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [
@@ -606,7 +849,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [
@@ -649,13 +892,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -685,13 +928,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -1,6 +1,13 @@
-import { IDocument, IField, IParentType, ITypeFragment, PrimitiveDocument } from '../models/datamapper';
+import {
+  IDocument,
+  IField,
+  IOriginalFieldState,
+  IParentType,
+  ITypeFragment,
+  PrimitiveDocument,
+} from '../models/datamapper';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { SchemaPathService } from './schema-path.service';
 
@@ -8,7 +15,7 @@ export type ParseTypeOverrideFn = (
   typeString: string,
   namespaceMap: Record<string, string>,
   field: IField,
-) => { type: Types; typeQName: QName; variant: TypeOverrideVariant };
+) => { type: Types; typeQName: QName; variant: FieldOverrideVariant };
 
 /**
  * The collection of utility functions shared among {@link DocumentService}, {@link XmlSchemaDocumentService}
@@ -38,13 +45,31 @@ export class DocumentUtilService {
    */
   static resolveTypeFragment(field: IField): IField {
     if (field.namedTypeFragmentRefs.length === 0) return field;
+    field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
     const doc = DocumentUtilService.getOwnerDocument(field);
-    field.namedTypeFragmentRefs.forEach((ref) => {
+    const unresolvedRefs: string[] = [];
+    for (const ref of field.namedTypeFragmentRefs) {
       const fragment = doc.namedTypeFragments[ref];
+      if (!fragment) {
+        unresolvedRefs.push(ref);
+        continue;
+      }
       DocumentUtilService.adoptTypeFragment(field, fragment);
-    });
-    field.namedTypeFragmentRefs = [];
+    }
+    field.namedTypeFragmentRefs = unresolvedRefs;
     return field;
+  }
+
+  private static captureOriginalFieldState(field: IField): IOriginalFieldState {
+    return {
+      name: field.name,
+      namespaceURI: field.namespaceURI,
+      namespacePrefix: field.namespacePrefix,
+      type: field.type,
+      typeQName: field.typeQName,
+      namedTypeFragmentRefs: [...field.namedTypeFragmentRefs],
+      fields: field.fields.length > 0 ? [...field.fields] : undefined,
+    };
   }
 
   /**
@@ -59,10 +84,11 @@ export class DocumentUtilService {
     if (fragment.minOccurs !== undefined) field.minOccurs = fragment.minOccurs;
     if (fragment.maxOccurs !== undefined) field.maxOccurs = fragment.maxOccurs;
     fragment.fields.forEach((f) => f.adopt(field));
-    fragment.namedTypeFragmentRefs.forEach((childRef) => {
+    for (const childRef of fragment.namedTypeFragmentRefs) {
       const childFragment = doc.namedTypeFragments[childRef];
+      if (!childFragment) continue;
       DocumentUtilService.adoptTypeFragment(field, childFragment);
-    });
+    }
   }
 
   /**
@@ -97,8 +123,8 @@ export class DocumentUtilService {
    * @example
    * ```typescript
    * const overrides = [
-   *   { schemaPath: '/ns0:ShipOrder/ns0:OrderPerson', type: 'xs:int', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE },
-   *   { schemaPath: '/ns0:ShipOrder/ShipTo/City', type: 'xs:boolean', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE }
+   *   { schemaPath: '/ns0:ShipOrder/ns0:OrderPerson', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+   *   { schemaPath: '/ns0:ShipOrder/ShipTo/City', type: 'xs:boolean', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE }
    * ];
    * DocumentUtilService.processTypeOverrides(
    *   document,
@@ -145,7 +171,7 @@ export class DocumentUtilService {
    *   schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
    *   type: 'xs:int',
    *   originalType: 'xs:string',
-   *   variant: TypeOverrideVariant.FORCE,
+   *   variant: FieldOverrideVariant.FORCE,
    * };
    * DocumentUtilService.processTypeOverride(
    *   document,
@@ -258,6 +284,8 @@ export class DocumentUtilService {
     namespaceMap: Record<string, string>,
     parseTypeOverride: ParseTypeOverrideFn,
   ): void {
+    field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
+
     const { type, typeQName, variant } = parseTypeOverride(typeString, namespaceMap, field);
 
     field.type = type;
@@ -282,13 +310,25 @@ export class DocumentUtilService {
    * @param field - The field to restore to its original type
    */
   private static restoreOriginalTypeToField(field: IField): void {
-    field.type = field.originalType;
-    field.typeQName = field.originalTypeQName;
-    field.typeOverride = TypeOverrideVariant.NONE;
-    field.fields = [];
+    const origType = field.originalField?.type ?? field.type;
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const origRefs = field.originalField?.namedTypeFragmentRefs;
+    const origFields = field.originalField?.fields;
 
-    if (field.originalType === Types.Container && field.originalTypeQName) {
-      field.namedTypeFragmentRefs = [field.originalTypeQName.toString()];
+    field.type = origType;
+    field.typeQName = origTypeQName;
+    if (field.originalField) {
+      field.namespaceURI = field.originalField.namespaceURI;
+      field.namespacePrefix = field.originalField.namespacePrefix;
+    }
+    field.typeOverride = FieldOverrideVariant.NONE;
+    field.originalField = undefined;
+
+    field.fields = origFields ?? [];
+    if (origRefs !== undefined) {
+      field.namedTypeFragmentRefs = [...origRefs];
+    } else if (!origFields && origType === Types.Container && origTypeQName) {
+      field.namedTypeFragmentRefs = [origTypeQName.toString()];
     } else {
       field.namedTypeFragmentRefs = [];
     }

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -9,7 +9,8 @@ import {
   PrimitiveDocument,
   RootElementOption,
 } from '../models/datamapper';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
 import { getCartJsonSchema, getMultipleElementsXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentService } from './document.service';
@@ -665,10 +666,16 @@ describe('DocumentService', () => {
           schemaPath: '/old:Order/field',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       originalDocument.definition.choiceSelections = [{ schemaPath: '/old:Order/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old:Order/field',
+        name: 'ns0:Sub',
+        originalName: 'ns0:Field',
+      };
+      originalDocument.definition.fieldSubstitutions = [substitution];
 
       const invoiceOption: RootElementOption = {
         name: 'Invoice',
@@ -679,6 +686,7 @@ describe('DocumentService', () => {
 
       expect(updatedDocument.definition.fieldTypeOverrides).toEqual([]);
       expect(updatedDocument.definition.choiceSelections).toEqual([]);
+      expect(updatedDocument.definition.fieldSubstitutions).toEqual([]);
     });
   });
 

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -8,7 +8,7 @@ import {
   Types,
 } from '../models/datamapper';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { getImportedTypesXsd, getNamedTypesXsd, getShipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { FieldTypeOverrideService } from './field-type-override.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
@@ -28,7 +28,7 @@ describe('FieldTypeOverrideService', () => {
     it('should return all types for xs:anyType fields', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const anyTypeField = doc.fields[0].fields[0];
-      anyTypeField.originalType = Types.AnyType;
+      anyTypeField.type = Types.AnyType;
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(anyTypeField, namespaceMap);
@@ -41,7 +41,7 @@ describe('FieldTypeOverrideService', () => {
     it('should return extensions and restrictions for Container types', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const containerField = doc.fields[0];
-      containerField.originalType = Types.Container;
+      containerField.type = Types.Container;
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(containerField, namespaceMap);
@@ -54,12 +54,62 @@ describe('FieldTypeOverrideService', () => {
       const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!stringField) throw new Error('Field not found');
 
-      stringField.originalType = Types.String;
+      stringField.type = Types.String;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(stringField, namespaceMap);
 
       expect(typeof candidates).toBe('object');
+    });
+
+    it('should return all types when originalField.type is AnyType even if current type differs', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!field) throw new Error('Field not found');
+
+      field.originalField = {
+        name: field.name,
+        namespaceURI: '',
+        namespacePrefix: '',
+        type: Types.AnyType,
+        typeQName: null,
+        namedTypeFragmentRefs: [],
+      };
+      field.type = Types.Integer;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+
+      expect(Object.keys(candidates).length).toBeGreaterThan(0);
+      expect(Object.values(candidates).some((c) => c.displayName === 'xs:string')).toBe(true);
+    });
+
+    it('should return empty Record for JSON Schema fields without AnyType original', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        {
+          'test.json': JSON.stringify({
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          }),
+        },
+      );
+
+      const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const root = doc.fields[0];
+      const nameField = root.fields.find((f) => f.key === 'name');
+      if (!nameField) throw new Error('Field not found');
+
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(nameField, {});
+
+      expect(typeof candidates).toBe('object');
+      expect(Object.keys(candidates).length).toBe(0);
     });
   });
 
@@ -145,8 +195,6 @@ describe('FieldTypeOverrideService', () => {
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
           undefined,
-          undefined,
-          undefined,
           { ns0: 'io.kaoto.datamapper.poc.test' },
         );
 
@@ -171,8 +219,6 @@ describe('FieldTypeOverrideService', () => {
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
-          undefined,
-          undefined,
           undefined,
           { ns0: 'io.kaoto.datamapper.poc.test', custom: 'http://example.com/custom' },
         );
@@ -241,8 +287,6 @@ describe('FieldTypeOverrideService', () => {
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
           undefined,
-          undefined,
-          undefined,
           { ns0: 'io.kaoto.datamapper.poc.test' },
         );
 
@@ -276,12 +320,13 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(override.schemaPath).toBe('/ns0:ShipOrder/ns0:OrderPerson');
       expect(override.type).toBe('xs:int');
-      expect(override.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(override.originalType).toBe('xs:string');
+      expect(override.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should create override with schema path through choice compositor', () => {
@@ -305,10 +350,52 @@ describe('FieldTypeOverrideService', () => {
         emailField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(override.schemaPath).toBe('/ns0:ShipOrder/{choice:0}/email');
+    });
+
+    it('should use originalField.type as originalType when field was already overridden', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      const intCandidate = {
+        displayName: 'xs:int',
+        typeString: 'xs:int',
+        type: Types.Integer,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+      const boolCandidate = {
+        displayName: 'xs:boolean',
+        typeString: 'xs:boolean',
+        type: Types.Boolean,
+        namespaceURI: NS_XML_SCHEMA,
+        isBuiltIn: true,
+      };
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.applyFieldTypeOverride(
+        doc,
+        stringField,
+        intCandidate,
+        namespaceMap,
+        FieldOverrideVariant.FORCE,
+      );
+
+      const firstOverrideOriginalType = doc.definition.fieldTypeOverrides![0].originalType;
+
+      const secondOverride = FieldTypeOverrideService.createFieldTypeOverride(
+        stringField,
+        boolCandidate,
+        namespaceMap,
+        FieldOverrideVariant.FORCE,
+      );
+
+      expect(secondOverride.originalType).toBe(firstOverrideOriginalType);
+      expect(secondOverride.originalType).not.toBe(intCandidate.typeString);
     });
   });
 
@@ -319,7 +406,7 @@ describe('FieldTypeOverrideService', () => {
       if (!stringField) throw new Error('Field not found');
 
       expect(stringField.type).toBe(Types.String);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const candidate = {
         displayName: 'xs:int',
@@ -335,11 +422,11 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(stringField.type).toBe(Types.Integer);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.FORCE);
       expect(doc.definition.fieldTypeOverrides).toBeDefined();
       expect(doc.definition.fieldTypeOverrides![0].schemaPath).toBe('/ns0:ShipOrder/ns0:OrderPerson');
     });
@@ -352,7 +439,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [{ schemaPath: '/ns0:ShipOrder/ShipTo/{choice:0}', selectedMemberIndex: 0 }];
@@ -374,7 +461,7 @@ describe('FieldTypeOverrideService', () => {
         shipToField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(doc.definition.fieldTypeOverrides?.some((o) => o.schemaPath === '/ns0:ShipOrder/ShipTo/City')).toBe(false);
@@ -414,10 +501,10 @@ describe('FieldTypeOverrideService', () => {
         isBuiltIn: true,
       };
 
-      FieldTypeOverrideService.applyFieldTypeOverride(doc, nameField, candidate, {}, TypeOverrideVariant.FORCE);
+      FieldTypeOverrideService.applyFieldTypeOverride(doc, nameField, candidate, {}, FieldOverrideVariant.FORCE);
 
       expect(nameField.type).toBe(Types.Numeric);
-      expect(nameField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(nameField.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should throw TypeError for PrimitiveDocument', () => {
@@ -433,10 +520,10 @@ describe('FieldTypeOverrideService', () => {
       };
 
       expect(() => {
-        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, FieldOverrideVariant.FORCE);
       }).toThrow(TypeError);
       expect(() => {
-        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, FieldOverrideVariant.FORCE);
       }).toThrow('Field type override is not supported for primitive documents');
     });
 
@@ -463,7 +550,7 @@ describe('FieldTypeOverrideService', () => {
           mockDoc as unknown as IField,
           candidate,
           {},
-          TypeOverrideVariant.FORCE,
+          FieldOverrideVariant.FORCE,
         );
       }).toThrow(TypeError);
       expect(() => {
@@ -472,7 +559,7 @@ describe('FieldTypeOverrideService', () => {
           mockDoc as unknown as IField,
           candidate,
           {},
-          TypeOverrideVariant.FORCE,
+          FieldOverrideVariant.FORCE,
         );
       }).toThrow('Unsupported document type');
     });
@@ -500,16 +587,16 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(stringField.type).toBe(Types.Integer);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.FORCE);
 
       FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
 
       expect(stringField.type).toBe(originalType);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
       expect(doc.definition.fieldTypeOverrides?.length).toBe(0);
     });
 
@@ -519,13 +606,13 @@ describe('FieldTypeOverrideService', () => {
       if (!stringField) throw new Error('Field not found');
 
       const originalType = stringField.type;
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
 
       expect(stringField.type).toBe(originalType);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
 
     it('should invalidate descendant overrides and selections after reverting type override', () => {
@@ -547,7 +634,7 @@ describe('FieldTypeOverrideService', () => {
         shipToField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       doc.definition.fieldTypeOverrides = [
@@ -556,7 +643,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [
@@ -641,7 +728,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [
@@ -742,7 +829,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections!.push({

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, IDocument, IField, PrimitiveDocument } from '../models/datamapper/document';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../models/datamapper/types';
 import { DocumentUtilService, ParseTypeOverrideFn } from './document-util.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -29,7 +29,7 @@ import { XmlSchemaTypesService } from './xml-schema-types.service';
  *   field,
  *   selectedCandidate,
  *   namespaceMap,
- *   TypeOverrideVariant.FORCE
+ *   FieldOverrideVariant.FORCE
  * );
  *
  * // Remove a type override
@@ -67,7 +67,7 @@ export class FieldTypeOverrideService {
     field: IField,
     namespaceMap: Record<string, string>,
   ): Record<string, IFieldTypeInfo> {
-    if (field.originalType === Types.AnyType) {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
       return FieldTypeOverrideService.getAllOverrideCandidates(field.ownerDocument, namespaceMap);
     }
 
@@ -155,13 +155,13 @@ export class FieldTypeOverrideService {
    *   orderPersonField,
    *   candidate,
    *   namespaceMap,
-   *   TypeOverrideVariant.FORCE
+   *   FieldOverrideVariant.FORCE
    * );
    * // Returns: {
    * //   schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
    * //   type: 'xs:int',
    * //   originalType: 'xs:string',
-   * //   variant: TypeOverrideVariant.FORCE
+   * //   variant: FieldOverrideVariant.FORCE
    * // }
    *
    * // Apply the override
@@ -178,10 +178,20 @@ export class FieldTypeOverrideService {
     field: IField,
     candidate: IFieldTypeInfo,
     namespaceMap: Record<string, string>,
-    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+    variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE,
   ): IFieldTypeOverride {
     const schemaPath = SchemaPathService.build(field, namespaceMap);
-    const originalTypeString = field.originalTypeQName?.toString() ?? field.originalType;
+    const origType = field.originalField?.type ?? field.type;
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const localPart = origTypeQName?.getLocalPart();
+    const namespaceURI = origTypeQName?.getNamespaceURI();
+    const prefix = namespaceURI ? Object.entries(namespaceMap).find(([, uri]) => uri === namespaceURI)?.[0] : undefined;
+    let originalTypeString: string;
+    if (localPart) {
+      originalTypeString = prefix ? `${prefix}:${localPart}` : localPart;
+    } else {
+      originalTypeString = origType;
+    }
     return {
       schemaPath,
       type: candidate.typeString,
@@ -223,7 +233,7 @@ export class FieldTypeOverrideService {
    *   field,
    *   candidate,
    *   namespaceMap,
-   *   TypeOverrideVariant.FORCE
+   *   FieldOverrideVariant.FORCE
    * );
    *
    * // Persist changes via provider
@@ -239,7 +249,7 @@ export class FieldTypeOverrideService {
     field: IField,
     candidate: IFieldTypeInfo,
     namespaceMap: Record<string, string>,
-    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+    variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE,
   ): void {
     if (document instanceof PrimitiveDocument) {
       throw new TypeError('Field type override is not supported for primitive documents');
@@ -285,7 +295,7 @@ export class FieldTypeOverrideService {
    * @see applyFieldTypeOverride
    */
   static revertFieldTypeOverride(document: IDocument, field: IField, namespaceMap: Record<string, string>): void {
-    if (field.typeOverride === TypeOverrideVariant.NONE) return;
+    if (field.typeOverride === FieldOverrideVariant.NONE) return;
     const schemaPath = SchemaPathService.build(field, namespaceMap);
     const changed = DocumentUtilService.removeTypeOverride(document, schemaPath, namespaceMap);
     if (changed) {
@@ -368,9 +378,10 @@ export class FieldTypeOverrideService {
       document.definition.name,
       mergedDefinitionFiles,
       document.definition.rootElementChoice,
+      updatedNamespaceMap,
       document.definition.fieldTypeOverrides,
       document.definition.choiceSelections,
-      updatedNamespaceMap,
+      document.definition.fieldSubstitutions,
     );
   }
 

--- a/packages/ui/src/services/json-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/json-schema-document-util.service.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import {
   JsonSchemaCollection,
@@ -245,7 +245,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(null, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse number type override', () => {
@@ -258,7 +258,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Numeric);
       expect(result.typeQName).toEqual(new QName(null, 'number'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse boolean type override', () => {
@@ -271,7 +271,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Boolean);
       expect(result.typeQName).toEqual(new QName(null, 'boolean'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse array type override', () => {
@@ -284,7 +284,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Array);
       expect(result.typeQName).toEqual(new QName(null, 'array'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse object type override', () => {
@@ -297,7 +297,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, 'object'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse type reference with #/ prefix as Container', () => {
@@ -310,7 +310,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, '#/definitions/MyType'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should return FORCE variant when overriding non-AnyType field', () => {
@@ -322,7 +322,7 @@ describe('JsonSchemaDocumentUtilService', () => {
       const result = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
 
       expect(result.type).toBe(Types.Numeric);
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -459,7 +459,6 @@ export class JsonSchemaField extends BaseField {
     const ownerDocument = ('ownerDocument' in parent ? parent.ownerDocument : parent) as JsonSchemaDocument;
     super(parent, ownerDocument, key);
     this.type = type;
-    this.originalType = type;
     this.name = JsonSchemaDocumentUtilService.toXsltTypeName(this.type);
     const keyPart = this.key ? `-${this.key}` : '';
     this.id = `fj-${this.name}${keyPart}${getCamelRandomId('', 4)}`;
@@ -518,8 +517,6 @@ export class JsonSchemaField extends BaseField {
     to.namespacePrefix = this.namespacePrefix;
     to.namespaceURI = this.namespaceURI;
     to.typeQName = this.typeQName;
-    to.originalType = this.originalType;
-    to.originalTypeQName = this.originalTypeQName;
     to.typeOverride = this.typeOverride;
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     to.isChoice = this.isChoice;

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -2,7 +2,9 @@ import { JSONSchema7 } from 'json-schema';
 
 import { DocumentDefinition, DocumentDefinitionType, PathExpression, Types } from '../models/datamapper';
 import { BODY_DOCUMENT_ID, DocumentType } from '../models/datamapper/document';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import {
   getAccountJsonSchema,
   getCamelYamlDslJsonSchema,
@@ -931,6 +933,34 @@ describe('JsonSchemaDocumentService', () => {
         namespaceUri: '',
         name: 'Account.schema.json',
       });
+    });
+
+    it('should clear fieldTypeOverrides, choiceSelections and fieldSubstitutions when primary schema is removed', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        { 'Account.schema.json': getAccountJsonSchema(), 'camelYamlDsl.json': getCamelYamlDslJsonSchema() },
+        { namespaceUri: '', name: 'Account.schema.json' },
+      );
+      definition.fieldTypeOverrides = [
+        { schemaPath: '/old/path', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+      ];
+      definition.choiceSelections = [{ schemaPath: '/old/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old/path',
+        name: 'ns0:newName',
+        originalName: 'ns0:oldName',
+      };
+      definition.fieldSubstitutions = [substitution];
+
+      const removeResult = JsonSchemaDocumentService.removeSchemaFile(definition, 'Account.schema.json');
+
+      expect(removeResult.validationStatus).not.toBe('error');
+      expect(removeResult.document).toBeDefined();
+      expect(removeResult.documentDefinition!.fieldTypeOverrides).toEqual([]);
+      expect(removeResult.documentDefinition!.choiceSelections).toEqual([]);
+      expect(removeResult.documentDefinition!.fieldSubstitutions).toEqual([]);
     });
   });
 });

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -167,9 +167,10 @@ export class JsonSchemaDocumentService {
       definition.name,
       updatedFiles,
       definition.rootElementChoice,
+      definition.namespaceMap,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
-      definition.namespaceMap,
+      definition.fieldSubstitutions,
     );
 
     // Try to create the Document object. It could fail if the primary schema is the removed schema file.
@@ -183,6 +184,9 @@ export class JsonSchemaDocumentService {
 
     // Unset the primary schema and retry
     updatedDefinition.rootElementChoice = undefined;
+    updatedDefinition.fieldTypeOverrides = [];
+    updatedDefinition.choiceSelections = [];
+    updatedDefinition.fieldSubstitutions = [];
     return JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition);
   }
 
@@ -523,7 +527,6 @@ export class JsonSchemaDocumentService {
   private assignRefTypeQName(field: JsonSchemaField, ref: string): void {
     const refQName = new QName(null, ref);
     field.typeQName = refQName;
-    field.originalTypeQName = refQName;
   }
 
   private assignTypeMetadata(field: JsonSchemaField, schema: JsonSchemaMetadata): void {
@@ -532,7 +535,6 @@ export class JsonSchemaDocumentService {
       const typeString = typeArray[0];
       const typeQName = new QName(null, typeString);
       field.typeQName = typeQName;
-      field.originalTypeQName = typeQName;
     }
 
     if (schema.required) {

--- a/packages/ui/src/services/json-schema-types.service.test.ts
+++ b/packages/ui/src/services/json-schema-types.service.test.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper/document';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { JsonSchemaTypesService } from './json-schema-types.service';
@@ -162,7 +162,7 @@ describe('JsonSchemaTypesService', () => {
 
       const parseResult = JsonSchemaTypesService.parseTypeOverride('string', {}, field);
 
-      expect(parseResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(parseResult.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should determine FORCE variant for non-AnyType field', () => {
@@ -179,7 +179,7 @@ describe('JsonSchemaTypesService', () => {
 
       const parseResult = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
 
-      expect(parseResult.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(parseResult.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 

--- a/packages/ui/src/services/json-schema-types.service.ts
+++ b/packages/ui/src/services/json-schema-types.service.ts
@@ -1,5 +1,5 @@
 import { IField } from '../models/datamapper/document';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { JsonSchemaDocument } from './json-schema-document.model';
 
@@ -31,7 +31,7 @@ export class JsonSchemaTypesService {
    * @example
    * ```typescript
    * const result = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
-   * // result = { type: Types.Numeric, typeQName: QName, variant: TypeOverrideVariant.SAFE }
+   * // result = { type: Types.Numeric, typeQName: QName, variant: FieldOverrideVariant.SAFE }
    *
    * const refResult = JsonSchemaTypesService.parseTypeOverride('#/definitions/Address', {}, field);
    * // result = { type: Types.Container, typeQName: QName, variant: ... }
@@ -41,7 +41,7 @@ export class JsonSchemaTypesService {
     typeString: string,
     _namespaceMap: Record<string, string>,
     field: IField,
-  ): { type: Types; typeQName: QName; variant: TypeOverrideVariant } {
+  ): { type: Types; typeQName: QName; variant: FieldOverrideVariant } {
     const type = typeString.startsWith('#/') ? Types.Container : JsonSchemaTypesService.mapTypeStringToEnum(typeString);
 
     const typeQName = new QName(null, typeString);
@@ -63,12 +63,12 @@ export class JsonSchemaTypesService {
    * @param _typeString - The type string (unused but kept for interface consistency)
    * @returns SAFE if original type is AnyType, FORCE otherwise
    */
-  static determineOverrideVariant(field: IField, _newType: Types, _typeString: string): TypeOverrideVariant {
-    if (field.originalType === Types.AnyType) {
-      return TypeOverrideVariant.SAFE;
+  static determineOverrideVariant(field: IField, _newType: Types, _typeString: string): FieldOverrideVariant {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
+      return FieldOverrideVariant.SAFE;
     }
 
-    return TypeOverrideVariant.FORCE;
+    return FieldOverrideVariant.FORCE;
   }
 
   /**
@@ -179,7 +179,7 @@ export class JsonSchemaTypesService {
    * // Always returns {}
    * ```
    */
-  static getTypeOverrideCandidatesForField(_field: { originalTypeQName?: unknown }): Record<string, IFieldTypeInfo> {
+  static getTypeOverrideCandidatesForField(_field: IField): Record<string, IFieldTypeInfo> {
     return {};
   }
 }

--- a/packages/ui/src/services/xml-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document-util.service.test.ts
@@ -1,7 +1,7 @@
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import { BaseDocument } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import {
   getAccountLcXsd,
   getAccountNs2Xsd,
@@ -251,7 +251,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:int type override', () => {
@@ -263,7 +263,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Integer);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'int'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:boolean type override', () => {
@@ -275,7 +275,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Boolean);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'boolean'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:date type override', () => {
@@ -287,7 +287,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Date);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'date'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:decimal type override', () => {
@@ -299,7 +299,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Decimal);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'decimal'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse custom type override with FORCE variant', () => {
@@ -311,7 +311,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse type without prefix', () => {
@@ -324,7 +324,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, 'CustomType'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should handle schema with extension types', () => {
@@ -377,7 +377,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       const result = XmlSchemaTypesService.parseTypeOverride('ns0:UnrelatedType', namespaceMap, shipTo);
 
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should return SAFE variant when re-overriding with compatible extension type', () => {
@@ -395,12 +395,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const requestField = doc.fields.find((f) => f.name === 'Request');
       if (!requestField) throw new Error('Request field not found');
 
-      requestField.originalType = Types.Container;
-      requestField.originalTypeQName = new QName('http://www.example.com/TEST', 'Message');
+      requestField.type = Types.Container;
+      requestField.typeQName = new QName('http://www.example.com/TEST', 'Message');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE extension variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'extension.xsd': getExtensionComplexXsd() },
+      );
+      const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(extensionResult.validationStatus).toBe('success');
+      const doc = extensionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
+
+      const requestField = doc.fields.find((f) => f.name === 'Request');
+      if (!requestField) throw new Error('Request field not found');
+
+      requestField.type = Types.String;
+      requestField.originalField = {
+        name: requestField.name,
+        namespaceURI: requestField.namespaceURI,
+        namespacePrefix: requestField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/TEST', 'Message'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -419,12 +450,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const addressField = doc.fields.find((f) => f.name === 'Address');
       if (!addressField) throw new Error('Address field not found');
 
-      addressField.originalType = Types.Container;
-      addressField.originalTypeQName = new QName('http://www.example.com/RESTRICT', 'BaseAddress');
+      addressField.type = Types.Container;
+      addressField.typeQName = new QName('http://www.example.com/RESTRICT', 'BaseAddress');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:SimpleAddress', namespaceMap, addressField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE restriction variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'restriction.xsd': getRestrictionComplexXsd() },
+      );
+      const restrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(restrictionResult.validationStatus).toBe('success');
+      const doc = restrictionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/RESTRICT', xs: NS_XML_SCHEMA };
+
+      const addressField = doc.fields.find((f) => f.name === 'Address');
+      if (!addressField) throw new Error('Address field not found');
+
+      addressField.type = Types.String;
+      addressField.originalField = {
+        name: addressField.name,
+        namespaceURI: addressField.namespaceURI,
+        namespacePrefix: addressField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/RESTRICT', 'BaseAddress'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:SimpleAddress', namespaceMap, addressField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -443,12 +505,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const requestField = doc.fields.find((f) => f.name === 'Request');
       if (!requestField) throw new Error('Request field not found');
 
-      requestField.originalType = Types.Container;
-      requestField.originalTypeQName = new QName('http://www.example.com/TEST', 'UnrelatedType');
+      requestField.type = Types.Container;
+      requestField.typeQName = new QName('http://www.example.com/TEST', 'UnrelatedType');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.FORCE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining FORCE incompatible variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'extension.xsd': getExtensionComplexXsd() },
+      );
+      const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(extensionResult.validationStatus).toBe('success');
+      const doc = extensionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
+
+      const requestField = doc.fields.find((f) => f.name === 'Request');
+      if (!requestField) throw new Error('Request field not found');
+
+      requestField.type = Types.String;
+      requestField.originalField = {
+        name: requestField.name,
+        namespaceURI: requestField.namespaceURI,
+        namespacePrefix: requestField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/TEST', 'UnrelatedType'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.FORCE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -467,8 +560,8 @@ describe('XmlSchemaDocumentUtilService', () => {
       const extendedValueField = doc.fields.find((f) => f.name === 'ExtendedValue');
       if (!extendedValueField) throw new Error('ExtendedValue field not found');
 
-      extendedValueField.originalType = Types.Container;
-      extendedValueField.originalTypeQName = new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType');
+      extendedValueField.type = Types.Container;
+      extendedValueField.typeQName = new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride(
         'ns0:ComplexExtendingSimple',
@@ -476,7 +569,42 @@ describe('XmlSchemaDocumentUtilService', () => {
         extendedValueField,
       );
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE derived simple type variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'simple.xsd': getSimpleTypeInheritanceXsd() },
+      );
+      const simpleInheritResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(simpleInheritResult.validationStatus).toBe('success');
+      const doc = simpleInheritResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/SIMPLEINHERIT', xs: NS_XML_SCHEMA };
+
+      const extendedValueField = doc.fields.find((f) => f.name === 'ExtendedValue');
+      if (!extendedValueField) throw new Error('ExtendedValue field not found');
+
+      extendedValueField.type = Types.String;
+      extendedValueField.originalField = {
+        name: extendedValueField.name,
+        namespaceURI: extendedValueField.namespaceURI,
+        namespacePrefix: extendedValueField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride(
+        'ns0:ComplexExtendingSimple',
+        namespaceMap,
+        extendedValueField,
+      );
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -495,12 +623,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const ageField = doc.fields.find((f) => f.name === 'Age');
       if (!ageField) throw new Error('Age field not found');
 
-      ageField.originalType = Types.Container;
-      ageField.originalTypeQName = new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger');
+      ageField.type = Types.Container;
+      ageField.typeQName = new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:AgeType', namespaceMap, ageField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE simple restriction variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'simple.xsd': getSimpleTypeRestrictionXsd() },
+      );
+      const simpleRestrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(simpleRestrictionResult.validationStatus).toBe('success');
+      const doc = simpleRestrictionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/SIMPLETYPE', xs: NS_XML_SCHEMA };
+
+      const ageField = doc.fields.find((f) => f.name === 'Age');
+      if (!ageField) throw new Error('Age field not found');
+
+      ageField.type = Types.String;
+      ageField.originalField = {
+        name: ageField.name,
+        namespaceURI: ageField.namespaceURI,
+        namespacePrefix: ageField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:AgeType', namespaceMap, ageField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
   });

--- a/packages/ui/src/services/xml-schema-document.model.ts
+++ b/packages/ui/src/services/xml-schema-document.model.ts
@@ -82,8 +82,6 @@ export class XmlSchemaField extends BaseField {
     const adopted = new XmlSchemaField(parent, this.name, this.isAttribute);
     adopted.type = this.type;
     adopted.typeQName = this.typeQName;
-    adopted.originalType = this.originalType;
-    adopted.originalTypeQName = this.originalTypeQName;
     adopted.typeOverride = this.typeOverride;
     adopted.minOccurs = this.minOccurs;
     adopted.maxOccurs = this.maxOccurs;

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -4,7 +4,8 @@ import {
   DocumentDefinitionType,
   DocumentType,
 } from '../models/datamapper/document';
-import { Types } from '../models/datamapper/types';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import {
   getAnonymousGlobalElementRefLargeXsd,
   getCamelSpringXsd,
@@ -1116,8 +1117,6 @@ describe('XmlSchemaDocumentService', () => {
         'test-doc',
         { 'main.xsd': mainSchema },
         undefined,
-        undefined,
-        undefined,
         { ns0: 'http://example.com/main' },
       );
 
@@ -1219,8 +1218,6 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         { 'main.xsd': mainSchema },
-        undefined,
-        undefined,
         undefined,
         { ns0: 'http://example.com/main' },
       );
@@ -1512,6 +1509,34 @@ describe('XmlSchemaDocumentService', () => {
         name: 'ShipOrder',
       });
     });
+
+    it('should clear fieldTypeOverrides, choiceSelections and fieldSubstitutions when rootElementChoice file is removed', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'shipOrder.xsd': getShipOrderXsd(), 'element-ref.xsd': getElementRefXsd() },
+        { namespaceUri: 'io.kaoto.datamapper.poc.test', name: 'ShipOrder' },
+      );
+      definition.fieldTypeOverrides = [
+        { schemaPath: '/old/path', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+      ];
+      definition.choiceSelections = [{ schemaPath: '/old/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old/path',
+        name: 'ns0:newName',
+        originalName: 'ns0:oldName',
+      };
+      definition.fieldSubstitutions = [substitution];
+
+      const removeResult = XmlSchemaDocumentService.removeSchemaFile(definition, 'shipOrder.xsd');
+
+      expect(removeResult.validationStatus).not.toBe('error');
+      expect(removeResult.document).toBeDefined();
+      expect(removeResult.documentDefinition!.fieldTypeOverrides).toEqual([]);
+      expect(removeResult.documentDefinition!.choiceSelections).toEqual([]);
+      expect(removeResult.documentDefinition!.fieldSubstitutions).toEqual([]);
+    });
   });
 
   it('should load attribute with inline simple type without crashing', () => {
@@ -1564,6 +1589,5 @@ describe('XmlSchemaDocumentService', () => {
     const typeA01Field = bigContainerFragment.fields.find((f) => f.name === 'TypeA01');
     expect(typeA01Field).toBeDefined();
     expect(typeA01Field!.type).toEqual(Types.Container);
-    expect(typeA01Field!.originalType).toEqual(Types.Container);
   });
 });

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -194,9 +194,10 @@ export class XmlSchemaDocumentService {
       definition.name,
       updatedFiles,
       definition.rootElementChoice,
+      definition.namespaceMap,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
-      definition.namespaceMap,
+      definition.fieldSubstitutions,
     );
 
     // Try to create the Document object. It could fail if the root element user chose was defined in the removed
@@ -210,6 +211,9 @@ export class XmlSchemaDocumentService {
 
     // Unset the root element and retry
     updatedDefinition.rootElementChoice = undefined;
+    updatedDefinition.fieldTypeOverrides = [];
+    updatedDefinition.choiceSelections = [];
+    updatedDefinition.fieldSubstitutions = [];
     return XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition);
   }
 
@@ -298,6 +302,7 @@ export class XmlSchemaDocumentService {
 
     document.definition.fieldTypeOverrides = [];
     document.definition.choiceSelections = [];
+    document.definition.fieldSubstitutions = [];
 
     const newDocument = new XmlSchemaDocument(document.definition, document.xmlSchemaCollection, newRootElement);
 
@@ -451,7 +456,6 @@ export class XmlSchemaDocumentService {
     }
 
     field.type = Types.Container;
-    field.originalType = Types.Container;
     field.namedTypeFragmentRefs.push(fragmentKey);
   }
 
@@ -465,12 +469,10 @@ export class XmlSchemaDocumentService {
       const newType = XmlSchemaDocumentUtilService.getFieldTypeFromName(schemaType.getName());
       if (!field.type || field.type === Types.AnyType) {
         field.type = newType;
-        field.originalType = newType;
       }
       const simpleTypeQName = schemaType.getQName();
       if (simpleTypeQName) {
         field.typeQName = simpleTypeQName;
-        field.originalTypeQName = simpleTypeQName;
       }
       return;
     } else if (!(schemaType instanceof XmlSchemaComplexType)) {
@@ -478,11 +480,9 @@ export class XmlSchemaDocumentService {
     }
 
     field.type = Types.Container;
-    field.originalType = Types.Container;
     const typeQName = schemaType.getQName();
     if (typeQName) {
       field.typeQName = typeQName;
-      field.originalTypeQName = typeQName;
       const namespace = typeQName.getNamespaceURI();
       if (!XmlSchemaDocumentUtilService.isStandardXmlNamespace(namespace)) {
         if (!field.namedTypeFragmentRefs.includes(typeQName.toString())) {
@@ -536,7 +536,6 @@ export class XmlSchemaDocumentService {
     field.defaultValue = attr.getDefaultValue() || attr.getFixedValue();
     const attrTypeName = attr.getSchemaTypeName()?.getLocalPart();
     field.type = (attrTypeName ? Types[capitalize(attrTypeName) as keyof typeof Types] : null) || Types.AnyType;
-    field.originalType = field.type;
     fields.push(field);
 
     ownerDoc.totalFieldCount++;
@@ -544,7 +543,6 @@ export class XmlSchemaDocumentService {
     const attrSchemaTypeQName = attr.getSchemaTypeName();
     if (attrSchemaTypeQName) {
       field.typeQName = attrSchemaTypeQName;
-      field.originalTypeQName = attrSchemaTypeQName;
     }
     const userDefinedAttrType =
       attrSchemaTypeQName &&

--- a/packages/ui/src/services/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/xml-schema-types.service.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeDerivation, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, TypeDerivation, Types } from '../models/datamapper/types';
 import {
   getExtensionComplexXsd,
   getRestrictionComplexXsd,
@@ -44,24 +44,24 @@ describe('XmlSchemaTypesService', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!field) throw new Error('Field not found');
-      field.originalType = Types.AnyType;
+      field.type = Types.AnyType;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const result = XmlSchemaTypesService.parseTypeOverride('xs:string', namespaceMap, field);
 
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should determine FORCE variant for incompatible type change', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!field) throw new Error('Field not found');
-      field.originalType = Types.String;
+      field.type = Types.String;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const result = XmlSchemaTypesService.parseTypeOverride('xs:int', namespaceMap, field);
 
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 
@@ -414,9 +414,8 @@ describe('XmlSchemaTypesService', () => {
       const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
 
       const messageQName = new QName('http://www.example.com/TEST', 'Message');
-      const field = {
-        originalTypeQName: messageQName,
-      };
+      const field = new XmlSchemaField(doc, 'testField', false);
+      field.typeQName = messageQName;
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
         field,
@@ -428,12 +427,13 @@ describe('XmlSchemaTypesService', () => {
       expect(Object.values(candidates).some((c) => c.displayName === 'BaseRequest')).toBe(true);
     });
 
-    it('should return empty when field has no originalTypeQName', () => {
+    it('should return empty when field has no typeQName', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const namespaceMap = { xs: NS_XML_SCHEMA };
+      const field = new XmlSchemaField(doc, 'emptyField', false);
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
-        {},
+        field,
         doc.xmlSchemaCollection,
         namespaceMap,
       );
@@ -441,12 +441,14 @@ describe('XmlSchemaTypesService', () => {
       expect(candidates).toEqual({});
     });
 
-    it('should return empty when originalTypeQName resolves to no type', () => {
+    it('should return empty when typeQName resolves to no type', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const namespaceMap = { xs: NS_XML_SCHEMA };
+      const field = new XmlSchemaField(doc, 'fakeField', false);
+      field.typeQName = new QName('http://nonexistent.com', 'Fake');
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
-        { originalTypeQName: new QName('http://nonexistent.com', 'Fake') },
+        field,
         doc.xmlSchemaCollection,
         namespaceMap,
       );
@@ -461,7 +463,7 @@ describe('XmlSchemaTypesService', () => {
         new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'json-doc'),
       );
       const field = new JsonSchemaField(jsonDoc, 'testField', Types.Container);
-      field.originalType = Types.Container;
+      field.type = Types.Container;
 
       const result = XmlSchemaTypesService.isCompatibleContainerTypeOverride(
         field,
@@ -486,8 +488,8 @@ describe('XmlSchemaTypesService', () => {
       const doc = result.document as XmlSchemaDocument;
 
       const field = new XmlSchemaField(doc, 'testField', false);
-      field.originalType = Types.Container;
-      field.originalTypeQName = new QName('http://www.example.com/TEST', 'Message');
+      field.type = Types.Container;
+      field.typeQName = new QName('http://www.example.com/TEST', 'Message');
 
       const isCompatible = XmlSchemaTypesService.isCompatibleContainerTypeOverride(
         field,
@@ -724,8 +726,8 @@ describe('XmlSchemaTypesService', () => {
       const baseRequestQName = new QName('http://www.example.com/TEST', 'BaseRequest');
 
       const field = new XmlSchemaField(doc, 'testField', false);
-      field.originalType = Types.Container;
-      field.originalTypeQName = messageQName;
+      field.type = Types.Container;
+      field.typeQName = messageQName;
 
       const variant = XmlSchemaTypesService.determineOverrideVariant(
         field,
@@ -734,7 +736,7 @@ describe('XmlSchemaTypesService', () => {
         'http://www.example.com/TEST',
       );
 
-      expect(variant).toBe(TypeOverrideVariant.SAFE);
+      expect(variant).toBe(FieldOverrideVariant.SAFE);
     });
   });
 });

--- a/packages/ui/src/services/xml-schema-types.service.ts
+++ b/packages/ui/src/services/xml-schema-types.service.ts
@@ -1,6 +1,6 @@
 import { IField } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { IFieldTypeInfo, TypeDerivation, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, TypeDerivation, Types } from '../models/datamapper/types';
 import { capitalize } from '../serializers/xml/utils/xml-utils';
 import {
   XmlSchemaCollection,
@@ -43,14 +43,14 @@ export class XmlSchemaTypesService {
    * @example
    * ```typescript
    * const result = XmlSchemaTypesService.parseTypeOverride('xs:int', namespaceMap, field);
-   * // result = { type: Types.Integer, typeQName: QName, variant: TypeOverrideVariant.SAFE }
+   * // result = { type: Types.Integer, typeQName: QName, variant: FieldOverrideVariant.SAFE }
    * ```
    */
   static parseTypeOverride(
     typeString: string,
     namespaceMap: Record<string, string>,
     field: IField,
-  ): { type: Types; typeQName: QName; variant: TypeOverrideVariant } {
+  ): { type: Types; typeQName: QName; variant: FieldOverrideVariant } {
     const parts = typeString.split(':');
     const prefix = parts.length > 1 ? parts[0] : '';
     const localPart = parts.length > 1 ? parts[1] : parts[0];
@@ -85,16 +85,16 @@ export class XmlSchemaTypesService {
     newType: Types,
     newTypeQName: QName,
     newNamespaceURI: string,
-  ): TypeOverrideVariant {
-    if (field.originalType === Types.AnyType) {
-      return TypeOverrideVariant.SAFE;
+  ): FieldOverrideVariant {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
+      return FieldOverrideVariant.SAFE;
     }
 
     if (XmlSchemaTypesService.isCompatibleContainerTypeOverride(field, newType, newTypeQName, newNamespaceURI)) {
-      return TypeOverrideVariant.SAFE;
+      return FieldOverrideVariant.SAFE;
     }
 
-    return TypeOverrideVariant.FORCE;
+    return FieldOverrideVariant.FORCE;
   }
 
   /**
@@ -116,8 +116,9 @@ export class XmlSchemaTypesService {
     newNamespaceURI: string,
   ): boolean {
     const isBuiltInType = newNamespaceURI === NS_XML_SCHEMA;
+    const origType = field.originalField?.type ?? field.type;
 
-    if (field.originalType !== Types.Container || newType !== Types.Container || isBuiltInType) {
+    if (origType !== Types.Container || newType !== Types.Container || isBuiltInType) {
       return false;
     }
 
@@ -128,8 +129,8 @@ export class XmlSchemaTypesService {
 
     const xmlDoc = ownerDoc as XmlSchemaDocument;
     const newSchemaType = xmlDoc.xmlSchemaCollection.getTypeByQName(newTypeQName);
-    const originalSchemaType =
-      field.originalTypeQName && xmlDoc.xmlSchemaCollection.getTypeByQName(field.originalTypeQName);
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const originalSchemaType = origTypeQName && xmlDoc.xmlSchemaCollection.getTypeByQName(origTypeQName);
 
     if (!newSchemaType || !originalSchemaType) {
       return false;
@@ -678,15 +679,16 @@ export class XmlSchemaTypesService {
    * ```
    */
   static getTypeOverrideCandidatesForField(
-    field: { originalTypeQName?: unknown },
+    field: IField,
     collection: XmlSchemaCollection,
     namespaceMap: Record<string, string>,
   ): Record<string, IFieldTypeInfo> {
-    if (!field.originalTypeQName) {
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    if (!origTypeQName) {
       return {};
     }
 
-    const baseType = collection.getTypeByQName(field.originalTypeQName as QName);
+    const baseType = collection.getTypeByQName(origTypeQName);
     if (!baseType) {
       return {};
     }


### PR DESCRIPTION
[WIP] This one possibly need some adjustment after https://github.com/KaotoIO/kaoto/pull/2962 is merged.

Fixes: https://github.com/KaotoIO/kaoto/issues/2989

The core design change is replacing the eagerly-populated `originalType`/`originalTypeQName` fields on `IField` with a lazily-captured `originalField?: IOriginalFieldState` snapshot. Previously, every field carried redundant copies of its own type set at document-parse time; now the snapshot is taken only on first expansion (`resolveTypeFragment`) or just before the first override is applied, and cleared when the override is reverted. This eliminates build-time data duplication and makes the snapshot a true runtime record of pre-override state.

Alongside this:
 - `SUBSTITUTION` variant added to `FieldOverrideVariant` (renamed from `TypeOverrideVariant` for accuracy)
 - `IFieldSubstitution` metadata interface introduced and plumbed through `IDocumentMetadata` / `DocumentDefinition`

Fixes: https://github.com/KaotoIO/kaoto/issues/2995

- By capturing original field snapshot to `originalField: IOriginalFieldState` on `IFleld`, `restoreOriginalTypeToField` restores both `fields[]` and `namedTypeFragmentRef` when Field Override is reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved override system to capture a field's original snapshot so edits and reverts restore prior field state more reliably.

* **New Features**
  * Document definitions now accept explicit namespace mappings and programmable field substitutions.
  * Added a new override variant to represent substitution cases.

* **Bug Fixes**
  * Removing or updating schema files now reliably clears related type overrides, choice selections, and field substitutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->