### PR TITLE
chore(container-image): Accept IPv6 connection

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,7 +43,7 @@ http {
 
     server {
         listen       8080 default_server;
-        #listen       [::]:8080 default_server;
+        listen       [::]:8080 default_server;
         server_name  _;
         root         /opt/app-root/src;
 


### PR DESCRIPTION
When you run the image and try to access with the URL `http://localhost:8080`, depending on host configuration, it could resolve to `::1` which is IPv6 localhost, then nginx refuses to serve. This PR makes nginx to listen on IPv6 localhost as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled IPv6 support for the server on port 8080, allowing clients to connect over IPv6 in addition to IPv4. No other behavior changed. This improves accessibility for IPv6-capable networks and modern clients without altering existing IPv4 connectivity or application behavior. No configuration changes visible to end users beyond improved network reachability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->