### PR TITLE
chore(DataMapper): UI mockup for xsl:for-each-group support

### DIFF
--- a/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroup.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroup.stories.tsx
@@ -1,0 +1,239 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { CSSProperties } from 'react';
+
+import { ForEachGroupMockup } from './ForEachGroupMockup';
+
+export default {
+  title: 'UI Mockups/DataMapper/ForEachGroup',
+  component: ForEachGroupMockup,
+} as Meta<typeof ForEachGroupMockup>;
+
+const STORY_WRAPPER: CSSProperties = { padding: '2rem', backgroundColor: '#f5f5f5' };
+const STORY_TITLE: CSSProperties = { marginBottom: '0.5rem' };
+const STORY_DESC: CSSProperties = { marginBottom: '1rem', color: '#666', maxWidth: '900px' };
+const STORY_COMPONENT_BOX: CSSProperties = {
+  backgroundColor: 'white',
+  padding: '1.5rem',
+  borderRadius: '4px',
+  border: '1px solid #ccc',
+};
+
+export const WorkflowOverview: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>for-each-group Support — Workflow Overview</h2>
+    <p>
+      Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2321">https://github.com/KaotoIO/kaoto/issues/2321</a>
+    </p>
+    <br />
+    <p style={{ ...STORY_DESC, marginBottom: '0.5rem' }}>
+      <strong>Scenario:</strong> group a source collection of <code>Item</code> elements by <code>Category</code> using
+      <code>xsl:for-each-group</code>, then iterate over each group&apos;s items with{' '}
+      <code>for-each current-group()</code> to map individual fields.
+    </p>
+    <ol style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px', paddingLeft: '1.5rem' }}>
+      <li>
+        <strong>Wrap with for-each-group</strong> — open the 3-dots context menu on the <code>Item</code> collection
+        field and choose <em>Wrap with for-each-group</em>.
+      </li>
+      <li>
+        <strong>Configure grouping</strong> — the modal opens automatically; select a grouping strategy (e.g.{' '}
+        <em>Group By</em>) and enter the grouping XPath expression (e.g. <code>Category</code>).
+      </li>
+      <li>
+        <strong>Set select expression</strong> — fill in the <code>select</code> inline input on the{' '}
+        <code>for-each-group</code> node (e.g. <code>$cart/ns0:Cart/Item</code>). Hover the label to inspect the
+        configured strategy and expression at any time.
+      </li>
+      <li>
+        <strong>Reconfigure if needed</strong> — open the 3-dots context menu on <code>for-each-group</code> and choose{' '}
+        <em>Configure grouping</em> to reopen the modal pre-populated with the current values.
+      </li>
+      <li>
+        <strong>Wrap with for-each current-group()</strong> — inside the <code>for-each-group</code>, open the 3-dots
+        context menu on <code>Item</code> and choose <em>Wrap with for-each current-group()</em>. The{' '}
+        <code>select</code> expression is set to <code>current-group()</code> automatically.
+      </li>
+      <li>
+        <strong>Map child fields</strong> — expand <code>Item</code> inside the inner <code>for-each</code> and map{' '}
+        <code>Title</code> and <code>Quantity</code> to their XPath expressions.
+      </li>
+    </ol>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+        showInnerForEach
+      />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Design decisions:</strong>
+      <ul style={{ marginTop: '0.5rem', marginLeft: '1.5rem' }}>
+        <li>
+          Grouping strategy and expression are configured in a <strong>modal</strong> (not an inline node) — keeps the
+          tree uncluttered and groups related inputs together.
+        </li>
+        <li>
+          The modal auto-opens on wrap so the user is guided immediately; it can be reopened later via the 3-dots
+          context menu.
+        </li>
+        <li>
+          A <strong>tooltip on the label</strong> summarises the current strategy and expression without requiring the
+          modal to be reopened.
+        </li>
+        <li>
+          <strong>&ldquo;Wrap with for-each current-group()&rdquo;</strong> is only offered on collection fields that
+          are direct children of a <code>for-each-group</code> node — scoped to avoid misuse.
+        </li>
+        <li>Deletion uses the trash icon button, consistent with all other mapping nodes in the tree.</li>
+      </ul>
+    </div>
+  </div>
+);
+WorkflowOverview.storyName = 'Workflow Overview';
+
+export const Step1_CollectionFieldMenu: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 1 — Wrap a collection field with for-each-group</h2>
+    <p style={STORY_DESC}>
+      Open the 3-dots context menu on the <code>Item</code> collection field in the target document tree. In addition to
+      the existing wrapping options, a new <strong>&ldquo;Wrap with for-each-group&rdquo;</strong> item appears.
+      Selecting it wraps the field and immediately opens the grouping configuration modal (Step 2).
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup phase="before-wrap" outerMenuOpen />
+    </div>
+  </div>
+);
+Step1_CollectionFieldMenu.storyName = 'Step 1: Collection field — 3-dot menu with "Wrap with for-each-group"';
+
+export const Step2_GroupingModal: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 2 — Configure the grouping strategy</h2>
+    <p style={STORY_DESC}>
+      Immediately after wrapping, the <strong>Configure for-each-group</strong> modal opens automatically. The user
+      selects one of the four grouping strategies and enters the grouping XPath expression. &ldquo;Group By&rdquo; is
+      pre-selected as the default. The <code>select</code> expression on the node itself is filled in separately via the
+      inline text input after the modal is closed.
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression=""
+        groupingStrategy="group-by"
+        groupingExpression=""
+        modalOpen
+      />
+    </div>
+  </div>
+);
+Step2_GroupingModal.storyName = 'Step 2: Grouping configuration modal — auto-opens after "Wrap with for-each-group"';
+
+export const Step3_LabelTooltip: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 3 — for-each-group node in the tree</h2>
+    <p style={STORY_DESC}>
+      After saving the modal, the <code>for-each-group</code> node appears in the tree with the wrapped{' '}
+      <strong>Item</strong> field as its child. The inline text input lets the user set the <code>select</code>{' '}
+      expression. <strong>Hover over the label</strong> to see a tooltip summarising the current grouping configuration
+      (strategy and expression), so the user can inspect the setup without reopening the modal.
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+      />
+    </div>
+  </div>
+);
+Step3_LabelTooltip.storyName = 'Step 3: for-each-group label — hover to see tooltip with strategy and expression';
+
+export const Step4_ForEachGroupMenu: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 4 — Reconfigure via the 3-dot menu</h2>
+    <p style={STORY_DESC}>
+      The 3-dots context menu on the <code>for-each-group</code> node exposes{' '}
+      <strong>&ldquo;Configure grouping&rdquo;</strong> to reopen the configuration modal. Deletion is handled by the
+      trash icon button next to the menu — consistent with how other mapping nodes are deleted in the tree.
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+        forEachGroupMenuOpen
+      />
+    </div>
+  </div>
+);
+Step4_ForEachGroupMenu.storyName = 'Step 4: for-each-group 3-dot menu — "Configure grouping" reopens modal';
+
+export const Step5_ReconfigureModal: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 5 — Reconfigure grouping</h2>
+    <p style={STORY_DESC}>
+      When the user clicks &ldquo;Configure grouping&rdquo;, the modal reopens pre-populated with the previously saved
+      strategy and expression. The user can switch to a different strategy or update the grouping expression, then save
+      to apply the changes.
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+        modalOpen
+      />
+    </div>
+  </div>
+);
+Step5_ReconfigureModal.storyName = 'Step 5: Reconfigure — modal pre-populated with existing strategy and expression';
+
+export const Step6_InnerForEachMenu: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 6 — Wrap Item with for-each current-group()</h2>
+    <p style={STORY_DESC}>
+      Inside the <code>for-each-group</code>, the user opens the 3-dots context menu on the wrapped{' '}
+      <strong>Item</strong> collection field. A new <strong>&ldquo;Wrap with for-each current-group()&rdquo;</strong>{' '}
+      option appears. Selecting it wraps Item with a <code>for-each</code> whose <code>select</code> expression is
+      automatically set to <code>current-group()</code> — a scoped XSLT 2.0 function that iterates over the items in the
+      current group.
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+        innerMenuOpen
+      />
+    </div>
+  </div>
+);
+Step6_InnerForEachMenu.storyName = 'Step 6: Inside for-each-group — "Wrap with for-each current-group()"';
+
+export const Step7_Complete: StoryFn = () => (
+  <div style={STORY_WRAPPER}>
+    <h2 style={STORY_TITLE}>Step 7 — Complete mapping structure</h2>
+    <p style={STORY_DESC}>
+      The fully configured structure. <code>for-each-group</code> iterates over the source collection and groups items
+      by the configured expression. Inside it, <code>for-each current-group()</code> iterates over each group&apos;s
+      items, and the user maps individual fields (Title, Quantity) from the expanded Item node. The generated XSLT uses{' '}
+      <code>xsl:for-each-group</code> with the chosen strategy attribute (e.g. <code>{'group-by="Category"'}</code>).
+    </p>
+    <div style={STORY_COMPONENT_BOX}>
+      <ForEachGroupMockup
+        phase="configured"
+        selectExpression="$cart/ns0:Cart/Item"
+        groupingStrategy="group-by"
+        groupingExpression="Category"
+        showInnerForEach
+      />
+    </div>
+  </div>
+);
+Step7_Complete.storyName = 'Step 7: Complete — for-each-group → for-each(current-group()) → child fields';

--- a/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
@@ -1,0 +1,583 @@
+import {
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Form,
+  FormGroup,
+  Icon,
+  InputGroup,
+  InputGroupItem,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Radio,
+  TextInput,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  EllipsisVIcon,
+  LayerGroupIcon,
+  PencilAltIcon,
+  TrashIcon,
+} from '@patternfly/react-icons';
+import { CSSProperties, FunctionComponent, MouseEvent, ReactNode, Ref, useEffect, useState } from 'react';
+
+export type GroupingStrategy = 'group-by' | 'group-adjacent' | 'group-starting-with' | 'group-ending-with';
+
+export const STRATEGY_LABELS: Record<GroupingStrategy, string> = {
+  'group-by': 'Group By',
+  'group-adjacent': 'Group Adjacent',
+  'group-starting-with': 'Group Starting With',
+  'group-ending-with': 'Group Ending With',
+};
+
+const STRATEGIES = Object.keys(STRATEGY_LABELS) as GroupingStrategy[];
+
+const ROW_BASE: CSSProperties = {
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  alignItems: 'center',
+  height: '2rem',
+  fontSize: '0.875rem',
+  boxSizing: 'border-box',
+};
+
+const ICON_SPACER: CSSProperties = {
+  margin: '0 0.25rem',
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+};
+
+const INPUT_HEIGHT = '1.75rem';
+
+const rowStyle = (rank: number, isLeaf: boolean): CSSProperties => ({
+  ...ROW_BASE,
+  marginLeft: `${rank * 1.2}rem`,
+  ...(isLeaf
+    ? {
+        color: 'var(--pf-t--global--color--text--subtle)',
+        borderLeft: '1px dotted gray',
+        paddingLeft: '0.5rem',
+      }
+    : {}),
+});
+
+interface MockTreeRowProps {
+  rank: number;
+  title: ReactNode;
+  isExpandable?: boolean;
+  isExpanded?: boolean;
+  isCollection?: boolean;
+  actions?: ReactNode;
+  onToggle?: () => void;
+}
+
+const MockTreeRow: FunctionComponent<MockTreeRowProps> = ({
+  rank,
+  title,
+  isExpandable = false,
+  isExpanded = false,
+  isCollection = false,
+  actions,
+  onToggle,
+}) => {
+  return (
+    <section style={rowStyle(rank, !isExpandable)}>
+      {isExpandable ? (
+        <Icon style={ICON_SPACER} onClick={onToggle}>
+          {isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+        </Icon>
+      ) : (
+        <span style={{ width: '1.25rem', flexShrink: 0 }} />
+      )}
+      {title}
+      {isCollection && (
+        <Icon style={ICON_SPACER}>
+          <LayerGroupIcon />
+        </Icon>
+      )}
+      {actions && (
+        <ActionList style={{ marginLeft: 'auto', flexShrink: 0 }}>
+          <ActionListGroup>{actions}</ActionListGroup>
+        </ActionList>
+      )}
+    </section>
+  );
+};
+
+interface MockExpressionInputProps {
+  value: string;
+  placeholder?: string;
+}
+
+const MockExpressionInput: FunctionComponent<MockExpressionInputProps> = ({
+  value,
+  placeholder = 'Add Grouping XPath expression',
+}) => (
+  <>
+    <ActionListItem style={{ flex: 1, minWidth: '220px' }}>
+      <TextInput
+        value={value}
+        onChange={() => {}}
+        placeholder={placeholder}
+        style={{ fontSize: '0.875rem', height: INPUT_HEIGHT, width: '100%' }}
+        aria-label={placeholder}
+      />
+    </ActionListItem>
+    <ActionListItem>
+      <Button
+        variant="plain"
+        aria-label="Edit XPath"
+        style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+        icon={<PencilAltIcon />}
+      />
+    </ActionListItem>
+  </>
+);
+
+const MockTrashButton: FunctionComponent<{ ariaLabel: string }> = ({ ariaLabel }) => (
+  <ActionListItem>
+    <Button
+      variant="plain"
+      aria-label={ariaLabel}
+      style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+      icon={<TrashIcon />}
+    />
+  </ActionListItem>
+);
+
+interface MockGroupingModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  strategy: GroupingStrategy;
+  expression: string;
+}
+
+const MockGroupingModal: FunctionComponent<MockGroupingModalProps> = ({ isOpen, onClose, strategy, expression }) => {
+  const [selectedStrategy, setSelectedStrategy] = useState<GroupingStrategy>(strategy);
+
+  return (
+    <Modal variant={ModalVariant.small} isOpen={isOpen} onClose={onClose} aria-labelledby="grouping-modal-title">
+      <ModalHeader title="Configure for-each-group" labelId="grouping-modal-title" />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Grouping strategy" isRequired fieldId="grouping-strategy">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', paddingTop: '0.25rem' }}>
+              {STRATEGIES.map((s) => (
+                <Radio
+                  key={s}
+                  id={`strategy-${s}`}
+                  name="grouping-strategy"
+                  label={STRATEGY_LABELS[s]}
+                  value={s}
+                  isChecked={selectedStrategy === s}
+                  onChange={() => setSelectedStrategy(s)}
+                />
+              ))}
+            </div>
+          </FormGroup>
+          <FormGroup label="Grouping expression" isRequired fieldId="grouping-expression">
+            <InputGroup>
+              <InputGroupItem isFill>
+                <TextInput
+                  id="grouping-expression"
+                  value={expression}
+                  onChange={() => {}}
+                  placeholder="Add Grouping XPath expression"
+                  aria-label="Grouping expression"
+                />
+              </InputGroupItem>
+              <InputGroupItem>
+                <Button variant="plain" aria-label="Edit grouping expression" icon={<PencilAltIcon />} />
+              </InputGroupItem>
+            </InputGroup>
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="save" variant="primary" onClick={onClose}>
+          Save
+        </Button>
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+interface MockCollectionFieldMenuProps {
+  initialOpen?: boolean;
+  onWrapWithForEachGroup?: () => void;
+}
+
+const MockCollectionFieldMenu: FunctionComponent<MockCollectionFieldMenuProps> = ({
+  initialOpen = false,
+  onWrapWithForEachGroup,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    if (initialOpen) setIsOpen(true);
+  }, [initialOpen]);
+
+  const handleSelect = (_e: MouseEvent | undefined, value: string | number | undefined) => {
+    if (value === 'foreach-group') {
+      onWrapWithForEachGroup?.();
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <ActionListItem>
+      <Dropdown
+        isOpen={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        onSelect={handleSelect}
+        toggle={(toggleRef: Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            icon={<EllipsisVIcon />}
+            variant="plain"
+            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            aria-label="Transformation Action list"
+            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+          />
+        )}
+        popperProps={{ position: 'end', preventOverflow: true }}
+        zIndex={100}
+      >
+        <DropdownList>
+          <DropdownItem key="foreach" value="foreach">
+            Wrap with <q>for-each</q>
+          </DropdownItem>
+          <DropdownItem key="foreach-group" value="foreach-group" style={{ fontWeight: 'bold' }}>
+            Wrap with <q>for-each-group</q>
+          </DropdownItem>
+          <DropdownItem key="if" value="if">
+            Wrap with <q>if</q>
+          </DropdownItem>
+          <DropdownItem key="choose" value="choose">
+            Wrap with <q>choose-when-otherwise</q>
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+    </ActionListItem>
+  );
+};
+
+interface MockInnerCollectionFieldMenuProps {
+  initialOpen?: boolean;
+}
+
+const MockInnerCollectionFieldMenu: FunctionComponent<MockInnerCollectionFieldMenuProps> = ({
+  initialOpen = false,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    if (initialOpen) setIsOpen(true);
+  }, [initialOpen]);
+
+  return (
+    <ActionListItem>
+      <Dropdown
+        isOpen={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        onSelect={() => setIsOpen(false)}
+        toggle={(toggleRef: Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            icon={<EllipsisVIcon />}
+            variant="plain"
+            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            aria-label="Transformation Action list"
+            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+          />
+        )}
+        popperProps={{ position: 'end', preventOverflow: true }}
+        zIndex={100}
+      >
+        <DropdownList>
+          <DropdownItem key="foreach" value="foreach">
+            Wrap with <q>for-each</q>
+          </DropdownItem>
+          <DropdownItem key="foreach-current-group" value="foreach-current-group" style={{ fontWeight: 'bold' }}>
+            Wrap with <q>for-each current-group()</q>
+          </DropdownItem>
+          <DropdownItem key="if" value="if">
+            Wrap with <q>if</q>
+          </DropdownItem>
+          <DropdownItem key="choose" value="choose">
+            Wrap with <q>choose-when-otherwise</q>
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+    </ActionListItem>
+  );
+};
+
+interface MockForEachGroupMenuProps {
+  initialOpen?: boolean;
+  onConfigure?: () => void;
+}
+
+const MockForEachGroupMenu: FunctionComponent<MockForEachGroupMenuProps> = ({ initialOpen = false, onConfigure }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    if (initialOpen) setIsOpen(true);
+  }, [initialOpen]);
+
+  const handleSelect = (_e: MouseEvent | undefined, value: string | number | undefined) => {
+    if (value === 'configure') {
+      onConfigure?.();
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <ActionListItem>
+      <Dropdown
+        isOpen={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        onSelect={handleSelect}
+        toggle={(toggleRef: Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            icon={<EllipsisVIcon />}
+            variant="plain"
+            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            aria-label="for-each-group actions"
+            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+          />
+        )}
+        popperProps={{ position: 'end', preventOverflow: true }}
+        zIndex={100}
+      >
+        <DropdownList>
+          <DropdownItem key="configure" value="configure">
+            Configure grouping
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+    </ActionListItem>
+  );
+};
+
+export interface ForEachGroupMockupProps {
+  phase: 'before-wrap' | 'configured';
+  selectExpression?: string;
+  groupingStrategy?: GroupingStrategy;
+  groupingExpression?: string;
+  outerMenuOpen?: boolean;
+  forEachGroupMenuOpen?: boolean;
+  innerMenuOpen?: boolean;
+  modalOpen?: boolean;
+  showInnerForEach?: boolean;
+}
+
+export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
+  phase,
+  selectExpression = '',
+  groupingStrategy = 'group-by',
+  groupingExpression = '',
+  outerMenuOpen = false,
+  forEachGroupMenuOpen = false,
+  innerMenuOpen = false,
+  modalOpen = false,
+  showInnerForEach = false,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  useEffect(() => {
+    if (modalOpen) setIsModalOpen(true);
+  }, [modalOpen]);
+  const [shipOrderExpanded, setShipOrderExpanded] = useState(true);
+  const [forEachGroupExpanded, setForEachGroupExpanded] = useState(true);
+  const [innerForEachExpanded, setInnerForEachExpanded] = useState(true);
+  const [itemExpanded, setItemExpanded] = useState(true);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const tooltipContent = (
+    <div>
+      <div>
+        <strong>Grouping Strategy:</strong> {STRATEGY_LABELS[groupingStrategy]}
+      </div>
+      {groupingExpression && (
+        <div>
+          <strong>Grouping Expression:</strong> {groupingExpression}
+        </div>
+      )}
+    </div>
+  );
+
+  const forEachGroupLabel = (
+    <Tooltip content={tooltipContent}>
+      <Label style={{ fontSize: '0.875rem', height: '1.25rem', cursor: 'default' }}>
+        <span>for-each-group</span>
+      </Label>
+    </Tooltip>
+  );
+
+  const forEachLabel = (
+    <Label style={{ fontSize: '0.875rem', height: '1.25rem' }}>
+      <span>for-each</span>
+    </Label>
+  );
+
+  return (
+    <>
+      <MockGroupingModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        strategy={groupingStrategy}
+        expression={groupingExpression}
+      />
+
+      <div
+        style={{
+          border: '1px solid var(--pf-t--global--border--color--default)',
+          borderRadius: '4px',
+          padding: '1rem',
+          maxWidth: '640px',
+          fontFamily: 'var(--pf-t--global--font--family--body)',
+          background: 'var(--pf-t--global--background--color--primary--default)',
+        }}
+      >
+        <div
+          style={{
+            marginBottom: '0.75rem',
+            paddingBottom: '0.5rem',
+            borderBottom: '1px solid var(--pf-t--global--border--color--default)',
+          }}
+        >
+          <Title headingLevel="h5">Body</Title>
+        </div>
+
+        <MockTreeRow
+          rank={0}
+          title={<span style={{ fontWeight: 'bold', marginRight: '0.25rem' }}>ShipOrder</span>}
+          isExpandable
+          isExpanded={shipOrderExpanded}
+          isCollection
+          onToggle={() => setShipOrderExpanded(!shipOrderExpanded)}
+        />
+
+        {shipOrderExpanded && (
+          <>
+            {phase === 'before-wrap' ? (
+              <MockTreeRow
+                rank={1}
+                title={<span>Item</span>}
+                isExpandable
+                isExpanded={false}
+                isCollection
+                actions={<MockCollectionFieldMenu initialOpen={outerMenuOpen} onWrapWithForEachGroup={openModal} />}
+              />
+            ) : (
+              <>
+                <MockTreeRow
+                  rank={1}
+                  title={forEachGroupLabel}
+                  isExpandable
+                  isExpanded={forEachGroupExpanded}
+                  onToggle={() => setForEachGroupExpanded(!forEachGroupExpanded)}
+                  actions={
+                    <>
+                      <MockExpressionInput value={selectExpression} placeholder="Add Select XPath Expression" />
+                      <MockForEachGroupMenu initialOpen={forEachGroupMenuOpen} onConfigure={openModal} />
+                      <MockTrashButton ariaLabel="Delete for-each-group" />
+                    </>
+                  }
+                />
+
+                {forEachGroupExpanded && (
+                  <>
+                    {showInnerForEach ? (
+                      <>
+                        <MockTreeRow
+                          rank={2}
+                          title={forEachLabel}
+                          isExpandable
+                          isExpanded={innerForEachExpanded}
+                          onToggle={() => setInnerForEachExpanded(!innerForEachExpanded)}
+                          actions={
+                            <>
+                              <MockExpressionInput value="current-group()" />
+                              <MockTrashButton ariaLabel="Delete for-each" />
+                            </>
+                          }
+                        />
+                        {innerForEachExpanded && (
+                          <>
+                            <MockTreeRow
+                              rank={3}
+                              title={<span>Item</span>}
+                              isExpandable
+                              isExpanded={itemExpanded}
+                              isCollection
+                              onToggle={() => setItemExpanded(!itemExpanded)}
+                            />
+                            {itemExpanded && (
+                              <>
+                                <MockTreeRow
+                                  rank={4}
+                                  title={<span>Title</span>}
+                                  isExpandable={false}
+                                  actions={
+                                    <>
+                                      <MockExpressionInput value="Title" />
+                                      <MockTrashButton ariaLabel="Delete Title mapping" />
+                                    </>
+                                  }
+                                />
+                                <MockTreeRow
+                                  rank={4}
+                                  title={<span>Quantity</span>}
+                                  isExpandable={false}
+                                  actions={
+                                    <>
+                                      <MockExpressionInput value="Quantity" />
+                                      <MockTrashButton ariaLabel="Delete Quantity mapping" />
+                                    </>
+                                  }
+                                />
+                              </>
+                            )}
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <MockTreeRow
+                        rank={2}
+                        title={<span>Item</span>}
+                        isExpandable
+                        isExpanded={false}
+                        isCollection
+                        actions={<MockInnerCollectionFieldMenu initialOpen={innerMenuOpen} />}
+                      />
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+};

--- a/packages/ui/src/stubs/datamapper/xml/ForEachGroupExample.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/ForEachGroupExample.xsl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Reference XSLT stub for xsl:for-each-group (Issue #2321).
+  Shows expected serialization for all 4 grouping strategies.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:ns0="kaoto.datamapper.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:param name="cart"/>
+    <xsl:template match="/">
+
+        <!-- Strategy: group-by -->
+        <!--
+        <xsl:for-each-group select="$cart/ns0:Cart/Item" group-by="Category">
+            <Order>
+                <Key><xsl:value-of select="current-grouping-key()"/></Key>
+                <xsl:for-each select="current-group()">
+                    <Item>
+                        <Title><xsl:value-of select="Title"/></Title>
+                        <Quantity><xsl:value-of select="Quantity"/></Quantity>
+                    </Item>
+                </xsl:for-each>
+            </Order>
+        </xsl:for-each-group>
+        -->
+
+        <!-- Strategy: group-adjacent -->
+        <!--
+        <xsl:for-each-group select="$cart/ns0:Cart/Item" group-adjacent="Category">
+            <Order>
+                <Key><xsl:value-of select="current-grouping-key()"/></Key>
+                <xsl:for-each select="current-group()">
+                    <Item><xsl:value-of select="Title"/></Item>
+                </xsl:for-each>
+            </Order>
+        </xsl:for-each-group>
+        -->
+
+        <!-- Strategy: group-starting-with -->
+        <!--
+        <xsl:for-each-group select="$cart/ns0:Cart/Item" group-starting-with="self::ns0:Header">
+            <Section>
+                <xsl:for-each select="current-group()">
+                    <Item><xsl:value-of select="Title"/></Item>
+                </xsl:for-each>
+            </Section>
+        </xsl:for-each-group>
+        -->
+
+        <!-- Strategy: group-ending-with -->
+        <!--
+        <xsl:for-each-group select="$cart/ns0:Cart/Item" group-ending-with="self::ns0:Footer">
+            <Section>
+                <xsl:for-each select="current-group()">
+                    <Item><xsl:value-of select="Title"/></Item>
+                </xsl:for-each>
+            </Section>
+        </xsl:for-each-group>
+        -->
+
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2860

---

# UI mockup for xsl:for-each-group support

This demonstrates the proposed DataMapper new feature, `xsl:for-each-group` support which allows user to configure `for-each-group` mapping supported by XSLT.

## Scenario
Group a source collection of Item elements by Category using XSLT 2.0 xsl:for-each-group, then iterate over each group's items with for-each current-group() to map individual fields.

1. **Wrap with for-each-group** — open the 3-dots context menu on the Item collection field and choose Wrap with for-each-group.
2. **Configure grouping** — the modal opens automatically; select a grouping strategy (e.g. Group By) and enter the grouping XPath expression (e.g. Category).
3. **Set select expression** — fill in the select inline input on the for-each-group node (e.g. $cart/ns0:Cart/Item). Hover the label to inspect the configured strategy and expression at any time.
4. **Reconfigure if needed** — open the ⋮ menu on for-each-group and choose Configure grouping to reopen the modal pre-populated with the current values.
5. **Wrap with for-each current-group()** — inside the for-each-group, open the ⋮ menu on Item and choose Wrap with for-each current-group(). The select expression is set to current-group() automatically.
6. **Map child fields** — expand Item inside the inner for-each and map Title and Quantity to their XPath expressions.
<img width="1113" height="518" alt="Screenshot From 2026-03-17 10-02-04" src="https://github.com/user-attachments/assets/7c551cdf-2dca-4c13-80e7-a9d088d91bae" />

---

## Step 1: Wrap a collection field with for-each-group
Open the 3-dots context menu on the Item collection field in the target document tree. In addition to the existing wrapping options, a new **“Wrap with for-each-group”** item appears. Selecting it wraps the field and immediately opens the grouping configuration modal (Step 2).
<img width="1121" height="525" alt="Screenshot From 2026-03-17 10-20-46" src="https://github.com/user-attachments/assets/f6e5f9a4-995e-48e9-ada2-f3b451dcb006" />


## Step 2: Configure the grouping strategy
Immediately after wrapping, the **Configure for-each-group** modal opens automatically. The user selects one of the four grouping strategies and enters the grouping XPath expression. “Group By” is pre-selected as the default. The select expression on the node itself is filled in separately via the inline text input after the modal is closed.
### Alternative idea exists
* Instead of this modal way, we might be able to show `Grouping Strategy` artificial node as a child of `for-each-group` node, then make the `Grouping Strategy` expression always visible in the target document tree.
<img width="1171" height="899" alt="Screenshot From 2026-03-31 13-47-46" src="https://github.com/user-attachments/assets/a5e9d2ec-cf73-4d35-8eb3-54ad2a2bff9f" />

## Step 3: for-each-group node in the tree
After saving the modal, the for-each-group node appears in the tree with the wrapped `Item` field as its child. The inline text input lets the user set the select expression. **Hover over the label** to see a tooltip summarising the current grouping configuration (strategy and expression), so the user can inspect the setup without reopening the modal.
<img width="856" height="276" alt="Screenshot From 2026-03-31 13-48-17" src="https://github.com/user-attachments/assets/a800485a-4ed7-4832-8b55-49a03494c4ce" />


## Step 4: Reconfigure via the 3-dot menu
The 3-dots context menu on the for-each-group node exposes **“Configure grouping”** to reopen the configuration modal. Deletion is handled by the trash icon button next to the menu — consistent with how other mapping nodes are deleted in the tree.
<img width="1156" height="371" alt="Screenshot From 2026-03-17 10-14-52" src="https://github.com/user-attachments/assets/a14ed20d-2437-478b-98d9-e197de33e84b" />

## Step 5: Reconfigure grouping
When the user clicks “Configure grouping”, the modal reopens pre-populated with the previously saved strategy and expression. The user can switch to a different strategy or update the grouping expression, then save to apply the changes.
<img width="1196" height="938" alt="Screenshot From 2026-03-17 10-16-00" src="https://github.com/user-attachments/assets/8fd43266-2057-42fe-bf12-82b54a4a304a" />

## Step 6: Wrap Item with for-each current-group()
Inside the for-each-group, the user opens the 3-dots context menu on the wrapped `Item` collection field. A new **“Wrap with for-each current-group()”** option appears. Selecting it wraps `Item` with a `for-each` whose select expression is automatically set to `current-group()` — a scoped XSLT function that iterates over the items in the current group.
<img width="1141" height="584" alt="Screenshot From 2026-03-17 10-18-08" src="https://github.com/user-attachments/assets/241c586e-2e3e-4e82-9ce8-74bead5d4652" />

## Step 7: Complete mapping structure
The fully configured structure. `for-each-group` iterates over the source collection and groups items by the configured expression. Inside it, `for-each` `current-group()` iterates over each group's items, and the user maps individual fields (`Title`, `Quantity`) from the expanded Item node. The generated XSLT uses `xsl:for-each-group` with the chosen strategy attribute (e.g. group-by="Category").
<img width="1121" height="525" alt="Screenshot From 2026-03-17 10-19-51" src="https://github.com/user-attachments/assets/a39445b9-6cef-4e01-8dc7-165ec1531415" />

---

## Expected XSLT output
```xslt
<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
                xmlns:ns0="kaoto.datamapper.test">
  <xsl:output method="xml" indent="yes"/>
  <xsl:param name="cart"/>
  <xsl:template match="/">
    <ShipOrder>
      <xsl:for-each-group select="$cart/ns0:Cart/Item" group-by="Category">
        <xsl:for-each select="current-group()">
          <Item>
            <Title><xsl:value-of select="Title"/></Title>
            <Quantity><xsl:value-of select="Quantity"/></Quantity>
          </Item>
        </xsl:for-each>
      </xsl:for-each-group>
    </ShipOrder>
  </xsl:template>
</xsl:stylesheet>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI mockup demonstrating the for-each-group data-mapper workflow across multiple phases with interactive states.

* **Documentation**
  * Added seven Storybook stories showing step-by-step configuration, menus, modals, tooltips, and transitions.
  * Added an XSLT reference example illustrating four for-each-group strategies.

* **Chores**
  * Storybook preview now forces a light theme for consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->