### PR TITLE
fix(vscode): improve styling

### DIFF
--- a/packages/ui/src/components/Visualization/Visualization.scss
+++ b/packages/ui/src/components/Visualization/Visualization.scss
@@ -3,6 +3,6 @@
   flex-flow: column;
 
   .pf-topology-content {
-    border-radius: 15px;
+    border-radius: var(--pf-t--global--border--radius--medium);
   }
 }

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -30,6 +30,8 @@ html body {
   flex-flow: column nowrap;
   position: relative;
   background-color: var(--pf-t--global--background--color--secondary--default);
+  border-radius: var(--pf-t--global--border--radius--medium);
+  overflow: hidden;
 
   // Tab header shouldn't grow or shrink
   > div[role='region'] {
@@ -52,9 +54,35 @@ html body {
 }
 
 .context-toolbar {
-  padding: var(--pf-v6-c-toolbar__content-section--ColumnGap);
+  padding: var(--pf-t--global--spacer--xs);
 }
 
-.pf-v6-c-divider {
-  display: none;
+/* Reduce outer toolbar padding to minimize space between divider and canvas */
+.canvas-surface .pf-v6-c-toolbar {
+  --pf-v6-c-toolbar--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+}
+
+/* Match backgrounds with the properties panel (Card) so the canvas
+   rounded corners are visible, consistent with standalone Kaoto.
+   See: https://github.com/KaotoIO/kaoto/issues/2749 */
+.canvas-surface .pf-v6-l-stack {
+  background-color: var(--pf-t--global--background--color--primary--default);
+  padding: 4px;
+
+  /* Round both the toolbar and the canvas/sidebar container */
+  /* stylelint-disable-next-line selector-class-pattern */
+  > .pf-v6-l-stack__item:not(.pf-m-fill) {
+    border-radius: var(--pf-t--global--border--radius--medium);
+    overflow: hidden;
+  }
+
+  > .pf-topology-container {
+    border-radius: var(--pf-t--global--border--radius--medium);
+    overflow: hidden;
+  }
+
+  /* Hide the divider between toolbar and canvas */
+  .pf-v6-c-divider {
+    display: none;
+  }
 }


### PR DESCRIPTION
Match the VS Code editor backgrounds and rounded corners with standalone Kaoto by using PF primary background on the TopologyView Stack, adding rounded corners to the toolbar and canvas containers, reducing toolbar padding, and hiding the divider.

Closes: https://github.com/KaotoIO/kaoto/issues/2749

<img width="1623" height="1035" alt="Screenshot 2026-03-12 at 14 30 23" src="https://github.com/user-attachments/assets/8fe71459-a7dc-4912-a2f1-dc1344867a52" />

<img width="1621" height="1039" alt="Screenshot 2026-03-12 at 14 32 14" src="https://github.com/user-attachments/assets/293631a2-f1fe-46f5-817d-1c471d4f5eeb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined border radii to use theme variables for consistent rounding across the editor.
  * Added overflow handling to shell, canvas, and nested containers to prevent visual bleed.
  * Adjusted tab header padding for improved spacing and hierarchy.
  * Unified canvas and properties panel backgrounds and hidden the divider between toolbar and canvas for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->