### PR TITLE
chore(DataMapper stubs): Load test files only when it's used

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -5,7 +5,7 @@ import { DocumentDefinitionType } from '../../models/datamapper/document';
 import { IDataMapperMetadata } from '../../models/datamapper/metadata';
 import { IMetadataApi, MetadataProvider } from '../../providers';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
-import { shipOrderToShipOrderXslt, shipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { getShipOrderToShipOrderXslt, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { DataMapper } from './DataMapper';
 
 describe('DataMapperPage', () => {
@@ -51,7 +51,7 @@ describe('DataMapperPage', () => {
   });
 
   it('should render initial XSLT mappings', async () => {
-    fileContents[metadata.xsltPath] = shipOrderToShipOrderXslt;
+    fileContents[metadata.xsltPath] = getShipOrderToShipOrderXslt();
     render(
       <MetadataProvider api={api}>
         <DataMapper vizNode={vizNode} />
@@ -62,7 +62,7 @@ describe('DataMapperPage', () => {
   });
 
   it('should render initial XSLT mappings with initial documents', async () => {
-    fileContents['ShipOrder.xsd'] = shipOrderXsd;
+    fileContents['ShipOrder.xsd'] = getShipOrderXsd();
     metadata.sourceBody = {
       filePath: ['ShipOrder.xsd'],
       type: DocumentDefinitionType.XML_SCHEMA,

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -10,7 +10,7 @@ import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../../providers/datamapper-canvas.provider';
 import { MappingLinksService } from '../../../services/mapping-links.service';
 import { MappingSerializerService } from '../../../services/mapping-serializer.service';
-import { shipOrderToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { getShipOrderToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { DebugLayout } from './DebugLayout';
 
 describe('DebugLayout', () => {
@@ -36,7 +36,7 @@ describe('DebugLayout', () => {
         setSourceBodyDocument(sourceDoc);
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
-        MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, mappingTree, sourceParameterMap);
+        MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
         setMappingTree(mappingTree);
         reloadNodeReferences();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -80,7 +80,7 @@ describe('DebugLayout', () => {
         setSourceBodyDocument(sourceDoc);
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
-        MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, mappingTree, sourceParameterMap);
+        MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
         setMappingTree(mappingTree);
         reloadNodeReferences();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,7 +156,7 @@ describe('DebugLayout', () => {
       act(() => {
         fireEvent.click(importButton);
       });
-      const fileContent = new File([new Blob([shipOrderToShipOrderXslt])], 'ShipOrderToShipOrder.xsl', {
+      const fileContent = new File([new Blob([getShipOrderToShipOrderXslt()])], 'ShipOrderToShipOrder.xsl', {
         type: 'text/plain',
       });
       const fileInput = screen.getByTestId('dm-debug-import-mappings-file-input');
@@ -204,7 +204,12 @@ describe('DebugLayout', () => {
           setSourceBodyDocument(sourceDoc);
           const targetDoc = TestUtil.createTargetOrderDoc();
           setTargetBodyDocument(targetDoc);
-          MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, mappingTree, sourceParameterMap);
+          MappingSerializerService.deserialize(
+            getShipOrderToShipOrderXslt(),
+            targetDoc,
+            mappingTree,
+            sourceParameterMap,
+          );
           setMappingTree(mappingTree);
           reloadNodeReferences();
           // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
 import { BrowserFilePickerMetadataProvider } from '../../stubs/BrowserFilePickerMetadataProvider';
-import { shipOrderJsonSchema, shipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { getShipOrderJsonSchema, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { ExpansionPanels } from '../ExpansionPanels/ExpansionPanels';
 import { ParametersSection } from './Parameters';
 
@@ -157,7 +157,7 @@ describe('ParametersSection', () => {
       fireEvent.click(importButton);
     });
 
-    const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
     const fileInput = screen.getByTestId('attach-schema-file-input');
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
@@ -225,7 +225,7 @@ describe('ParametersSection', () => {
       fireEvent.click(importButton);
     });
 
-    const fileContent = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
     const fileInput = screen.getByTestId('attach-schema-file-input');
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -16,14 +16,14 @@ import { DataMapperCanvasProvider } from '../../../../providers/datamapper-canva
 import { DocumentService } from '../../../../services/document.service';
 import { BrowserFilePickerMetadataProvider } from '../../../../stubs/BrowserFilePickerMetadataProvider';
 import {
-  multiIncludeComponentAXsd,
-  multiIncludeMainXsd,
-  multipleElementsXsd,
-  noTopElementXsd,
-  shipOrderEmptyFirstLineXsd,
-  shipOrderJsonSchema,
-  shipOrderJsonXslt,
-  shipOrderXsd,
+  getMultiIncludeComponentAXsd,
+  getMultiIncludeMainXsd,
+  getMultipleElementsXsd,
+  getNoTopElementXsd,
+  getShipOrderEmptyFirstLineXsd,
+  getShipOrderJsonSchema,
+  getShipOrderJsonXslt,
+  getShipOrderXsd,
 } from '../../../../stubs/datamapper/data-mapper';
 import { readFileAsString } from '../../../../stubs/read-file-as-string';
 import { AttachSchemaModal } from './AttachSchemaModal';
@@ -37,7 +37,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should import XML schema', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderXsd);
+    mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -62,7 +62,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
@@ -84,7 +84,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should import JSON schema', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderJsonSchema);
+    mockReadFileAsString.mockResolvedValue(getShipOrderJsonSchema());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -109,7 +109,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
@@ -131,7 +131,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should show inline error for invalid schema', async () => {
-    mockReadFileAsString.mockResolvedValue(noTopElementXsd);
+    mockReadFileAsString.mockResolvedValue(getNoTopElementXsd());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -156,7 +156,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([noTopElementXsd])], 'NoTopElement.xsd', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getNoTopElementXsd()])], 'NoTopElement.xsd', { type: 'text/plain' });
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
@@ -169,7 +169,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should show inline error for XML parse error', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderEmptyFirstLineXsd);
+    mockReadFileAsString.mockResolvedValue(getShipOrderEmptyFirstLineXsd());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -194,7 +194,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderEmptyFirstLineXsd])], 'ShipOrderEmptyFirstLine.xsd', {
+    const fileContent = new File([new Blob([getShipOrderEmptyFirstLineXsd()])], 'ShipOrderEmptyFirstLine.xsd', {
       type: 'text/plain',
     });
     act(() => {
@@ -209,7 +209,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should show inline error when attaching JSON schema on the source body', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderJsonSchema);
+    mockReadFileAsString.mockResolvedValue(getShipOrderJsonSchema());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -234,7 +234,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', {
+    const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', {
       type: 'text/plain',
     });
     act(() => {
@@ -252,7 +252,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should show inline error when attaching unknown file to source body', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderJsonXslt);
+    mockReadFileAsString.mockResolvedValue(getShipOrderJsonXslt());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -277,7 +277,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderJsonXslt])], 'ShipOrderJson.xsl', {
+    const fileContent = new File([new Blob([getShipOrderJsonXslt()])], 'ShipOrderJson.xsl', {
       type: 'text/plain',
     });
     act(() => {
@@ -297,7 +297,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should show inline error when attaching unknown file to target body', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderJsonXslt);
+    mockReadFileAsString.mockResolvedValue(getShipOrderJsonXslt());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -322,7 +322,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderJsonXslt])], 'ShipOrderJson.xsl', {
+    const fileContent = new File([new Blob([getShipOrderJsonXslt()])], 'ShipOrderJson.xsl', {
       type: 'text/plain',
     });
     act(() => {
@@ -441,7 +441,7 @@ describe('AttachSchemaModal', () => {
   });
 
   it('should disable radio buttons when files are selected', async () => {
-    mockReadFileAsString.mockResolvedValue(shipOrderXsd);
+    mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
     render(
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
@@ -469,7 +469,7 @@ describe('AttachSchemaModal', () => {
     });
 
     const fileInput = await screen.findByTestId('attach-schema-file-input');
-    const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+    const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
     act(() => {
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
     });
@@ -485,7 +485,7 @@ describe('AttachSchemaModal', () => {
 
   describe('Root Element Selection', () => {
     it('should show root element selector when multiple elements are available', async () => {
-      mockReadFileAsString.mockResolvedValue(multipleElementsXsd);
+      mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -510,7 +510,9 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([multipleElementsXsd])], 'MultipleElements.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getMultipleElementsXsd()])], 'MultipleElements.xsd', {
+        type: 'text/plain',
+      });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -543,7 +545,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should show root element selector for single element schemas with pre-selected option', async () => {
-      mockReadFileAsString.mockResolvedValue(shipOrderXsd);
+      mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -568,7 +570,7 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -597,7 +599,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should allow user to select different root elements', async () => {
-      mockReadFileAsString.mockResolvedValue(multipleElementsXsd);
+      mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -622,7 +624,9 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([multipleElementsXsd])], 'MultipleElements.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getMultipleElementsXsd()])], 'MultipleElements.xsd', {
+        type: 'text/plain',
+      });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -656,7 +660,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should commit schema with selected root element', async () => {
-      mockReadFileAsString.mockResolvedValue(multipleElementsXsd);
+      mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
       let dataMapperContext: ReturnType<typeof useDataMapper>;
 
       const TestComponent = () => {
@@ -690,7 +694,9 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([multipleElementsXsd])], 'MultipleElements.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getMultipleElementsXsd()])], 'MultipleElements.xsd', {
+        type: 'text/plain',
+      });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -728,7 +734,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should not show root element selector for JSON schemas', async () => {
-      mockReadFileAsString.mockResolvedValue(shipOrderJsonSchema);
+      mockReadFileAsString.mockResolvedValue(getShipOrderJsonSchema());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -753,7 +759,7 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -768,7 +774,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should preserve root element selection when removing an unrelated file', async () => {
-      mockReadFileAsString.mockResolvedValue(multipleElementsXsd);
+      mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
 
       render(
         <BrowserFilePickerMetadataProvider>
@@ -794,8 +800,8 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const file1 = new File([new Blob([multipleElementsXsd])], 'MultipleElements.xsd', { type: 'text/plain' });
-      const file2 = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const file1 = new File([new Blob([getMultipleElementsXsd()])], 'MultipleElements.xsd', { type: 'text/plain' });
+      const file2 = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, {
           target: { files: { item: (i: number) => [file1, file2][i], length: 2, 0: file1, 1: file2 } },
@@ -844,7 +850,9 @@ describe('AttachSchemaModal', () => {
 
   describe('File Management', () => {
     it('should remove a single file from the list', async () => {
-      mockReadFileAsString.mockResolvedValueOnce(multiIncludeMainXsd).mockResolvedValueOnce(multiIncludeComponentAXsd);
+      mockReadFileAsString
+        .mockResolvedValueOnce(getMultiIncludeMainXsd())
+        .mockResolvedValueOnce(getMultiIncludeComponentAXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -869,8 +877,8 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const file1 = new File([new Blob([multiIncludeMainXsd])], 'MultiIncludeMain.xsd', { type: 'text/plain' });
-      const file2 = new File([new Blob([multiIncludeComponentAXsd])], 'MultiIncludeComponentA.xsd', {
+      const file1 = new File([new Blob([getMultiIncludeMainXsd()])], 'MultiIncludeMain.xsd', { type: 'text/plain' });
+      const file2 = new File([new Blob([getMultiIncludeComponentAXsd()])], 'MultiIncludeComponentA.xsd', {
         type: 'text/plain',
       });
       act(() => {
@@ -896,7 +904,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should remove all files and reset state', async () => {
-      mockReadFileAsString.mockResolvedValue(shipOrderXsd);
+      mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -921,7 +929,7 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -945,7 +953,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should show error when mixing XML and JSON schema files', async () => {
-      mockReadFileAsString.mockResolvedValueOnce(shipOrderXsd).mockResolvedValueOnce(shipOrderJsonSchema);
+      mockReadFileAsString.mockResolvedValueOnce(getShipOrderXsd()).mockResolvedValueOnce(getShipOrderJsonSchema());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -970,7 +978,7 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const xsdFile = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const xsdFile = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => xsdFile, length: 1, 0: xsdFile } } });
       });
@@ -983,7 +991,7 @@ describe('AttachSchemaModal', () => {
         fireEvent.click(importButton);
       });
 
-      const jsonFile = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', { type: 'text/plain' });
+      const jsonFile = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => jsonFile, length: 1, 0: jsonFile } } });
       });
@@ -996,7 +1004,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should show warning items from schema analysis with missing includes', async () => {
-      mockReadFileAsString.mockResolvedValue(multiIncludeMainXsd);
+      mockReadFileAsString.mockResolvedValue(getMultiIncludeMainXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -1021,7 +1029,9 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([multiIncludeMainXsd])], 'MultiIncludeMain.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getMultiIncludeMainXsd()])], 'MultiIncludeMain.xsd', {
+        type: 'text/plain',
+      });
       act(() => {
         fireEvent.change(fileInput, {
           target: { files: { item: () => fileContent, length: 1, 0: fileContent } },
@@ -1039,7 +1049,7 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should remove the last file and reset state', async () => {
-      mockReadFileAsString.mockResolvedValue(shipOrderXsd);
+      mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -1064,7 +1074,7 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
@@ -1088,7 +1098,9 @@ describe('AttachSchemaModal', () => {
     });
 
     it('should show filter toggles and allow toggling them', async () => {
-      mockReadFileAsString.mockResolvedValueOnce(multiIncludeMainXsd).mockResolvedValueOnce(multiIncludeComponentAXsd);
+      mockReadFileAsString
+        .mockResolvedValueOnce(getMultiIncludeMainXsd())
+        .mockResolvedValueOnce(getMultiIncludeComponentAXsd());
       render(
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
@@ -1113,8 +1125,8 @@ describe('AttachSchemaModal', () => {
       });
 
       const fileInput = await screen.findByTestId('attach-schema-file-input');
-      const file1 = new File([new Blob([multiIncludeMainXsd])], 'MultiIncludeMain.xsd', { type: 'text/plain' });
-      const file2 = new File([new Blob([multiIncludeComponentAXsd])], 'MultiIncludeComponentA.xsd', {
+      const file1 = new File([new Blob([getMultiIncludeMainXsd()])], 'MultiIncludeMain.xsd', { type: 'text/plain' });
+      const file2 = new File([new Blob([getMultiIncludeComponentAXsd()])], 'MultiIncludeComponentA.xsd', {
         type: 'text/plain',
       });
       act(() => {

--- a/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
@@ -6,7 +6,7 @@ import { MappingNodeData, TargetDocumentNodeData } from '../../../models/datamap
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../../providers/datamapper-canvas.provider';
 import { MappingSerializerService } from '../../../services/mapping-serializer.service';
-import { conditionalMappingsToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { getConditionalMappingsToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { DeleteMappingItemAction } from './DeleteMappingItemAction';
 
 describe('DeleteMappingItemAction', () => {
@@ -46,7 +46,7 @@ describe('DeleteMappingItemAction', () => {
     const targetDoc = TestUtil.createTargetOrderDoc();
     const paramsMap = TestUtil.createParameterMap();
     const tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-    MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+    MappingSerializerService.deserialize(getConditionalMappingsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
     const docData = new TargetDocumentNodeData(targetDoc, tree);
     const nodeData = new MappingNodeData(docData, tree.children[0].children[0] as ForEachItem);

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
 import { BrowserFilePickerMetadataProvider } from '../../stubs/BrowserFilePickerMetadataProvider';
-import { camelYamlDslJsonSchema, shipOrderJsonSchema, shipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { getCamelYamlDslJsonSchema, getShipOrderJsonSchema, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { SourceTargetView } from './SourceTargetView';
 
 // Mock ResizeObserver for ExpansionPanels
@@ -42,7 +42,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(importButton);
       });
 
-      const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.click(attachButton);
       });
@@ -115,7 +115,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(importButton);
       });
 
-      const fileContent = new File([new Blob([shipOrderXsd])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
       act(() => {
         fireEvent.click(attachButton);
       });
@@ -170,7 +170,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(importButton);
       });
 
-      const fileContent = new File([new Blob([shipOrderJsonSchema])], 'ShipOrder.json', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
       act(() => {
         fireEvent.click(attachButton);
       });
@@ -225,7 +225,9 @@ describe('SourceTargetView', () => {
         fireEvent.click(importButton);
       });
 
-      const fileContent = new File([new Blob([camelYamlDslJsonSchema])], 'CamelYamlDsl.json', { type: 'text/plain' });
+      const fileContent = new File([new Blob([getCamelYamlDslJsonSchema()])], 'CamelYamlDsl.json', {
+        type: 'text/plain',
+      });
       act(() => {
         fireEvent.click(attachButton);
       });

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -16,10 +16,10 @@ import { CanvasView } from '../models/datamapper/view';
 import { DocumentService } from '../services/document.service';
 import { MappingService } from '../services/mapping.service';
 import {
-  accountJsonSchema,
-  cartJsonSchema,
-  shipOrderJsonSchema,
-  shipOrderJsonXslt,
+  getAccountJsonSchema,
+  getCartJsonSchema,
+  getShipOrderJsonSchema,
+  getShipOrderJsonXslt,
 } from '../stubs/datamapper/data-mapper';
 import { DataMapperContext, DataMapperProvider } from './datamapper.provider';
 
@@ -168,7 +168,7 @@ describe('DataMapperProvider', () => {
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.JSON_SCHEMA,
       'ShipOrderJson',
-      { ShipOrderJson: shipOrderJsonSchema },
+      { ShipOrderJson: getShipOrderJsonSchema() },
     );
 
     // Create a mock document - in practice this would come from DocumentService
@@ -460,14 +460,14 @@ describe('DataMapperProvider', () => {
   it('should initialize JSON mappings with DocumentInitializationModel and initialXsltFile', async () => {
     const sourceDocDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'Body', {});
     const targetDocDef = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, 'Body', {
-      ShipOrder: shipOrderJsonSchema,
+      ShipOrder: getShipOrderJsonSchema(),
     });
     const parameters = {
       Account: new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-        Account: accountJsonSchema,
+        Account: getAccountJsonSchema(),
       }),
       Cart: new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-        Cart: cartJsonSchema,
+        Cart: getCartJsonSchema(),
       }),
       OrderSequence: new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence', {}),
     };
@@ -477,7 +477,7 @@ describe('DataMapperProvider', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <DataMapperProvider
         documentInitializationModel={documentInitializationModel}
-        initialXsltFile={shipOrderJsonXslt}
+        initialXsltFile={getShipOrderJsonXslt()}
         onUpdateMappings={(xslt) => (latestXslt = xslt)}
       >
         {children}
@@ -737,7 +737,7 @@ describe('DataMapperProvider', () => {
       const { result } = renderHook(() => useDataMapper(), { wrapper });
 
       const docDef = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-        Account: accountJsonSchema,
+        Account: getAccountJsonSchema(),
       });
 
       const mockDocument = {
@@ -785,7 +785,7 @@ describe('DataMapperProvider', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'Body',
         {
-          ShipOrder: shipOrderJsonSchema,
+          ShipOrder: getShipOrderJsonSchema(),
         },
       );
       const documentInitializationModel = new DocumentInitializationModel({}, sourceDocDef, targetDocDef);
@@ -804,7 +804,7 @@ describe('DataMapperProvider', () => {
 
     it('should initialize with only initialXsltFile', async () => {
       const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <DataMapperProvider initialXsltFile={shipOrderJsonXslt}>{children}</DataMapperProvider>
+        <DataMapperProvider initialXsltFile={getShipOrderJsonXslt()}>{children}</DataMapperProvider>
       );
 
       const { result } = renderHook(() => useContext(DataMapperContext), { wrapper });

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -2,7 +2,7 @@ import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentT
 import { IChoiceSelection, IDataMapperMetadata, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { TypeOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
-import { commonTypesJsonSchema, customerJsonSchema, orderJsonSchema } from '../stubs/datamapper/data-mapper';
+import { getCommonTypesJsonSchema, getCustomerJsonSchema, getOrderJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DataMapperMetadataService } from './datamapper-metadata.service';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { EMPTY_XSL } from './mapping-serializer.service';
@@ -237,9 +237,9 @@ describe('DataMapperMetadataService', () => {
       };
 
       mockApi.getResourceContent.mockImplementation((path) => {
-        if (path === 'Order.schema.json') return Promise.resolve(orderJsonSchema);
-        if (path === 'Customer.schema.json') return Promise.resolve(customerJsonSchema);
-        if (path === 'CommonTypes.schema.json') return Promise.resolve(commonTypesJsonSchema);
+        if (path === 'Order.schema.json') return Promise.resolve(getOrderJsonSchema());
+        if (path === 'Customer.schema.json') return Promise.resolve(getCustomerJsonSchema());
+        if (path === 'CommonTypes.schema.json') return Promise.resolve(getCommonTypesJsonSchema());
         return Promise.resolve(undefined);
       });
 
@@ -269,9 +269,9 @@ describe('DataMapperMetadataService', () => {
       };
 
       mockApi.getResourceContent.mockImplementation((path) => {
-        if (path === 'Order.schema.json') return Promise.resolve(orderJsonSchema);
-        if (path === 'Customer.schema.json') return Promise.resolve(customerJsonSchema);
-        if (path === 'CommonTypes.schema.json') return Promise.resolve(commonTypesJsonSchema);
+        if (path === 'Order.schema.json') return Promise.resolve(getOrderJsonSchema());
+        if (path === 'Customer.schema.json') return Promise.resolve(getCustomerJsonSchema());
+        if (path === 'CommonTypes.schema.json') return Promise.resolve(getCommonTypesJsonSchema());
         return Promise.resolve(undefined);
       });
 
@@ -445,9 +445,9 @@ describe('DataMapperMetadataService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'Order.schema.json': orderJsonSchema,
-          'Customer.schema.json': customerJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'Order.schema.json': getOrderJsonSchema(),
+          'Customer.schema.json': getCustomerJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
         { namespaceUri: '', name: 'Customer.schema.json' },
       );

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -1,7 +1,7 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType, Types } from '../models/datamapper';
 import { IFieldTypeOverride } from '../models/datamapper/metadata';
 import { TypeOverrideVariant } from '../models/datamapper/types';
-import { accountJsonSchema } from '../stubs/datamapper/data-mapper';
+import { getAccountJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -126,7 +126,7 @@ describe('DocumentUtilService - JSON Schema', () => {
   describe('processTypeOverrides()', () => {
     it('should apply type override to top-level JSON field', () => {
       const definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'account', {
-        'account.json': accountJsonSchema,
+        'account.json': getAccountJsonSchema(),
       });
       const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');
@@ -150,7 +150,7 @@ describe('DocumentUtilService - JSON Schema', () => {
 
     it('should apply type override to nested JSON field', () => {
       const definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'account', {
-        'account.json': accountJsonSchema,
+        'account.json': getAccountJsonSchema(),
       });
       const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -9,7 +9,7 @@ import { IField } from '../models/datamapper/document';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { TypeOverrideVariant } from '../models/datamapper/types';
-import { camelSpringXsd, lazyLoadingTestXsd, TestUtil } from '../stubs/datamapper/data-mapper';
+import { getCamelSpringXsd, getLazyLoadingTestXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { XmlSchemaField } from './xml-schema-document.model';
 import { XmlSchemaDocumentService } from './xml-schema-document.service';
@@ -71,7 +71,7 @@ describe('DocumentUtilService', () => {
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'camel-spring.xsd': camelSpringXsd },
+        { 'camel-spring.xsd': getCamelSpringXsd() },
         { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -261,7 +261,7 @@ describe('DocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'lazy.xsd': lazyLoadingTestXsd },
+        { 'lazy.xsd': getLazyLoadingTestXsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');
@@ -296,7 +296,7 @@ describe('DocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'lazy.xsd': lazyLoadingTestXsd },
+        { 'lazy.xsd': getLazyLoadingTestXsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');
@@ -386,7 +386,7 @@ describe('DocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'lazy.xsd': lazyLoadingTestXsd },
+        { 'lazy.xsd': getLazyLoadingTestXsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../models/datamapper';
 import { TypeOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
-import { cartJsonSchema, multipleElementsXsd, TestUtil } from '../stubs/datamapper/data-mapper';
+import { getCartJsonSchema, getMultipleElementsXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentService } from './document.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { XmlSchemaDocument, XmlSchemaField } from './xml-schema-document.model';
@@ -48,7 +48,7 @@ describe('DocumentService', () => {
 
     it('should create XML schema document with multiple root elements', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(multipleElementsXsd),
+        getResourceContent: jest.fn().mockResolvedValue(getMultipleElementsXsd()),
       };
 
       const result = await DocumentService.createDocument(
@@ -575,7 +575,7 @@ describe('DocumentService', () => {
 
     it('should return QName for XML schema document', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(multipleElementsXsd),
+        getResourceContent: jest.fn().mockResolvedValue(getMultipleElementsXsd()),
       };
 
       const result = await DocumentService.createDocument(
@@ -610,7 +610,7 @@ describe('DocumentService', () => {
 
     it('should create new document with different root element for XML schema documents', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(multipleElementsXsd),
+        getResourceContent: jest.fn().mockResolvedValue(getMultipleElementsXsd()),
       };
 
       const result = await DocumentService.createDocument(
@@ -646,7 +646,7 @@ describe('DocumentService', () => {
 
     it('should clear fieldTypeOverrides and choiceSelections from the definition when root element changes', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(multipleElementsXsd),
+        getResourceContent: jest.fn().mockResolvedValue(getMultipleElementsXsd()),
       };
 
       const result = await DocumentService.createDocument(
@@ -745,7 +745,7 @@ describe('DocumentService', () => {
 
     it('should rename a XML document', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(multipleElementsXsd),
+        getResourceContent: jest.fn().mockResolvedValue(getMultipleElementsXsd()),
       };
 
       const result = await DocumentService.createDocument(
@@ -770,7 +770,7 @@ describe('DocumentService', () => {
 
     it('should rename a JSON document', async () => {
       const mockApi = {
-        getResourceContent: jest.fn().mockResolvedValue(cartJsonSchema),
+        getResourceContent: jest.fn().mockResolvedValue(getCartJsonSchema()),
       };
 
       const result = await DocumentService.createDocument(

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../models/datamapper';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { TypeOverrideVariant } from '../models/datamapper/types';
-import { importedTypesXsd, namedTypesXsd, shipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
+import { getImportedTypesXsd, getNamedTypesXsd, getShipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { FieldTypeOverrideService } from './field-type-override.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -69,7 +69,7 @@ describe('FieldTypeOverrideService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'NamedTypes.xsd': namedTypesXsd },
+        { 'NamedTypes.xsd': getNamedTypesXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -143,7 +143,7 @@ describe('FieldTypeOverrideService', () => {
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
-          { 'ShipOrder.xsd': shipOrderXsd },
+          { 'ShipOrder.xsd': getShipOrderXsd() },
           undefined,
           undefined,
           undefined,
@@ -154,7 +154,7 @@ describe('FieldTypeOverrideService', () => {
         const document = result.document as XmlSchemaDocument;
 
         const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
-          'ImportedTypes.xsd': importedTypesXsd,
+          'ImportedTypes.xsd': getImportedTypesXsd(),
         });
 
         expect(Object.keys(updatedDef.definitionFiles || {})).toContain('ShipOrder.xsd');
@@ -170,7 +170,7 @@ describe('FieldTypeOverrideService', () => {
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
-          { 'ShipOrder.xsd': shipOrderXsd },
+          { 'ShipOrder.xsd': getShipOrderXsd() },
           undefined,
           undefined,
           undefined,
@@ -181,7 +181,7 @@ describe('FieldTypeOverrideService', () => {
         const document = result.document as XmlSchemaDocument;
 
         const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
-          'ImportedTypes.xsd': importedTypesXsd,
+          'ImportedTypes.xsd': getImportedTypesXsd(),
         });
 
         const namespaceMap = updatedDef.namespaceMap || {};
@@ -239,7 +239,7 @@ describe('FieldTypeOverrideService', () => {
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
-          { 'ShipOrder.xsd': shipOrderXsd },
+          { 'ShipOrder.xsd': getShipOrderXsd() },
           undefined,
           undefined,
           undefined,

--- a/packages/ui/src/services/json-schema-analysis.service.test.ts
+++ b/packages/ui/src/services/json-schema-analysis.service.test.ts
@@ -1,11 +1,11 @@
 import { JSONSchema7 } from 'json-schema';
 
 import {
-  commonTypesJsonSchema,
-  customerJsonSchema,
-  mainWithRefJsonSchema,
-  orderJsonSchema,
-  productJsonSchema,
+  getCommonTypesJsonSchema,
+  getCustomerJsonSchema,
+  getMainWithRefJsonSchema,
+  getOrderJsonSchema,
+  getProductJsonSchema,
 } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaAnalysisService } from './json-schema-analysis.service';
 import { JsonSchemaMetadata } from './json-schema-document.model';
@@ -219,7 +219,7 @@ describe('JsonSchemaAnalysisService', () => {
     });
 
     it('should extract refs from real Order schema', () => {
-      const schema = JSON.parse(orderJsonSchema) as JSONSchema7;
+      const schema = JSON.parse(getOrderJsonSchema()) as JSONSchema7;
 
       const refs = JsonSchemaAnalysisService.extractRefs(schema);
 
@@ -464,9 +464,9 @@ describe('JsonSchemaAnalysisService', () => {
 
     describe('real schemas', () => {
       it('should analyze Order -> Customer -> CommonTypes correctly', () => {
-        const order = parseMetadata('Order.schema.json', orderJsonSchema);
-        const customer = parseMetadata('Customer.schema.json', customerJsonSchema);
-        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+        const order = parseMetadata('Order.schema.json', getOrderJsonSchema());
+        const customer = parseMetadata('Customer.schema.json', getCustomerJsonSchema());
+        const common = parseMetadata('CommonTypes.schema.json', getCommonTypesJsonSchema());
 
         const result = JsonSchemaAnalysisService.analyze([order, customer, common]);
 
@@ -487,8 +487,8 @@ describe('JsonSchemaAnalysisService', () => {
       });
 
       it('should analyze MainWithRef -> CommonTypes correctly', () => {
-        const main = parseMetadata('MainWithRef.schema.json', mainWithRefJsonSchema);
-        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+        const main = parseMetadata('MainWithRef.schema.json', getMainWithRefJsonSchema());
+        const common = parseMetadata('CommonTypes.schema.json', getCommonTypesJsonSchema());
 
         const result = JsonSchemaAnalysisService.analyze([main, common]);
 
@@ -504,8 +504,8 @@ describe('JsonSchemaAnalysisService', () => {
       });
 
       it('should analyze nested/Product -> CommonTypes with ../ path', () => {
-        const product = parseMetadata('nested/Product.schema.json', productJsonSchema);
-        const common = parseMetadata('CommonTypes.schema.json', commonTypesJsonSchema);
+        const product = parseMetadata('nested/Product.schema.json', getProductJsonSchema());
+        const common = parseMetadata('CommonTypes.schema.json', getCommonTypesJsonSchema());
 
         const result = JsonSchemaAnalysisService.analyze([product, common]);
 
@@ -521,7 +521,7 @@ describe('JsonSchemaAnalysisService', () => {
       });
 
       it('should detect missing schema when CommonTypes is not provided', () => {
-        const main = parseMetadata('MainWithRef.schema.json', mainWithRefJsonSchema);
+        const main = parseMetadata('MainWithRef.schema.json', getMainWithRefJsonSchema());
 
         const result = JsonSchemaAnalysisService.analyze([main]);
 
@@ -742,8 +742,8 @@ describe('JsonSchemaAnalysisService', () => {
   describe('analyzeFromDefinitionFiles', () => {
     it('should parse and analyze definition files', () => {
       const definitionFiles = {
-        'MainWithRef.schema.json': mainWithRefJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'MainWithRef.schema.json': getMainWithRefJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       };
 
       const result = JsonSchemaAnalysisService.analyzeFromDefinitionFiles(definitionFiles);
@@ -765,9 +765,9 @@ describe('JsonSchemaAnalysisService', () => {
 
     it('should analyze multi-file scenario', () => {
       const definitionFiles = {
-        'Order.schema.json': orderJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Order.schema.json': getOrderJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       };
 
       const result = JsonSchemaAnalysisService.analyzeFromDefinitionFiles(definitionFiles);

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -4,13 +4,13 @@ import { DocumentDefinition, DocumentDefinitionType, PathExpression, Types } fro
 import { BODY_DOCUMENT_ID, DocumentType } from '../models/datamapper/document';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
 import {
-  accountJsonSchema,
-  camelYamlDslJsonSchema,
-  commonTypesJsonSchema,
-  customerJsonSchema,
-  mainWithRefJsonSchema,
-  orderJsonSchema,
-  productJsonSchema,
+  getAccountJsonSchema,
+  getCamelYamlDslJsonSchema,
+  getCommonTypesJsonSchema,
+  getCustomerJsonSchema,
+  getMainWithRefJsonSchema,
+  getOrderJsonSchema,
+  getProductJsonSchema,
 } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
@@ -254,7 +254,7 @@ describe('JsonSchemaDocumentService', () => {
   });
 
   it('should parse camelYamlDsl', () => {
-    const camelDoc = createTestJsonDocument(DocumentType.PARAM, 'test', camelYamlDslJsonSchema);
+    const camelDoc = createTestJsonDocument(DocumentType.PARAM, 'test', getCamelYamlDslJsonSchema());
 
     expect(camelDoc).toBeDefined();
     expect(camelDoc.fields.length).toBe(1);
@@ -529,9 +529,9 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should load multiple schema files', () => {
       const doc = createMultiSchemaDocument(DocumentType.PARAM, 'multiTest1', {
-        'Order.schema.json': orderJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Order.schema.json': getOrderJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       expect(doc).toBeDefined();
@@ -543,9 +543,9 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should resolve relative path external $ref', () => {
       const doc = createMultiSchemaDocument(DocumentType.PARAM, 'multiTest2', {
-        'Order.schema.json': orderJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Order.schema.json': getOrderJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const root = doc.fields[0];
@@ -564,9 +564,9 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should resolve $id-based URI external $ref', () => {
       const doc = createMultiSchemaDocument(DocumentType.PARAM, 'multiTest3', {
-        'Order.schema.json': orderJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Order.schema.json': getOrderJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const root = doc.fields[0];
@@ -582,9 +582,9 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should handle nested cross-file references', () => {
       const doc = createMultiSchemaDocument(DocumentType.PARAM, 'multiTest4', {
-        'Order.schema.json': orderJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Order.schema.json': getOrderJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const root = doc.fields[0];
@@ -602,8 +602,8 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should use first schema as document schema', () => {
       const customerFirstDoc = createMultiSchemaDocument(DocumentType.PARAM, 'customerFirst', {
-        'Customer.schema.json': customerJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const root = customerFirstDoc.fields[0];
@@ -612,7 +612,7 @@ describe('JsonSchemaDocumentService', () => {
     });
 
     it('should maintain backward compatibility with single-file schemas', () => {
-      const singleFileDoc = createTestJsonDocument(DocumentType.PARAM, 'test', accountJsonSchema);
+      const singleFileDoc = createTestJsonDocument(DocumentType.PARAM, 'test', getAccountJsonSchema());
 
       expect(singleFileDoc.fields[0].type).toBe(Types.Container);
     });
@@ -622,9 +622,9 @@ describe('JsonSchemaDocumentService', () => {
         DocumentType.PARAM,
         'customer',
         {
-          'Order.schema.json': orderJsonSchema,
-          'Customer.schema.json': customerJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'Order.schema.json': getOrderJsonSchema(),
+          'Customer.schema.json': getCustomerJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
         { namespaceUri: '', name: 'Customer.schema.json' },
       );
@@ -639,9 +639,9 @@ describe('JsonSchemaDocumentService', () => {
 
     it('should default to first file when rootElementChoice not specified', () => {
       const doc = createMultiSchemaDocument(DocumentType.PARAM, 'customer', {
-        'Customer.schema.json': customerJsonSchema,
-        'Order.schema.json': orderJsonSchema,
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'Customer.schema.json': getCustomerJsonSchema(),
+        'Order.schema.json': getOrderJsonSchema(),
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const root = doc.fields[0];
@@ -655,7 +655,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'order',
         {
-          'Order.schema.json': orderJsonSchema,
+          'Order.schema.json': getOrderJsonSchema(),
         },
         { namespaceUri: '', name: 'NonExistent.schema.json' },
       );
@@ -675,8 +675,8 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
         {
-          'MainWithRef.schema.json': mainWithRefJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'MainWithRef.schema.json': getMainWithRefJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
       );
 
@@ -704,8 +704,8 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
         {
-          'nested/Product.schema.json': productJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'nested/Product.schema.json': getProductJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
       );
 
@@ -733,7 +733,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
         {
-          'MainWithRef.schema.json': mainWithRefJsonSchema,
+          'MainWithRef.schema.json': getMainWithRefJsonSchema(),
         },
       );
 
@@ -763,7 +763,7 @@ describe('JsonSchemaDocumentService', () => {
       expect(document).toBeDefined();
 
       JsonSchemaDocumentService.addSchemaFiles(document, {
-        'CommonTypes.schema.json': commonTypesJsonSchema,
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
       });
 
       const collection = document.schemaCollection;
@@ -808,8 +808,8 @@ describe('JsonSchemaDocumentService', () => {
       const document = result.document!;
 
       JsonSchemaDocumentService.addSchemaFiles(document, {
-        'CommonTypes.schema.json': commonTypesJsonSchema,
-        'Customer.schema.json': customerJsonSchema,
+        'CommonTypes.schema.json': getCommonTypesJsonSchema(),
+        'Customer.schema.json': getCustomerJsonSchema(),
       });
 
       const collection = document.schemaCollection;
@@ -843,8 +843,8 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
         {
-          'MainWithRef.schema.json': mainWithRefJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'MainWithRef.schema.json': getMainWithRefJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
       );
       const initialResult = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
@@ -864,7 +864,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
-        { 'Account.schema.json': accountJsonSchema, 'camelYamlDsl.json': camelYamlDslJsonSchema },
+        { 'Account.schema.json': getAccountJsonSchema(), 'camelYamlDsl.json': getCamelYamlDslJsonSchema() },
       );
 
       const removeResult = JsonSchemaDocumentService.removeSchemaFile(definition, 'camelYamlDsl.json');
@@ -877,7 +877,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
-        { 'Account.schema.json': accountJsonSchema },
+        { 'Account.schema.json': getAccountJsonSchema() },
       );
 
       const removeResult = JsonSchemaDocumentService.removeSchemaFile(definition, 'Account.schema.json');
@@ -891,8 +891,8 @@ describe('JsonSchemaDocumentService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
         {
-          'MainWithRef.schema.json': mainWithRefJsonSchema,
-          'CommonTypes.schema.json': commonTypesJsonSchema,
+          'MainWithRef.schema.json': getMainWithRefJsonSchema(),
+          'CommonTypes.schema.json': getCommonTypesJsonSchema(),
         },
       );
 
@@ -905,7 +905,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
-        { 'Account.schema.json': accountJsonSchema, 'camelYamlDsl.json': camelYamlDslJsonSchema },
+        { 'Account.schema.json': getAccountJsonSchema(), 'camelYamlDsl.json': getCamelYamlDslJsonSchema() },
         { namespaceUri: '', name: 'Account.schema.json' },
       );
 
@@ -920,7 +920,7 @@ describe('JsonSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
         'test-doc',
-        { 'Account.schema.json': accountJsonSchema, 'camelYamlDsl.json': camelYamlDslJsonSchema },
+        { 'Account.schema.json': getAccountJsonSchema(), 'camelYamlDsl.json': getCamelYamlDslJsonSchema() },
         { namespaceUri: '', name: 'Account.schema.json' },
       );
 

--- a/packages/ui/src/services/mapping-links.service.json.test.ts
+++ b/packages/ui/src/services/mapping-links.service.json.test.ts
@@ -13,10 +13,10 @@ import { MappingTree } from '../models/datamapper/mapping';
 import { NodeReference } from '../models/datamapper/visualization';
 import { mockRandomValues } from '../stubs';
 import {
-  accountJsonSchema,
-  cartJsonSchema,
-  shipOrderJsonSchema,
-  shipOrderJsonXslt,
+  getAccountJsonSchema,
+  getCartJsonSchema,
+  getShipOrderJsonSchema,
+  getShipOrderJsonXslt,
 } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -42,13 +42,13 @@ describe('MappingLinksService : JSON', () => {
       DocumentType.PARAM,
       DocumentDefinitionType.JSON_SCHEMA,
       'Account',
-      { 'Account.json': accountJsonSchema },
+      { 'Account.json': getAccountJsonSchema() },
     );
     const accountResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
     expect(accountResult.validationStatus).toBe('success');
     accountParamDoc = accountResult.document as JsonSchemaDocument;
     const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-      'Cart.json': cartJsonSchema,
+      'Cart.json': getCartJsonSchema(),
     });
     const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
     expect(cartResult.validationStatus).toBe('success');
@@ -65,13 +65,13 @@ describe('MappingLinksService : JSON', () => {
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.JSON_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'ShipOrder.json': shipOrderJsonSchema },
+      { 'ShipOrder.json': getShipOrderJsonSchema() },
     );
     const targetResult = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
     expect(targetResult.validationStatus).toBe('success');
     targetDoc = targetResult.document as JsonSchemaDocument;
     mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-    MappingSerializerService.deserialize(shipOrderJsonXslt, targetDoc, mappingTree, paramsMap);
+    MappingSerializerService.deserialize(getShipOrderJsonXslt(), targetDoc, mappingTree, paramsMap);
   });
 
   describe('extractMappingLinks()', () => {

--- a/packages/ui/src/services/mapping-links.service.test.ts
+++ b/packages/ui/src/services/mapping-links.service.test.ts
@@ -12,21 +12,21 @@ import { MappingTree } from '../models/datamapper/mapping';
 import { NodeReference } from '../models/datamapper/visualization';
 import { mockRandomValues } from '../stubs';
 import {
-  contactsXsd,
-  invoice850Xsd,
-  message837Xsd,
-  orgToContactsXslt,
-  orgXsd,
-  shipOrderJsonSchema,
-  shipOrderToShipOrderCollectionIndexXslt,
-  shipOrderToShipOrderMultipleForEachXslt,
-  shipOrderToShipOrderXslt,
-  shipOrderWithCurrentXslt,
+  getContactsXsd,
+  getInvoice850Xsd,
+  getMessage837Xsd,
+  getOrgToContactsXslt,
+  getOrgXsd,
+  getShipOrderJsonSchema,
+  getShipOrderToShipOrderCollectionIndexXslt,
+  getShipOrderToShipOrderMultipleForEachXslt,
+  getShipOrderToShipOrderXslt,
+  getShipOrderWithCurrentXslt,
+  getX12837PDfdlXsd,
+  getX12837PXslt,
+  getX12850DfdlXsd,
+  getX12850ForEachXslt,
   TestUtil,
-  x12837PDfdlXsd,
-  x12837PXslt,
-  x12850DfdlXsd,
-  x12850ForEachXslt,
 } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { MappingLinksService } from './mapping-links.service';
@@ -71,7 +71,7 @@ describe('MappingLinksService', () => {
     targetDoc = TestUtil.createTargetOrderDoc();
     paramsMap = TestUtil.createParameterMap();
     tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-    MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, tree, paramsMap);
+    MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, tree, paramsMap);
   });
 
   describe('extractMappingLinks()', () => {
@@ -107,18 +107,18 @@ describe('MappingLinksService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'x12837PDfdl.xsd': x12837PDfdlXsd },
+        { 'x12837PDfdl.xsd': getX12837PDfdlXsd() },
       );
       sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(sourceDefinition).document!;
       const targetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'message837.xsd': message837Xsd },
+        { 'message837.xsd': getMessage837Xsd() },
       );
       targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(x12837PXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getX12837PXslt(), targetDoc, tree, paramsMap);
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(14);
       expect(links[0].sourceNodePath).toMatch('fx-GS-02');
@@ -156,30 +156,30 @@ describe('MappingLinksService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'x12850Dfdl.xsd': x12850DfdlXsd },
+        { 'x12850Dfdl.xsd': getX12850DfdlXsd() },
       );
       sourceDoc = XmlSchemaDocumentService.createXmlSchemaDocument(sourceDefinition).document!;
       const targetDefinition = new DocumentDefinition(
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'invoice850.xsd': invoice850Xsd },
+        { 'invoice850.xsd': getInvoice850Xsd() },
       );
       targetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(x12850ForEachXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getX12850ForEachXslt(), targetDoc, tree, paramsMap);
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.find((l) => l.sourceNodePath === 'sourceBody:X12-850.dfdl.xsd://')).toBeUndefined();
     });
 
     it('should generate mapping links for multiple for-each on a same target collection', () => {
-      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderMultipleForEachXslt(), targetDoc, tree, paramsMap);
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(10);
     });
 
     it('should generate mapping links for multiple field item on a same target collection', () => {
-      MappingSerializerService.deserialize(shipOrderToShipOrderCollectionIndexXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderCollectionIndexXslt(), targetDoc, tree, paramsMap);
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links.length).toEqual(8);
     });
@@ -189,11 +189,11 @@ describe('MappingLinksService', () => {
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.json': shipOrderJsonSchema },
+        { 'shipOrder.json': getShipOrderJsonSchema() },
       );
       const jsonTargetDoc = JsonSchemaDocumentService.createJsonSchemaDocument(jsonTargetDefinition).document!;
       tree = new MappingTree(jsonTargetDoc.documentType, jsonTargetDoc.documentId, DocumentDefinitionType.JSON_SCHEMA);
-      MappingSerializerService.deserialize(shipOrderToShipOrderXslt, jsonTargetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), jsonTargetDoc, tree, paramsMap);
     });
 
     it('should generate mapping links for parent references', () => {
@@ -201,7 +201,7 @@ describe('MappingLinksService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'org.xsd': orgXsd },
+        { 'org.xsd': getOrgXsd() },
       );
       const orgSourceResult = XmlSchemaDocumentService.createXmlSchemaDocument(orgSourceDefinition);
       expect(orgSourceResult.validationStatus).toBe('success');
@@ -210,7 +210,7 @@ describe('MappingLinksService', () => {
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'contacts.xsd': contactsXsd },
+        { 'contacts.xsd': getContactsXsd() },
       );
       const contactsResult = XmlSchemaDocumentService.createXmlSchemaDocument(contactsTargetDefinition);
       expect(contactsResult.validationStatus).toBe('success');
@@ -221,7 +221,7 @@ describe('MappingLinksService', () => {
         contactsTargetDoc.documentId,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      MappingSerializerService.deserialize(orgToContactsXslt, contactsTargetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getOrgToContactsXslt(), contactsTargetDoc, tree, paramsMap);
 
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, orgSourceDoc);
 
@@ -245,7 +245,7 @@ describe('MappingLinksService', () => {
 
     it('should generate mapping links for current() expressions', () => {
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(shipOrderWithCurrentXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderWithCurrentXslt(), targetDoc, tree, paramsMap);
 
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
 

--- a/packages/ui/src/services/mapping-serializer-json-addon.test.ts
+++ b/packages/ui/src/services/mapping-serializer-json-addon.test.ts
@@ -1,7 +1,7 @@
 import { DocumentDefinitionType, FieldItem, MappingTree, NS_XSL, PrimitiveDocument, Types } from '../models/datamapper';
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentType } from '../models/datamapper/document';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
-import { cartToShipOrderJsonXslt, shipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
+import { getCartToShipOrderJsonXslt, getShipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
 import { MappingSerializerService } from './mapping-serializer.service';
 import {
@@ -23,7 +23,7 @@ describe('mappingSerializerJsonAddon', () => {
 
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.JSON_SCHEMA);
       MappingSerializerService.deserialize(
-        cartToShipOrderJsonXslt,
+        getCartToShipOrderJsonXslt(),
         TestUtil.createTargetOrderDoc(),
         mappings,
         TestUtil.createParameterMap(),
@@ -121,7 +121,7 @@ describe('mappingSerializerJsonAddon', () => {
     it('should populate a FieldItem', () => {
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.JSON_SCHEMA);
       MappingSerializerService.deserialize(
-        cartToShipOrderJsonXslt,
+        getCartToShipOrderJsonXslt(),
         TestUtil.createTargetOrderDoc(),
         mappings,
         TestUtil.createParameterMap(),
@@ -186,7 +186,7 @@ describe('mappingSerializerJsonAddon', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd },
+        { 'shipOrder.xsd': getShipOrderXsd() },
       );
       const doc = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
       const mappings = new MappingTree(DocumentType.TARGET_BODY, 'Body', DocumentDefinitionType.XML_SCHEMA);

--- a/packages/ui/src/services/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping-serializer.service.json.test.ts
@@ -14,10 +14,10 @@ import {
 } from '../models/datamapper';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
 import {
-  accountJsonSchema,
-  cartJsonSchema,
-  shipOrderJsonSchema,
-  shipOrderJsonXslt,
+  getAccountJsonSchema,
+  getCartJsonSchema,
+  getShipOrderJsonSchema,
+  getShipOrderJsonXslt,
 } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaField } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -26,13 +26,13 @@ import { TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 describe('MappingSerializerService / JSON', () => {
   const accountDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-    'Account.json': accountJsonSchema,
+    'Account.json': getAccountJsonSchema(),
   });
   const accountDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
   expect(accountDocResult.validationStatus).toBe('success');
   const accountParamDoc = accountDocResult.document!;
   const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-    'Cart.json': cartJsonSchema,
+    'Cart.json': getCartJsonSchema(),
   });
   const cartDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
   expect(cartDocResult.validationStatus).toBe('success');
@@ -49,7 +49,7 @@ describe('MappingSerializerService / JSON', () => {
     DocumentType.TARGET_BODY,
     DocumentDefinitionType.JSON_SCHEMA,
     BODY_DOCUMENT_ID,
-    { 'ShipOrder.json': shipOrderJsonSchema },
+    { 'ShipOrder.json': getShipOrderJsonSchema() },
   );
   const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
   expect(result.validationStatus).toBe('success');
@@ -58,7 +58,12 @@ describe('MappingSerializerService / JSON', () => {
   describe('deserialize()', () => {
     it('should deserialize XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(shipOrderJsonXslt, targetDoc, mappingTree, sourceParameterMap);
+      mappingTree = MappingSerializerService.deserialize(
+        getShipOrderJsonXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      );
       expect(targetDoc.fields[0].fields[3].fields[0].fields.length).toEqual(3);
       const namespaces = mappingTree.namespaceMap;
       expect(mappingTree.children.length).toBe(1);
@@ -200,7 +205,12 @@ describe('MappingSerializerService / JSON', () => {
 
     it('should serialize JSON mappings', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(shipOrderJsonXslt, targetDoc, mappingTree, sourceParameterMap);
+      mappingTree = MappingSerializerService.deserialize(
+        getShipOrderJsonXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      );
       const xsltString = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(xsltString, 'text/xml');
 

--- a/packages/ui/src/services/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping-serializer.service.test.ts
@@ -17,13 +17,13 @@ import {
 import { NS_XSL } from '../models/datamapper/standard-namespaces';
 import { Types } from '../models/datamapper/types';
 import {
-  invoice850Xsd,
-  shipOrderToShipOrderCollectionIndexXslt,
-  shipOrderToShipOrderInvalidForEachXslt,
-  shipOrderToShipOrderMultipleForEachXslt,
-  shipOrderToShipOrderXslt,
+  getInvoice850Xsd,
+  getShipOrderToShipOrderCollectionIndexXslt,
+  getShipOrderToShipOrderInvalidForEachXslt,
+  getShipOrderToShipOrderMultipleForEachXslt,
+  getShipOrderToShipOrderXslt,
+  getX12850ForEachXslt,
   TestUtil,
-  x12850ForEachXslt,
 } from '../stubs/datamapper/data-mapper';
 import { EMPTY_XSL, MappingSerializerService } from './mapping-serializer.service';
 import { XmlSchemaField } from './xml-schema-document.model';
@@ -59,7 +59,7 @@ describe('MappingSerializerService', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       expect(Object.keys(mappingTree.namespaceMap).length).toEqual(0);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderXslt,
+        getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
@@ -181,7 +181,7 @@ describe('MappingSerializerService', () => {
     it('should deserialize incomplete XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderInvalidForEachXslt,
+        getShipOrderToShipOrderInvalidForEachXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
@@ -197,14 +197,14 @@ describe('MappingSerializerService', () => {
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'Invoice',
-        { 'Invoice.xsd': invoice850Xsd },
+        { 'Invoice.xsd': getInvoice850Xsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition850);
       expect(result.validationStatus).toBe('success');
       const targetDoc850 = result.document!;
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        x12850ForEachXslt,
+        getX12850ForEachXslt(),
         targetDoc850,
         mappingTree,
         sourceParameterMap,
@@ -222,7 +222,7 @@ describe('MappingSerializerService', () => {
     it('should deserialize multiple for-each mappings on a same target collection', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderMultipleForEachXslt,
+        getShipOrderToShipOrderMultipleForEachXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
@@ -245,7 +245,7 @@ describe('MappingSerializerService', () => {
       jest.spyOn(globalThis, 'crypto', 'get').mockImplementation(() => mockCrypto as unknown as Crypto);
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderCollectionIndexXslt,
+        getShipOrderToShipOrderCollectionIndexXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
@@ -277,7 +277,7 @@ describe('MappingSerializerService', () => {
     it('should serialize mappings', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderXslt,
+        getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
@@ -371,7 +371,7 @@ describe('MappingSerializerService', () => {
     it('should serialize mappings with respecting Document field order', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       mappingTree = MappingSerializerService.deserialize(
-        shipOrderToShipOrderXslt,
+        getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,

--- a/packages/ui/src/services/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping.service.test.ts
@@ -12,14 +12,14 @@ import {
 } from '../models/datamapper/mapping';
 import { mockRandomValues } from '../stubs';
 import {
-  cartToShipOrderJsonXslt,
-  cartToShipOrderXslt,
-  conditionalMappingsToShipOrderJsonXslt,
-  conditionalMappingsToShipOrderXslt,
-  multipleForEachJsonXslt,
-  nestedConditionalsToShipOrderXslt,
-  shipOrderToShipOrderMultipleForEachXslt,
-  shipOrderToShipOrderXslt,
+  getCartToShipOrderJsonXslt,
+  getCartToShipOrderXslt,
+  getConditionalMappingsToShipOrderJsonXslt,
+  getConditionalMappingsToShipOrderXslt,
+  getMultipleForEachJsonXslt,
+  getNestedConditionalsToShipOrderXslt,
+  getShipOrderToShipOrderMultipleForEachXslt,
+  getShipOrderToShipOrderXslt,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
 import { DocumentService } from './document.service';
@@ -44,7 +44,7 @@ describe('MappingService', () => {
     targetDoc = TestUtil.createTargetOrderDoc();
     paramsMap = TestUtil.createParameterMap();
     tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-    MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, tree, paramsMap);
+    MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, tree, paramsMap);
   });
 
   describe('filterMappingsForField()', () => {
@@ -60,7 +60,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(nestedConditionalsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getNestedConditionalsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
       const shipOrderField = targetDoc.fields[0];
       const orderPersonField = targetDoc.fields[0].fields[1];
@@ -87,7 +87,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(nestedConditionalsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getNestedConditionalsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
       const shipToField = targetDoc.fields[0].fields[2];
       const shipToNameField = targetDoc.fields[0].fields[2].fields[0];
@@ -118,7 +118,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(nestedConditionalsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getNestedConditionalsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
       const itemField = targetDoc.fields[0].fields[3];
       const noteField = targetDoc.fields[0].fields[3].fields[1];
@@ -171,7 +171,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getConditionalMappingsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
       expect(tree.children.length).toEqual(1);
       MappingService.removeAllMappingsForDocument(tree, DocumentType.PARAM, 'cart');
@@ -182,7 +182,7 @@ describe('MappingService', () => {
       const targetJSONDoc = TestUtil.createJSONTargetOrderDoc();
       paramsMap = TestUtil.createJSONParameterMap();
       tree = new MappingTree(targetJSONDoc.documentType, targetJSONDoc.documentId, DocumentDefinitionType.JSON_SCHEMA);
-      MappingSerializerService.deserialize(conditionalMappingsToShipOrderJsonXslt, targetJSONDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getConditionalMappingsToShipOrderJsonXslt(), targetJSONDoc, tree, paramsMap);
 
       expect(tree.children[0].children[0].children.length).toEqual(1);
       const forEach = tree.children[0].children[0].children[0] as ForEachItem;
@@ -196,7 +196,7 @@ describe('MappingService', () => {
       const targetJSONDoc = TestUtil.createJSONTargetOrderDoc();
       paramsMap = TestUtil.createJSONParameterMap();
       tree = new MappingTree(targetJSONDoc.documentType, targetJSONDoc.documentId, DocumentDefinitionType.JSON_SCHEMA);
-      MappingSerializerService.deserialize(multipleForEachJsonXslt, targetJSONDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getMultipleForEachJsonXslt(), targetJSONDoc, tree, paramsMap);
 
       expect(tree.children[0].children[0].children.length).toEqual(2);
       let forEach1 = tree.children[0].children[0].children[0] as ForEachItem;
@@ -214,7 +214,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderMultipleForEachXslt(), targetDoc, tree, paramsMap);
 
       const validateForEach = (forEachItem: ForEachItem) => {
         expect(forEachItem.children.length).toEqual(1);
@@ -249,7 +249,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderMultipleForEachXslt(), targetDoc, tree, paramsMap);
 
       const bodyForEach = tree.children[0].children[0] as ForEachItem;
       const paramForEach = tree.children[0].children[1] as ForEachItem;
@@ -266,7 +266,7 @@ describe('MappingService', () => {
       targetDoc = TestUtil.createTargetOrderDoc();
       paramsMap = TestUtil.createParameterMap();
       tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
-      MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderMultipleForEachXslt(), targetDoc, tree, paramsMap);
 
       const bodyForEach = tree.children[0].children[0] as ForEachItem;
       expect(bodyForEach.children[0].children.length).toEqual(4);
@@ -303,7 +303,7 @@ describe('MappingService', () => {
     };
 
     it('should rename simple mappings for XML document', () => {
-      MappingSerializerService.deserialize(cartToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getCartToShipOrderXslt(), targetDoc, tree, paramsMap);
       expect(tree.children.length).toEqual(1);
       const linksBefore = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       MappingService.renameParameterInMappings(tree, 'cart', 'newTargetParam');
@@ -319,7 +319,7 @@ describe('MappingService', () => {
     });
 
     it('should rename conditional mappings for XML document', () => {
-      MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getConditionalMappingsToShipOrderXslt(), targetDoc, tree, paramsMap);
       expect(tree.children.length).toEqual(1);
       const linksBefore = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       MappingService.renameParameterInMappings(tree, 'cart', 'newTargetParam');
@@ -342,7 +342,7 @@ describe('MappingService', () => {
         targetJSONDoc.documentId,
         DocumentDefinitionType.JSON_SCHEMA,
       );
-      MappingSerializerService.deserialize(cartToShipOrderJsonXslt, targetJSONDoc, mappingTree, jsonParamsMap);
+      MappingSerializerService.deserialize(getCartToShipOrderJsonXslt(), targetJSONDoc, mappingTree, jsonParamsMap);
 
       expect(mappingTree.children.length).toEqual(1);
       const linksBefore = MappingLinksService.extractMappingLinks(mappingTree, jsonParamsMap, sourceDoc);
@@ -367,7 +367,7 @@ describe('MappingService', () => {
         DocumentDefinitionType.JSON_SCHEMA,
       );
       MappingSerializerService.deserialize(
-        conditionalMappingsToShipOrderJsonXslt,
+        getConditionalMappingsToShipOrderJsonXslt(),
         targetJSONDoc,
         mappingTree,
         jsonParamsMap,
@@ -653,7 +653,7 @@ describe('MappingService', () => {
     });
 
     it('should delete the empty root field item when it has no children', () => {
-      MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getConditionalMappingsToShipOrderXslt(), targetDoc, tree, paramsMap);
 
       expect(tree.children[0].children.length).toEqual(1);
       const forEachItem = tree.children[0].children[0] as ForEachItem;

--- a/packages/ui/src/services/visualization.service.json.test.ts
+++ b/packages/ui/src/services/visualization.service.json.test.ts
@@ -18,11 +18,11 @@ import {
   ValueSelector,
 } from '../models/datamapper';
 import {
-  accountJsonSchema,
-  camelYamlDslJsonSchema,
-  cartJsonSchema,
-  shipOrderJsonSchema,
-  shipOrderJsonXslt,
+  getAccountJsonSchema,
+  getCamelYamlDslJsonSchema,
+  getCartJsonSchema,
+  getShipOrderJsonSchema,
+  getShipOrderJsonXslt,
 } from '../stubs/datamapper/data-mapper';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { MappingSerializerService } from './mapping-serializer.service';
@@ -30,13 +30,13 @@ import { VisualizationService } from './visualization.service';
 
 describe('VisualizationService / JSON', () => {
   const accountDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-    'Account.json': accountJsonSchema,
+    'Account.json': getAccountJsonSchema(),
   });
   const accountResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
   expect(accountResult.validationStatus).toBe('success');
   const accountDoc = accountResult.document!;
   const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-    'Cart.json': cartJsonSchema,
+    'Cart.json': getCartJsonSchema(),
   });
   const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
   expect(cartResult.validationStatus).toBe('success');
@@ -48,7 +48,7 @@ describe('VisualizationService / JSON', () => {
     DocumentType.TARGET_BODY,
     DocumentDefinitionType.JSON_SCHEMA,
     BODY_DOCUMENT_ID,
-    { 'ShipOrder.json': shipOrderJsonSchema },
+    { 'ShipOrder.json': getShipOrderJsonSchema() },
   );
   const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
   expect(result.validationStatus).toBe('success');
@@ -147,7 +147,12 @@ describe('VisualizationService / JSON', () => {
 
   it('should render deserialized mappings', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-    mappingTree = MappingSerializerService.deserialize(shipOrderJsonXslt, targetDoc, mappingTree, sourceParameterMap);
+    mappingTree = MappingSerializerService.deserialize(
+      getShipOrderJsonXslt(),
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
     expect(mappingTree.children.length).toEqual(1);
 
     targetDocNode = new TargetDocumentNodeData(targetDoc, mappingTree);
@@ -201,7 +206,7 @@ describe('VisualizationService / JSON', () => {
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.JSON_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'CamelYamlDsl.json': camelYamlDslJsonSchema },
+      { 'CamelYamlDsl.json': getCamelYamlDslJsonSchema() },
     );
     const result = JsonSchemaDocumentService.createJsonSchemaDocument(camelYamlDefinition);
     expect(result.validationStatus).toBe('success');

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -31,17 +31,17 @@ import {
   TargetNodeData,
 } from '../models/datamapper/visualization';
 import {
-  conditionalMappingsToShipOrderXslt,
-  contactsXsd,
-  extensionComplexXsd,
-  extensionSimpleXsd,
-  nestedConditionalsToShipOrderXslt,
-  orgXsd,
-  schemaTestXsd,
-  shipOrderToShipOrderCollectionIndexXslt,
-  shipOrderToShipOrderInvalidForEachXslt,
-  shipOrderToShipOrderMultipleForEachXslt,
-  shipOrderToShipOrderXslt,
+  getConditionalMappingsToShipOrderXslt,
+  getContactsXsd,
+  getExtensionComplexXsd,
+  getExtensionSimpleXsd,
+  getNestedConditionalsToShipOrderXslt,
+  getOrgXsd,
+  getSchemaTestXsd,
+  getShipOrderToShipOrderCollectionIndexXslt,
+  getShipOrderToShipOrderInvalidForEachXslt,
+  getShipOrderToShipOrderMultipleForEachXslt,
+  getShipOrderToShipOrderXslt,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
@@ -522,7 +522,7 @@ describe('VisualizationService', () => {
       });
 
       it('should not remove for-each targeted field item when selector is removed', () => {
-        MappingSerializerService.deserialize(shipOrderToShipOrderInvalidForEachXslt, targetDoc, tree, paramsMap);
+        MappingSerializerService.deserialize(getShipOrderToShipOrderInvalidForEachXslt(), targetDoc, tree, paramsMap);
 
         targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
         let targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -550,7 +550,7 @@ describe('VisualizationService', () => {
       });
 
       it('should not remove for-each targeted field item when descendent is removed', () => {
-        MappingSerializerService.deserialize(shipOrderToShipOrderInvalidForEachXslt, targetDoc, tree, paramsMap);
+        MappingSerializerService.deserialize(getShipOrderToShipOrderInvalidForEachXslt(), targetDoc, tree, paramsMap);
 
         targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
         let targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -627,7 +627,7 @@ describe('VisualizationService', () => {
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           BODY_DOCUMENT_ID,
-          { 'ExtensionSimple.xsd': extensionSimpleXsd },
+          { 'ExtensionSimple.xsd': getExtensionSimpleXsd() },
         );
         const sourceDocResult = XmlSchemaDocumentService.createXmlSchemaDocument(extensionSimpleDef);
         const targetDocResult = XmlSchemaDocumentService.createXmlSchemaDocument(extensionSimpleDef);
@@ -661,7 +661,7 @@ describe('VisualizationService', () => {
     });
     it('should fill ContextItemExpr (.) and AbbrevReverseStep (..) in xpath when it maps under for-each', () => {
       const orgDefinition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'Org', {
-        'Org.xsd': orgXsd,
+        'Org.xsd': getOrgXsd(),
       });
       const orgResult = XmlSchemaDocumentService.createXmlSchemaDocument(orgDefinition);
       expect(orgResult.validationStatus).toBe('success');
@@ -670,7 +670,7 @@ describe('VisualizationService', () => {
         DocumentType.TARGET_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'Contacts.xsd': contactsXsd },
+        { 'Contacts.xsd': getContactsXsd() },
       );
       const contactsResult = XmlSchemaDocumentService.createXmlSchemaDocument(contactsDefinition);
       expect(contactsResult.validationStatus).toBe('success');
@@ -756,7 +756,7 @@ describe('VisualizationService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'extensionSimple.xsd': extensionSimpleXsd },
+        { 'extensionSimple.xsd': getExtensionSimpleXsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');
@@ -798,7 +798,7 @@ describe('VisualizationService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'extensionComplex.xsd': extensionComplexXsd },
+        { 'extensionComplex.xsd': getExtensionComplexXsd() },
         { namespaceUri: 'http://www.example.com/TEST', name: 'Request' },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -829,7 +829,7 @@ describe('VisualizationService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'schemaTest.xsd': schemaTestXsd },
+        { 'schemaTest.xsd': getSchemaTestXsd() },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(result.validationStatus).toBe('success');
@@ -890,7 +890,7 @@ describe('VisualizationService', () => {
 
   describe('with pre-populated mappings', () => {
     beforeEach(() => {
-      MappingSerializerService.deserialize(shipOrderToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, tree, paramsMap);
       targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
     });
 
@@ -991,7 +991,7 @@ describe('VisualizationService', () => {
   });
 
   it('should generate for multiple for-each on a same collection target field', () => {
-    MappingSerializerService.deserialize(shipOrderToShipOrderMultipleForEachXslt, targetDoc, tree, paramsMap);
+    MappingSerializerService.deserialize(getShipOrderToShipOrderMultipleForEachXslt(), targetDoc, tree, paramsMap);
     targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
 
     const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -1041,7 +1041,7 @@ describe('VisualizationService', () => {
       .spyOn(globalThis, 'crypto', 'get')
       .mockImplementation(() => ({ getRandomValues: () => [Math.random() * 10000] }) as unknown as Crypto);
 
-    MappingSerializerService.deserialize(shipOrderToShipOrderCollectionIndexXslt, targetDoc, tree, paramsMap);
+    MappingSerializerService.deserialize(getShipOrderToShipOrderCollectionIndexXslt(), targetDoc, tree, paramsMap);
     targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
 
     const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -1079,7 +1079,7 @@ describe('VisualizationService', () => {
 
   describe('isDeletableNode', () => {
     it('should identify deletable nodes', () => {
-      MappingSerializerService.deserialize(conditionalMappingsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getConditionalMappingsToShipOrderXslt(), targetDoc, tree, paramsMap);
       const docData = new TargetDocumentNodeData(targetDoc, tree);
 
       const fieldNodeData = new FieldItemNodeData(docData, tree.children[0] as FieldItem);
@@ -1098,7 +1098,7 @@ describe('VisualizationService', () => {
 
   describe('with nested conditional mappings', () => {
     beforeEach(() => {
-      MappingSerializerService.deserialize(nestedConditionalsToShipOrderXslt, targetDoc, tree, paramsMap);
+      MappingSerializerService.deserialize(getNestedConditionalsToShipOrderXslt(), targetDoc, tree, paramsMap);
       targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
     });
 

--- a/packages/ui/src/services/xml-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document-util.service.test.ts
@@ -3,14 +3,14 @@ import { BaseDocument } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { TypeOverrideVariant, Types } from '../models/datamapper/types';
 import {
-  accountLcXsd,
-  accountNs2Xsd,
-  accountNsXsd,
-  extensionComplexXsd,
-  multipleElementsXsd,
-  restrictionComplexXsd,
-  simpleTypeInheritanceXsd,
-  simpleTypeRestrictionXsd,
+  getAccountLcXsd,
+  getAccountNs2Xsd,
+  getAccountNsXsd,
+  getExtensionComplexXsd,
+  getMultipleElementsXsd,
+  getRestrictionComplexXsd,
+  getSimpleTypeInheritanceXsd,
+  getSimpleTypeRestrictionXsd,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
 import { QName } from '../xml-schema-ts/QName';
@@ -332,7 +332,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
       const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(extensionResult.validationStatus).toBe('success');
@@ -353,7 +353,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'restriction.xsd': restrictionComplexXsd },
+        { 'restriction.xsd': getRestrictionComplexXsd() },
       );
       const restrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(restrictionResult.validationStatus).toBe('success');
@@ -385,7 +385,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
       const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(extensionResult.validationStatus).toBe('success');
@@ -409,7 +409,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'restriction.xsd': restrictionComplexXsd },
+        { 'restriction.xsd': getRestrictionComplexXsd() },
       );
       const restrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(restrictionResult.validationStatus).toBe('success');
@@ -433,7 +433,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
       const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(extensionResult.validationStatus).toBe('success');
@@ -457,7 +457,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'simple.xsd': simpleTypeInheritanceXsd },
+        { 'simple.xsd': getSimpleTypeInheritanceXsd() },
       );
       const simpleInheritResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(simpleInheritResult.validationStatus).toBe('success');
@@ -485,7 +485,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'simple.xsd': simpleTypeRestrictionXsd },
+        { 'simple.xsd': getSimpleTypeRestrictionXsd() },
       );
       const simpleRestrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
       expect(simpleRestrictionResult.validationStatus).toBe('success');
@@ -648,8 +648,8 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'account-ns.xsd': accountNsXsd,
-          'account-ns2.xsd': accountNs2Xsd,
+          'account-ns.xsd': getAccountNsXsd(),
+          'account-ns2.xsd': getAccountNs2Xsd(),
         },
       );
 
@@ -675,8 +675,8 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'account-lc.xsd': accountLcXsd,
-          'account-ns.xsd': accountNsXsd,
+          'account-lc.xsd': getAccountLcXsd(),
+          'account-ns.xsd': getAccountNsXsd(),
         },
       );
 
@@ -702,7 +702,7 @@ describe('XmlSchemaDocumentUtilService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'MultipleElements.xsd': multipleElementsXsd,
+          'MultipleElements.xsd': getMultipleElementsXsd(),
         },
       );
 

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -6,30 +6,30 @@ import {
 } from '../models/datamapper/document';
 import { Types } from '../models/datamapper/types';
 import {
-  anonymousGlobalElementRefLargeXsd,
-  camelSpringXsd,
-  commonTypesXsd,
-  elementRefXsd,
-  extensionComplexXsd,
-  extensionSimpleXsd,
-  importedTypesXsd,
-  inlineAttrSimpleTypeXsd,
-  invalidComplexExtensionXsd,
-  mainWithImportXsd,
-  mainWithIncludeXsd,
-  multiIncludeComponentAXsd,
-  multiIncludeComponentBXsd,
-  multiIncludeMainXsd,
-  multiLevelExtensionXsd,
-  multiLevelRestrictionXsd,
-  restrictionComplexXsd,
-  restrictionInheritanceXsd,
-  restrictionSimpleXsd,
-  schemaTestXsd,
-  shipOrderEmptyFirstLineXsd,
-  shipOrderXsd,
-  simpleTypeInheritanceXsd,
-  testDocumentXsd,
+  getAnonymousGlobalElementRefLargeXsd,
+  getCamelSpringXsd,
+  getCommonTypesXsd,
+  getElementRefXsd,
+  getExtensionComplexXsd,
+  getExtensionSimpleXsd,
+  getImportedTypesXsd,
+  getInlineAttrSimpleTypeXsd,
+  getInvalidComplexExtensionXsd,
+  getMainWithImportXsd,
+  getMainWithIncludeXsd,
+  getMultiIncludeComponentAXsd,
+  getMultiIncludeComponentBXsd,
+  getMultiIncludeMainXsd,
+  getMultiLevelExtensionXsd,
+  getMultiLevelRestrictionXsd,
+  getRestrictionComplexXsd,
+  getRestrictionInheritanceXsd,
+  getRestrictionSimpleXsd,
+  getSchemaTestXsd,
+  getShipOrderEmptyFirstLineXsd,
+  getShipOrderXsd,
+  getSimpleTypeInheritanceXsd,
+  getTestDocumentXsd,
 } from '../stubs/datamapper/data-mapper';
 import { QName } from '../xml-schema-ts/QName';
 import { DocumentUtilService } from './document-util.service';
@@ -44,7 +44,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'shipOrder.xsd': shipOrderXsd,
+        'shipOrder.xsd': getShipOrderXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -68,7 +68,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'testDocument.xsd': testDocumentXsd,
+        'testDocument.xsd': getTestDocumentXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -87,7 +87,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'camel-spring.xsd': camelSpringXsd,
+        'camel-spring.xsd': getCamelSpringXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -125,7 +125,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'extensionSimple.xsd': extensionSimpleXsd,
+        'extensionSimple.xsd': getExtensionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -185,7 +185,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'extensionComplex.xsd': extensionComplexXsd },
+      { 'extensionComplex.xsd': getExtensionComplexXsd() },
       { namespaceUri: 'http://www.example.com/TEST', name: 'Request' },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -218,7 +218,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.TARGET_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'camel-spring.xsd': camelSpringXsd },
+      { 'camel-spring.xsd': getCamelSpringXsd() },
       { namespaceUri: 'http://camel.apache.org/schema/spring', name: 'routes' },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -247,7 +247,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'shipOrder.xsd': shipOrderXsd,
+        'shipOrder.xsd': getShipOrderXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -264,7 +264,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       'ShipOrderEmptyFirstLine',
-      { 'ShipOrderEmptyFirstLine.xsd': shipOrderEmptyFirstLineXsd },
+      { 'ShipOrderEmptyFirstLine.xsd': getShipOrderEmptyFirstLineXsd() },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
     expect(result.validationStatus).toBe('error');
@@ -277,7 +277,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'schemaTest.xsd': schemaTestXsd,
+        'schemaTest.xsd': getSchemaTestXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -350,7 +350,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'extensionSimple.xsd': extensionSimpleXsd,
+        'extensionSimple.xsd': getExtensionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -386,7 +386,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'restrictionSimple.xsd': restrictionSimpleXsd,
+        'restrictionSimple.xsd': getRestrictionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -428,7 +428,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'restrictionComplex.xsd': restrictionComplexXsd,
+        'restrictionComplex.xsd': getRestrictionComplexXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -487,7 +487,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'restrictionInheritance.xsd': restrictionInheritanceXsd,
+        'restrictionInheritance.xsd': getRestrictionInheritanceXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -546,7 +546,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'multiLevelExtension.xsd': multiLevelExtensionXsd,
+        'multiLevelExtension.xsd': getMultiLevelExtensionXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -599,7 +599,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'multiLevelRestriction.xsd': multiLevelRestrictionXsd,
+        'multiLevelRestriction.xsd': getMultiLevelRestrictionXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -649,7 +649,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'extensionSimple.xsd': extensionSimpleXsd,
+        'extensionSimple.xsd': getExtensionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -680,7 +680,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'restrictionSimple.xsd': restrictionSimpleXsd,
+        'restrictionSimple.xsd': getRestrictionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -709,7 +709,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'extensionSimple.xsd': extensionSimpleXsd,
+        'extensionSimple.xsd': getExtensionSimpleXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -742,7 +742,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'invalidComplexExtension.xsd': invalidComplexExtensionXsd,
+        'invalidComplexExtension.xsd': getInvalidComplexExtensionXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -794,7 +794,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'simpleTypeInheritance.xsd': simpleTypeInheritanceXsd,
+        'simpleTypeInheritance.xsd': getSimpleTypeInheritanceXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -831,7 +831,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'element-ref.xsd': elementRefXsd },
+      { 'element-ref.xsd': getElementRefXsd() },
       { namespaceUri: '', name: 'CSV' },
     );
 
@@ -854,8 +854,8 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         {
-          'MainWithInclude.xsd': mainWithIncludeXsd,
-          'CommonTypes.xsd': commonTypesXsd,
+          'MainWithInclude.xsd': getMainWithIncludeXsd(),
+          'CommonTypes.xsd': getCommonTypesXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -888,7 +888,7 @@ describe('XmlSchemaDocumentService', () => {
         'test-doc',
         {
           'schemas/main.xsd': mainSchema,
-          'schemas/common.xsd': commonTypesXsd,
+          'schemas/common.xsd': getCommonTypesXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -903,7 +903,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         {
-          'MainWithInclude.xsd': mainWithIncludeXsd,
+          'MainWithInclude.xsd': getMainWithIncludeXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -919,9 +919,9 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'MultiIncludeMain.xsd': multiIncludeMainXsd,
-          'MultiIncludeComponentA.xsd': multiIncludeComponentAXsd,
-          'MultiIncludeComponentB.xsd': multiIncludeComponentBXsd,
+          'MultiIncludeMain.xsd': getMultiIncludeMainXsd(),
+          'MultiIncludeComponentA.xsd': getMultiIncludeComponentAXsd(),
+          'MultiIncludeComponentB.xsd': getMultiIncludeComponentBXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -944,8 +944,8 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         {
-          'MainWithImport.xsd': mainWithImportXsd,
-          'ImportedTypes.xsd': importedTypesXsd,
+          'MainWithImport.xsd': getMainWithImportXsd(),
+          'ImportedTypes.xsd': getImportedTypesXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -982,7 +982,7 @@ describe('XmlSchemaDocumentService', () => {
         'test-doc',
         {
           'schemas/main.xsd': mainSchema,
-          'schemas/types.xsd': importedTypesXsd,
+          'schemas/types.xsd': getImportedTypesXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -1006,7 +1006,7 @@ describe('XmlSchemaDocumentService', () => {
         'test-doc',
         {
           'schema1.xsd': schema1,
-          'ImportedTypes.xsd': importedTypesXsd,
+          'ImportedTypes.xsd': getImportedTypesXsd(),
         },
       );
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -1420,8 +1420,8 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'MainWithInclude.xsd': mainWithIncludeXsd,
-          'CommonTypes.xsd': commonTypesXsd,
+          'MainWithInclude.xsd': getMainWithIncludeXsd(),
+          'CommonTypes.xsd': getCommonTypesXsd(),
         },
       );
       const initialResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -1441,7 +1441,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd, 'ImportedTypes.xsd': importedTypesXsd },
+        { 'shipOrder.xsd': getShipOrderXsd(), 'ImportedTypes.xsd': getImportedTypesXsd() },
       );
 
       const removeResult = XmlSchemaDocumentService.removeSchemaFile(definition, 'ImportedTypes.xsd');
@@ -1454,7 +1454,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd },
+        { 'shipOrder.xsd': getShipOrderXsd() },
       );
 
       const removeResult = XmlSchemaDocumentService.removeSchemaFile(definition, 'shipOrder.xsd');
@@ -1468,8 +1468,8 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
         {
-          'MainWithInclude.xsd': mainWithIncludeXsd,
-          'CommonTypes.xsd': commonTypesXsd,
+          'MainWithInclude.xsd': getMainWithIncludeXsd(),
+          'CommonTypes.xsd': getCommonTypesXsd(),
         },
       );
 
@@ -1482,7 +1482,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd, 'element-ref.xsd': elementRefXsd },
+        { 'shipOrder.xsd': getShipOrderXsd(), 'element-ref.xsd': getElementRefXsd() },
         { namespaceUri: 'io.kaoto.datamapper.poc.test', name: 'ShipOrder' },
       );
 
@@ -1500,7 +1500,7 @@ describe('XmlSchemaDocumentService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd, 'element-ref.xsd': elementRefXsd },
+        { 'shipOrder.xsd': getShipOrderXsd(), 'element-ref.xsd': getElementRefXsd() },
         { namespaceUri: 'io.kaoto.datamapper.poc.test', name: 'ShipOrder' },
       );
 
@@ -1519,7 +1519,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'InlineAttrSimpleType.xsd': inlineAttrSimpleTypeXsd },
+      { 'InlineAttrSimpleType.xsd': getInlineAttrSimpleTypeXsd() },
       { namespaceUri: '', name: 'Root' },
     );
 
@@ -1539,7 +1539,7 @@ describe('XmlSchemaDocumentService', () => {
       DocumentType.SOURCE_BODY,
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
-      { 'AnonymousGlobalElementRefLarge.xsd': anonymousGlobalElementRefLargeXsd },
+      { 'AnonymousGlobalElementRefLarge.xsd': getAnonymousGlobalElementRefLargeXsd() },
       { namespaceUri: '', name: 'Root' },
     );
 

--- a/packages/ui/src/services/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/xml-schema-types.service.test.ts
@@ -2,9 +2,9 @@ import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../mod
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { TypeDerivation, TypeOverrideVariant, Types } from '../models/datamapper/types';
 import {
-  extensionComplexXsd,
-  restrictionComplexXsd,
-  simpleTypeInheritanceXsd,
+  getExtensionComplexXsd,
+  getRestrictionComplexXsd,
+  getSimpleTypeInheritanceXsd,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
 import { QName } from '../xml-schema-ts/QName';
@@ -108,7 +108,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -138,7 +138,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'restriction.xsd': restrictionComplexXsd },
+        { 'restriction.xsd': getRestrictionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -170,7 +170,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'simpleType.xsd': restrictionComplexXsd },
+        { 'simpleType.xsd': getRestrictionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -234,7 +234,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -286,7 +286,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -309,7 +309,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -374,7 +374,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -405,7 +405,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -478,7 +478,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -506,7 +506,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -527,7 +527,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -547,7 +547,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -568,7 +568,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -649,7 +649,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'simpleType.xsd': simpleTypeInheritanceXsd },
+        { 'simpleType.xsd': getSimpleTypeInheritanceXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -680,7 +680,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'simpleType.xsd': simpleTypeInheritanceXsd },
+        { 'simpleType.xsd': getSimpleTypeInheritanceXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -713,7 +713,7 @@ describe('XmlSchemaTypesService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
-        { 'extension.xsd': extensionComplexXsd },
+        { 'extension.xsd': getExtensionComplexXsd() },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -7,7 +7,7 @@ import {
   IDocument,
 } from '../../models/datamapper/document';
 import { Predicate, PredicateOperator } from '../../models/datamapper/xpath';
-import { cartXsd, shipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { getCartXsd, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaDocumentService } from '../xml-schema-document.service';
 import { LiteralNode, XPathNodeType } from './syntaxtree/xpath-syntaxtree-model';
 import { XPathUtil } from './syntaxtree/xpath-syntaxtree-util';
@@ -791,11 +791,11 @@ describe('XPathService', () => {
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.XML_SCHEMA,
         BODY_DOCUMENT_ID,
-        { 'shipOrder.xsd': shipOrderXsd },
+        { 'shipOrder.xsd': getShipOrderXsd() },
       );
       bodyDoc = XmlSchemaDocumentService.createXmlSchemaDocument(bodyDefinition).document!;
       const cart2Definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.XML_SCHEMA, 'Cart2', {
-        'cart.xsd': cartXsd,
+        'cart.xsd': getCartXsd(),
       });
       cart2Doc = XmlSchemaDocumentService.createXmlSchemaDocument(cart2Definition).document!;
     });

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -44,137 +44,215 @@ export const twoDataMapperRouteDefinitionStub = parse(`
             - to:
                 uri: ${XSLT_COMPONENT_NAME}:transform-2.xsl`);
 
-export const shipOrderXsd = fs.readFileSync(path.resolve(__dirname, './xml/ShipOrder.xsd')).toString();
-export const cartXsd = fs.readFileSync(path.resolve(__dirname, './xml/Cart.xsd')).toString();
-export const crossSchemaBaseTypesXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/CrossSchemaBaseTypes.xsd'))
-  .toString();
-export const crossSchemaDerivedTypesXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/CrossSchemaDerivedTypes.xsd'))
-  .toString();
+const fileCache = new Map<string, string>();
+function readStubFile(relativePath: string): string {
+  if (!fileCache.has(relativePath)) {
+    fileCache.set(relativePath, fs.readFileSync(path.resolve(__dirname, relativePath)).toString());
+  }
+  return fileCache.get(relativePath)!;
+}
 
-export const testDocumentXsd = fs.readFileSync(path.resolve(__dirname, './xml/TestDocument.xsd')).toString();
-export const noTopElementXsd = fs.readFileSync(path.resolve(__dirname, './xml/NoTopElement.xsd')).toString();
-export const namedTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/NamedTypes.xsd')).toString();
-export const camelSpringXsd = fs.readFileSync(path.resolve(__dirname, './xml/camel-spring.xsd')).toString();
-export const multipleElementsXsd = fs.readFileSync(path.resolve(__dirname, './xml/MultipleElements.xsd')).toString();
-export const cartToShipOrderXslt = fs.readFileSync(path.resolve(__dirname, './xml/CartToShipOrder.xsl')).toString();
-export const shipOrderToShipOrderXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderToShipOrder.xsl'))
-  .toString();
-export const conditionalMappingsToShipOrderXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ConditionalMappingsToShipOrder.xsl'))
-  .toString();
-export const shipOrderToShipOrderInvalidForEachXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderToShipOrderInvalidForEach.xsl'))
-  .toString();
-export const shipOrderEmptyFirstLineXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderEmptyFirstLine.xsd'))
-  .toString();
-export const shipOrderToShipOrderMultipleForEachXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderToShipOrderMultipleForEach.xsl'))
-  .toString();
-export const shipOrderToShipOrderCollectionIndexXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderToShipOrderCollectionIndex.xsl'))
-  .toString();
-export const nestedConditionalsToShipOrderXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/NestedConditionalsToShipOrder.xsl'))
-  .toString();
-export const shipOrderWithCurrentXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/ShipOrderWithCurrent.xsl'))
-  .toString();
-
-export const x12837PDfdlXsd = fs.readFileSync(path.resolve(__dirname, './xml/X12-837P.dfdl.xsd')).toString();
-export const message837Xsd = fs.readFileSync(path.resolve(__dirname, './xml/Message837.xsd')).toString();
-export const x12837PXslt = fs.readFileSync(path.resolve(__dirname, './xml/X12-837.xsl')).toString();
-
-export const x12850DfdlXsd = fs.readFileSync(path.resolve(__dirname, './xml/X12-850.dfdl.xsd')).toString();
-export const invoice850Xsd = fs.readFileSync(path.resolve(__dirname, './xml/Invoice850.xsd')).toString();
-export const x12850ForEachXslt = fs
-  .readFileSync(path.resolve(__dirname, './xml/X12-850-Invoice-for-each.xsl'))
-  .toString();
-
-export const camelYamlDslJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/camelYamlDsl.json')).toString();
-
-export const cartJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/Cart.schema.json')).toString();
-export const accountJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/Account.schema.json')).toString();
-export const shipOrderJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/ShipOrder.schema.json')).toString();
-export const shipOrderJsonXslt = fs.readFileSync(path.resolve(__dirname, './json/ShipOrderJson.xsl')).toString();
-export const cartToShipOrderJsonXslt = fs
-  .readFileSync(path.resolve(__dirname, './json/CartToShipOrderJson.xsl'))
-  .toString();
-export const conditionalMappingsToShipOrderJsonXslt = fs
-  .readFileSync(path.resolve(__dirname, './json/ConditionalMappingsToShipOrderJson.xsl'))
-  .toString();
-export const multipleForEachJsonXslt = fs
-  .readFileSync(path.resolve(__dirname, './json/MultipleForEach.xsl'))
-  .toString();
-
-export const commonTypesJsonSchema = fs
-  .readFileSync(path.resolve(__dirname, './json/CommonTypes.schema.json'))
-  .toString();
-export const customerJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/Customer.schema.json')).toString();
-export const orderJsonSchema = fs.readFileSync(path.resolve(__dirname, './json/Order.schema.json')).toString();
-export const mainWithRefJsonSchema = fs
-  .readFileSync(path.resolve(__dirname, './json/MainWithRef.schema.json'))
-  .toString();
-export const productJsonSchema = fs
-  .readFileSync(path.resolve(__dirname, './json/nested/Product.schema.json'))
-  .toString();
-
-export const orgXsd = fs.readFileSync(path.resolve(__dirname, './xml/Org.xsd')).toString();
-export const contactsXsd = fs.readFileSync(path.resolve(__dirname, './xml/Contacts.xsd')).toString();
-export const orgToContactsXslt = fs.readFileSync(path.resolve(__dirname, './xml/OrgToContacts.xsl')).toString();
-export const extensionSimpleXsd = fs.readFileSync(path.resolve(__dirname, './xml/ExtensionSimple.xsd')).toString();
-export const extensionComplexXsd = fs.readFileSync(path.resolve(__dirname, './xml/ExtensionComplex.xsd')).toString();
-export const schemaTestXsd = fs.readFileSync(path.resolve(__dirname, './xml/SchemaTest.xsd')).toString();
-export const restrictionComplexXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/RestrictionComplex.xsd'))
-  .toString();
-export const restrictionSimpleXsd = fs.readFileSync(path.resolve(__dirname, './xml/RestrictionSimple.xsd')).toString();
-export const restrictionInheritanceXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/RestrictionInheritance.xsd'))
-  .toString();
-export const multiLevelExtensionXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/MultiLevelExtension.xsd'))
-  .toString();
-export const multiLevelRestrictionXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/MultiLevelRestriction.xsd'))
-  .toString();
-export const invalidComplexExtensionXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/InvalidComplexExtension.xsd'))
-  .toString();
-export const simpleTypeInheritanceXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/SimpleTypeInheritance.xsd'))
-  .toString();
-export const simpleTypeRestrictionXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/SimpleTypeRestriction.xsd'))
-  .toString();
-export const lazyLoadingTestXsd = fs.readFileSync(path.resolve(__dirname, './xml/LazyLoadingTest.xsd')).toString();
-export const adtInXsd = fs.readFileSync(path.resolve(__dirname, './xml/ADT_IN.xsd')).toString();
-export const adtOutXsd = fs.readFileSync(path.resolve(__dirname, './xml/ADT_OUT.xsd')).toString();
-export const elementRefXsd = fs.readFileSync(path.resolve(__dirname, './xml/element-ref.xsd')).toString();
-export const accountLcXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-lc.xsd')).toString();
-export const accountNsXsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns.xsd')).toString();
-export const accountNs2Xsd = fs.readFileSync(path.resolve(__dirname, './xml/account-ns2.xsd')).toString();
-export const mainWithIncludeXsd = fs.readFileSync(path.resolve(__dirname, './xml/MainWithInclude.xsd')).toString();
-export const commonTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/CommonTypes.xsd')).toString();
-export const mainWithImportXsd = fs.readFileSync(path.resolve(__dirname, './xml/MainWithImport.xsd')).toString();
-export const importedTypesXsd = fs.readFileSync(path.resolve(__dirname, './xml/ImportedTypes.xsd')).toString();
-export const multiIncludeMainXsd = fs.readFileSync(path.resolve(__dirname, './xml/MultiIncludeMain.xsd')).toString();
-export const multiIncludeComponentAXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/MultiIncludeComponentA.xsd'))
-  .toString();
-export const multiIncludeComponentBXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/MultiIncludeComponentB.xsd'))
-  .toString();
-
-export const inlineAttrSimpleTypeXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/InlineAttrSimpleType.xsd'))
-  .toString();
-export const anonymousGlobalElementRefLargeXsd = fs
-  .readFileSync(path.resolve(__dirname, './xml/AnonymousGlobalElementRefLarge.xsd'))
-  .toString();
+export function getShipOrderXsd(): string {
+  return readStubFile('./xml/ShipOrder.xsd');
+}
+export function getCartXsd(): string {
+  return readStubFile('./xml/Cart.xsd');
+}
+export function getCrossSchemaBaseTypesXsd(): string {
+  return readStubFile('./xml/CrossSchemaBaseTypes.xsd');
+}
+export function getCrossSchemaDerivedTypesXsd(): string {
+  return readStubFile('./xml/CrossSchemaDerivedTypes.xsd');
+}
+export function getTestDocumentXsd(): string {
+  return readStubFile('./xml/TestDocument.xsd');
+}
+export function getNoTopElementXsd(): string {
+  return readStubFile('./xml/NoTopElement.xsd');
+}
+export function getNamedTypesXsd(): string {
+  return readStubFile('./xml/NamedTypes.xsd');
+}
+export function getCamelSpringXsd(): string {
+  return readStubFile('./xml/camel-spring.xsd');
+}
+export function getMultipleElementsXsd(): string {
+  return readStubFile('./xml/MultipleElements.xsd');
+}
+export function getCartToShipOrderXslt(): string {
+  return readStubFile('./xml/CartToShipOrder.xsl');
+}
+export function getShipOrderToShipOrderXslt(): string {
+  return readStubFile('./xml/ShipOrderToShipOrder.xsl');
+}
+export function getConditionalMappingsToShipOrderXslt(): string {
+  return readStubFile('./xml/ConditionalMappingsToShipOrder.xsl');
+}
+export function getShipOrderToShipOrderInvalidForEachXslt(): string {
+  return readStubFile('./xml/ShipOrderToShipOrderInvalidForEach.xsl');
+}
+export function getShipOrderEmptyFirstLineXsd(): string {
+  return readStubFile('./xml/ShipOrderEmptyFirstLine.xsd');
+}
+export function getShipOrderToShipOrderMultipleForEachXslt(): string {
+  return readStubFile('./xml/ShipOrderToShipOrderMultipleForEach.xsl');
+}
+export function getShipOrderToShipOrderCollectionIndexXslt(): string {
+  return readStubFile('./xml/ShipOrderToShipOrderCollectionIndex.xsl');
+}
+export function getNestedConditionalsToShipOrderXslt(): string {
+  return readStubFile('./xml/NestedConditionalsToShipOrder.xsl');
+}
+export function getShipOrderWithCurrentXslt(): string {
+  return readStubFile('./xml/ShipOrderWithCurrent.xsl');
+}
+export function getX12837PDfdlXsd(): string {
+  return readStubFile('./xml/X12-837P.dfdl.xsd');
+}
+export function getMessage837Xsd(): string {
+  return readStubFile('./xml/Message837.xsd');
+}
+export function getX12837PXslt(): string {
+  return readStubFile('./xml/X12-837.xsl');
+}
+export function getX12850DfdlXsd(): string {
+  return readStubFile('./xml/X12-850.dfdl.xsd');
+}
+export function getInvoice850Xsd(): string {
+  return readStubFile('./xml/Invoice850.xsd');
+}
+export function getX12850ForEachXslt(): string {
+  return readStubFile('./xml/X12-850-Invoice-for-each.xsl');
+}
+export function getCamelYamlDslJsonSchema(): string {
+  return readStubFile('./json/camelYamlDsl.json');
+}
+export function getCartJsonSchema(): string {
+  return readStubFile('./json/Cart.schema.json');
+}
+export function getAccountJsonSchema(): string {
+  return readStubFile('./json/Account.schema.json');
+}
+export function getShipOrderJsonSchema(): string {
+  return readStubFile('./json/ShipOrder.schema.json');
+}
+export function getShipOrderJsonXslt(): string {
+  return readStubFile('./json/ShipOrderJson.xsl');
+}
+export function getCartToShipOrderJsonXslt(): string {
+  return readStubFile('./json/CartToShipOrderJson.xsl');
+}
+export function getConditionalMappingsToShipOrderJsonXslt(): string {
+  return readStubFile('./json/ConditionalMappingsToShipOrderJson.xsl');
+}
+export function getMultipleForEachJsonXslt(): string {
+  return readStubFile('./json/MultipleForEach.xsl');
+}
+export function getCommonTypesJsonSchema(): string {
+  return readStubFile('./json/CommonTypes.schema.json');
+}
+export function getCustomerJsonSchema(): string {
+  return readStubFile('./json/Customer.schema.json');
+}
+export function getOrderJsonSchema(): string {
+  return readStubFile('./json/Order.schema.json');
+}
+export function getMainWithRefJsonSchema(): string {
+  return readStubFile('./json/MainWithRef.schema.json');
+}
+export function getProductJsonSchema(): string {
+  return readStubFile('./json/nested/Product.schema.json');
+}
+export function getOrgXsd(): string {
+  return readStubFile('./xml/Org.xsd');
+}
+export function getContactsXsd(): string {
+  return readStubFile('./xml/Contacts.xsd');
+}
+export function getOrgToContactsXslt(): string {
+  return readStubFile('./xml/OrgToContacts.xsl');
+}
+export function getExtensionSimpleXsd(): string {
+  return readStubFile('./xml/ExtensionSimple.xsd');
+}
+export function getExtensionComplexXsd(): string {
+  return readStubFile('./xml/ExtensionComplex.xsd');
+}
+export function getSchemaTestXsd(): string {
+  return readStubFile('./xml/SchemaTest.xsd');
+}
+export function getRestrictionComplexXsd(): string {
+  return readStubFile('./xml/RestrictionComplex.xsd');
+}
+export function getRestrictionSimpleXsd(): string {
+  return readStubFile('./xml/RestrictionSimple.xsd');
+}
+export function getRestrictionInheritanceXsd(): string {
+  return readStubFile('./xml/RestrictionInheritance.xsd');
+}
+export function getMultiLevelExtensionXsd(): string {
+  return readStubFile('./xml/MultiLevelExtension.xsd');
+}
+export function getMultiLevelRestrictionXsd(): string {
+  return readStubFile('./xml/MultiLevelRestriction.xsd');
+}
+export function getInvalidComplexExtensionXsd(): string {
+  return readStubFile('./xml/InvalidComplexExtension.xsd');
+}
+export function getSimpleTypeInheritanceXsd(): string {
+  return readStubFile('./xml/SimpleTypeInheritance.xsd');
+}
+export function getSimpleTypeRestrictionXsd(): string {
+  return readStubFile('./xml/SimpleTypeRestriction.xsd');
+}
+export function getLazyLoadingTestXsd(): string {
+  return readStubFile('./xml/LazyLoadingTest.xsd');
+}
+export function getAdtInXsd(): string {
+  return readStubFile('./xml/ADT_IN.xsd');
+}
+export function getAdtOutXsd(): string {
+  return readStubFile('./xml/ADT_OUT.xsd');
+}
+export function getElementRefXsd(): string {
+  return readStubFile('./xml/element-ref.xsd');
+}
+export function getAccountLcXsd(): string {
+  return readStubFile('./xml/account-lc.xsd');
+}
+export function getAccountNsXsd(): string {
+  return readStubFile('./xml/account-ns.xsd');
+}
+export function getAccountNs2Xsd(): string {
+  return readStubFile('./xml/account-ns2.xsd');
+}
+export function getMainWithIncludeXsd(): string {
+  return readStubFile('./xml/MainWithInclude.xsd');
+}
+export function getCommonTypesXsd(): string {
+  return readStubFile('./xml/CommonTypes.xsd');
+}
+export function getMainWithImportXsd(): string {
+  return readStubFile('./xml/MainWithImport.xsd');
+}
+export function getImportedTypesXsd(): string {
+  return readStubFile('./xml/ImportedTypes.xsd');
+}
+export function getMultiIncludeMainXsd(): string {
+  return readStubFile('./xml/MultiIncludeMain.xsd');
+}
+export function getMultiIncludeComponentAXsd(): string {
+  return readStubFile('./xml/MultiIncludeComponentA.xsd');
+}
+export function getMultiIncludeComponentBXsd(): string {
+  return readStubFile('./xml/MultiIncludeComponentB.xsd');
+}
+export function getInlineAttrSimpleTypeXsd(): string {
+  return readStubFile('./xml/InlineAttrSimpleType.xsd');
+}
+export function getAnonymousGlobalElementRefLargeXsd(): string {
+  return readStubFile('./xml/AnonymousGlobalElementRefLarge.xsd');
+}
 
 export class TestUtil {
   static createSourceOrderDoc() {
@@ -183,7 +261,7 @@ export class TestUtil {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'shipOrder.xsd': shipOrderXsd,
+        'shipOrder.xsd': getShipOrderXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -199,7 +277,7 @@ export class TestUtil {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'camelSpring.xsd': camelSpringXsd,
+        'camelSpring.xsd': getCamelSpringXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -215,7 +293,7 @@ export class TestUtil {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'shipOrder.xsd': shipOrderXsd,
+        'shipOrder.xsd': getShipOrderXsd(),
       },
     );
     const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -231,7 +309,7 @@ export class TestUtil {
       DocumentDefinitionType.JSON_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'shipOrder.json': shipOrderJsonSchema,
+        'shipOrder.json': getShipOrderJsonSchema(),
       },
     );
     const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
@@ -245,12 +323,12 @@ export class TestUtil {
     let answer: BaseDocument;
     if (schemaType === DocumentDefinitionType.JSON_SCHEMA) {
       const definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, name, {
-        [`${name}.json`]: content || cartJsonSchema,
+        [`${name}.json`]: content || getCartJsonSchema(),
       });
       answer = JsonSchemaDocumentService.createJsonSchemaDocument(definition).document!;
     } else {
       const definition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.XML_SCHEMA, name, {
-        [`${name}.xsd`]: content || shipOrderXsd,
+        [`${name}.xsd`]: content || getShipOrderXsd(),
       });
       answer = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
     }
@@ -263,7 +341,7 @@ export class TestUtil {
     const sourcePrimitiveParamDoc = new PrimitiveDocument(
       new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'primitive'),
     );
-    const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.XML_SCHEMA, cartXsd);
+    const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.XML_SCHEMA, getCartXsd());
     return new Map<string, IDocument>([
       ['sourceParam1', sourceParamDoc],
       ['primitive', sourcePrimitiveParamDoc],
@@ -275,8 +353,12 @@ export class TestUtil {
     const sourcePrimitiveParamDoc = new PrimitiveDocument(
       new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'primitive'),
     );
-    const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.JSON_SCHEMA, cartJsonSchema);
-    const cart2ParamDoc = TestUtil.createParamOrderDoc('cart2', DocumentDefinitionType.JSON_SCHEMA, cartJsonSchema);
+    const cartParamDoc = TestUtil.createParamOrderDoc('cart', DocumentDefinitionType.JSON_SCHEMA, getCartJsonSchema());
+    const cart2ParamDoc = TestUtil.createParamOrderDoc(
+      'cart2',
+      DocumentDefinitionType.JSON_SCHEMA,
+      getCartJsonSchema(),
+    );
     return new Map<string, IDocument>([
       ['primitive', sourcePrimitiveParamDoc],
       ['cart', cartParamDoc],
@@ -290,7 +372,7 @@ export class TestUtil {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'ADT_IN.xsd': adtInXsd,
+        'ADT_IN.xsd': getAdtInXsd(),
       },
     );
     return XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -302,7 +384,7 @@ export class TestUtil {
       DocumentDefinitionType.XML_SCHEMA,
       BODY_DOCUMENT_ID,
       {
-        'ADT_OUT.xsd': adtOutXsd,
+        'ADT_OUT.xsd': getAdtOutXsd(),
       },
     );
     return XmlSchemaDocumentService.createXmlSchemaDocument(definition);

--- a/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
@@ -1,12 +1,12 @@
 import {
-  camelSpringXsd,
-  crossSchemaBaseTypesXsd,
-  crossSchemaDerivedTypesXsd,
-  namedTypesXsd,
-  restrictionInheritanceXsd,
-  shipOrderEmptyFirstLineXsd,
-  shipOrderXsd,
-  testDocumentXsd,
+  getCamelSpringXsd,
+  getCrossSchemaBaseTypesXsd,
+  getCrossSchemaDerivedTypesXsd,
+  getNamedTypesXsd,
+  getRestrictionInheritanceXsd,
+  getShipOrderEmptyFirstLineXsd,
+  getShipOrderXsd,
+  getTestDocumentXsd,
 } from '../stubs/datamapper/data-mapper';
 import { XmlSchemaAttribute } from './attribute/XmlSchemaAttribute';
 import { XmlSchemaAttributeGroupRef } from './attribute/XmlSchemaAttributeGroupRef';
@@ -24,7 +24,7 @@ import { XmlSchemaUse } from './XmlSchemaUse';
 describe('XmlSchemaCollection', () => {
   it('should parse ShipOrder XML schema', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(shipOrderXsd, () => {});
+    const xmlSchema = collection.read(getShipOrderXsd(), () => {});
     const attributes = xmlSchema.getAttributes();
     expect(attributes.size).toEqual(0);
 
@@ -89,7 +89,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should parse TestDocument XML schema', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(testDocumentXsd, () => {});
+    const xmlSchema = collection.read(getTestDocumentXsd(), () => {});
     const attributes = xmlSchema.getAttributes();
     expect(attributes.size).toEqual(0);
     const elements = xmlSchema.getElements();
@@ -104,7 +104,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should parse NamedTypes XML schema', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(namedTypesXsd, () => {});
+    const xmlSchema = collection.read(getNamedTypesXsd(), () => {});
     const elements = xmlSchema.getElements();
     expect(elements.size).toEqual(1);
     const element1 = elements.get(new QName('io.kaoto.datamapper.poc.test', 'Element1'));
@@ -119,7 +119,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should parse camel-spring XML schema', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(camelSpringXsd, () => {});
+    const xmlSchema = collection.read(getCamelSpringXsd(), () => {});
     const aggregate = xmlSchema.getElements().get(new QName('http://camel.apache.org/schema/spring', 'aggregate'));
     const aggregateComplexType = aggregate!.getSchemaType() as XmlSchemaComplexType;
     expect(aggregateComplexType.getParticle()).toBeNull();
@@ -135,7 +135,7 @@ describe('XmlSchemaCollection', () => {
   it('should parse ShipOrderEmptyFirstLine.xsd', () => {
     const collection = new XmlSchemaCollection();
     try {
-      collection.read(shipOrderEmptyFirstLineXsd, () => {});
+      collection.read(getShipOrderEmptyFirstLineXsd(), () => {});
     } catch (error) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((error as any).message).toContain('an XML declaration must be at the start of the document');
@@ -146,7 +146,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should track explicit minOccurs/maxOccurs flags in ShipOrder elements', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(shipOrderXsd, () => {});
+    const xmlSchema = collection.read(getShipOrderXsd(), () => {});
 
     const shipOrderElement = xmlSchema.getElements().get(new QName('io.kaoto.datamapper.poc.test', 'ShipOrder'));
     expect(shipOrderElement).toBeDefined();
@@ -174,7 +174,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should correctly handle explicit flags in RestrictionInheritance.xsd', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(restrictionInheritanceXsd, () => {});
+    const xmlSchema = collection.read(getRestrictionInheritanceXsd(), () => {});
 
     const restrictedType = xmlSchema
       .getSchemaTypes()
@@ -208,7 +208,7 @@ describe('XmlSchemaCollection', () => {
 
   it('should handle explicit flags in sequence particles', () => {
     const collection = new XmlSchemaCollection();
-    const xmlSchema = collection.read(shipOrderXsd, () => {});
+    const xmlSchema = collection.read(getShipOrderXsd(), () => {});
 
     const shipOrderElement = xmlSchema.getElements().get(new QName('io.kaoto.datamapper.poc.test', 'ShipOrder'));
     const shipOrderComplexType = shipOrderElement!.getSchemaType() as XmlSchemaComplexType;
@@ -223,8 +223,8 @@ describe('XmlSchemaCollection', () => {
   describe('Cross-schema type resolution', () => {
     it('should load multiple schema files into the same collection', () => {
       const collection = new XmlSchemaCollection();
-      const baseSchema = collection.read(crossSchemaBaseTypesXsd, () => {});
-      const derivedSchema = collection.read(crossSchemaDerivedTypesXsd, () => {});
+      const baseSchema = collection.read(getCrossSchemaBaseTypesXsd(), () => {});
+      const derivedSchema = collection.read(getCrossSchemaDerivedTypesXsd(), () => {});
 
       expect(baseSchema).toBeTruthy();
       expect(derivedSchema).toBeTruthy();
@@ -234,8 +234,8 @@ describe('XmlSchemaCollection', () => {
 
     it('should resolve complex type extension across schema files', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(crossSchemaBaseTypesXsd, () => {});
-      const derivedSchema = collection.read(crossSchemaDerivedTypesXsd, () => {});
+      collection.read(getCrossSchemaBaseTypesXsd(), () => {});
+      const derivedSchema = collection.read(getCrossSchemaDerivedTypesXsd(), () => {});
 
       const employeeType = derivedSchema
         .getSchemaTypes()
@@ -260,8 +260,8 @@ describe('XmlSchemaCollection', () => {
 
     it('should resolve complex type restriction across schema files', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(crossSchemaBaseTypesXsd, () => {});
-      const derivedSchema = collection.read(crossSchemaDerivedTypesXsd, () => {});
+      collection.read(getCrossSchemaBaseTypesXsd(), () => {});
+      const derivedSchema = collection.read(getCrossSchemaDerivedTypesXsd(), () => {});
 
       const usAddressType = derivedSchema
         .getSchemaTypes()
@@ -286,8 +286,8 @@ describe('XmlSchemaCollection', () => {
 
     it('should resolve simple type restriction across schema files', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(crossSchemaBaseTypesXsd, () => {});
-      const derivedSchema = collection.read(crossSchemaDerivedTypesXsd, () => {});
+      collection.read(getCrossSchemaBaseTypesXsd(), () => {});
+      const derivedSchema = collection.read(getCrossSchemaDerivedTypesXsd(), () => {});
 
       const specialCodeType = derivedSchema
         .getSchemaTypes()
@@ -309,8 +309,8 @@ describe('XmlSchemaCollection', () => {
 
     it('should correctly populate fields when extension base is in another schema', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(crossSchemaBaseTypesXsd, () => {});
-      const derivedSchema = collection.read(crossSchemaDerivedTypesXsd, () => {});
+      collection.read(getCrossSchemaBaseTypesXsd(), () => {});
+      const derivedSchema = collection.read(getCrossSchemaDerivedTypesXsd(), () => {});
 
       const employeeElement = derivedSchema.getElements().get(new QName('http://www.example.com/DERIVED', 'Employee'));
 
@@ -338,7 +338,7 @@ describe('XmlSchemaCollection', () => {
   describe('getUserSchemas', () => {
     it('should return only user-defined schemas, excluding standard namespaces', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(camelSpringXsd, () => {});
+      collection.read(getCamelSpringXsd(), () => {});
 
       const userSchemas = collection.getUserSchemas();
       const allSchemas = collection.getXmlSchemas();
@@ -355,7 +355,7 @@ describe('XmlSchemaCollection', () => {
 
     it('should include camel-spring schema in user schemas', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(camelSpringXsd, () => {});
+      collection.read(getCamelSpringXsd(), () => {});
 
       const userSchemas = collection.getUserSchemas();
 
@@ -366,7 +366,7 @@ describe('XmlSchemaCollection', () => {
 
     it('should exclude built-in XSD schema from user schemas', () => {
       const collection = new XmlSchemaCollection();
-      collection.read(camelSpringXsd, () => {});
+      collection.read(getCamelSpringXsd(), () => {});
 
       const userSchemas = collection.getUserSchemas();
 


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test fixtures and stubs now provide schema/XSD/XSLT/JSON contents via on-demand getter functions instead of static exported constants. Test code updated to call these getters where needed. Behavior and test assertions unchanged; this improves fixture loading, caching, and maintainability across the test suite.

(Note: no user-facing functionality changed.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->