### PR TITLE
fix(DataMapper): substitution: S.1: Field Override model update

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
@@ -7,7 +7,7 @@ import { FunctionComponent } from 'react';
 import OptIcon from '../../../assets/data-mapper/field-icons/OptIcon';
 import Repeat0Icon from '../../../assets/data-mapper/field-icons/Repeat0Icon';
 import Repeat1Icon from '../../../assets/data-mapper/field-icons/Repeat1Icon';
-import { TypeOverrideVariant } from '../../../models/datamapper/types';
+import { FieldOverrideVariant } from '../../../models/datamapper/types';
 import {
   AddMappingNodeData,
   FieldItemNodeData,
@@ -62,11 +62,11 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
     const optionalField = nodeData.field.minOccurs === 0;
     const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
     const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
-    const hasTypeOverride = nodeData.field.typeOverride !== TypeOverrideVariant.NONE;
+    const hasTypeOverride = nodeData.field.typeOverride !== FieldOverrideVariant.NONE;
 
     // Format type names with namespace prefixes for display
     const originalTypeDisplay = hasTypeOverride
-      ? formatQNameWithPrefix(nodeData.field.originalTypeQName, namespaceMap, nodeData.field.originalType)
+      ? formatQNameWithPrefix(nodeData.field.originalField?.typeQName, namespaceMap, nodeData.field.originalField?.type)
       : '';
     const overriddenTypeDisplay = hasTypeOverride
       ? formatQNameWithPrefix(nodeData.field.typeQName, namespaceMap, nodeData.field.type)

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
 import { MappingTree } from '../../../../models/datamapper/mapping';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { QName } from '../../../../xml-schema-ts/QName';
@@ -99,7 +99,7 @@ describe('FieldTypeOverride', () => {
       field,
       mockSelectedType,
       testMappingTree.namespaceMap,
-      TypeOverrideVariant.SAFE,
+      FieldOverrideVariant.SAFE,
     );
     expect(mockUpdateDocument).toHaveBeenCalled();
     expect(mockOnComplete).toHaveBeenCalled();

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useCallback } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
-import { IFieldTypeInfo, TypeOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo } from '../../../../models/datamapper/types';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 import { revertTypeOverride } from './revert-type-override';
 import { TypeOverrideModal } from './TypeOverrideModal';
@@ -54,7 +54,7 @@ export const FieldTypeOverride: FunctionComponent<FieldTypeOverrideProps> = ({
           field,
           selectedType,
           namespaceMap,
-          TypeOverrideVariant.SAFE,
+          FieldOverrideVariant.SAFE,
         );
       }
       updateDocument(document, document.definition, previousRefId);

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideIndicator.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideIndicator.tsx
@@ -3,7 +3,7 @@ import { WrenchIcon } from '@patternfly/react-icons';
 import { FunctionComponent } from 'react';
 
 import { IField } from '../../../../models/datamapper/document';
-import { TypeOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import { formatQNameWithPrefix } from '../../../../services/qname-util';
 
 interface TypeOverrideIndicatorProps {
@@ -13,8 +13,12 @@ interface TypeOverrideIndicatorProps {
 
 /** Wrench icon indicator for a field with a type override. Renders nothing if no override. */
 export const TypeOverrideIndicator: FunctionComponent<TypeOverrideIndicatorProps> = ({ field, namespaceMap = {} }) => {
-  if (!field || field.typeOverride === TypeOverrideVariant.NONE) return null;
-  const originalDisplay = formatQNameWithPrefix(field.originalTypeQName, namespaceMap, field.originalType);
+  if (!field || field.typeOverride === FieldOverrideVariant.NONE) return null;
+  const originalDisplay = formatQNameWithPrefix(
+    field.originalField?.typeQName,
+    namespaceMap,
+    field.originalField?.type,
+  );
   const currentDisplay = formatQNameWithPrefix(field.typeQName, namespaceMap, field.type);
   return (
     <Icon

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IField } from '../../../../models/datamapper/document';
 import { MappingTree } from '../../../../models/datamapper/mapping';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
 import { IMetadataApi, MetadataContext } from '../../../../providers';
 import { DataMapperMetadataService } from '../../../../services/datamapper-metadata.service';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
@@ -31,8 +31,15 @@ describe('TypeOverrideModal', () => {
     });
 
     testField = testTargetDoc.fields[0];
-    testField.typeOverride = TypeOverrideVariant.NONE;
-    testField.originalType = Types.String;
+    testField.typeOverride = FieldOverrideVariant.NONE;
+    testField.originalField = {
+      name: testField.name,
+      namespaceURI: testField.namespaceURI,
+      namespacePrefix: testField.namespacePrefix,
+      type: Types.String,
+      typeQName: null,
+      namedTypeFragmentRefs: [],
+    };
   });
 
   afterEach(() => {
@@ -185,7 +192,7 @@ describe('TypeOverrideModal', () => {
   });
 
   it('should not show Remove Override button when field has no override', () => {
-    testField.typeOverride = TypeOverrideVariant.NONE;
+    testField.typeOverride = FieldOverrideVariant.NONE;
 
     render(
       <TypeOverrideModal
@@ -275,8 +282,15 @@ describe('TypeOverrideModal', () => {
   });
 
   it('should call onRemove when Remove Override button is clicked', () => {
-    testField.typeOverride = TypeOverrideVariant.SAFE;
-    testField.originalType = Types.String;
+    testField.typeOverride = FieldOverrideVariant.SAFE;
+    testField.originalField = {
+      name: testField.name,
+      namespaceURI: testField.namespaceURI,
+      namespacePrefix: testField.namespacePrefix,
+      type: Types.String,
+      typeQName: null,
+      namedTypeFragmentRefs: [],
+    };
 
     const onRemoveMock = jest.fn();
 
@@ -406,7 +420,7 @@ describe('TypeOverrideModal', () => {
 
     jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockCandidates);
 
-    testField.typeOverride = TypeOverrideVariant.SAFE;
+    testField.typeOverride = FieldOverrideVariant.SAFE;
     testField.typeQName = new QName(NS_XML_SCHEMA, 'int');
 
     render(

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
@@ -22,7 +22,7 @@ import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useEffect,
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField, SCHEMA_FILE_NAME_PATTERN_XML } from '../../../../models/datamapper/document';
-import { IFieldTypeInfo, TypeOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo } from '../../../../models/datamapper/types';
 import { MetadataContext } from '../../../../providers';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 import { formatQNameWithPrefix } from '../../../../services/qname-util';
@@ -67,7 +67,7 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
     setTypeCandidates(candidates);
 
     // If field has an existing override, pre-select it by matching namespace URI + local part
-    if (field.typeOverride !== TypeOverrideVariant.NONE && field.typeQName) {
+    if (field.typeOverride !== FieldOverrideVariant.NONE && field.typeQName) {
       const typeString = formatQNameWithPrefix(field.typeQName, namespaceMap);
       setSelectedType(candidates[typeString] || null);
     } else {
@@ -203,9 +203,10 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
     [handleToggleSelect, isSelectOpen, selectedType?.displayName],
   );
 
-  const hasExistingOverride = field?.typeOverride !== TypeOverrideVariant.NONE;
+  const hasExistingOverride = field?.typeOverride !== FieldOverrideVariant.NONE;
 
-  const originalTypeDisplay = field?.originalTypeQName?.toString() || field?.originalType || field?.type || 'Unknown';
+  const originalTypeDisplay =
+    field?.originalField?.typeQName?.toString() || field?.originalField?.type || field?.type || 'Unknown';
   const fieldName = field?.displayName || field?.name || 'Field';
   const fieldPath = field?.path?.toString() || '';
   const modalTitle = (

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { DocumentTree } from '../../../../models/datamapper/document-tree';
-import { TypeOverrideVariant, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../../../../models/datamapper/types';
 import { DocumentNodeData, FieldNodeData } from '../../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
@@ -168,8 +168,15 @@ describe('withFieldOverrideContextMenu', () => {
   it('should show Reset Override menu item when field has type override', () => {
     const { documentNodeData, fieldNode } = createFieldNode();
     const field = (fieldNode.nodeData as FieldNodeData).field;
-    field.typeOverride = TypeOverrideVariant.SAFE;
-    field.originalType = Types.String;
+    field.typeOverride = FieldOverrideVariant.SAFE;
+    field.originalField = {
+      name: field.name,
+      namespaceURI: field.namespaceURI,
+      namespacePrefix: field.namespacePrefix,
+      type: Types.String,
+      typeQName: null,
+      namedTypeFragmentRefs: [],
+    };
 
     render(
       <SourceDocumentNodeWithContextMenu
@@ -192,8 +199,15 @@ describe('withFieldOverrideContextMenu', () => {
   it('should call revertFieldTypeOverride when clicking Reset Override', () => {
     const { document, documentNodeData, fieldNode } = createFieldNode();
     const field = (fieldNode.nodeData as FieldNodeData).field;
-    field.typeOverride = TypeOverrideVariant.SAFE;
-    field.originalType = Types.String;
+    field.typeOverride = FieldOverrideVariant.SAFE;
+    field.originalField = {
+      name: field.name,
+      namespaceURI: field.namespaceURI,
+      namespacePrefix: field.namespacePrefix,
+      type: Types.String,
+      typeQName: null,
+      namedTypeFragmentRefs: [],
+    };
 
     const revertSpy = jest.spyOn(FieldTypeOverrideService, 'revertFieldTypeOverride');
 
@@ -283,7 +297,7 @@ describe('withFieldOverrideContextMenu', () => {
       field,
       mockCandidates['xs:int'],
       expect.any(Object),
-      TypeOverrideVariant.SAFE,
+      FieldOverrideVariant.SAFE,
     );
 
     applySpy.mockRestore();

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.tsx
@@ -2,7 +2,7 @@ import { ComponentType, MouseEvent, useCallback, useEffect, useRef, useState } f
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { DocumentTreeNode } from '../../../../models/datamapper/document-tree-node';
-import { TypeOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import { VisualizationService } from '../../../../services/visualization.service';
 import { FieldContextMenu } from '../FieldContextMenu';
 import { FieldTypeOverride } from './FieldTypeOverride';
@@ -32,7 +32,7 @@ export function withFieldOverrideContextMenu<P extends WithTreeNode>(
     const { mappingTree, updateDocument, refreshMappingTree } = useDataMapper();
 
     const field = VisualizationService.getField(treeNode.nodeData);
-    const hasTypeOverride = !!field && field.typeOverride !== TypeOverrideVariant.NONE;
+    const hasTypeOverride = !!field && field.typeOverride !== FieldOverrideVariant.NONE;
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -1,10 +1,10 @@
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { MaxOccursType } from '../../xml-schema-ts/constants';
 import { QName } from '../../xml-schema-ts/QName';
-import { IChoiceSelection, IFieldTypeOverride } from './metadata';
+import { IChoiceSelection, IFieldSubstitution, IFieldTypeOverride } from './metadata';
 import { NodePath } from './nodepath';
 import { ReportMessage } from './schema';
-import { TypeOverrideVariant, Types } from './types';
+import { FieldOverrideVariant, Types } from './types';
 import { Predicate } from './xpath';
 
 /**
@@ -12,6 +12,50 @@ import { Predicate } from './xpath';
  * A field can be a child of either a document or another field.
  */
 export type IParentType = IDocument | IField;
+
+/**
+ * Immutable snapshot of a field's identity and structure taken **before** the first type override
+ * or substitution is applied. Stored on {@link IField.originalField} and cleared on revert.
+ *
+ * ## Restoration strategy
+ *
+ * On revert, `restoreOriginalTypeToField` restores `fields` and `namedTypeFragmentRefs`
+ * independently to cover all schema variants:
+ *
+ * | Schema variant | Snapshot | Restored state |
+ * |---|---|---|
+ * | XML named type | `refs=[T]`, `fields=undefined` | `fields=[]`, `refs=[T]` — re-expandable via `resolveTypeFragment` |
+ * | XML inline anonymous type | `refs=[]`, `fields=[c1,c2]` | `fields=[c1,c2]`, `refs=[]` — inline children restored directly |
+ * | JSON `$ref` + `properties` | `refs=[R]`, `fields=[inline]` | `fields=[inline]`, `refs=[R]` — pre-expansion state restored |
+ * | Simple / primitive type | `refs=[]`, `fields=undefined` | `fields=[]`, `refs=[]` (or derived from type) |
+ *
+ * ## Snapshot safety
+ *
+ * The snapshot is always taken in a **pre-adoption** context via `??=` guards in
+ * `resolveTypeFragment` (before `adoptTypeFragment` runs) and `applyTypeOverrideToField` (only
+ * fires when `originalField` is still `undefined`, which means `resolveTypeFragment` has not yet
+ * expanded the field). Post-adoption children therefore can never appear in `fields`.
+ *
+ * `fields` is captured as a **shallow-copied array** of field references (not a deep copy).
+ * This preserves pre-override membership while keeping object identity for existing child nodes.
+ * `applyTypeOverrideToField` replaces `field.fields` with a new empty array rather than mutating
+ * existing elements, so the snapshot remains unaffected by subsequent adoptions.
+ */
+export interface IOriginalFieldState {
+  name: string;
+  namespaceURI: string | null;
+  namespacePrefix: string | null;
+  type: Types;
+  typeQName: QName | null;
+  /** Original `namedTypeFragmentRefs` at snapshot time. Set at field expansion for named types; empty for inline types. */
+  namedTypeFragmentRefs: string[];
+  /**
+   * Original `fields` at snapshot time. Present when the field held inline children at capture
+   * time (XML anonymous complex type, or JSON `$ref` + `properties` mixed node). Absent (`undefined`)
+   * for named-type fields whose children are re-derived from `namedTypeFragmentRefs` on expansion.
+   */
+  fields?: IField[];
+}
 
 /**
  * Document ID constant for the main body document.
@@ -39,12 +83,14 @@ export interface IField {
   type: Types;
   /** The data format specific, qualified name of the current type of this field, if applicable */
   typeQName: QName | null;
-  /** Original data type of this field before any overrides, in DataMapper common style */
-  originalType: Types;
-  /** The data format specific, qualified name of the original type of this field before any overrides, if applicable */
-  originalTypeQName: QName | null;
+  /**
+   * Snapshot of the original field state. Set lazily on field expansion or just before the first override or substitution,
+   * whichever comes first. Cleared when the override is reverted.
+   * @see IOriginalFieldState for the restoration strategy covering all schema variants.
+   */
+  originalField?: IOriginalFieldState;
   /** Indicates whether and how the type has been overridden */
-  typeOverride: TypeOverrideVariant;
+  typeOverride: FieldOverrideVariant;
   /** Child fields for complex types */
   fields: IField[];
   /** Whether this field represents an attribute (vs element) */
@@ -208,9 +254,7 @@ export class PrimitiveDocument extends BaseDocument implements IField {
   parent: IParentType = this;
   type = Types.AnyType;
   typeQName: QName | null = null;
-  originalType = Types.AnyType;
-  originalTypeQName: QName | null = null;
-  typeOverride = TypeOverrideVariant.NONE;
+  typeOverride = FieldOverrideVariant.NONE;
   path: NodePath;
   id: string;
   displayName: string;
@@ -250,9 +294,7 @@ export class BaseField implements IField {
   isAttribute: boolean = false;
   type = Types.AnyType;
   typeQName: QName | null = null;
-  originalType = Types.AnyType;
-  originalTypeQName: QName | null = null;
-  typeOverride = TypeOverrideVariant.NONE;
+  typeOverride = FieldOverrideVariant.NONE;
   minOccurs: number = 0;
   maxOccurs: MaxOccursType = 1;
   defaultValue: string | null = null;
@@ -262,6 +304,7 @@ export class BaseField implements IField {
   predicates: Predicate[] = [];
   isChoice?: boolean;
   selectedMemberIndex?: number;
+  originalField?: IOriginalFieldState;
 
   protected mergeInto(existing: IField): void {
     if (this.type && this.type !== Types.AnyType) existing.type = this.type;
@@ -285,9 +328,8 @@ export class BaseField implements IField {
     adopted.isAttribute = this.isAttribute;
     adopted.type = this.type;
     adopted.typeQName = this.typeQName;
-    adopted.originalType = this.originalType;
-    adopted.originalTypeQName = this.originalTypeQName;
     adopted.typeOverride = this.typeOverride;
+    adopted.originalField = this.originalField;
     adopted.minOccurs = this.minOccurs;
     adopted.maxOccurs = this.maxOccurs;
     adopted.defaultValue = this.defaultValue;
@@ -333,6 +375,7 @@ export class DocumentDefinition {
     public rootElementChoice?: RootElementOption,
     public fieldTypeOverrides?: IFieldTypeOverride[],
     public choiceSelections?: IChoiceSelection[],
+    public fieldSubstitutions?: IFieldSubstitution[],
   ) {
     if (!definitionFiles) this.definitionFiles = {};
   }

--- a/packages/ui/src/models/datamapper/metadata.ts
+++ b/packages/ui/src/models/datamapper/metadata.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinitionType, RootElementOption } from './document';
-import { TypeOverrideVariant } from './types';
+import { FieldOverrideVariant } from './types';
 
 /**
  * Shared base for overrides and selections that are addressed by schema path.
@@ -23,12 +23,16 @@ export interface IBaseOverride {
  */
 export interface IFieldTypeOverride extends IBaseOverride {
   /**
-   * The new type to apply to the field.
+   * The new type to apply to the field, in `<prefix>:<localName>` form
+   * (e.g. `xs:string`, `ns0:MyType`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
    */
   type: string;
 
   /**
-   * The original type of the field before the override.
+   * The original type of the field before the override, in `<prefix>:<localName>` form
+   * (e.g. `xs:string`, `ns0:MyType`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
    */
   originalType: string;
 
@@ -37,7 +41,27 @@ export interface IFieldTypeOverride extends IBaseOverride {
    * - SAFE: The override is safe and compatible with the original type.
    * - FORCE: The override is forced and may not be compatible with the original type.
    */
-  variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE;
+  variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE;
+}
+
+/**
+ * Represents an element substitution for a field in a document.
+ * Used to substitute an element with another element from the same substitution group.
+ */
+export interface IFieldSubstitution extends IBaseOverride {
+  /**
+   * The substitute element name in `<prefix>:<localName>` form
+   * (e.g. `ns0:AlrtMetaDtaReq`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
+   */
+  name: string;
+
+  /**
+   * The original element name in `<prefix>:<localName>` form
+   * (e.g. `ns0:Message`). The prefix is resolved via
+   * {@link IDataMapperMetadata.namespaceMap}.
+   */
+  originalName: string;
 }
 
 /**
@@ -75,6 +99,12 @@ export interface IDocumentMetadata {
    * Persists which choice member is selected for each choice field.
    */
   choiceSelections?: IChoiceSelection[];
+
+  /**
+   * Array of element substitutions for fields in the document.
+   * Allows substituting an element with another from the same substitution group.
+   */
+  fieldSubstitutions?: IFieldSubstitution[];
 }
 
 /**

--- a/packages/ui/src/models/datamapper/types.ts
+++ b/packages/ui/src/models/datamapper/types.ts
@@ -32,10 +32,11 @@ export enum Types {
   Array = 'Array',
 }
 
-export enum TypeOverrideVariant {
+export enum FieldOverrideVariant {
   NONE = 'NONE',
   SAFE = 'SAFE',
   FORCE = 'FORCE',
+  SUBSTITUTION = 'SUBSTITUTION',
 }
 
 /**

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -1,6 +1,11 @@
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
-import { IChoiceSelection, IDataMapperMetadata, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import {
+  IChoiceSelection,
+  IDataMapperMetadata,
+  IFieldSubstitution,
+  IFieldTypeOverride,
+} from '../models/datamapper/metadata';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
 import { getCommonTypesJsonSchema, getCustomerJsonSchema, getOrderJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DataMapperMetadataService } from './datamapper-metadata.service';
@@ -465,7 +470,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Root/Field1',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       const definition = new DocumentDefinition(
@@ -513,6 +518,31 @@ describe('DataMapperMetadataService', () => {
 
       expect(metadata.sourceBody.fieldTypeOverrides).toBeUndefined();
     });
+
+    it('should persist fieldSubstitutions from DocumentDefinition', async () => {
+      const metadata = DataMapperMetadataService.createMetadata('test.xsl');
+      const fieldSubstitutions: IFieldSubstitution[] = [
+        {
+          schemaPath: '/ns0:Root/ns0:Message',
+          name: 'ns0:AlrtMetaDtaReq',
+          originalName: 'ns0:Message',
+        },
+      ];
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'source.xsd': '<schema/>' },
+        undefined,
+        undefined,
+        undefined,
+        fieldSubstitutions,
+      );
+
+      await DataMapperMetadataService.updateSourceBodyMetadata(mockApi, 'test-id', metadata, definition);
+
+      expect(metadata.sourceBody.fieldSubstitutions).toEqual(fieldSubstitutions);
+    });
   });
 
   describe('updateTargetBodyMetadata', () => {
@@ -544,7 +574,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns1:Order/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [{ schemaPath: '/ns1:Order/{choice:0}', selectedMemberIndex: 0 }];
@@ -616,7 +646,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Config/Setting',
           type: 'xs:string',
           originalType: 'xs:anyType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [{ schemaPath: '/ns0:Config/{choice:0}', selectedMemberIndex: 1 }];
@@ -905,13 +935,13 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/Field1',
               type: 'ns0:Type1',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
             {
               schemaPath: '/ns0:Root/Field2',
               type: 'ns0:Type2',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
           ],
         },
@@ -927,13 +957,13 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns0:Root/Field1',
         type: 'ns0:Type1',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
       expect(overrides[1]).toEqual({
         schemaPath: '/ns0:Root/Field2',
         type: 'ns0:Type2',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -949,7 +979,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns1:Order/ShipTo',
               type: 'ns1:ExtendedShipTo',
               originalType: 'xs:anyType',
-              variant: TypeOverrideVariant.SAFE,
+              variant: FieldOverrideVariant.SAFE,
             },
           ],
         },
@@ -963,7 +993,7 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns1:Order/ShipTo',
         type: 'ns1:ExtendedShipTo',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -979,7 +1009,7 @@ describe('DataMapperMetadataService', () => {
                 schemaPath: '/ns0:Config/Setting',
                 type: 'xs:string',
                 originalType: 'xs:anyType',
-                variant: TypeOverrideVariant.SAFE,
+                variant: FieldOverrideVariant.SAFE,
               },
             ],
           },
@@ -995,7 +1025,7 @@ describe('DataMapperMetadataService', () => {
         schemaPath: '/ns0:Config/Setting',
         type: 'xs:string',
         originalType: 'xs:anyType',
-        variant: TypeOverrideVariant.SAFE,
+        variant: FieldOverrideVariant.SAFE,
       });
     });
 
@@ -1041,6 +1071,32 @@ describe('DataMapperMetadataService', () => {
 
       expect(overrides).toEqual([]);
     });
+
+    it('should return empty array for PARAM document type without paramName', () => {
+      const metadata: IDataMapperMetadata = {
+        sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        sourceParameters: {},
+        targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        xsltPath: 'transform.xsl',
+      };
+
+      const overrides = DataMapperMetadataService.getFieldTypeOverrides(metadata, DocumentType.PARAM);
+
+      expect(overrides).toEqual([]);
+    });
+
+    it('should return empty array for unknown DocumentType', () => {
+      const metadata: IDataMapperMetadata = {
+        sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        sourceParameters: {},
+        targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+        xsltPath: 'transform.xsl',
+      };
+
+      const overrides = DataMapperMetadataService.getFieldTypeOverrides(metadata, 99 as unknown as DocumentType);
+
+      expect(overrides).toEqual([]);
+    });
   });
 
   describe('setFieldTypeOverrides()', () => {
@@ -1054,7 +1110,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/OldField',
               type: 'xs:int',
               originalType: 'xs:string',
-              variant: TypeOverrideVariant.FORCE,
+              variant: FieldOverrideVariant.FORCE,
             },
           ],
         },
@@ -1068,13 +1124,13 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Root/Field1',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
         {
           schemaPath: '/ns0:Root/Field2',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -1103,7 +1159,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns1:Order/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -1134,7 +1190,7 @@ describe('DataMapperMetadataService', () => {
           schemaPath: '/ns0:Config/Setting',
           type: 'xs:string',
           originalType: 'xs:anyType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
 
@@ -1161,7 +1217,7 @@ describe('DataMapperMetadataService', () => {
               schemaPath: '/ns0:Root/Field',
               type: 'xs:int',
               originalType: 'xs:string',
-              variant: TypeOverrideVariant.FORCE,
+              variant: FieldOverrideVariant.FORCE,
             },
           ],
         },

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -156,6 +156,7 @@ export class DataMapperMetadataService {
           documentMetadata.rootElementChoice,
           documentMetadata.fieldTypeOverrides,
           documentMetadata.choiceSelections,
+          documentMetadata.fieldSubstitutions,
         );
         resolve(answer);
       });
@@ -200,6 +201,7 @@ export class DataMapperMetadataService {
       rootElementChoice: definition.rootElementChoice,
       fieldTypeOverrides: definition.fieldTypeOverrides,
       choiceSelections: definition.choiceSelections,
+      fieldSubstitutions: definition.fieldSubstitutions,
     };
     const filePromises =
       api.shouldSaveSchema && definition.definitionFiles

--- a/packages/ui/src/services/document-util.service.json.test.ts
+++ b/packages/ui/src/services/document-util.service.json.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType, Types } from '../models/datamapper';
 import { IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { getAccountJsonSchema } from '../stubs/datamapper/data-mapper';
 import { DocumentUtilService } from './document-util.service';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
@@ -137,7 +137,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:string[@key="AccountId"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -145,7 +145,7 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const accountIdField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'AccountId');
       expect(accountIdField?.type).toBe(Types.Numeric);
-      expect(accountIdField?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(accountIdField?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply type override to nested JSON field', () => {
@@ -161,7 +161,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:map[@key="Address"]/fn:string[@key="City"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -170,7 +170,7 @@ describe('DocumentUtilService - JSON Schema', () => {
       const addressField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'Address');
       const cityField = addressField?.fields.find((f) => 'key' in f && f.key === 'City');
       expect(cityField?.type).toBe(Types.Numeric);
-      expect(cityField?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(cityField?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should distinguish between fields with same key at different levels', () => {
@@ -201,7 +201,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:map[@key="map"]/fn:string[@key="foo"]',
           type: 'number',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -209,12 +209,12 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.String);
-      expect(topLevelFoo?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(topLevelFoo?.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const mapField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'map');
       const nestedFoo = mapField?.fields.find((f) => 'key' in f && f.key === 'foo');
       expect(nestedFoo?.type).toBe(Types.Numeric);
-      expect(nestedFoo?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(nestedFoo?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply override to /fn:map/fn:string[@key=foo] but not /fn:map[@key=map]/fn:string[@key=foo]', () => {
@@ -245,7 +245,7 @@ describe('DocumentUtilService - JSON Schema', () => {
           schemaPath: '/fn:map/fn:string[@key="foo"]',
           type: 'boolean',
           originalType: 'string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -253,12 +253,12 @@ describe('DocumentUtilService - JSON Schema', () => {
 
       const topLevelFoo = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'foo');
       expect(topLevelFoo?.type).toBe(Types.Boolean);
-      expect(topLevelFoo?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(topLevelFoo?.typeOverride).toBe(FieldOverrideVariant.FORCE);
 
       const mapField = doc.fields[0].fields.find((f) => 'key' in f && f.key === 'map');
       const nestedFoo = mapField?.fields.find((f) => 'key' in f && f.key === 'foo');
       expect(nestedFoo?.type).toBe(Types.String);
-      expect(nestedFoo?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(nestedFoo?.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
   });
 });

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -3,13 +3,14 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
+  PrimitiveDocument,
   Types,
 } from '../models/datamapper';
 import { IField } from '../models/datamapper/document';
 import { DocumentTree } from '../models/datamapper/document-tree';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { DocumentNodeData } from '../models/datamapper/visualization';
 import {
   getCamelSpringXsd,
@@ -44,6 +45,13 @@ describe('DocumentUtilService', () => {
       const stackWithSelf = DocumentUtilService.getFieldStack(sourceDoc.fields[0].fields[1], true);
       expect(stackWithSelf.length).toEqual(2);
       expect(stackWithSelf[0].name).toEqual('OrderPerson');
+    });
+
+    it('should return empty array for PrimitiveDocument', () => {
+      const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test-doc');
+      const primitiveDoc = new PrimitiveDocument(definition);
+      const stack = DocumentUtilService.getFieldStack(primitiveDoc);
+      expect(stack).toEqual([]);
     });
   });
 
@@ -93,6 +101,47 @@ describe('DocumentUtilService', () => {
       // occurrences must be taken from the referrer as opposed to the other attributes
       expect(route?.minOccurs).toEqual(0);
       expect(route?.maxOccurs).toEqual('unbounded');
+    });
+
+    it('should not overwrite originalField if already set', () => {
+      const testDoc = TestUtil.createSourceOrderDoc();
+      const testChildField = new XmlSchemaField(testDoc, 'testField', false);
+      testChildField.type = Types.String;
+      testDoc.namedTypeFragments['testFragment'] = {
+        type: Types.Container,
+        minOccurs: 1,
+        maxOccurs: 1,
+        namedTypeFragmentRefs: [],
+        fields: [testChildField],
+      };
+
+      const refField = new XmlSchemaField(testDoc.fields[0], 'testRefField', false);
+      refField.namedTypeFragmentRefs.push('testFragment');
+      testDoc.fields[0].fields.push(refField);
+
+      const existingOriginalField = {
+        name: 'testRefField',
+        namespaceURI: null,
+        namespacePrefix: null,
+        type: Types.String,
+        typeQName: null,
+        namedTypeFragmentRefs: ['testFragment'],
+      };
+      refField.originalField = existingOriginalField;
+
+      DocumentUtilService.resolveTypeFragment(refField);
+
+      expect(refField.originalField).toBe(existingOriginalField);
+    });
+
+    it('should not throw and preserve unresolved refs when a namedTypeFragmentRef does not exist in namedTypeFragments', () => {
+      const testDoc = TestUtil.createSourceOrderDoc();
+      const refField = new XmlSchemaField(testDoc.fields[0], 'missingRefField', false);
+      refField.namedTypeFragmentRefs = ['nonExistentRef'];
+      testDoc.fields[0].fields.push(refField);
+
+      expect(() => DocumentUtilService.resolveTypeFragment(refField)).not.toThrow();
+      expect(refField.namedTypeFragmentRefs).toEqual(['nonExistentRef']);
     });
   });
 
@@ -164,6 +213,19 @@ describe('DocumentUtilService', () => {
 
       expect(field.fields.length).toBe(2);
     });
+
+    it('should not throw when a namedTypeFragmentRef inside a fragment does not exist in namedTypeFragments', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const field = new XmlSchemaField(doc, 'testField', false);
+
+      const fragment = {
+        fields: [],
+        namedTypeFragmentRefs: ['nonExistentChildRef'],
+      };
+
+      expect(() => DocumentUtilService.adoptTypeFragment(field, fragment)).not.toThrow();
+      expect(field.fields).toHaveLength(0);
+    });
   });
 
   describe('processTypeOverrides()', () => {
@@ -174,7 +236,7 @@ describe('DocumentUtilService', () => {
       DocumentUtilService.processTypeOverrides(doc, [], {}, XmlSchemaTypesService.parseTypeOverride);
 
       expect(orderPerson?.type).toBe(Types.String);
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
 
     it('should apply type override to top-level field', () => {
@@ -185,7 +247,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -193,7 +255,7 @@ describe('DocumentUtilService', () => {
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Integer);
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should apply type override to nested field', () => {
@@ -204,7 +266,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -213,7 +275,7 @@ describe('DocumentUtilService', () => {
       const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo');
       const city = shipTo?.fields.find((f) => f.name === 'City');
       expect(city?.type).toBe(Types.Integer);
-      expect(city?.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(city?.typeOverride).toBe(FieldOverrideVariant.FORCE);
       expect(city?.fields).toEqual([]);
     });
 
@@ -225,13 +287,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -253,7 +315,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'ns0:CustomType',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
 
@@ -261,8 +323,7 @@ describe('DocumentUtilService', () => {
 
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       expect(orderPerson?.type).toBe(Types.Container);
-      // Eager resolution clears namedTypeFragmentRefs even when fragment is not found
-      expect(orderPerson?.namedTypeFragmentRefs).toHaveLength(0);
+      expect(orderPerson?.namedTypeFragmentRefs).toHaveLength(1);
       expect(orderPerson?.fields).toEqual([]);
     });
 
@@ -290,7 +351,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Name',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -322,7 +383,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Address/tns:City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -354,7 +415,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -382,7 +443,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/{choice:0}/targetField',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -415,13 +476,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Name',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/tns:Root/tns:Company/tns:CompanyName',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -460,7 +521,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
 
       const result = DocumentUtilService.processTypeOverride(
@@ -483,7 +544,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:NonExistent',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
 
       const result = DocumentUtilService.processTypeOverride(
@@ -503,7 +564,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, first, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -511,7 +572,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:boolean',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, second, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -529,7 +590,7 @@ describe('DocumentUtilService', () => {
         schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
         type: 'xs:int',
         originalType: 'xs:string',
-        variant: TypeOverrideVariant.FORCE,
+        variant: FieldOverrideVariant.FORCE,
       };
       DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
 
@@ -537,7 +598,7 @@ describe('DocumentUtilService', () => {
 
       expect(result).toBe(true);
       const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
-      expect(orderPerson?.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(orderPerson?.typeOverride).toBe(FieldOverrideVariant.NONE);
       expect(doc.definition.fieldTypeOverrides).toHaveLength(0);
     });
 
@@ -556,6 +617,187 @@ describe('DocumentUtilService', () => {
       const result = DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap);
 
       expect(result).toBe(false);
+    });
+
+    it('should return false when schemaPath is not present in fieldTypeOverrides', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      doc.definition.fieldTypeOverrides = [
+        {
+          schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+          type: 'xs:int',
+          originalType: 'xs:string',
+          variant: FieldOverrideVariant.FORCE,
+        },
+      ];
+
+      const result = DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/NonExistent', namespaceMap);
+
+      expect(result).toBe(false);
+    });
+
+    it('should restore fields=[] and refs=[] when reverting override on a simple-type field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+        type: 'xs:int',
+        originalType: 'xs:string',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson')!;
+      expect(orderPerson.originalField?.fields).toBeUndefined();
+      expect(orderPerson.originalField?.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap);
+
+      expect(orderPerson.fields).toHaveLength(0);
+      expect(orderPerson.namedTypeFragmentRefs).toHaveLength(0);
+      expect(orderPerson.originalField).toBeUndefined();
+    });
+
+    it('should restore namedTypeFragmentRefs when reverting override on a named-type field', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'lazy.xsd': getLazyLoadingTestXsd() },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const lazyNamespaceMap = { tns: 'http://www.example.com/LAZYTEST', xs: NS_XML_SCHEMA };
+
+      const person = doc.fields[0].fields.find((f) => f.name === 'Person')!;
+      expect(person.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/tns:Root/tns:Person',
+        type: 'xs:string',
+        originalType: 'tns:PersonType',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, lazyNamespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(person.originalField?.fields).toBeUndefined();
+      expect(person.originalField?.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+      expect(person.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/tns:Root/tns:Person', lazyNamespaceMap);
+
+      expect(person.namedTypeFragmentRefs).toHaveLength(1);
+      expect(person.fields).toHaveLength(0);
+      expect(person.originalField).toBeUndefined();
+    });
+
+    it('should restore inline children when reverting override on an XML anonymous-type field', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo')!;
+      const originalChildren = shipTo.fields;
+      expect(originalChildren).toHaveLength(4);
+      expect(shipTo.namedTypeFragmentRefs).toHaveLength(0);
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ShipTo',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(shipTo.fields).toHaveLength(0);
+      expect(shipTo.originalField?.fields).toEqual(originalChildren);
+      expect(shipTo.originalField?.namedTypeFragmentRefs).toHaveLength(0);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ShipTo', namespaceMap);
+
+      expect(shipTo.fields).toEqual(originalChildren);
+      expect(shipTo.fields.map((f) => f.name)).toEqual(['Name', 'Address', 'City', 'Country']);
+      expect(shipTo.namedTypeFragmentRefs).toHaveLength(0);
+      expect(shipTo.originalField).toBeUndefined();
+    });
+
+    it('should preserve namespace values across apply and revert of a type override', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const namespaceMap2 = { ns0: 'io.kaoto.datamapper.poc.test', xs: NS_XML_SCHEMA };
+      const orderPerson = doc.fields[0].fields.find((f) => f.name === 'OrderPerson')!;
+      const originalNamespaceURI = orderPerson.namespaceURI;
+      const originalNamespacePrefix = orderPerson.namespacePrefix;
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
+        type: 'xs:int',
+        originalType: 'xs:string',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap2, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(orderPerson.originalField!.namespaceURI).toBe(originalNamespaceURI);
+      expect(orderPerson.originalField!.namespacePrefix).toBe(originalNamespacePrefix);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ns0:OrderPerson', namespaceMap2);
+
+      expect(orderPerson.namespaceURI).toBe(originalNamespaceURI);
+      expect(orderPerson.namespacePrefix).toBe(originalNamespacePrefix);
+    });
+
+    it('should capture and restore null namespace values without coercing to empty string', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const namespaceMap2 = { ns0: 'io.kaoto.datamapper.poc.test', xs: NS_XML_SCHEMA };
+      const shipTo = doc.fields[0].fields.find((f) => f.name === 'ShipTo')!;
+      shipTo.namespaceURI = null;
+      shipTo.namespacePrefix = null;
+
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/ShipTo',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap2, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(shipTo.originalField!.namespaceURI).toBeNull();
+      expect(shipTo.originalField!.namespacePrefix).toBeNull();
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/ShipTo', namespaceMap2);
+
+      expect(shipTo.namespaceURI).toBeNull();
+      expect(shipTo.namespacePrefix).toBeNull();
+    });
+
+    it('should restore both inline children and refs when reverting override on a field with both set', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const shipOrderField = doc.fields[0];
+
+      const mixedField = new XmlSchemaField(shipOrderField, 'mixedField', false);
+      mixedField.type = Types.Container;
+      mixedField.namedTypeFragmentRefs = ['someRef'];
+      const childField = new XmlSchemaField(mixedField, 'child', false);
+      childField.type = Types.String;
+      mixedField.fields.push(childField);
+      shipOrderField.fields.push(mixedField);
+
+      const originalChildren = mixedField.fields;
+      const override: IFieldTypeOverride = {
+        schemaPath: '/ns0:ShipOrder/mixedField',
+        type: 'xs:string',
+        originalType: 'container',
+        variant: FieldOverrideVariant.FORCE,
+      };
+      DocumentUtilService.processTypeOverride(doc, override, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
+
+      expect(mixedField.fields).toHaveLength(0);
+      expect(mixedField.namedTypeFragmentRefs).toHaveLength(0);
+      expect(mixedField.originalField?.fields).toEqual(originalChildren);
+      expect(mixedField.originalField?.namedTypeFragmentRefs).toEqual(['someRef']);
+
+      DocumentUtilService.removeTypeOverride(doc, '/ns0:ShipOrder/mixedField', namespaceMap);
+
+      expect(mixedField.fields).toEqual(originalChildren);
+      expect(mixedField.namedTypeFragmentRefs).toEqual(['someRef']);
+      expect(mixedField.originalField).toBeUndefined();
     });
   });
 
@@ -580,7 +822,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [
@@ -616,7 +858,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       const choiceSelections: IChoiceSelection[] = [
@@ -659,13 +901,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -695,13 +937,13 @@ describe('DocumentUtilService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
         {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:boolean',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
 
@@ -1073,7 +1315,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Address',
           type: 'tns:DetailedAddressType',
           originalType: 'tns:USAddressType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);
@@ -1129,7 +1371,7 @@ describe('DocumentUtilService', () => {
           schemaPath: '/tns:Root/tns:Person/tns:Address',
           type: 'tns:DetailedAddressType',
           originalType: 'tns:USAddressType',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       DocumentUtilService.processTypeOverrides(doc, overrides, namespaceMap, XmlSchemaTypesService.parseTypeOverride);

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -1,6 +1,13 @@
-import { IDocument, IField, IParentType, ITypeFragment, PrimitiveDocument } from '../models/datamapper';
+import {
+  IDocument,
+  IField,
+  IOriginalFieldState,
+  IParentType,
+  ITypeFragment,
+  PrimitiveDocument,
+} from '../models/datamapper';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { SchemaPathService } from './schema-path.service';
 
@@ -8,7 +15,7 @@ export type ParseTypeOverrideFn = (
   typeString: string,
   namespaceMap: Record<string, string>,
   field: IField,
-) => { type: Types; typeQName: QName; variant: TypeOverrideVariant };
+) => { type: Types; typeQName: QName; variant: FieldOverrideVariant };
 
 /**
  * The collection of utility functions shared among {@link DocumentService}, {@link XmlSchemaDocumentService}
@@ -38,15 +45,31 @@ export class DocumentUtilService {
    */
   static resolveTypeFragment(field: IField): IField {
     if (field.namedTypeFragmentRefs.length === 0) return field;
+    field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
     const doc = DocumentUtilService.getOwnerDocument(field);
-    field.namedTypeFragmentRefs.forEach((ref) => {
+    const unresolvedRefs: string[] = [];
+    for (const ref of field.namedTypeFragmentRefs) {
       const fragment = doc.namedTypeFragments[ref];
-      if (fragment) {
-        DocumentUtilService.adoptTypeFragment(field, fragment);
+      if (!fragment) {
+        unresolvedRefs.push(ref);
+        continue;
       }
-    });
-    field.namedTypeFragmentRefs = [];
+      DocumentUtilService.adoptTypeFragment(field, fragment);
+    }
+    field.namedTypeFragmentRefs = unresolvedRefs;
     return field;
+  }
+
+  private static captureOriginalFieldState(field: IField): IOriginalFieldState {
+    return {
+      name: field.name,
+      namespaceURI: field.namespaceURI,
+      namespacePrefix: field.namespacePrefix,
+      type: field.type,
+      typeQName: field.typeQName,
+      namedTypeFragmentRefs: [...field.namedTypeFragmentRefs],
+      fields: field.fields.length > 0 ? [...field.fields] : undefined,
+    };
   }
 
   /**
@@ -61,12 +84,11 @@ export class DocumentUtilService {
     if (fragment.minOccurs !== undefined) field.minOccurs = fragment.minOccurs;
     if (fragment.maxOccurs !== undefined) field.maxOccurs = fragment.maxOccurs;
     fragment.fields.forEach((f) => f.adopt(field));
-    fragment.namedTypeFragmentRefs.forEach((childRef) => {
+    for (const childRef of fragment.namedTypeFragmentRefs) {
       const childFragment = doc.namedTypeFragments[childRef];
-      if (childFragment) {
-        DocumentUtilService.adoptTypeFragment(field, childFragment);
-      }
-    });
+      if (!childFragment) continue;
+      DocumentUtilService.adoptTypeFragment(field, childFragment);
+    }
   }
 
   /**
@@ -101,8 +123,8 @@ export class DocumentUtilService {
    * @example
    * ```typescript
    * const overrides = [
-   *   { schemaPath: '/ns0:ShipOrder/ns0:OrderPerson', type: 'xs:int', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE },
-   *   { schemaPath: '/ns0:ShipOrder/ShipTo/City', type: 'xs:boolean', originalType: 'xs:string', variant: TypeOverrideVariant.FORCE }
+   *   { schemaPath: '/ns0:ShipOrder/ns0:OrderPerson', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+   *   { schemaPath: '/ns0:ShipOrder/ShipTo/City', type: 'xs:boolean', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE }
    * ];
    * DocumentUtilService.processTypeOverrides(
    *   document,
@@ -149,7 +171,7 @@ export class DocumentUtilService {
    *   schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
    *   type: 'xs:int',
    *   originalType: 'xs:string',
-   *   variant: TypeOverrideVariant.FORCE,
+   *   variant: FieldOverrideVariant.FORCE,
    * };
    * DocumentUtilService.processTypeOverride(
    *   document,
@@ -262,6 +284,8 @@ export class DocumentUtilService {
     namespaceMap: Record<string, string>,
     parseTypeOverride: ParseTypeOverrideFn,
   ): void {
+    field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
+
     const { type, typeQName, variant } = parseTypeOverride(typeString, namespaceMap, field);
 
     field.type = type;
@@ -288,13 +312,25 @@ export class DocumentUtilService {
    * @param field - The field to restore to its original type
    */
   private static restoreOriginalTypeToField(field: IField): void {
-    field.type = field.originalType;
-    field.typeQName = field.originalTypeQName;
-    field.typeOverride = TypeOverrideVariant.NONE;
-    field.fields = [];
+    const origType = field.originalField?.type ?? field.type;
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const origRefs = field.originalField?.namedTypeFragmentRefs;
+    const origFields = field.originalField?.fields;
 
-    if (field.originalType === Types.Container && field.originalTypeQName) {
-      field.namedTypeFragmentRefs = [field.originalTypeQName.toString()];
+    field.type = origType;
+    field.typeQName = origTypeQName;
+    if (field.originalField) {
+      field.namespaceURI = field.originalField.namespaceURI;
+      field.namespacePrefix = field.originalField.namespacePrefix;
+    }
+    field.typeOverride = FieldOverrideVariant.NONE;
+    field.originalField = undefined;
+
+    field.fields = origFields ?? [];
+    if (origRefs !== undefined) {
+      field.namedTypeFragmentRefs = [...origRefs];
+    } else if (!origFields && origType === Types.Container && origTypeQName) {
+      field.namedTypeFragmentRefs = [origTypeQName.toString()];
       // Eagerly resolve type fragment so children are immediately available
       DocumentUtilService.resolveTypeFragment(field);
     } else {

--- a/packages/ui/src/services/document.service.test.ts
+++ b/packages/ui/src/services/document.service.test.ts
@@ -9,7 +9,8 @@ import {
   PrimitiveDocument,
   RootElementOption,
 } from '../models/datamapper';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { IMetadataApi } from '../providers';
 import { getCartJsonSchema, getMultipleElementsXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { DocumentService } from './document.service';
@@ -665,10 +666,16 @@ describe('DocumentService', () => {
           schemaPath: '/old:Order/field',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.SAFE,
+          variant: FieldOverrideVariant.SAFE,
         },
       ];
       originalDocument.definition.choiceSelections = [{ schemaPath: '/old:Order/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old:Order/field',
+        name: 'ns0:Sub',
+        originalName: 'ns0:Field',
+      };
+      originalDocument.definition.fieldSubstitutions = [substitution];
 
       const invoiceOption: RootElementOption = {
         name: 'Invoice',
@@ -679,6 +686,7 @@ describe('DocumentService', () => {
 
       expect(updatedDocument.definition.fieldTypeOverrides).toEqual([]);
       expect(updatedDocument.definition.choiceSelections).toEqual([]);
+      expect(updatedDocument.definition.fieldSubstitutions).toEqual([]);
     });
   });
 

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -8,7 +8,7 @@ import {
   Types,
 } from '../models/datamapper';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant } from '../models/datamapper/types';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import { getImportedTypesXsd, getNamedTypesXsd, getShipOrderXsd, TestUtil } from '../stubs/datamapper/data-mapper';
 import { QName } from '../xml-schema-ts/QName';
 import { FieldTypeOverrideService } from './field-type-override.service';
@@ -29,7 +29,7 @@ describe('FieldTypeOverrideService', () => {
     it('should return all types for xs:anyType fields', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const anyTypeField = doc.fields[0].fields[0];
-      anyTypeField.originalType = Types.AnyType;
+      anyTypeField.type = Types.AnyType;
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(anyTypeField, namespaceMap);
@@ -42,7 +42,7 @@ describe('FieldTypeOverrideService', () => {
     it('should return extensions and restrictions for Container types', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const containerField = doc.fields[0];
-      containerField.originalType = Types.Container;
+      containerField.type = Types.Container;
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(containerField, namespaceMap);
@@ -55,12 +55,62 @@ describe('FieldTypeOverrideService', () => {
       const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!stringField) throw new Error('Field not found');
 
-      stringField.originalType = Types.String;
+      stringField.type = Types.String;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(stringField, namespaceMap);
 
       expect(typeof candidates).toBe('object');
+    });
+
+    it('should return all types when originalField.type is AnyType even if current type differs', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!field) throw new Error('Field not found');
+
+      field.originalField = {
+        name: field.name,
+        namespaceURI: '',
+        namespacePrefix: '',
+        type: Types.AnyType,
+        typeQName: null,
+        namedTypeFragmentRefs: [],
+      };
+      field.type = Types.Integer;
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+
+      expect(Object.keys(candidates).length).toBeGreaterThan(0);
+      expect(Object.values(candidates).some((c) => c.displayName === 'xs:string')).toBe(true);
+    });
+
+    it('should return empty Record for JSON Schema fields without AnyType original', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        {
+          'test.json': JSON.stringify({
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          }),
+        },
+      );
+
+      const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const root = doc.fields[0];
+      const nameField = root.fields.find((f) => f.key === 'name');
+      if (!nameField) throw new Error('Field not found');
+
+      const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(nameField, {});
+
+      expect(typeof candidates).toBe('object');
+      expect(Object.keys(candidates).length).toBe(0);
     });
   });
 
@@ -255,12 +305,13 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(override.schemaPath).toBe('/ns0:ShipOrder/ns0:OrderPerson');
       expect(override.type).toBe('xs:int');
-      expect(override.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(override.originalType).toBe('xs:string');
+      expect(override.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should create override with schema path through choice compositor', () => {
@@ -283,10 +334,50 @@ describe('FieldTypeOverrideService', () => {
         emailField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(override.schemaPath).toBe('/ns0:ShipOrder/{choice:0}/email');
+    });
+
+    it('should use originalField.type as originalType when field was already overridden', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      const intCandidate = {
+        displayName: 'xs:int',
+        typeQName: new QName(NS_XML_SCHEMA, 'int'),
+        type: Types.Integer,
+        isBuiltIn: true,
+      };
+      const boolCandidate = {
+        displayName: 'xs:boolean',
+        typeQName: new QName(NS_XML_SCHEMA, 'boolean'),
+        type: Types.Boolean,
+        isBuiltIn: true,
+      };
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.applyFieldTypeOverride(
+        doc,
+        stringField,
+        intCandidate,
+        namespaceMap,
+        FieldOverrideVariant.FORCE,
+      );
+
+      const firstOverrideOriginalType = doc.definition.fieldTypeOverrides![0].originalType;
+
+      const secondOverride = FieldTypeOverrideService.createFieldTypeOverride(
+        stringField,
+        boolCandidate,
+        namespaceMap,
+        FieldOverrideVariant.FORCE,
+      );
+
+      expect(secondOverride.originalType).toBe(firstOverrideOriginalType);
+      expect(secondOverride.originalType).not.toBe(intCandidate.displayName);
     });
   });
 
@@ -297,7 +388,7 @@ describe('FieldTypeOverrideService', () => {
       if (!stringField) throw new Error('Field not found');
 
       expect(stringField.type).toBe(Types.String);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const candidate = {
         displayName: 'xs:int',
@@ -312,11 +403,11 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(stringField.type).toBe(Types.Integer);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.FORCE);
       expect(doc.definition.fieldTypeOverrides).toBeDefined();
       expect(doc.definition.fieldTypeOverrides![0].schemaPath).toBe('/ns0:ShipOrder/ns0:OrderPerson');
     });
@@ -329,7 +420,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [{ schemaPath: '/ns0:ShipOrder/ShipTo/{choice:0}', selectedMemberIndex: 0 }];
@@ -350,7 +441,7 @@ describe('FieldTypeOverrideService', () => {
         shipToField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(doc.definition.fieldTypeOverrides?.some((o) => o.schemaPath === '/ns0:ShipOrder/ShipTo/City')).toBe(false);
@@ -389,10 +480,10 @@ describe('FieldTypeOverrideService', () => {
         isBuiltIn: true,
       };
 
-      FieldTypeOverrideService.applyFieldTypeOverride(doc, nameField, candidate, {}, TypeOverrideVariant.FORCE);
+      FieldTypeOverrideService.applyFieldTypeOverride(doc, nameField, candidate, {}, FieldOverrideVariant.FORCE);
 
       expect(nameField.type).toBe(Types.Numeric);
-      expect(nameField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(nameField.typeOverride).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should register unknown namespaceURI in namespaceMap and store prefixed typeString', () => {
@@ -414,7 +505,7 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(Object.values(namespaceMap)).toContain(newNamespace);
@@ -435,10 +526,10 @@ describe('FieldTypeOverrideService', () => {
       };
 
       expect(() => {
-        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, FieldOverrideVariant.FORCE);
       }).toThrow(TypeError);
       expect(() => {
-        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, TypeOverrideVariant.FORCE);
+        FieldTypeOverrideService.applyFieldTypeOverride(document, document, candidate, {}, FieldOverrideVariant.FORCE);
       }).toThrow('Field type override is not supported for primitive documents');
     });
 
@@ -464,7 +555,7 @@ describe('FieldTypeOverrideService', () => {
           mockDoc as unknown as IField,
           candidate,
           {},
-          TypeOverrideVariant.FORCE,
+          FieldOverrideVariant.FORCE,
         );
       }).toThrow(TypeError);
       expect(() => {
@@ -473,7 +564,7 @@ describe('FieldTypeOverrideService', () => {
           mockDoc as unknown as IField,
           candidate,
           {},
-          TypeOverrideVariant.FORCE,
+          FieldOverrideVariant.FORCE,
         );
       }).toThrow('Unsupported document type');
     });
@@ -500,16 +591,16 @@ describe('FieldTypeOverrideService', () => {
         stringField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       expect(stringField.type).toBe(Types.Integer);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.FORCE);
 
       FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
 
       expect(stringField.type).toBe(originalType);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
       expect(doc.definition.fieldTypeOverrides?.length).toBe(0);
     });
 
@@ -519,13 +610,13 @@ describe('FieldTypeOverrideService', () => {
       if (!stringField) throw new Error('Field not found');
 
       const originalType = stringField.type;
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
 
       const namespaceMap = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
       FieldTypeOverrideService.revertFieldTypeOverride(doc, stringField, namespaceMap);
 
       expect(stringField.type).toBe(originalType);
-      expect(stringField.typeOverride).toBe(TypeOverrideVariant.NONE);
+      expect(stringField.typeOverride).toBe(FieldOverrideVariant.NONE);
     });
 
     it('should invalidate descendant overrides and selections after reverting type override', () => {
@@ -546,7 +637,7 @@ describe('FieldTypeOverrideService', () => {
         shipToField,
         candidate,
         namespaceMap,
-        TypeOverrideVariant.FORCE,
+        FieldOverrideVariant.FORCE,
       );
 
       doc.definition.fieldTypeOverrides = [
@@ -555,7 +646,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/ShipTo/City',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [
@@ -640,7 +731,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections = [
@@ -741,7 +832,7 @@ describe('FieldTypeOverrideService', () => {
           schemaPath: '/ns0:ShipOrder/{choice:0}/email/emailAddress',
           type: 'xs:int',
           originalType: 'xs:string',
-          variant: TypeOverrideVariant.FORCE,
+          variant: FieldOverrideVariant.FORCE,
         },
       ];
       doc.definition.choiceSelections!.push({

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, IDocument, IField, PrimitiveDocument } from '../models/datamapper/document';
 import { IChoiceSelection, IFieldTypeOverride } from '../models/datamapper/metadata';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../models/datamapper/types';
 import { DocumentUtilService, ParseTypeOverrideFn } from './document-util.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -30,7 +30,7 @@ import { XmlSchemaTypesService } from './xml-schema-types.service';
  *   field,
  *   selectedCandidate,
  *   namespaceMap,
- *   TypeOverrideVariant.FORCE
+ *   FieldOverrideVariant.FORCE
  * );
  *
  * // Remove a type override
@@ -68,7 +68,7 @@ export class FieldTypeOverrideService {
     field: IField,
     namespaceMap: Record<string, string>,
   ): Record<string, IFieldTypeInfo> {
-    if (field.originalType === Types.AnyType) {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
       return FieldTypeOverrideService.getAllOverrideCandidates(field.ownerDocument, namespaceMap);
     }
 
@@ -156,13 +156,13 @@ export class FieldTypeOverrideService {
    *   orderPersonField,
    *   candidate,
    *   namespaceMap,
-   *   TypeOverrideVariant.FORCE
+   *   FieldOverrideVariant.FORCE
    * );
    * // Returns: {
    * //   schemaPath: '/ns0:ShipOrder/ns0:OrderPerson',
    * //   type: 'xs:int',
    * //   originalType: 'xs:string',
-   * //   variant: TypeOverrideVariant.FORCE
+   * //   variant: FieldOverrideVariant.FORCE
    * // }
    *
    * // Apply the override
@@ -179,10 +179,12 @@ export class FieldTypeOverrideService {
     field: IField,
     candidate: IFieldTypeInfo,
     namespaceMap: Record<string, string>,
-    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+    variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE,
   ): IFieldTypeOverride {
     const schemaPath = SchemaPathService.build(field, namespaceMap);
-    const originalTypeString = formatQNameWithPrefix(field.originalTypeQName, namespaceMap);
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const origType = field.originalField?.type ?? field.type;
+    const originalTypeString = formatQNameWithPrefix(origTypeQName, namespaceMap, origType);
     const typeString = formatQNameWithPrefix(candidate.typeQName, namespaceMap);
     return {
       schemaPath,
@@ -232,7 +234,7 @@ export class FieldTypeOverrideService {
    *   field,
    *   candidate,
    *   namespaceMap,
-   *   TypeOverrideVariant.FORCE
+   *   FieldOverrideVariant.FORCE
    * );
    *
    * // Persist changes via provider
@@ -248,7 +250,7 @@ export class FieldTypeOverrideService {
     field: IField,
     candidate: IFieldTypeInfo,
     namespaceMap: Record<string, string>,
-    variant: TypeOverrideVariant.SAFE | TypeOverrideVariant.FORCE,
+    variant: FieldOverrideVariant.SAFE | FieldOverrideVariant.FORCE,
   ): void {
     if (document instanceof PrimitiveDocument) {
       throw new TypeError('Field type override is not supported for primitive documents');
@@ -295,7 +297,7 @@ export class FieldTypeOverrideService {
    * @see applyFieldTypeOverride
    */
   static revertFieldTypeOverride(document: IDocument, field: IField, namespaceMap: Record<string, string>): void {
-    if (field.typeOverride === TypeOverrideVariant.NONE) return;
+    if (field.typeOverride === FieldOverrideVariant.NONE) return;
     const schemaPath = SchemaPathService.build(field, namespaceMap);
     const changed = DocumentUtilService.removeTypeOverride(document, schemaPath, namespaceMap);
     if (changed) {
@@ -357,6 +359,7 @@ export class FieldTypeOverrideService {
       document.definition.rootElementChoice,
       document.definition.fieldTypeOverrides,
       document.definition.choiceSelections,
+      document.definition.fieldSubstitutions,
     );
   }
 

--- a/packages/ui/src/services/json-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/json-schema-document-util.service.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import {
   JsonSchemaCollection,
@@ -245,7 +245,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(null, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse number type override', () => {
@@ -258,7 +258,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Numeric);
       expect(result.typeQName).toEqual(new QName(null, 'number'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse boolean type override', () => {
@@ -271,7 +271,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Boolean);
       expect(result.typeQName).toEqual(new QName(null, 'boolean'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse array type override', () => {
@@ -284,7 +284,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Array);
       expect(result.typeQName).toEqual(new QName(null, 'array'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse object type override', () => {
@@ -297,7 +297,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, 'object'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should parse type reference with #/ prefix as Container', () => {
@@ -310,7 +310,7 @@ describe('JsonSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, '#/definitions/MyType'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should return FORCE variant when overriding non-AnyType field', () => {
@@ -322,7 +322,7 @@ describe('JsonSchemaDocumentUtilService', () => {
       const result = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
 
       expect(result.type).toBe(Types.Numeric);
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 

--- a/packages/ui/src/services/json-schema-document.model.ts
+++ b/packages/ui/src/services/json-schema-document.model.ts
@@ -459,7 +459,6 @@ export class JsonSchemaField extends BaseField {
     const ownerDocument = ('ownerDocument' in parent ? parent.ownerDocument : parent) as JsonSchemaDocument;
     super(parent, ownerDocument, key);
     this.type = type;
-    this.originalType = type;
     this.name = JsonSchemaDocumentUtilService.toXsltTypeName(this.type);
     const keyPart = this.key ? `-${this.key}` : '';
     this.id = `fj-${this.name}${keyPart}${getCamelRandomId('', 4)}`;
@@ -518,9 +517,8 @@ export class JsonSchemaField extends BaseField {
     to.namespacePrefix = this.namespacePrefix;
     to.namespaceURI = this.namespaceURI;
     to.typeQName = this.typeQName;
-    to.originalType = this.originalType;
-    to.originalTypeQName = this.originalTypeQName;
     to.typeOverride = this.typeOverride;
+    to.originalField = this.originalField;
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     to.isChoice = this.isChoice;
     to.selectedMemberIndex = this.selectedMemberIndex;

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -2,7 +2,9 @@ import { JSONSchema7 } from 'json-schema';
 
 import { DocumentDefinition, DocumentDefinitionType, PathExpression, Types } from '../models/datamapper';
 import { BODY_DOCUMENT_ID, DocumentType } from '../models/datamapper/document';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
 import { NS_XPATH_FUNCTIONS } from '../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../models/datamapper/types';
 import {
   getAccountJsonSchema,
   getCamelYamlDslJsonSchema,
@@ -931,6 +933,34 @@ describe('JsonSchemaDocumentService', () => {
         namespaceUri: '',
         name: 'Account.schema.json',
       });
+    });
+
+    it('should clear fieldTypeOverrides, choiceSelections and fieldSubstitutions when primary schema is removed', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.JSON_SCHEMA,
+        'test-doc',
+        { 'Account.schema.json': getAccountJsonSchema(), 'camelYamlDsl.json': getCamelYamlDslJsonSchema() },
+        { namespaceUri: '', name: 'Account.schema.json' },
+      );
+      definition.fieldTypeOverrides = [
+        { schemaPath: '/old/path', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+      ];
+      definition.choiceSelections = [{ schemaPath: '/old/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old/path',
+        name: 'ns0:newName',
+        originalName: 'ns0:oldName',
+      };
+      definition.fieldSubstitutions = [substitution];
+
+      const removeResult = JsonSchemaDocumentService.removeSchemaFile(definition, 'Account.schema.json');
+
+      expect(removeResult.validationStatus).not.toBe('error');
+      expect(removeResult.document).toBeDefined();
+      expect(removeResult.documentDefinition!.fieldTypeOverrides).toEqual([]);
+      expect(removeResult.documentDefinition!.choiceSelections).toEqual([]);
+      expect(removeResult.documentDefinition!.fieldSubstitutions).toEqual([]);
     });
   });
 });

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -173,6 +173,7 @@ export class JsonSchemaDocumentService {
       definition.rootElementChoice,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
+      definition.fieldSubstitutions,
     );
 
     // Try to create the Document object. It could fail if the primary schema is the removed schema file.
@@ -186,6 +187,9 @@ export class JsonSchemaDocumentService {
 
     // Unset the primary schema and retry
     updatedDefinition.rootElementChoice = undefined;
+    updatedDefinition.fieldTypeOverrides = [];
+    updatedDefinition.choiceSelections = [];
+    updatedDefinition.fieldSubstitutions = [];
     return JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition, namespaceMap);
   }
 
@@ -526,7 +530,6 @@ export class JsonSchemaDocumentService {
   private assignRefTypeQName(field: JsonSchemaField, ref: string): void {
     const refQName = new QName(null, ref);
     field.typeQName = refQName;
-    field.originalTypeQName = refQName;
   }
 
   private assignTypeMetadata(field: JsonSchemaField, schema: JsonSchemaMetadata): void {
@@ -535,7 +538,6 @@ export class JsonSchemaDocumentService {
       const typeString = typeArray[0];
       const typeQName = new QName(null, typeString);
       field.typeQName = typeQName;
-      field.originalTypeQName = typeQName;
     }
 
     if (schema.required) {

--- a/packages/ui/src/services/json-schema-types.service.test.ts
+++ b/packages/ui/src/services/json-schema-types.service.test.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper/document';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import { JsonSchemaDocument, JsonSchemaField } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { JsonSchemaTypesService } from './json-schema-types.service';
@@ -162,7 +162,7 @@ describe('JsonSchemaTypesService', () => {
 
       const parseResult = JsonSchemaTypesService.parseTypeOverride('string', {}, field);
 
-      expect(parseResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(parseResult.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should determine FORCE variant for non-AnyType field', () => {
@@ -179,7 +179,7 @@ describe('JsonSchemaTypesService', () => {
 
       const parseResult = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
 
-      expect(parseResult.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(parseResult.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 

--- a/packages/ui/src/services/json-schema-types.service.ts
+++ b/packages/ui/src/services/json-schema-types.service.ts
@@ -1,5 +1,5 @@
 import { IField } from '../models/datamapper/document';
-import { IFieldTypeInfo, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../models/datamapper/types';
 import { QName } from '../xml-schema-ts/QName';
 import { JsonSchemaDocument } from './json-schema-document.model';
 
@@ -31,7 +31,7 @@ export class JsonSchemaTypesService {
    * @example
    * ```typescript
    * const result = JsonSchemaTypesService.parseTypeOverride('number', {}, field);
-   * // result = { type: Types.Numeric, typeQName: QName, variant: TypeOverrideVariant.SAFE }
+   * // result = { type: Types.Numeric, typeQName: QName, variant: FieldOverrideVariant.SAFE }
    *
    * const refResult = JsonSchemaTypesService.parseTypeOverride('#/definitions/Address', {}, field);
    * // result = { type: Types.Container, typeQName: QName, variant: ... }
@@ -41,7 +41,7 @@ export class JsonSchemaTypesService {
     typeString: string,
     _namespaceMap: Record<string, string>,
     field: IField,
-  ): { type: Types; typeQName: QName; variant: TypeOverrideVariant } {
+  ): { type: Types; typeQName: QName; variant: FieldOverrideVariant } {
     const type = typeString.startsWith('#/') ? Types.Container : JsonSchemaTypesService.mapTypeStringToEnum(typeString);
 
     const typeQName = new QName(null, typeString);
@@ -63,12 +63,12 @@ export class JsonSchemaTypesService {
    * @param _typeString - The type string (unused but kept for interface consistency)
    * @returns SAFE if original type is AnyType, FORCE otherwise
    */
-  static determineOverrideVariant(field: IField, _newType: Types, _typeString: string): TypeOverrideVariant {
-    if (field.originalType === Types.AnyType) {
-      return TypeOverrideVariant.SAFE;
+  static determineOverrideVariant(field: IField, _newType: Types, _typeString: string): FieldOverrideVariant {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
+      return FieldOverrideVariant.SAFE;
     }
 
-    return TypeOverrideVariant.FORCE;
+    return FieldOverrideVariant.FORCE;
   }
 
   /**
@@ -179,7 +179,7 @@ export class JsonSchemaTypesService {
    * // Always returns {}
    * ```
    */
-  static getTypeOverrideCandidatesForField(_field: { originalTypeQName?: unknown }): Record<string, IFieldTypeInfo> {
+  static getTypeOverrideCandidatesForField(_field: IField): Record<string, IFieldTypeInfo> {
     return {};
   }
 }

--- a/packages/ui/src/services/xml-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document-util.service.test.ts
@@ -1,7 +1,7 @@
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import { BaseDocument } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import {
   getAccountLcXsd,
   getAccountNs2Xsd,
@@ -251,7 +251,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:int type override', () => {
@@ -263,7 +263,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Integer);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'int'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:boolean type override', () => {
@@ -275,7 +275,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Boolean);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'boolean'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:date type override', () => {
@@ -287,7 +287,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Date);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'date'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse xs:decimal type override', () => {
@@ -299,7 +299,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Decimal);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'decimal'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse custom type override with FORCE variant', () => {
@@ -311,7 +311,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.String);
       expect(result.typeQName).toEqual(new QName(NS_XML_SCHEMA, 'string'));
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should parse type without prefix', () => {
@@ -324,7 +324,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       expect(result.type).toBe(Types.Container);
       expect(result.typeQName).toEqual(new QName(null, 'CustomType'));
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should handle schema with extension types', () => {
@@ -377,7 +377,7 @@ describe('XmlSchemaDocumentUtilService', () => {
 
       const result = XmlSchemaTypesService.parseTypeOverride('ns0:UnrelatedType', namespaceMap, shipTo);
 
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
 
     it('should return SAFE variant when re-overriding with compatible extension type', () => {
@@ -395,12 +395,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const requestField = doc.fields.find((f) => f.name === 'Request');
       if (!requestField) throw new Error('Request field not found');
 
-      requestField.originalType = Types.Container;
-      requestField.originalTypeQName = new QName('http://www.example.com/TEST', 'Message');
+      requestField.type = Types.Container;
+      requestField.typeQName = new QName('http://www.example.com/TEST', 'Message');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE extension variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'extension.xsd': getExtensionComplexXsd() },
+      );
+      const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(extensionResult.validationStatus).toBe('success');
+      const doc = extensionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
+
+      const requestField = doc.fields.find((f) => f.name === 'Request');
+      if (!requestField) throw new Error('Request field not found');
+
+      requestField.type = Types.String;
+      requestField.originalField = {
+        name: requestField.name,
+        namespaceURI: requestField.namespaceURI,
+        namespacePrefix: requestField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/TEST', 'Message'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -419,12 +450,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const addressField = doc.fields.find((f) => f.name === 'Address');
       if (!addressField) throw new Error('Address field not found');
 
-      addressField.originalType = Types.Container;
-      addressField.originalTypeQName = new QName('http://www.example.com/RESTRICT', 'BaseAddress');
+      addressField.type = Types.Container;
+      addressField.typeQName = new QName('http://www.example.com/RESTRICT', 'BaseAddress');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:SimpleAddress', namespaceMap, addressField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE restriction variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'restriction.xsd': getRestrictionComplexXsd() },
+      );
+      const restrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(restrictionResult.validationStatus).toBe('success');
+      const doc = restrictionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/RESTRICT', xs: NS_XML_SCHEMA };
+
+      const addressField = doc.fields.find((f) => f.name === 'Address');
+      if (!addressField) throw new Error('Address field not found');
+
+      addressField.type = Types.String;
+      addressField.originalField = {
+        name: addressField.name,
+        namespaceURI: addressField.namespaceURI,
+        namespacePrefix: addressField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/RESTRICT', 'BaseAddress'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:SimpleAddress', namespaceMap, addressField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -443,12 +505,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const requestField = doc.fields.find((f) => f.name === 'Request');
       if (!requestField) throw new Error('Request field not found');
 
-      requestField.originalType = Types.Container;
-      requestField.originalTypeQName = new QName('http://www.example.com/TEST', 'UnrelatedType');
+      requestField.type = Types.Container;
+      requestField.typeQName = new QName('http://www.example.com/TEST', 'UnrelatedType');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.FORCE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining FORCE incompatible variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'extension.xsd': getExtensionComplexXsd() },
+      );
+      const extensionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(extensionResult.validationStatus).toBe('success');
+      const doc = extensionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
+
+      const requestField = doc.fields.find((f) => f.name === 'Request');
+      if (!requestField) throw new Error('Request field not found');
+
+      requestField.type = Types.String;
+      requestField.originalField = {
+        name: requestField.name,
+        namespaceURI: requestField.namespaceURI,
+        namespacePrefix: requestField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/TEST', 'UnrelatedType'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:BaseRequest', namespaceMap, requestField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.FORCE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -467,8 +560,8 @@ describe('XmlSchemaDocumentUtilService', () => {
       const extendedValueField = doc.fields.find((f) => f.name === 'ExtendedValue');
       if (!extendedValueField) throw new Error('ExtendedValue field not found');
 
-      extendedValueField.originalType = Types.Container;
-      extendedValueField.originalTypeQName = new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType');
+      extendedValueField.type = Types.Container;
+      extendedValueField.typeQName = new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride(
         'ns0:ComplexExtendingSimple',
@@ -476,7 +569,42 @@ describe('XmlSchemaDocumentUtilService', () => {
         extendedValueField,
       );
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE derived simple type variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'simple.xsd': getSimpleTypeInheritanceXsd() },
+      );
+      const simpleInheritResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(simpleInheritResult.validationStatus).toBe('success');
+      const doc = simpleInheritResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/SIMPLEINHERIT', xs: NS_XML_SCHEMA };
+
+      const extendedValueField = doc.fields.find((f) => f.name === 'ExtendedValue');
+      if (!extendedValueField) throw new Error('ExtendedValue field not found');
+
+      extendedValueField.type = Types.String;
+      extendedValueField.originalField = {
+        name: extendedValueField.name,
+        namespaceURI: extendedValueField.namespaceURI,
+        namespacePrefix: extendedValueField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/SIMPLEINHERIT', 'ExtendedValueType'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride(
+        'ns0:ComplexExtendingSimple',
+        namespaceMap,
+        extendedValueField,
+      );
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
 
@@ -495,12 +623,43 @@ describe('XmlSchemaDocumentUtilService', () => {
       const ageField = doc.fields.find((f) => f.name === 'Age');
       if (!ageField) throw new Error('Age field not found');
 
-      ageField.originalType = Types.Container;
-      ageField.originalTypeQName = new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger');
+      ageField.type = Types.Container;
+      ageField.typeQName = new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger');
 
       const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:AgeType', namespaceMap, ageField);
 
-      expect(overrideResult.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
+      expect(overrideResult.type).toBe(Types.Container);
+    });
+
+    it('should use originalField type/typeQName over field state when determining SAFE simple restriction variant', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'simple.xsd': getSimpleTypeRestrictionXsd() },
+      );
+      const simpleRestrictionResult = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(simpleRestrictionResult.validationStatus).toBe('success');
+      const doc = simpleRestrictionResult.document!;
+      const namespaceMap = { ns0: 'http://www.example.com/SIMPLETYPE', xs: NS_XML_SCHEMA };
+
+      const ageField = doc.fields.find((f) => f.name === 'Age');
+      if (!ageField) throw new Error('Age field not found');
+
+      ageField.type = Types.String;
+      ageField.originalField = {
+        name: ageField.name,
+        namespaceURI: ageField.namespaceURI,
+        namespacePrefix: ageField.namespacePrefix,
+        type: Types.Container,
+        typeQName: new QName('http://www.example.com/SIMPLETYPE', 'BaseInteger'),
+        namedTypeFragmentRefs: [],
+      };
+
+      const overrideResult = XmlSchemaTypesService.parseTypeOverride('ns0:AgeType', namespaceMap, ageField);
+
+      expect(overrideResult.variant).toBe(FieldOverrideVariant.SAFE);
       expect(overrideResult.type).toBe(Types.Container);
     });
   });

--- a/packages/ui/src/services/xml-schema-document.model.ts
+++ b/packages/ui/src/services/xml-schema-document.model.ts
@@ -82,9 +82,8 @@ export class XmlSchemaField extends BaseField {
     const adopted = new XmlSchemaField(parent, this.name, this.isAttribute);
     adopted.type = this.type;
     adopted.typeQName = this.typeQName;
-    adopted.originalType = this.originalType;
-    adopted.originalTypeQName = this.originalTypeQName;
     adopted.typeOverride = this.typeOverride;
+    adopted.originalField = this.originalField;
     adopted.minOccurs = this.minOccurs;
     adopted.maxOccurs = this.maxOccurs;
     adopted.minOccursExplicit = this.minOccursExplicit;

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -4,7 +4,8 @@ import {
   DocumentDefinitionType,
   DocumentType,
 } from '../models/datamapper/document';
-import { Types } from '../models/datamapper/types';
+import { IFieldSubstitution } from '../models/datamapper/metadata';
+import { FieldOverrideVariant, Types } from '../models/datamapper/types';
 import {
   getAnonymousGlobalElementRefLargeXsd,
   getCamelSpringXsd,
@@ -1444,6 +1445,34 @@ describe('XmlSchemaDocumentService', () => {
         name: 'ShipOrder',
       });
     });
+
+    it('should clear fieldTypeOverrides, choiceSelections and fieldSubstitutions when rootElementChoice file is removed', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'shipOrder.xsd': getShipOrderXsd(), 'element-ref.xsd': getElementRefXsd() },
+        { namespaceUri: 'io.kaoto.datamapper.poc.test', name: 'ShipOrder' },
+      );
+      definition.fieldTypeOverrides = [
+        { schemaPath: '/old/path', type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.FORCE },
+      ];
+      definition.choiceSelections = [{ schemaPath: '/old/{choice:0}', selectedMemberIndex: 1 }];
+      const substitution: IFieldSubstitution = {
+        schemaPath: '/old/path',
+        name: 'ns0:newName',
+        originalName: 'ns0:oldName',
+      };
+      definition.fieldSubstitutions = [substitution];
+
+      const removeResult = XmlSchemaDocumentService.removeSchemaFile(definition, 'shipOrder.xsd');
+
+      expect(removeResult.validationStatus).not.toBe('error');
+      expect(removeResult.document).toBeDefined();
+      expect(removeResult.documentDefinition!.fieldTypeOverrides).toEqual([]);
+      expect(removeResult.documentDefinition!.choiceSelections).toEqual([]);
+      expect(removeResult.documentDefinition!.fieldSubstitutions).toEqual([]);
+    });
   });
 
   it('should load attribute with inline simple type without crashing', () => {
@@ -1496,6 +1525,5 @@ describe('XmlSchemaDocumentService', () => {
     const typeA01Field = bigContainerFragment.fields.find((f) => f.name === 'TypeA01');
     expect(typeA01Field).toBeDefined();
     expect(typeA01Field!.type).toEqual(Types.Container);
-    expect(typeA01Field!.originalType).toEqual(Types.Container);
   });
 });

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -244,6 +244,7 @@ export class XmlSchemaDocumentService {
       definition.rootElementChoice,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
+      definition.fieldSubstitutions,
     );
 
     // Try to create the Document object. It could fail if the root element user chose was defined in the removed
@@ -257,6 +258,9 @@ export class XmlSchemaDocumentService {
 
     // Unset the root element and retry
     updatedDefinition.rootElementChoice = undefined;
+    updatedDefinition.fieldTypeOverrides = [];
+    updatedDefinition.choiceSelections = [];
+    updatedDefinition.fieldSubstitutions = [];
     return XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition, namespaceMap);
   }
 
@@ -277,6 +281,7 @@ export class XmlSchemaDocumentService {
 
     document.definition.fieldTypeOverrides = [];
     document.definition.choiceSelections = [];
+    document.definition.fieldSubstitutions = [];
 
     const newDocument = new XmlSchemaDocument(document.definition, document.xmlSchemaCollection, newRootElement);
 
@@ -430,7 +435,6 @@ export class XmlSchemaDocumentService {
     }
 
     field.type = Types.Container;
-    field.originalType = Types.Container;
     field.namedTypeFragmentRefs.push(fragmentKey);
   }
 
@@ -444,12 +448,10 @@ export class XmlSchemaDocumentService {
       const newType = XmlSchemaDocumentUtilService.getFieldTypeFromName(schemaType.getName());
       if (!field.type || field.type === Types.AnyType) {
         field.type = newType;
-        field.originalType = newType;
       }
       const simpleTypeQName = schemaType.getQName();
       if (simpleTypeQName) {
         field.typeQName = simpleTypeQName;
-        field.originalTypeQName = simpleTypeQName;
       }
       return;
     } else if (!(schemaType instanceof XmlSchemaComplexType)) {
@@ -457,11 +459,9 @@ export class XmlSchemaDocumentService {
     }
 
     field.type = Types.Container;
-    field.originalType = Types.Container;
     const typeQName = schemaType.getQName();
     if (typeQName) {
       field.typeQName = typeQName;
-      field.originalTypeQName = typeQName;
       const namespace = typeQName.getNamespaceURI();
       if (!XmlSchemaDocumentUtilService.isStandardXmlNamespace(namespace)) {
         if (!field.namedTypeFragmentRefs.includes(typeQName.toString())) {
@@ -515,7 +515,6 @@ export class XmlSchemaDocumentService {
     field.defaultValue = attr.getDefaultValue() || attr.getFixedValue();
     const attrTypeName = attr.getSchemaTypeName()?.getLocalPart();
     field.type = (attrTypeName ? Types[capitalize(attrTypeName) as keyof typeof Types] : null) || Types.AnyType;
-    field.originalType = field.type;
     fields.push(field);
 
     ownerDoc.totalFieldCount++;
@@ -523,7 +522,6 @@ export class XmlSchemaDocumentService {
     const attrSchemaTypeQName = attr.getSchemaTypeName();
     if (attrSchemaTypeQName) {
       field.typeQName = attrSchemaTypeQName;
-      field.originalTypeQName = attrSchemaTypeQName;
     }
     const userDefinedAttrType =
       attrSchemaTypeQName &&

--- a/packages/ui/src/services/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/xml-schema-types.service.test.ts
@@ -1,6 +1,6 @@
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { TypeDerivation, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, TypeDerivation, Types } from '../models/datamapper/types';
 import {
   getExtensionComplexXsd,
   getRestrictionComplexXsd,
@@ -44,24 +44,24 @@ describe('XmlSchemaTypesService', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!field) throw new Error('Field not found');
-      field.originalType = Types.AnyType;
+      field.type = Types.AnyType;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const result = XmlSchemaTypesService.parseTypeOverride('xs:string', namespaceMap, field);
 
-      expect(result.variant).toBe(TypeOverrideVariant.SAFE);
+      expect(result.variant).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should determine FORCE variant for incompatible type change', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const field = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
       if (!field) throw new Error('Field not found');
-      field.originalType = Types.String;
+      field.type = Types.String;
 
       const namespaceMap = { xs: NS_XML_SCHEMA };
       const result = XmlSchemaTypesService.parseTypeOverride('xs:int', namespaceMap, field);
 
-      expect(result.variant).toBe(TypeOverrideVariant.FORCE);
+      expect(result.variant).toBe(FieldOverrideVariant.FORCE);
     });
   });
 
@@ -412,9 +412,8 @@ describe('XmlSchemaTypesService', () => {
       const namespaceMap = { ns0: 'http://www.example.com/TEST', xs: NS_XML_SCHEMA };
 
       const messageQName = new QName('http://www.example.com/TEST', 'Message');
-      const field = {
-        originalTypeQName: messageQName,
-      };
+      const field = new XmlSchemaField(doc, 'testField', false);
+      field.typeQName = messageQName;
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
         field,
@@ -426,12 +425,13 @@ describe('XmlSchemaTypesService', () => {
       expect(Object.values(candidates).some((c) => c.displayName === 'BaseRequest')).toBe(true);
     });
 
-    it('should return empty when field has no originalTypeQName', () => {
+    it('should return empty when field has no typeQName', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const namespaceMap = { xs: NS_XML_SCHEMA };
+      const field = new XmlSchemaField(doc, 'emptyField', false);
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
-        {},
+        field,
         doc.xmlSchemaCollection,
         namespaceMap,
       );
@@ -439,12 +439,14 @@ describe('XmlSchemaTypesService', () => {
       expect(candidates).toEqual({});
     });
 
-    it('should return empty when originalTypeQName resolves to no type', () => {
+    it('should return empty when typeQName resolves to no type', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const namespaceMap = { xs: NS_XML_SCHEMA };
+      const field = new XmlSchemaField(doc, 'fakeField', false);
+      field.typeQName = new QName('http://nonexistent.com', 'Fake');
 
       const candidates = XmlSchemaTypesService.getTypeOverrideCandidatesForField(
-        { originalTypeQName: new QName('http://nonexistent.com', 'Fake') },
+        field,
         doc.xmlSchemaCollection,
         namespaceMap,
       );
@@ -459,7 +461,7 @@ describe('XmlSchemaTypesService', () => {
         new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'json-doc'),
       );
       const field = new JsonSchemaField(jsonDoc, 'testField', Types.Container);
-      field.originalType = Types.Container;
+      field.type = Types.Container;
 
       const result = XmlSchemaTypesService.isCompatibleContainerTypeOverride(
         field,
@@ -484,8 +486,8 @@ describe('XmlSchemaTypesService', () => {
       const doc = result.document as XmlSchemaDocument;
 
       const field = new XmlSchemaField(doc, 'testField', false);
-      field.originalType = Types.Container;
-      field.originalTypeQName = new QName('http://www.example.com/TEST', 'Message');
+      field.type = Types.Container;
+      field.typeQName = new QName('http://www.example.com/TEST', 'Message');
 
       const isCompatible = XmlSchemaTypesService.isCompatibleContainerTypeOverride(
         field,
@@ -723,8 +725,8 @@ describe('XmlSchemaTypesService', () => {
       const baseRequestQName = new QName('http://www.example.com/TEST', 'BaseRequest');
 
       const field = new XmlSchemaField(doc, 'testField', false);
-      field.originalType = Types.Container;
-      field.originalTypeQName = messageQName;
+      field.type = Types.Container;
+      field.typeQName = messageQName;
 
       const variant = XmlSchemaTypesService.determineOverrideVariant(
         field,
@@ -733,7 +735,7 @@ describe('XmlSchemaTypesService', () => {
         'http://www.example.com/TEST',
       );
 
-      expect(variant).toBe(TypeOverrideVariant.SAFE);
+      expect(variant).toBe(FieldOverrideVariant.SAFE);
     });
   });
 });

--- a/packages/ui/src/services/xml-schema-types.service.ts
+++ b/packages/ui/src/services/xml-schema-types.service.ts
@@ -1,6 +1,6 @@
 import { IField } from '../models/datamapper/document';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
-import { IFieldTypeInfo, TypeDerivation, TypeOverrideVariant, Types } from '../models/datamapper/types';
+import { FieldOverrideVariant, IFieldTypeInfo, TypeDerivation, Types } from '../models/datamapper/types';
 import { capitalize } from '../serializers/xml/utils/xml-utils';
 import {
   XmlSchemaCollection,
@@ -44,14 +44,14 @@ export class XmlSchemaTypesService {
    * @example
    * ```typescript
    * const result = XmlSchemaTypesService.parseTypeOverride('xs:int', namespaceMap, field);
-   * // result = { type: Types.Integer, typeQName: QName, variant: TypeOverrideVariant.SAFE }
+   * // result = { type: Types.Integer, typeQName: QName, variant: FieldOverrideVariant.SAFE }
    * ```
    */
   static parseTypeOverride(
     typeString: string,
     namespaceMap: Record<string, string>,
     field: IField,
-  ): { type: Types; typeQName: QName; variant: TypeOverrideVariant } {
+  ): { type: Types; typeQName: QName; variant: FieldOverrideVariant } {
     const parts = typeString.split(':');
     const prefix = parts.length > 1 ? parts[0] : '';
     const localPart = parts.length > 1 ? parts[1] : parts[0];
@@ -86,16 +86,16 @@ export class XmlSchemaTypesService {
     newType: Types,
     newTypeQName: QName,
     newNamespaceURI: string,
-  ): TypeOverrideVariant {
-    if (field.originalType === Types.AnyType) {
-      return TypeOverrideVariant.SAFE;
+  ): FieldOverrideVariant {
+    if ((field.originalField?.type ?? field.type) === Types.AnyType) {
+      return FieldOverrideVariant.SAFE;
     }
 
     if (XmlSchemaTypesService.isCompatibleContainerTypeOverride(field, newType, newTypeQName, newNamespaceURI)) {
-      return TypeOverrideVariant.SAFE;
+      return FieldOverrideVariant.SAFE;
     }
 
-    return TypeOverrideVariant.FORCE;
+    return FieldOverrideVariant.FORCE;
   }
 
   /**
@@ -117,8 +117,9 @@ export class XmlSchemaTypesService {
     newNamespaceURI: string,
   ): boolean {
     const isBuiltInType = newNamespaceURI === NS_XML_SCHEMA;
+    const origType = field.originalField?.type ?? field.type;
 
-    if (field.originalType !== Types.Container || newType !== Types.Container || isBuiltInType) {
+    if (origType !== Types.Container || newType !== Types.Container || isBuiltInType) {
       return false;
     }
 
@@ -129,8 +130,8 @@ export class XmlSchemaTypesService {
 
     const xmlDoc = ownerDoc as XmlSchemaDocument;
     const newSchemaType = xmlDoc.xmlSchemaCollection.getTypeByQName(newTypeQName);
-    const originalSchemaType =
-      field.originalTypeQName && xmlDoc.xmlSchemaCollection.getTypeByQName(field.originalTypeQName);
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const originalSchemaType = origTypeQName && xmlDoc.xmlSchemaCollection.getTypeByQName(origTypeQName);
 
     if (!newSchemaType || !originalSchemaType) {
       return false;
@@ -657,15 +658,16 @@ export class XmlSchemaTypesService {
    * ```
    */
   static getTypeOverrideCandidatesForField(
-    field: { originalTypeQName?: unknown },
+    field: IField,
     collection: XmlSchemaCollection,
     namespaceMap: Record<string, string>,
   ): Record<string, IFieldTypeInfo> {
-    if (!field.originalTypeQName) {
+    const origTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    if (!origTypeQName) {
       return {};
     }
 
-    const baseType = collection.getTypeByQName(field.originalTypeQName as QName);
+    const baseType = collection.getTypeByQName(origTypeQName);
     if (!baseType) {
       return {};
     }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2989

The core design change is replacing the eagerly-populated `originalType`/`originalTypeQName` fields on `IField` with a lazily-captured `originalField?: IOriginalFieldState` snapshot. Previously, every field carried redundant copies of its own type set at document-parse time; now the snapshot is taken only on first expansion (`resolveTypeFragment`) or just before the first override is applied, and cleared when the override is reverted. This eliminates build-time data duplication and makes the snapshot a true runtime record of pre-override state.

Alongside this:
 - `SUBSTITUTION` variant added to `FieldOverrideVariant` (renamed from `TypeOverrideVariant` for accuracy)
 - `IFieldSubstitution` metadata interface introduced and plumbed through `IDocumentMetadata` / `DocumentDefinition`

Fixes: https://github.com/KaotoIO/kaoto/issues/2995

- By capturing original field snapshot to `originalField: IOriginalFieldState` on `IFleld`, `restoreOriginalTypeToField` restores both `fields[]` and `namedTypeFragmentRef` when Field Override is reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved field type override data model to better track and restore original field states when overrides are applied or removed.
  * Enhanced field data structure to support field substitutions, enabling more flexible field handling in data mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->