### PR TITLE
chore(storybook): Set theme to light

### DIFF
--- a/packages/ui-tests/.storybook/preview.tsx
+++ b/packages/ui-tests/.storybook/preview.tsx
@@ -7,6 +7,8 @@ import '@patternfly/patternfly/utilities/Spacing/spacing.css';
 
 import type { Preview } from '@storybook/react';
 
+document.documentElement.setAttribute('data-theme-setting', 'light');
+
 const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
Due to the carbon css recently introduced, storybook stories now shows light gray font for many of titles and it's hard to read on the storybook light background. This change sets the theme to light explicitly so that the stories use light theme font.

Note: Probably this reproduces only when OS/browser theme is set to dark.

### Before
<img width="2062" height="1093" alt="Screenshot From 2026-03-31 11-31-58" src="https://github.com/user-attachments/assets/85834171-5a1f-4fd1-be94-a9fbf10fb347" />

### After
<img width="2062" height="1093" alt="Screenshot From 2026-03-31 13-08-05" src="https://github.com/user-attachments/assets/b9e51a18-c66d-4c75-a75b-b5f049bfb0a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default theme configuration in the development environment to ensure consistent styling across component documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->