### PR TITLE
fix(Datamapper): Stop infinite rerender

### DIFF
--- a/packages/ui/src/providers/datamapper-canvas.provider.tsx
+++ b/packages/ui/src/providers/datamapper-canvas.provider.tsx
@@ -57,9 +57,9 @@ export const DataMapperCanvasProvider: FunctionComponent<PropsWithChildren> = (p
   );
 
   const reloadNodeReferences = useCallback(() => {
-    setNodeReferenceMap(new Map(nodeReferenceMap));
+    setNodeReferenceMap((prevMap) => new Map(prevMap));
     setNodeReferenceVersion((v) => v + 1);
-  }, [nodeReferenceMap]);
+  }, []);
 
   useEffect(() => {
     if (mappingTree) reloadNodeReferences();


### PR DESCRIPTION
### Context
Currently, there's an infinite rerender in the Datamapper due to a `useState()` call inside of a `useCallback()` depending on the variable being updated.

```typescript
  const reloadNodeReferences = useCallback(() => {
    setNodeReferenceMap(new Map(nodeReferenceMap));
    setNodeReferenceVersion((v) => v + 1);
  }, [nodeReferenceMap]);
```

https://github.com/user-attachments/assets/690e85d5-527f-4e78-9d25-b2715eef2c7e

### Changes
As a temporary fix, we're moving to a function signature for the `useState` call. The reason why this is temporary is because #2954 removes the `DataMapperCanvasProvider` entirely, fixing the issue from the root.

relates: https://github.com/KaotoIO/kaoto/issues/2396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal state management performance for the data mapper canvas component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->