### PR TITLE
fix(Rest): Import OpenAPI generated route invalid

### DIFF
--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -167,12 +167,72 @@ describe('useRestDslImportWizard', () => {
     });
   });
 
-  it('does not create duplicate route when operation direct route already exists', () => {
+  it('does not create duplicate route when operation direct route already exists (direct:operationId format)', () => {
     const camelResource = new CamelRouteResource([
       {
         route: {
           from: {
             uri: 'direct:addPet',
+            steps: [],
+          },
+        },
+      },
+    ]);
+
+    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
+    const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
+
+    const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <SettingsContext.Provider value={mockSettingsContext}>
+        <Provider>{children}</Provider>
+      </SettingsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
+
+    const spec: OpenApi = {
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/pet': {
+          post: {
+            operationId: 'addPet',
+            responses: {
+              '200': { description: 'ok' },
+            },
+          },
+        },
+      },
+    };
+
+    act(() => {
+      result.current.setOpenApiSpecText(JSON.stringify(spec));
+    });
+
+    act(() => {
+      result.current.handleParseOpenApiSpec();
+    });
+
+    let imported = false;
+    act(() => {
+      imported = result.current.handleImportOpenApi();
+    });
+
+    expect(imported).toBe(false);
+    expect(addNewEntitySpy).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not create duplicate route when operation direct route already exists (parameters.name format)', () => {
+    const camelResource = new CamelRouteResource([
+      {
+        route: {
+          from: {
+            uri: 'direct',
+            parameters: { name: 'addPet' },
             steps: [],
           },
         },
@@ -553,7 +613,8 @@ describe('useRestDslImportWizard', () => {
 
       expect(imported).toBe(true);
       expect(camelResource.addNewEntity).toHaveBeenCalledWith('route');
-      expect(mockRouteEntity.updateModel).toHaveBeenCalledWith('route.from.uri', 'direct:getPet');
+      expect(mockRouteEntity.updateModel).toHaveBeenCalledWith('route.from.uri', 'direct');
+      expect(mockRouteEntity.updateModel).toHaveBeenCalledWith('route.from.parameters', { name: 'getPet' });
       expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
       expect(result.current.importStatus).toEqual({
         type: 'success',

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
@@ -93,6 +93,11 @@ export const useRestDslImportWizard = () => {
         const uri = routeEntity.entityDef?.route?.from?.uri ?? '';
         if (uri.startsWith('direct:')) {
           routeNames.add(uri.slice('direct:'.length).split('?')[0]);
+        } else if (uri === 'direct') {
+          const name = routeEntity.entityDef?.route?.from?.parameters?.['name'];
+          if (typeof name === 'string' && name) {
+            routeNames.add(name);
+          }
         }
       });
     }
@@ -172,7 +177,8 @@ export const useRestDslImportWizard = () => {
 
         routeEntity?.updateModel('route.id', `route-${operation.operationId}`);
         routeEntity?.updateModel('route.from.id', `direct-from-${operation.operationId}`);
-        routeEntity?.updateModel('route.from.uri', `direct:${operation.operationId}`);
+        routeEntity?.updateModel('route.from.uri', 'direct');
+        routeEntity?.updateModel('route.from.parameters', { name: operation.operationId });
         routeEntity?.updateModel('route.from.steps', [
           {
             setBody: {


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3016

The route template is a timer route which has timer parameters in `from`. In order to generate a direct route for REST operation, those timer parameter needs to be removed. Also use just `direct` for `uri` and put operationId in `parameters`, which is the Kaoto default style.

generated routes
```yaml
- route:
    id: route-updateUser
    from:
      id: direct-from-updateUser
      uri: direct
      parameters:
        name: updateUser
      steps:
        - setBody:
            constant: Operation updateUser not yet implemented
- route:
    id: route-deleteUser
    from:
      id: direct-from-deleteUser
      uri: direct
      parameters:
        name: deleteUser
      steps:
        - setBody:
            constant: Operation deleteUser not yet implemented
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-route detection when importing OpenAPI operations; prevents redundant direct routes created from different route formats and ensures imports don't produce duplicate entities.

* **Tests**
  * Expanded test coverage for the REST import flow to validate handling of direct routes supplied via parameters and to confirm duplicate-prevention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->