### PR TITLE
chore: Address SonarCloud issues in xml-schema-ts

### DIFF
--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -265,6 +265,12 @@ export function getUnknownApplyTemplateAfterFieldXslt(): string {
 export function getUnknownApplyTemplateBeforeFieldXslt(): string {
   return readStubFile('./xml/UnknownApplyTemplateBeforeField.xsl');
 }
+export function getDerivationMethodsXsd(): string {
+  return readStubFile('./xml/DerivationMethods.xsd');
+}
+export function getConstraintsXsd(): string {
+  return readStubFile('./xml/Constraints.xsd');
+}
 
 export class TestUtil {
   static createSourceOrderDoc() {

--- a/packages/ui/src/stubs/datamapper/xml/Constraints.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/Constraints.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ext="http://www.example.com/ext"
+           xmlns:tns="http://www.example.com/CONSTRAINTS"
+           targetNamespace="http://www.example.com/CONSTRAINTS"
+           elementFormDefault="qualified">
+
+  <xs:group name="AddressGroup">
+    <xs:sequence>
+      <xs:element name="street" type="xs:string"/>
+      <xs:element name="city" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="AddressType">
+    <xs:group ref="tns:AddressGroup"/>
+  </xs:complexType>
+
+  <xs:complexType name="PersonType" mixed="true">
+    <xs:sequence>
+      <xs:element name="id" type="xs:string"/>
+      <xs:element name="name" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="role" type="xs:string" ext:label="ext:personRole"/>
+  </xs:complexType>
+
+  <xs:element name="Catalog">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Person" type="tns:PersonType" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="PersonKey">
+      <xs:annotation><xs:documentation>Primary key for Person</xs:documentation></xs:annotation>
+      <xs:selector xpath="tns:Person">
+        <xs:annotation><xs:documentation>Selects Person elements</xs:documentation></xs:annotation>
+      </xs:selector>
+      <xs:field xpath="tns:id">
+        <xs:annotation><xs:documentation>Identifies the id field</xs:documentation></xs:annotation>
+      </xs:field>
+    </xs:key>
+    <xs:unique name="PersonNameUnique">
+      <xs:selector xpath="tns:Person"/>
+      <xs:field xpath="tns:name"/>
+    </xs:unique>
+  </xs:element>
+
+  <xs:element name="Order">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="personRef" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:keyref name="OrderPersonRef" refer="tns:PersonKey">
+      <xs:selector xpath="tns:Order"/>
+      <xs:field xpath="tns:personRef"/>
+    </xs:keyref>
+  </xs:element>
+
+</xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/DerivationMethods.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/DerivationMethods.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.example.com/DERIVATION"
+           xmlns:tns="http://www.example.com/DERIVATION"
+           elementFormDefault="qualified">
+
+  <xs:complexType name="FinalAllType" final="#all">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="FinalExtensionType" final="extension">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="BlockExtensionRestrictionType" block="extension restriction">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="Root" type="tns:BlockExtensionRestrictionType" block="extension"/>
+
+</xs:schema>

--- a/packages/ui/src/xml-schema-ts/SchemaBuilder.ts
+++ b/packages/ui/src/xml-schema-ts/SchemaBuilder.ts
@@ -51,7 +51,7 @@ import { xmlSchemaUseValueOf } from './XmlSchemaUse';
 import { XmlSchemaXPath } from './XmlSchemaXPath';
 
 export class SchemaBuilder {
-  private resolvedSchemas = new Map<string, XmlSchema>();
+  private readonly resolvedSchemas = new Map<string, XmlSchema>();
   private static readonly RESERVED_ATTRIBUTES = new Set<string>([
     'name',
     'type',
@@ -62,12 +62,12 @@ export class SchemaBuilder {
     'use',
     'ref',
   ]);
-  private currentSchema = new XmlSchema();
+  private readonly currentSchema = new XmlSchema();
   private extReg?: ExtensionRegistry;
 
   constructor(
-    private collection: XmlSchemaCollection,
-    private currentValidator?: (s: XmlSchema) => void,
+    private readonly collection: XmlSchemaCollection,
+    private readonly currentValidator?: (s: XmlSchema) => void,
   ) {
     if (this.collection.getExtReg() != null) {
       this.extReg = this.collection.getExtReg();
@@ -88,7 +88,7 @@ export class SchemaBuilder {
   }
 
   getDerivation(el: Element, attrName: string) {
-    if (el.hasAttribute(attrName) && !(el.getAttribute(attrName) === '')) {
+    if (el.hasAttribute(attrName) && el.getAttribute(attrName) !== '') {
       // #all | List of (extension | restriction | substitution)
       const derivationMethod = el.getAttribute(attrName)!.trim();
       return XmlSchemaDerivationMethod.schemaValueOf(derivationMethod);
@@ -104,7 +104,7 @@ export class SchemaBuilder {
   }
 
   getFormDefault(el: Element, attrName: string) {
-    if (el.getAttributeNode(attrName) != null) {
+    if (el.hasAttribute(attrName)) {
       const value = el.getAttribute(attrName)!;
       return xmlSchemaFormValueOf(value);
     } else {
@@ -222,11 +222,7 @@ export class SchemaBuilder {
         ct.getAttributes().push(this.handleAttributeGroupRef(schema, el));
       } else if (el.localName === 'group') {
         const group = this.handleGroupRef(schema, el, schemaEl);
-        if (group.getParticle() == null) {
-          ct.setParticle(group);
-        } else {
-          ct.setParticle(group.getParticle());
-        }
+        ct.setParticle(group.getParticle() ?? group);
       } else if (el.localName === 'simpleContent') {
         ct.setContentModel(this.handleSimpleContent(schema, el, schemaEl));
       } else if (el.localName === 'complexContent') {
@@ -237,30 +233,7 @@ export class SchemaBuilder {
         ct.setAnyAttribute(this.handleAnyAttribute(schema, el, schemaEl));
       }
     }
-    if (complexEl.hasAttribute('block')) {
-      const blockStr = complexEl.getAttribute('block')!;
-      ct.setBlock(XmlSchemaDerivationMethod.schemaValueOf(blockStr));
-    }
-    if (complexEl.hasAttribute('final')) {
-      const finalstr = complexEl.getAttribute('final')!;
-      ct.setFinal(XmlSchemaDerivationMethod.schemaValueOf(finalstr));
-    }
-    if (complexEl.hasAttribute('abstract')) {
-      const abs = complexEl.getAttribute('abstract')!;
-      if (abs.toLowerCase() === 'true') {
-        ct.setAbstract(true);
-      } else {
-        ct.setAbstract(false);
-      }
-    }
-    if (complexEl.hasAttribute('mixed')) {
-      const mixed = complexEl.getAttribute('mixed')!;
-      if (mixed.toLowerCase() === 'true') {
-        ct.setMixed(true);
-      } else {
-        ct.setMixed(false);
-      }
-    }
+    this.applyComplexTypeAttributes(ct, complexEl);
 
     // process extra attributes and elements
     this.processExtensibilityComponents(ct, complexEl, true);
@@ -308,57 +281,23 @@ export class SchemaBuilder {
     // String namespace = (schema.targetNamespace==null)?
     // "" : schema.targetNamespace;
 
-    let isQualified = schema.getElementFormDefault() == XmlSchemaForm.QUALIFIED;
-    isQualified = this.handleElementForm(el, element, isQualified);
-
-    this.handleElementName(isGlobal, element, isQualified);
+    this.handleElementForm(el, element);
     this.handleElementAnnotation(el, element);
     this.handleElementGlobalType(el, element);
 
-    let complexTypeEl: Element | null;
-    let keyEl: Element | null;
-    let keyrefEl: Element | null;
-    let uniqueEl: Element | null;
     const simpleTypeEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'simpleType');
-    if (simpleTypeEl != null) {
+    if (simpleTypeEl === null) {
+      const complexTypeEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'complexType');
+      if (complexTypeEl !== null) {
+        element.setSchemaType(this.handleComplexType(schema, complexTypeEl, schemaEl, false));
+      }
+    } else {
       const simpleType = this.handleSimpleType(schema, simpleTypeEl, schemaEl, false);
       element.setSchemaType(simpleType);
       element.setSchemaTypeName(simpleType.getQName());
-    } else {
-      complexTypeEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'complexType');
-      if (complexTypeEl != null) {
-        element.setSchemaType(this.handleComplexType(schema, complexTypeEl, schemaEl, false));
-      }
     }
 
-    keyEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'key');
-    if (keyEl != null) {
-      while (keyEl != null) {
-        element.getConstraints().push(this.handleConstraint(keyEl, new XmlSchemaKey()));
-        keyEl = XDOMUtil.getNextSiblingElementNS(keyEl, XmlSchema.SCHEMA_NS, 'key');
-      }
-    }
-
-    keyrefEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'keyref');
-    if (keyrefEl != null) {
-      while (keyrefEl != null) {
-        const keyRef = this.handleConstraint(keyrefEl, new XmlSchemaKeyref()) as XmlSchemaKeyref;
-        if (keyrefEl.hasAttribute('refer')) {
-          const name = keyrefEl.getAttribute('refer')!;
-          keyRef.refer = this.getRefQName(name, el);
-        }
-        element.getConstraints().push(keyRef);
-        keyrefEl = XDOMUtil.getNextSiblingElementNS(keyrefEl, XmlSchema.SCHEMA_NS, 'keyref');
-      }
-    }
-
-    uniqueEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'unique');
-    if (uniqueEl != null) {
-      while (uniqueEl != null) {
-        element.getConstraints().push(this.handleConstraint(uniqueEl, new XmlSchemaUnique()));
-        uniqueEl = XDOMUtil.getNextSiblingElementNS(uniqueEl, XmlSchema.SCHEMA_NS, 'unique');
-      }
-    }
+    this.handleElementConstraints(element, el);
 
     if (el.hasAttribute('abstract')) {
       element.setAbstractElement(/true/i.test(el.getAttribute('abstract')!));
@@ -538,7 +477,7 @@ export class SchemaBuilder {
       return existing;
     }
 
-    this.handleSchemaElementBasics(schemaEl, systemId, schemaKey);
+    this.handleSchemaElementBasics(schemaEl, schemaKey, systemId ?? null);
 
     let el = XDOMUtil.getFirstChildElementNS(schemaEl, XmlSchema.SCHEMA_NS);
     for (; el != null; el = XDOMUtil.getNextSiblingElementNS(el, XmlSchema.SCHEMA_NS)) {
@@ -563,12 +502,8 @@ export class SchemaBuilder {
     baseUri: string | null,
     validator: (s: XmlSchema) => void,
   ) {
-    if (baseUri == null) {
-      baseUri = this.collection.baseUri;
-    }
-    if (targetNamespace == null) {
-      targetNamespace = Constants.NULL_NS_URI;
-    }
+    baseUri ??= this.collection.baseUri;
+    targetNamespace ??= Constants.NULL_NS_URI;
 
     if (
       targetNamespace != null &&
@@ -581,7 +516,7 @@ export class SchemaBuilder {
 
     // use the entity resolver provided if the schema location is present
     // null
-    if (schemaLocation != null && !('' === schemaLocation)) {
+    if (schemaLocation != null && '' !== schemaLocation) {
       const source = this.collection.getSchemaResolver().resolveEntity(targetNamespace, schemaLocation, baseUri);
 
       // the entity resolver was unable to resolve this!!
@@ -590,7 +525,7 @@ export class SchemaBuilder {
         // known namespace map
         return this.collection.getKnownSchema(targetNamespace);
       }
-      //const systemId = source.getSystemId() == null ? schemaLocation : source.getSystemId();
+
       const systemId = schemaLocation;
       // Push repaired system id back into source where read sees it.
       // It is perhaps a bad thing to patch the source, but this fixes
@@ -649,14 +584,8 @@ export class SchemaBuilder {
    * @return The cached schema if one exists for this thread or null.
    */
   private getCachedSchema(targetNamespace: string, schemaLocation: string, baseUri: string) {
-    let resolvedSchema: XmlSchema | null = null;
-
-    if (this.resolvedSchemas != null) {
-      // cache is initialized, use it
-      const schemaKey = targetNamespace + schemaLocation + baseUri;
-      resolvedSchema = this.resolvedSchemas.get(schemaKey) || null;
-    }
-    return resolvedSchema;
+    const schemaKey = targetNamespace + schemaLocation + baseUri;
+    return this.resolvedSchemas.get(schemaKey) ?? null;
   }
 
   private getChildren(content: Element) {
@@ -686,10 +615,7 @@ export class SchemaBuilder {
     if (offset == -1) {
       uri = pContext.getNamespaceURI(Constants.DEFAULT_NS_PREFIX);
       if (Constants.NULL_NS_URI === uri) {
-        if (
-          this.currentSchema.getTargetNamespace() == null &&
-          !(this.currentSchema.getLogicalTargetNamespace() === '')
-        ) {
+        if (this.currentSchema.getTargetNamespace() == null && this.currentSchema.getLogicalTargetNamespace() !== '') {
           // If object is unqualified in a schema without a target namespace then it could
           // be that this schema is included in another one. The including namespace
           // should then be used for this reference
@@ -703,10 +629,7 @@ export class SchemaBuilder {
       prefix = pName.substring(0, offset);
       uri = pContext.getNamespaceURI(prefix);
       const parentSchema = this.currentSchema.getParent();
-      if (
-        uri == null ||
-        (Constants.NULL_NS_URI === uri && parentSchema != null && parentSchema.getNamespaceContext() != null)
-      ) {
+      if (uri == null || (Constants.NULL_NS_URI === uri && parentSchema?.getNamespaceContext() != null)) {
         uri = parentSchema!.getNamespaceContext()!.getNamespaceURI(prefix);
       }
 
@@ -783,9 +706,9 @@ export class SchemaBuilder {
       const contentProcessing = this.getEnumString(anyAttrEl, 'processContents');
 
       anyAttr.processContent =
-        contentProcessing != null
-          ? xmlSchemaContentProcessingValueOf(contentProcessing)
-          : XmlSchemaContentProcessing.NONE;
+        contentProcessing == null
+          ? XmlSchemaContentProcessing.NONE
+          : xmlSchemaContentProcessingValueOf(contentProcessing);
     }
     if (anyAttrEl.hasAttribute('id')) {
       anyAttr.setId(anyAttrEl.getAttribute('id'));
@@ -837,7 +760,7 @@ export class SchemaBuilder {
     }
 
     if (attrEl.hasAttribute('id')) {
-      attr.setId(attrEl.getAttribute('id')!);
+      attr.setId(attrEl.getAttribute('id'));
     }
 
     if (attrEl.hasAttribute('use')) {
@@ -863,32 +786,7 @@ export class SchemaBuilder {
       attr.setAnnotation(annotation);
     }
 
-    const attrNodes = attrEl.attributes;
-    const attrs: Attr[] = [];
-    let ctx: NodeNamespaceContext | null = null;
-    for (let i = 0; i < attrNodes.length; i++) {
-      const att = attrNodes.item(i) as Attr;
-      const attName = att.name;
-      if (!SchemaBuilder.RESERVED_ATTRIBUTES.has(attName)) {
-        attrs.push(att);
-        const value = att.value;
-
-        if (value.indexOf(':') > -1) {
-          // there is a possibility of some namespace mapping
-          const prefix = value.substring(0, value.indexOf(':'));
-          if (ctx == null) {
-            ctx = NodeNamespaceContext.getNamespaceContext(attrEl);
-          }
-          const namespace = ctx.getNamespaceURI(prefix);
-          if (Constants.NULL_NS_URI !== namespace) {
-            const nsAttr = attrEl.ownerDocument.createAttributeNS(Constants.XMLNS_ATTRIBUTE_NS_URI, 'xmlns:' + prefix);
-            nsAttr.value = namespace;
-            attrs.push(nsAttr);
-          }
-        }
-      }
-    }
-
+    const attrs = this.collectExtensionAttributes(attrEl);
     if (attrs.length > 0) {
       attr.setUnhandledAttributes(attrs);
     }
@@ -896,6 +794,67 @@ export class SchemaBuilder {
     // process extra attributes and elements
     this.processExtensibilityComponents(attr, attrEl, true);
     return attr;
+  }
+
+  private applyComplexTypeAttributes(ct: XmlSchemaComplexType, complexEl: Element): void {
+    if (complexEl.hasAttribute('block')) {
+      ct.setBlock(XmlSchemaDerivationMethod.schemaValueOf(complexEl.getAttribute('block')!));
+    }
+    if (complexEl.hasAttribute('final')) {
+      ct.setFinal(XmlSchemaDerivationMethod.schemaValueOf(complexEl.getAttribute('final')!));
+    }
+    if (complexEl.hasAttribute('abstract')) {
+      ct.setAbstract(complexEl.getAttribute('abstract')!.toLowerCase() === 'true');
+    }
+    if (complexEl.hasAttribute('mixed')) {
+      ct.setMixed(complexEl.getAttribute('mixed')!.toLowerCase() === 'true');
+    }
+  }
+
+  private handleElementConstraints(element: XmlSchemaElement, el: Element): void {
+    let keyEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'key');
+    while (keyEl !== null) {
+      element.getConstraints().push(this.handleConstraint(keyEl, new XmlSchemaKey()));
+      keyEl = XDOMUtil.getNextSiblingElementNS(keyEl, XmlSchema.SCHEMA_NS, 'key');
+    }
+    let keyrefEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'keyref');
+    while (keyrefEl !== null) {
+      const keyRef = this.handleConstraint(keyrefEl, new XmlSchemaKeyref()) as XmlSchemaKeyref;
+      element.getConstraints().push(keyRef);
+      keyrefEl = XDOMUtil.getNextSiblingElementNS(keyrefEl, XmlSchema.SCHEMA_NS, 'keyref');
+    }
+    let uniqueEl = XDOMUtil.getFirstChildElementNS(el, XmlSchema.SCHEMA_NS, 'unique');
+    while (uniqueEl !== null) {
+      element.getConstraints().push(this.handleConstraint(uniqueEl, new XmlSchemaUnique()));
+      uniqueEl = XDOMUtil.getNextSiblingElementNS(uniqueEl, XmlSchema.SCHEMA_NS, 'unique');
+    }
+  }
+
+  private collectExtensionAttributes(attrEl: Element): Attr[] {
+    const attrs: Attr[] = [];
+    const syntheticPrefixes = new Set<string>();
+    let ctx: NodeNamespaceContext | undefined = undefined;
+    const attrNodes = attrEl.attributes;
+    for (let i = 0; i < attrNodes.length; i++) {
+      const att = attrNodes.item(i) as Attr;
+      const attName = att.name;
+      if (!SchemaBuilder.RESERVED_ATTRIBUTES.has(attName)) {
+        attrs.push(att);
+        const value = att.value;
+        if (value.includes(':')) {
+          const prefix = value.substring(0, value.indexOf(':'));
+          ctx ??= NodeNamespaceContext.getNamespaceContext(attrEl);
+          const namespace = ctx.getNamespaceURI(prefix);
+          if (Constants.NULL_NS_URI !== namespace && !syntheticPrefixes.has(prefix)) {
+            const nsAttr = attrEl.ownerDocument.createAttributeNS(Constants.XMLNS_ATTRIBUTE_NS_URI, 'xmlns:' + prefix);
+            nsAttr.value = namespace;
+            attrs.push(nsAttr);
+            syntheticPrefixes.add(prefix);
+          }
+        }
+      }
+    }
+    return attrs;
   }
 
   private handleAttributeGroup(schema: XmlSchema, groupEl: Element, schemaEl: Element) {
@@ -1144,12 +1103,11 @@ export class SchemaBuilder {
     }
   }
 
-  private handleElementForm(el: Element, element: XmlSchemaElement, _isQualified: boolean) {
+  private handleElementForm(el: Element, element: XmlSchemaElement) {
     if (el.hasAttribute('form')) {
       const formDef = el.getAttribute('form')!;
       element.setForm(xmlSchemaFormValueOf(formDef));
     }
-    return element.getForm() == XmlSchemaForm.QUALIFIED;
   }
 
   private handleElementGlobalType(el: Element, element: XmlSchemaElement) {
@@ -1170,8 +1128,6 @@ export class SchemaBuilder {
       element.getRef().setTargetQName(refQName);
     }
   }
-
-  private handleElementName(_isGlobal: boolean, _element: XmlSchemaElement, _isQualified: boolean) {}
 
   /*
    * handle_simple_content_restriction if( restriction has base attribute ) set the baseType else if(
@@ -1248,7 +1204,7 @@ export class SchemaBuilder {
     const notation = new XmlSchemaNotation(schema);
 
     if (notationEl.hasAttribute('id')) {
-      notation.setId(notationEl.getAttribute('id')!);
+      notation.setId(notationEl.getAttribute('id'));
     }
 
     if (notationEl.hasAttribute('name')) {
@@ -1333,15 +1289,9 @@ export class SchemaBuilder {
     return redefine;
   }
 
-  private handleSchemaElementBasics(schemaEl: Element, systemId: string | null = null, schemaKey: SchemaKey): void {
-    if (!this.collection.containsSchema(schemaKey)) {
-      this.collection.addSchema(schemaKey, this.currentSchema);
-      this.currentSchema.setParent(this.collection); // establish parentage now.
-    } else {
-      throw new Error(
-        'Schema name conflict in collection. Namespace: ' + this.currentSchema.getLogicalTargetNamespace(),
-      );
-    }
+  private handleSchemaElementBasics(schemaEl: Element, schemaKey: SchemaKey, systemId: string | null = null): void {
+    this.collection.addSchema(schemaKey, this.currentSchema);
+    this.currentSchema.setParent(this.collection); // establish parentage now.
 
     this.currentSchema.setElementFormDefault(this.getFormDefault(schemaEl, 'elementFormDefault'));
     this.currentSchema.setAttributeFormDefault(this.getFormDefault(schemaEl, 'attributeFormDefault'));
@@ -1656,14 +1606,12 @@ export class SchemaBuilder {
       };
       if (isEmpty(pSchema.getSyntacticalTargetNamespace())) {
         pSchema.setLogicalTargetNamespace(schema.getLogicalTargetNamespace());
-      } else {
-        if (pSchema.getSyntacticalTargetNamespace() !== schema.getLogicalTargetNamespace()) {
-          let msg = 'An included schema was announced to have the default target namespace';
-          if (!isEmpty(schema.getLogicalTargetNamespace())) {
-            msg += ' or the target namespace ' + schema.getLogicalTargetNamespace();
-          }
-          throw new Error(msg + ', but has the target namespace ' + pSchema.getLogicalTargetNamespace());
+      } else if (pSchema.getSyntacticalTargetNamespace() !== schema.getLogicalTargetNamespace()) {
+        let msg = 'An included schema was announced to have the default target namespace';
+        if (!isEmpty(schema.getLogicalTargetNamespace())) {
+          msg += ' or the target namespace ' + schema.getLogicalTargetNamespace();
         }
+        throw new Error(msg + ', but has the target namespace ' + pSchema.getLogicalTargetNamespace());
       }
     };
   }
@@ -1673,44 +1621,44 @@ export class SchemaBuilder {
     parentElement: Element,
     namespaces: boolean,
   ): void {
-    if (this.extReg != null) {
-      // process attributes
-      const attributes = parentElement.attributes;
-      for (let i = 0; i < attributes.length; i++) {
-        const attribute = attributes.item(i) as Attr;
+    if (this.extReg == null) return;
 
-        const namespaceURI = attribute.namespaceURI;
-        const name = attribute.localName;
+    // process attributes
+    const attributes = parentElement.attributes;
+    for (let i = 0; i < attributes.length; i++) {
+      const attribute = attributes.item(i) as Attr;
 
-        if (
-          namespaceURI != null &&
-          '' !== namespaceURI && // ignore unqualified attributes
-          // ignore namespaces
-          (namespaces || !namespaceURI.startsWith(Constants.XMLNS_ATTRIBUTE_NS_URI)) &&
-          // does not belong to the schema namespace by any chance!
-          Constants.URI_2001_SCHEMA_XSD !== namespaceURI
-        ) {
+      const namespaceURI = attribute.namespaceURI;
+      const name = attribute.localName;
+
+      if (
+        namespaceURI != null &&
+        '' !== namespaceURI && // ignore unqualified attributes
+        // ignore namespaces
+        (namespaces || !namespaceURI.startsWith(Constants.XMLNS_ATTRIBUTE_NS_URI)) &&
+        // does not belong to the schema namespace by any chance!
+        Constants.URI_2001_SCHEMA_XSD !== namespaceURI
+      ) {
+        const qName = new QName(namespaceURI, name);
+        this.extReg.deserializeExtension(schemaObject, qName, attribute);
+      }
+    }
+
+    // process elements
+    let child = parentElement.firstChild;
+    while (child != null) {
+      if (child.nodeType == Node.ELEMENT_NODE) {
+        const extElement = child as Element;
+        const namespaceURI = extElement.namespaceURI;
+        const name = extElement.localName;
+
+        if (namespaceURI != null && Constants.URI_2001_SCHEMA_XSD !== namespaceURI) {
+          // does not belong to the schema namespace
           const qName = new QName(namespaceURI, name);
-          this.extReg.deserializeExtension(schemaObject, qName, attribute);
+          this.extReg.deserializeExtension(schemaObject, qName, extElement);
         }
       }
-
-      // process elements
-      let child = parentElement.firstChild;
-      while (child != null) {
-        if (child.nodeType == Node.ELEMENT_NODE) {
-          const extElement = child as Element;
-          const namespaceURI = extElement.namespaceURI;
-          const name = extElement.localName;
-
-          if (namespaceURI != null && Constants.URI_2001_SCHEMA_XSD !== namespaceURI) {
-            // does not belong to the schema namespace
-            const qName = new QName(namespaceURI, name);
-            this.extReg.deserializeExtension(schemaObject, qName, extElement);
-          }
-        }
-        child = child.nextSibling;
-      }
+      child = child.nextSibling;
     }
   }
 
@@ -1724,9 +1672,7 @@ export class SchemaBuilder {
    * @param readSchema
    */
   private putCachedSchema(targetNamespace: string, schemaLocation: string, baseUri: string, readSchema: XmlSchema) {
-    if (this.resolvedSchemas != null) {
-      const schemaKey = targetNamespace + schemaLocation + baseUri;
-      this.resolvedSchemas.set(schemaKey, readSchema);
-    }
+    const schemaKey = targetNamespace + schemaLocation + baseUri;
+    this.resolvedSchemas.set(schemaKey, readSchema);
   }
 }

--- a/packages/ui/src/xml-schema-ts/SchemaKey.ts
+++ b/packages/ui/src/xml-schema-ts/SchemaKey.ts
@@ -1,10 +1,10 @@
 export class SchemaKey {
-  private namespace: string;
-  private systemId: string;
+  private readonly namespace: string;
+  private readonly systemId: string;
 
   constructor(namespace?: string | null, systemId?: string | null) {
-    this.namespace = namespace != null ? namespace : '';
-    this.systemId = systemId != null ? systemId : '';
+    this.namespace = namespace ?? '';
+    this.systemId = systemId ?? '';
   }
 
   toString() {

--- a/packages/ui/src/xml-schema-ts/XmlSchema.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchema.ts
@@ -23,19 +23,19 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
   static readonly SCHEMA_NS = URI_2001_SCHEMA_XSD;
   static readonly UTF_8_ENCODING = 'UTF-8';
 
-  private items: XmlSchemaObject[] = [];
+  private readonly items: XmlSchemaObject[] = [];
   private parent: XmlSchemaCollection | null = null;
   private blockDefault = XmlSchemaDerivationMethod.NONE;
   private finalDefault = XmlSchemaDerivationMethod.NONE;
   private elementFormDefault = XmlSchemaForm.UNQUALIFIED;
   private attributeFormDefault = XmlSchemaForm.UNQUALIFIED;
-  private externals: XmlSchemaExternal[] = [];
-  private attributeGroups = new QNameMap<XmlSchemaAttributeGroup>();
-  private attributes = new QNameMap<XmlSchemaAttribute>();
-  private elements = new QNameMap<XmlSchemaElement>();
-  private groups = new QNameMap<XmlSchemaGroup>();
-  private notations = new QNameMap<XmlSchemaNotation>();
-  private schemaTypes = new QNameMap<XmlSchemaType>();
+  private readonly externals: XmlSchemaExternal[] = [];
+  private readonly attributeGroups = new QNameMap<XmlSchemaAttributeGroup>();
+  private readonly attributes = new QNameMap<XmlSchemaAttribute>();
+  private readonly elements = new QNameMap<XmlSchemaElement>();
+  private readonly groups = new QNameMap<XmlSchemaGroup>();
+  private readonly notations = new QNameMap<XmlSchemaNotation>();
+  private readonly schemaTypes = new QNameMap<XmlSchemaType>();
   private syntacticalTargetNamespace: string | null = null;
   private schemaNamespacePrefix: string | null = null;
   private logicalTargetNamespace: string | null = null;
@@ -46,7 +46,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
   constructor(namespace?: string, systemId?: string, parent?: XmlSchemaCollection) {
     super();
     if (namespace == null) return;
-    const systemIdToUse = systemId ? systemId : namespace;
+    const systemIdToUse = systemId ?? namespace;
     this.parent = parent || null;
     this.logicalTargetNamespace = namespace;
     this.syntacticalTargetNamespace = namespace;
@@ -82,33 +82,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
    * @protected
    */
   getAttributeByQName(name: QName, deep: boolean = true, schemaStack?: XmlSchema[]): XmlSchemaAttribute | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-    let attribute = this.attributes.get(name) as XmlSchemaAttribute | null;
-    if (deep) {
-      if (attribute == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            attribute = schema.getAttributeByQName(name, deep, schemaStack);
-            if (attribute != null) {
-              return attribute;
-            }
-          }
-        }
-      } else {
-        return attribute;
-      }
-    }
-    return attribute;
+    return this.findByQName(name, this.attributes, deep, schemaStack, (s, n, d, st) => s.getAttributeByQName(n, d, st));
   }
 
   /**
@@ -142,37 +116,9 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
     deep: boolean = true,
     schemaStack?: XmlSchema[],
   ): XmlSchemaAttributeGroup | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-
-    let group = this.attributeGroups.get(name) || null;
-    if (deep) {
-      if (group == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            // create an empty stack - push the current parent in
-            // and
-            // use the protected method to process the schema
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            group = schema.getAttributeGroupByQName(name, deep, schemaStack);
-            if (group != null) {
-              return group;
-            }
-          }
-        }
-      } else {
-        return group;
-      }
-    }
-    return group;
+    return this.findByQName(name, this.attributeGroups, deep, schemaStack, (s, n, d, st) =>
+      s.getAttributeGroupByQName(n, d, st),
+    );
   }
 
   /**
@@ -221,37 +167,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
    * @return the element.
    */
   getElementByQName(name: QName, deep: boolean = true, schemaStack?: XmlSchema[]): XmlSchemaElement | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-
-    let element = this.elements.get(name) || null;
-    if (deep) {
-      if (element == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            // create an empty stack - push the current parent in
-            // and
-            // use the protected method to process the schema
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            element = schema.getElementByQName(name, deep, schemaStack);
-            if (element != null) {
-              return element;
-            }
-          }
-        }
-      } else {
-        return element;
-      }
-    }
-    return element;
+    return this.findByQName(name, this.elements, deep, schemaStack, (s, n, d, st) => s.getElementByQName(n, d, st));
   }
 
   /**
@@ -314,36 +230,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
    * @return
    */
   getGroupByQName(name: QName, deep: boolean = true, schemaStack?: XmlSchema[]): XmlSchemaGroup | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-    let group = this.groups.get(name) || null;
-    if (deep) {
-      if (group == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            // create an empty stack - push the current parent in
-            // and
-            // use the protected method to process the schema
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            group = schema.getGroupByQName(name, deep, schemaStack);
-            if (group != null) {
-              return group;
-            }
-          }
-        }
-      } else {
-        return group;
-      }
-    }
-    return group;
+    return this.findByQName(name, this.groups, deep, schemaStack, (s, n, d, st) => s.getGroupByQName(n, d, st));
   }
 
   /**
@@ -404,36 +291,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
    * @return the notation
    */
   getNotationByQName(name: QName, deep: boolean = true, schemaStack?: XmlSchema[]): XmlSchemaNotation | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-    let notation = this.notations.get(name) || null;
-    if (deep) {
-      if (notation == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            // create an empty stack - push the current parent in
-            // and
-            // use the protected method to process the schema
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            notation = schema.getNotationByQName(name, deep, schemaStack);
-            if (notation != null) {
-              return notation;
-            }
-          }
-        }
-      } else {
-        return notation;
-      }
-    }
-    return notation;
+    return this.findByQName(name, this.notations, deep, schemaStack, (s, n, d, st) => s.getNotationByQName(n, d, st));
   }
 
   /**
@@ -509,36 +367,7 @@ export class XmlSchema extends XmlSchemaAnnotated implements NamespaceContextOwn
    * @return the type.
    */
   getTypeByQName(name: QName, deep: boolean = true, schemaStack?: XmlSchema[]): XmlSchemaType | null {
-    if (schemaStack != null && schemaStack.includes(this)) {
-      // recursive schema - just return null
-      return null;
-    }
-    let type = this.schemaTypes.get(name) || null;
-
-    if (deep) {
-      if (type == null) {
-        // search the imports
-        for (const item of this.externals) {
-          const schema = this.getSchema(item);
-
-          if (schema != null) {
-            // create an empty stack - push the current parent
-            // use the protected method to process the schema
-            if (schemaStack == null) {
-              schemaStack = [];
-            }
-            schemaStack.push(this);
-            type = schema.getTypeByQName(name, deep, schemaStack);
-            if (type != null) {
-              return type;
-            }
-          }
-        }
-      } else {
-        return type;
-      }
-    }
-    return type;
+    return this.findByQName(name, this.schemaTypes, deep, schemaStack, (s, n, d, st) => s.getTypeByQName(n, d, st));
   }
 
   /**
@@ -714,6 +543,33 @@ public void write(Writer writer, Map<String, String> options) {
     this.syntacticalTargetNamespace = syntacticalTargetNamespace;
   }
 
+  private findByQName<T>(
+    name: QName,
+    map: QNameMap<T>,
+    deep: boolean,
+    schemaStack: XmlSchema[] | undefined,
+    deepGetter: (schema: XmlSchema, name: QName, deep: boolean, stack: XmlSchema[] | undefined) => T | null,
+  ): T | null {
+    if (schemaStack?.includes(this)) {
+      return null;
+    }
+    const item = map.get(name) ?? null;
+    if (!deep || item !== null) {
+      return item;
+    }
+    for (const ext of this.externals) {
+      const schema = this.getSchema(ext);
+      if (schema !== null) {
+        const stack = [...(schemaStack ?? []), this];
+        const found = deepGetter(schema, name, deep, stack);
+        if (found !== null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
   /**
    * Get a schema from an import
    *
@@ -722,10 +578,8 @@ public void write(Writer writer, Map<String, String> options) {
    */
   private getSchema(includeOrImport: object): XmlSchema | null {
     let schema: XmlSchema | null = null;
-    if (includeOrImport instanceof XmlSchemaImport) {
-      schema = (includeOrImport as XmlSchemaImport).getSchema();
-    } else if (includeOrImport instanceof XmlSchemaInclude) {
-      schema = (includeOrImport as XmlSchemaInclude).getSchema();
+    if (includeOrImport instanceof XmlSchemaImport || includeOrImport instanceof XmlSchemaInclude) {
+      schema = includeOrImport.getSchema();
     }
     return schema;
   }

--- a/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaCollection.test.ts
@@ -1,24 +1,34 @@
 import {
   getCamelSpringXsd,
+  getConstraintsXsd,
   getCrossSchemaBaseTypesXsd,
   getCrossSchemaDerivedTypesXsd,
+  getDerivationMethodsXsd,
+  getExtensionComplexXsd,
   getNamedTypesXsd,
   getRestrictionInheritanceXsd,
+  getSchemaTestXsd,
   getShipOrderEmptyFirstLineXsd,
   getShipOrderXsd,
   getTestDocumentXsd,
 } from '../stubs/datamapper/data-mapper';
 import { XmlSchemaAttribute } from './attribute/XmlSchemaAttribute';
+import { XmlSchemaAttributeGroup } from './attribute/XmlSchemaAttributeGroup';
 import { XmlSchemaAttributeGroupRef } from './attribute/XmlSchemaAttributeGroupRef';
 import { XmlSchemaComplexContentExtension } from './complex/XmlSchemaComplexContentExtension';
 import { XmlSchemaComplexContentRestriction } from './complex/XmlSchemaComplexContentRestriction';
 import { XmlSchemaComplexType } from './complex/XmlSchemaComplexType';
+import { XmlSchemaKey } from './constraint/XmlSchemaKey';
+import { XmlSchemaKeyref } from './constraint/XmlSchemaKeyref';
+import { XmlSchemaUnique } from './constraint/XmlSchemaUnique';
 import { XmlSchemaElement } from './particle/XmlSchemaElement';
+import { XmlSchemaGroupRef } from './particle/XmlSchemaGroupRef';
 import { XmlSchemaSequence } from './particle/XmlSchemaSequence';
 import { QName } from './QName';
 import { XmlSchemaSimpleType } from './simple/XmlSchemaSimpleType';
 import { XmlSchemaSimpleTypeRestriction } from './simple/XmlSchemaSimpleTypeRestriction';
 import { XmlSchemaCollection } from './XmlSchemaCollection';
+import { XmlSchemaGroup } from './XmlSchemaGroup';
 import { XmlSchemaUse } from './XmlSchemaUse';
 
 describe('XmlSchemaCollection', () => {
@@ -385,6 +395,185 @@ describe('XmlSchemaCollection', () => {
 
       expect(collection.baseUri).toBe(testUri);
       expect(collection.getSchemaResolver().getCollectionBaseURI()).toBe(testUri);
+    });
+  });
+
+  describe('Derivation method parsing', () => {
+    it('should parse final="extension restriction" on complexType in camel-spring', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getCamelSpringXsd(), () => {});
+      const constantsType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://camel.apache.org/schema/spring', 'constants')) as XmlSchemaComplexType;
+      expect(constantsType).toBeTruthy();
+      const finalMethod = constantsType.getFinal();
+      expect(finalMethod.isExtension()).toBe(true);
+      expect(finalMethod.isRestriction()).toBe(true);
+      expect(finalMethod.isAll()).toBe(false);
+    });
+
+    it('should parse abstract="true" on complexType in ExtensionComplex schema', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getExtensionComplexXsd(), () => {});
+      const baseRequestType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/TEST', 'BaseRequest')) as XmlSchemaComplexType;
+      expect(baseRequestType).toBeTruthy();
+      expect(baseRequestType.isAbstract()).toBe(true);
+    });
+
+    it('should parse final="#all" as all derivation methods on complexType', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getDerivationMethodsXsd(), () => {});
+      const finalAllType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/DERIVATION', 'FinalAllType')) as XmlSchemaComplexType;
+      expect(finalAllType).toBeTruthy();
+      expect(finalAllType.getFinal().isAll()).toBe(true);
+    });
+
+    it('should parse block="extension restriction" on complexType', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getDerivationMethodsXsd(), () => {});
+      const blockType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/DERIVATION', 'BlockExtensionRestrictionType')) as XmlSchemaComplexType;
+      expect(blockType).toBeTruthy();
+      const blockMethod = blockType.getBlock();
+      expect(blockMethod.isExtension()).toBe(true);
+      expect(blockMethod.isRestriction()).toBe(true);
+      expect(blockMethod.isAll()).toBe(false);
+    });
+  });
+
+  describe('XmlSchema QName lookup methods', () => {
+    it('should find element by QName using getElementByQName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getShipOrderXsd(), () => {});
+      const ns = xmlSchema.getTargetNamespace();
+      const el = xmlSchema.getElementByQName(new QName(ns, 'ShipOrder'));
+      expect(el).toBeInstanceOf(XmlSchemaElement);
+    });
+
+    it('should return null for unknown element QName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getShipOrderXsd(), () => {});
+      const el = xmlSchema.getElementByQName(new QName('http://unknown', 'nope'));
+      expect(el).toBeNull();
+    });
+
+    it('should find type by QName using getTypeByQName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getNamedTypesXsd(), () => {});
+      const ns = xmlSchema.getTargetNamespace();
+      const type = xmlSchema.getTypeByQName(new QName(ns, 'complexType1'));
+      expect(type).toBeInstanceOf(XmlSchemaComplexType);
+    });
+
+    it('should return null for attribute QName not in schema using getAttributeByQName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+      const attr = xmlSchema.getAttributeByQName(new QName('http://www.example.com/CONSTRAINTS', 'nope'));
+      expect(attr).toBeNull();
+    });
+
+    it('should find group by QName using getGroupByQName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+      const group = xmlSchema.getGroupByQName(new QName('http://www.example.com/CONSTRAINTS', 'AddressGroup'));
+      expect(group).not.toBeNull();
+      expect(group).toBeInstanceOf(XmlSchemaGroup);
+    });
+
+    it('should find attribute group by QName using getAttributeGroupByQName', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getSchemaTestXsd(), () => {});
+      const attrGroup = xmlSchema.getAttributeGroupByQName(
+        new QName('http://www.example.com/test', 'ExtendedAttributes'),
+      );
+      expect(attrGroup).not.toBeNull();
+      expect(attrGroup).toBeInstanceOf(XmlSchemaAttributeGroup);
+    });
+  });
+
+  describe('Constraints XSD parsing', () => {
+    it('should parse xs:group ref as direct particle of complexType', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const addressType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'AddressType')) as XmlSchemaComplexType;
+      expect(addressType).toBeTruthy();
+      expect(addressType.getParticle()).toBeInstanceOf(XmlSchemaGroupRef);
+    });
+
+    it('should parse xs:key constraint on element', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const catalogEl = xmlSchema
+        .getElements()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'Catalog')) as XmlSchemaElement;
+      expect(catalogEl).toBeTruthy();
+      const constraints = catalogEl.getConstraints();
+      const key = constraints.find((c) => c instanceof XmlSchemaKey);
+      expect(key).toBeTruthy();
+      expect((key as XmlSchemaKey).getName()).toBe('PersonKey');
+    });
+
+    it('should parse xs:unique constraint on element', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const catalogEl = xmlSchema
+        .getElements()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'Catalog')) as XmlSchemaElement;
+      const constraints = catalogEl.getConstraints();
+      const unique = constraints.find((c) => c instanceof XmlSchemaUnique);
+      expect(unique).toBeTruthy();
+      expect((unique as XmlSchemaUnique).getName()).toBe('PersonNameUnique');
+    });
+
+    it('should parse xs:keyref constraint on element', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const orderEl = xmlSchema
+        .getElements()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'Order')) as XmlSchemaElement;
+      expect(orderEl).toBeTruthy();
+      const constraints = orderEl.getConstraints();
+      const keyref = constraints.find((c) => c instanceof XmlSchemaKeyref);
+      expect(keyref).toBeTruthy();
+      expect((keyref as XmlSchemaKeyref).getName()).toBe('OrderPersonRef');
+    });
+
+    it('should parse mixed="true" on complexType', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const personType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'PersonType')) as XmlSchemaComplexType;
+      expect(personType).toBeTruthy();
+      expect(personType.isMixed()).toBe(true);
+    });
+
+    it('should collect non-reserved extension attributes on xs:attribute', () => {
+      const collection = new XmlSchemaCollection();
+      const xmlSchema = collection.read(getConstraintsXsd(), () => {});
+
+      const personType = xmlSchema
+        .getSchemaTypes()
+        .get(new QName('http://www.example.com/CONSTRAINTS', 'PersonType')) as XmlSchemaComplexType;
+      expect(personType).toBeTruthy();
+      const roleAttr = personType
+        .getAttributes()
+        .find((a) => a instanceof XmlSchemaAttribute && a.getName() === 'role') as XmlSchemaAttribute;
+      expect(roleAttr).toBeTruthy();
+      expect(roleAttr.getUnhandledAttributes()).not.toBeNull();
+      expect(roleAttr.getUnhandledAttributes()!.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/ui/src/xml-schema-ts/XmlSchemaCollection.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaCollection.ts
@@ -20,18 +20,18 @@ import { XmlSchema } from './XmlSchema';
 import type { XmlSchemaType } from './XmlSchemaType';
 
 export class XmlSchemaCollection {
-  baseUri: string | null;
-  private stack: SchemaKey[];
-  private unresolvedTypes: QNameMap<TypeReceiver[]>;
-  private xsd: XmlSchema;
+  baseUri: string | null = null;
+  private readonly stack: SchemaKey[];
+  private readonly unresolvedTypes: QNameMap<TypeReceiver[]>;
+  private readonly xsd: XmlSchema;
   private extReg: ExtensionRegistry;
 
   private knownNamespaceMap: Record<string, XmlSchema>;
   private namespaceContext: NamespacePrefixList | null;
   private schemaResolver: DefaultURIResolver;
-  private schemas: SchemaKeyMap<XmlSchema>;
+  private readonly schemas: SchemaKeyMap<XmlSchema>;
+
   constructor() {
-    this.baseUri = null;
     this.stack = [];
     this.unresolvedTypes = new QNameMap();
     this.extReg = new ExtensionRegistry();
@@ -114,9 +114,7 @@ export class XmlSchemaCollection {
    * @return array of XmlSchema objects
    */
   getXmlSchema(systemId: string | null) {
-    if (systemId == null) {
-      systemId = '';
-    }
+    systemId ??= '';
     const result: XmlSchema[] = [];
     for (const entry of this.schemas.entries()) {
       if (entry[0].getSystemId() === systemId) {
@@ -276,7 +274,7 @@ export class XmlSchemaCollection {
 
     this.setDerivationByRestriction(xsd, Constants.XSD_INTEGER, Constants.XSD_DECIMAL, [
       new XmlSchemaFractionDigitsFacet(0, true),
-      new XmlSchemaPatternFacet('[\\-+]?[0-9]+', false),
+      new XmlSchemaPatternFacet(String.raw`[\-+]?[0-9]+`, false),
     ]);
     this.setDerivationByRestriction(xsd, Constants.XSD_NONPOSITIVEINTEGER, Constants.XSD_INTEGER, [
       new XmlSchemaMaxInclusiveFacet(0, false),
@@ -332,13 +330,13 @@ export class XmlSchemaCollection {
       new XmlSchemaPatternFacet('[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*', false),
     ]);
     this.setDerivationByRestriction(xsd, Constants.XSD_NMTOKEN, Constants.XSD_TOKEN, [
-      new XmlSchemaPatternFacet('\\c+', false),
+      new XmlSchemaPatternFacet(String.raw`\c+`, false),
     ]);
     this.setDerivationByRestriction(xsd, Constants.XSD_NAME, Constants.XSD_NMTOKEN, [
-      new XmlSchemaPatternFacet('\\i\\c*', false),
+      new XmlSchemaPatternFacet(String.raw`\i\c*`, false),
     ]);
     this.setDerivationByRestriction(xsd, Constants.XSD_NCNAME, Constants.XSD_TOKEN, [
-      new XmlSchemaPatternFacet('[\\i-[:]][\\c-[:]]*', false),
+      new XmlSchemaPatternFacet(String.raw`[\i-[:]][\c-[:]]*`, false),
     ]);
     this.setDerivationByRestriction(xsd, Constants.XSD_ID, Constants.XSD_NCNAME);
     this.setDerivationByRestriction(xsd, Constants.XSD_IDREF, Constants.XSD_NCNAME);

--- a/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.test.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.test.ts
@@ -1,0 +1,71 @@
+import { XmlSchemaDerivationMethod } from './XmlSchemaDerivationMethod';
+
+describe('XmlSchemaDerivationMethod', () => {
+  describe('schemaValueOf', () => {
+    it('should return method with no flags for empty string', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('');
+      expect(method.isNone()).toBe(true);
+    });
+
+    it('should set multiple flags for space-separated tokens', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('extension restriction');
+      expect(method.isExtension()).toBe(true);
+      expect(method.isRestriction()).toBe(true);
+      expect(method.isList()).toBe(false);
+    });
+
+    it('should handle extra whitespace between tokens', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('  extension   restriction  ');
+      expect(method.isExtension()).toBe(true);
+      expect(method.isRestriction()).toBe(true);
+    });
+
+    it('should set all flag for "#all" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('#all');
+      expect(method.isAll()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+
+    it('should set all flag for case-insensitive "#ALL" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('#ALL');
+      expect(method.isAll()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+
+    it('should set all flag for bare "ALL" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('ALL');
+      expect(method.isAll()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+
+    it('should throw when "#all" conflicts with other tokens after it', () => {
+      expect(() => XmlSchemaDerivationMethod.schemaValueOf('extension #all')).toThrow(
+        'Derivation method cannot be #all and something else.',
+      );
+    });
+
+    it('should throw when other tokens come after "#all"', () => {
+      expect(() => XmlSchemaDerivationMethod.schemaValueOf('#all extension')).toThrow(
+        'Derivation method cannot be #all and something else.',
+      );
+    });
+
+    it('should set list flag for "list" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('list');
+      expect(method.isList()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+
+    it('should set substitution flag for "substitution" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('substitution');
+      expect(method.isSubstitution()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+
+    it('should set union flag for "union" token', () => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf('union');
+      expect(method.isUnion()).toBe(true);
+      expect(method.isExtension()).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.ts
@@ -9,33 +9,37 @@ export class XmlSchemaDerivationMethod {
   private union = false;
 
   static schemaValueOf(name: string): XmlSchemaDerivationMethod {
-    const tokens = name.split('\\s');
+    const tokens = name.trim().split(/\s+/);
     const method = new XmlSchemaDerivationMethod();
-    for (const t in tokens) {
-      if ('#all' === t.toLowerCase() || 'all' === t.toLowerCase()) {
-        if (method.notAll()) {
-          throw new Error('Derivation method cannot be #all and something else.');
-        } else {
-          method.setAll(true);
-        }
-      } else {
-        if (method.isAll()) {
-          throw new Error('Derivation method cannot be #all and something else.');
-        }
-        if ('extension' === t) {
-          method.setExtension(true);
-        } else if ('list' === t) {
-          method.setList(true);
-        } else if ('restriction' === t) {
-          method.setRestriction(true);
-        } else if ('substitution' === t) {
-          method.setSubstitution(true);
-        } else if ('union' === t) {
-          method.setUnion(true);
-        }
-      }
+    for (const t of tokens) {
+      XmlSchemaDerivationMethod.applyToken(method, t);
     }
     return method;
+  }
+
+  private static applyToken(method: XmlSchemaDerivationMethod, token: string): void {
+    const lowerToken = token.toLowerCase();
+    if ('#all' === lowerToken || 'all' === lowerToken) {
+      if (method.notAll()) {
+        throw new Error('Derivation method cannot be #all and something else.');
+      }
+      method.setAll(true);
+    } else {
+      if (method.isAll()) {
+        throw new Error('Derivation method cannot be #all and something else.');
+      }
+      if ('extension' === lowerToken) {
+        method.setExtension(true);
+      } else if ('list' === lowerToken) {
+        method.setList(true);
+      } else if ('restriction' === lowerToken) {
+        method.setRestriction(true);
+      } else if ('substitution' === lowerToken) {
+        method.setSubstitution(true);
+      } else if ('union' === lowerToken) {
+        method.setUnion(true);
+      }
+    }
   }
 
   notAll(): boolean {

--- a/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttribute.ts
+++ b/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttribute.ts
@@ -107,16 +107,15 @@ export class XmlSchemaAttribute
     return this.namedDelegate.isTopLevel();
   }
 
-  setName(name: string) {
-    const fName = name;
-    if (this.isTopLevel() && this.getName() != null) {
+  setName(name: string | null) {
+    if (this.isTopLevel() && name === null) {
+      throw new Error('Top-level attributes may not be anonymous');
+    }
+    if (this.isTopLevel() && this.getName() !== null) {
       this.getParent().getAttributes().delete(this.getQName()!);
     }
-    this.namedDelegate.setName(fName);
+    this.namedDelegate.setName(name);
     if (this.isTopLevel()) {
-      if (fName == null) {
-        throw new Error('Top-level attributes may not be anonymous');
-      }
       this.getParent().getAttributes().set(this.getQName()!, this);
     }
   }
@@ -141,7 +140,7 @@ export class XmlSchemaAttribute
   }
 
   isRef() {
-    return this.ref.getTargetQName() != null;
+    return this.ref.getTargetQName() !== null;
   }
 
   getTargetQName() {

--- a/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.test.ts
+++ b/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.test.ts
@@ -1,0 +1,49 @@
+import { QName } from '../QName';
+import { XmlSchemaObject } from '../XmlSchemaObject';
+import { ExtensionDeserializer } from './ExtensionDeserializer';
+import { ExtensionRegistry } from './ExtensionRegistry';
+import { ExtensionSerializer } from './ExtensionSerializer';
+
+describe('ExtensionRegistry', () => {
+  let registry: ExtensionRegistry;
+  const mockNode = {} as Node;
+  const mockSchemaObject = {} as XmlSchemaObject;
+
+  beforeEach(() => {
+    registry = new ExtensionRegistry();
+  });
+
+  describe('serializeExtension', () => {
+    it('should call registered serializer when one is registered for the type', () => {
+      const serializer: ExtensionSerializer = { serialize: jest.fn() };
+      registry.registerSerializer('MyType', serializer);
+      registry.serializeExtension(mockSchemaObject, 'MyType', mockNode);
+      expect(serializer.serialize).toHaveBeenCalledWith(mockSchemaObject, 'MyType', mockNode);
+    });
+
+    it('should call default serializer when no serializer is registered for the type', () => {
+      const defaultSerializer: ExtensionSerializer = { serialize: jest.fn() };
+      registry.setDefaultExtensionSerializer(defaultSerializer);
+      registry.serializeExtension(mockSchemaObject, 'UnknownType', mockNode);
+      expect(defaultSerializer.serialize).toHaveBeenCalledWith(mockSchemaObject, 'UnknownType', mockNode);
+    });
+  });
+
+  describe('deserializeExtension', () => {
+    it('should call registered deserializer when one is registered for the QName', () => {
+      const qName = new QName('http://example.com', 'myElement');
+      const deserializer: ExtensionDeserializer = { deserialize: jest.fn() };
+      registry.registerDeserializer(qName, deserializer);
+      registry.deserializeExtension(mockSchemaObject, qName, mockNode);
+      expect(deserializer.deserialize).toHaveBeenCalledWith(mockSchemaObject, qName, mockNode);
+    });
+
+    it('should call default deserializer when no deserializer is registered for the QName', () => {
+      const defaultDeserializer: ExtensionDeserializer = { deserialize: jest.fn() };
+      registry.setDefaultExtensionDeserializer(defaultDeserializer);
+      const qName = new QName('http://example.com', 'unknown');
+      registry.deserializeExtension(mockSchemaObject, qName, mockNode);
+      expect(defaultDeserializer.deserialize).toHaveBeenCalledWith(mockSchemaObject, qName, mockNode);
+    });
+  });
+});

--- a/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.ts
+++ b/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.ts
@@ -9,8 +9,8 @@ export class ExtensionRegistry {
   /**
    * Maps for the storage of extension serializers /deserializers
    */
-  private extensionSerializers = new Map<string, ExtensionSerializer>();
-  private extensionDeserializers = new Map<QName, ExtensionDeserializer>();
+  private readonly extensionSerializers = new Map<string, ExtensionSerializer>();
+  private readonly extensionDeserializers = new Map<QName, ExtensionDeserializer>();
 
   /**
    * Default serializer and serializer
@@ -47,8 +47,8 @@ export class ExtensionRegistry {
   /**
    * Register a serializer with a Class
    *
-   * @param classOfType - the class of the object that would be serialized
-   * @param serializer - an instance of the deserializer
+   * @param typeName
+   * @param serializer - an instance of the serializer
    */
   registerSerializer(typeName: string, serializer: ExtensionSerializer) {
     this.extensionSerializers.set(typeName, serializer);
@@ -57,7 +57,7 @@ export class ExtensionRegistry {
   /**
    * remove the registration for a serializer with a Class
    *
-   * @param classOfType - the Class of the element/attribute the serializer is associated with
+   * @param typeName
    */
   unregisterSerializer(typeName: string) {
     this.extensionSerializers.delete(typeName);
@@ -83,10 +83,10 @@ export class ExtensionRegistry {
    */
   serializeExtension(parentSchemaObject: XmlSchemaObject, typeName: string, node: Node) {
     const serializerObject = this.extensionSerializers.get(typeName);
-    if (serializerObject != null) {
-      serializerObject.serialize(parentSchemaObject, typeName, node);
-    } else if (this.defaultExtensionSerializer != null) {
+    if (serializerObject === undefined) {
       this.defaultExtensionSerializer.serialize(parentSchemaObject, typeName, node);
+    } else {
+      serializerObject.serialize(parentSchemaObject, typeName, node);
     }
   }
 
@@ -104,10 +104,10 @@ export class ExtensionRegistry {
    */
   deserializeExtension(parentSchemaObject: XmlSchemaObject, name: QName, rawNode: Node) {
     const deserializerObject = this.extensionDeserializers.get(name);
-    if (deserializerObject != null) {
-      deserializerObject.deserialize(parentSchemaObject, name, rawNode);
-    } else if (this.defaultExtensionDeserializer != null) {
+    if (deserializerObject === undefined) {
       this.defaultExtensionDeserializer.deserialize(parentSchemaObject, name, rawNode);
+    } else {
+      deserializerObject.deserialize(parentSchemaObject, name, rawNode);
     }
   }
 }

--- a/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.test.ts
+++ b/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.test.ts
@@ -115,15 +115,6 @@ describe('NodeNamespaceContext', () => {
   });
 
   describe('getNamespaceURI', () => {
-    it('should throw error when prefix is null', () => {
-      const xml = `<root></root>`;
-      const parser = new JSDOM(xml, { contentType: 'text/xml' });
-      const node = parser.window.document.documentElement;
-      const context = NodeNamespaceContext.getNamespaceContext(node);
-
-      expect(() => context.getNamespaceURI(null as unknown as string)).toThrow('Prefix cannot be null');
-    });
-
     it('should return XML_NS_URI for xml prefix', () => {
       const xml = `<root></root>`;
       const parser = new JSDOM(xml, { contentType: 'text/xml' });
@@ -171,15 +162,6 @@ describe('NodeNamespaceContext', () => {
   });
 
   describe('getPrefix', () => {
-    it('should throw error when namespace URI is null', () => {
-      const xml = `<root></root>`;
-      const parser = new JSDOM(xml, { contentType: 'text/xml' });
-      const node = parser.window.document.documentElement;
-      const context = NodeNamespaceContext.getNamespaceContext(node);
-
-      expect(() => context.getPrefix(null as unknown as string)).toThrow('Namespace URI cannot be null');
-    });
-
     it('should return XML_NS_PREFIX for XML_NS_URI', () => {
       const xml = `<root></root>`;
       const parser = new JSDOM(xml, { contentType: 'text/xml' });
@@ -241,15 +223,6 @@ describe('NodeNamespaceContext', () => {
   });
 
   describe('getPrefixes', () => {
-    it('should throw error when namespace URI is null', () => {
-      const xml = `<root></root>`;
-      const parser = new JSDOM(xml, { contentType: 'text/xml' });
-      const node = parser.window.document.documentElement;
-      const context = NodeNamespaceContext.getNamespaceContext(node);
-
-      expect(() => context.getPrefixes(null as unknown as string)).toThrow('Namespace URI cannot be null');
-    });
-
     it('should return array with XML_NS_PREFIX for XML_NS_URI', () => {
       const xml = `<root></root>`;
       const parser = new JSDOM(xml, { contentType: 'text/xml' });

--- a/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
+++ b/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
@@ -16,16 +16,13 @@ export class NodeNamespaceContext implements NamespacePrefixList {
   }
 
   getDeclaredPrefixes(): string[] {
-    if (this.prefixes == null) {
+    if (this.prefixes === undefined) {
       this.prefixes = Object.keys(this.declarations);
     }
     return this.prefixes;
   }
 
   getNamespaceURI(pPrefix: string): string {
-    if (pPrefix == null) {
-      throw new Error('Prefix cannot be null');
-    }
     if (XML_NS_PREFIX === pPrefix) {
       return XML_NS_URI;
     }
@@ -33,13 +30,10 @@ export class NodeNamespaceContext implements NamespacePrefixList {
       return XMLNS_ATTRIBUTE_NS_URI;
     }
     const uri = this.declarations[pPrefix];
-    return uri == null ? NULL_NS_URI : uri;
+    return uri ?? NULL_NS_URI;
   }
 
   getPrefix(pNamespaceURI: string): string {
-    if (pNamespaceURI == null) {
-      throw new Error('Namespace URI cannot be null');
-    }
     if (XML_NS_URI === pNamespaceURI) {
       return XML_NS_PREFIX;
     }
@@ -51,9 +45,6 @@ export class NodeNamespaceContext implements NamespacePrefixList {
   }
 
   getPrefixes(pNamespaceURI: string): string[] {
-    if (pNamespaceURI == null) {
-      throw new Error('Namespace URI cannot be null');
-    }
     if (XML_NS_URI === pNamespaceURI) {
       return [XML_NS_PREFIX];
     }

--- a/packages/ui/src/xml-schema-ts/utils/XDOMUtil.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XDOMUtil.ts
@@ -9,7 +9,7 @@ export class XDOMUtil {
   static getNextSiblingElement(node: Node): Element | null {
     // search for node
     let sibling = node.nextSibling;
-    while (sibling != null) {
+    while (sibling !== null) {
       if (sibling.nodeType == Node.ELEMENT_NODE) {
         return sibling as Element;
       }
@@ -25,12 +25,12 @@ export class XDOMUtil {
   static getFirstChildElementNS(parent: Node, uri: string, localpart?: string): Element | null {
     // search for node
     let child = parent.firstChild;
-    while (child != null) {
+    while (child !== null) {
       if (child.nodeType == Node.ELEMENT_NODE) {
         const childElement = child as Element;
         const childURI = childElement.namespaceURI;
-        if (childURI != null && childURI === uri) {
-          if (localpart == null || childElement.localName === localpart) {
+        if (childURI !== null && childURI === uri) {
+          if (localpart === undefined || childElement.localName === localpart) {
             return childElement;
           }
         }
@@ -47,12 +47,12 @@ export class XDOMUtil {
   static getNextSiblingElementByNamesNS(node: Node, elemNames: string[][]) {
     // search for node
     let sibling = node.nextSibling;
-    while (sibling != null) {
+    while (sibling !== null) {
       if (sibling.nodeType == Node.ELEMENT_NODE) {
         const siblingElement = sibling as Element;
         for (const elemName of elemNames) {
           const uri = siblingElement.namespaceURI;
-          if (uri != null && uri === elemName[0] && siblingElement.localName === elemName[1]) {
+          if (uri !== null && uri === elemName[0] && siblingElement.localName === elemName[1]) {
             return siblingElement;
           }
         }
@@ -69,11 +69,15 @@ export class XDOMUtil {
   static getNextSiblingElementNS(node: Node, uri: string, localpart?: string) {
     // search for node
     let sibling = node.nextSibling;
-    while (sibling != null) {
+    while (sibling !== null) {
       if (sibling.nodeType == Node.ELEMENT_NODE) {
         const siblingElement = sibling as Element;
         const siblingURI = siblingElement.namespaceURI;
-        if (siblingURI != null && siblingURI === uri && (localpart == null || siblingElement.localName === localpart)) {
+        if (
+          siblingURI !== null &&
+          siblingURI === uri &&
+          (localpart === undefined || siblingElement.localName === localpart)
+        ) {
           return siblingElement;
         }
       }

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.ts
@@ -34,7 +34,7 @@ export class XmlSchemaNamedImpl implements XmlSchemaNamed {
   }
 
   getName() {
-    if (this.qname == null) {
+    if (this.qname === null) {
       return null;
     } else {
       return this.qname.getLocalPart();
@@ -42,16 +42,16 @@ export class XmlSchemaNamedImpl implements XmlSchemaNamed {
   }
 
   isAnonymous() {
-    return this.qname == null;
+    return this.qname === null;
   }
 
   setName(name: string | null) {
-    if (name == null) {
+    if (name === null) {
       this.qname = null;
     } else if ('' === name) {
       throw new Error('Attempt to set empty name.');
     } else {
-      if (this.refTwin != null && this.refTwin.getTargetQName() != null) {
+      if (this.refTwin !== undefined && this.refTwin.getTargetQName() !== null) {
         throw new Error("Attempt to set name on object with ref='xxx'");
       }
       this.qname = new QName(this.parentSchema.getLogicalTargetNamespace(), name);

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.ts
@@ -65,7 +65,7 @@ export class XmlSchemaNamedWithFormImpl extends XmlSchemaNamedImpl implements Xm
   getWireName() {
     // If this is a ref= case, then we take the name from the ref=, not from the QName.
     // what about ref='foo' form='unqualified'? Is that possible?
-    if (this.refTwin != null && this.refTwin.getTargetQName() != null) {
+    if (this.refTwin !== undefined && this.refTwin.getTargetQName() !== null) {
       return this.refTwin.getTargetQName();
     } else {
       return this.wireName;


### PR DESCRIPTION
https://github.com/KaotoIO/kaoto/issues/3008

 - Fixed two bugs in XmlSchemaDerivationMethod.schemaValueOf: the split regex used a literal \s (never matched spaces), and for...in iterated array indices instead of values
 - Reduced cognitive complexity in SchemaBuilder, XmlSchema, and XmlSchemaDerivationMethod by extracting focused helper methods (applyToken, findByQName, applyComplexTypeAttributes, handleElementConstraints, collectExtensionAttributes) and adding early-return guards
 - Replaced the 6 nearly-identical getXxxByQName methods in XmlSchema with a single generic findByQName<T> helper
 - Added readonly to fields that are initialized once and never reassigned across SchemaBuilder, XmlSchema, XmlSchemaCollection, and SchemaKey
 - Replaced == null / != null with strict === null / !== null (or ?? / ?? =) throughout the module and subdirectories
 - Added unit tests for XmlSchemaDerivationMethod edge cases and integration tests covering final, block, and abstract derivation method parsing through real XSD fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in DerivationMethods and Constraints XML schemas for richer schema scenarios.

* **Refactor**
  * Hardened internal schema handling with stricter null/undefined checks and increased immutability to improve parsing reliability and namespace/name resolution.

* **Tests**
  * Expanded test coverage for parsing, derivation semantics, constraints, extension registry dispatch, and namespace utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->