### PR TITLE
[WIP] fix(DataMapper):  Add DnD drop validation with visual feedback and er…

### DIFF
--- a/packages/ui/src/components/Document/NodeContainer.scss
+++ b/packages/ui/src/components/Document/NodeContainer.scss
@@ -10,6 +10,16 @@
   box-sizing: border-box;
 }
 
+.droppable-invalid {
+  color: var(--pf-t--global--text--color--disabled);
+  border-style: dashed;
+  border-color: var(--pf-t--global--text--color--disabled);
+  border-width: 1px;
+  cursor: not-allowed;
+  border-radius: var(--pf-v6-c-droppable--m-dragging--after--BorderRadius);
+  box-sizing: border-box;
+}
+
 .draggable-container {
   font-weight: bold;
   color: var(--pf-t--global--icon--color--brand--default);

--- a/packages/ui/src/components/Document/NodeContainer.test.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.test.tsx
@@ -1,0 +1,102 @@
+import { useDroppable } from '@dnd-kit/core';
+import { render } from '@testing-library/react';
+
+import { NodeData } from '../../models/datamapper/visualization';
+import { DataMapperDndContext } from '../../providers/datamapper-dnd.provider';
+import { MappingValidationService } from '../../services/mapping-validation.service';
+import { DroppableContainer } from './NodeContainer';
+
+jest.mock('@dnd-kit/core', () => ({
+  useDroppable: jest.fn().mockReturnValue({ isOver: false, setNodeRef: jest.fn() }),
+  useDraggable: jest.fn().mockReturnValue({
+    isDragging: false,
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+  }),
+}));
+
+jest.mock('../../services/mapping-validation.service', () => ({
+  MappingValidationService: {
+    validateMappingPair: jest.fn().mockReturnValue({ isValid: true }),
+  },
+}));
+
+describe('DroppableContainer', () => {
+  const mockNodeData = {
+    id: 'test-node',
+    title: 'Test Node',
+    isSource: false,
+    isPrimitive: false,
+    path: {},
+  } as unknown as NodeData;
+
+  const activeSourceNode = {
+    id: 'active-source',
+    title: 'Active Source',
+    isSource: true,
+    isPrimitive: false,
+    path: {},
+  } as unknown as NodeData;
+
+  beforeEach(() => {
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: false, setNodeRef: jest.fn() });
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: true });
+  });
+
+  it('should call useDroppable with disabled: false when there is no active node', () => {
+    render(
+      <DataMapperDndContext.Provider value={{}}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+    expect(useDroppable).toHaveBeenCalledWith(expect.objectContaining({ disabled: false }));
+  });
+
+  it('should call useDroppable with disabled: true when the active node is on the same side', () => {
+    const sameSideNode = { ...mockNodeData, id: 'same-side', isSource: false } as unknown as NodeData;
+    render(
+      <DataMapperDndContext.Provider value={{ activeNode: sameSideNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+    expect(useDroppable).toHaveBeenCalledWith(expect.objectContaining({ disabled: true }));
+  });
+
+  it('should apply droppable-invalid class when hovering over an invalid cross-side drop', () => {
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: false });
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: true, setNodeRef: jest.fn() });
+
+    const { container } = render(
+      <DataMapperDndContext.Provider value={{ activeNode: activeSourceNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+
+    expect(container.querySelector('.droppable-invalid')).toBeTruthy();
+    expect(container.querySelector('.droppable-container')).toBeFalsy();
+  });
+
+  it('should apply droppable-container class when hovering over a valid cross-side drop', () => {
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: true });
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: true, setNodeRef: jest.fn() });
+
+    const { container } = render(
+      <DataMapperDndContext.Provider value={{ activeNode: activeSourceNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+
+    expect(container.querySelector('.droppable-container')).toBeTruthy();
+    expect(container.querySelector('.droppable-invalid')).toBeFalsy();
+  });
+});

--- a/packages/ui/src/components/Document/NodeContainer.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.tsx
@@ -3,9 +3,11 @@ import './NodeContainer.scss';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { isDefined } from '@kaoto/forms';
 import clsx from 'clsx';
-import { forwardRef, FunctionComponent, PropsWithChildren } from 'react';
+import { forwardRef, FunctionComponent, PropsWithChildren, useContext, useMemo } from 'react';
 
 import { DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
+import { DataMapperDndContext } from '../../providers/datamapper-dnd.provider';
+import { MappingValidationService } from '../../services/mapping-validation.service';
 import { VisualizationService } from '../../services/visualization.service';
 
 type DnDContainerProps = PropsWithChildren & {
@@ -19,16 +21,35 @@ type BaseContainerProps = PropsWithChildren & {
 };
 
 export const DroppableContainer: FunctionComponent<BaseContainerProps> = ({ className, id, nodeData, children }) => {
+  const { activeNode } = useContext(DataMapperDndContext);
+
+  const isInvalidDrop = useMemo(() => {
+    if (!activeNode) return false;
+    if (activeNode.isSource === nodeData.isSource) return false;
+    return !MappingValidationService.validateMappingPair(activeNode, nodeData).isValid;
+  }, [activeNode, nodeData]);
+
+  // unlike `isInvalidDrop` which shows disabled hover effect and show an error toast if it's dropped,
+  // if it's same side (source<->source / target<->target), disable DnDKit to show no hover effect
+  // nor error, but just silently ignore it
+  const isSameSide = !!activeNode && activeNode.isSource === nodeData.isSource;
+
   const { isOver, setNodeRef: setDroppableNodeRef } = useDroppable({
     id: `droppable-${id}`,
     data: nodeData,
+    disabled: isSameSide,
   });
 
   return (
     <div
       id={`droppable-${id}`}
       ref={setDroppableNodeRef}
-      className={clsx(className, { 'droppable-container': isOver }, 'pf-v6-c-droppable')}
+      className={clsx(
+        className,
+        { 'droppable-container': isOver && !isInvalidDrop },
+        { 'droppable-invalid': isOver && isInvalidDrop },
+        'pf-v6-c-droppable',
+      )}
       data-dnd-droppable={isOver ? `${id}` : undefined}
     >
       {children}

--- a/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
@@ -1,4 +1,11 @@
-import { canScrollPanel, scrollAwareCollision } from './datamapper-dnd.provider';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import { AlertVariant } from '@patternfly/react-core';
+import { act, render } from '@testing-library/react';
+import { ReactNode } from 'react';
+
+import { useDataMapper } from '../hooks/useDataMapper';
+import { MappingTree } from '../models/datamapper/mapping';
+import { canScrollPanel, DatamapperDndProvider, scrollAwareCollision } from './datamapper-dnd.provider';
 
 // Mock rectIntersection to control collision detection in tests
 jest.mock('@dnd-kit/core', () => {
@@ -13,8 +20,16 @@ jest.mock('@dnd-kit/core', () => {
       }));
     }),
     pointerWithin: jest.fn(() => []),
+    DndContext: jest.fn(),
+    DragOverlay: jest.fn(() => null),
+    useSensor: jest.fn(),
+    useSensors: jest.fn().mockReturnValue([]),
   };
 });
+
+jest.mock('../hooks/useDataMapper', () => ({
+  useDataMapper: jest.fn(),
+}));
 
 // Helper to create mock rect object
 const createMockRect = (top: number, bottom: number, left: number, right: number) => ({
@@ -334,5 +349,80 @@ describe('datamapper-dnd.provider', () => {
 
       expect(result).toBe(false);
     });
+  });
+});
+
+describe('DatamapperDndProvider', () => {
+  const mockSendAlert = jest.fn();
+  const mockRefreshMappingTree = jest.fn();
+  const mockMappingTree = {} as MappingTree;
+
+  const mockDragEndEvent = {
+    active: { id: 'a', data: { current: null } },
+    over: null,
+  } as unknown as DragEndEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (DndContext as unknown as jest.Mock).mockImplementation(({ children }: { children: ReactNode }) => children);
+    (useDataMapper as jest.Mock).mockReturnValue({
+      mappingTree: mockMappingTree,
+      refreshMappingTree: mockRefreshMappingTree,
+      sendAlert: mockSendAlert,
+    });
+  });
+
+  const invokeOnDragEnd = async (event: DragEndEvent) => {
+    const onDragEnd = (DndContext as unknown as jest.Mock).mock.calls.at(-1)[0].onDragEnd as (e: DragEndEvent) => void;
+    await act(async () => {
+      onDragEnd(event);
+    });
+  };
+
+  it('should call sendAlert with danger variant when handler returns failure with error message', async () => {
+    const mockHandler = {
+      handleDragEnd: jest.fn().mockReturnValue({ success: false, errorMessage: 'error msg' }),
+      handleDragStart: jest.fn(),
+      handleDragOver: jest.fn(),
+    };
+
+    render(
+      <DatamapperDndProvider handler={mockHandler}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+
+    expect(mockSendAlert).toHaveBeenCalledWith({ variant: AlertVariant.danger, title: 'error msg' });
+  });
+
+  it('should not call sendAlert when handler returns success', async () => {
+    const mockHandler = {
+      handleDragEnd: jest.fn().mockReturnValue({ success: true }),
+      handleDragStart: jest.fn(),
+      handleDragOver: jest.fn(),
+    };
+
+    render(
+      <DatamapperDndProvider handler={mockHandler}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+
+    expect(mockSendAlert).not.toHaveBeenCalled();
+  });
+
+  it('should not crash when no handler is provided', async () => {
+    render(
+      <DatamapperDndProvider handler={undefined}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+    expect(mockSendAlert).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/providers/datamapper-dnd.provider.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.tsx
@@ -16,7 +16,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { Label } from '@patternfly/react-core';
+import { AlertVariant, Label } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useDataMapper } from '../hooks/useDataMapper';
@@ -116,6 +116,7 @@ export const canScrollPanel = (element: Element, activeDragSideRef: { current: D
 
 export interface IDataMapperDndContext {
   handler?: DnDHandler;
+  activeNode?: NodeData;
 }
 
 export const DataMapperDndContext = createContext<IDataMapperDndContext>({});
@@ -125,7 +126,7 @@ type DataMapperDndContextProps = PropsWithChildren & {
 };
 
 export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps> = (props) => {
-  const { mappingTree, refreshMappingTree } = useDataMapper();
+  const { mappingTree, refreshMappingTree, sendAlert } = useDataMapper();
   const [activeData, setActiveData] = useState<DataRef<NodeData> | null>(null);
   const activeDragSideRef = useRef<'source' | 'target' | null>(null);
 
@@ -164,20 +165,30 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
     [props.handler],
   );
 
+  const clearActiveDrag = useCallback(() => {
+    setActiveData(null);
+    activeDragSideRef.current = null;
+  }, []);
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      props.handler && props.handler.handleDragEnd(event, mappingTree, refreshMappingTree);
-      setActiveData(null);
-      activeDragSideRef.current = null;
+      if (props.handler) {
+        const result = props.handler.handleDragEnd(event, mappingTree, refreshMappingTree);
+        if (!result.success && result.errorMessage) {
+          sendAlert({ variant: AlertVariant.danger, title: result.errorMessage });
+        }
+      }
+      clearActiveDrag();
     },
-    [mappingTree, props.handler, refreshMappingTree],
+    [clearActiveDrag, mappingTree, props.handler, refreshMappingTree, sendAlert],
   );
 
   const handler = useMemo(() => {
     return {
       handler: props.handler,
+      activeNode: activeData?.current,
     };
-  }, [props.handler]);
+  }, [props.handler, activeData]);
 
   const draggingLabel = activeData?.current?.title ? activeData.current.title : 'dragging...';
   return (
@@ -194,10 +205,15 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
+        onDragCancel={clearActiveDrag}
       >
         {props.children}
         <DragOverlay dropAnimation={null}>
-          <div className={'pf-v6-c-draggable node__row dragging-container'} data-dnd-dragging={draggingLabel}>
+          <div
+            className={'pf-v6-c-draggable node__row dragging-container'}
+            data-dnd-dragging={draggingLabel}
+            style={{ pointerEvents: 'none' }}
+          >
             <Label>{draggingLabel}</Label>
           </div>
         </DragOverlay>

--- a/packages/ui/src/providers/dnd/DnDHandler.ts
+++ b/packages/ui/src/providers/dnd/DnDHandler.ts
@@ -2,8 +2,13 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { MappingTree } from '../../models/datamapper/mapping';
 
+export interface DnDResult {
+  success: boolean;
+  errorMessage?: string;
+}
+
 export interface DnDHandler {
   handleDragStart(event: DragStartEvent): void;
   handleDragOver(event: DragOverEvent): void;
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): void;
+  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult;
 }

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
@@ -1,0 +1,103 @@
+import { DragEndEvent } from '@dnd-kit/core';
+
+import { DocumentType, IField } from '../../models/datamapper/document';
+import { ExpressionItem, IFunctionDefinition, MappingTree } from '../../models/datamapper/mapping';
+import { NodePath } from '../../models/datamapper/nodepath';
+import { Types } from '../../models/datamapper/types';
+import { EditorNodeData, FieldNodeData, FunctionNodeData, NodeData } from '../../models/datamapper/visualization';
+import { MappingService } from '../../services/mapping.service';
+import { ExpressionEditorDnDHandler } from './ExpressionEditorDnDHandler';
+
+jest.mock('../../services/mapping.service', () => ({
+  MappingService: {
+    mapToCondition: jest.fn(),
+    wrapWithFunction: jest.fn(),
+  },
+}));
+
+const makeDragEvent = (fromNode?: NodeData, toNode?: NodeData) =>
+  ({
+    active: { id: 'a', data: { current: fromNode } },
+    over: toNode ? { id: 'b', data: { current: toNode } } : null,
+  }) as unknown as DragEndEvent;
+
+describe('ExpressionEditorDnDHandler', () => {
+  let handler: ExpressionEditorDnDHandler;
+  let mockMappingTree: MappingTree;
+  let mockOnUpdate: jest.Mock;
+  let mockMapToCondition: jest.Mock;
+  let mockWrapWithFunction: jest.Mock;
+
+  const mockParentNode = {
+    path: NodePath.fromDocument(DocumentType.SOURCE_BODY, 'Body'),
+    isSource: true,
+    isPrimitive: false,
+  } as unknown as NodeData;
+
+  const mockField = {
+    displayName: 'testField',
+    id: 'testField',
+    type: Types.String,
+  } as unknown as IField;
+
+  const mockFunctionDef = {
+    name: 'fn',
+    displayName: 'fn',
+    description: '',
+    returnType: Types.String,
+    arguments: [],
+  } as unknown as IFunctionDefinition;
+
+  const mockMapping = {} as unknown as ExpressionItem;
+
+  beforeEach(() => {
+    handler = new ExpressionEditorDnDHandler();
+    mockMappingTree = {} as MappingTree;
+    mockOnUpdate = jest.fn();
+    mockMapToCondition = MappingService.mapToCondition as jest.Mock;
+    mockWrapWithFunction = MappingService.wrapWithFunction as jest.Mock;
+  });
+
+  describe('handleDragEnd', () => {
+    it('should return { success: false } when fromNode is undefined', () => {
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(undefined, editorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when fromNode is neither FieldNodeData nor FunctionNodeData', () => {
+      const genericNode = { title: 'generic', id: 'g', isSource: true, isPrimitive: false } as unknown as NodeData;
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(genericNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when toNode is not EditorNodeData', () => {
+      const fieldNode = new FieldNodeData(mockParentNode, mockField);
+      const nonEditorNode = { title: 'other', id: 'o', isSource: false, isPrimitive: false } as unknown as NodeData;
+      const result = handler.handleDragEnd(makeDragEvent(fieldNode, nonEditorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should call MappingService.mapToCondition and return { success: true } when fromNode is FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(mockParentNode, mockField);
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(fieldNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(mockMapToCondition).toHaveBeenCalledWith(mockMapping, mockField);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should call MappingService.wrapWithFunction and return { success: true } when fromNode is FunctionNodeData', () => {
+      const funcNode = new FunctionNodeData(mockFunctionDef);
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(funcNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(mockWrapWithFunction).toHaveBeenCalledWith(mockMapping, mockFunctionDef);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
@@ -2,10 +2,10 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { EditorNodeData, FieldNodeData, FunctionNodeData, MappingTree, NodeData } from '../../models/datamapper';
 import { MappingService } from '../../services/mapping.service';
-import { DnDHandler } from './DnDHandler';
+import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class ExpressionEditorDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, _mappingTree: MappingTree, onUpdate: () => void): void {
+  handleDragEnd(event: DragEndEvent, _mappingTree: MappingTree, onUpdate: () => void): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
     if (
@@ -14,7 +14,7 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
       (!(fromNode instanceof FunctionNodeData) && !(fromNode instanceof FieldNodeData)) ||
       !(toNode instanceof EditorNodeData)
     )
-      return;
+      return { success: false };
     const editorNodeData = toNode as EditorNodeData;
     if (fromNode instanceof FieldNodeData) {
       MappingService.mapToCondition(editorNodeData.mapping, fromNode.field);
@@ -22,6 +22,7 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
       MappingService.wrapWithFunction(editorNodeData.mapping, fromNode.functionDefinition);
     }
     onUpdate();
+    return { success: true };
   }
 
   handleDragOver(_event: DragOverEvent): void {}

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
@@ -1,0 +1,85 @@
+import { DragEndEvent } from '@dnd-kit/core';
+
+import { MappingTree } from '../../models/datamapper/mapping';
+import { NodeData } from '../../models/datamapper/visualization';
+import { MappingValidationService } from '../../services/mapping-validation.service';
+import { VisualizationService } from '../../services/visualization.service';
+import { SourceTargetDnDHandler } from './SourceTargetDnDHandler';
+
+jest.mock('../../services/mapping-validation.service', () => ({
+  MappingValidationService: {
+    validateMappingPair: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/visualization.service', () => ({
+  VisualizationService: {
+    engageMapping: jest.fn(),
+  },
+}));
+
+const makeDragEvent = (fromNode?: NodeData, toNode?: NodeData) =>
+  ({
+    active: { id: 'a', data: { current: fromNode } },
+    over: toNode ? { id: 'b', data: { current: toNode } } : null,
+  }) as unknown as DragEndEvent;
+
+describe('SourceTargetDnDHandler', () => {
+  let handler: SourceTargetDnDHandler;
+  let mockMappingTree: MappingTree;
+  let mockOnUpdate: jest.Mock;
+  let mockValidateMappingPair: jest.Mock;
+  let mockEngageMapping: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new SourceTargetDnDHandler();
+    mockMappingTree = {} as MappingTree;
+    mockOnUpdate = jest.fn();
+    mockValidateMappingPair = MappingValidationService.validateMappingPair as jest.Mock;
+    mockEngageMapping = VisualizationService.engageMapping as jest.Mock;
+  });
+
+  describe('handleDragEnd', () => {
+    it('should return { success: false } when fromNode is undefined', () => {
+      const result = handler.handleDragEnd(makeDragEvent(), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockValidateMappingPair).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when toNode is undefined (over is null)', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const result = handler.handleDragEnd(makeDragEvent(fromNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockValidateMappingPair).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false, errorMessage } when validation is invalid with a message', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: false, errorMessage: 'err' });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false, errorMessage: 'err' });
+      expect(mockEngageMapping).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false, errorMessage: undefined } when validation is invalid without message', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: false });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false, errorMessage: undefined });
+      expect(mockEngageMapping).not.toHaveBeenCalled();
+    });
+
+    it('should call engageMapping and onUpdate and return { success: true } when validation passes with nodes', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: true, sourceNode: fromNode, targetNode: toNode });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(mockEngageMapping).toHaveBeenCalledWith(mockMappingTree, fromNode, toNode);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
@@ -2,20 +2,24 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { MappingTree } from '../../models/datamapper/mapping';
 import { NodeData } from '../../models/datamapper/visualization';
+import { MappingValidationService } from '../../services/mapping-validation.service';
 import { VisualizationService } from '../../services/visualization.service';
-import { DnDHandler } from './DnDHandler';
+import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class SourceTargetDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): void {
+  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
-    if (!fromNode || !toNode) return;
+    if (!fromNode || !toNode) return { success: false };
 
-    const { sourceNode, targetNode } = VisualizationService.testNodePair(fromNode, toNode);
-    if (sourceNode && targetNode) {
-      VisualizationService.engageMapping(mappingTree, sourceNode, targetNode);
-      onUpdate();
+    const validation = MappingValidationService.validateMappingPair(fromNode, toNode);
+    if (!validation.isValid) {
+      return { success: false, errorMessage: validation.errorMessage };
     }
+
+    VisualizationService.engageMapping(mappingTree, validation.sourceNode!, validation.targetNode!);
+    onUpdate();
+    return { success: true };
   }
 
   handleDragOver(_event: DragOverEvent): void {}

--- a/packages/ui/src/services/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/mapping-validation.service.test.ts
@@ -1,0 +1,203 @@
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IField,
+  PrimitiveDocument,
+} from '../models/datamapper/document';
+import { MappingTree } from '../models/datamapper/mapping';
+import { Types } from '../models/datamapper/types';
+import {
+  DocumentNodeData,
+  FieldNodeData,
+  NodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../models/datamapper/visualization';
+import { TestUtil } from '../stubs/datamapper/data-mapper';
+import { MappingValidationService } from './mapping-validation.service';
+
+function createMockField(overrides: Partial<IField> = {}): IField {
+  return {
+    type: Types.String,
+    isChoice: false,
+    selectedMemberIndex: undefined,
+    fields: [],
+    ...overrides,
+  } as unknown as IField;
+}
+
+describe('MappingValidationService', () => {
+  describe('validateFieldPair', () => {
+    describe('container-to-terminal validation', () => {
+      it('should reject source-container to target-terminal', () => {
+        const source = createMockField({ type: Types.Container });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toBeDefined();
+      });
+
+      it('should reject source-terminal to target-container', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.Container });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toBeDefined();
+      });
+
+      it('should allow source-container to target-container', () => {
+        const source = createMockField({ type: Types.Container });
+        const target = createMockField({ type: Types.Container });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-terminal to target-terminal', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('choice validation', () => {
+      it('should reject any source to unselected choice target', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toContain('unselected choice');
+      });
+
+      it('should reject source-choice to unselected choice target', () => {
+        const source = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should reject source-choice-member to unselected choice target', () => {
+        const source = createMockField({ isChoice: false });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should allow source to target with selected choice member (selectedMemberIndex defined)', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: 0 });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-choice to target-non-choice field', () => {
+        const source = createMockField({ isChoice: true });
+        const target = createMockField({ isChoice: false });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-choice-member to target-regular', () => {
+        const source = createMockField({ isChoice: false });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-regular to target-choice-member', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: false });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-regular to target-regular', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+    });
+  });
+
+  describe('validateMappingPair', () => {
+    let sourceDoc: ReturnType<typeof TestUtil.createSourceOrderDoc>;
+    let targetDoc: ReturnType<typeof TestUtil.createTargetOrderDoc>;
+    let tree: MappingTree;
+    let sourceDocNode: DocumentNodeData;
+    let targetDocNode: TargetDocumentNodeData;
+
+    beforeEach(() => {
+      sourceDoc = TestUtil.createSourceOrderDoc();
+      targetDoc = TestUtil.createTargetOrderDoc();
+      tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      sourceDocNode = new DocumentNodeData(sourceDoc);
+      targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+    });
+
+    it('should reject same-side drops (both source) silently (no errorMessage)', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new FieldNodeData(sourceDocNode, sourceField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should reject same-side drops (both target) silently (no errorMessage)', () => {
+      const targetField = createMockField({ type: Types.String });
+      const fromNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should return sourceNode and targetNode on valid cross-side drop', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const targetField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+
+    it('should reject cross-side drop to unselected choice target with errorMessage', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const targetField = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeDefined();
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+
+    it('should return valid for cross-side drop when target is document node (not field-level)', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField) as NodeData;
+      const result = MappingValidationService.validateMappingPair(fromNode, targetDocNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(targetDocNode);
+    });
+
+    it('should return valid when source is a PrimitiveDocument node and target is a field', () => {
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const primDocNode = new DocumentNodeData(primitiveDoc);
+      const targetField = createMockField({ type: Types.String });
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(primDocNode, toNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(primDocNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+  });
+});

--- a/packages/ui/src/services/mapping-validation.service.ts
+++ b/packages/ui/src/services/mapping-validation.service.ts
@@ -1,0 +1,127 @@
+import { IField, PrimitiveDocument } from '../models/datamapper/document';
+import { Types } from '../models/datamapper/types';
+import {
+  FieldItemNodeData,
+  MappingNodeData,
+  NodeData,
+  SourceNodeDataType,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+  TargetNodeData,
+} from '../models/datamapper/visualization';
+
+/**
+ * Result returned by mapping validation operations.
+ *
+ * When `isValid` is `false` and the pair was rejected due to a user-correctable
+ * condition (e.g. unselected choice, container/terminal mismatch), `errorMessage`
+ * carries a human-readable explanation.  Same-side drops are silently rejected
+ * (`isValid: false`, no `errorMessage`).
+ *
+ * `sourceNode` and `targetNode` are populated on cross-side pairs regardless of
+ * validity, so callers can use them for highlighting or further processing.
+ */
+export interface ValidationResult {
+  /** Whether the drag-and-drop pair is a valid mapping operation. */
+  isValid: boolean;
+  /** Human-readable explanation when the pair is invalid due to a user-correctable condition. */
+  errorMessage?: string;
+  /** The resolved source node for this pair. */
+  sourceNode?: SourceNodeDataType;
+  /** The resolved target node for this pair. */
+  targetNode?: TargetNodeData;
+}
+
+/**
+ * Stateless service that validates drag-and-drop mapping pairs in the DataMapper.
+ *
+ * Validation is split into two levels:
+ * - **Node-level** ({@link validateMappingPair}): determines which node is source/target,
+ *   and short-circuits when the target is not a field (e.g. a document root drop).
+ * - **Field-level** ({@link validateFieldPair}): applies ordered schema rules
+ *   (choice selection, container compatibility) to the underlying `IField` values.
+ */
+export class MappingValidationService {
+  /**
+   * Validates a drag-and-drop pair at the node level.
+   *
+   * Rejects same-side drops silently (no `errorMessage`). For cross-side pairs,
+   * identifies which node is source and which is target, then delegates to
+   * {@link validateFieldPair} when both sides resolve to concrete fields.
+   * Document-root targets bypass field-level validation and are always accepted.
+   *
+   * @param fromNode - The node being dragged.
+   * @param toNode - The node being dropped onto.
+   * @returns A {@link ValidationResult} describing whether the pair is mappable.
+   */
+  static validateMappingPair(fromNode: NodeData, toNode: NodeData): ValidationResult {
+    if ((fromNode.isSource && toNode.isSource) || (!fromNode.isSource && !toNode.isSource)) {
+      return { isValid: false };
+    }
+
+    const sourceNode = (fromNode.isSource ? fromNode : toNode) as SourceNodeDataType;
+    const targetNode = (fromNode.isSource ? toNode : fromNode) as TargetNodeData;
+
+    if (targetNode instanceof MappingNodeData || targetNode instanceof TargetDocumentNodeData) {
+      return { isValid: true, sourceNode, targetNode };
+    }
+    if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {
+      return { isValid: false, sourceNode, targetNode };
+    }
+
+    const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
+    const targetField = targetNode.field;
+
+    const fieldValidation = MappingValidationService.validateFieldPair(sourceField, targetField);
+    return { ...fieldValidation, sourceNode, targetNode };
+  }
+
+  private static readonly validationRules: ReadonlyArray<(source: IField, target: IField) => ValidationResult> = [
+    MappingValidationService.validateChoiceRules,
+    MappingValidationService.validateContainerRules,
+  ];
+
+  /**
+   * Validates a pair of `IField` values against all registered schema rules.
+   *
+   * Rules are applied in order; the first failing rule short-circuits and its
+   * result is returned.  Currently enforced rules are:
+   * 1. Choice selection — a choice target must have a member selected before mapping.
+   * 2. Container/terminal compatibility — a container field cannot be mapped to a terminal field and vice versa.
+   *
+   * @param sourceField - The source schema field.
+   * @param targetField - The target schema field.
+   * @returns A {@link ValidationResult} with `isValid: true` when all rules pass.
+   */
+  static validateFieldPair(sourceField: IField, targetField: IField): ValidationResult {
+    for (const rule of MappingValidationService.validationRules) {
+      const result = rule(sourceField, targetField);
+      if (!result.isValid) return result;
+    }
+    return { isValid: true };
+  }
+
+  private static validateContainerRules(source: IField, target: IField): ValidationResult {
+    if (MappingValidationService.isContainer(source) !== MappingValidationService.isContainer(target)) {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map between a container field and a terminal field.',
+      };
+    }
+    return { isValid: true };
+  }
+
+  private static isContainer(source: IField) {
+    return source.type === Types.Container;
+  }
+
+  private static validateChoiceRules(_source: IField, target: IField): ValidationResult {
+    if (target.isChoice === true && target.selectedMemberIndex === undefined) {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map to an unselected choice. Please select a specific choice member first.',
+      };
+    }
+    return { isValid: true };
+  }
+}


### PR DESCRIPTION
…ror toasts

https://github.com/KaotoIO/kaoto/pull/2954 has to go in before this one, and this one needs adjustment. Keep this as draft until then.

Fixes: https://github.com/KaotoIO/kaoto/issues/2898

Introduces mapping validation when user performs drag and drop to create a data mapping.

Introduces `MappingValidationService` to centralise mapping pair validation rules, replacing `VisualizationService testNodePair()`. `DnDHandler.handleDragEnd()` now returns a `DnDResult` to propagate error message if there is.
 - Invalid cross-side drops (unselected xs:choice, container/terminal mismatch) show an error toast
 - Hovering over an invalid target shows a disabled border and field name style
 - Hovering over a same-side droppable (source→source, target→target) is disabled at DNDKit level, i.e. no visual feedback on hover, silently ignored if dropped


https://github.com/user-attachments/assets/fe42c6c6-4dd8-4b13-ad14-1c5123a71775



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invalid drop targets now display visual feedback to prevent unintended mappings.
  * Drag-and-drop operations now show error alerts when validation fails, providing immediate feedback to users.

* **Tests**
  * Added comprehensive test coverage for drag-and-drop validation and component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->