### PR TITLE
Revert "Notify operator repo on stable release"

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -127,22 +127,3 @@ jobs:
         run: |
           docker push quay.io/kaotoio/kaoto-app:stable
         if: ${{ github.event.inputs.stable }}
-
-      - name: '🔑 Generate GitHub App token'
-        if: ${{ github.event.inputs.stable && !contains(github.event.inputs.tag_version, '-RC') }}
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.KAOTO_RELEASE_APP_KEY }}
-          private-key: ${{ secrets.KAOTO_NPM_TOKEN }}
-          owner: KaotoIO
-          repositories: kaoto-operator
-
-      - name: '🔔 Notify operator repo'
-        if: ${{ github.event.inputs.stable == 'true' && !contains(github.event.inputs.tag_version, '-RC') }}
-        run: |
-          gh api repos/KaotoIO/kaoto-operator/dispatches \
-            --field event_type=kaoto-release \
-            --field 'client_payload[kaoto_version]=${{ github.event.inputs.tag_version }}'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Reverts KaotoIO/kaoto#2975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated token generation and release event dispatch steps from the stable release workflow. These steps no longer execute during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->