### PR TITLE
feat(Canvas): Filter placeholder nodes in screenshots and docs

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/nodeConfiguration.ts
+++ b/packages/ui-tests/cypress/support/next-commands/nodeConfiguration.ts
@@ -159,6 +159,9 @@ Cypress.Commands.add('generateDocumentationPreview', () => {
 });
 
 Cypress.Commands.add('documentationTableCompare', (routeName: string, expectedTableData: string[][]) => {
+  // Wait until the loading distractor is no longer in the document
+  cy.get('[data-testid="Loading markdown preview"]', { timeout: 30_000 }).should('not.exist');
+
   cy.contains('h1', routeName)
     .next('table')
     .find('.pf-v6-c-table__tbody')

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/flow.service.test.ts.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/flow.service.test.ts.snap
@@ -1,5 +1,189 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FlowService getFlowDiagram should remove placeholders 1`] = `
+[
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from",
+    "parentNode": "test|route",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.0.set-header",
+    "parentNode": "test|route",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.1.choice.when.0.steps.0.log",
+    "parentNode": "test|route.from.steps.1.choice.when.0",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [
+      "test|route.from.steps.1.choice.when.0.steps.0.log",
+    ],
+    "data": {},
+    "group": true,
+    "id": "test|route.from.steps.1.choice.when.0",
+    "label": "route.from.steps.1.choice.when.0",
+    "parentNode": "test|route.from.steps.1.choice",
+    "style": {
+      "padding": 40,
+    },
+    "type": "group",
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.1.choice.otherwise.steps.0.to",
+    "parentNode": "test|route.from.steps.1.choice.otherwise",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.1.choice.otherwise.steps.1.to",
+    "parentNode": "test|route.from.steps.1.choice.otherwise",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.1.choice.otherwise.steps.2.log",
+    "parentNode": "test|route.from.steps.1.choice.otherwise",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [
+      "test|route.from.steps.1.choice.otherwise.steps.0.to",
+      "test|route.from.steps.1.choice.otherwise.steps.1.to",
+      "test|route.from.steps.1.choice.otherwise.steps.2.log",
+    ],
+    "data": {},
+    "group": true,
+    "id": "test|route.from.steps.1.choice.otherwise",
+    "label": "route.from.steps.1.choice.otherwise",
+    "parentNode": "test|route.from.steps.1.choice",
+    "style": {
+      "padding": 40,
+    },
+    "type": "group",
+  },
+  {
+    "children": [
+      "test|route.from.steps.1.choice.when.0",
+      "test|route.from.steps.1.choice.otherwise",
+    ],
+    "data": {},
+    "group": true,
+    "id": "test|route.from.steps.1.choice",
+    "label": "route.from.steps.1.choice",
+    "parentNode": "test|route",
+    "style": {
+      "padding": 40,
+    },
+    "type": "group",
+  },
+  {
+    "children": [],
+    "data": {},
+    "group": false,
+    "height": 75,
+    "id": "test|route.from.steps.2.to",
+    "parentNode": "test|route",
+    "shape": "rect",
+    "type": "node",
+    "width": 90,
+  },
+  {
+    "children": [
+      "test|route.from",
+      "test|route.from.steps.0.set-header",
+      "test|route.from.steps.1.choice",
+      "test|route.from.steps.2.to",
+    ],
+    "data": {},
+    "group": true,
+    "id": "test|route",
+    "label": "route",
+    "parentNode": undefined,
+    "style": {
+      "padding": 40,
+    },
+    "type": "group",
+  },
+]
+`;
+
+exports[`FlowService getFlowDiagram should remove placeholders 2`] = `
+[
+  {
+    "edgeStyle": "solid",
+    "id": "test|route.from >>> route.from.steps.0.set-header",
+    "source": "test|route.from",
+    "target": "test|route.from.steps.0.set-header",
+    "type": "edge",
+  },
+  {
+    "edgeStyle": "solid",
+    "id": "test|route.from.steps.0.set-header >>> route.from.steps.1.choice",
+    "source": "test|route.from.steps.0.set-header",
+    "target": "test|route.from.steps.1.choice",
+    "type": "edge",
+  },
+  {
+    "edgeStyle": "solid",
+    "id": "test|route.from.steps.1.choice.otherwise.steps.0.to >>> route.from.steps.1.choice.otherwise.steps.1.to",
+    "source": "test|route.from.steps.1.choice.otherwise.steps.0.to",
+    "target": "test|route.from.steps.1.choice.otherwise.steps.1.to",
+    "type": "edge",
+  },
+  {
+    "edgeStyle": "solid",
+    "id": "test|route.from.steps.1.choice.otherwise.steps.1.to >>> route.from.steps.1.choice.otherwise.steps.2.log",
+    "source": "test|route.from.steps.1.choice.otherwise.steps.1.to",
+    "target": "test|route.from.steps.1.choice.otherwise.steps.2.log",
+    "type": "edge",
+  },
+  {
+    "edgeStyle": "solid",
+    "id": "test|route.from.steps.1.choice >>> route.from.steps.2.to",
+    "source": "test|route.from.steps.1.choice",
+    "target": "test|route.from.steps.2.to",
+    "type": "edge",
+  },
+]
+`;
+
 exports[`FlowService getFlowDiagram should return nodes and edges for a group with children 1`] = `
 [
   {

--- a/packages/ui/src/components/Visualization/Canvas/flow.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/flow.service.test.ts
@@ -1,6 +1,7 @@
 import { CatalogKind } from '../../../models';
 import { EntityType } from '../../../models/camel/entities';
 import { CamelRouteVisualEntity, createVisualizationNode } from '../../../models/visualization';
+import { camelRouteJson } from '../../../stubs/camel-route';
 import { FlowService } from './flow.service';
 
 describe('FlowService', () => {
@@ -125,6 +126,18 @@ describe('FlowService', () => {
       const group = nodes[nodes.length - 1];
       expect(group.children).toEqual(['test|route.from', 'test|route.from.steps.0.placeholder']);
       expect(group.group).toBeTruthy();
+    });
+
+    it('should remove placeholders', () => {
+      const routeNode = new CamelRouteVisualEntity(camelRouteJson).toVizNode();
+
+      const { nodes, edges } = FlowService.getFlowDiagram('test', routeNode, { removePlaceholder: true });
+      nodes.forEach((node) => {
+        delete node.data!.vizNode;
+      });
+
+      expect(nodes).toMatchSnapshot();
+      expect(edges).toMatchSnapshot();
     });
 
     it('should scope nodes & edges IDs', () => {

--- a/packages/ui/src/components/Visualization/Canvas/flow.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/flow.service.ts
@@ -9,12 +9,16 @@ export class FlowService {
   static edges: CanvasEdge[] = [];
   private static visitedNodes: string[] = [];
 
-  static getFlowDiagram(scope: string, vizNode: IVisualizationNode): CanvasNodesAndEdges {
+  static getFlowDiagram(
+    scope: string,
+    vizNode: IVisualizationNode,
+    options: { removePlaceholder?: boolean } = {},
+  ): CanvasNodesAndEdges {
     this.nodes = [];
     this.edges = [];
     this.visitedNodes = [];
 
-    this.appendNodesAndEdges(vizNode);
+    this.appendNodesAndEdges(vizNode, options);
 
     this.nodes.forEach((node) => {
       node.id = `${scope}|${node.id}`;
@@ -31,19 +35,25 @@ export class FlowService {
   }
 
   /** Method for iterating over all the IVisualizationNode and its children using a depth-first algorithm */
-  private static appendNodesAndEdges(vizNodeParam: IVisualizationNode): void {
-    if (this.visitedNodes.includes(vizNodeParam.id)) {
+  private static appendNodesAndEdges(
+    vizNodeParam: IVisualizationNode,
+    options: { removePlaceholder?: boolean } = {},
+  ): void {
+    const removePlaceholder = options.removePlaceholder ?? false;
+    if (this.visitedNodes.includes(vizNodeParam.id) || (removePlaceholder && vizNodeParam.data.isPlaceholder)) {
       return;
     }
-
     let node: CanvasNode;
 
-    const children = vizNodeParam.getChildren() ?? [];
+    let children = vizNodeParam.getChildren() ?? [];
+    if (removePlaceholder) {
+      children = children.filter((child) => !child.data.isPlaceholder);
+    }
     const hasRealChildren = children.length > 0;
 
     if (vizNodeParam.data.isGroup && hasRealChildren) {
       children.forEach((child) => {
-        this.appendNodesAndEdges(child);
+        this.appendNodesAndEdges(child, options);
       });
 
       node = this.getGroup(vizNodeParam.id, {
@@ -64,7 +74,7 @@ export class FlowService {
     this.visitedNodes.push(node.id);
 
     /** Add edges */
-    this.edges.push(...this.getEdgesFromVizNode(vizNodeParam));
+    this.edges.push(...this.getEdgesFromVizNode(vizNodeParam, options));
   }
 
   private static getCanvasNode(vizNodeParam: IVisualizationNode): CanvasNode {
@@ -86,10 +96,18 @@ export class FlowService {
     return canvasNode;
   }
 
-  private static getEdgesFromVizNode(vizNodeParam: IVisualizationNode): CanvasEdge[] {
+  private static getEdgesFromVizNode(
+    vizNodeParam: IVisualizationNode,
+    options: { removePlaceholder?: boolean } = {},
+  ): CanvasEdge[] {
     const edges: CanvasEdge[] = [];
     const prev = vizNodeParam.getPreviousNode?.();
     const next = vizNodeParam.getNextNode?.();
+
+    const removePlaceholder = options.removePlaceholder ?? false;
+    if (removePlaceholder && next?.data.isPlaceholder) {
+      return edges;
+    }
 
     const isGroup = vizNodeParam.data?.isGroup === true;
     const hasChildren = (vizNodeParam.getChildren() ?? []).length > 0;

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
@@ -1,8 +1,10 @@
-import { act, fireEvent, render } from '@testing-library/react';
+import { VisualizationProvider } from '@patternfly/react-topology';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
 import { CamelResource, CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/camel/entities';
 import { TestProvidersWrapper } from '../../../../stubs';
+import { ControllerService } from '../../Canvas/controller.service';
 import { ExportDocument } from './ExportDocument';
 
 describe('FlowExportDocument.tsx', () => {
@@ -19,9 +21,11 @@ describe('FlowExportDocument.tsx', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     const { Provider } = TestProvidersWrapper({ camelResource });
     const wrapper = render(
-      <Provider>
-        <ExportDocument />
-      </Provider>,
+      <VisualizationProvider controller={ControllerService.createController()}>
+        <Provider>
+          <ExportDocument />
+        </Provider>
+      </VisualizationProvider>,
     );
 
     const exportButton = wrapper.getByTestId('documentationPreviewButton');
@@ -42,9 +46,14 @@ describe('FlowExportDocument.tsx', () => {
       fireEvent.click(showAllBtn);
     });
 
-    const headers = await wrapper.findAllByTestId('export-document-preview-h1');
-    expect(headers.length).toEqual(3);
-    const tables = await wrapper.findAllByTestId('export-document-preview-table');
-    expect(tables.length).toEqual(1);
+    await waitFor(async () => {
+      const header = await wrapper.findByTestId('documentationPreviewModal');
+      expect(header).toBeInTheDocument();
+    });
+
+    await waitFor(async () => {
+      const tables = await wrapper.findAllByTestId('export-document-preview-body');
+      expect(tables.length).toEqual(1);
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.tsx
@@ -22,7 +22,13 @@ export const ExportDocument: FunctionComponent = () => {
         variant="control"
         data-testid="documentationPreviewButton"
       />
-      {isModalOpen && <ExportDocumentPreviewModal onClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && (
+        <ExportDocumentPreviewModal
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
@@ -1,0 +1,243 @@
+import { GRAPH_LAYOUT_END_EVENT, useEventListener, VisualizationProvider } from '@patternfly/react-topology';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toBlob } from 'html-to-image';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { CamelRouteResource } from '../../../../models/camel';
+import { DocumentationService } from '../../../../services/documentation.service';
+import { camelRouteJson, TestProvidersWrapper } from '../../../../stubs';
+import { CanvasNode } from '../../Canvas/canvas.models';
+import { ControllerService } from '../../Canvas/controller.service';
+import { FlowService } from '../../Canvas/flow.service';
+import { ExportDocumentPreviewModal } from './ExportDocumentPreviewModal';
+
+jest.mock('html-to-image', () => ({
+  toBlob: jest.fn(),
+}));
+
+jest.mock('@patternfly/react-topology', () => ({
+  ...jest.requireActual('@patternfly/react-topology'),
+  useEventListener: jest.fn(),
+  GRAPH_LAYOUT_END_EVENT: 'graph.layout.end',
+}));
+
+jest.mock('../../Canvas/flow.service');
+
+describe('ExportDocumentPreviewModal', () => {
+  const camelResource = new CamelRouteResource([camelRouteJson]);
+  let onCloseSpy: jest.Mock;
+  let wrapper: FunctionComponent<PropsWithChildren>;
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+  let clickSpy: jest.SpyInstance;
+  let eventListenerCallback: ((event?: Event) => void) | null = null;
+
+  beforeEach(() => {
+    onCloseSpy = jest.fn();
+
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = jest.fn();
+
+    clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    (FlowService.getFlowDiagram as jest.Mock).mockReturnValue({
+      nodes: [{ id: 'node-1', type: 'node' } as CanvasNode],
+      edges: [{ id: 'edge-1', type: 'edge' }],
+    });
+
+    (toBlob as jest.Mock).mockResolvedValue(new Blob(['fake-image-data'], { type: 'image/png' }));
+
+    (useEventListener as jest.Mock).mockImplementation((eventType: string, callback: (event?: Event) => void) => {
+      if (eventType === GRAPH_LAYOUT_END_EVENT) {
+        eventListenerCallback = callback;
+      }
+    });
+
+    const { Provider } = TestProvidersWrapper({ camelResource });
+    wrapper = ({ children }) => (
+      <VisualizationProvider controller={ControllerService.createController()}>
+        <Provider>{children}</Provider>
+      </VisualizationProvider>
+    );
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    clickSpy.mockRestore();
+    eventListenerCallback = null;
+  });
+
+  it('renders the top toolbar', () => {
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    expect(screen.getByLabelText('Generate Route Documentation')).toBeInTheDocument();
+    expect(screen.getByTestId('entities-list-dropdown')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Download File Name');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('route-export.zip');
+
+    expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument();
+  });
+
+  it('shows loading spinner initially', () => {
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    expect(screen.getByLabelText('Loading markdown preview')).toBeInTheDocument();
+  });
+
+  it('calls onClose when modal is closed', async () => {
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates download file name when input changes', async () => {
+    const user = userEvent.setup();
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    const input = screen.getByLabelText('Download File Name');
+    await user.clear(input);
+    await user.type(input, 'custom-export.zip');
+
+    expect(input).toHaveValue('custom-export.zip');
+  });
+
+  it('initializes with documentation entities from DocumentationService', () => {
+    const getDocumentationEntitiesSpy = jest.spyOn(DocumentationService, 'getDocumentationEntities');
+
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    expect(getDocumentationEntitiesSpy).toHaveBeenCalledWith(camelResource, {});
+  });
+
+  it('creates blob URL and markdown when HiddenCanvas generates blob', async () => {
+    const generateMarkdownSpy = jest.spyOn(DocumentationService, 'generateMarkdown');
+
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    // Trigger the GRAPH_LAYOUT_END_EVENT to simulate canvas layout completion
+    act(() => {
+      eventListenerCallback?.();
+    });
+
+    await waitFor(() => {
+      expect(URL.createObjectURL as jest.Mock).toHaveBeenCalled();
+      expect(generateMarkdownSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('hides loading spinner after blob is generated', async () => {
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    // Initially loading spinner should be visible
+    expect(screen.getByLabelText('Loading markdown preview')).toBeInTheDocument();
+
+    // Trigger the GRAPH_LAYOUT_END_EVENT to simulate canvas layout completion
+    act(() => {
+      eventListenerCallback?.();
+    });
+
+    // Wait for loading spinner to be removed
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Loading markdown preview')).not.toBeInTheDocument();
+    });
+  });
+
+  it('generates zip with blob and markdown when downloading', async () => {
+    const generateDocumentationZipSpy = jest
+      .spyOn(DocumentationService, 'generateDocumentationZip')
+      .mockResolvedValue(new Blob(['fake-zip-data'], { type: 'application/zip' }));
+
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    // Trigger blob generation
+    act(() => {
+      eventListenerCallback?.();
+    });
+
+    // Wait for blob to be generated
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Loading markdown preview')).not.toBeInTheDocument();
+    });
+
+    // Click download button
+    const downloadButton = screen.getByRole('button', { name: /download/i });
+    fireEvent.click(downloadButton);
+
+    await waitFor(() => {
+      expect(generateDocumentationZipSpy).toHaveBeenCalledWith(expect.any(Blob), expect.any(String), 'route-export');
+    });
+
+    generateDocumentationZipSpy.mockRestore();
+  });
+
+  it('creates download link with correct filename', async () => {
+    const user = userEvent.setup();
+    jest
+      .spyOn(DocumentationService, 'generateDocumentationZip')
+      .mockResolvedValue(new Blob(['fake-zip-data'], { type: 'application/zip' }));
+
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    // Change filename
+    const input = screen.getByLabelText('Download File Name');
+    await user.clear(input);
+    await user.type(input, 'my-custom-export.zip');
+
+    // Trigger blob generation
+    act(() => {
+      eventListenerCallback?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Loading markdown preview')).not.toBeInTheDocument();
+    });
+
+    // Click download button
+    const downloadButton = screen.getByRole('button', { name: /download/i });
+    fireEvent.click(downloadButton);
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    // Verify the download attribute was set correctly
+    const downloadLink = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(downloadLink.download).toBe('my-custom-export.zip');
+  });
+
+  it('creates blob URL for zip download', async () => {
+    const zipBlob = new Blob(['fake-zip-data'], { type: 'application/zip' });
+    jest.spyOn(DocumentationService, 'generateDocumentationZip').mockResolvedValue(zipBlob);
+
+    render(<ExportDocumentPreviewModal onClose={onCloseSpy} />, { wrapper });
+
+    // Trigger blob generation
+    act(() => {
+      eventListenerCallback?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Loading markdown preview')).not.toBeInTheDocument();
+    });
+
+    // Clear previous calls to createObjectURL (from image blob)
+    (URL.createObjectURL as jest.Mock).mockClear();
+
+    // Click download button
+    const downloadButton = screen.getByRole('button', { name: /download/i });
+    fireEvent.click(downloadButton);
+
+    await waitFor(() => {
+      expect(URL.createObjectURL as jest.Mock).toHaveBeenCalledWith(zipBlob);
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
@@ -15,36 +15,42 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
+import { useVisualizationController } from '@patternfly/react-topology';
 import { Element } from 'hast';
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { DocumentationEntity } from '../../../../models/documentation';
-import { EntitiesContext, VisibleFlowsContext } from '../../../../providers';
+import { VisibleFlowsContext } from '../../../../providers';
 import { DocumentationService } from '../../../../services/documentation.service';
+import { LayoutType } from '../../Canvas/canvas.models';
+import { HiddenCanvas } from '../FlowExportImage/HiddenCanvas';
 import { EntitiesMenu } from './EntitiesMenu';
 import { markdownComponentMapping } from './MarkdownComponentMapping';
 
 type IExportDocumentPreviewModal = {
-  isOpen?: boolean;
   onClose: () => void;
 };
 
-export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPreviewModal> = ({
-  isOpen = true,
-  onClose,
-}) => {
-  const fileNameBase = 'route-export';
-  const { camelResource } = useContext(EntitiesContext)!;
+const FILENAME_BASE = 'route-export';
+
+export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPreviewModal> = ({ onClose }) => {
+  const { camelResource } = useEntityContext();
   const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
+  const controller = useVisualizationController();
+  const { visualEntities } = useEntityContext();
   const [markdownText, setMarkdownText] = useState<string>('');
   const [flowImageBlob, setFlowImageBlob] = useState<Blob>();
-  const [downloadFileName, setDownloadFileName] = useState<string>(fileNameBase + '.zip');
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(isOpen);
+  const [flowImageUrl, setFlowImageUrl] = useState<string>();
+  const [downloadFileName, setDownloadFileName] = useState<string>(`${FILENAME_BASE}.zip`);
   const initialDocEntities = DocumentationService.getDocumentationEntities(camelResource, visibleFlows);
   const [documentationEntities, setDocumentationEntities] = useState<DocumentationEntity[]>(initialDocEntities);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isGeneratingImage, setIsGeneratingImage] = useState<boolean>(false);
+
+  const currentLayout = controller.getGraph().getLayout() as LayoutType | undefined;
 
   const onUpdateDocumentationEntities = (documentationEntities: DocumentationEntity[]) => {
     documentationEntities.forEach((docEntity) => {
@@ -60,54 +66,53 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
     setDocumentationEntities([...documentationEntities]);
   };
 
+  const handleBlobGenerated = (blob: Blob) => {
+    setFlowImageBlob(blob);
+    // Revoke previous object URL before creating a new one
+    if (flowImageUrl) {
+      URL.revokeObjectURL(flowImageUrl);
+    }
+    const imageUrl = URL.createObjectURL(blob);
+    setFlowImageUrl(imageUrl);
+    const md = DocumentationService.generateMarkdown(documentationEntities, imageUrl);
+    setMarkdownText(md);
+    setIsLoading(false);
+  };
+
+  const handleImageGenerationComplete = () => {
+    setIsGeneratingImage(false);
+  };
+
   useEffect(() => {
     setIsLoading(true);
-    const updatePreview = () => {
-      let imageUrl = '';
-      DocumentationService.generateFlowImage()
-        .then((imageBlob) => {
-          if (imageBlob) {
-            setFlowImageBlob(imageBlob);
-            imageUrl = window.URL.createObjectURL(imageBlob);
-          }
-        })
-        .catch((error) => {
-          console.error(error);
-        })
-        .finally(() => {
-          const md = DocumentationService.generateMarkdown(documentationEntities, imageUrl);
-          setMarkdownText(md);
-          setIsLoading(false);
-        });
-    };
-
-    // A workaround for React 18 synchronous useEffect execution, which causes the flow image
-    // to be captured before the entity visibility reflects
-    // https://react.dev/reference/react/useEffect#caveats
-    const timeout = setTimeout(updatePreview);
-    return () => {
-      clearTimeout(timeout);
-    };
+    setIsGeneratingImage(true);
   }, [documentationEntities, visibleFlows]);
 
   const onDownload = async () => {
     if (!flowImageBlob) return;
 
-    const md = DocumentationService.generateMarkdown(documentationEntities, fileNameBase + '.png');
+    const md = DocumentationService.generateMarkdown(documentationEntities, FILENAME_BASE + '.png');
 
-    const zipBlob = await DocumentationService.generateDocumentationZip(flowImageBlob, md, fileNameBase);
-    const dataUrl = window.URL.createObjectURL(zipBlob);
-    if (!dataUrl) return;
+    const zipBlob = await DocumentationService.generateDocumentationZip(flowImageBlob, md, FILENAME_BASE);
+    const downloadUrl = URL.createObjectURL(zipBlob);
+    if (!downloadUrl) return;
     const link = document.createElement('a');
     link.download = downloadFileName;
-    link.href = dataUrl;
+    link.href = downloadUrl;
     link.click();
+    // Revoke the temporary download URL after a short timeout
+    setTimeout(() => {
+      URL.revokeObjectURL(downloadUrl);
+    }, 100);
   };
 
   const imageUrlTransform = (url: string, _key: string, _node: Readonly<Element>): string | null | undefined => url;
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
+    // Revoke the object URL when modal closes
+    if (flowImageUrl) {
+      URL.revokeObjectURL(flowImageUrl);
+    }
     onClose();
   };
 
@@ -115,7 +120,7 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
     <Modal
       aria-label="Generate Route Documentation"
       variant={ModalVariant.large}
-      isOpen={isModalOpen}
+      isOpen
       data-testid="documentationPreviewModal"
       onClose={handleModalClose}
       className="export-document-preview-modal"
@@ -165,7 +170,7 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
       <ModalBody tabIndex={0} className="export-document-preview-body" data-testid="export-document-preview-body">
         {isLoading ? (
           <Bullseye>
-            <Spinner aria-label="Loading markdown preview" />
+            <Spinner aria-label="Loading markdown preview" data-testid="Loading markdown preview" />
           </Bullseye>
         ) : (
           <Markdown components={markdownComponentMapping} remarkPlugins={[remarkGfm]} urlTransform={imageUrlTransform}>
@@ -173,6 +178,15 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
           </Markdown>
         )}
       </ModalBody>
+
+      {isGeneratingImage && (
+        <HiddenCanvas
+          entities={visualEntities}
+          layout={currentLayout}
+          onComplete={handleImageGenerationComplete}
+          onBlobGenerated={handleBlobGenerated}
+        />
+      )}
     </Modal>
   );
 };

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
@@ -1,16 +1,16 @@
 import { Button } from '@patternfly/react-core';
 import { ImageIcon } from '@patternfly/react-icons';
 import { useVisualizationController } from '@patternfly/react-topology';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { LayoutType } from '../../Canvas/canvas.models';
 import { HiddenCanvas } from './HiddenCanvas';
 
 export function FlowExportImage() {
   const controller = useVisualizationController();
   const [isExporting, setIsExporting] = useState(false);
-  const entitiesContext = useContext(EntitiesContext);
+  const { visualEntities } = useEntityContext();
 
   const onClick = () => {
     setIsExporting(true);
@@ -19,8 +19,6 @@ export function FlowExportImage() {
   const handleExportComplete = () => {
     setIsExporting(false);
   };
-
-  if (!entitiesContext) return null;
 
   const currentLayout = controller.getGraph().getLayout() as LayoutType | undefined;
 
@@ -36,11 +34,7 @@ export function FlowExportImage() {
       />
 
       {isExporting && (
-        <HiddenCanvas
-          entities={entitiesContext.visualEntities}
-          layout={currentLayout}
-          onComplete={handleExportComplete}
-        />
+        <HiddenCanvas autoDownload entities={visualEntities} layout={currentLayout} onComplete={handleExportComplete} />
       )}
     </>
   );

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
@@ -39,6 +39,8 @@ describe('HiddenCanvas', () => {
   let originalCreateObjectURL: typeof URL.createObjectURL;
   let originalRevokeObjectURL: typeof URL.revokeObjectURL;
   let originalRAF: typeof globalThis.requestAnimationFrame;
+  let originalCAF: typeof globalThis.cancelAnimationFrame;
+  let originalCT: typeof globalThis.clearTimeout;
   let clickSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -48,6 +50,8 @@ describe('HiddenCanvas', () => {
     originalCreateObjectURL = URL.createObjectURL;
     originalRevokeObjectURL = URL.revokeObjectURL;
     originalRAF = globalThis.requestAnimationFrame;
+    originalCAF = globalThis.cancelAnimationFrame;
+    originalCT = globalThis.clearTimeout;
 
     URL.createObjectURL = jest.fn(() => 'blob:mock-url');
     URL.revokeObjectURL = jest.fn();
@@ -57,6 +61,8 @@ describe('HiddenCanvas', () => {
       cb(0);
       return 1;
     }) as unknown as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = jest.fn();
+    globalThis.clearTimeout = jest.fn();
 
     clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
     mockOnComplete = jest.fn();
@@ -93,6 +99,8 @@ describe('HiddenCanvas', () => {
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
     globalThis.requestAnimationFrame = originalRAF;
+    globalThis.cancelAnimationFrame = originalCAF;
+    globalThis.clearTimeout = originalCT;
     clickSpy.mockRestore();
   });
 
@@ -177,8 +185,11 @@ describe('HiddenCanvas', () => {
     });
   });
 
-  it('revokes blob URL after download', async () => {
-    render(<HiddenCanvas entities={[mockEntity]} onComplete={mockOnComplete} />, { wrapper });
+  it('revokes blob URL after download when autoDownload is true', async () => {
+    const createObjectURLSpy = jest.spyOn(URL, 'createObjectURL');
+    const revokeObjectURLSpy = jest.spyOn(URL, 'revokeObjectURL');
+
+    render(<HiddenCanvas entities={[mockEntity]} onComplete={mockOnComplete} autoDownload />, { wrapper });
 
     act(() => {
       eventListenerCallback?.();
@@ -187,15 +198,17 @@ describe('HiddenCanvas', () => {
     });
 
     await waitFor(() => {
-      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(createObjectURLSpy).toHaveBeenCalled();
     });
 
     act(() => {
-      // Fast-forward the cleanup timer (100ms)
+      // Fast-forward the cleanup timer (150ms)
       jest.advanceTimersByTime(150);
     });
 
-    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    await waitFor(() => {
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+    });
   });
 
   it('triggers fallback timer if layout does not complete', async () => {
@@ -293,5 +306,54 @@ describe('HiddenCanvas', () => {
     unmount();
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it('calls onBlobGenerated callback with the generated blob', async () => {
+    const mockBlob = new Blob(['fake-image-data'], { type: 'image/png' });
+    (toBlob as jest.Mock).mockResolvedValue(mockBlob);
+    const mockOnBlobGenerated = jest.fn();
+
+    render(<HiddenCanvas entities={[mockEntity]} onComplete={mockOnComplete} onBlobGenerated={mockOnBlobGenerated} />, {
+      wrapper,
+    });
+
+    act(() => {
+      eventListenerCallback?.();
+      jest.advanceTimersByTime(0);
+    });
+
+    await waitFor(() => {
+      expect(mockOnBlobGenerated).toHaveBeenCalledWith(mockBlob);
+    });
+  });
+
+  it('does not auto-download when autoDownload is false', async () => {
+    render(<HiddenCanvas entities={[mockEntity]} onComplete={mockOnComplete} autoDownload={false} />, { wrapper });
+
+    act(() => {
+      eventListenerCallback?.();
+      jest.advanceTimersByTime(0);
+    });
+
+    await waitFor(() => {
+      expect(toBlob).toHaveBeenCalled();
+    });
+
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto-downloads when autoDownload is true', async () => {
+    render(<HiddenCanvas entities={[mockEntity]} onComplete={mockOnComplete} autoDownload />, { wrapper });
+
+    act(() => {
+      eventListenerCallback?.();
+      jest.advanceTimersByTime(0);
+    });
+
+    await waitFor(() => {
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(clickSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
@@ -20,13 +20,17 @@ import { FlowService } from '../../Canvas/flow.service';
 interface HiddenCanvasProps {
   entities: BaseVisualCamelEntity[];
   layout?: LayoutType;
+  autoDownload?: boolean;
   onComplete: () => void;
+  onBlobGenerated?: (blob: Blob) => void;
 }
 
 export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
   entities,
   layout = LayoutType.DagreHorizontal,
   onComplete,
+  onBlobGenerated,
+  autoDownload = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [layoutComplete, setLayoutComplete] = useState(false);
@@ -53,7 +57,9 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
 
     entities.forEach((entity) => {
       if (visibleFlows[entity.id]) {
-        const { nodes: childNodes, edges: childEdges } = FlowService.getFlowDiagram(entity.id, entity.toVizNode());
+        const { nodes: childNodes, edges: childEdges } = FlowService.getFlowDiagram(entity.id, entity.toVizNode(), {
+          removePlaceholder: true,
+        });
         nodes.push(...childNodes);
         edges.push(...childEdges);
       }
@@ -134,14 +140,21 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
           return;
         }
 
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'kaoto-flow.png';
-        link.click();
+        onBlobGenerated?.(blob);
 
-        // Clean up the blob URL after a short delay to ensure download starts
-        setTimeout(() => URL.revokeObjectURL(url), 100);
+        // Only auto-download if enabled
+        if (autoDownload) {
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = 'kaoto-flow.png';
+          link.click();
+
+          // Clean up the blob URL after a short delay to ensure download starts
+          setTimeout(() => {
+            URL.revokeObjectURL(url);
+          }, 100);
+        }
       } catch (err) {
         console.error('Export failed', err);
       } finally {
@@ -154,7 +167,7 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [layoutComplete]);
+  }, [layoutComplete, onBlobGenerated, autoDownload]);
 
   return (
     <div ref={containerRef} className="hidden-canvas">

--- a/packages/ui/src/models/placeholder.constants.ts
+++ b/packages/ui/src/models/placeholder.constants.ts
@@ -3,7 +3,7 @@
  * Dynamic placeholder names (e.g. 'when', 'otherwise', 'to') are derived from path
  * in base-node-mapper and are not listed here.
  */
-export enum PlaceholderType {
+export const enum PlaceholderType {
   /** Generic "add step" placeholder in the flow */
   Placeholder = 'placeholder',
   /** Special empty-state placeholder (e.g. empty REST DSL) */

--- a/packages/ui/src/services/documentation.service.test.ts
+++ b/packages/ui/src/services/documentation.service.test.ts
@@ -50,19 +50,6 @@ describe('DocumentationService', () => {
     return DocumentationService.getDocumentationEntities(camelResource, visibleFlows);
   };
 
-  describe('generateFlowImage()', () => {
-    it('should fail', async () => {
-      try {
-        await DocumentationService.generateFlowImage();
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-      } catch (error: any) {
-        expect(error.message).toEqual('generateFlowImage called but the flow diagram is not found');
-        return;
-      }
-      throw new Error('expected to throw an error');
-    });
-  });
-
   describe('getDocumentationEntities()', () => {
     it('should generate route and beans documentation entities', () => {
       const documentationEntities = createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);

--- a/packages/ui/src/services/documentation.service.ts
+++ b/packages/ui/src/services/documentation.service.ts
@@ -1,4 +1,3 @@
-import { toBlob } from 'html-to-image';
 import JSZip from 'jszip';
 import { MarkdownEntry, TableRow, tsMarkdown } from 'ts-markdown';
 
@@ -40,22 +39,6 @@ export class DocumentationService {
     jszip.file(imageFileName, flowImage);
     jszip.file(markdownFileName, markdownText);
     return jszip.generateAsync({ type: 'blob' });
-  }
-
-  static generateFlowImage(isDark?: boolean): Promise<Blob | null> {
-    const element = document.querySelector<HTMLElement>('.pf-topology-container') ?? undefined;
-    if (!element) {
-      return Promise.reject(new Error('generateFlowImage called but the flow diagram is not found'));
-    }
-
-    return toBlob(element, {
-      cacheBust: true,
-      backgroundColor: isDark ? '#0f1214' : '#f0f0f0',
-      filter: (element) => {
-        /**  Filter @patternfly/react-topology controls */
-        return !element?.classList?.contains('pf-v6-c-toolbar__group');
-      },
-    });
   }
 
   static generateMarkdown(documentationEntities: DocumentationEntity[], flowImageFileName: string) {


### PR DESCRIPTION
### Context
Currently, there are multiple placeholder nodes across the Canvas making interacting with the flows easier. The downside is that when exporting screenshots or documentation about the flow, all these placeholders are included, making the picture more complicated than it needs to be.

### Changes
The fix is to filter all placeholders before drawing the graph. In addition to that, both `ExportDocumentPreviewModal` and `FlowExportImage` components should use the same `<HiddenCanvas>` component to have a consistent image.

### Note
A follow-up is needed to consolidate all `placeholder-related` logic, because in some cases, the `placeholder` wording gets added to the path, while in others not.

### Screenshots
#### Canvas view
<img width="1563" height="753" alt="image" src="https://github.com/user-attachments/assets/b8e47d44-d1cf-4fd1-bc2c-041034787464" />

| Exported screenshot | Exported documentation |
| --- | --- |
| <img width="3274" height="2580" alt="kaoto-flow (1)" src="https://github.com/user-attachments/assets/5d0e3442-88ac-41c2-8926-650fdee5a737" /> | <img width="3274" height="2580" alt="image" src="https://github.com/user-attachments/assets/b9ed6628-8bf2-456b-9552-fba2d13a2b28" /> |

fix: https://github.com/KaotoIO/kaoto/issues/3029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hidden canvas now supports automatic download and notifies when an image blob is generated.
  * Option to exclude placeholder nodes from flow diagram exports for cleaner visuals.

* **Improvements**
  * Overhauled export preview workflow for more reliable image/ZIP generation and URL cleanup.
  * Better integration with visualization context for smoother export UX.

* **Tests**
  * Expanded tests for export preview, hidden canvas, and overall export flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->