### PR TITLE
feat(ExpansionPanel): Fire all callbacks when a panel resizes

### DIFF
--- a/packages/ui/src/components/ExpansionPanels/ExpansionContext.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionContext.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen } from '@testing-library/react';
+import { useContext } from 'react';
+
+import { ExpansionContext } from './ExpansionContext';
+
+describe('ExpansionContext', () => {
+  describe('Default Implementation', () => {
+    it('should provide a default context value', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        return <div data-testid="test">{context ? 'Context exists' : 'No context'}</div>;
+      };
+
+      render(<TestComponent />);
+
+      expect(screen.getByTestId('test')).toHaveTextContent('Context exists');
+    });
+
+    it('should have register method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        const mockElement = document.createElement('div');
+
+        // Should not throw
+        expect(() => {
+          context.register('test-id', 100, 200, mockElement, true);
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have unregister method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+
+        // Should not throw
+        expect(() => {
+          context.unregister('test-id');
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have resize method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+
+        // Should not throw
+        expect(() => {
+          context.resize('test-id', 300);
+        }).not.toThrow();
+
+        // Should not throw with optional isTopHandle parameter
+        expect(() => {
+          context.resize('test-id', 300, true);
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have setExpanded method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+
+        // Should not throw
+        expect(() => {
+          context.setExpanded('test-id', true);
+        }).not.toThrow();
+
+        expect(() => {
+          context.setExpanded('test-id', false);
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have queueLayoutChange method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        const mockCallback = jest.fn();
+
+        // Should not throw
+        expect(() => {
+          context.queueLayoutChange(mockCallback);
+        }).not.toThrow();
+
+        // Callback should not be called by default implementation
+        expect(mockCallback).not.toHaveBeenCalled();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have registerLayoutCallback method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        const mockCallback = jest.fn();
+
+        // Should not throw
+        expect(() => {
+          context.registerLayoutCallback('test-id', mockCallback);
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should have unregisterLayoutCallback method that does nothing by default', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+
+        // Should not throw
+        expect(() => {
+          context.unregisterLayoutCallback('test-id');
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+
+    it('should allow multiple method calls without errors', () => {
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        const mockElement = document.createElement('div');
+        const mockCallback = jest.fn();
+
+        // Should not throw when calling multiple methods in sequence
+        expect(() => {
+          context.register('panel-1', 100, 200, mockElement, true);
+          context.setExpanded('panel-1', false);
+          context.resize('panel-1', 150);
+          context.registerLayoutCallback('panel-1', mockCallback);
+          context.queueLayoutChange(mockCallback);
+          context.unregisterLayoutCallback('panel-1');
+          context.unregister('panel-1');
+        }).not.toThrow();
+
+        return <div>Test</div>;
+      };
+
+      render(<TestComponent />);
+    });
+  });
+
+  describe('Context Provider Override', () => {
+    it('should allow custom context values to override defaults', () => {
+      const mockRegister = jest.fn();
+      const mockUnregister = jest.fn();
+      const mockResize = jest.fn();
+      const mockSetExpanded = jest.fn();
+      const mockQueueLayoutChange = jest.fn();
+      const mockRegisterLayoutCallback = jest.fn();
+      const mockUnregisterLayoutCallback = jest.fn();
+
+      const customContextValue = {
+        register: mockRegister,
+        unregister: mockUnregister,
+        resize: mockResize,
+        setExpanded: mockSetExpanded,
+        queueLayoutChange: mockQueueLayoutChange,
+        registerLayoutCallback: mockRegisterLayoutCallback,
+        unregisterLayoutCallback: mockUnregisterLayoutCallback,
+      };
+
+      const TestComponent = () => {
+        const context = useContext(ExpansionContext);
+        const mockElement = document.createElement('div');
+        const mockCallback = jest.fn();
+
+        context.register('test-id', 100, 200, mockElement, true);
+        context.unregister('test-id');
+        context.resize('test-id', 300);
+        context.setExpanded('test-id', true);
+        context.queueLayoutChange(mockCallback);
+        context.registerLayoutCallback('test-id', mockCallback);
+        context.unregisterLayoutCallback('test-id');
+
+        return <div>Test</div>;
+      };
+
+      render(
+        <ExpansionContext.Provider value={customContextValue}>
+          <TestComponent />
+        </ExpansionContext.Provider>,
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-id', 100, 200, expect.any(HTMLDivElement), true);
+      expect(mockUnregister).toHaveBeenCalledWith('test-id');
+      expect(mockResize).toHaveBeenCalledWith('test-id', 300);
+      expect(mockSetExpanded).toHaveBeenCalledWith('test-id', true);
+      expect(mockQueueLayoutChange).toHaveBeenCalledWith(expect.any(Function));
+      expect(mockRegisterLayoutCallback).toHaveBeenCalledWith('test-id', expect.any(Function));
+      expect(mockUnregisterLayoutCallback).toHaveBeenCalledWith('test-id');
+    });
+  });
+});

--- a/packages/ui/src/components/ExpansionPanels/ExpansionContext.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionContext.tsx
@@ -22,6 +22,8 @@ interface ExpansionContextValue {
   resize: (id: string, newHeight: number, isTopHandle?: boolean) => void;
   setExpanded: (id: string, isExpanded: boolean) => void;
   queueLayoutChange: (callback: () => void) => void;
+  registerLayoutCallback: (id: string, callback: () => void) => void;
+  unregisterLayoutCallback: (id: string) => void;
 }
 
 export const ExpansionContext = createContext<ExpansionContextValue>({
@@ -30,4 +32,6 @@ export const ExpansionContext = createContext<ExpansionContextValue>({
   resize: () => {},
   setExpanded: () => {},
   queueLayoutChange: () => {},
+  registerLayoutCallback: () => {},
+  unregisterLayoutCallback: () => {},
 });

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -9,6 +9,8 @@ describe('ExpansionPanel', () => {
   let mockResize: jest.Mock;
   let mockSetExpanded: jest.Mock;
   let mockQueueLayoutChange: jest.Mock;
+  let mockRegisterLayoutCallback: jest.Mock;
+  let mockUnregisterLayoutCallback: jest.Mock;
 
   beforeEach(() => {
     mockRegister = jest.fn();
@@ -16,6 +18,8 @@ describe('ExpansionPanel', () => {
     mockResize = jest.fn();
     mockSetExpanded = jest.fn();
     mockQueueLayoutChange = jest.fn();
+    mockRegisterLayoutCallback = jest.fn();
+    mockUnregisterLayoutCallback = jest.fn();
   });
 
   const renderPanel = (props: Partial<React.ComponentProps<typeof ExpansionPanel>> = {}) => {
@@ -33,6 +37,8 @@ describe('ExpansionPanel', () => {
           resize: mockResize,
           setExpanded: mockSetExpanded,
           queueLayoutChange: mockQueueLayoutChange,
+          registerLayoutCallback: mockRegisterLayoutCallback,
+          unregisterLayoutCallback: mockUnregisterLayoutCallback,
         }}
       >
         <ExpansionPanel {...defaultProps} {...props} />
@@ -70,6 +76,8 @@ describe('ExpansionPanel', () => {
         resize: mockResize,
         setExpanded: mockSetExpanded,
         queueLayoutChange: mockQueueLayoutChange,
+        registerLayoutCallback: mockRegisterLayoutCallback,
+        unregisterLayoutCallback: mockUnregisterLayoutCallback,
       };
 
       const { rerender } = render(
@@ -207,6 +215,8 @@ describe('ExpansionPanel', () => {
             resize: mockResize,
             setExpanded: mockSetExpanded,
             queueLayoutChange: mockQueueLayoutChange,
+            registerLayoutCallback: mockRegisterLayoutCallback,
+            unregisterLayoutCallback: mockUnregisterLayoutCallback,
           }}
         >
           <ExpansionPanel id="test-panel" summary={<div>Test Summary</div>} defaultExpanded={true}>
@@ -423,6 +433,33 @@ describe('ExpansionPanel', () => {
       expect(panel).toHaveClass('expansion-panel');
       expect(panel).toHaveAttribute('data-expanded', 'true');
       expect(panel).toHaveAttribute('data-resizing', 'false');
+    });
+  });
+
+  describe('Layout Callback Registration', () => {
+    it('should register layout callback when onLayoutChange is provided', () => {
+      const onLayoutChange = jest.fn();
+      renderPanel({ id: 'test-panel', onLayoutChange });
+
+      // Should register the callback
+      expect(mockRegisterLayoutCallback).toHaveBeenCalledWith('test-panel', expect.any(Function));
+    });
+
+    it('should unregister layout callback on unmount when onLayoutChange was provided', () => {
+      const onLayoutChange = jest.fn();
+      const { unmount } = renderPanel({ id: 'test-panel', onLayoutChange });
+
+      unmount();
+
+      // Should unregister the callback
+      expect(mockUnregisterLayoutCallback).toHaveBeenCalledWith('test-panel');
+    });
+
+    it('should NOT register layout callback when onLayoutChange is not provided', () => {
+      renderPanel({ id: 'test-panel' });
+
+      // Should not register callback when no onLayoutChange provided
+      expect(mockRegisterLayoutCallback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -192,6 +192,19 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
   // CRITICAL: Only id and context in deps - minHeight, defaultHeight, defaultExpanded excluded
   // to prevent infinite unregister/register loops that reset panel state
 
+  // Register layout callback to receive broadcasts when any panel's layout changes
+  useEffect(() => {
+    if (onLayoutChange) {
+      context.registerLayoutCallback(id, () => onLayoutChange(id));
+    }
+
+    return () => {
+      if (onLayoutChange) {
+        context.unregisterLayoutCallback(id);
+      }
+    };
+  }, [id, context, onLayoutChange]);
+
   useEffect(() => {
     return () => {
       document.removeEventListener('mousemove', stableMouseMoveHandler);

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
@@ -30,6 +30,9 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
   // Track pending layout change callbacks - executed after CSS transition completes
   const layoutChangeQueueRef = useRef<Array<() => void>>([]);
 
+  // Track registered layout callbacks per panel - used to broadcast updates to all panels
+  const panelCallbacksRef = useRef<Map<string, () => void>>(new Map());
+
   /**
    * Update panel orders based on actual DOM order
    * This ensures grid template matches visual panel positions,
@@ -59,6 +62,16 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
     });
   }, [firstPanelId, lastPanelId]); // Only depends on panel ID props (stable)
 
+  /**
+   * Queue all registered panel callbacks
+   * Called whenever grid layout changes to notify all panels to update their connection ports
+   */
+  const queueAllLayoutCallbacks = useCallback(() => {
+    panelCallbacksRef.current.forEach((callback) => {
+      layoutChangeQueueRef.current.push(callback);
+    });
+  }, []);
+
   const updateGridTemplate = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -77,7 +90,11 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
 
     const template = templateParts.join(' ');
     container.style.setProperty('--grid-template', template);
-  }, []);
+
+    // Queue all panel callbacks so every panel can update its connection ports
+    // This is critical for virtual scroll scenarios where grid changes affect all panels
+    queueAllLayoutCallbacks();
+  }, [queueAllLayoutCallbacks]);
 
   /**
    * Fit panels to container height using proportional resize
@@ -371,9 +388,32 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
     layoutChangeQueueRef.current.push(callback);
   }, []);
 
+  /**
+   * Register a panel's layout callback
+   * The callback will be invoked whenever any panel's layout changes
+   */
+  const registerLayoutCallback = useCallback((id: string, callback: () => void) => {
+    panelCallbacksRef.current.set(id, callback);
+  }, []);
+
+  /**
+   * Unregister a panel's layout callback
+   */
+  const unregisterLayoutCallback = useCallback((id: string) => {
+    panelCallbacksRef.current.delete(id);
+  }, []);
+
   const value = useMemo(
-    () => ({ register, unregister, resize, setExpanded, queueLayoutChange }),
-    [register, unregister, resize, setExpanded, queueLayoutChange],
+    () => ({
+      register,
+      unregister,
+      resize,
+      setExpanded,
+      queueLayoutChange,
+      registerLayoutCallback,
+      unregisterLayoutCallback,
+    }),
+    [register, unregister, resize, setExpanded, queueLayoutChange, registerLayoutCallback, unregisterLayoutCallback],
   );
 
   // Update panel orders whenever children change


### PR DESCRIPTION
### Context
Currently, when expanding or collapsing a `ExpansionPanel`, only the callbacks from the panel being interacted with are being triggered. This is problematic for the Datamapper since we need to recalculate the mapping lines when the panels move.

relates: https://github.com/KaotoIO/kaoto/issues/2396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites validating layout callback registration and context behavior.

* **New Features**
  * Introduced layout callback registration and unregistration mechanisms for panels to notify state changes to parent components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->