### PR TITLE
chore(DataMapper): UI mockup for xsl:variable support

### DIFF
--- a/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceMockup.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceMockup.stories.tsx
@@ -109,6 +109,10 @@ export const MainStory: StoryFn = () => {
   return (
     <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
       <h2 style={{ marginBottom: '0.5rem' }}>Choice Workflow</h2>
+      <p>
+        Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2358">https://github.com/KaotoIO/kaoto/issues/2358</a>
+      </p>
+      <br />
       <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
         This story demonstrates the complete choice workflow in a realistic Person object context. The Person schema
         contains standard fields (firstName, lastName, age) plus three different types of choices: standard choice

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
@@ -16,6 +16,10 @@ const Template: StoryFn<typeof CommentsModal> = (args) => {
 
   return (
     <div style={{ padding: '1rem' }}>
+      <p>
+        Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2439">https://github.com/KaotoIO/kaoto/issues/2439</a>
+      </p>
+      <br />
       <Button variant="primary" onClick={() => setIsOpen(true)} style={{ marginBottom: '1rem' }}>
         Open Modal
       </Button>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverride.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-type-override/TypeOverride.stories.tsx
@@ -105,6 +105,10 @@ export const InteractiveWorkflow: StoryFn = () => {
   return (
     <div style={{ padding: '20px', minHeight: '400px' }}>
       <h3>Interactive Type Override Workflow</h3>
+      <p>
+        Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2715">https://github.com/KaotoIO/kaoto/issues/2715</a>
+      </p>
+      <br />
       <p style={{ marginBottom: '20px', color: '#6a6e73' }}>
         Three schemas are pre-attached for demonstration. Right-click on any field to override its type. Safe override
         shows only compatible types, while force override shows all types:

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableInputPlaceholder.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableInputPlaceholder.tsx
@@ -1,0 +1,87 @@
+import './VariableMockup.scss';
+
+import { ActionList, ActionListGroup, ActionListItem, Button } from '@patternfly/react-core';
+import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
+
+interface VariableInputPlaceholderProps {
+  initialName?: string;
+  onConfirm: (name: string) => void;
+  onCancel: () => void;
+}
+
+const VALID_NAME = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/;
+
+export const VariableInputPlaceholder: FunctionComponent<VariableInputPlaceholderProps> = ({
+  initialName = '',
+  onConfirm,
+  onCancel,
+}) => {
+  const [name, setName] = useState(initialName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    if (initialName !== '') {
+      inputRef.current?.select();
+    }
+  }, []);
+
+  const validation: 'default' | 'success' | 'error' = useMemo(() => {
+    if (name === '') return 'default';
+    return VALID_NAME.test(name) ? 'success' : 'error';
+  }, [name]);
+
+  const errorMessage = useMemo(() => {
+    if (validation === 'error') {
+      return `Invalid name '${name}': must start with a letter or underscore, followed by letters, digits, underscores, dots or hyphens`;
+    }
+    return undefined;
+  }, [validation, name]);
+
+  return (
+    <div className="variable-input-placeholder">
+      <div className="variable-input-placeholder__row">
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <input
+                ref={inputRef}
+                className={`variable-input-placeholder__input variable-input-placeholder__input--${validation}`}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="variable name"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && validation === 'success') onConfirm(name);
+                  if (e.key === 'Escape') onCancel();
+                }}
+              />
+            </ActionListItem>
+          </ActionListGroup>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button
+                icon={<CheckIcon />}
+                variant="link"
+                isDisabled={validation !== 'success'}
+                onClick={() => onConfirm(name)}
+                aria-label="Confirm variable name"
+                data-testid="variable-name-confirm-btn"
+              />
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                icon={<TimesIcon />}
+                variant="plain"
+                onClick={onCancel}
+                aria-label="Cancel"
+                data-testid="variable-name-cancel-btn"
+              />
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </div>
+      {errorMessage && <div className="variable-input-placeholder__error">{errorMessage}</div>}
+    </div>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.scss
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.scss
@@ -1,0 +1,245 @@
+.variable-mockup-view {
+  position: relative;
+  min-height: 600px;
+
+  &__panels {
+    display: flex;
+    gap: 2rem;
+    position: relative;
+    max-width: 960px;
+  }
+
+  &__source {
+    flex: 0 0 340px;
+    min-width: 300px;
+
+    h3 {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    .expansion-panels {
+      height: 520px;
+      border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+      border-radius: 4px;
+    }
+  }
+
+  &__target {
+    flex: 0 1 auto;
+    min-width: 380px;
+    max-width: 500px;
+
+    h3 {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+  }
+
+  &__lines {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+
+    line {
+      transition: opacity 0.2s;
+
+      &:hover {
+        opacity: 1 !important;
+        stroke-width: 3;
+      }
+    }
+  }
+}
+
+/* Tree node structure styles (mirrors Document.scss which is not imported by any component) */
+.node {
+  &__container {
+    padding: 5px;
+    padding-left: var(--pf-t--global--spacer--md);
+  }
+
+  &__header,
+  &__children {
+    border-bottom: 1px solid var(--pf-t--global--color--disabled--100);
+    border-left: 1px solid var(--pf-t--global--color--disabled--100);
+    border-bottom-left-radius: var(--pf-t--global--border--radius--small);
+  }
+
+  &__children {
+    padding: var(--pf-t--global--spacer--xs) var(--pf-t--global--spacer--md);
+  }
+
+  &__target__actions {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    .pf-v6-c-button {
+      height: 1.75rem;
+      min-width: auto;
+      padding: 0 0.25rem;
+    }
+  }
+}
+
+.variable-section-header {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+
+  &__title {
+    flex: 1;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0;
+  }
+}
+
+.variable-row {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  gap: 0.25rem;
+  background-color: var(--pf-t--global--background--color--primary--default, #fff);
+
+  &__name {
+    flex: 1;
+    font-family: monospace;
+    font-weight: 600;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0;
+
+    .pf-v6-c-button {
+      height: 1.75rem;
+      min-width: auto;
+      padding: 0 0.25rem;
+    }
+  }
+}
+
+.variable-input-placeholder {
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem;
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    height: 2rem;
+  }
+
+  &__input {
+    flex: 1;
+    height: 1.75rem;
+    font-size: 0.875rem;
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    border-radius: 2px;
+    padding: 0 0.5rem;
+
+    &--error {
+      border-color: var(--pf-t--global--color--status--danger--default, #c9190b);
+    }
+
+    &--success {
+      border-color: var(--pf-t--global--color--status--success--default, #3e8635);
+    }
+  }
+
+  &__error {
+    font-size: 0.75rem;
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
+    padding-top: 0.125rem;
+  }
+
+  .pf-v6-c-button {
+    height: 1.75rem;
+    min-width: auto;
+    padding: 0 0.25rem;
+  }
+}
+
+.for-each-row {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  height: 2rem;
+  font-size: 0.875rem;
+  padding-left: var(--pf-t--global--spacer--sm);
+  gap: 0.375rem;
+
+}
+
+.tgt-variable-row {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  height: 2rem;
+  font-size: 0.875rem;
+  padding-left: var(--pf-t--global--spacer--sm);
+
+  .pf-v6-c-button {
+    height: 1.75rem;
+    min-width: auto;
+    padding: 0 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.tgt-xpath-input {
+  flex: 1;
+  height: 1.5rem;
+  min-width: 4rem;
+  font-size: 0.75rem;
+  font-family: monospace;
+  border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+  border-radius: 2px;
+  padding: 0 0.25rem;
+  margin: 0 0.25rem;
+  background: var(--pf-t--global--background--color--primary--default, #fff);
+  color: var(--pf-t--global--color--text--subtle, #6a6e73);
+}
+
+.variable-node__actions {
+  display: flex;
+  align-items: center;
+  gap: 0;
+
+  .pf-v6-c-button {
+    height: 1.75rem;
+    min-width: auto;
+    padding: 0 0.25rem;
+  }
+}
+
+.mock-parameters-header {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--pf-t--global--color--text--subtle, #6a6e73);
+}

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.stories.tsx
@@ -1,0 +1,154 @@
+import { Meta, StoryFn } from '@storybook/react';
+
+import { VariableMockup } from './VariableMockup';
+
+export default {
+  title: 'UI Mockups/DataMapper/Variable',
+  component: VariableMockup,
+} as Meta<typeof VariableMockup>;
+
+export const WorkflowOverview: StoryFn = () => (
+  <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+    <h2 style={{ marginBottom: '0.5rem' }}>Variable Support — Workflow Overview</h2>
+    <p>
+      Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2840">https://github.com/KaotoIO/kaoto/issues/2840</a>
+    </p>
+    <br />
+    <p style={{ marginBottom: '0.5rem', color: '#666', maxWidth: '900px' }}>
+      <strong>Scenario:</strong> the source has an <code>Orders</code> collection parameter. The target{' '}
+      <code>Invoice</code> document has a <code>Subtotals</code> collection field wrapped with{' '}
+      <code>for-each ($Orders/Order)</code>. Inside the loop, <code>$taxAmount</code> captures the per-item tax so it
+      can be reused in the <code>Subtotal</code> expression without duplicating the calculation.
+    </p>
+    <ol style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px', paddingLeft: '1.5rem' }}>
+      <li>
+        <strong>Add variable</strong> — open the 3-dots context menu on the <code>for-each</code> node and choose{' '}
+        <strong>Add Variable…</strong>.
+      </li>
+      <li>
+        <strong>Map source field → variable</strong> — drag <code>Price</code> onto <code>$taxAmount</code>. The XPath
+        expression is prefilled with <code>Price</code>; extend it to <code>Price * 0.1</code>.
+      </li>
+      <li>
+        <strong>Map to Subtotal</strong> — drag both <code>Price</code> and <code>$taxAmount</code> onto{' '}
+        <code>Subtotal</code>. Make the expression to be <code>Price + $taxAmount</code>.
+      </li>
+    </ol>
+    <div style={{ backgroundColor: 'white', padding: '1.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+      <VariableMockup step={4} />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Design decisions:</strong>
+      <ul style={{ marginTop: '0.5rem', marginLeft: '1.5rem' }}>
+        <li>
+          Source panel order: <strong>Variables → Parameters → Source Body</strong>
+        </li>
+        <li>
+          Variable label: compact <strong>$</strong> badge + plain name (consistent with <code>choose</code>/
+          <code>when</code> control-flow badges)
+        </li>
+        <li>
+          Variables are scoped to the <code>for-each</code> block — &quot;Add Variable…&quot; is in the{' '}
+          <code>for-each</code> ⋮ menu
+        </li>
+        <li>Pencil icon = XPath editor; rename is in the ⋮ menu only</li>
+        <li>Source variables are draggable (flat list, no scope grouping)</li>
+      </ul>
+    </div>
+  </div>
+);
+WorkflowOverview.storyName = 'Workflow Overview';
+
+export const StepOneAddVariable: StoryFn = () => (
+  <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+    <h2 style={{ marginBottom: '0.5rem' }}>Step 1 — Add Variable</h2>
+    <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px' }}>
+      The <code>for-each ($Orders/Order)</code> block is already defined under <code>Subtotals</code>. Open the 3-dots
+      context menu on the <code>for-each</code> node and choose <strong>Add Variable…</strong>. An inline name input
+      appears inside the <code>for-each</code> block. Type <code>taxAmount</code> and click <strong>✓</strong> to
+      confirm. The input validates in real-time: must be a valid variable name. Click <strong>✕</strong> to cancel. Once
+      the variable is created, it appears in <strong>Variables</strong> section in the Source Panel.
+    </p>
+    <div style={{ backgroundColor: 'white', padding: '1.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+      <VariableMockup step={1} />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Interaction pattern:</strong>
+      <ul style={{ marginTop: '0.5rem', marginLeft: '1.5rem' }}>
+        <li>Same inline input pattern as Parameters — no modal dialog</li>
+        <li>Auto-focused on open</li>
+        <li>
+          Valid: <code>taxAmount</code>, <code>item_total</code>, <code>v1</code>
+        </li>
+        <li>
+          Invalid: <code>1rate</code>, <code>tax amount</code>, <code>tax@rate</code>
+        </li>
+      </ul>
+    </div>
+  </div>
+);
+StepOneAddVariable.storyName = 'Step 1 — Add Variable';
+
+export const StepTwoRenameVariable: StoryFn = () => (
+  <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+    <h2 style={{ marginBottom: '0.5rem' }}>Step 2 — Rename Variable</h2>
+    <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px' }}>
+      After the variable is created, it can be renamed at any time. Open the 3-dots context menu on the{' '}
+      <code>$taxAmount</code> variable node in the target tree and choose <strong>Rename variable…</strong>. The
+      variable name becomes an inline input pre-filled with the current name. Edit the name and click <strong>✓</strong>{' '}
+      to confirm, or <strong>✕</strong> to cancel. The new name is reflected immediately in both the target tree and the
+      source <strong>Variables</strong> section.
+    </p>
+    <div style={{ backgroundColor: 'white', padding: '1.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+      <VariableMockup step={2} />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Interaction pattern:</strong>
+      <ul style={{ marginTop: '0.5rem', marginLeft: '1.5rem' }}>
+        <li>Same inline input as creation — pre-filled with current name</li>
+        <li>Auto-focused and fully selected on open</li>
+        <li>Validation identical to creation: must be a valid variable name</li>
+        <li>Rename updates both the target node and the source Variables entry atomically</li>
+      </ul>
+    </div>
+  </div>
+);
+StepTwoRenameVariable.storyName = 'Step 2 — Rename Variable';
+
+export const StepThreeMapToVariable: StoryFn = () => (
+  <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+    <h2 style={{ marginBottom: '0.5rem' }}>Step 3 — Map Source Field to Variable</h2>
+    <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px' }}>
+      Drag <code>Price</code> from the <code>Orders</code> parameter onto the <code>$taxAmount</code> variable node. The
+      XPath expression is pre-filled with <code>Price</code> (relative to the current loop item). The user extends it to{' '}
+      <code>Price * 0.1</code>.
+    </p>
+    <div style={{ backgroundColor: 'white', padding: '1.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+      <VariableMockup step={3} />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Result:</strong> <code>$taxAmount</code> expression = <code>Price * 0.1</code>. The variable is scoped to
+      the <code>for-each</code> iteration and ready to be used in the <code>Subtotal</code> mapping.
+    </div>
+  </div>
+);
+StepThreeMapToVariable.storyName = 'Step 3 — Map Field to Variable';
+
+export const StepFourMapVariableToField: StoryFn = () => (
+  <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+    <h2 style={{ marginBottom: '0.5rem' }}>Step 4 — Map from Variable</h2>
+    <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '900px' }}>
+      Drag <code>Price</code> and <code>$taxAmount</code> from the source panel onto <code>Subtotal</code>. Make the
+      expression to be <code>Price + $taxAmount</code>. The tax is computed once per iteration via the variable and
+      reused — no need to duplicate <code>Price * 0.1</code> inline.
+    </p>
+    <div style={{ backgroundColor: 'white', padding: '1.5rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+      <VariableMockup step={4} />
+    </div>
+    <div style={{ marginTop: '1rem', padding: '1rem', backgroundColor: '#e3f2fd', borderRadius: '4px' }}>
+      <strong>Result:</strong> <code>Subtotal</code> = <code>Price + $taxAmount</code>. For each order in{' '}
+      <code>$Orders/Order</code>, one <code>Subtotal</code> element is emitted with the correct value.
+    </div>
+  </div>
+);
+StepFourMapVariableToField.storyName = 'Step 4 — Map from Variable';

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
@@ -1,0 +1,469 @@
+import './VariableMockup.scss';
+
+import { Draggable } from '@carbon/icons-react';
+import { BaseNode, ExpansionPanel, ExpansionPanels, Types } from '@kaoto/kaoto/testing';
+import { Button, Dropdown, DropdownItem, DropdownList, Icon, Label, MenuToggle, Tooltip } from '@patternfly/react-core';
+import { EllipsisVIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent, MouseEvent, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { VariableInputPlaceholder } from './VariableInputPlaceholder';
+
+interface MockVariable {
+  id: string;
+  name: string;
+  expression: string;
+  nodePath: string;
+}
+
+interface MappingLine {
+  sourceId: string;
+  targetId: string;
+}
+
+/** Workflow step:
+ * 1 = for-each already defined, its menu open → "Add Variable..."
+ * 2 = Variable created ($taxAmount inside for-each, no expression)
+ * 3 = Map price→$taxAmount (expression pre-filled with "price")
+ * 4 / undefined = Final state (all expressions + all mapping lines)
+ */
+interface VariableMockupProps {
+  step?: 1 | 2 | 3 | 4;
+}
+
+const PANEL_COLLAPSED_HEIGHT = 32;
+const PANEL_MIN_HEIGHT = 32;
+
+const VAR_NODE_PATH = 'Invoice/Subtotals/for-each($Orders/Order)';
+const VAR_NO_EXPRESSION: MockVariable[] = [{ id: 'v1', name: 'taxAmount', expression: '', nodePath: VAR_NODE_PATH }];
+const VAR_PARTIAL_EXPRESSION: MockVariable[] = [
+  { id: 'v1', name: 'taxAmount', expression: 'Price', nodePath: VAR_NODE_PATH },
+];
+const VAR_WITH_EXPRESSION: MockVariable[] = [
+  { id: 'v1', name: 'taxAmount', expression: 'Price * 0.1', nodePath: VAR_NODE_PATH },
+];
+
+const SUBTOTAL_EXPRESSION = 'Price + $taxAmount';
+
+export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step }) => {
+  const initialVariables =
+    step === 1 ? [] : step === 2 ? VAR_NO_EXPRESSION : step === 3 ? VAR_PARTIAL_EXPRESSION : VAR_WITH_EXPRESSION;
+  const showVarExpression = !step || step >= 3;
+  const showFieldExpressions = !step || step >= 4;
+  const hideMappingLines = step === 1 || step === 2;
+
+  const [variables, setVariables] = useState<MockVariable[]>(initialVariables);
+  const [isAddingTargetVar, setIsAddingTargetVar] = useState(false);
+  const [renamingVarInTargetId, setRenamingVarInTargetId] = useState<string | null>(null);
+  const [targetVarMenuOpenId, setTargetVarMenuOpenId] = useState<string | null>(null);
+  const [isForEachMenuOpen, setIsForEachMenuOpen] = useState(false);
+  const [isTargetExpanded, setIsTargetExpanded] = useState(true);
+  const [isSubtotalExpanded, setIsSubtotalExpanded] = useState(true);
+  const [nodeRefs, setNodeRefs] = useState<Record<string, DOMRect>>({});
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  /* Step 3: price → $taxAmount (fills variable expression)
+   * Step 4: price + $taxAmount → Subtotal (both sources reused) */
+  const allMappingLines: MappingLine[] = useMemo(
+    () => [
+      { sourceId: 'src-price', targetId: 'tgt-v1' },
+      { sourceId: 'src-price', targetId: 'tgt-subtotal' },
+      { sourceId: 'src-v1', targetId: 'tgt-subtotal' },
+    ],
+    [],
+  );
+
+  const mappingLines = useMemo(() => {
+    if (step === 3) return allMappingLines.slice(0, 1);
+    return allMappingLines;
+  }, [step, allMappingLines]);
+
+  const persistentLines: MappingLine[] = useMemo(() => [{ sourceId: 'src-order', targetId: 'tgt-for-each' }], []);
+
+  useEffect(() => {
+    if (step === 1) setIsForEachMenuOpen(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const updatePositions = () => {
+      const refs: Record<string, DOMRect> = {};
+      const linesToTrack = [...persistentLines, ...(hideMappingLines ? [] : mappingLines)];
+      for (const line of linesToTrack) {
+        const srcEl = document.getElementById(line.sourceId);
+        const tgtEl = document.getElementById(line.targetId);
+        if (srcEl) refs[line.sourceId] = srcEl.getBoundingClientRect();
+        if (tgtEl) refs[line.targetId] = tgtEl.getBoundingClientRect();
+      }
+      setNodeRefs(refs);
+    };
+
+    updatePositions();
+    window.addEventListener('resize', updatePositions);
+    return () => window.removeEventListener('resize', updatePositions);
+  }, [
+    variables,
+    isAddingTargetVar,
+    renamingVarInTargetId,
+    isTargetExpanded,
+    isSubtotalExpanded,
+    mappingLines,
+    hideMappingLines,
+    persistentLines,
+  ]);
+
+  const containerRect = containerRef.current?.getBoundingClientRect();
+
+  const handleAddVar = useCallback((name: string) => {
+    setVariables((prev) => [...prev, { id: `v-${Date.now()}`, name, expression: '', nodePath: VAR_NODE_PATH }]);
+    setIsAddingTargetVar(false);
+  }, []);
+
+  const handleRenameVar = useCallback((id: string, name: string) => {
+    setVariables((prev) => prev.map((v) => (v.id === id ? { ...v, name } : v)));
+    setRenamingVarInTargetId(null);
+  }, []);
+
+  const handleDeleteVar = useCallback((id: string) => {
+    setVariables((prev) => prev.filter((v) => v.id !== id));
+    setTargetVarMenuOpenId(null);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="variable-mockup-view">
+      <div className="variable-mockup-view__panels">
+        {/* Source panel */}
+        <div className="variable-mockup-view__source">
+          <h3>Source</h3>
+          <ExpansionPanels firstPanelId="variables-header" lastPanelId="source-body">
+            <ExpansionPanel
+              id="variables-header"
+              summary={<div className="variable-section-header">Variables</div>}
+              defaultExpanded={false}
+              defaultHeight={PANEL_COLLAPSED_HEIGHT}
+              minHeight={PANEL_MIN_HEIGHT}
+            />
+
+            {variables.map((variable) => (
+              <ExpansionPanel
+                key={variable.id}
+                id={`var-${variable.id}`}
+                summary={
+                  <Tooltip
+                    content={
+                      <div>
+                        <div>Path: {variable.nodePath}</div>
+                        <div>Expression: {variable.expression || '(empty)'}</div>
+                      </div>
+                    }
+                    position="right"
+                  >
+                    <div className="variable-row" id={`src-${variable.id}`}>
+                      <Icon>
+                        <Draggable />
+                      </Icon>
+                      <Label isCompact>$</Label>
+                      <span className="variable-row__name">{variable.name}</span>
+                    </div>
+                  </Tooltip>
+                }
+                defaultExpanded={false}
+                defaultHeight={PANEL_COLLAPSED_HEIGHT}
+                minHeight={PANEL_MIN_HEIGHT}
+              />
+            ))}
+
+            <ExpansionPanel
+              id="parameters-header"
+              summary={<div className="mock-parameters-header">Parameters</div>}
+              defaultExpanded
+              defaultHeight={PANEL_COLLAPSED_HEIGHT * 4}
+              minHeight={PANEL_MIN_HEIGHT}
+            >
+              <div className="node__container">
+                <div id="src-orders" className="node__header">
+                  <BaseNode
+                    isExpandable
+                    isExpanded
+                    isDraggable={false}
+                    iconType={Types.Container}
+                    title={<span className="node__spacer">Orders</span>}
+                    rank={0}
+                  />
+                </div>
+                <div className="node__children">
+                  <div className="node__container">
+                    <div id="src-order" className="node__header">
+                      <BaseNode
+                        isExpandable
+                        isExpanded
+                        isDraggable={false}
+                        isCollectionField
+                        iconType={Types.Container}
+                        title={<span className="node__spacer">Order</span>}
+                        rank={1}
+                      />
+                    </div>
+                    <div className="node__children">
+                      <div className="node__container">
+                        <div className="node__header" id="src-price">
+                          <BaseNode
+                            isExpandable={false}
+                            isDraggable
+                            iconType={Types.Decimal}
+                            title={<span className="node__spacer">Price</span>}
+                            rank={2}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </ExpansionPanel>
+
+            <ExpansionPanel
+              id="source-body"
+              summary={<div className="mock-parameters-header">Body</div>}
+              defaultExpanded={false}
+              defaultHeight={PANEL_COLLAPSED_HEIGHT}
+              minHeight={PANEL_MIN_HEIGHT}
+            />
+          </ExpansionPanels>
+        </div>
+
+        {/* Target panel */}
+        <div className="variable-mockup-view__target">
+          <h3>Target</h3>
+          <div className="mock-parameters-header">Body</div>
+          <div className="node__container">
+            <div className="node__header">
+              <BaseNode
+                isExpandable
+                isExpanded={isTargetExpanded}
+                onExpandChange={() => setIsTargetExpanded((p) => !p)}
+                isDraggable={false}
+                iconType={Types.Container}
+                title={<span className="node__spacer">Invoice</span>}
+                rank={0}
+              />
+            </div>
+
+            {isTargetExpanded && (
+              <div className="node__children">
+                {/* Subtotal collection field */}
+                <div className="node__container">
+                  <div className="node__header">
+                    <BaseNode
+                      isExpandable
+                      isExpanded={isSubtotalExpanded}
+                      onExpandChange={() => setIsSubtotalExpanded((p) => !p)}
+                      isDraggable={false}
+                      iconType={Types.Decimal}
+                      title={<span className="node__spacer">Subtotals</span>}
+                      rank={1}
+                    />
+                  </div>
+
+                  {isSubtotalExpanded && (
+                    <div className="node__children">
+                      {/* for-each node */}
+                      <div className="node__container">
+                        <div id="tgt-for-each" className="node__header">
+                          <div className="for-each-row">
+                            <Label>for-each</Label>
+                            <input
+                              className="tgt-xpath-input"
+                              value="$Orders/Order"
+                              readOnly
+                              aria-label="for-each expression"
+                            />
+                            <div className="variable-node__actions">
+                              <Dropdown
+                                isOpen={isForEachMenuOpen}
+                                onOpenChange={(isOpen) => setIsForEachMenuOpen(isOpen)}
+                                toggle={(toggleRef: Ref<HTMLButtonElement>) => (
+                                  <MenuToggle
+                                    icon={<EllipsisVIcon />}
+                                    ref={toggleRef}
+                                    onClick={(e: MouseEvent) => {
+                                      e.stopPropagation();
+                                      setIsForEachMenuOpen(!isForEachMenuOpen);
+                                    }}
+                                    variant="plain"
+                                    isExpanded={isForEachMenuOpen}
+                                    aria-label="for-each actions"
+                                  />
+                                )}
+                              >
+                                <DropdownList>
+                                  <DropdownItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setIsAddingTargetVar(true);
+                                      setIsForEachMenuOpen(false);
+                                    }}
+                                  >
+                                    Add Variable...
+                                  </DropdownItem>
+                                </DropdownList>
+                              </Dropdown>
+                              <Button variant="plain" icon={<TrashIcon />} aria-label="Delete for-each" />
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="node__children">
+                          {/* Variable nodes inside for-each */}
+                          {variables.map((variable) =>
+                            renamingVarInTargetId === variable.id ? (
+                              <div key={`tgt-renaming-${variable.id}`} className="node__container">
+                                <div className="node__header">
+                                  <VariableInputPlaceholder
+                                    initialName={variable.name}
+                                    onConfirm={(name) => handleRenameVar(variable.id, name)}
+                                    onCancel={() => setRenamingVarInTargetId(null)}
+                                  />
+                                </div>
+                              </div>
+                            ) : (
+                              <div key={variable.id} className="node__container">
+                                <div id={`tgt-${variable.id}`} className="node__header">
+                                  <div className="tgt-variable-row">
+                                    <Label isCompact>$</Label>
+                                    <span style={{ marginLeft: '0.25rem' }}>{variable.name}</span>
+                                    {showVarExpression && (
+                                      <input
+                                        className="tgt-xpath-input"
+                                        value={variable.expression}
+                                        readOnly
+                                        aria-label="XPath expression"
+                                      />
+                                    )}
+                                    <div className="variable-node__actions">
+                                      <Tooltip content="Edit XPath expression">
+                                        <Button variant="plain" icon={<PencilAltIcon />} aria-label="Edit XPath" />
+                                      </Tooltip>
+                                      <Dropdown
+                                        isOpen={targetVarMenuOpenId === variable.id}
+                                        onOpenChange={(isOpen) => setTargetVarMenuOpenId(isOpen ? variable.id : null)}
+                                        toggle={(toggleRef: Ref<HTMLButtonElement>) => (
+                                          <MenuToggle
+                                            icon={<EllipsisVIcon />}
+                                            ref={toggleRef}
+                                            onClick={(e: MouseEvent) => {
+                                              e.stopPropagation();
+                                              setTargetVarMenuOpenId(
+                                                targetVarMenuOpenId === variable.id ? null : variable.id,
+                                              );
+                                            }}
+                                            variant="plain"
+                                            isExpanded={targetVarMenuOpenId === variable.id}
+                                            aria-label="Variable actions"
+                                          />
+                                        )}
+                                      >
+                                        <DropdownList>
+                                          <DropdownItem
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              setRenamingVarInTargetId(variable.id);
+                                              setTargetVarMenuOpenId(null);
+                                            }}
+                                          >
+                                            Rename variable...
+                                          </DropdownItem>
+                                        </DropdownList>
+                                      </Dropdown>
+                                      <Button
+                                        variant="plain"
+                                        icon={<TrashIcon />}
+                                        aria-label="Delete variable"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          handleDeleteVar(variable.id);
+                                        }}
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            ),
+                          )}
+
+                          {isAddingTargetVar && (
+                            <div className="node__container">
+                              <div className="node__header">
+                                <VariableInputPlaceholder
+                                  onConfirm={handleAddVar}
+                                  onCancel={() => setIsAddingTargetVar(false)}
+                                />
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Subtotal field item inside for-each */}
+                          <div className="node__container">
+                            <div id="tgt-subtotal" className="node__header">
+                              <BaseNode
+                                isExpandable={false}
+                                isDraggable={false}
+                                isCollectionField
+                                iconType={Types.Decimal}
+                                title={<span className="node__spacer">Subtotal</span>}
+                                rank={2}
+                              >
+                                {showFieldExpressions && (
+                                  <input
+                                    className="tgt-xpath-input"
+                                    value={SUBTOTAL_EXPRESSION}
+                                    readOnly
+                                    aria-label="XPath expression"
+                                  />
+                                )}
+                                {showFieldExpressions && (
+                                  <div className="variable-node__actions">
+                                    <Button variant="plain" icon={<TrashIcon />} aria-label="Delete mapping" />
+                                  </div>
+                                )}
+                              </BaseNode>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {containerRect && (
+        <svg className="variable-mockup-view__lines" data-testid="mapping-lines">
+          {[...persistentLines, ...(hideMappingLines ? [] : mappingLines)].map((line) => {
+            const srcRect = nodeRefs[line.sourceId];
+            const tgtRect = nodeRefs[line.targetId];
+            if (!srcRect || !tgtRect) return null;
+            const x1 = srcRect.right - containerRect.left;
+            const y1 = srcRect.top + srcRect.height / 2 - containerRect.top;
+            const x2 = tgtRect.left - containerRect.left;
+            const y2 = tgtRect.top + tgtRect.height / 2 - containerRect.top;
+            return (
+              <line
+                key={`${line.sourceId}-${line.targetId}`}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                stroke="#0066cc"
+                strokeWidth="2"
+                opacity="0.6"
+              />
+            );
+          })}
+        </svg>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
@@ -18,6 +18,7 @@ import {
   NodeData,
   TargetChoiceFieldNodeData,
   UnknownMappingNodeData,
+  VariableNodeData,
 } from '../../../models/datamapper/visualization';
 import { formatQNameWithPrefix } from '../../../services/namespace-util';
 import { VisualizationService } from '../../../services/visualization.service';
@@ -47,6 +48,15 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
 
   if (nodeData instanceof UnknownMappingNodeData) {
     return <UnknownMappingLabel nodeData={nodeData} content={content} />;
+  }
+
+  if (nodeData instanceof VariableNodeData) {
+    return (
+      <>
+        <Label isCompact>$</Label>
+        {content}
+      </>
+    );
   }
 
   if (nodeData instanceof MappingNodeData && !(nodeData instanceof FieldItemNodeData)) {

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -819,7 +819,7 @@ describe('TargetDocumentNode', () => {
         });
       });
 
-      expect(screen.getByText('$taxRate')).toBeInTheDocument();
+      expect(screen.getByText('taxRate')).toBeInTheDocument();
       expect(screen.getByTestId('variable-node-icon')).toBeInTheDocument();
     });
   });

--- a/packages/ui/src/components/Document/actions/DeleteMappingItemAction.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteMappingItemAction.tsx
@@ -12,7 +12,7 @@ import { FunctionComponent, useCallback } from 'react';
 
 import { useToggle } from '../../../hooks/useToggle';
 import { InstructionItem } from '../../../models/datamapper/mapping';
-import { TargetNodeData } from '../../../models/datamapper/visualization';
+import { TargetNodeData, VariableNodeData } from '../../../models/datamapper/visualization';
 import { VisualizationService } from '../../../services/visualization.service';
 
 type DeleteItemProps = {
@@ -28,7 +28,8 @@ export const DeleteMappingItemAction: FunctionComponent<DeleteItemProps> = ({ no
     onDelete();
     closeModal();
   }, [closeModal, nodeData, onDelete]);
-  const title = `Delete ${nodeData.title} mapping`;
+  const displayName = nodeData instanceof VariableNodeData ? nodeData.displayTitle : nodeData.title;
+  const title = `Delete ${displayName} mapping`;
   let warningMessage = undefined;
   if (
     nodeData.mapping &&
@@ -36,7 +37,7 @@ export const DeleteMappingItemAction: FunctionComponent<DeleteItemProps> = ({ no
     nodeData.mapping.children.length > 0 &&
     nodeData.mapping.children[0].children.length > 0
   ) {
-    warningMessage = `Deleting a ${nodeData.title} mapping will also remove all its child mappings.`;
+    warningMessage = `Deleting a ${displayName} mapping will also remove all its child mappings.`;
   }
 
   return (

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
@@ -3,7 +3,7 @@ import { ActionListItem, Button, Icon } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useState } from 'react';
 
 import { IExpressionHolder, MappingItem } from '../../../models/datamapper/mapping';
-import { TargetNodeData } from '../../../models/datamapper/visualization';
+import { TargetNodeData, VariableNodeData } from '../../../models/datamapper/visualization';
 import { XPathEditorModal } from '../../XPath/XPathEditorModal';
 
 type XPathEditorProps = {
@@ -34,7 +34,7 @@ export const XPathEditorAction: FunctionComponent<XPathEditorProps> = ({ nodeDat
         }
       />
       <XPathEditorModal
-        title={nodeData.title}
+        title={nodeData instanceof VariableNodeData ? nodeData.displayTitle : nodeData.title}
         isOpen={isEditorOpen}
         onClose={closeXPathEditor}
         mapping={mapping}

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -220,7 +220,11 @@ export class VariableNodeData extends MappingNodeData {
     public mapping: VariableItem,
   ) {
     super(parent, mapping);
-    this.title = `$${mapping.name}`;
+    this.title = mapping.name;
+  }
+
+  get displayTitle(): string {
+    return `$${this.title}`;
   }
 }
 

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -2312,7 +2312,7 @@ describe('VisualizationService', () => {
       const children = VisualizationService.generateNonDocumentNodeDataChildren(fieldItemNodeData);
       const variableNodeData = children.find((c) => c instanceof VariableNodeData);
       expect(variableNodeData).toBeInstanceOf(VariableNodeData);
-      expect(variableNodeData!.title).toBe('$taxRate');
+      expect(variableNodeData!.title).toBe('taxRate');
     });
   });
 });


### PR DESCRIPTION
https://github.com/KaotoIO/kaoto/pull/3090 needs to go in before this one

Fixes: https://github.com/KaotoIO/kaoto/issues/2840

---

# UI mockup for xsl:variable support
This demonstrates the proposed DataMapper new feature, `xsl:variable` support which allows user to create a scoped variable in the target document tree, create an interim value from other source field values, then use it as a source variable.

## Scenario
the source has an Orders collection parameter. The target Invoice document has a Subtotals collection field wrapped with for-each ($Orders/Order). Inside the loop, $taxAmount captures the per-item tax so it can be reused in the Subtotal expression without duplicating the calculation.

1. **Add variable** — open the 3-dots context menu on the `for-each` node and choose `Add Variable….`
2. **Map source field → variable** — drag Price onto `$taxAmount`. The XPath expression is prefilled with `Price`; extend it to `Price * 0.1`.
3. **Map to Subtotal** — drag both `Price` and `$taxAmount` onto `Subtotal`. Make the expression to be `Price + $taxAmount`.
<img width="1463" height="1033" alt="Screenshot From 2026-03-17 11-08-05" src="https://github.com/user-attachments/assets/aad56752-54b6-4537-ae60-a8d27d196f2c" />


---

## Step 1: Add Variable
The `for-each ($Orders/Order)` block is already defined under Subtotals. Open the 3-dots context menu on the for-each node and choose Add Variable…. An inline name input appears inside the for-each block. Type taxAmount and click ✓ to confirm. The input validates in real-time: must be a valid QName. Click ✕ to cancel. Once the variable is created, it appears in Variables section in the Source Panel.
<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-09-26" src="https://github.com/user-attachments/assets/40823d8f-8025-4b78-8a2d-40ba99a6d11c" />

<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-09-45" src="https://github.com/user-attachments/assets/19b80cf5-f0a0-41fc-8858-8d57905dc806" />

<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-09-53" src="https://github.com/user-attachments/assets/20e86a2f-b09c-4952-a48a-729338d65a0b" />

## Step 2: Rename Variable
After the variable is created, it can be renamed at any time. Open the 3-dots context menu on the `$taxAmount` variable node in the target tree and choose **Rename variable….** The variable name becomes an inline input pre-filled with the current name. Edit the name and click `✓` to confirm, or `✕` to cancel. The new name is reflected immediately in both the target tree and the source **Variables** section.
<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-12-37" src="https://github.com/user-attachments/assets/adeb70a4-3d15-4e37-a247-8334cee60db5" />

<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-12-47" src="https://github.com/user-attachments/assets/2eb29bfd-9a39-4e42-9f79-d9ae13394231" />

<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-12-54" src="https://github.com/user-attachments/assets/ddc4afbd-3b1b-4bc3-949a-27d52c71ec6a" />

## Step 3: Map Source Field to Variable
Drag `Price` from the `Orders` parameter onto the `$taxAmount` variable node. The XPath expression is pre-filled with `Price` (relative to the current loop item). The user extends it to `Price * 0.1`.
<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-14-49" src="https://github.com/user-attachments/assets/63137eea-3ff4-494a-9cec-ae11235ad2c7" />

## Step 4: Map from Variable
Drag `Price` and `$taxAmount` from the source panel onto `Subtotal`. Make the expression to be `Price + $taxAmount`. The tax is computed once per iteration via the variable and reused — no need to duplicate `Price * 0.1` inline.
<img width="1478" height="1030" alt="Screenshot From 2026-03-17 11-19-58" src="https://github.com/user-attachments/assets/b9d87a03-727d-4b68-8cb6-c875dd08da1f" />

---

## Expected XSLT output
```xslt
<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
  <xsl:output method="xml" indent="yes"/>
  <xsl:param name="Orders"/>
  <xsl:template match="/">
    <Invoice>
      <Subtotals>
        <xsl:for-each select="$Orders/Order">
          <xsl:variable name="taxAmount" select="Price * 0.1"/>
          <Subtotal>
            <xsl:value-of select="Price + $taxAmount"/>
          </Subtotal>
        </xsl:for-each>
      </Subtotals>
    </Invoice>
  </xsl:template>
</xsl:stylesheet>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variable-mapping mock UI with step-driven workflow, inline variable-name input (focus/select, validation, Enter/Escape, confirm/cancel).

* **Documentation**
  * Added Storybook stories for variable workflows; several mockups include links to issue tracker entries.

* **Style**
  * New stylesheet for variable mockup layout, panels, rows, inputs, and mapping visuals.

* **User-visible Changes**
  * Variable labels now display without a leading "$" across UI, dialogs, and confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->