### PR TITLE
fix(Rest): Importing OpenAPI from invalid URL lacks error

### DIFF
--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
@@ -9,6 +9,7 @@ describe('ApicurioImportSource', () => {
 
   afterEach(() => {
     fetchSpy.mockRestore();
+    mockOnSchemaLoaded.mockReset();
   });
 
   it('shows message when registry URL is not configured', () => {
@@ -87,6 +88,7 @@ describe('ApicurioImportSource', () => {
         ok: true,
         text: jest.fn().mockResolvedValue(artifactContent),
       } as unknown as Response);
+    mockOnSchemaLoaded.mockReturnValue({});
 
     render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
 
@@ -106,6 +108,38 @@ describe('ApicurioImportSource', () => {
     });
 
     expect(screen.getByText('Loaded')).toBeInTheDocument();
+  });
+
+  it('shows error and hides "Loaded" when onSchemaLoaded returns an error', async () => {
+    const mockArtifacts = {
+      artifacts: [{ id: 'artifact-1', name: 'API Spec', type: 'OPENAPI' }],
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockArtifacts),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('<html>error</html>'),
+      } as unknown as Response);
+    mockOnSchemaLoaded.mockReturnValue({ error: 'Invalid OpenAPI specification.' });
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Spec')).toBeInTheDocument();
+    });
+
+    const radio = screen.getByLabelText(/API Spec/);
+    fireEvent.click(radio);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid OpenAPI specification.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Loaded')).not.toBeInTheDocument();
   });
 
   it('shows error when artifact fetch fails', async () => {
@@ -177,6 +211,19 @@ describe('ApicurioImportSource', () => {
 
     await waitFor(() => {
       expect(screen.getByText('No OpenAPI artifacts found.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when initial artifact list fetch returns non-ok status', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as unknown as Response);
+
+    render(<ApicurioImportSource registryUrl={registryUrl} onSchemaLoaded={mockOnSchemaLoaded} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch artifacts \(503\)/)).toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
@@ -6,7 +6,7 @@ import { ApicurioArtifact, ApicurioArtifactSearchResult, SchemaLoadedResult } fr
 
 type ApicurioImportSourceProps = {
   registryUrl?: string;
-  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+  onSchemaLoaded: (result: SchemaLoadedResult) => { error?: string };
 };
 
 export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> = ({ registryUrl, onSchemaLoaded }) => {
@@ -19,11 +19,6 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
   const [error, setError] = useState('');
 
   const fetchArtifacts = useCallback(async () => {
-    if (!registryUrl) {
-      setError('Apicurio Registry URL is missing.');
-      return;
-    }
-
     setIsLoading(true);
     setError('');
 
@@ -78,14 +73,19 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
         }
         const specText = await response.text();
 
-        onSchemaLoaded({
+        const loadResult = onSchemaLoaded({
           schema: specText,
           source: 'apicurio',
           sourceIdentifier: artifactUrl,
         });
 
-        setIsLoaded(true);
-        setError('');
+        if (loadResult?.error) {
+          setError(loadResult.error);
+          setIsLoaded(false);
+        } else {
+          setIsLoaded(true);
+          setError('');
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unable to download the selected artifact.';
         setError(message);

--- a/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
@@ -6,7 +6,7 @@ describe('FileImportSource', () => {
   const mockOnSchemaLoaded = jest.fn();
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('renders file upload component', () => {
@@ -104,6 +104,7 @@ describe('FileImportSource', () => {
   it('calls onSchemaLoaded and shows success when a file is uploaded', async () => {
     const fileContent = '{"openapi": "3.0.0"}';
     const file = new File([fileContent], 'spec.json', { type: 'application/json' });
+    mockOnSchemaLoaded.mockReturnValue({});
 
     const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -119,6 +120,23 @@ describe('FileImportSource', () => {
     });
 
     expect(screen.getByText('Schema loaded successfully')).toBeInTheDocument();
+  });
+
+  it('shows error and hides success when onSchemaLoaded returns an error', async () => {
+    const fileContent = '<html>Not an OpenAPI spec</html>';
+    const file = new File([fileContent], 'bad.json', { type: 'application/json' });
+    mockOnSchemaLoaded.mockReturnValue({ error: 'Invalid OpenAPI specification.' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid OpenAPI specification.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Schema loaded successfully')).not.toBeInTheDocument();
   });
 
   it('shows error when onSchemaLoaded throws', async () => {
@@ -143,6 +161,7 @@ describe('FileImportSource', () => {
   it('clears file state when clear button is clicked', async () => {
     const fileContent = '{"openapi": "3.0.0"}';
     const file = new File([fileContent], 'spec.json', { type: 'application/json' });
+    mockOnSchemaLoaded.mockReturnValue({});
 
     const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -159,6 +178,19 @@ describe('FileImportSource', () => {
 
     expect(textarea).toHaveValue('');
     expect(screen.queryByText('Schema loaded successfully')).not.toBeInTheDocument();
+  });
+
+  it('shows success when onSchemaLoaded returns no value', async () => {
+    const file = new File(['{"openapi": "3.0.0"}'], 'spec.json', { type: 'application/json' });
+
+    const { container } = render(<FileImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Schema loaded successfully')).toBeInTheDocument();
+    });
   });
 
   it('allows manual text input in the textarea', () => {

--- a/packages/ui/src/pages/RestDslImport/components/FileImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/FileImportSource.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, useCallback, useRef, useState } from 'react';
 import { SchemaLoadedResult } from '../RestDslImportTypes';
 
 type FileImportSourceProps = {
-  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+  onSchemaLoaded: (result: SchemaLoadedResult) => { error?: string };
 };
 
 export const FileImportSource: FunctionComponent<FileImportSourceProps> = ({ onSchemaLoaded }) => {
@@ -33,13 +33,18 @@ export const FileImportSource: FunctionComponent<FileImportSourceProps> = ({ onS
       }
 
       try {
-        onSchemaLoaded({
+        const loadResult = onSchemaLoaded({
           schema: fileContent,
           source: 'file',
           sourceIdentifier: filenameRef.current || 'uploaded-file',
         });
-        setIsLoaded(true);
-        setError('');
+        if (loadResult?.error) {
+          setError(loadResult.error);
+          setIsLoaded(false);
+        } else {
+          setIsLoaded(true);
+          setError('');
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unable to read the uploaded specification.';
         setError(message);

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
@@ -37,6 +37,7 @@ describe('UriImportSource', () => {
       ok: true,
       text: jest.fn().mockResolvedValue(specContent),
     } as unknown as Response);
+    mockOnSchemaLoaded.mockReturnValue({});
 
     render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
     const input = screen.getByRole('textbox');
@@ -58,6 +59,29 @@ describe('UriImportSource', () => {
     expect(screen.getByText('Loaded')).toBeInTheDocument();
   });
 
+  it('shows error and hides "Loaded" when onSchemaLoaded returns an error', async () => {
+    const specContent = '<html>Not Found</html>';
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(specContent),
+    } as unknown as Response);
+    mockOnSchemaLoaded.mockReturnValue({ error: 'Invalid OpenAPI specification.' });
+
+    render(<UriImportSource onSchemaLoaded={mockOnSchemaLoaded} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'http://example.com/spec.yaml' } });
+
+    const fetchButton = screen.getByRole('button', { name: /fetch/i });
+    fireEvent.click(fetchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid OpenAPI specification.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Loaded')).not.toBeInTheDocument();
+  });
+
   it('shows error message when fetch fails', async () => {
     fetchSpy.mockResolvedValue({
       ok: false,
@@ -73,7 +97,7 @@ describe('UriImportSource', () => {
     fireEvent.click(fetchButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Failed to fetch specification \(404\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Failed to fetch specification \(HTTP 404\)/)).toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, useCallback, useState } from 'react';
 import { SchemaLoadedResult } from '../RestDslImportTypes';
 
 type UriImportSourceProps = {
-  onSchemaLoaded: (result: SchemaLoadedResult) => void;
+  onSchemaLoaded: (result: SchemaLoadedResult) => { error?: string };
 };
 
 export const UriImportSource: FunctionComponent<UriImportSourceProps> = ({ onSchemaLoaded }) => {
@@ -16,10 +16,6 @@ export const UriImportSource: FunctionComponent<UriImportSourceProps> = ({ onSch
 
   const handleFetch = useCallback(async () => {
     const trimmed = uri.trim();
-    if (!trimmed) {
-      setError('Provide a specification URI to fetch.');
-      return;
-    }
 
     setIsLoading(true);
     setError('');
@@ -28,18 +24,23 @@ export const UriImportSource: FunctionComponent<UriImportSourceProps> = ({ onSch
     try {
       const response = await fetch(trimmed);
       if (!response.ok) {
-        throw new Error(`Failed to fetch specification (${response.status})`);
+        throw new Error(`Failed to fetch specification (HTTP ${response.status})`);
       }
       const specText = await response.text();
 
-      onSchemaLoaded({
+      const loadResult = onSchemaLoaded({
         schema: specText,
         source: 'uri',
         sourceIdentifier: trimmed,
       });
 
-      setIsLoaded(true);
-      setError('');
+      if (loadResult?.error) {
+        setError(loadResult.error);
+        setIsLoaded(false);
+      } else {
+        setIsLoaded(true);
+        setError('');
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch the specification.';
       setError(message);

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -49,14 +49,16 @@ describe('useRestDslImportWizard', () => {
         },
       });
 
+      let returnValue: { error?: string } | undefined;
       act(() => {
-        result.current.handleSchemaLoaded({
+        returnValue = result.current.handleSchemaLoaded({
           schema: validSpec,
           source: 'file',
           sourceIdentifier: 'openapi.json',
         });
       });
 
+      expect(returnValue).toEqual({});
       expect(result.current.isOpenApiParsed).toBe(true);
       expect(result.current.openApiLoadSource).toBe('file');
       expect(result.current.sourceIdentifier).toBe('openapi.json');
@@ -127,18 +129,20 @@ describe('useRestDslImportWizard', () => {
     it('handles invalid OpenAPI spec gracefully', () => {
       const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
 
+      let returnValue: { error?: string } | undefined;
       act(() => {
-        result.current.handleSchemaLoaded({
+        returnValue = result.current.handleSchemaLoaded({
           schema: 'invalid json {{{',
           source: 'file',
           sourceIdentifier: 'invalid.json',
         });
       });
 
+      expect(returnValue).toEqual({ error: expect.stringMatching(/Invalid OpenAPI specification/) });
       expect(result.current.isOpenApiParsed).toBe(false);
       expect(result.current.importStatus).toEqual({
         type: 'error',
-        message: expect.stringMatching(/Invalid spec/),
+        message: expect.stringMatching(/Invalid OpenAPI specification/),
       });
     });
 
@@ -151,14 +155,16 @@ describe('useRestDslImportWizard', () => {
         paths: {},
       });
 
+      let returnValue: { error?: string } | undefined;
       act(() => {
-        result.current.handleSchemaLoaded({
+        returnValue = result.current.handleSchemaLoaded({
           schema: noPaths,
           source: 'file',
           sourceIdentifier: 'empty.json',
         });
       });
 
+      expect(returnValue).toEqual({ error: 'No operations were found in the specification.' });
       expect(result.current.isOpenApiParsed).toBe(false);
       expect(result.current.importStatus).toEqual({
         type: 'error',

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.tsx
@@ -45,11 +45,20 @@ export const useRestDslImportWizard = () => {
       return { success: false, error: 'Provide an OpenAPI specification to import.' };
     }
 
+    let spec: OpenApi;
     try {
-      const spec = parseYaml(specText) as OpenApi;
-      if (!spec || typeof spec !== 'object' || !('paths' in spec)) {
-        throw new Error('Invalid spec');
-      }
+      spec = parseYaml(specText) as OpenApi;
+    } catch {
+      setImportOperations([]);
+      setIsOpenApiParsed(false);
+      return { success: false, error: 'Invalid OpenAPI specification.' };
+    }
+
+    if (!spec || typeof spec !== 'object' || !('paths' in spec)) {
+      return { success: false, error: 'Invalid OpenAPI specification.' };
+    }
+
+    try {
       setOpenApiSpecText(JSON.stringify(spec, null, 2));
       const operations = OpenApiProcessingService.buildOperationsFromSpec(spec);
       if (operations.length === 0) {
@@ -71,15 +80,20 @@ export const useRestDslImportWizard = () => {
   }, []);
 
   const handleSchemaLoaded = useCallback(
-    (result: SchemaLoadedResult) => {
+    (result: SchemaLoadedResult): { error?: string } => {
       const parsed = parseOpenApiSpec(result.schema);
       if (parsed.success) {
         setOpenApiLoadSource(result.source);
         setSourceIdentifier(result.sourceIdentifier);
         setImportStatus(null);
+        return {};
       } else if (parsed.error) {
+        setOpenApiLoadSource(undefined);
+        setSourceIdentifier('');
         setImportStatus({ type: 'error', message: parsed.error });
+        return { error: parsed.error };
       }
+      return {};
     },
     [parseOpenApiSpec],
   );


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3017

<img width="2095" height="1264" alt="Screenshot From 2026-03-06 16-26-00" src="https://github.com/user-attachments/assets/198e32a4-2c76-4b91-b21b-6c843e98f122" />
<img width="2095" height="1264" alt="Screenshot From 2026-03-06 16-26-31" src="https://github.com/user-attachments/assets/6aa450a5-b199-4144-ae3c-7fa7b7af11b5" />
<img width="2095" height="1264" alt="Screenshot From 2026-03-06 16-27-01" src="https://github.com/user-attachments/assets/18f8114f-9e9b-4942-aed9-7a0eb665546a" />
<img width="2095" height="1264" alt="Screenshot From 2026-03-06 16-27-16" src="https://github.com/user-attachments/assets/5000df86-5ae1-40fe-aed2-bd4298a4b5eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import errors are now surfaced in the UI with clearer messages (e.g., "Invalid OpenAPI specification", "Failed to fetch specification (HTTP 404)").
  * When an import reports an error, success/"Loaded" indicators are hidden so the UI accurately reflects failure.
  * Loading and error states are handled more consistently for uploads and URI fetches.

* **Tests**
  * Added/updated tests to verify error propagation and UI feedback for various import failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->