### PR TITLE
chore(forms): Update forms library

### DIFF
--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@kaoto/camel-catalog": "^0.4.0",
-    "@kaoto/forms": "^1.6.0",
+    "@kaoto/forms": "^1.7.0",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,7 +55,7 @@
     "@carbon/icons-react": "^11.67.0",
     "@carbon/react": "^1.102.0",
     "@dnd-kit/core": "^6.1.0",
-    "@kaoto/forms": "^1.6.0",
+    "@kaoto/forms": "^1.7.0",
     "@kie-tools-core/editor": "^10.0.0",
     "@kie-tools-core/notifications": "^10.0.0",
     "@visx/shape": "^3.12.0",

--- a/packages/ui/src/components/MetadataEditor/__snapshots__/MetadataEditor.test.tsx.snap
+++ b/packages/ui/src/components/MetadataEditor/__snapshots__/MetadataEditor.test.tsx.snap
@@ -269,6 +269,34 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         class="pf-v6-c-text-input-group__utilities"
                       >
                         <button
+                          aria-label="Open suggestions"
+                          class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                          data-ouia-component-type="PF6/Button"
+                          data-ouia-safe="true"
+                          data-testid="#.name__open-suggestions-button"
+                          title="Open suggestions (Ctrl+Space)"
+                          type="button"
+                        >
+                          <span
+                            class="pf-v6-c-button__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 352 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                        <button
                           aria-expanded="false"
                           aria-label="#.name__field-actions"
                           class="pf-v6-c-menu-toggle pf-m-plain"
@@ -334,7 +362,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         <span
                           aria-label="More info for type field"
                           class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           role="button"
@@ -390,6 +418,34 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       <div
                         class="pf-v6-c-text-input-group__utilities"
                       >
+                        <button
+                          aria-label="Open suggestions"
+                          class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                          data-ouia-component-type="PF6/Button"
+                          data-ouia-safe="true"
+                          data-testid="#.type__open-suggestions-button"
+                          title="Open suggestions (Ctrl+Space)"
+                          type="button"
+                        >
+                          <span
+                            class="pf-v6-c-button__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 352 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
                         <button
                           aria-expanded="false"
                           aria-label="#.type__field-actions"
@@ -456,7 +512,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         <span
                           aria-label="More info for [object Object] field"
                           class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           role="button"
@@ -506,7 +562,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                         <button
                           aria-label="Add a new property"
                           class="pf-v6-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
                           data-ouia-component-type="PF6/Button"
                           data-ouia-safe="true"
                           data-testid="#.properties__add"
@@ -885,6 +941,34 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       class="pf-v6-c-text-input-group__utilities"
                     >
                       <button
+                        aria-label="Open suggestions"
+                        class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        data-testid="#.name__open-suggestions-button"
+                        title="Open suggestions (Ctrl+Space)"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <button
                         aria-expanded="false"
                         aria-label="#.name__field-actions"
                         class="pf-v6-c-menu-toggle pf-m-plain"
@@ -950,7 +1034,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       <span
                         aria-label="More info for type field"
                         class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         role="button"
@@ -1006,6 +1090,34 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                     <div
                       class="pf-v6-c-text-input-group__utilities"
                     >
+                      <button
+                        aria-label="Open suggestions"
+                        class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        data-testid="#.type__open-suggestions-button"
+                        title="Open suggestions (Ctrl+Space)"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
                       <button
                         aria-expanded="false"
                         aria-label="#.type__field-actions"
@@ -1072,7 +1184,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       <span
                         aria-label="More info for [object Object] field"
                         class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-5"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         role="button"
@@ -1122,7 +1234,7 @@ exports[`MetadataEditor.tsx component renders 1`] = `
                       <button
                         aria-label="Add a new property"
                         class="pf-v6-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-6"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         data-testid="#.properties__add"

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -90,6 +90,34 @@ exports[`SettingsForm should render 1`] = `
           class="pf-v6-c-text-input-group__utilities"
         >
           <button
+            aria-label="Open suggestions"
+            class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#.catalogUrl__open-suggestions-button"
+            title="Open suggestions (Ctrl+Space)"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
             aria-expanded="false"
             aria-label="#.catalogUrl__field-actions"
             class="pf-v6-c-menu-toggle pf-m-plain"
@@ -148,7 +176,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Node label to display in canvas field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-id="OUIA-Generated-Button-plain-3"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -210,7 +238,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeLabel__clear"
@@ -298,7 +326,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Open Node toolbar field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-4"
+            data-ouia-component-id="OUIA-Generated-Button-plain-5"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -360,7 +388,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeToolbarTrigger__clear"
@@ -448,7 +476,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Color scheme field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-6"
+            data-ouia-component-id="OUIA-Generated-Button-plain-7"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -510,7 +538,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.colorScheme__clear"
@@ -598,7 +626,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Canvas layout direction field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-8"
+            data-ouia-component-id="OUIA-Generated-Button-plain-9"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -660,7 +688,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.canvasLayoutDirection__clear"
@@ -738,7 +766,7 @@ exports[`SettingsForm should render 1`] = `
         <button
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-10"
+          data-ouia-component-id="OUIA-Generated-Button-plain-11"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.rest__remove"
@@ -782,7 +810,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Rest configuration field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-id="OUIA-Generated-Button-plain-12"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -843,7 +871,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Apicurio Registry URL field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-id="OUIA-Generated-Button-plain-13"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -899,6 +927,34 @@ exports[`SettingsForm should render 1`] = `
             <div
               class="pf-v6-c-text-input-group__utilities"
             >
+              <button
+                aria-label="Open suggestions"
+                class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                data-testid="#.rest.apicurioRegistryUrl__open-suggestions-button"
+                title="Open suggestions (Ctrl+Space)"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                    />
+                  </svg>
+                </span>
+              </button>
               <button
                 aria-expanded="false"
                 aria-label="#.rest.apicurioRegistryUrl__field-actions"
@@ -958,7 +1014,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Custom media types field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/__snapshots__/BeanField.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/__snapshots__/BeanField.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`BeanField UnprefixedBeanField should render 1`] = `
           <span
             aria-label="More info for # field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-119"
+            data-ouia-component-id="OUIA-Generated-Button-plain-175"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -246,7 +246,7 @@ exports[`BeanField UnprefixedBeanField should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-120"
+              data-ouia-component-id="OUIA-Generated-Button-plain-176"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#__clear"

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/__snapshots__/ExpressionField.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/__snapshots__/ExpressionField.test.tsx.snap
@@ -399,9 +399,37 @@ exports[`ExpressionField renders expression field with selection 1`] = `
               class="pf-v6-c-input-group__item"
             >
               <button
+                aria-label="Open suggestions"
+                class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                data-testid="simple.expression__open-suggestions-button"
+                title="Open suggestions (Ctrl+Space)"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
                 aria-label="Clear expression field"
                 class="pf-v6-c-button pf-m-plain"
-                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-id="OUIA-Generated-Button-plain-6"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 data-testid="simple.expression__clear"

--- a/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
+++ b/packages/ui/src/pages/Metadata/__snapshots__/MetadataPage.test.tsx.snap
@@ -224,6 +224,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.creationTimestamp__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
               aria-expanded="false"
               aria-label="#.creationTimestamp__field-actions"
               class="pf-v6-c-menu-toggle pf-m-plain"
@@ -282,7 +310,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for deletionGracePeriodSeconds field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -337,6 +365,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.deletionGracePeriodSeconds__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.deletionGracePeriodSeconds__field-actions"
@@ -396,7 +452,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for deletionTimestamp field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-id="OUIA-Generated-Button-plain-7"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -452,6 +508,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.deletionTimestamp__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
               aria-expanded="false"
               aria-label="#.deletionTimestamp__field-actions"
               class="pf-v6-c-menu-toggle pf-m-plain"
@@ -500,7 +584,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <button
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-6"
+            data-ouia-component-id="OUIA-Generated-Button-plain-9"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.finalizers__add"
@@ -544,7 +628,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                 <span
                   aria-label="More info for finalizers field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -602,7 +686,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for generateName field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -657,6 +741,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-12"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.generateName__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.generateName__field-actions"
@@ -716,7 +828,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for generation field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+              data-ouia-component-id="OUIA-Generated-Button-plain-13"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -771,6 +883,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-14"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.generation__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.generation__field-actions"
@@ -837,7 +977,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for [object Object] field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-id="OUIA-Generated-Button-plain-15"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -887,7 +1027,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <button
               aria-label="Add a new property"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-id="OUIA-Generated-Button-plain-16"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.labels__add"
@@ -940,7 +1080,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <button
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-12"
+            data-ouia-component-id="OUIA-Generated-Button-plain-17"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.managedFields__add"
@@ -984,7 +1124,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                 <span
                   aria-label="More info for managedFields field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -1042,7 +1182,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for name field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-14"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1097,6 +1237,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.name__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.name__field-actions"
@@ -1156,7 +1324,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for namespace field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-15"
+              data-ouia-component-id="OUIA-Generated-Button-plain-21"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1212,6 +1380,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             class="pf-v6-c-text-input-group__utilities"
           >
             <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-22"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.namespace__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
               aria-expanded="false"
               aria-label="#.namespace__field-actions"
               class="pf-v6-c-menu-toggle pf-m-plain"
@@ -1260,7 +1456,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <button
             aria-label="Add new item"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-16"
+            data-ouia-component-id="OUIA-Generated-Button-plain-23"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#.ownerReferences__add"
@@ -1304,7 +1500,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
                 <span
                   aria-label="More info for ownerReferences field"
                   class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   role="button"
@@ -1362,7 +1558,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for resourceVersion field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+              data-ouia-component-id="OUIA-Generated-Button-plain-25"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1417,6 +1613,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-26"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.resourceVersion__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.resourceVersion__field-actions"
@@ -1476,7 +1700,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for selfLink field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-id="OUIA-Generated-Button-plain-27"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1531,6 +1755,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-28"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.selfLink__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.selfLink__field-actions"
@@ -1590,7 +1842,7 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
             <span
               aria-label="More info for uid field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-id="OUIA-Generated-Button-plain-29"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -1645,6 +1897,34 @@ exports[`MetadataPage renders the KaotoForm when the resource type is supported 
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-30"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.uid__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.uid__field-actions"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,9 +3446,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/forms@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@kaoto/forms@npm:1.6.0"
+"@kaoto/forms@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@kaoto/forms@npm:1.7.0"
   dependencies:
     ajv: "npm:^8.12.0"
     clsx: "npm:^2.1.0"
@@ -3460,7 +3460,7 @@ __metadata:
     "@patternfly/react-icons": 6.4.0
     react: ^18.3.1
     react-dom: ^18.3.1
-  checksum: 10/8c8b30daca3bb4b59b314805eb2c5ddb7835119370eb9e4e616bfb8da8470e930c003cd25a610bb223a3b5c48ecc9259dffc8d11a810b249ad2b77cdeac0c175
+  checksum: 10/4e48c85f4a072bb978eada8e951e2ad0293ab74f65afddad64bdbd16b3c22386257d52d33edb58df755f2824ef3df6c0c0a8c0962a6ce1ecc6f6486e8c0b7dee
   languageName: node
   linkType: hard
 
@@ -3472,7 +3472,7 @@ __metadata:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.4.0"
-    "@kaoto/forms": "npm:^1.6.0"
+    "@kaoto/forms": "npm:^1.7.0"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.4.0"
     "@patternfly/react-code-editor": "npm:^6.4.0"
@@ -3526,7 +3526,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.4.0"
-    "@kaoto/forms": "npm:^1.6.0"
+    "@kaoto/forms": "npm:^1.7.0"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
     "@patternfly/patternfly": "npm:^6.4.0"


### PR DESCRIPTION
### Context
Update the `@kaoto/forms` library to include a button to show field suggestions

<img width="1628" height="1220" alt="image" src="https://github.com/user-attachments/assets/e28f71ed-0dd3-4e71-8edb-cc5e17ef930c" />

relates: https://github.com/KaotoIO/forms/pull/98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the forms library dependency to the latest compatible version across UI packages to ensure compatibility and incorporate upstream improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->