### PR TITLE
fix(Canvas): Move after/before icons dependency on layout

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -2,8 +2,6 @@ import './StepToolbar.scss';
 
 import { Button } from '@patternfly/react-core';
 import {
-  AngleDoubleDownIcon,
-  AngleDoubleUpIcon,
   BanIcon,
   BlueprintIcon,
   CheckIcon,
@@ -15,10 +13,11 @@ import {
   TrashIcon,
 } from '@patternfly/react-icons';
 import clsx from 'clsx';
-import { FunctionComponent, useContext } from 'react';
+import { FunctionComponent, useContext, useMemo } from 'react';
 
 import { AddStepMode, IDataTestID, IVisualizationNode } from '../../../../models';
 import { SettingsContext } from '../../../../providers/settings.provider';
+import { getMoveIcons } from '../../Custom/ContextMenu/get-move-icons.util';
 import { useDeleteGroup } from '../../Custom/hooks/delete-group.hook';
 import { useDeleteStep } from '../../Custom/hooks/delete-step.hook';
 import { useDisableStep } from '../../Custom/hooks/disable-step.hook';
@@ -27,6 +26,7 @@ import { useEnableAllSteps } from '../../Custom/hooks/enable-all-steps.hook';
 import { useInsertStep } from '../../Custom/hooks/insert-step.hook';
 import { useMoveStep } from '../../Custom/hooks/move-step.hook';
 import { useReplaceStep } from '../../Custom/hooks/replace-step.hook';
+import { useGraphLayout } from '../../Custom/hooks/use-graph-layout.hook';
 
 interface IStepToolbar extends IDataTestID {
   vizNode: IVisualizationNode;
@@ -44,6 +44,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
   'data-testid': dataTestId,
 }) => {
   const settingsAdapter = useContext(SettingsContext);
+  const layout = useGraphLayout();
   const { canHaveSpecialChildren, canBeDisabled, canReplaceStep, canRemoveStep, canRemoveFlow } =
     vizNode.getNodeInteraction();
   const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
@@ -56,6 +57,9 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
   const { canDuplicate, onDuplicate } = useDuplicateStep(vizNode);
   const { canBeMoved: canMoveBefore, onMoveStep: onMoveBefore } = useMoveStep(vizNode, AddStepMode.PrependStep);
   const { canBeMoved: canMoveAfter, onMoveStep: onMoveAfter } = useMoveStep(vizNode, AddStepMode.AppendStep);
+
+  // Get the appropriate move icons based on layout and node type
+  const icons = useMemo(() => getMoveIcons(layout, vizNode), [layout, vizNode]);
 
   return (
     <div className="step-toolbar-wrapper">
@@ -76,7 +80,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
 
         {canMoveBefore && (
           <Button
-            icon={<AngleDoubleUpIcon />}
+            icon={icons.moveBefore}
             className="step-toolbar__button"
             data-testid={`${label}|step-toolbar-button-move-before`}
             variant="control"
@@ -90,7 +94,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
 
         {canMoveAfter && (
           <Button
-            icon={<AngleDoubleDownIcon />}
+            icon={icons.moveNext}
             className="step-toolbar__button"
             data-testid={`${label}|step-toolbar-button-move-after`}
             variant="control"

--- a/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
@@ -3,15 +3,8 @@ import { EdgeModel, NodeModel } from '@patternfly/react-topology';
 import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 
 export const enum LayoutType {
-  BreadthFirst = 'BreadthFirst',
-  Cola = 'Cola',
-  ColaNoForce = 'ColaNoForce',
-  Concentric = 'Concentric',
   DagreVertical = 'DagreVertical',
   DagreHorizontal = 'DagreHorizontal',
-  Force = 'Force',
-  Grid = 'Grid',
-  ColaGroups = 'ColaGroups',
 }
 
 /**

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
@@ -15,7 +15,6 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
-import { useVisualizationController } from '@patternfly/react-topology';
 import { Element } from 'hast';
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
@@ -25,7 +24,7 @@ import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityCo
 import { DocumentationEntity } from '../../../../models/documentation';
 import { VisibleFlowsContext } from '../../../../providers';
 import { DocumentationService } from '../../../../services/documentation.service';
-import { LayoutType } from '../../Canvas/canvas.models';
+import { useGraphLayout } from '../../Custom/hooks/use-graph-layout.hook';
 import { HiddenCanvas } from '../FlowExportImage/HiddenCanvas';
 import { EntitiesMenu } from './EntitiesMenu';
 import { markdownComponentMapping } from './MarkdownComponentMapping';
@@ -39,7 +38,6 @@ const FILENAME_BASE = 'route-export';
 export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPreviewModal> = ({ onClose }) => {
   const { camelResource } = useEntityContext();
   const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
-  const controller = useVisualizationController();
   const { visualEntities } = useEntityContext();
   const [markdownText, setMarkdownText] = useState<string>('');
   const [flowImageBlob, setFlowImageBlob] = useState<Blob>();
@@ -50,7 +48,7 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isGeneratingImage, setIsGeneratingImage] = useState<boolean>(false);
 
-  const currentLayout = controller.getGraph().getLayout() as LayoutType | undefined;
+  const currentLayout = useGraphLayout();
 
   const onUpdateDocumentationEntities = (documentationEntities: DocumentationEntity[]) => {
     documentationEntities.forEach((docEntity) => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
@@ -1,14 +1,12 @@
 import { Button } from '@patternfly/react-core';
 import { ImageIcon } from '@patternfly/react-icons';
-import { useVisualizationController } from '@patternfly/react-topology';
 import { useState } from 'react';
 
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
-import { LayoutType } from '../../Canvas/canvas.models';
+import { useGraphLayout } from '../../Custom/hooks/use-graph-layout.hook';
 import { HiddenCanvas } from './HiddenCanvas';
 
 export function FlowExportImage() {
-  const controller = useVisualizationController();
   const [isExporting, setIsExporting] = useState(false);
   const { visualEntities } = useEntityContext();
 
@@ -20,7 +18,7 @@ export function FlowExportImage() {
     setIsExporting(false);
   };
 
-  const currentLayout = controller.getGraph().getLayout() as LayoutType | undefined;
+  const currentLayout = useGraphLayout();
 
   return (
     <>

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
@@ -1,21 +1,10 @@
-import {
-  AngleDoubleDownIcon,
-  AngleDoubleLeftIcon,
-  AngleDoubleRightIcon,
-  AngleDoubleUpIcon,
-  ArrowDownIcon,
-  ArrowLeftIcon,
-  ArrowRightIcon,
-  ArrowUpIcon,
-  BlueprintIcon,
-  CodeBranchIcon,
-  PlusIcon,
-} from '@patternfly/react-icons';
+import { BlueprintIcon, CodeBranchIcon, PlusIcon } from '@patternfly/react-icons';
 import { ContextMenuSeparator, ElementModel, GraphElement } from '@patternfly/react-topology';
 import { forwardRef, ReactElement } from 'react';
 
 import { AddStepMode, IVisualizationNode, NodeInteraction } from '../../../../models/visualization/base-visual-entity';
-import { CanvasNode } from '../../Canvas/canvas.models';
+import { CanvasNode, LayoutType } from '../../Canvas/canvas.models';
+import { getMoveIcons } from './get-move-icons.util';
 import { ItemAddStep } from './ItemAddStep';
 import { ItemCopyStep } from './ItemCopyStep';
 import { ItemDeleteGroup } from './ItemDeleteGroup';
@@ -29,24 +18,13 @@ import { ItemMoveStep } from './ItemMoveStep';
 import { ItemPasteStep } from './ItemPasteStep';
 import { ItemReplaceStep } from './ItemReplaceStep';
 
-const getLayoutIcons = (element: GraphElement<ElementModel, CanvasNode['data']>) => {
-  const layout = element?.getGraph?.().getLayout?.() ?? '';
-  const isVertical = layout.includes('Vertical');
-
-  return {
-    prepend: isVertical ? <ArrowUpIcon /> : <ArrowLeftIcon />,
-    append: isVertical ? <ArrowDownIcon /> : <ArrowRightIcon />,
-    moveBefore: isVertical ? <AngleDoubleUpIcon /> : <AngleDoubleLeftIcon />,
-    moveNext: isVertical ? <AngleDoubleDownIcon /> : <AngleDoubleRightIcon />,
-  };
-};
-
 export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode['data']>) => {
   const items: ReactElement[] = [];
   const vizNode = element.getData()?.vizNode;
   if (!vizNode) return items;
 
-  const icons = getLayoutIcons(element);
+  const layout = element.getGraph?.().getLayout?.() as LayoutType | undefined;
+  const icons = getMoveIcons(layout, vizNode);
   const nodeInteractions = vizNode.getNodeInteraction();
   const childrenNodes = vizNode.getChildren();
   const isStepWithChildren = childrenNodes !== undefined && childrenNodes.length > 0;

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.test.ts
@@ -1,0 +1,192 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import {
+  AngleDoubleDownIcon,
+  AngleDoubleLeftIcon,
+  AngleDoubleRightIcon,
+  AngleDoubleUpIcon,
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+} from '@patternfly/react-icons';
+
+import { CatalogKind } from '../../../../models/catalog-kind';
+import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
+import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
+import { LayoutType } from '../../Canvas/canvas.models';
+import { getMoveIcons } from './get-move-icons.util';
+
+describe('getMoveIcons', () => {
+  const createMockVizNode = (processorName: string): IVisualizationNode => {
+    const data: CamelRouteVisualEntityData = {
+      catalogKind: CatalogKind.Processor,
+      name: processorName,
+      path: `route.from.steps.0.${processorName}`,
+      processorName: processorName as keyof ProcessorDefinition,
+    };
+    return createVisualizationNode(`test-${processorName}`, data);
+  };
+
+  describe('Regular steps (non-special children)', () => {
+    it('should return vertical icons for regular steps in vertical layout', () => {
+      const vizNode = createMockVizNode('log');
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowUpIcon);
+      expect(icons.append.type).toBe(ArrowDownIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleUpIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleDownIcon);
+    });
+
+    it('should return horizontal icons for regular steps in horizontal layout', () => {
+      const vizNode = createMockVizNode('log');
+
+      const icons = getMoveIcons(LayoutType.DagreHorizontal, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+
+    it('should return horizontal icons for regular steps when layout is undefined', () => {
+      const vizNode = createMockVizNode('to');
+
+      const icons = getMoveIcons(undefined, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+  });
+
+  describe('Special child nodes (array-clause processors) - inverted direction', () => {
+    it('should return horizontal icons for "when" node in vertical layout (inverted)', () => {
+      const vizNode = createMockVizNode('when');
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+
+    it('should return vertical icons for "when" node in horizontal layout (inverted)', () => {
+      const vizNode = createMockVizNode('when');
+
+      const icons = getMoveIcons(LayoutType.DagreHorizontal, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowUpIcon);
+      expect(icons.append.type).toBe(ArrowDownIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleUpIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleDownIcon);
+    });
+
+    it('should return horizontal icons for "doCatch" node in vertical layout (inverted)', () => {
+      const vizNode = createMockVizNode('doCatch');
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+
+    it('should return horizontal icons for REST DSL verb "get" in vertical layout (inverted)', () => {
+      const vizNode = createMockVizNode('get');
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+
+    it('should return horizontal icons for "onFallback" node in vertical layout (inverted)', () => {
+      const vizNode = createMockVizNode('onFallback');
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return horizontal icons when layout is undefined', () => {
+      const vizNode = createMockVizNode('log');
+
+      const icons = getMoveIcons(undefined, vizNode);
+
+      // Default to horizontal when no layout info available
+      expect(icons.prepend.type).toBe(ArrowLeftIcon);
+      expect(icons.append.type).toBe(ArrowRightIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+    });
+
+    it('should return vertical icons when vizNode is undefined', () => {
+      const icons = getMoveIcons(LayoutType.DagreVertical);
+
+      // Without vizNode, treat as regular step and follow layout
+      expect(icons.prepend.type).toBe(ArrowUpIcon);
+      expect(icons.append.type).toBe(ArrowDownIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleUpIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleDownIcon);
+    });
+
+    it('should handle vizNode without processorName', () => {
+      const data = {
+        catalogKind: CatalogKind.Processor,
+        name: 'unknown',
+        path: 'route.from.steps.0',
+      } as CamelRouteVisualEntityData;
+      const vizNode = createVisualizationNode('test-unknown', data);
+
+      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+      // Without processorName, treat as regular step
+      expect(icons.prepend.type).toBe(ArrowUpIcon);
+      expect(icons.append.type).toBe(ArrowDownIcon);
+      expect(icons.moveBefore.type).toBe(AngleDoubleUpIcon);
+      expect(icons.moveNext.type).toBe(AngleDoubleDownIcon);
+    });
+  });
+
+  describe('All special child processors', () => {
+    const specialChildProcessors = [
+      'when',
+      'otherwise',
+      'doCatch',
+      'doFinally',
+      'onFallback',
+      'get',
+      'post',
+      'put',
+      'delete',
+      'patch',
+      'head',
+    ];
+
+    specialChildProcessors.forEach((processorName) => {
+      it(`should return horizontal icons for "${processorName}" in vertical layout (inverted)`, () => {
+        const vizNode = createMockVizNode(processorName);
+
+        const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+
+        expect(icons.prepend.type).toBe(ArrowLeftIcon);
+        expect(icons.append.type).toBe(ArrowRightIcon);
+        expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+        expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+      });
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
@@ -1,0 +1,82 @@
+import {
+  AngleDoubleDownIcon,
+  AngleDoubleLeftIcon,
+  AngleDoubleRightIcon,
+  AngleDoubleUpIcon,
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+} from '@patternfly/react-icons';
+import { ReactElement } from 'react';
+
+import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
+import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
+import { LayoutType } from '../../Canvas/canvas.models';
+
+export interface MoveIcons {
+  prepend: ReactElement;
+  append: ReactElement;
+  moveBefore: ReactElement;
+  moveNext: ReactElement;
+}
+
+/**
+ * Determines the appropriate move icons based on graph layout and node type.
+ *
+ * Regular step nodes follow the graph layout:
+ * - Vertical layout: up/down arrows
+ * - Horizontal layout: left/right arrows
+ *
+ * Special child nodes (e.g., 'when' clauses in 'choice', 'doCatch' in 'doTry')
+ * use inverted direction relative to the parent container's layout:
+ * - In horizontal flow: vertical arrows (up/down)
+ * - In vertical flow: horizontal arrows (left/right)
+ *
+ * @param layout - The graph layout (LayoutType.DagreVertical or LayoutType.DagreHorizontal)
+ * @param vizNode - Optional visualization node to check if it's a special child
+ * @returns Object containing appropriate icons for prepend, append, moveBefore, and moveNext actions
+ */
+export function getMoveIcons(layout: LayoutType | undefined, vizNode?: IVisualizationNode): MoveIcons {
+  const isVerticalLayout = layout === LayoutType.DagreVertical;
+
+  // Check if this node is a special child that uses inverted direction
+  const isSpecialChild = isSpecialChildNode(vizNode);
+
+  // Special children use inverted direction: horizontal icons in vertical layout, vertical icons in horizontal layout
+  // Regular steps use icons based on the graph layout
+  const useHorizontalIcons = isSpecialChild ? isVerticalLayout : !isVerticalLayout;
+
+  return {
+    prepend: useHorizontalIcons ? <ArrowLeftIcon /> : <ArrowUpIcon />,
+    append: useHorizontalIcons ? <ArrowRightIcon /> : <ArrowDownIcon />,
+    moveBefore: useHorizontalIcons ? <AngleDoubleLeftIcon /> : <AngleDoubleUpIcon />,
+    moveNext: useHorizontalIcons ? <AngleDoubleRightIcon /> : <AngleDoubleDownIcon />,
+  };
+}
+
+/**
+ * Determines if a visualization node is a special child that uses inverted direction.
+ *
+ * Special children are nodes that belong to array-clause properties (e.g., 'when', 'doCatch')
+ * and use inverted direction relative to the parent's layout (horizontal icons in vertical flow,
+ * vertical icons in horizontal flow).
+ *
+ * @param vizNode - The visualization node to check
+ * @returns true if the node is a special child, false otherwise
+ */
+function isSpecialChildNode(vizNode?: IVisualizationNode): boolean {
+  if (!vizNode?.data) {
+    return false;
+  }
+
+  const processorName = (vizNode.data as CamelRouteVisualEntityData).processorName;
+  if (!processorName) {
+    return false;
+  }
+
+  // Check if this processor is in the list of special child processors
+  // These are processors that are part of array-clause properties and use inverted direction
+  return CamelComponentSchemaService.SPECIAL_CHILD_PROCESSORS.includes(processorName);
+}

--- a/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.tsx
@@ -26,6 +26,7 @@ import { AddStepMode, IVisualizationNode } from '../../../../models';
 import { LayoutType } from '../../Canvas';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { canDropOnEdge, GROUP_DRAG_TYPE, NODE_DRAG_TYPE } from '../customComponentUtils';
+import { useGraphLayout } from '../hooks/use-graph-layout.hook';
 import { AddStepIcon } from './AddStepIcon';
 
 type DefaultEdgeProps = Parameters<typeof DefaultEdge>[0];
@@ -59,6 +60,7 @@ export const CustomEdge: FunctionComponent<CustomEdgeProps> = observer(({ elemen
 
   const entitiesContext = useEntityContext();
   const catalogModalContext = useContext(CatalogModalContext)!;
+  const layout = useGraphLayout();
   const edgeDRef = useRef<string | null>(null);
   const startPointRef = useRef<Point | null>(null);
   const endPointRef = useRef<Point | null>(null);
@@ -109,7 +111,7 @@ export const CustomEdge: FunctionComponent<CustomEdgeProps> = observer(({ elemen
 
   const startPoint = element.getStartPoint();
   const endPoint = element.getEndPoint();
-  const isHorizontal = element.getGraph().getLayout() === LayoutType.DagreHorizontal;
+  const isHorizontal = layout === LayoutType.DagreHorizontal;
 
   let x = startPoint.x + (endPoint.x - startPoint.x - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2;
   let y = startPoint.y + (endPoint.y - startPoint.y - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2;

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.test.ts
@@ -1,0 +1,59 @@
+import { useVisualizationController } from '@patternfly/react-topology';
+import { renderHook } from '@testing-library/react';
+
+import { LayoutType } from '../../Canvas/canvas.models';
+import { useGraphLayout } from './use-graph-layout.hook';
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: jest.fn(),
+}));
+
+describe('useGraphLayout', () => {
+  it('should return the layout from the controller', () => {
+    const mockController = {
+      getGraph: jest.fn(() => ({
+        getLayout: jest.fn(() => LayoutType.DagreVertical),
+      })),
+    };
+    (useVisualizationController as jest.Mock).mockReturnValue(mockController);
+
+    const { result } = renderHook(() => useGraphLayout());
+
+    expect(result.current).toBe(LayoutType.DagreVertical);
+  });
+
+  it('should return default layout when getLayout is not available', () => {
+    const mockController = {
+      getGraph: jest.fn(() => ({
+        getLayout: undefined,
+      })),
+    };
+    (useVisualizationController as jest.Mock).mockReturnValue(mockController);
+
+    const { result } = renderHook(() => useGraphLayout());
+
+    expect(result.current).toBe(LayoutType.DagreHorizontal);
+  });
+
+  it('should return default layout when getGraph returns undefined', () => {
+    const mockController = {
+      getGraph: jest.fn(() => undefined),
+    };
+    (useVisualizationController as jest.Mock).mockReturnValue(mockController);
+
+    const { result } = renderHook(() => useGraphLayout());
+
+    expect(result.current).toBe(LayoutType.DagreHorizontal);
+  });
+
+  it('should return default layout when getGraph is not available', () => {
+    const mockController = {
+      getGraph: undefined,
+    };
+    (useVisualizationController as jest.Mock).mockReturnValue(mockController);
+
+    const { result } = renderHook(() => useGraphLayout());
+
+    expect(result.current).toBe(LayoutType.DagreHorizontal);
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.ts
@@ -1,0 +1,14 @@
+import { useVisualizationController } from '@patternfly/react-topology';
+
+import { LayoutType } from '../../Canvas/canvas.models';
+
+/**
+ * Custom hook to get the current graph layout.
+ *
+ * @returns The current graph layout (LayoutType.DagreVertical or LayoutType.DagreHorizontal)
+ */
+export const useGraphLayout = (): LayoutType => {
+  const controller = useVisualizationController();
+  const graph = controller?.getGraph?.();
+  return (graph?.getLayout?.() as LayoutType) ?? LayoutType.DagreHorizontal;
+};


### PR DESCRIPTION
This commit consider the canvas layout in order to use icons pointing in the right direction depending on Vertical or Horizontal layouts.

| Before | After |
| --- | --- |
| <img width="671" height="574" alt="image" src="https://github.com/user-attachments/assets/3199b9ab-2b4d-4c8a-a863-cfbef0f75ffd" /> | <img width="671" height="574" alt="image" src="https://github.com/user-attachments/assets/511824e1-9ef7-4740-9c12-052581150626" /> |




fix: https://github.com/KaotoIO/kaoto/issues/2849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated layout sourcing so components use a shared layout hook for consistent orientation handling.
  * Reduced supported layouts to Vertical and Horizontal only.
* **New Features**
  * Centralized move-icon logic that adapts icons based on layout and node type.
* **Tests**
  * Added unit tests for layout hook and move-icon behavior across layouts and special node cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->