### PR TITLE
[WIP] fix(DataMapper): Add `VariableItem` and refactor other mapping item c…

### DIFF
--- a/packages/ui/src/components/Document/actions/DeleteMappingItemAction.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteMappingItemAction.tsx
@@ -12,7 +12,7 @@ import { FunctionComponent, useCallback } from 'react';
 
 import { useCanvas } from '../../../hooks/useCanvas';
 import { useToggle } from '../../../hooks/useToggle';
-import { ConditionItem } from '../../../models/datamapper/mapping';
+import { InstructionItem } from '../../../models/datamapper/mapping';
 import { TargetNodeData } from '../../../models/datamapper/visualization';
 import { VisualizationService } from '../../../services/visualization.service';
 
@@ -26,7 +26,7 @@ export const DeleteMappingItemAction: FunctionComponent<DeleteItemProps> = ({ no
   const { clearNodeReferencesForPath, reloadNodeReferences } = useCanvas();
 
   const onConfirmDelete = useCallback(() => {
-    if (nodeData.mapping && nodeData.mapping instanceof ConditionItem) {
+    if (nodeData.mapping && nodeData.mapping instanceof InstructionItem) {
       clearNodeReferencesForPath(nodeData.mapping.nodePath.toString());
       reloadNodeReferences();
     }
@@ -38,7 +38,7 @@ export const DeleteMappingItemAction: FunctionComponent<DeleteItemProps> = ({ no
   let warningMessage = undefined;
   if (
     nodeData.mapping &&
-    nodeData.mapping instanceof ConditionItem &&
+    nodeData.mapping instanceof InstructionItem &&
     nodeData.mapping.children.length > 0 &&
     nodeData.mapping.children[0].children.length > 0
   ) {

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
@@ -3,13 +3,13 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useCallback, useState } from 'react';
 
 import { useCanvas } from '../../../hooks/useCanvas';
-import { ExpressionItem } from '../../../models/datamapper/mapping';
+import { IExpressionHolder, MappingItem } from '../../../models/datamapper/mapping';
 import { TargetNodeData } from '../../../models/datamapper/visualization';
 import { XPathEditorModal } from '../../XPath/XPathEditorModal';
 
 type XPathEditorProps = {
   nodeData: TargetNodeData;
-  mapping: ExpressionItem;
+  mapping: IExpressionHolder & MappingItem;
   onUpdate: () => void;
 };
 export const XPathEditorAction: FunctionComponent<XPathEditorProps> = ({ nodeData, mapping, onUpdate }) => {

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -15,12 +15,12 @@ import {
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { ExpressionItem } from '../../../models/datamapper/mapping';
+import { IExpressionHolder } from '../../../models/datamapper/mapping';
 import { XPathService } from '../../../services/xpath/xpath.service';
 import { ValidatedXPathParseResult } from '../../../services/xpath/xpath-model';
 
 type XPathInputProps = {
-  mapping: ExpressionItem;
+  mapping: IExpressionHolder;
   onUpdate: () => void;
 };
 export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, onUpdate }) => {

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -3,12 +3,12 @@ import './XPathEditor.scss';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 
-import { ExpressionItem } from '../../models/datamapper';
+import { IExpressionHolder } from '../../models/datamapper';
 import { XPathService } from '../../services/xpath/xpath.service';
 import { xpathEditorConstrufctionOption, xpathEditorTheme } from './monaco-options';
 
 type XPathEditorProps = {
-  mapping: ExpressionItem;
+  mapping: IExpressionHolder;
   onChange: (expression: string | undefined) => void;
 };
 

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import { BODY_DOCUMENT_ID, ExpressionItem, MappingTree, ValueSelector } from '../../models/datamapper';
+import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
@@ -13,7 +13,7 @@ describe('XPathEditorLayout - Search Field', () => {
     disconnect: jest.fn(),
   }));
   const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-  const mapping: ExpressionItem = new ValueSelector(tree);
+  const mapping: IExpressionHolder & MappingItem = new ValueSelector(tree);
   mapping.expression = '/to/some/field';
   const onUpdate = jest.fn();
   const setup = () => {

--- a/packages/ui/src/components/XPath/XPathEditorLayout.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.tsx
@@ -15,8 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { EditorNodeData, FunctionNodeData } from '../../models/datamapper';
-import { ExpressionItem } from '../../models/datamapper/mapping';
+import { EditorNodeData, FunctionNodeData, IExpressionHolder, MappingItem } from '../../models/datamapper';
 import { DatamapperDndProvider } from '../../providers/datamapper-dnd.provider';
 import { DataMapperDnDMonitor } from '../../providers/dnd/DataMapperDndMonitor';
 import { ExpressionEditorDnDHandler } from '../../providers/dnd/ExpressionEditorDnDHandler';
@@ -27,7 +26,7 @@ import { SourcePanel } from '../View/SourcePanel';
 import { XPathEditor } from './XPathEditor';
 
 type XPathEditorLayoutProps = {
-  mapping: ExpressionItem;
+  mapping: IExpressionHolder & MappingItem;
   onUpdate: () => void;
 };
 

--- a/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import { BODY_DOCUMENT_ID, ExpressionItem, MappingTree, ValueSelector } from '../../models/datamapper';
+import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { DataMapperCanvasProvider } from '../../providers/datamapper-canvas.provider';
@@ -13,7 +13,7 @@ describe('XPathEditorModal', () => {
     disconnect: jest.fn(),
   }));
   const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-  const mapping: ExpressionItem = new ValueSelector(tree);
+  const mapping: IExpressionHolder & MappingItem = new ValueSelector(tree);
   mapping.expression = '/to/some/field';
   const onClose = jest.fn();
   const onUpdate = jest.fn();

--- a/packages/ui/src/components/XPath/XPathEditorModal.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorModal.tsx
@@ -16,7 +16,7 @@ import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { ExpressionItem } from '../../models/datamapper';
+import { IExpressionHolder, MappingItem } from '../../models/datamapper';
 import { XPathService } from '../../services/xpath/xpath.service';
 import { ValidatedXPathParseResult } from '../../services/xpath/xpath-model';
 import { XPathEditorLayout } from './XPathEditorLayout';
@@ -25,7 +25,7 @@ type XPathEditorModalProps = {
   isOpen: boolean;
   onClose: () => void;
   title: string;
-  mapping: ExpressionItem;
+  mapping: IExpressionHolder & MappingItem;
   onUpdate: () => void;
 };
 

--- a/packages/ui/src/models/datamapper/mapping.test.ts
+++ b/packages/ui/src/models/datamapper/mapping.test.ts
@@ -1,0 +1,174 @@
+import { DocumentDefinitionType, DocumentType } from './document';
+import {
+  ChooseItem,
+  ForEachItem,
+  IfItem,
+  isExpressionHolder,
+  MappingTree,
+  OtherwiseItem,
+  SortItem,
+  ValueSelector,
+  ValueType,
+  VariableItem,
+  WhenItem,
+} from './mapping';
+
+describe('mapping.ts', () => {
+  let tree: MappingTree;
+
+  beforeEach(() => {
+    tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+  });
+
+  describe('isExpressionHolder()', () => {
+    it('should return true for objects with an expression property', () => {
+      expect(isExpressionHolder(new IfItem(tree))).toBe(true);
+      expect(isExpressionHolder(new WhenItem(tree))).toBe(true);
+      expect(isExpressionHolder(new ForEachItem(tree))).toBe(true);
+      expect(isExpressionHolder(new ValueSelector(tree))).toBe(true);
+      expect(isExpressionHolder(new VariableItem(tree, 'myVar'))).toBe(true);
+    });
+
+    it('should return false for MappingItems without an expression property', () => {
+      expect(isExpressionHolder(new ChooseItem(tree))).toBe(false);
+      expect(isExpressionHolder(new OtherwiseItem(tree))).toBe(false);
+    });
+  });
+
+  describe('IfItem', () => {
+    it('clone() should copy expression and children', () => {
+      const item = new IfItem(tree);
+      item.expression = 'count($x) > 0';
+      const child = new ValueSelector(item);
+      child.expression = '$x/name';
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.expression).toBe('count($x) > 0');
+      expect(cloned.children).toHaveLength(1);
+      expect((cloned.children[0] as ValueSelector).expression).toBe('$x/name');
+      expect(cloned).not.toBe(item);
+    });
+
+    it('clone() should reparent cloned children to the cloned parent', () => {
+      const item = new IfItem(tree);
+      const child = new ValueSelector(item);
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.children[0].parent).toBe(cloned);
+      expect(cloned.children[0].parent).not.toBe(item);
+    });
+  });
+
+  describe('ChooseItem', () => {
+    it('doClone() should create a new ChooseItem with the same field', () => {
+      const field = { id: 'testField', name: 'testField', isAttribute: false, fields: [], type: 'string' };
+      const item = new ChooseItem(tree, field as never);
+      const cloned = item.clone() as ChooseItem;
+
+      expect(cloned).not.toBe(item);
+      expect(cloned.field).toBe(field);
+    });
+  });
+
+  describe('WhenItem', () => {
+    it('clone() should copy expression and children', () => {
+      const choose = new ChooseItem(tree);
+      const item = new WhenItem(choose);
+      item.expression = '@type = "express"';
+      const child = new ValueSelector(item);
+      child.expression = '$x/value';
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.expression).toBe('@type = "express"');
+      expect(cloned.children).toHaveLength(1);
+      expect((cloned.children[0] as ValueSelector).expression).toBe('$x/value');
+      expect(cloned).not.toBe(item);
+    });
+  });
+
+  describe('OtherwiseItem', () => {
+    it('doClone() should create a new OtherwiseItem', () => {
+      const item = new OtherwiseItem(tree);
+      const cloned = item.clone() as OtherwiseItem;
+
+      expect(cloned).not.toBe(item);
+      expect(cloned).toBeInstanceOf(OtherwiseItem);
+    });
+  });
+
+  describe('ForEachItem', () => {
+    it('doClone() should copy sortItems', () => {
+      const item = new ForEachItem(tree);
+      const sort = new SortItem();
+      sort.expression = '@price';
+      sort.order = 'descending';
+      item.sortItems = [sort];
+
+      const cloned = item.clone();
+
+      expect(cloned.sortItems).toHaveLength(1);
+      expect(cloned.sortItems[0].expression).toBe('@price');
+      expect(cloned.sortItems[0].order).toBe('descending');
+      expect(cloned.sortItems[0]).not.toBe(sort);
+    });
+
+    it('clone() should copy expression and children', () => {
+      const item = new ForEachItem(tree);
+      item.expression = '/Order/Items/Item';
+      const child = new ValueSelector(item);
+      child.expression = 'ItemId';
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.expression).toBe('/Order/Items/Item');
+      expect(cloned.children).toHaveLength(1);
+      expect((cloned.children[0] as ValueSelector).expression).toBe('ItemId');
+      expect(cloned).not.toBe(item);
+    });
+  });
+
+  describe('ValueSelector', () => {
+    it('clone() should copy expression and valueType', () => {
+      const item = new ValueSelector(tree, ValueType.ATTRIBUTE);
+      item.expression = '/Order/@id';
+
+      const cloned = item.clone();
+
+      expect(cloned.expression).toBe('/Order/@id');
+      expect(cloned.valueType).toBe(ValueType.ATTRIBUTE);
+      expect(cloned).not.toBe(item);
+    });
+  });
+
+  describe('VariableItem', () => {
+    it('clone() should copy name, expression, and children', () => {
+      const item = new VariableItem(tree, 'myVar');
+      item.expression = '/Order/Id';
+      const child = new ValueSelector(item);
+      child.expression = 'ItemId';
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.name).toBe('myVar');
+      expect(cloned.expression).toBe('/Order/Id');
+      expect(cloned.children).toHaveLength(1);
+      expect((cloned.children[0] as ValueSelector).expression).toBe('ItemId');
+      expect(cloned).not.toBe(item);
+    });
+
+    it('nodePath should be derived from parent nodePath and item id', () => {
+      const item = new VariableItem(tree, 'myVar');
+
+      expect(item.nodePath).toBeDefined();
+      expect(item.nodePath.pathSegments).toContain(item.id);
+    });
+  });
+});

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -5,8 +5,14 @@ import { NodePath } from './nodepath';
 import { Types } from './types';
 import { PathExpression } from './xpath';
 
+/** Valid parent types for any node in the mapping tree. */
 export type MappingParentType = MappingTree | MappingItem;
 
+/**
+ * Root of the mapping tree for a single target document.
+ * Holds top-level {@link MappingItem} children and shared state such as
+ * the namespace map used when evaluating XPath expressions.
+ */
 export class MappingTree {
   constructor(
     documentType: DocumentType,
@@ -21,6 +27,11 @@ export class MappingTree {
   namespaceMap: { [prefix: string]: string } = {};
 }
 
+/**
+ * Abstract base for every node in the mapping tree.
+ * Subclasses represent either data mappings ({@link FieldItem}, {@link ValueSelector})
+ * or XSLT instruction elements ({@link InstructionItem} subtypes).
+ */
 export abstract class MappingItem {
   constructor(
     public parent: MappingParentType,
@@ -29,22 +40,33 @@ export abstract class MappingItem {
   ) {
     this.mappingTree = parent instanceof MappingTree ? parent : parent.mappingTree;
   }
+  /** The root {@link MappingTree} this item belongs to. */
   mappingTree: MappingTree;
   children: MappingItem[] = [];
   get nodePath(): NodePath {
     return NodePath.childOf(this.parent.nodePath, this.id);
   }
+  /** XPath context path inherited from the nearest enclosing {@link ForEachItem}, or undefined at root. */
   get contextPath(): PathExpression | undefined {
     return this.parent.contextPath;
   }
   protected abstract doClone(): MappingItem;
+  /** Returns a deep clone of this item, including all children. */
   clone(): MappingItem {
     const cloned = this.doClone();
-    cloned.children = this.children.map((c) => c.clone());
+    cloned.children = this.children.map((c) => {
+      const cc = c.clone();
+      cc.parent = cloned;
+      return cc;
+    });
     return cloned;
   }
 }
 
+/**
+ * Maps a target schema field. Corresponds to an output XML element or attribute
+ * in the generated XSLT template.
+ */
 export class FieldItem extends MappingItem {
   constructor(
     public parent: MappingParentType,
@@ -58,41 +80,59 @@ export class FieldItem extends MappingItem {
   }
 }
 
-export abstract class ConditionItem extends MappingItem {
+/**
+ * Implemented by any mapping item that carries an XPath expression,
+ * such as {@link IfItem}, {@link WhenItem}, {@link ForEachItem}, and {@link ValueSelector}.
+ */
+export interface IExpressionHolder {
+  expression: string;
+}
+
+/**
+ * Runtime type guard for {@link IExpressionHolder}.
+ * Use this instead of `instanceof` since interfaces are erased at runtime.
+ * The narrowed type includes {@link MappingItem} so callers can access
+ * both the expression and mapping tree properties without casting.
+ */
+export function isExpressionHolder(item: MappingItem): item is IExpressionHolder & MappingItem {
+  return 'expression' in item;
+}
+
+/**
+ * Abstract base for XSLT instruction elements (`xsl:if`, `xsl:choose`, `xsl:for-each`, etc.).
+ * Instruction items control the structure and flow of the generated XSLT template
+ * and are distinct from {@link FieldItem} (data) and {@link ValueSelector} (value expression).
+ */
+export abstract class InstructionItem extends MappingItem {
   constructor(
     public parent: MappingParentType,
     public name: string,
   ) {
     super(parent, name, getCamelRandomId(name, 4));
   }
-  readonly isCondition = true;
 }
 
-export abstract class ExpressionItem extends ConditionItem {
-  constructor(
-    public parent: MappingParentType,
-    public name: string,
-  ) {
-    super(parent, name);
+/** Represents an `xsl:if` instruction. Renders its children only when {@link expression} evaluates to true. */
+export class IfItem extends InstructionItem implements IExpressionHolder {
+  constructor(public parent: MappingParentType) {
+    super(parent, 'if');
   }
   expression = '';
+  doClone() {
+    return new IfItem(this.parent);
+  }
   clone() {
-    const cloned = super.clone() as ExpressionItem;
+    const cloned = super.clone() as IfItem;
     cloned.expression = this.expression;
     return cloned;
   }
 }
 
-export class IfItem extends ExpressionItem {
-  constructor(public parent: MappingParentType) {
-    super(parent, 'if');
-  }
-  doClone() {
-    return new IfItem(this.parent);
-  }
-}
-
-export class ChooseItem extends ConditionItem {
+/**
+ * Represents an `xsl:choose` instruction.
+ * Children are {@link WhenItem} branches and an optional {@link OtherwiseItem} fallback.
+ */
+export class ChooseItem extends InstructionItem {
   constructor(
     public parent: MappingParentType,
     public field?: IField,
@@ -102,24 +142,32 @@ export class ChooseItem extends ConditionItem {
   get when() {
     return this.children.filter((c) => c instanceof WhenItem) as WhenItem[];
   }
-  get otherwise() {
-    return this.children.find((c) => c instanceof OtherwiseItem) as OtherwiseItem;
+  get otherwise(): OtherwiseItem | undefined {
+    return this.children.find((c): c is OtherwiseItem => c instanceof OtherwiseItem);
   }
   doClone() {
     return new ChooseItem(this.parent, this.field);
   }
 }
 
-export class WhenItem extends ExpressionItem {
+/** Represents an `xsl:when` branch inside a {@link ChooseItem}. Active when {@link expression} evaluates to true. */
+export class WhenItem extends InstructionItem implements IExpressionHolder {
   constructor(public parent: MappingParentType) {
     super(parent, 'when');
   }
+  expression = '';
   doClone() {
     return new WhenItem(this.parent);
   }
+  clone() {
+    const cloned = super.clone() as WhenItem;
+    cloned.expression = this.expression;
+    return cloned;
+  }
 }
 
-export class OtherwiseItem extends ConditionItem {
+/** Represents the `xsl:otherwise` fallback branch inside a {@link ChooseItem}. */
+export class OtherwiseItem extends InstructionItem {
   constructor(public parent: MappingParentType) {
     super(parent, 'otherwise');
   }
@@ -128,10 +176,18 @@ export class OtherwiseItem extends ConditionItem {
   }
 }
 
-export class ForEachItem extends ExpressionItem {
+/**
+ * Represents an `xsl:for-each` instruction.
+ * {@link expression} selects the node-set to iterate over.
+ * Overrides {@link contextPath} so that descendant XPath expressions
+ * are evaluated relative to each iteration node.
+ */
+export class ForEachItem extends InstructionItem implements IExpressionHolder {
   constructor(public parent: MappingParentType) {
     super(parent, 'for-each');
   }
+
+  expression = '';
 
   get contextPath() {
     const answer = XPathService.extractFieldPaths(this.expression)[0];
@@ -154,31 +210,77 @@ export class ForEachItem extends ExpressionItem {
     });
     return cloned;
   }
+
+  clone() {
+    const cloned = super.clone() as ForEachItem;
+    cloned.expression = this.expression;
+    return cloned;
+  }
 }
 
+/** Sorting criteria for an `xsl:sort` element. Used by `xsl:for-each` and `xsl:for-each-group` instructions. */
 export class SortItem {
   expression: string = '';
   order: 'ascending' | 'descending' = 'ascending';
 }
 
+/** Distinguishes how a {@link ValueSelector} produces its output in the generated XSLT. */
 export enum ValueType {
+  /** Emits a text value via `xsl:value-of`. */
   VALUE = 'value',
+  /** Emits a structured element container. */
   CONTAINER = 'container',
+  /** Emits an XML attribute. */
   ATTRIBUTE = 'attribute',
 }
 
-export class ValueSelector extends ExpressionItem {
+/**
+ * Leaf node that supplies the value for a target {@link FieldItem}.
+ * Serializes as `xsl:value-of` for scalar values and attributes,
+ * or `xsl:copy-of` for container nodes, depending on {@link valueType}.
+ */
+export class ValueSelector extends MappingItem implements IExpressionHolder {
   constructor(
     public parent: MappingParentType,
     public valueType: ValueType = ValueType.VALUE,
   ) {
-    super(parent, 'value');
+    super(parent, 'value', getCamelRandomId('value', 4));
   }
+  expression = '';
   doClone() {
     return new ValueSelector(this.parent, this.valueType);
   }
+  clone() {
+    const cloned = super.clone() as ValueSelector;
+    cloned.expression = this.expression;
+    return cloned;
+  }
 }
 
+/**
+ * Represents an `xsl:variable` element.
+ * {@link name} is the variable name; {@link expression} is the XPath `select` attribute value.
+ * Can be a child of FieldItem, ForEachItem, IfItem, WhenItem, or OtherwiseItem.
+ */
+export class VariableItem extends MappingItem implements IExpressionHolder {
+  constructor(
+    public parent: MappingParentType,
+    public name: string,
+  ) {
+    super(parent, name, getCamelRandomId(name, 4));
+  }
+  expression = '';
+  doClone() {
+    return new VariableItem(this.parent, this.name);
+  }
+  clone() {
+    const cloned = super.clone() as VariableItem;
+    cloned.expression = this.expression;
+    return cloned;
+  }
+}
+
+/** Describes an XPath/XSLT function available in the expression editor. */
 export interface IFunctionDefinition {
   name: string;
   displayName: string;
@@ -188,6 +290,7 @@ export interface IFunctionDefinition {
   arguments: IFunctionArgumentDefinition[];
 }
 
+/** Describes a single argument of an {@link IFunctionDefinition}. */
 export interface IFunctionArgumentDefinition {
   name: string;
   type: Types;

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -2,7 +2,14 @@ import { AlertProps } from '@patternfly/react-core';
 import { RefObject } from 'react';
 
 import { DocumentType, IDocument, IField, PrimitiveDocument } from './document';
-import { ExpressionItem, FieldItem, IFunctionDefinition, MappingItem, MappingParentType, MappingTree } from './mapping';
+import {
+  FieldItem,
+  IExpressionHolder,
+  IFunctionDefinition,
+  MappingItem,
+  MappingParentType,
+  MappingTree,
+} from './mapping';
 import { NodePath } from './nodepath';
 import { Types } from './types';
 
@@ -154,7 +161,7 @@ class SimpleNodePath extends NodePath {
   }
 }
 export class EditorNodeData implements NodeData {
-  constructor(public mapping: ExpressionItem) {}
+  constructor(public mapping: IExpressionHolder & MappingItem) {}
   id: string = 'editor';
   isPrimitive: boolean = false;
   isSource: boolean = false;

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
@@ -15,7 +15,7 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
       !(toNode instanceof EditorNodeData)
     )
       return;
-    const editorNodeData = toNode as EditorNodeData;
+    const editorNodeData = toNode;
     if (fromNode instanceof FieldNodeData) {
       MappingService.mapToCondition(editorNodeData.mapping, fromNode.field);
     } else {
@@ -24,6 +24,10 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
     onUpdate();
   }
 
-  handleDragOver(_event: DragOverEvent): void {}
-  handleDragStart(_event: DragStartEvent): void {}
+  handleDragOver(_event: DragOverEvent): void {
+    // no-op ATM
+  }
+  handleDragStart(_event: DragStartEvent): void {
+    // no-op ATM
+  }
 }

--- a/packages/ui/src/services/mapping-links.service.ts
+++ b/packages/ui/src/services/mapping-links.service.ts
@@ -1,10 +1,11 @@
 import { RefObject } from 'react';
 
 import {
-  ExpressionItem,
   FieldItem,
   IDocument,
+  IExpressionHolder,
   IMappingLink,
+  isExpressionHolder,
   LineCoord,
   LineProps,
   MappingItem,
@@ -28,7 +29,7 @@ export class MappingLinksService {
   ): IMappingLink[] {
     const answer = [] as IMappingLink[];
     const targetNodePath = item.nodePath.toString();
-    if (item instanceof ExpressionItem) {
+    if (item instanceof MappingItem && isExpressionHolder(item)) {
       const links = MappingLinksService.doExtractMappingLinks(
         item,
         targetNodePath,
@@ -63,7 +64,7 @@ export class MappingLinksService {
   }
 
   private static doExtractMappingLinks(
-    sourceExpressionItem: ExpressionItem,
+    sourceExpressionItem: IExpressionHolder & MappingItem,
     targetNodePath: string,
     sourceParameterMap: Map<string, IDocument>,
     sourceBody: IDocument,

--- a/packages/ui/src/services/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping-serializer.service.ts
@@ -12,10 +12,10 @@ import {
 } from '../models/datamapper/document';
 import {
   ChooseItem,
-  ConditionItem,
   FieldItem,
   ForEachItem,
   IfItem,
+  InstructionItem,
   MappingItem,
   MappingParentType,
   MappingTree,
@@ -48,11 +48,11 @@ export class MappingSerializerService {
 
   private static sortMappingItem(left: MappingItem, right: MappingItem) {
     const leftFields =
-      left instanceof FieldItem ? [left.field] : MappingService.getConditionalFields(left as ConditionItem);
+      left instanceof FieldItem ? [left.field] : MappingService.getInstructionFields(left as InstructionItem);
     if (leftFields.length === 0) return 1;
     if (leftFields.find((f) => f.isAttribute)) return -1;
     const rightFields =
-      right instanceof FieldItem ? [right.field] : MappingService.getConditionalFields(right as ConditionItem);
+      right instanceof FieldItem ? [right.field] : MappingService.getInstructionFields(right as InstructionItem);
     if (rightFields.length === 0) return -1;
     if (rightFields.find((f) => f.isAttribute)) return 1;
     const leftFirst = leftFields.sort(MappingSerializerService.sortFields)[0];

--- a/packages/ui/src/services/mapping.service.ts
+++ b/packages/ui/src/services/mapping.service.ts
@@ -1,12 +1,13 @@
 import { DocumentType, IDocument, IField, PrimitiveDocument } from '../models/datamapper/document';
 import {
   ChooseItem,
-  ConditionItem,
-  ExpressionItem,
   FieldItem,
   ForEachItem,
+  IExpressionHolder,
   IfItem,
   IFunctionDefinition,
+  InstructionItem,
+  isExpressionHolder,
   MappingItem,
   MappingParentType,
   MappingTree,
@@ -27,16 +28,18 @@ export class MappingService {
         return mapping.field === field;
       } else if (mapping instanceof ValueSelector) {
         return false;
+      } else if (mapping instanceof InstructionItem) {
+        return MappingService.getInstructionFields(mapping).includes(field);
       } else {
-        return MappingService.getConditionalFields(mapping as ConditionItem).includes(field);
+        return false;
       }
     });
   }
 
-  private static getConditionalFieldItems(mapping: ConditionItem): FieldItem[] {
+  private static getInstructionFieldItems(mapping: InstructionItem): FieldItem[] {
     if (mapping instanceof ChooseItem) {
       return [...mapping.when, mapping.otherwise].reduce((acc, branch) => {
-        branch && acc.push(...MappingService.getConditionalFieldItems(branch));
+        branch && acc.push(...MappingService.getInstructionFieldItems(branch));
         return acc;
       }, [] as FieldItem[]);
     } else if (
@@ -48,8 +51,8 @@ export class MappingService {
       return mapping.children.reduce((acc, child) => {
         if (child instanceof FieldItem) {
           acc.push(child);
-        } else if (child instanceof ConditionItem) {
-          acc.push(...MappingService.getConditionalFieldItems(child));
+        } else if (child instanceof InstructionItem) {
+          acc.push(...MappingService.getInstructionFieldItems(child));
         }
         return acc;
       }, [] as FieldItem[]);
@@ -57,8 +60,8 @@ export class MappingService {
     return [];
   }
 
-  static getConditionalFields(mapping: ConditionItem): IField[] {
-    return MappingService.getConditionalFieldItems(mapping).map((item) => item.field);
+  static getInstructionFields(mapping: InstructionItem): IField[] {
+    return MappingService.getInstructionFieldItems(mapping).map((item) => item.field);
   }
 
   /**
@@ -94,7 +97,7 @@ export class MappingService {
     item.children = item.children.reduce((acc, child) => {
       MappingService.doRemoveAllMappingsForSourceDocument(child, documentType, documentReferenceId);
       if (
-        child instanceof ExpressionItem &&
+        isExpressionHolder(child) &&
         MappingService.hasStaleSourceDocument(child, documentType, documentReferenceId)
       ) {
         return acc;
@@ -106,7 +109,7 @@ export class MappingService {
   }
 
   private static hasStaleSourceDocument(
-    expressionItem: ExpressionItem,
+    expressionItem: IExpressionHolder & MappingItem,
     documentType: DocumentType,
     documentReferenceId?: string,
   ) {
@@ -149,9 +152,12 @@ export class MappingService {
           child = MappingService.updateFieldItemField(child, compatibleField);
         }
       }
-      if (compatibleField && child.children.length > 0) {
-        acc.push(child);
-      } else if (child.parent instanceof ConditionItem || child instanceof ConditionItem) {
+      if (
+        (compatibleField && child.children.length > 0) ||
+        child.parent instanceof InstructionItem ||
+        child instanceof InstructionItem ||
+        child instanceof ValueSelector
+      ) {
         acc.push(child);
       }
       return acc;
@@ -175,10 +181,10 @@ export class MappingService {
   private static doRemoveStaleMappingsForSourceDocument(item: MappingTree | MappingItem, document: IDocument) {
     item.children = item.children.reduce((acc, child) => {
       MappingService.doRemoveStaleMappingsForSourceDocument(child, document);
-      if (child instanceof ExpressionItem && MappingService.hasStaleSourceField(child, document)) {
+      if (isExpressionHolder(child) && MappingService.hasStaleSourceField(child, document)) {
         return acc;
       }
-      if (!(child.parent instanceof ConditionItem) && child instanceof FieldItem && child.children.length === 0) {
+      if (!(child.parent instanceof InstructionItem) && child instanceof FieldItem && child.children.length === 0) {
         return acc;
       }
       acc.push(child);
@@ -186,7 +192,7 @@ export class MappingService {
     }, [] as MappingItem[]);
   }
 
-  private static hasStaleSourceField(expressionItem: ExpressionItem, document: IDocument): boolean {
+  private static hasStaleSourceField(expressionItem: IExpressionHolder & MappingItem, document: IDocument): boolean {
     const namespaces = expressionItem.mappingTree.namespaceMap;
     let fieldPaths = [];
     try {
@@ -235,8 +241,12 @@ export class MappingService {
     for (const child of item.children) {
       MappingService.renameParameterInMappings(child, oldDocumentId, newDocumentId);
       // Update XPath expressions in the item
-      if (child instanceof ExpressionItem) {
-        child.expression = child.expression.replace(new RegExp(`\\$${oldDocumentId}\\b`, 'g'), `$${newDocumentId}`);
+      if (isExpressionHolder(child)) {
+        const escapedOldId = oldDocumentId.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+        child.expression = child.expression.replace(
+          new RegExp(String.raw`\$${escapedOldId}\b`, 'g'),
+          `$${newDocumentId}`,
+        );
       }
     }
   }
@@ -311,7 +321,7 @@ export class MappingService {
     return otherwiseItem;
   }
 
-  static wrapWithFunction(condition: ExpressionItem, func: IFunctionDefinition) {
+  static wrapWithFunction(condition: IExpressionHolder, func: IFunctionDefinition) {
     condition.expression = `${func.name}(${condition.expression})`;
   }
 
@@ -324,7 +334,7 @@ export class MappingService {
     );
     if (condition instanceof ForEachItem) {
       condition.expression = XPathService.toXPathString(pathExpression);
-    } else if (condition instanceof ExpressionItem) {
+    } else if (isExpressionHolder(condition)) {
       condition.expression = XPathService.addSource(condition.expression, pathExpression);
     }
   }
@@ -397,9 +407,9 @@ export class MappingService {
 
   static deleteMappingItem(item: MappingParentType) {
     item.children = item.children.filter((child) => !(child instanceof ValueSelector));
-    const isConditionItem = item instanceof ConditionItem;
+    const isInstructionItem = item instanceof InstructionItem;
     const isParentFieldItem = 'parent' in item && item.parent instanceof FieldItem;
-    if (isConditionItem || isParentFieldItem) {
+    if (isInstructionItem || isParentFieldItem) {
       MappingService.deleteFromParent(item);
     }
   }

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../models/datamapper/document';
 import {
   ChooseItem,
-  ExpressionItem,
   FieldItem,
   ForEachItem,
   IfItem,
@@ -515,7 +514,7 @@ describe('VisualizationService', () => {
         const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEach);
         VisualizationService.engageMapping(tree, sourceItem, forEachChildren[0] as TargetFieldNodeData);
 
-        expect((forEach.mapping as ExpressionItem).expression).toEqual('');
+        expect((forEach.mapping as ForEachItem).expression).toEqual('');
         expect(((forEachChildren[0] as FieldItemNodeData).mapping.children[0] as ValueSelector).expression).toEqual(
           '/ns0:ShipOrder/Item',
         );

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -1,10 +1,11 @@
 import { IField, PrimitiveDocument } from '../models/datamapper/document';
 import {
   ChooseItem,
-  ExpressionItem,
   FieldItem,
   ForEachItem,
+  IExpressionHolder,
   IfItem,
+  isExpressionHolder,
   MappingItem,
   MappingTree,
   OtherwiseItem,
@@ -270,9 +271,9 @@ export class VisualizationService {
     return VisualizationService.getFieldValueSelector(nodeData) !== undefined;
   }
 
-  static getExpressionItemForNode(nodeData: TargetNodeData) {
+  static getExpressionItemForNode(nodeData: TargetNodeData): (IExpressionHolder & MappingItem) | undefined {
     if (!nodeData.mapping) return;
-    if (nodeData.mapping instanceof ExpressionItem) return nodeData.mapping as ExpressionItem;
+    if (nodeData.mapping instanceof MappingItem && isExpressionHolder(nodeData.mapping)) return nodeData.mapping;
     return VisualizationService.getFieldValueSelector(nodeData);
   }
 


### PR DESCRIPTION
…lasses to follow XSLT terminology

https://github.com/KaotoIO/kaoto/pull/3026 needs to go in before this one.

Fixes: https://github.com/KaotoIO/kaoto/issues/2837
Fixes: https://github.com/KaotoIO/kaoto/issues/2838

Add `VariableItem` and refactor other mapping items. Align class names to follow correct terminology from XSLT perspective. Currently `ConditionItem` contains `ForEachItem` but `for-each` is not a condition. Rename it to `InstructionItem` to be accurate. Also, remove `ExpressionItem` abstract class from hierarchy and introduce `ExpressionHolder` interface to properly represent the mapping item with expressions. A side effect is that we are no longer able to do `if (item instanceof ExpressionItem)`, which is replaced with the usage of `isExpressionHolder()` function. Also removed unused `isCondition` property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned the mapping model and instruction handling for more consistent, reliable data mapping and expression handling across the UI.
  * Improved internal type validation and traversal so mapping operations (including cloning, iteration, and conditional branches) behave more predictably.

* **Tests**
  * Added extensive tests covering mapping structures, cloning semantics, and expression-related behaviors to reduce regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->