### PR TITLE
fix(DataMapper): xs:choice support improvement

### DIFF
--- a/packages/ui/src/components/Document/NodeContainer.scss
+++ b/packages/ui/src/components/Document/NodeContainer.scss
@@ -10,6 +10,16 @@
   box-sizing: border-box;
 }
 
+.droppable-invalid {
+  color: var(--pf-t--global--text--color--disabled);
+  border-style: dashed;
+  border-color: var(--pf-t--global--text--color--disabled);
+  border-width: 1px;
+  cursor: not-allowed;
+  border-radius: var(--pf-v6-c-droppable--m-dragging--after--BorderRadius);
+  box-sizing: border-box;
+}
+
 .draggable-container {
   font-weight: bold;
   color: var(--pf-t--global--icon--color--brand--default);

--- a/packages/ui/src/components/Document/NodeContainer.test.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.test.tsx
@@ -1,0 +1,102 @@
+import { useDroppable } from '@dnd-kit/core';
+import { render } from '@testing-library/react';
+
+import { NodeData } from '../../models/datamapper/visualization';
+import { DataMapperDndContext } from '../../providers/datamapper-dnd.provider';
+import { MappingValidationService } from '../../services/mapping-validation.service';
+import { DroppableContainer } from './NodeContainer';
+
+jest.mock('@dnd-kit/core', () => ({
+  useDroppable: jest.fn().mockReturnValue({ isOver: false, setNodeRef: jest.fn() }),
+  useDraggable: jest.fn().mockReturnValue({
+    isDragging: false,
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+  }),
+}));
+
+jest.mock('../../services/mapping-validation.service', () => ({
+  MappingValidationService: {
+    validateMappingPair: jest.fn().mockReturnValue({ isValid: true }),
+  },
+}));
+
+describe('DroppableContainer', () => {
+  const mockNodeData = {
+    id: 'test-node',
+    title: 'Test Node',
+    isSource: false,
+    isPrimitive: false,
+    path: {},
+  } as unknown as NodeData;
+
+  const activeSourceNode = {
+    id: 'active-source',
+    title: 'Active Source',
+    isSource: true,
+    isPrimitive: false,
+    path: {},
+  } as unknown as NodeData;
+
+  beforeEach(() => {
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: false, setNodeRef: jest.fn() });
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: true });
+  });
+
+  it('should call useDroppable with disabled: false when there is no active node', () => {
+    render(
+      <DataMapperDndContext.Provider value={{}}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+    expect(useDroppable).toHaveBeenCalledWith(expect.objectContaining({ disabled: false }));
+  });
+
+  it('should call useDroppable with disabled: true when the active node is on the same side', () => {
+    const sameSideNode = { ...mockNodeData, id: 'same-side', isSource: false } as unknown as NodeData;
+    render(
+      <DataMapperDndContext.Provider value={{ activeNode: sameSideNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+    expect(useDroppable).toHaveBeenCalledWith(expect.objectContaining({ disabled: true }));
+  });
+
+  it('should apply droppable-invalid class when hovering over an invalid cross-side drop', () => {
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: false });
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: true, setNodeRef: jest.fn() });
+
+    const { container } = render(
+      <DataMapperDndContext.Provider value={{ activeNode: activeSourceNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+
+    expect(container.querySelector('.droppable-invalid')).toBeTruthy();
+    expect(container.querySelector('.droppable-container')).toBeFalsy();
+  });
+
+  it('should apply droppable-container class when hovering over a valid cross-side drop', () => {
+    (MappingValidationService.validateMappingPair as jest.Mock).mockReturnValue({ isValid: true });
+    (useDroppable as jest.Mock).mockReturnValue({ isOver: true, setNodeRef: jest.fn() });
+
+    const { container } = render(
+      <DataMapperDndContext.Provider value={{ activeNode: activeSourceNode }}>
+        <DroppableContainer id="test" nodeData={mockNodeData}>
+          content
+        </DroppableContainer>
+      </DataMapperDndContext.Provider>,
+    );
+
+    expect(container.querySelector('.droppable-container')).toBeTruthy();
+    expect(container.querySelector('.droppable-invalid')).toBeFalsy();
+  });
+});

--- a/packages/ui/src/components/Document/NodeContainer.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.tsx
@@ -3,9 +3,11 @@ import './NodeContainer.scss';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { isDefined } from '@kaoto/forms';
 import clsx from 'clsx';
-import { forwardRef, FunctionComponent, PropsWithChildren } from 'react';
+import { forwardRef, FunctionComponent, PropsWithChildren, useContext, useMemo } from 'react';
 
 import { DocumentNodeData, NodeData } from '../../models/datamapper/visualization';
+import { DataMapperDndContext } from '../../providers/datamapper-dnd.provider';
+import { MappingValidationService } from '../../services/mapping-validation.service';
 import { VisualizationService } from '../../services/visualization.service';
 
 type DnDContainerProps = PropsWithChildren & {
@@ -19,16 +21,35 @@ type BaseContainerProps = PropsWithChildren & {
 };
 
 export const DroppableContainer: FunctionComponent<BaseContainerProps> = ({ className, id, nodeData, children }) => {
+  const { activeNode } = useContext(DataMapperDndContext);
+
+  const isInvalidDrop = useMemo(() => {
+    if (!activeNode) return false;
+    if (activeNode.isSource === nodeData.isSource) return false;
+    return !MappingValidationService.validateMappingPair(activeNode, nodeData).isValid;
+  }, [activeNode, nodeData]);
+
+  // unlike `isInvalidDrop` which shows disabled hover effect and show an error toast if it's dropped,
+  // if it's same side (source<->source / target<->target), disable DnDKit to show no hover effect
+  // nor error, but just silently ignore it
+  const isSameSide = !!activeNode && activeNode.isSource === nodeData.isSource;
+
   const { isOver, setNodeRef: setDroppableNodeRef } = useDroppable({
     id: `droppable-${id}`,
     data: nodeData,
+    disabled: isSameSide,
   });
 
   return (
     <div
       id={`droppable-${id}`}
       ref={setDroppableNodeRef}
-      className={clsx(className, { 'droppable-container': isOver }, 'pf-v6-c-droppable')}
+      className={clsx(
+        className,
+        { 'droppable-container': isOver && !isInvalidDrop },
+        { 'droppable-invalid': isOver && isInvalidDrop },
+        'pf-v6-c-droppable',
+      )}
       data-dnd-droppable={isOver ? `${id}` : undefined}
     >
       {children}

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
@@ -6,6 +6,10 @@
     max-width: 100%;
     display: inline-block;
     vertical-align: middle;
+
+    &__choice {
+      font-style: italic;
+    }
   }
 }
 

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../models/datamapper/document';
 import { IfItem, MappingTree, UnknownMappingItem } from '../../../models/datamapper/mapping';
 import {
+  ChoiceFieldNodeData,
   DocumentNodeData,
   FieldNodeData,
   MappingNodeData,
@@ -224,6 +225,31 @@ describe('NodeTitle', () => {
         expect(screen.getByText(/apply-templates/)).toBeInTheDocument();
       });
     });
+  });
+
+  it('should render choice wrapper with Label badge and italic member text', () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const memberFields = [
+      { ...baseField, name: 'email', displayName: 'email', fields: [] },
+      { ...baseField, name: 'phone', displayName: 'phone', fields: [] },
+    ];
+    const choiceField = {
+      ...baseField,
+      name: '__choice__',
+      displayName: 'choice',
+      isChoice: true,
+      fields: memberFields,
+    } as unknown as typeof baseField;
+    const choiceNodeData = new ChoiceFieldNodeData(documentNodeData, choiceField);
+
+    render(<NodeTitle nodeData={choiceNodeData} isDocument={false} rank={0} />);
+
+    expect(screen.getByText('choice')).toBeInTheDocument();
+    const memberText = screen.getByText('(email | phone)');
+    expect(memberText).toBeInTheDocument();
+    expect(memberText).toHaveClass('node-title__text__choice');
   });
 
   it('should not display popover for MappingNodeData', async () => {

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
@@ -11,13 +11,16 @@ import Repeat1Icon from '../../../assets/data-mapper/field-icons/Repeat1Icon';
 import { FieldOverrideVariant } from '../../../models/datamapper/types';
 import {
   AddMappingNodeData,
+  ChoiceFieldNodeData,
   FieldItemNodeData,
   FieldNodeData,
   MappingNodeData,
   NodeData,
+  TargetChoiceFieldNodeData,
   UnknownMappingNodeData,
 } from '../../../models/datamapper/visualization';
 import { formatQNameWithPrefix } from '../../../services/namespace-util';
+import { VisualizationService } from '../../../services/visualization.service';
 import { UnknownMappingLabel } from './UnknownMappingLabel';
 
 interface INodeTitle {
@@ -35,7 +38,7 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
   isDocument,
   namespaceMap = {},
 }) => {
-  const title = nodeData.title;
+  const title = VisualizationService.createNodeTitle(nodeData);
   const content = (
     <span className={clsx('node-title__text', className)} data-rank={rank}>
       {title}
@@ -60,6 +63,9 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
     nodeData instanceof FieldItemNodeData ||
     nodeData instanceof AddMappingNodeData
   ) {
+    const isChoiceWrapper =
+      (nodeData instanceof ChoiceFieldNodeData || nodeData instanceof TargetChoiceFieldNodeData) &&
+      !nodeData.choiceField;
     const optionalField = nodeData.field.minOccurs === 0;
     const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
     const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
@@ -104,7 +110,11 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
         }
       >
         <div className="node-title-container">
-          <span className={clsx('node-title__text', className)} data-rank={rank}>
+          {isChoiceWrapper && <Label>choice</Label>}
+          <span
+            className={clsx('node-title__text', isChoiceWrapper && 'node-title__text__choice', className)}
+            data-rank={rank}
+          >
             {title}
           </span>
           {optionalField && !repeatingField0 && (

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -6,7 +6,6 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
-  IField,
   PrimitiveDocument,
 } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
@@ -14,7 +13,6 @@ import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import { ChoiceFieldNodeData, DocumentNodeData } from '../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
-import { DocumentUtilService } from '../../services/document-util.service';
 import { TreeParsingService } from '../../services/tree-parsing.service';
 import { TreeUIService } from '../../services/tree-ui.service';
 import { VisualizationService } from '../../services/visualization.service';
@@ -180,7 +178,7 @@ describe('SourceDocumentNode', () => {
     const choiceField = {
       ...baseField,
       name: 'choice',
-      displayName: DocumentUtilService.formatChoiceDisplayName(memberFields as unknown as IField[]),
+      displayName: 'choice',
       isChoice: true,
       fields: memberFields,
     } as unknown as typeof baseField;

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -6,7 +6,6 @@ import {
   DocumentDefinition,
   DocumentDefinitionType,
   DocumentType,
-  IField,
   PrimitiveDocument,
 } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
@@ -21,7 +20,6 @@ import {
 } from '../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
-import { DocumentUtilService } from '../../services/document-util.service';
 import { TreeParsingService } from '../../services/tree-parsing.service';
 import { TreeUIService } from '../../services/tree-ui.service';
 import { VisualizationService } from '../../services/visualization.service';
@@ -178,7 +176,7 @@ describe('TargetDocumentNode', () => {
     const choiceField = {
       ...baseField,
       name: 'choice',
-      displayName: DocumentUtilService.formatChoiceDisplayName(memberFields as unknown as IField[]),
+      displayName: 'choice',
       isChoice: true,
       fields: memberFields,
     } as unknown as typeof baseField;

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -146,8 +146,20 @@ export class ChoiceFieldNodeData extends FieldNodeData {
 /**
  * Target-side counterpart of {@link ChoiceFieldNodeData}.
  * Carries the same selected/unselected semantics; see that class for details.
+ *
+ * When unselected (`field.isChoice === true`), the wrapper is **path-transparent**:
+ * its {@link path} equals its parent's path so that children compute paths matching
+ * the mapping tree hierarchy (which has no choice wrapper nodes). This ensures
+ * {@link MappingLinksService} can match visual node paths to mapping node paths
+ * for line rendering.
  */
 export class TargetChoiceFieldNodeData extends TargetFieldNodeData {
+  constructor(parent: TargetNodeData, field: IField, mapping?: FieldItem) {
+    super(parent, field, mapping);
+    if (field.isChoice) {
+      this.path = parent.path;
+    }
+  }
   /** The choice wrapper field when a member is selected; `undefined` for the unselected wrapper itself. */
   choiceField?: IField;
 }

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -14,24 +14,46 @@ import {
 import { NodePath } from './nodepath';
 import { Types } from './types';
 
+/**
+ * Base interface for all visualization nodes in the DataMapper tree.
+ * Every node on both the source and target sides implements this interface.
+ */
 export interface NodeData {
+  /** Raw display name sourced from `IField.displayName` or the document/mapping name. For choice wrapper nodes use {@link VisualizationService.createNodeTitle} to obtain the rendered title. */
   title: string;
+  /** The document this node belongs to, present on document-level nodes. */
   document?: IDocument;
+  /** The field type, present on field nodes. */
   type?: Types;
+  /** Stable identifier used for keying and DnD operations. */
   id: string;
+  /** Full path from the document root to this node. */
   path: NodePath;
+  /** `true` for source-side nodes, `false` for target-side nodes. */
   isSource: boolean;
+  /** `true` when the owning document is a {@link PrimitiveDocument}. */
   isPrimitive: boolean;
 }
 
+/**
+ * Extension of {@link NodeData} for target-side nodes that carry mapping information.
+ */
 export interface TargetNodeData extends NodeData {
+  /** The root mapping tree for the target document. */
   mappingTree: MappingTree;
+  /** The mapping item associated with this node, if one exists. */
   mapping?: MappingParentType;
 }
 
+/** Union of all valid source-side node types. */
 export type SourceNodeDataType = DocumentNodeData | FieldNodeData | ChoiceFieldNodeData;
+/** Union of all valid target-side node types. */
 export type TargetNodeDataType = TargetDocumentNodeData | TargetFieldNodeData | TargetChoiceFieldNodeData;
 
+/**
+ * Visualization node for a source or target document root.
+ * Its `title` is set to the document's `documentId`.
+ */
 export class DocumentNodeData implements NodeData {
   constructor(document: IDocument) {
     this.title = document.documentId;
@@ -50,6 +72,10 @@ export class DocumentNodeData implements NodeData {
   isPrimitive: boolean;
 }
 
+/**
+ * Visualization node for a target document root.
+ * Extends {@link DocumentNodeData} with the root {@link MappingTree}.
+ */
 export class TargetDocumentNodeData extends DocumentNodeData implements TargetNodeData {
   constructor(document: IDocument, mappingTree: MappingTree) {
     super(document);
@@ -60,6 +86,10 @@ export class TargetDocumentNodeData extends DocumentNodeData implements TargetNo
   mapping: MappingTree;
 }
 
+/**
+ * Visualization node for a regular (non-choice) source or target field.
+ * Its `title` is set to `field.displayName`.
+ */
 export class FieldNodeData implements NodeData {
   constructor(
     public parent: NodeData,
@@ -81,6 +111,9 @@ export class FieldNodeData implements NodeData {
   isPrimitive: boolean;
 }
 
+/**
+ * Visualization node for a target field with an optional associated {@link FieldItem} mapping.
+ */
 export class TargetFieldNodeData extends FieldNodeData implements TargetNodeData {
   constructor(
     public parent: TargetNodeData,
@@ -93,14 +126,36 @@ export class TargetFieldNodeData extends FieldNodeData implements TargetNodeData
   mappingTree: MappingTree;
 }
 
+/**
+ * Visualization node for a source xs:choice field.
+ *
+ * When `choiceField` is `undefined`, this node represents an **unselected** choice wrapper:
+ * `field` is the choice wrapper itself (`isChoice: true`) and {@link VisualizationService.createNodeTitle}
+ * returns the member list label (e.g. `"(email | phone)"`). {@link NodeTitle} renders a
+ * `<Label>choice</Label>` badge alongside the italic member list in this state.
+ *
+ * When `choiceField` is set, a member has been selected: `field` is the selected member and
+ * `choiceField` holds the choice wrapper. {@link VisualizationService.createNodeTitle} returns
+ * the member's own display name and {@link NodeTitle} renders it as a plain field title.
+ */
 export class ChoiceFieldNodeData extends FieldNodeData {
+  /** The choice wrapper field when a member is selected; `undefined` for the unselected wrapper itself. */
   choiceField?: IField;
 }
 
+/**
+ * Target-side counterpart of {@link ChoiceFieldNodeData}.
+ * Carries the same selected/unselected semantics; see that class for details.
+ */
 export class TargetChoiceFieldNodeData extends TargetFieldNodeData {
+  /** The choice wrapper field when a member is selected; `undefined` for the unselected wrapper itself. */
   choiceField?: IField;
 }
 
+/**
+ * Visualization node for a mapping item (e.g. `if`, `choose`, `forEach`, `valueSelector`).
+ * Its `title` is set to `mapping.name`.
+ */
 export class MappingNodeData implements TargetNodeData {
   constructor(
     public parent: TargetNodeData,
@@ -121,6 +176,11 @@ export class MappingNodeData implements TargetNodeData {
   mappingTree: MappingTree;
 }
 
+/**
+ * Visualization node for a {@link FieldItem} mapping — a mapping item that is directly tied to
+ * a document field. Its `title` is overridden to `mapping.field.displayName` so the node label
+ * matches the field name rather than the generic mapping name.
+ */
 export class FieldItemNodeData extends MappingNodeData {
   constructor(
     public parent: TargetNodeData,
@@ -152,6 +212,10 @@ export class VariableNodeData extends MappingNodeData {
   }
 }
 
+/**
+ * Placeholder node rendered when a collection field already has a mapping and the user can add
+ * an additional one. Its `title` is the field name and its `id` is prefixed with `"add-mapping-"`.
+ */
 export class AddMappingNodeData implements TargetNodeData {
   constructor(
     public parent: TargetNodeData,
@@ -180,6 +244,11 @@ class SimpleNodePath extends NodePath {
     return this.path;
   }
 }
+
+/**
+ * Sentinel node used to represent the expression editor panel in the visualization graph.
+ * Not part of the document or mapping tree — used only for canvas wiring.
+ */
 export class EditorNodeData implements NodeData {
   constructor(public mapping: IExpressionHolder & MappingItem) {}
   id: string = 'editor';
@@ -189,6 +258,10 @@ export class EditorNodeData implements NodeData {
   title: string = 'Editor';
 }
 
+/**
+ * Visualization node for a DataMapper function available in the function palette.
+ * Always on the source side (`isSource: true`).
+ */
 export class FunctionNodeData implements NodeData {
   constructor(public functionDefinition: IFunctionDefinition) {
     this.id = functionDefinition.name;
@@ -203,6 +276,7 @@ export class FunctionNodeData implements NodeData {
   title: string;
 }
 
+/** Describes a drawn mapping line between a source and a target node. */
 export interface IMappingLink {
   sourceNodePath: string;
   targetNodePath: string;
@@ -211,6 +285,7 @@ export interface IMappingLink {
   isSelected: boolean;
 }
 
+/** SVG line endpoint coordinates. */
 export type LineCoord = {
   x1: number;
   y1: number;
@@ -218,6 +293,7 @@ export type LineCoord = {
   y2: number;
 };
 
+/** Full props for rendering a single mapping line in the SVG overlay. */
 export type LineProps = LineCoord & {
   sourceNodePath: string;
   targetNodePath: string;
@@ -227,4 +303,5 @@ export type LineProps = LineCoord & {
   isTargetEdge: boolean;
 };
 
+/** Props passed to the alert notification handler. */
 export type SendAlertProps = Partial<AlertProps & { description: string }>;

--- a/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
@@ -1,4 +1,11 @@
-import { canScrollPanel, scrollAwareCollision } from './datamapper-dnd.provider';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import { AlertVariant } from '@patternfly/react-core';
+import { act, render } from '@testing-library/react';
+import { ReactNode } from 'react';
+
+import { useDataMapper } from '../hooks/useDataMapper';
+import { MappingTree } from '../models/datamapper/mapping';
+import { canScrollPanel, DatamapperDndProvider, scrollAwareCollision } from './datamapper-dnd.provider';
 
 // Mock rectIntersection to control collision detection in tests
 jest.mock('@dnd-kit/core', () => {
@@ -13,8 +20,16 @@ jest.mock('@dnd-kit/core', () => {
       }));
     }),
     pointerWithin: jest.fn(() => []),
+    DndContext: jest.fn(),
+    DragOverlay: jest.fn(() => null),
+    useSensor: jest.fn(),
+    useSensors: jest.fn().mockReturnValue([]),
   };
 });
+
+jest.mock('../hooks/useDataMapper', () => ({
+  useDataMapper: jest.fn(),
+}));
 
 // Helper to create mock rect object
 const createMockRect = (top: number, bottom: number, left: number, right: number) => ({
@@ -334,5 +349,80 @@ describe('datamapper-dnd.provider', () => {
 
       expect(result).toBe(false);
     });
+  });
+});
+
+describe('DatamapperDndProvider', () => {
+  const mockSendAlert = jest.fn();
+  const mockRefreshMappingTree = jest.fn();
+  const mockMappingTree = {} as MappingTree;
+
+  const mockDragEndEvent = {
+    active: { id: 'a', data: { current: null } },
+    over: null,
+  } as unknown as DragEndEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (DndContext as unknown as jest.Mock).mockImplementation(({ children }: { children: ReactNode }) => children);
+    (useDataMapper as jest.Mock).mockReturnValue({
+      mappingTree: mockMappingTree,
+      refreshMappingTree: mockRefreshMappingTree,
+      sendAlert: mockSendAlert,
+    });
+  });
+
+  const invokeOnDragEnd = async (event: DragEndEvent) => {
+    const onDragEnd = (DndContext as unknown as jest.Mock).mock.calls.at(-1)[0].onDragEnd as (e: DragEndEvent) => void;
+    await act(async () => {
+      onDragEnd(event);
+    });
+  };
+
+  it('should call sendAlert with danger variant when handler returns failure with error message', async () => {
+    const mockHandler = {
+      handleDragEnd: jest.fn().mockReturnValue({ success: false, errorMessage: 'error msg' }),
+      handleDragStart: jest.fn(),
+      handleDragOver: jest.fn(),
+    };
+
+    render(
+      <DatamapperDndProvider handler={mockHandler}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+
+    expect(mockSendAlert).toHaveBeenCalledWith({ variant: AlertVariant.danger, title: 'error msg' });
+  });
+
+  it('should not call sendAlert when handler returns success', async () => {
+    const mockHandler = {
+      handleDragEnd: jest.fn().mockReturnValue({ success: true }),
+      handleDragStart: jest.fn(),
+      handleDragOver: jest.fn(),
+    };
+
+    render(
+      <DatamapperDndProvider handler={mockHandler}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+
+    expect(mockSendAlert).not.toHaveBeenCalled();
+  });
+
+  it('should not crash when no handler is provided', async () => {
+    render(
+      <DatamapperDndProvider handler={undefined}>
+        <div />
+      </DatamapperDndProvider>,
+    );
+
+    await invokeOnDragEnd(mockDragEndEvent);
+    expect(mockSendAlert).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/providers/datamapper-dnd.provider.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.tsx
@@ -16,7 +16,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { Label } from '@patternfly/react-core';
+import { AlertVariant, Label } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useDataMapper } from '../hooks/useDataMapper';
@@ -116,6 +116,7 @@ export const canScrollPanel = (element: Element, activeDragSideRef: { current: D
 
 export interface IDataMapperDndContext {
   handler?: DnDHandler;
+  activeNode?: NodeData;
 }
 
 export const DataMapperDndContext = createContext<IDataMapperDndContext>({});
@@ -125,7 +126,7 @@ type DataMapperDndContextProps = PropsWithChildren & {
 };
 
 export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps> = (props) => {
-  const { mappingTree, refreshMappingTree } = useDataMapper();
+  const { mappingTree, refreshMappingTree, sendAlert } = useDataMapper();
   const [activeData, setActiveData] = useState<DataRef<NodeData> | null>(null);
   const activeDragSideRef = useRef<'source' | 'target' | null>(null);
 
@@ -164,20 +165,30 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
     [props.handler],
   );
 
+  const clearActiveDrag = useCallback(() => {
+    setActiveData(null);
+    activeDragSideRef.current = null;
+  }, []);
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      props.handler && props.handler.handleDragEnd(event, mappingTree, refreshMappingTree);
-      setActiveData(null);
-      activeDragSideRef.current = null;
+      if (props.handler) {
+        const result = props.handler.handleDragEnd(event, mappingTree, refreshMappingTree);
+        if (!result.success && result.errorMessage) {
+          sendAlert({ variant: AlertVariant.danger, title: result.errorMessage });
+        }
+      }
+      clearActiveDrag();
     },
-    [mappingTree, props.handler, refreshMappingTree],
+    [clearActiveDrag, mappingTree, props.handler, refreshMappingTree, sendAlert],
   );
 
   const handler = useMemo(() => {
     return {
       handler: props.handler,
+      activeNode: activeData?.current,
     };
-  }, [props.handler]);
+  }, [props.handler, activeData]);
 
   const draggingLabel = activeData?.current?.title ? activeData.current.title : 'dragging...';
   return (
@@ -194,10 +205,15 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
+        onDragCancel={clearActiveDrag}
       >
         {props.children}
         <DragOverlay dropAnimation={null}>
-          <div className={'pf-v6-c-draggable node__row dragging-container'} data-dnd-dragging={draggingLabel}>
+          <div
+            className={'pf-v6-c-draggable node__row dragging-container'}
+            data-dnd-dragging={draggingLabel}
+            style={{ pointerEvents: 'none' }}
+          >
             <Label>{draggingLabel}</Label>
           </div>
         </DragOverlay>

--- a/packages/ui/src/providers/datamapper-dnd.provider.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.tsx
@@ -21,6 +21,7 @@ import { createContext, FunctionComponent, PropsWithChildren, useCallback, useMe
 
 import { useDataMapper } from '../hooks/useDataMapper';
 import { NodeData } from '../models/datamapper';
+import { VisualizationService } from '../services/visualization.service';
 import { DnDHandler } from './dnd/DnDHandler';
 
 /** Type for tracking which side (source/target) is currently active during drag operations */
@@ -190,7 +191,7 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
     };
   }, [props.handler, activeData]);
 
-  const draggingLabel = activeData?.current?.title ? activeData.current.title : 'dragging...';
+  const draggingLabel = activeData?.current ? VisualizationService.createNodeTitle(activeData.current) : 'dragging...';
   return (
     <DataMapperDndContext.Provider value={handler}>
       <DndContext

--- a/packages/ui/src/providers/dnd/DnDHandler.ts
+++ b/packages/ui/src/providers/dnd/DnDHandler.ts
@@ -2,8 +2,13 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { MappingTree } from '../../models/datamapper/mapping';
 
+export interface DnDResult {
+  success: boolean;
+  errorMessage?: string;
+}
+
 export interface DnDHandler {
   handleDragStart(event: DragStartEvent): void;
   handleDragOver(event: DragOverEvent): void;
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): void;
+  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult;
 }

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
@@ -51,6 +51,7 @@ describe('ExpressionEditorDnDHandler', () => {
   const mockMapping = {} as unknown as ExpressionItem;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     handler = new ExpressionEditorDnDHandler();
     mockMappingTree = {} as MappingTree;
     mockOnUpdate = jest.fn();

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
@@ -1,7 +1,7 @@
 import { DragEndEvent } from '@dnd-kit/core';
 
 import { DocumentType, IField } from '../../models/datamapper/document';
-import { ExpressionItem, IFunctionDefinition, MappingTree } from '../../models/datamapper/mapping';
+import { IExpressionHolder, IFunctionDefinition, MappingItem, MappingTree } from '../../models/datamapper/mapping';
 import { NodePath } from '../../models/datamapper/nodepath';
 import { Types } from '../../models/datamapper/types';
 import { EditorNodeData, FieldNodeData, FunctionNodeData, NodeData } from '../../models/datamapper/visualization';
@@ -48,7 +48,7 @@ describe('ExpressionEditorDnDHandler', () => {
     arguments: [],
   } as unknown as IFunctionDefinition;
 
-  const mockMapping = {} as unknown as ExpressionItem;
+  const mockMapping = {} as unknown as IExpressionHolder & MappingItem;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
@@ -1,0 +1,103 @@
+import { DragEndEvent } from '@dnd-kit/core';
+
+import { DocumentType, IField } from '../../models/datamapper/document';
+import { ExpressionItem, IFunctionDefinition, MappingTree } from '../../models/datamapper/mapping';
+import { NodePath } from '../../models/datamapper/nodepath';
+import { Types } from '../../models/datamapper/types';
+import { EditorNodeData, FieldNodeData, FunctionNodeData, NodeData } from '../../models/datamapper/visualization';
+import { MappingService } from '../../services/mapping.service';
+import { ExpressionEditorDnDHandler } from './ExpressionEditorDnDHandler';
+
+jest.mock('../../services/mapping.service', () => ({
+  MappingService: {
+    mapToCondition: jest.fn(),
+    wrapWithFunction: jest.fn(),
+  },
+}));
+
+const makeDragEvent = (fromNode?: NodeData, toNode?: NodeData) =>
+  ({
+    active: { id: 'a', data: { current: fromNode } },
+    over: toNode ? { id: 'b', data: { current: toNode } } : null,
+  }) as unknown as DragEndEvent;
+
+describe('ExpressionEditorDnDHandler', () => {
+  let handler: ExpressionEditorDnDHandler;
+  let mockMappingTree: MappingTree;
+  let mockOnUpdate: jest.Mock;
+  let mockMapToCondition: jest.Mock;
+  let mockWrapWithFunction: jest.Mock;
+
+  const mockParentNode = {
+    path: NodePath.fromDocument(DocumentType.SOURCE_BODY, 'Body'),
+    isSource: true,
+    isPrimitive: false,
+  } as unknown as NodeData;
+
+  const mockField = {
+    displayName: 'testField',
+    id: 'testField',
+    type: Types.String,
+  } as unknown as IField;
+
+  const mockFunctionDef = {
+    name: 'fn',
+    displayName: 'fn',
+    description: '',
+    returnType: Types.String,
+    arguments: [],
+  } as unknown as IFunctionDefinition;
+
+  const mockMapping = {} as unknown as ExpressionItem;
+
+  beforeEach(() => {
+    handler = new ExpressionEditorDnDHandler();
+    mockMappingTree = {} as MappingTree;
+    mockOnUpdate = jest.fn();
+    mockMapToCondition = MappingService.mapToCondition as jest.Mock;
+    mockWrapWithFunction = MappingService.wrapWithFunction as jest.Mock;
+  });
+
+  describe('handleDragEnd', () => {
+    it('should return { success: false } when fromNode is undefined', () => {
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(undefined, editorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when fromNode is neither FieldNodeData nor FunctionNodeData', () => {
+      const genericNode = { title: 'generic', id: 'g', isSource: true, isPrimitive: false } as unknown as NodeData;
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(genericNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when toNode is not EditorNodeData', () => {
+      const fieldNode = new FieldNodeData(mockParentNode, mockField);
+      const nonEditorNode = { title: 'other', id: 'o', isSource: false, isPrimitive: false } as unknown as NodeData;
+      const result = handler.handleDragEnd(makeDragEvent(fieldNode, nonEditorNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockMapToCondition).not.toHaveBeenCalled();
+    });
+
+    it('should call MappingService.mapToCondition and return { success: true } when fromNode is FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(mockParentNode, mockField);
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(fieldNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(mockMapToCondition).toHaveBeenCalledWith(mockMapping, mockField);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should call MappingService.wrapWithFunction and return { success: true } when fromNode is FunctionNodeData', () => {
+      const funcNode = new FunctionNodeData(mockFunctionDef);
+      const editorNode = new EditorNodeData(mockMapping);
+      const result = handler.handleDragEnd(makeDragEvent(funcNode, editorNode), mockMappingTree, mockOnUpdate);
+      expect(mockWrapWithFunction).toHaveBeenCalledWith(mockMapping, mockFunctionDef);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
@@ -2,10 +2,10 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { EditorNodeData, FieldNodeData, FunctionNodeData, MappingTree, NodeData } from '../../models/datamapper';
 import { MappingService } from '../../services/mapping.service';
-import { DnDHandler } from './DnDHandler';
+import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class ExpressionEditorDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, _mappingTree: MappingTree, onUpdate: () => void): void {
+  handleDragEnd(event: DragEndEvent, _mappingTree: MappingTree, onUpdate: () => void): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
     if (
@@ -13,8 +13,9 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
       !toNode ||
       (!(fromNode instanceof FunctionNodeData) && !(fromNode instanceof FieldNodeData)) ||
       !(toNode instanceof EditorNodeData)
-    )
-      return;
+    ) {
+      return { success: false };
+    }
     const editorNodeData = toNode;
     if (fromNode instanceof FieldNodeData) {
       MappingService.mapToCondition(editorNodeData.mapping, fromNode.field);
@@ -22,6 +23,7 @@ export class ExpressionEditorDnDHandler implements DnDHandler {
       MappingService.wrapWithFunction(editorNodeData.mapping, fromNode.functionDefinition);
     }
     onUpdate();
+    return { success: true };
   }
 
   handleDragOver(_event: DragOverEvent): void {

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
@@ -1,0 +1,85 @@
+import { DragEndEvent } from '@dnd-kit/core';
+
+import { MappingTree } from '../../models/datamapper/mapping';
+import { NodeData } from '../../models/datamapper/visualization';
+import { MappingValidationService } from '../../services/mapping-validation.service';
+import { VisualizationService } from '../../services/visualization.service';
+import { SourceTargetDnDHandler } from './SourceTargetDnDHandler';
+
+jest.mock('../../services/mapping-validation.service', () => ({
+  MappingValidationService: {
+    validateMappingPair: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/visualization.service', () => ({
+  VisualizationService: {
+    engageMapping: jest.fn(),
+  },
+}));
+
+const makeDragEvent = (fromNode?: NodeData, toNode?: NodeData) =>
+  ({
+    active: { id: 'a', data: { current: fromNode } },
+    over: toNode ? { id: 'b', data: { current: toNode } } : null,
+  }) as unknown as DragEndEvent;
+
+describe('SourceTargetDnDHandler', () => {
+  let handler: SourceTargetDnDHandler;
+  let mockMappingTree: MappingTree;
+  let mockOnUpdate: jest.Mock;
+  let mockValidateMappingPair: jest.Mock;
+  let mockEngageMapping: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new SourceTargetDnDHandler();
+    mockMappingTree = {} as MappingTree;
+    mockOnUpdate = jest.fn();
+    mockValidateMappingPair = MappingValidationService.validateMappingPair as jest.Mock;
+    mockEngageMapping = VisualizationService.engageMapping as jest.Mock;
+  });
+
+  describe('handleDragEnd', () => {
+    it('should return { success: false } when fromNode is undefined', () => {
+      const result = handler.handleDragEnd(makeDragEvent(), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockValidateMappingPair).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false } when toNode is undefined (over is null)', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const result = handler.handleDragEnd(makeDragEvent(fromNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false });
+      expect(mockValidateMappingPair).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false, errorMessage } when validation is invalid with a message', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: false, errorMessage: 'err' });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false, errorMessage: 'err' });
+      expect(mockEngageMapping).not.toHaveBeenCalled();
+    });
+
+    it('should return { success: false, errorMessage: undefined } when validation is invalid without message', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: false });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(result).toEqual({ success: false, errorMessage: undefined });
+      expect(mockEngageMapping).not.toHaveBeenCalled();
+    });
+
+    it('should call engageMapping and onUpdate and return { success: true } when validation passes with nodes', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: true, sourceNode: fromNode, targetNode: toNode });
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(mockEngageMapping).toHaveBeenCalledWith(mockMappingTree, fromNode, toNode);
+      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
@@ -2,20 +2,24 @@ import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 import { MappingTree } from '../../models/datamapper/mapping';
 import { NodeData } from '../../models/datamapper/visualization';
+import { MappingValidationService } from '../../services/mapping-validation.service';
 import { VisualizationService } from '../../services/visualization.service';
-import { DnDHandler } from './DnDHandler';
+import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class SourceTargetDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): void {
+  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
-    if (!fromNode || !toNode) return;
+    if (!fromNode || !toNode) return { success: false };
 
-    const { sourceNode, targetNode } = VisualizationService.testNodePair(fromNode, toNode);
-    if (sourceNode && targetNode) {
-      VisualizationService.engageMapping(mappingTree, sourceNode, targetNode);
-      onUpdate();
+    const validation = MappingValidationService.validateMappingPair(fromNode, toNode);
+    if (!validation.isValid) {
+      return { success: false, errorMessage: validation.errorMessage };
     }
+
+    VisualizationService.engageMapping(mappingTree, validation.sourceNode!, validation.targetNode!);
+    onUpdate();
+    return { success: true };
   }
 
   handleDragOver(_event: DragOverEvent): void {}

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
@@ -17,7 +17,8 @@ export class SourceTargetDnDHandler implements DnDHandler {
       return { success: false, errorMessage: validation.errorMessage };
     }
 
-    VisualizationService.engageMapping(mappingTree, validation.sourceNode!, validation.targetNode!);
+    if (!validation.sourceNode || !validation.targetNode) return { success: false };
+    VisualizationService.engageMapping(mappingTree, validation.sourceNode, validation.targetNode);
     onUpdate();
     return { success: true };
   }

--- a/packages/ui/src/services/document-util.service.test.ts
+++ b/packages/ui/src/services/document-util.service.test.ts
@@ -6,7 +6,6 @@ import {
   PrimitiveDocument,
   Types,
 } from '../models/datamapper';
-import { IField } from '../models/datamapper/document';
 import { DocumentTree } from '../models/datamapper/document-tree';
 import { IChoiceSelection, IFieldSubstitution, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
@@ -1536,29 +1535,6 @@ describe('DocumentUtilService', () => {
       expect(() => {
         DocumentUtilService.invalidateDescendants(doc, '/ns0:ShipOrder');
       }).not.toThrow();
-    });
-  });
-
-  describe('formatChoiceDisplayName()', () => {
-    it('should format with member names', () => {
-      expect(DocumentUtilService.formatChoiceDisplayName([{ name: 'email' }, { name: 'phone' }] as IField[])).toEqual(
-        'choice (email | phone)',
-      );
-    });
-
-    it('should return "choice (empty)" when members array is empty', () => {
-      expect(DocumentUtilService.formatChoiceDisplayName([])).toEqual('choice (empty)');
-    });
-
-    it('should return "choice (empty)" when members is undefined', () => {
-      expect(DocumentUtilService.formatChoiceDisplayName()).toEqual('choice (empty)');
-    });
-
-    it('should truncate long member lists', () => {
-      const longMembers = Array.from({ length: 20 }, (_, i) => ({ name: `VeryLongMemberName${i}` })) as IField[];
-      const result = DocumentUtilService.formatChoiceDisplayName(longMembers);
-      expect(result).toContain('...');
-      expect(result).toMatch(/^choice \(.+\.\.\.\)$/);
     });
   });
 

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -597,22 +597,4 @@ export class DocumentUtilService {
       );
     }
   }
-
-  /**
-   * Generates a human-readable display name for a choice compositor based on its member names.
-   * Joins member names with ' | ' and truncates to 40 characters if needed.
-   * @param choiceMembers - The member fields of the choice compositor
-   * @returns A formatted display string such as "choice (option1 | option2)"
-   */
-  static formatChoiceDisplayName(choiceMembers?: IField[]): string {
-    if (!choiceMembers || choiceMembers.length === 0) {
-      return 'choice (empty)';
-    }
-    const memberNames = choiceMembers.map((m) => m.name).join(' | ');
-    const maxLength = 40;
-    if (memberNames.length > maxLength) {
-      return `choice (${memberNames.substring(0, maxLength - 3)}...)`;
-    }
-    return `choice (${memberNames})`;
-  }
 }

--- a/packages/ui/src/services/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/mapping-validation.service.test.ts
@@ -9,6 +9,7 @@ import {
 import { FieldItem, MappingTree } from '../models/datamapper/mapping';
 import { Types } from '../models/datamapper/types';
 import {
+  ChoiceFieldNodeData,
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
@@ -212,6 +213,25 @@ describe('MappingValidationService', () => {
       const result = MappingValidationService.validateMappingPair(fromNode, toNode);
       expect(result.isValid).toBe(false);
       expect(result.errorMessage).toContain('container');
+    });
+
+    it('should reject unselected choice source dropped onto document root', () => {
+      const choiceField = createMockField({ isChoice: true, type: Types.Container });
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+      const result = MappingValidationService.validateMappingPair(choiceNode, targetDocNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toContain('choice');
+      expect(result.sourceNode).toBe(choiceNode);
+      expect(result.targetNode).toBe(targetDocNode);
+    });
+
+    it('should allow unselected choice source dropped onto a target field', () => {
+      const choiceField = createMockField({ isChoice: true, type: Types.Container });
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+      const targetField = createMockField({ type: Types.String });
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(choiceNode, toNode);
+      expect(result.isValid).toBe(true);
     });
 
     it('should return valid when source is a PrimitiveDocument node and target is a field', () => {

--- a/packages/ui/src/services/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/mapping-validation.service.test.ts
@@ -1,0 +1,203 @@
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IField,
+  PrimitiveDocument,
+} from '../models/datamapper/document';
+import { MappingTree } from '../models/datamapper/mapping';
+import { Types } from '../models/datamapper/types';
+import {
+  DocumentNodeData,
+  FieldNodeData,
+  NodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../models/datamapper/visualization';
+import { TestUtil } from '../stubs/datamapper/data-mapper';
+import { MappingValidationService } from './mapping-validation.service';
+
+function createMockField(overrides: Partial<IField> = {}): IField {
+  return {
+    type: Types.String,
+    isChoice: false,
+    selectedMemberIndex: undefined,
+    fields: [],
+    ...overrides,
+  } as unknown as IField;
+}
+
+describe('MappingValidationService', () => {
+  describe('validateFieldPair', () => {
+    describe('container-to-terminal validation', () => {
+      it('should reject source-container to target-terminal', () => {
+        const source = createMockField({ type: Types.Container });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toBeDefined();
+      });
+
+      it('should reject source-terminal to target-container', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.Container });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toBeDefined();
+      });
+
+      it('should allow source-container to target-container', () => {
+        const source = createMockField({ type: Types.Container });
+        const target = createMockField({ type: Types.Container });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-terminal to target-terminal', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('choice validation', () => {
+      it('should reject any source to unselected choice target', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toContain('unselected choice');
+      });
+
+      it('should reject source-choice to unselected choice target', () => {
+        const source = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should reject source-choice-member to unselected choice target', () => {
+        const source = createMockField({ isChoice: false });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should allow source to target with selected choice member (selectedMemberIndex defined)', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: 0 });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-choice to target-non-choice field', () => {
+        const source = createMockField({ isChoice: true });
+        const target = createMockField({ isChoice: false });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-choice-member to target-regular', () => {
+        const source = createMockField({ isChoice: false });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-regular to target-choice-member', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ isChoice: false });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-regular to target-regular', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+    });
+  });
+
+  describe('validateMappingPair', () => {
+    let sourceDoc: ReturnType<typeof TestUtil.createSourceOrderDoc>;
+    let targetDoc: ReturnType<typeof TestUtil.createTargetOrderDoc>;
+    let tree: MappingTree;
+    let sourceDocNode: DocumentNodeData;
+    let targetDocNode: TargetDocumentNodeData;
+
+    beforeEach(() => {
+      sourceDoc = TestUtil.createSourceOrderDoc();
+      targetDoc = TestUtil.createTargetOrderDoc();
+      tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      sourceDocNode = new DocumentNodeData(sourceDoc);
+      targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+    });
+
+    it('should reject same-side drops (both source) silently (no errorMessage)', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new FieldNodeData(sourceDocNode, sourceField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should reject same-side drops (both target) silently (no errorMessage)', () => {
+      const targetField = createMockField({ type: Types.String });
+      const fromNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should return sourceNode and targetNode on valid cross-side drop', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const targetField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+
+    it('should reject cross-side drop to unselected choice target with errorMessage', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const targetField = createMockField({ isChoice: true, selectedMemberIndex: undefined });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBeDefined();
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+
+    it('should return valid for cross-side drop when target is document node (not field-level)', () => {
+      const sourceField = createMockField({ type: Types.String });
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField) as NodeData;
+      const result = MappingValidationService.validateMappingPair(fromNode, targetDocNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(fromNode);
+      expect(result.targetNode).toBe(targetDocNode);
+    });
+
+    it('should return valid when source is a PrimitiveDocument node and target is a field', () => {
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const primDocNode = new DocumentNodeData(primitiveDoc);
+      const targetField = createMockField({ type: Types.String });
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(primDocNode, toNode);
+      expect(result.isValid).toBe(true);
+      expect(result.sourceNode).toBe(primDocNode);
+      expect(result.targetNode).toBe(toNode);
+    });
+  });
+});

--- a/packages/ui/src/services/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/mapping-validation.service.test.ts
@@ -6,10 +6,11 @@ import {
   IField,
   PrimitiveDocument,
 } from '../models/datamapper/document';
-import { MappingTree } from '../models/datamapper/mapping';
+import { FieldItem, MappingTree } from '../models/datamapper/mapping';
 import { Types } from '../models/datamapper/types';
 import {
   DocumentNodeData,
+  FieldItemNodeData,
   FieldNodeData,
   NodeData,
   TargetDocumentNodeData,
@@ -199,6 +200,18 @@ describe('MappingValidationService', () => {
       expect(result.isValid).toBe(true);
       expect(result.sourceNode).toBe(fromNode);
       expect(result.targetNode).toBe(targetDocNode);
+    });
+
+    it('should run field validation when target is a FieldItemNodeData', () => {
+      const sourceField = createMockField({ type: Types.Container });
+      const targetField = createMockField({ type: Types.String });
+      const targetFieldNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const fieldItem = new FieldItem(tree, targetField);
+      const fromNode = new FieldNodeData(sourceDocNode, sourceField);
+      const toNode = new FieldItemNodeData(targetFieldNode, fieldItem);
+      const result = MappingValidationService.validateMappingPair(fromNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toContain('container');
     });
 
     it('should return valid when source is a PrimitiveDocument node and target is a field', () => {

--- a/packages/ui/src/services/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/mapping-validation.service.test.ts
@@ -119,6 +119,20 @@ describe('MappingValidationService', () => {
         const result = MappingValidationService.validateFieldPair(source, target);
         expect(result.isValid).toBe(true);
       });
+
+      it('should skip container check for choice source with container type mapped to terminal target', () => {
+        const source = createMockField({ isChoice: true, type: Types.Container });
+        const target = createMockField({ type: Types.String });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow source-choice to target-choice with selected member', () => {
+        const source = createMockField({ isChoice: true });
+        const target = createMockField({ isChoice: true, selectedMemberIndex: 0 });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
     });
   });
 

--- a/packages/ui/src/services/mapping-validation.service.ts
+++ b/packages/ui/src/services/mapping-validation.service.ts
@@ -1,0 +1,127 @@
+import { IField, PrimitiveDocument } from '../models/datamapper/document';
+import { Types } from '../models/datamapper/types';
+import {
+  FieldItemNodeData,
+  MappingNodeData,
+  NodeData,
+  SourceNodeDataType,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+  TargetNodeData,
+} from '../models/datamapper/visualization';
+
+/**
+ * Result returned by mapping validation operations.
+ *
+ * When `isValid` is `false` and the pair was rejected due to a user-correctable
+ * condition (e.g. unselected choice, container/terminal mismatch), `errorMessage`
+ * carries a human-readable explanation.  Same-side drops are silently rejected
+ * (`isValid: false`, no `errorMessage`).
+ *
+ * `sourceNode` and `targetNode` are populated on cross-side pairs regardless of
+ * validity, so callers can use them for highlighting or further processing.
+ */
+export interface ValidationResult {
+  /** Whether the drag-and-drop pair is a valid mapping operation. */
+  isValid: boolean;
+  /** Human-readable explanation when the pair is invalid due to a user-correctable condition. */
+  errorMessage?: string;
+  /** The resolved source node for this pair. */
+  sourceNode?: SourceNodeDataType;
+  /** The resolved target node for this pair. */
+  targetNode?: TargetNodeData;
+}
+
+/**
+ * Stateless service that validates drag-and-drop mapping pairs in the DataMapper.
+ *
+ * Validation is split into two levels:
+ * - **Node-level** ({@link validateMappingPair}): determines which node is source/target,
+ *   and short-circuits when the target is not a field (e.g. a document root drop).
+ * - **Field-level** ({@link validateFieldPair}): applies ordered schema rules
+ *   (choice selection, container compatibility) to the underlying `IField` values.
+ */
+export class MappingValidationService {
+  /**
+   * Validates a drag-and-drop pair at the node level.
+   *
+   * Rejects same-side drops silently (no `errorMessage`). For cross-side pairs,
+   * identifies which node is source and which is target, then delegates to
+   * {@link validateFieldPair} when both sides resolve to concrete fields.
+   * Document-root targets bypass field-level validation and are always accepted.
+   *
+   * @param fromNode - The node being dragged.
+   * @param toNode - The node being dropped onto.
+   * @returns A {@link ValidationResult} describing whether the pair is mappable.
+   */
+  static validateMappingPair(fromNode: NodeData, toNode: NodeData): ValidationResult {
+    if ((fromNode.isSource && toNode.isSource) || (!fromNode.isSource && !toNode.isSource)) {
+      return { isValid: false };
+    }
+
+    const sourceNode = (fromNode.isSource ? fromNode : toNode) as SourceNodeDataType;
+    const targetNode = (fromNode.isSource ? toNode : fromNode) as TargetNodeData;
+
+    if (targetNode instanceof MappingNodeData || targetNode instanceof TargetDocumentNodeData) {
+      return { isValid: true, sourceNode, targetNode };
+    }
+    if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {
+      return { isValid: false, sourceNode, targetNode };
+    }
+
+    const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
+    const targetField = targetNode.field;
+
+    const fieldValidation = MappingValidationService.validateFieldPair(sourceField, targetField);
+    return { ...fieldValidation, sourceNode, targetNode };
+  }
+
+  private static readonly validationRules: ReadonlyArray<(source: IField, target: IField) => ValidationResult> = [
+    MappingValidationService.validateChoiceRules,
+    MappingValidationService.validateContainerRules,
+  ];
+
+  /**
+   * Validates a pair of `IField` values against all registered schema rules.
+   *
+   * Rules are applied in order; the first failing rule short-circuits and its
+   * result is returned.  Currently enforced rules are:
+   * 1. Choice selection — a choice target must have a member selected before mapping.
+   * 2. Container/terminal compatibility — a container field cannot be mapped to a terminal field and vice versa.
+   *
+   * @param sourceField - The source schema field.
+   * @param targetField - The target schema field.
+   * @returns A {@link ValidationResult} with `isValid: true` when all rules pass.
+   */
+  static validateFieldPair(sourceField: IField, targetField: IField): ValidationResult {
+    for (const rule of MappingValidationService.validationRules) {
+      const result = rule(sourceField, targetField);
+      if (!result.isValid) return result;
+    }
+    return { isValid: true };
+  }
+
+  private static validateContainerRules(source: IField, target: IField): ValidationResult {
+    if (MappingValidationService.isContainer(source) !== MappingValidationService.isContainer(target)) {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map between a container field and a terminal field.',
+      };
+    }
+    return { isValid: true };
+  }
+
+  private static isContainer(source: IField) {
+    return source.type === Types.Container;
+  }
+
+  private static validateChoiceRules(_source: IField, target: IField): ValidationResult {
+    if (target.isChoice === true && target.selectedMemberIndex === undefined) {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map to an unselected choice. Please select a specific choice member first.',
+      };
+    }
+    return { isValid: true };
+  }
+}

--- a/packages/ui/src/services/mapping-validation.service.ts
+++ b/packages/ui/src/services/mapping-validation.service.ts
@@ -62,7 +62,10 @@ export class MappingValidationService {
     const sourceNode = (fromNode.isSource ? fromNode : toNode) as SourceNodeDataType;
     const targetNode = (fromNode.isSource ? toNode : fromNode) as TargetNodeData;
 
-    if (targetNode instanceof MappingNodeData || targetNode instanceof TargetDocumentNodeData) {
+    if (targetNode instanceof TargetDocumentNodeData) {
+      return { isValid: true, sourceNode, targetNode };
+    }
+    if (targetNode instanceof MappingNodeData && !(targetNode instanceof FieldItemNodeData)) {
       return { isValid: true, sourceNode, targetNode };
     }
     if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {

--- a/packages/ui/src/services/mapping-validation.service.ts
+++ b/packages/ui/src/services/mapping-validation.service.ts
@@ -102,6 +102,9 @@ export class MappingValidationService {
   }
 
   private static validateContainerRules(source: IField, target: IField): ValidationResult {
+    /** While choice node is also a container, it has its own rule in {@link validateChoiceRules()} */
+    if (source.isChoice) return { isValid: true };
+
     if (MappingValidationService.isContainer(source) !== MappingValidationService.isContainer(target)) {
       return {
         isValid: false,

--- a/packages/ui/src/services/mapping-validation.service.ts
+++ b/packages/ui/src/services/mapping-validation.service.ts
@@ -1,6 +1,7 @@
 import { IField, PrimitiveDocument } from '../models/datamapper/document';
 import { Types } from '../models/datamapper/types';
 import {
+  ChoiceFieldNodeData,
   FieldItemNodeData,
   MappingNodeData,
   NodeData,
@@ -61,6 +62,17 @@ export class MappingValidationService {
 
     const sourceNode = (fromNode.isSource ? fromNode : toNode) as SourceNodeDataType;
     const targetNode = (fromNode.isSource ? toNode : fromNode) as TargetNodeData;
+
+    if (sourceNode instanceof ChoiceFieldNodeData && !sourceNode.choiceField) {
+      if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {
+        return {
+          isValid: false,
+          sourceNode,
+          targetNode,
+          errorMessage: 'Drop a choice node onto a target field to create a conditional mapping.',
+        };
+      }
+    }
 
     if (targetNode instanceof TargetDocumentNodeData) {
       return { isValid: true, sourceNode, targetNode };

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -4,7 +4,6 @@ import {
   DocumentDefinitionType,
   DocumentType,
   IDocument,
-  IField,
   PrimitiveDocument,
 } from '../models/datamapper/document';
 import {
@@ -45,10 +44,10 @@ import {
   getShipOrderToShipOrderInvalidForEachXslt,
   getShipOrderToShipOrderMultipleForEachXslt,
   getShipOrderToShipOrderXslt,
+  getTestDocumentXsd,
   getUnknownApplyTemplateXslt,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
-import { DocumentUtilService } from './document-util.service';
 import { MappingSerializerService } from './mapping-serializer.service';
 import { VisualizationService } from './visualization.service';
 import { XmlSchemaDocument } from './xml-schema-document.model';
@@ -851,7 +850,8 @@ describe('VisualizationService', () => {
       expect(personField).toBeDefined();
       const personChildren = VisualizationService.generateNonDocumentNodeDataChildren(personField);
 
-      expect(personChildren.length).toEqual(11);
+      // name, street, city, choice wrapper, createdBy, createdDate, @id, @version, @status
+      expect(personChildren.length).toEqual(9);
 
       const nameField = personChildren.find((child) => child.title === 'name');
       expect(nameField).toBeDefined();
@@ -862,13 +862,22 @@ describe('VisualizationService', () => {
       const cityField = personChildren.find((child) => child.title === 'city');
       expect(cityField).toBeDefined();
 
-      const emailField = personChildren.find((child) => child.title === 'email');
+      // xs:choice is represented as a ChoiceFieldNodeData; email/phone are inside nested choice
+      const outerChoiceNode = personChildren.find(
+        (child) => child instanceof ChoiceFieldNodeData,
+      ) as ChoiceFieldNodeData;
+      expect(outerChoiceNode).toBeDefined();
+      const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
+      const innerChoiceNode = outerChoiceChildren.find(
+        (child) => child instanceof ChoiceFieldNodeData,
+      ) as ChoiceFieldNodeData;
+      expect(innerChoiceNode).toBeDefined();
+      const innerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
+      const emailField = innerChoiceChildren.find((child) => child.title === 'email');
       expect(emailField).toBeDefined();
-
-      const phoneField = personChildren.find((child) => child.title === 'phone');
+      const phoneField = innerChoiceChildren.find((child) => child.title === 'phone');
       expect(phoneField).toBeDefined();
-
-      const faxField = personChildren.find((child) => child.title === 'fax');
+      const faxField = outerChoiceChildren.find((child) => child.title === 'fax');
       expect(faxField).toBeDefined();
 
       const createdByField = personChildren.find((child) => child.title === 'createdBy');
@@ -1199,7 +1208,7 @@ describe('VisualizationService', () => {
       return {
         ...baseField,
         name: 'choice',
-        displayName: DocumentUtilService.formatChoiceDisplayName(memberFields as unknown as IField[]),
+        displayName: 'choice',
         isChoice: true,
         selectedMemberIndex,
         fields: memberFields,
@@ -1356,6 +1365,182 @@ describe('VisualizationService', () => {
         const children = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
         expect(children.length).toEqual(2);
       });
+
+      it('should fall back to all members when selectedMemberIndex is out of bounds', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 99);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const children = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
+        expect(children.length).toEqual(2);
+        expect(children[0].title).toEqual('email');
+        expect(children[1].title).toEqual('phone');
+      });
+
+      describe('XSD integration: choice wrapper expandability from real parsed schema', () => {
+        let testDocumentChildren: ReturnType<typeof VisualizationService.generateNonDocumentNodeDataChildren>;
+
+        beforeEach(() => {
+          const definition = new DocumentDefinition(
+            DocumentType.SOURCE_BODY,
+            DocumentDefinitionType.XML_SCHEMA,
+            BODY_DOCUMENT_ID,
+            { 'testDocument.xsd': getTestDocumentXsd() },
+          );
+          const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+          const docNode = new DocumentNodeData(result.document!);
+          const docChildren = VisualizationService.generateStructuredDocumentChildren(docNode);
+          const testDocumentNode = docChildren[0];
+          testDocumentChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentNode);
+        });
+
+        it('simple choice: members from elements and group ref are shown as children in order', () => {
+          expect(testDocumentChildren[2].title).toEqual('ChoiceElement');
+          const choiceElementChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+            testDocumentChildren[2],
+          );
+          expect(choiceElementChildren.length).toEqual(1);
+          const choiceNode = choiceElementChildren[0] as ChoiceFieldNodeData;
+          expect(choiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(choiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(choiceNode)).toEqual(
+            '(Choice1 | Choice2 | Group1Element1 | +1 more)',
+          );
+          const members = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
+          expect(members.length).toEqual(4);
+          expect(members[0].title).toEqual('Choice1');
+          expect(members[1].title).toEqual('Choice2');
+          expect(members[2].title).toEqual('Group1Element1');
+          expect(members[3].title).toEqual('Group1Element2');
+        });
+
+        it('sibling choices: two sibling xs:choice wrappers appear as distinct ChoiceFieldNodeData in order', () => {
+          expect(testDocumentChildren[3].title).toEqual('SiblingChoicesElement');
+          const children = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentChildren[3]);
+          expect(children.length).toEqual(2);
+          expect(children[0]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(children[0].title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(children[0] as ChoiceFieldNodeData)).toEqual('(SibA1 | SibA2)');
+          expect(children[1]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(children[1].title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(children[1] as ChoiceFieldNodeData)).toEqual('(SibB1 | SibB2)');
+          const firstMembers = VisualizationService.generateNonDocumentNodeDataChildren(
+            children[0] as ChoiceFieldNodeData,
+          );
+          expect(firstMembers.length).toEqual(2);
+          expect(firstMembers[0].title).toEqual('SibA1');
+          expect(firstMembers[1].title).toEqual('SibA2');
+          const secondMembers = VisualizationService.generateNonDocumentNodeDataChildren(
+            children[1] as ChoiceFieldNodeData,
+          );
+          expect(secondMembers.length).toEqual(2);
+          expect(secondMembers[0].title).toEqual('SibB1');
+          expect(secondMembers[1].title).toEqual('SibB2');
+        });
+
+        it('direct nested choice: inner xs:choice appears as nested ChoiceFieldNodeData in order', () => {
+          expect(testDocumentChildren[4].title).toEqual('DirectNestedChoiceElement');
+          const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentChildren[4]);
+          expect(outerChoiceChildren.length).toEqual(1);
+          const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
+          expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(outerChoiceNode)).toEqual('(Direct1 | choice)');
+          const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
+          expect(outerMembers.length).toEqual(2);
+          expect(outerMembers[0]).not.toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerMembers[0].title).toEqual('Direct1');
+          const innerChoiceNode = outerMembers[1] as ChoiceFieldNodeData;
+          expect(innerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(innerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(innerChoiceNode)).toEqual('(NestedDirect1 | NestedDirect2)');
+          const innerMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
+          expect(innerMembers.length).toEqual(2);
+          expect(innerMembers[0].title).toEqual('NestedDirect1');
+          expect(innerMembers[1].title).toEqual('NestedDirect2');
+        });
+
+        it('multiple nested choices: outer title uses numbered suffixes without truncation', () => {
+          expect(testDocumentChildren[5].title).toEqual('MultipleNestedChoicesElement');
+          const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentChildren[5]);
+          expect(outerChoiceChildren.length).toEqual(1);
+          const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
+          expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(outerChoiceNode)).toEqual('(choice1 | choice2)');
+          const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
+          expect(outerMembers.length).toEqual(2);
+          const innerChoiceA = outerMembers[0] as ChoiceFieldNodeData;
+          expect(innerChoiceA).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(innerChoiceA.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(innerChoiceA)).toEqual('(InnerA1 | InnerA2)');
+          const innerChoiceB = outerMembers[1] as ChoiceFieldNodeData;
+          expect(innerChoiceB).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(innerChoiceB.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(innerChoiceB)).toEqual('(InnerB1 | InnerB2)');
+          const innerAMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceA);
+          expect(innerAMembers.length).toEqual(2);
+          expect(innerAMembers[0].title).toEqual('InnerA1');
+          expect(innerAMembers[1].title).toEqual('InnerA2');
+          const innerBMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceB);
+          expect(innerBMembers.length).toEqual(2);
+          expect(innerBMembers[0].title).toEqual('InnerB1');
+          expect(innerBMembers[1].title).toEqual('InnerB2');
+        });
+
+        it('too many nested choices: outer title is truncated with numbered suffixes', () => {
+          expect(testDocumentChildren[6].title).toEqual('TooManyNestedChoicesElement');
+          const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentChildren[6]);
+          expect(outerChoiceChildren.length).toEqual(1);
+          const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
+          expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(outerChoiceNode)).toEqual(
+            '(choice1 | choice2 | choice3 | +2 more)',
+          );
+          const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
+          expect(outerMembers.length).toEqual(5);
+          const innerChoices = outerMembers as ChoiceFieldNodeData[];
+          expect(innerChoices[0]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationService.createNodeTitle(innerChoices[0])).toEqual('(InnerA1 | InnerA2)');
+          expect(innerChoices[1]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationService.createNodeTitle(innerChoices[1])).toEqual('(InnerB1 | InnerB2)');
+          expect(innerChoices[2]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationService.createNodeTitle(innerChoices[2])).toEqual('(InnerC1 | InnerC2)');
+          expect(innerChoices[3]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationService.createNodeTitle(innerChoices[3])).toEqual('(InnerD1 | InnerD2)');
+          expect(innerChoices[4]).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationService.createNodeTitle(innerChoices[4])).toEqual('(InnerE1 | InnerE2)');
+          const innerAMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoices[0]);
+          expect(innerAMembers.length).toEqual(2);
+          expect(innerAMembers[0].title).toEqual('InnerA1');
+          expect(innerAMembers[1].title).toEqual('InnerA2');
+          const innerEMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoices[4]);
+          expect(innerEMembers.length).toEqual(2);
+          expect(innerEMembers[0].title).toEqual('InnerE1');
+          expect(innerEMembers[1].title).toEqual('InnerE2');
+        });
+
+        it('indirect nested choice via group ref: group xs:choice appears as nested ChoiceFieldNodeData in order', () => {
+          expect(testDocumentChildren[7].title).toEqual('IndirectNestedChoiceElement');
+          const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentChildren[7]);
+          expect(outerChoiceChildren.length).toEqual(1);
+          const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
+          expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(outerChoiceNode)).toEqual('(Indirect1 | choice)');
+          const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
+          expect(outerMembers.length).toEqual(2);
+          expect(outerMembers[0]).not.toBeInstanceOf(ChoiceFieldNodeData);
+          expect(outerMembers[0].title).toEqual('Indirect1');
+          const innerChoiceNode = outerMembers[1] as ChoiceFieldNodeData;
+          expect(innerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(innerChoiceNode.title).toEqual('choice');
+          expect(VisualizationService.createNodeTitle(innerChoiceNode)).toEqual('(ChoiceGroupEl1 | ChoiceGroupEl2)');
+          const innerMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
+          expect(innerMembers.length).toEqual(2);
+          expect(innerMembers[0].title).toEqual('ChoiceGroupEl1');
+          expect(innerMembers[1].title).toEqual('ChoiceGroupEl2');
+        });
+      });
     });
 
     describe('nested choice fields', () => {
@@ -1368,7 +1553,7 @@ describe('VisualizationService', () => {
         const innerChoice = {
           ...baseField,
           name: 'choice',
-          displayName: DocumentUtilService.formatChoiceDisplayName(innerMembers as unknown as IField[]),
+          displayName: 'choice',
           isChoice: true,
           fields: innerMembers,
           selectedMemberIndex: innerSelectedIndex,
@@ -1384,7 +1569,7 @@ describe('VisualizationService', () => {
         const outerChoice = {
           ...baseField,
           name: 'choice',
-          displayName: DocumentUtilService.formatChoiceDisplayName(outerMembers as unknown as IField[]),
+          displayName: 'choice',
           isChoice: true,
           fields: outerMembers,
           selectedMemberIndex: outerSelectedIndex,
@@ -1511,6 +1696,87 @@ describe('VisualizationService', () => {
       });
     });
 
+    describe('getChoiceMemberLabel', () => {
+      it('should return member names joined with | in parentheses', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }, { name: 'fax' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.getChoiceMemberLabel(choiceNode)).toEqual('(email | phone | fax)');
+      });
+
+      it('should return "(empty)" for a choice with no members', () => {
+        const choiceField = createMockChoiceField([]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.getChoiceMemberLabel(choiceNode)).toEqual('(empty)');
+      });
+
+      it('should label a single nested choice member as "choice"', () => {
+        const baseField = sourceDoc.fields[0];
+        const innerChoice = { ...baseField, name: 'choice', displayName: 'choice', isChoice: true, fields: [] };
+        const choiceField = {
+          ...baseField,
+          name: 'choice',
+          displayName: 'choice',
+          isChoice: true,
+          fields: [innerChoice, { ...baseField, name: 'direct', displayName: 'direct', isChoice: false, fields: [] }],
+        } as unknown as typeof baseField;
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.getChoiceMemberLabel(choiceNode)).toEqual('(choice | direct)');
+      });
+
+      it('should distinguish multiple nested choices with numbered labels', () => {
+        const baseField = sourceDoc.fields[0];
+        const inner1 = { ...baseField, name: 'choice', displayName: 'choice', isChoice: true, fields: [] };
+        const inner2 = { ...baseField, name: 'choice', displayName: 'choice', isChoice: true, fields: [] };
+        const choiceField = {
+          ...baseField,
+          name: 'choice',
+          displayName: 'choice',
+          isChoice: true,
+          fields: [inner1, inner2],
+        } as unknown as typeof baseField;
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.getChoiceMemberLabel(choiceNode)).toEqual('(choice1 | choice2)');
+      });
+
+      it('should truncate long member lists showing first 3 and count', () => {
+        const members = Array.from({ length: 10 }, (_, i) => ({ name: `member${i}` }));
+        const choiceField = createMockChoiceField(members);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.getChoiceMemberLabel(choiceNode)).toEqual(
+          '(member0 | member1 | member2 | +7 more)',
+        );
+      });
+    });
+
+    describe('createNodeTitle', () => {
+      it('should return member label for unselected choice wrapper (no choiceField)', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        expect(VisualizationService.createNodeTitle(choiceNode)).toEqual('(email | phone)');
+      });
+
+      it('should return nodeData.title for selected choice member (choiceField set)', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 0);
+        const parentField = { ...sourceDoc.fields[0], fields: [choiceField] };
+        const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+        const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+        const selectedNode = children[0] as ChoiceFieldNodeData;
+        expect(selectedNode.choiceField).toBeDefined();
+        expect(VisualizationService.createNodeTitle(selectedNode)).toEqual('email');
+      });
+
+      it('should return nodeData.title for regular FieldNodeData', () => {
+        const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+        expect(VisualizationService.createNodeTitle(fieldNode)).toEqual(fieldNode.title);
+      });
+
+      it('should return member label for unselected TargetChoiceFieldNodeData', () => {
+        const choiceField = createMockChoiceField([{ name: 'a' }, { name: 'b' }]);
+        const choiceNode = new TargetChoiceFieldNodeData(targetDocNode, choiceField);
+        expect(VisualizationService.createNodeTitle(choiceNode)).toEqual('(a | b)');
+      });
+    });
+
     describe('engageMapping with choice source', () => {
       let localTargetDocNode: TargetDocumentNodeData;
 
@@ -1617,6 +1883,19 @@ describe('VisualizationService', () => {
         expect(targetFieldItem.children.length).toEqual(1);
         expect(targetFieldItem.children[0]).toBeInstanceOf(ValueSelector);
         expect(targetFieldItem.children[0]).not.toBeInstanceOf(ChooseItem);
+      });
+
+      it('should not create duplicate ChooseItem when mapping the same choice source twice', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        const targetFieldItem = tree.children[0];
+        const chooseItems = targetFieldItem.children.filter((c) => c instanceof ChooseItem);
+        expect(chooseItems.length).toEqual(1);
       });
     });
   });

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -1510,6 +1510,95 @@ describe('VisualizationService', () => {
         expect(outerMembers[1].title).toEqual('regularField');
       });
     });
+
+    describe('engageMapping with choice source', () => {
+      let localTargetDocNode: TargetDocumentNodeData;
+
+      beforeEach(() => {
+        localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      });
+
+      it('should create ChooseItem with WhenItems and OtherwiseItem for choice source with 2 members', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        expect(tree.children.length).toEqual(1);
+        const targetFieldItem = tree.children[0];
+        expect(targetFieldItem).toBeInstanceOf(FieldItem);
+        expect(targetFieldItem.children.length).toEqual(1);
+
+        const chooseItem = targetFieldItem.children[0] as ChooseItem;
+        expect(chooseItem).toBeInstanceOf(ChooseItem);
+        expect(chooseItem.when.length).toEqual(2);
+        expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
+      });
+
+      it('each WhenItem expression should be the XPath of the corresponding choice member', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        const chooseItem = tree.children[0].children[0] as ChooseItem;
+        expect(chooseItem.when[0].expression).toEqual('/ns0:email');
+        expect(chooseItem.when[1].expression).toEqual('/ns0:phone');
+      });
+
+      it('each WhenItem ValueSelector expression should be the XPath of the corresponding choice member', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        const chooseItem = tree.children[0].children[0] as ChooseItem;
+        const emailSelector = chooseItem.when[0].children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        const phoneSelector = chooseItem.when[1].children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        expect(emailSelector.expression).toEqual('/ns0:email');
+        expect(phoneSelector.expression).toEqual('/ns0:phone');
+      });
+
+      it('should create ChooseItem when dropping choice source onto an existing FieldItemNodeData target', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(localTargetDocNode);
+        VisualizationService.engageMapping(
+          tree,
+          sourceDocChildren[0] as FieldNodeData,
+          targetDocChildren[0] as TargetNodeData,
+        );
+
+        const updatedTargetDocChildren = VisualizationService.generateStructuredDocumentChildren(localTargetDocNode);
+        const fieldItemNode = updatedTargetDocChildren[0] as FieldItemNodeData;
+        expect(fieldItemNode).toBeInstanceOf(FieldItemNodeData);
+
+        VisualizationService.engageMapping(tree, choiceNode, fieldItemNode);
+
+        const chooseItem = fieldItemNode.mapping.children.find((c) => c instanceof ChooseItem) as ChooseItem;
+        expect(chooseItem).toBeInstanceOf(ChooseItem);
+        expect(chooseItem.when.length).toEqual(2);
+        expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
+      });
+
+      it('should create ChooseItem with only OtherwiseItem for empty-member choice source', () => {
+        const choiceField = createMockChoiceField([]);
+        const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        const chooseItem = tree.children[0].children[0] as ChooseItem;
+        expect(chooseItem).toBeInstanceOf(ChooseItem);
+        expect(chooseItem.when.length).toEqual(0);
+        expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
+      });
+    });
   });
 
   describe('formatXml()', () => {

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -1207,7 +1207,7 @@ describe('VisualizationService', () => {
       }));
       return {
         ...baseField,
-        name: 'choice',
+        name: '__choice__',
         displayName: 'choice',
         isChoice: true,
         selectedMemberIndex,
@@ -1552,7 +1552,7 @@ describe('VisualizationService', () => {
         ];
         const innerChoice = {
           ...baseField,
-          name: 'choice',
+          name: '__choice__',
           displayName: 'choice',
           isChoice: true,
           fields: innerMembers,
@@ -1568,7 +1568,7 @@ describe('VisualizationService', () => {
         const outerMembers = [innerChoice, regularMember];
         const outerChoice = {
           ...baseField,
-          name: 'choice',
+          name: '__choice__',
           displayName: 'choice',
           isChoice: true,
           fields: outerMembers,
@@ -1844,12 +1844,17 @@ describe('VisualizationService', () => {
         const fieldItemNode = updatedTargetDocChildren[0] as FieldItemNodeData;
         expect(fieldItemNode).toBeInstanceOf(FieldItemNodeData);
 
+        const valueSelectorBefore = fieldItemNode.mapping.children.some((c) => c instanceof ValueSelector);
+        expect(valueSelectorBefore).toBe(true);
+
         VisualizationService.engageMapping(tree, choiceNode, fieldItemNode);
 
         const chooseItem = fieldItemNode.mapping.children.find((c) => c instanceof ChooseItem) as ChooseItem;
         expect(chooseItem).toBeInstanceOf(ChooseItem);
         expect(chooseItem.when.length).toEqual(2);
         expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
+        const valueSelectorAfter = fieldItemNode.mapping.children.some((c) => c instanceof ValueSelector);
+        expect(valueSelectorAfter).toBe(false);
       });
 
       it('should create ChooseItem with only OtherwiseItem for empty-member choice source', () => {
@@ -1896,6 +1901,318 @@ describe('VisualizationService', () => {
         const targetFieldItem = tree.children[0];
         const chooseItems = targetFieldItem.children.filter((c) => c instanceof ChooseItem);
         expect(chooseItems.length).toEqual(1);
+      });
+    });
+
+    describe('mapping through unselected target choice wrapper', () => {
+      let localTargetDocNode: TargetDocumentNodeData;
+      let parentFieldNode: TargetFieldNodeData;
+      let choiceField: ReturnType<typeof createMockChoiceField>;
+
+      beforeEach(() => {
+        localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        choiceField = createMockChoiceField([{ name: 'contactEmail' }, { name: 'contactPhone' }]);
+        const parentField = {
+          ...targetDoc.fields[0],
+          fields: [choiceField],
+        };
+        parentFieldNode = new TargetFieldNodeData(localTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+      });
+
+      it('getOrCreateFieldItem should skip unselected choice wrapper and create FieldItem under grandparent', () => {
+        // Build the node hierarchy: parentField -> choiceWrapper -> memberField
+        const choiceNode = new TargetChoiceFieldNodeData(parentFieldNode, choiceField);
+        // choiceField property is undefined = unselected wrapper
+        expect(choiceNode.choiceField).toBeUndefined();
+
+        const memberField = choiceField.fields[0];
+        const memberNode = new TargetFieldNodeData(choiceNode, memberField);
+
+        // engageMapping triggers getOrCreateFieldItem for the member inside the choice wrapper
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
+        const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
+
+        VisualizationService.engageMapping(tree, sourceChildren[0] as FieldNodeData, memberNode);
+
+        // The mapping tree should have the member's FieldItem directly under the parent FieldItem,
+        // not under a spurious choice wrapper FieldItem.
+        const parentItem = tree.children[0]; // FieldItem for parentField (e.g. ShipOrder)
+        expect(parentItem).toBeInstanceOf(FieldItem);
+        const memberItem = parentItem.children.find(
+          (c) => c instanceof FieldItem && c.field === memberField,
+        ) as FieldItem;
+        expect(memberItem).toBeDefined();
+        expect(memberItem.field.name).toEqual('contactEmail');
+      });
+
+      it('generateNonDocumentNodeDataChildren should find mappings for fields inside unselected choice wrapper', () => {
+        // First create a mapping for a member field inside the choice wrapper
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
+        const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
+
+        // Build the node hierarchy and engage mapping
+        const choiceNode = new TargetChoiceFieldNodeData(parentFieldNode, choiceField);
+        const memberField = choiceField.fields[0];
+        const memberNode = new TargetFieldNodeData(choiceNode, memberField);
+
+        VisualizationService.engageMapping(tree, sourceChildren[0] as FieldNodeData, memberNode);
+
+        // Now regenerate the target tree from scratch and verify the choice wrapper children
+        // resolve the existing mapping correctly
+        const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const freshParentField = {
+          ...targetDoc.fields[0],
+          fields: [choiceField],
+        };
+        const freshParentNode = new TargetFieldNodeData(
+          freshTargetDocNode,
+          freshParentField as (typeof targetDoc.fields)[0],
+        );
+        // parentField should have a mapping now
+        freshParentNode.mapping = tree.children[0] as FieldItem;
+
+        const freshChoiceNode = new TargetChoiceFieldNodeData(freshParentNode, choiceField);
+        // Unselected wrapper — choiceField property is undefined
+        const choiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshChoiceNode);
+
+        // The member 'contactEmail' should be rendered as a FieldItemNodeData (has mapping),
+        // not as a plain TargetFieldNodeData (no mapping found)
+        const contactEmailNode = choiceChildren.find((c) => c.title === 'contactEmail');
+        expect(contactEmailNode).toBeDefined();
+        expect(contactEmailNode).toBeInstanceOf(FieldItemNodeData);
+      });
+
+      it('FieldItemNodeData.path should match FieldItem.nodePath so mapping lines render correctly', () => {
+        // Create a mapping for a member field inside the choice wrapper
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
+        const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
+
+        const choiceNode = new TargetChoiceFieldNodeData(parentFieldNode, choiceField);
+        const memberField = choiceField.fields[0];
+        const memberNode = new TargetFieldNodeData(choiceNode, memberField);
+
+        VisualizationService.engageMapping(tree, sourceChildren[0] as FieldNodeData, memberNode);
+
+        // Re-render the visual tree using FieldItemNodeData for the parent (as the
+        // real rendering pipeline would, since it has a mapping)
+        const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const parentItem = tree.children[0] as FieldItem;
+        const freshParentNode = new FieldItemNodeData(freshTargetDocNode, parentItem);
+        // Override field to include the choice member
+        freshParentNode.field = {
+          ...freshParentNode.field,
+          fields: [choiceField],
+        } as typeof freshParentNode.field;
+
+        const freshChoiceNode = new TargetChoiceFieldNodeData(freshParentNode, choiceField);
+        const choiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshChoiceNode);
+        const contactEmailNode = choiceChildren.find((c) => c.title === 'contactEmail') as FieldItemNodeData;
+
+        // The visual node path must match the mapping tree nodePath for line rendering
+        const mappingFieldItem = parentItem.children.find(
+          (c) => c instanceof FieldItem && c.field === memberField,
+        ) as FieldItem;
+        expect(contactEmailNode.path.toString()).toEqual(mappingFieldItem.nodePath.toString());
+      });
+
+      it('should work for nested fields inside choice member (mapping + rendering + path)', () => {
+        // Create a choice field where the member has nested children
+        const baseField = sourceDoc.fields[0];
+        const nestedField = {
+          ...baseField,
+          name: 'emailAddress',
+          displayName: 'emailAddress',
+          fields: [] as unknown[],
+          isChoice: false,
+        } as unknown as typeof baseField;
+        const memberWithChildren = {
+          ...baseField,
+          name: 'contactEmail',
+          displayName: 'contactEmail',
+          fields: [nestedField],
+          isChoice: false,
+        } as unknown as typeof baseField;
+        (nestedField as unknown as Record<string, unknown>).parent = memberWithChildren;
+        const nestedChoiceField = {
+          ...baseField,
+          name: 'choice',
+          displayName: 'choice',
+          isChoice: true,
+          selectedMemberIndex: undefined,
+          fields: [memberWithChildren],
+        } as unknown as typeof baseField;
+
+        const nestedParentField = {
+          ...targetDoc.fields[0],
+          fields: [nestedChoiceField],
+        };
+        const nestedParentNode = new TargetFieldNodeData(
+          localTargetDocNode,
+          nestedParentField as (typeof targetDoc.fields)[0],
+        );
+
+        // Build the visual tree: parent → choice → contactEmail → emailAddress
+        const nestedChoiceNode = new TargetChoiceFieldNodeData(nestedParentNode, nestedChoiceField);
+        const contactEmailNode = new TargetFieldNodeData(nestedChoiceNode, memberWithChildren);
+        const emailAddressNode = new TargetFieldNodeData(contactEmailNode, nestedField);
+
+        // Map source to the nested emailAddress field
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
+        const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
+
+        VisualizationService.engageMapping(tree, sourceChildren[0] as FieldNodeData, emailAddressNode);
+
+        // Verify mapping tree structure: parent → contactEmail → emailAddress
+        const parentItem = tree.children[0] as FieldItem;
+        expect(parentItem).toBeInstanceOf(FieldItem);
+        const contactEmailItem = parentItem.children.find(
+          (c) => c instanceof FieldItem && c.field === memberWithChildren,
+        ) as FieldItem;
+        expect(contactEmailItem).toBeDefined();
+        const emailAddressItem = contactEmailItem.children.find(
+          (c) => c instanceof FieldItem && c.field === nestedField,
+        ) as FieldItem;
+        expect(emailAddressItem).toBeDefined();
+
+        // Verify ValueSelector was created with an expression
+        const valueSelector = emailAddressItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        expect(valueSelector).toBeDefined();
+        expect(valueSelector.expression).not.toEqual('');
+
+        // Re-render using FieldItemNodeData for the parent (realistic rendering)
+        const freshTargetDocNode2 = new TargetDocumentNodeData(targetDoc, tree);
+        const freshParentNode2 = new FieldItemNodeData(freshTargetDocNode2, parentItem);
+        freshParentNode2.field = {
+          ...freshParentNode2.field,
+          fields: [nestedChoiceField],
+        } as typeof freshParentNode2.field;
+
+        const freshChoiceNode2 = new TargetChoiceFieldNodeData(freshParentNode2, nestedChoiceField);
+        const freshChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshChoiceNode2);
+
+        // contactEmail should be found as FieldItemNodeData
+        const freshContactEmailNode = freshChoiceChildren.find((c) => c.title === 'contactEmail') as FieldItemNodeData;
+        expect(freshContactEmailNode).toBeInstanceOf(FieldItemNodeData);
+
+        // Expand contactEmail — emailAddress should be found as FieldItemNodeData
+        const contactEmailChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshContactEmailNode);
+        const freshEmailAddressNode = contactEmailChildren.find((c) => c.title === 'emailAddress');
+        expect(freshEmailAddressNode).toBeDefined();
+        expect(freshEmailAddressNode).toBeInstanceOf(FieldItemNodeData);
+
+        // Path must match mapping tree nodePath for line rendering
+        expect((freshEmailAddressNode as FieldItemNodeData).path.toString()).toEqual(
+          emailAddressItem.nodePath.toString(),
+        );
+      });
+    });
+
+    describe('nested choice wrappers (choice inside choice)', () => {
+      it('should map to a field inside a nested choice and render the mapping correctly', () => {
+        // Use TestDocument.xsd which has DirectNestedChoiceElement:
+        //   <xs:choice>
+        //     <xs:element name="Direct1"/>
+        //     <xs:choice>
+        //       <xs:element name="NestedDirect1"/>
+        //       <xs:element name="NestedDirect2"/>
+        //     </xs:choice>
+        //   </xs:choice>
+        const definition = new DocumentDefinition(
+          DocumentType.TARGET_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          BODY_DOCUMENT_ID,
+          { 'testDocument.xsd': getTestDocumentXsd() },
+        );
+        const testTargetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
+        const testTree = new MappingTree(
+          testTargetDoc.documentType,
+          testTargetDoc.documentId,
+          DocumentDefinitionType.XML_SCHEMA,
+        );
+        const testTargetDocNode = new TargetDocumentNodeData(testTargetDoc, testTree);
+
+        // Navigate to DirectNestedChoiceElement
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(testTargetDocNode);
+        const testDocumentNode = docChildren[0];
+        const testDocumentChildren = VisualizationService.generateNonDocumentNodeDataChildren(testDocumentNode);
+        // DirectNestedChoiceElement is the 3rd child (index 2) after ChoiceElement, SiblingChoicesElement
+        const directNestedNode = testDocumentChildren.find((c) => c.title === 'DirectNestedChoiceElement')!;
+        const directNestedChildren = VisualizationService.generateNonDocumentNodeDataChildren(directNestedNode);
+
+        // Should have one outer choice wrapper
+        expect(directNestedChildren.length).toEqual(1);
+        const outerChoice = directNestedChildren[0] as TargetChoiceFieldNodeData;
+        expect(outerChoice).toBeInstanceOf(TargetChoiceFieldNodeData);
+
+        // Expand outer choice: [Direct1, inner_choice]
+        const outerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(outerChoice);
+        expect(outerChoiceChildren[0].title).toEqual('Direct1');
+        const innerChoice = outerChoiceChildren.find(
+          (c) => c instanceof TargetChoiceFieldNodeData,
+        ) as TargetChoiceFieldNodeData;
+        expect(innerChoice).toBeDefined();
+
+        // Expand inner choice: [NestedDirect1, NestedDirect2]
+        const innerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(innerChoice);
+        const nestedDirect1 = innerChoiceChildren.find((c) => c.title === 'NestedDirect1')! as TargetFieldNodeData;
+        expect(nestedDirect1).toBeDefined();
+
+        // Map source field to NestedDirect1 inside the nested choice
+        const sourceDocChildren2 = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceFieldNode2 = sourceDocChildren2[0] as FieldNodeData;
+        const sourceChildren2 = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode2);
+        VisualizationService.engageMapping(testTree, sourceChildren2[0] as FieldNodeData, nestedDirect1);
+
+        // Verify mapping tree: TestDocument → DirectNestedChoiceElement → NestedDirect1
+        // (both choice wrappers skipped)
+        const testDocItem = testTree.children[0] as FieldItem;
+        expect(testDocItem).toBeInstanceOf(FieldItem);
+        const directNestedItem = testDocItem.children.find(
+          (c) => c instanceof FieldItem && c.field.name === 'DirectNestedChoiceElement',
+        ) as FieldItem;
+        expect(directNestedItem).toBeDefined();
+        const nestedDirect1Item = directNestedItem.children.find(
+          (c) => c instanceof FieldItem && c.field.name === 'NestedDirect1',
+        ) as FieldItem;
+        expect(nestedDirect1Item).toBeDefined();
+
+        // Re-render from scratch and verify nested field is found with correct path
+        const freshDocNode = new TargetDocumentNodeData(testTargetDoc, testTree);
+        const freshDocChildren = VisualizationService.generateStructuredDocumentChildren(freshDocNode);
+        const freshTestDocNode = freshDocChildren[0];
+        const freshTestDocChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshTestDocNode);
+        const freshDirectNestedNode = freshTestDocChildren.find(
+          (c) => c.title === 'DirectNestedChoiceElement',
+        )! as FieldItemNodeData;
+        expect(freshDirectNestedNode).toBeInstanceOf(FieldItemNodeData);
+
+        // DirectNestedChoiceElement → [outerChoice]
+        const freshDirectNestedChildren =
+          VisualizationService.generateNonDocumentNodeDataChildren(freshDirectNestedNode);
+        const freshOuterChoice = freshDirectNestedChildren[0] as TargetChoiceFieldNodeData;
+        expect(freshOuterChoice).toBeInstanceOf(TargetChoiceFieldNodeData);
+
+        // outerChoice → [Direct1, innerChoice]
+        const freshOuterChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshOuterChoice);
+        const freshInnerChoice = freshOuterChoiceChildren.find(
+          (c) => c instanceof TargetChoiceFieldNodeData,
+        ) as TargetChoiceFieldNodeData;
+        expect(freshInnerChoice).toBeDefined();
+
+        // innerChoice → [NestedDirect1, NestedDirect2]
+        const freshInnerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshInnerChoice);
+        const freshNestedDirect1 = freshInnerChoiceChildren.find((c) => c.title === 'NestedDirect1');
+        expect(freshNestedDirect1).toBeDefined();
+        expect(freshNestedDirect1).toBeInstanceOf(FieldItemNodeData);
+
+        // Path must match mapping tree nodePath
+        expect((freshNestedDirect1 as FieldItemNodeData).path.toString()).toEqual(
+          nestedDirect1Item.nodePath.toString(),
+        );
       });
     });
   });

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -1598,6 +1598,26 @@ describe('VisualizationService', () => {
         expect(chooseItem.when.length).toEqual(0);
         expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
       });
+
+      it('should create a simple field mapping when dragging a selected choice member', () => {
+        const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 0);
+        const selectedMember = choiceField.fields[0];
+        const choiceNode = new ChoiceFieldNodeData(
+          sourceDocNode,
+          selectedMember as unknown as (typeof sourceDoc.fields)[0],
+        );
+        choiceNode.choiceField = choiceField;
+        const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, targetDoc.fields[0]);
+
+        VisualizationService.engageMapping(tree, choiceNode, targetFieldNode);
+
+        expect(tree.children.length).toEqual(1);
+        const targetFieldItem = tree.children[0];
+        expect(targetFieldItem).toBeInstanceOf(FieldItem);
+        expect(targetFieldItem.children.length).toEqual(1);
+        expect(targetFieldItem.children[0]).toBeInstanceOf(ValueSelector);
+        expect(targetFieldItem.children[0]).not.toBeInstanceOf(ChooseItem);
+      });
     });
   });
 

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -570,7 +570,12 @@ export class VisualizationService {
       sourceNode instanceof ChoiceFieldNodeData &&
       (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)
     ) {
-      VisualizationService.createChooseFromChoice(sourceNode.field, targetNode);
+      if (sourceNode.choiceField !== undefined) {
+        const item = VisualizationService.getOrCreateFieldItem(targetNode);
+        MappingService.mapToField(sourceNode.field, item);
+      } else {
+        VisualizationService.createChooseFromChoice(sourceNode.field, targetNode);
+      }
       return;
     }
 

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -46,20 +46,38 @@ type MappingNodePairType = {
   targetNode?: TargetNodeDataType;
 };
 
+/**
+ * Static utility service for the DataMapper visualization layer.
+ *
+ * Provides methods for generating {@link NodeData} hierarchies from document
+ * and mapping models, inspecting node characteristics, and applying mapping
+ * operations (if, forEach, choose/when/otherwise, value selectors).
+ */
 export class VisualizationService {
+  /**
+   * Dispatches to the correct child-generation strategy based on node type.
+   * @param nodeData - The parent node whose children should be generated.
+   * @returns An array of child {@link NodeData} instances.
+   */
   static generateNodeDataChildren(nodeData: NodeData): NodeData[] {
     const isDocument = nodeData instanceof DocumentNodeData;
     const isPrimitive = nodeData.isPrimitive;
 
     if (isDocument && isPrimitive) {
       return VisualizationService.generatePrimitiveDocumentChildren(nodeData);
-    } else if (isDocument && !isPrimitive) {
-      return VisualizationService.generateStructuredDocumentChildren(nodeData);
-    } else {
-      return VisualizationService.generateNonDocumentNodeDataChildren(nodeData);
     }
+    if (isDocument && !isPrimitive) {
+      return VisualizationService.generateStructuredDocumentChildren(nodeData);
+    }
+    return VisualizationService.generateNonDocumentNodeDataChildren(nodeData);
   }
 
+  /**
+   * Returns {@link MappingNodeData} children for a primitive target document.
+   * Only non-{@link ValueSelector} mapping children are included.
+   * @param document - The primitive document node.
+   * @returns An array of child {@link NodeData} instances, or an empty array if not applicable.
+   */
   static generatePrimitiveDocumentChildren(document: DocumentNodeData): NodeData[] {
     if (!(document instanceof TargetDocumentNodeData) || !document.mapping?.children) return [];
     return document.mapping.children
@@ -67,6 +85,12 @@ export class VisualizationService {
       .map((child) => VisualizationService.createNodeDataFromMappingItem(document, child));
   }
 
+  /**
+   * Returns field-based children for a structured (non-primitive) document node.
+   * For target documents, existing mappings are correlated with document fields.
+   * @param document - The structured document node.
+   * @returns An array of child {@link NodeData} instances.
+   */
   static generateStructuredDocumentChildren(document: DocumentNodeData): NodeData[] {
     return VisualizationService.doGenerateNodeDataFromFields(
       document,
@@ -108,9 +132,9 @@ export class VisualizationService {
       if (parent.isPrimitive) {
         filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof ValueSelector;
       }
-      mappings
-        .filter(filterPriorityMappingItem)
-        .forEach((m) => answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m)));
+      for (const m of mappings.filter(filterPriorityMappingItem)) {
+        answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m));
+      }
     }
 
     return fields.reduce((acc, field) => {
@@ -126,12 +150,11 @@ export class VisualizationService {
           : new TargetFieldNodeData(parent as TargetNodeData, field);
         acc.push(fieldNodeData);
       } else {
-        mappingsForField
+        for (const mapping of mappingsForField
           .filter((mapping) => !VisualizationService.isExistingMapping(acc as TargetNodeData[], mapping))
-          .sort((left, right) => MappingService.sortMappingItem(left, right))
-          .forEach((mapping) =>
-            acc.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, mapping)),
-          );
+          .sort((left, right) => MappingService.sortMappingItem(left, right))) {
+          acc.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, mapping));
+        }
         if (DocumentService.isCollectionField(field)) {
           acc.push(new AddMappingNodeData(parent as TargetNodeData, field));
         }
@@ -141,9 +164,15 @@ export class VisualizationService {
   }
 
   private static isExistingMapping(nodes: TargetNodeData[], mapping: MappingItem) {
-    return nodes.find((node) => 'mapping' in node && node.mapping === mapping);
+    return nodes.some((node) => 'mapping' in node && node.mapping === mapping);
   }
 
+  /**
+   * Returns children for choice, field, and mapping nodes (i.e. non-document nodes).
+   * Resolves type fragments for complex fields before generating children.
+   * @param parent - The non-document parent node.
+   * @returns An array of child {@link NodeData} instances.
+   */
   static generateNonDocumentNodeDataChildren(parent: NodeData): NodeData[] {
     if (parent instanceof ChoiceFieldNodeData || parent instanceof TargetChoiceFieldNodeData) {
       let fields: IField[];
@@ -168,12 +197,11 @@ export class VisualizationService {
         parent.field.fields,
         'mapping' in parent ? parent.mapping?.children : undefined,
       );
-    } else if (parent instanceof MappingNodeData) {
-      return parent.mapping?.children
-        ? parent.mapping.children
-            .sort((left, right) => MappingService.sortMappingItem(left, right))
-            .map((m) => VisualizationService.createNodeDataFromMappingItem(parent, m))
-        : [];
+    }
+    if (parent instanceof MappingNodeData) {
+      if (!parent.mapping?.children) return [];
+      const sorted = [...parent.mapping.children].sort((left, right) => MappingService.sortMappingItem(left, right));
+      return sorted.map((m) => VisualizationService.createNodeDataFromMappingItem(parent, m));
     }
     return [];
   }
@@ -185,6 +213,13 @@ export class VisualizationService {
     return new MappingNodeData(parent, mapping);
   }
 
+  /**
+   * Validates that two nodes form a valid source/target pair and returns them typed accordingly.
+   * Returns an empty object when both nodes are on the same side (both source or both target).
+   * @param fromNode - The originating node (e.g. the drag source).
+   * @param toNode - The destination node (e.g. the drop target).
+   * @returns A {@link MappingNodePairType} with `sourceNode` and `targetNode`, or an empty object if invalid.
+   */
   static testNodePair(fromNode: NodeData, toNode: NodeData): MappingNodePairType {
     const answer: MappingNodePairType = {};
     if ((fromNode.isSource && toNode.isSource) || (!fromNode.isSource && !toNode.isSource)) return answer;
@@ -194,14 +229,26 @@ export class VisualizationService {
     return { sourceNode, targetNode };
   }
 
+  /**
+   * Returns `true` if the node is a {@link DocumentNodeData}.
+   * @param nodeData - The node to test.
+   */
   static isDocumentNode(nodeData: NodeData) {
     return nodeData instanceof DocumentNodeData;
   }
 
+  /**
+   * Returns `true` if the node wraps a {@link PrimitiveDocument}.
+   * @param nodeData - The node to test.
+   */
   static isPrimitiveDocumentNode(nodeData: NodeData) {
     return nodeData instanceof DocumentNodeData && nodeData.document instanceof PrimitiveDocument;
   }
 
+  /**
+   * Returns `true` if the node's field is a collection (array/repeating element).
+   * @param nodeData - The node to test.
+   */
   static isCollectionField(nodeData: NodeData) {
     return (
       (nodeData instanceof FieldNodeData || nodeData instanceof FieldItemNodeData) &&
@@ -209,6 +256,10 @@ export class VisualizationService {
     );
   }
 
+  /**
+   * Returns `true` if the node's field is an XML attribute.
+   * @param nodeData - The node to test.
+   */
   static isAttributeField(nodeData: NodeData) {
     return nodeData instanceof FieldNodeData && nodeData.field?.isAttribute;
   }
@@ -220,20 +271,32 @@ export class VisualizationService {
     return undefined;
   }
 
+  /**
+   * Returns `true` if the node is a choice field (union/anyOf member selection), on either source or target side.
+   * @param nodeData - The node to test.
+   */
   static isChoiceField(nodeData: NodeData) {
     return nodeData instanceof ChoiceFieldNodeData || nodeData instanceof TargetChoiceFieldNodeData;
   }
 
+  /**
+   * Returns `true` if the node represents a recursive field reference (self-referencing type).
+   * @param nodeData - The node to test.
+   */
   static isRecursiveField(nodeData: NodeData) {
     return nodeData instanceof FieldNodeData && DocumentService.isRecursiveField(nodeData.field);
   }
 
+  /**
+   * Returns `true` if the node has renderable children in the visualization tree.
+   * @param nodeData - The node to inspect.
+   */
   static hasChildren(nodeData: NodeData) {
     if (nodeData instanceof DocumentNodeData) {
       if (DocumentService.hasFields(nodeData.document)) return true;
       const isPrimitiveDocument = nodeData instanceof TargetDocumentNodeData && nodeData.isPrimitive;
       const isPrimitiveDocumentWithConditionItem =
-        isPrimitiveDocument && !!nodeData.mapping.children.find((m) => !(m instanceof ValueSelector));
+        isPrimitiveDocument && nodeData.mapping.children.some((m) => !(m instanceof ValueSelector));
       if (isPrimitiveDocumentWithConditionItem) return true;
     }
     if (nodeData instanceof FieldNodeData) return DocumentService.hasChildren(nodeData.field);
@@ -246,12 +309,24 @@ export class VisualizationService {
     return false;
   }
 
+  /**
+   * Returns `true` if the node should be collapsed on initial render.
+   * Document nodes are never collapsed; recursive fields and nodes beyond the expanded rank threshold are.
+   * @param nodeData - The node to evaluate.
+   * @param initialExpandedRank - The maximum depth rank that should be auto-expanded.
+   * @param rank - The current depth rank of the node.
+   */
   static shouldCollapseByDefault(nodeData: NodeData, initialExpandedRank: number, rank: number) {
     if (nodeData instanceof DocumentNodeData) return false;
     const isRecursiveField = VisualizationService.isRecursiveField(nodeData);
     return isRecursiveField || rank > initialExpandedRank;
   }
 
+  /**
+   * Returns `true` if an "if" or "choose" condition can be added to the node.
+   * Nodes that are already `ValueSelector`, `WhenItem`, `OtherwiseItem`, `IfItem`, or `ChooseItem` mappings are excluded.
+   * @param nodeData - The target node to evaluate.
+   */
   static allowIfChoose(nodeData: TargetNodeData) {
     if (nodeData instanceof MappingNodeData) {
       const mapping = nodeData.mapping;
@@ -267,6 +342,11 @@ export class VisualizationService {
     return true;
   }
 
+  /**
+   * Returns `true` if a `forEach` wrapper can be applied to the node.
+   * Applicable to {@link AddMappingNodeData} placeholders and collection field nodes.
+   * @param nodeData - The target node to evaluate.
+   */
   static allowForEach(nodeData: TargetNodeData) {
     return (
       nodeData instanceof AddMappingNodeData ||
@@ -275,24 +355,47 @@ export class VisualizationService {
     );
   }
 
+  /**
+   * Returns `true` if the node's mapping is a {@link ForEachItem}.
+   * @param nodeData - The target node to test.
+   */
   static isForEachNode(nodeData: TargetNodeData) {
     return nodeData instanceof MappingNodeData && nodeData.mapping instanceof ForEachItem;
   }
 
+  /**
+   * Returns `true` if the node's mapping is a {@link ValueSelector}.
+   * @param nodeData - The target node to test.
+   */
   static isValueSelectorNode(nodeData: TargetNodeData) {
     return nodeData instanceof MappingNodeData && nodeData.mapping instanceof ValueSelector;
   }
 
+  /**
+   * Returns `true` if the node's mapping is a {@link ChooseItem}.
+   * @param nodeData - The target node to test.
+   */
   static isChooseNode(nodeData: TargetNodeData) {
     return nodeData instanceof MappingNodeData && nodeData.mapping instanceof ChooseItem;
   }
 
+  /**
+   * Returns `true` if the mapping node can be removed from the mapping tree.
+   * A node is deletable if it is a pure {@link MappingNodeData} (not a {@link FieldItemNodeData}),
+   * or if it has an associated {@link ValueSelector} child.
+   * @param nodeData - The target node to evaluate.
+   */
   static isDeletableNode(nodeData: TargetNodeData) {
     if (nodeData instanceof MappingNodeData && !(nodeData instanceof FieldItemNodeData)) return true;
     return VisualizationService.getFieldValueSelector(nodeData) !== undefined;
   }
 
-  static getExpressionItemForNode(nodeData: TargetNodeData): (IExpressionHolder & MappingItem) | undefined {
+  /**
+   * Returns the {@link IExpressionHolder} (or a {@link ValueSelector} child acting as one) associated with the node.
+   * Returns `undefined` if the node has no mapping or no applicable expression item.
+   * @param nodeData - The target node to inspect.
+   */
+  static getExpressionItemForNode(nodeData: TargetNodeData) {
     if (!nodeData.mapping) return;
     if (nodeData.mapping instanceof MappingItem && isExpressionHolder(nodeData.mapping)) return nodeData.mapping;
     return VisualizationService.getFieldValueSelector(nodeData);
@@ -304,6 +407,11 @@ export class VisualizationService {
     }
   }
 
+  /**
+   * Returns `true` if the condition context menu should be shown for the node.
+   * Hidden for nodes that are direct children of a `forEach` mapping, and for `when`/`otherwise`/`forEach` mappings.
+   * @param nodeData - The target node to evaluate.
+   */
   static allowConditionMenu(nodeData: TargetNodeData) {
     if (
       nodeData instanceof TargetFieldNodeData ||
@@ -325,6 +433,11 @@ export class VisualizationService {
     );
   }
 
+  /**
+   * Returns `true` if a value selector can be added to the node.
+   * Excluded for {@link AddMappingNodeData} placeholders, choose nodes, existing value selector nodes, and forEach nodes.
+   * @param nodeData - The target node to evaluate.
+   */
   static allowValueSelector(nodeData: TargetNodeData) {
     return (
       !(nodeData instanceof AddMappingNodeData) &&
@@ -335,88 +448,154 @@ export class VisualizationService {
     );
   }
 
+  /**
+   * Returns `true` if the node's mapping already has a {@link ValueSelector} child.
+   * @param nodeData - The target node to inspect.
+   */
   static hasValueSelector(nodeData: TargetNodeData) {
-    return !!(nodeData.mapping && nodeData.mapping.children.find((c) => c instanceof ValueSelector));
+    return nodeData.mapping?.children.some((c) => c instanceof ValueSelector) ?? false;
   }
 
+  /**
+   * Removes the mapping item associated with the node from the mapping tree.
+   * No-op if the node has no mapping.
+   * @param nodeData - The target node whose mapping should be deleted.
+   */
   static deleteMappingItem(nodeData: TargetNodeData) {
     if (nodeData.mapping) {
       MappingService.deleteMappingItem(nodeData.mapping);
     }
   }
 
+  /**
+   * Wraps or adds an {@link IfItem} condition to the node's mapping.
+   * For document nodes, adds the if directly to the mapping tree.
+   * For field and mapping nodes, creates the field item if needed before wrapping.
+   * @param nodeData - The target node to apply the condition to.
+   */
   static applyIf(nodeData: TargetNodeData) {
     if (nodeData instanceof TargetDocumentNodeData) {
       const valueSelector = nodeData.mappingTree.children.find((c) => c instanceof ValueSelector);
       MappingService.addIf(nodeData.mappingTree, valueSelector);
     } else if (nodeData instanceof MappingNodeData || nodeData instanceof TargetFieldNodeData) {
-      const mapping = nodeData.mapping
-        ? nodeData.mapping
-        : nodeData instanceof TargetFieldNodeData
-          ? (VisualizationService.getOrCreateFieldItem(nodeData) as FieldItem)
-          : undefined;
+      const createdFieldItem =
+        nodeData instanceof TargetFieldNodeData ? VisualizationService.getOrCreateFieldItem(nodeData) : undefined;
+      const mapping = nodeData.mapping ?? createdFieldItem;
       if (!mapping) return;
       MappingService.wrapWithIf(mapping);
     }
   }
 
+  /**
+   * Wraps or adds a {@link ChooseItem} with `when`/`otherwise` branches to the node's mapping.
+   * No-op if the node already contains a `ChooseItem`.
+   * For field and mapping nodes, creates the field item if needed before wrapping.
+   * @param nodeData - The target node to apply the choose/when/otherwise structure to.
+   */
   static applyChooseWhenOtherwise(nodeData: TargetNodeData) {
     if (nodeData instanceof TargetDocumentNodeData) {
-      if (nodeData.mappingTree.children.find((c) => c instanceof ChooseItem)) return;
+      if (nodeData.mappingTree.children.some((c) => c instanceof ChooseItem)) return;
 
       const valueSelector = nodeData.mappingTree.children.find((c) => c instanceof ValueSelector);
       MappingService.addChooseWhenOtherwise(nodeData.mappingTree, valueSelector);
     } else if (nodeData instanceof MappingNodeData || nodeData instanceof TargetFieldNodeData) {
-      if (nodeData.mapping && nodeData.mapping.children.find((c) => c instanceof ChooseItem)) return;
+      if (nodeData.mapping?.children.some((c) => c instanceof ChooseItem)) return;
 
-      const mapping = nodeData.mapping
-        ? nodeData.mapping
-        : nodeData instanceof TargetFieldNodeData
-          ? (VisualizationService.getOrCreateFieldItem(nodeData) as FieldItem)
-          : undefined;
+      const createdFieldItem =
+        nodeData instanceof TargetFieldNodeData ? VisualizationService.getOrCreateFieldItem(nodeData) : undefined;
+      const mapping = nodeData.mapping ?? createdFieldItem;
       if (!mapping) return;
       MappingService.wrapWithChooseWhenOtherwise(mapping);
     }
   }
 
+  /**
+   * Appends a new {@link WhenItem} to the {@link ChooseItem} mapping of the node.
+   * @param nodeData - The target node whose mapping is a `ChooseItem`.
+   */
   static applyWhen(nodeData: TargetNodeData) {
     const chooseItem = nodeData.mapping as ChooseItem;
     MappingService.addWhen(chooseItem, undefined, chooseItem.field);
   }
 
+  /**
+   * Sets the {@link OtherwiseItem} on the {@link ChooseItem} mapping of the node.
+   * @param nodeData - The target node whose mapping is a `ChooseItem`.
+   */
   static applyOtherwise(nodeData: TargetNodeData) {
     const chooseItem = nodeData.mapping as ChooseItem;
     MappingService.addOtherwise(chooseItem, undefined, chooseItem.field);
   }
 
+  /**
+   * Wraps the target field's mapping item with a {@link ForEachItem}.
+   * Creates the field item first if it does not yet exist.
+   * @param nodeData - The target field node to wrap.
+   */
   static applyForEach(nodeData: TargetFieldNodeData) {
     const fieldItem = VisualizationService.getOrCreateFieldItem(nodeData);
-    MappingService.wrapWithForEach(fieldItem as MappingItem);
+    MappingService.wrapWithForEach(fieldItem);
   }
 
+  /**
+   * Adds a {@link ValueSelector} child to the node's mapping.
+   * Creates the underlying field item first if the node is a {@link TargetFieldNodeData} without a mapping.
+   * No-op if a `ValueSelector` already exists.
+   * @param nodeData - The target node to add the value selector to.
+   */
   static applyValueSelector(nodeData: TargetNodeData) {
     const mapping =
       nodeData instanceof TargetFieldNodeData && !nodeData.mapping
         ? VisualizationService.getOrCreateFieldItem(nodeData)
         : nodeData.mapping;
     if (!mapping) return;
-    const existing = mapping.children.find((c: MappingItem) => c instanceof ValueSelector);
-    if (!existing) {
+    if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
       const valueSelector = MappingService.createValueSelector(mapping);
       mapping.children.push(valueSelector);
     }
   }
 
+  /**
+   * Creates a mapping connection from a source node to a target node in the mapping tree.
+   * Handles choice-to-field mappings (auto-generating choose/when/otherwise) as well as
+   * field-to-field, field-to-condition, and field-to-document mappings.
+   * @param mappingTree - The root mapping tree.
+   * @param sourceNode - The source node being mapped from.
+   * @param targetNode - The target node being mapped to.
+   */
   static engageMapping(mappingTree: MappingTree, sourceNode: SourceNodeDataType, targetNode: TargetNodeData) {
     const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
+
+    if (
+      sourceNode instanceof ChoiceFieldNodeData &&
+      (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)
+    ) {
+      VisualizationService.createChooseFromChoice(sourceNode.field, targetNode);
+      return;
+    }
+
     if (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData) {
       const item = VisualizationService.getOrCreateFieldItem(targetNode);
-      MappingService.mapToField(sourceField, item as MappingItem);
+      MappingService.mapToField(sourceField, item);
     } else if (targetNode instanceof MappingNodeData) {
       MappingService.mapToCondition(targetNode.mapping, sourceField);
     } else if (targetNode instanceof TargetDocumentNodeData) {
       MappingService.mapToDocument(mappingTree, sourceField);
     }
+  }
+
+  private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
+    const targetItem = VisualizationService.getOrCreateFieldItem(targetNode);
+    const chooseItem = new ChooseItem(targetItem);
+
+    for (const member of sourceField.fields) {
+      const whenItem = MappingService.addWhen(chooseItem);
+      MappingService.mapToCondition(whenItem, member);
+      MappingService.mapToField(member, whenItem);
+    }
+
+    MappingService.addOtherwise(chooseItem);
+    targetItem.children.push(chooseItem);
   }
 
   private static getOrCreateFieldItem(nodeData: TargetNodeData): MappingItem {
@@ -435,6 +614,12 @@ export class VisualizationService {
     }
   }
 
+  /**
+   * Generates a stable drag-and-drop identifier string for a node.
+   * Document nodes use their `id`; field nodes derive the ID from their path with `/` and `:` replaced by `-`.
+   * @param nodeData - The node for which to generate the DnD ID.
+   * @returns A string identifier unique within the current document side (source vs target).
+   */
   static generateDndId(nodeData: NodeData) {
     // Use full path with documentType to ensure unique IDs between source and target
     return nodeData instanceof DocumentNodeData
@@ -442,6 +627,11 @@ export class VisualizationService {
       : nodeData.path.toString().replace(FORWARD_SLASH_REGEX, '-').replace(COLON_REGEX, '-');
   }
 
+  /**
+   * Creates a new {@link FieldItem} mapping for an {@link AddMappingNodeData} placeholder node.
+   * This is used when the user explicitly adds an additional mapping for a collection field.
+   * @param nodeData - The placeholder node representing the "add mapping" action.
+   */
   static addMapping(nodeData: AddMappingNodeData) {
     const parentItem = VisualizationService.getOrCreateFieldItem(nodeData.parent);
     MappingService.createFieldItem(parentItem, nodeData.field);

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -190,6 +190,24 @@ export class VisualizationService {
   }
 
   /**
+   * Resolves mapping children for a choice wrapper node. Unselected target choice wrappers
+   * have no mapping tree counterpart, so we walk up through any nested unselected choice
+   * wrappers to find the nearest real ancestor that carries mapping children.
+   */
+  private static resolveChoiceNodeMappings(
+    parent: ChoiceFieldNodeData | TargetChoiceFieldNodeData,
+  ): MappingItem[] | undefined {
+    if (!(parent instanceof TargetChoiceFieldNodeData) || parent.choiceField) {
+      return 'mapping' in parent ? parent.mapping?.children : undefined;
+    }
+    let ancestor: TargetNodeData = parent.parent;
+    while (ancestor instanceof TargetChoiceFieldNodeData && !ancestor.choiceField) {
+      ancestor = ancestor.parent;
+    }
+    return ancestor.mapping?.children;
+  }
+
+  /**
    * Returns children for choice, field, and mapping nodes (i.e. non-document nodes).
    * Resolves type fragments for complex fields before generating children.
    * @param parent - The non-document parent node.
@@ -200,7 +218,7 @@ export class VisualizationService {
       return VisualizationService.doGenerateNodeDataFromFields(
         parent,
         VisualizationService.resolveChoiceNodeFields(parent.field),
-        'mapping' in parent ? parent.mapping?.children : undefined,
+        VisualizationService.resolveChoiceNodeMappings(parent),
       );
     }
     if (parent instanceof FieldNodeData || parent instanceof FieldItemNodeData) {
@@ -605,6 +623,7 @@ export class VisualizationService {
   private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
     const targetItem = VisualizationService.getOrCreateFieldItem(targetNode);
     if (targetItem.children.some((c) => c instanceof ChooseItem)) return;
+    targetItem.children = targetItem.children.filter((c) => !(c instanceof ValueSelector));
     const chooseItem = new ChooseItem(targetItem);
 
     for (const member of sourceField.fields ?? []) {
@@ -620,6 +639,12 @@ export class VisualizationService {
   private static getOrCreateFieldItem(nodeData: TargetNodeData): MappingItem {
     if (nodeData.mapping) return nodeData.mapping as MappingItem;
     const fieldNodeData = nodeData as TargetFieldNodeData;
+    // Skip unselected choice wrappers — they are artificial document nodes with no
+    // mapping tree counterpart. Go straight to their parent so the FieldItem is
+    // created at the correct mapping tree level.
+    if (fieldNodeData instanceof TargetChoiceFieldNodeData && !fieldNodeData.choiceField) {
+      return VisualizationService.getOrCreateFieldItem(fieldNodeData.parent);
+    }
     const parentItem = VisualizationService.getOrCreateFieldItem(fieldNodeData.parent);
     return MappingService.createFieldItem(parentItem, fieldNodeData.field);
   }
@@ -644,7 +669,7 @@ export class VisualizationService {
     const nestedChoiceCount = members.filter((m) => m.isChoice).length;
     let choiceIndex = 0;
     const labels = members.map((m) => {
-      if (!m.isChoice) return m.name;
+      if (!m.isChoice) return m.displayName ?? m.name;
       return nestedChoiceCount > 1 ? `choice${++choiceIndex}` : 'choice';
     });
     if (labels.length === 0) return '(empty)';

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -99,6 +99,18 @@ export class VisualizationService {
     );
   }
 
+  /**
+   * Creates a {@link ChoiceFieldNodeData} or {@link TargetChoiceFieldNodeData} for a choice wrapper field.
+   *
+   * When no member is selected (`field.selectedMemberIndex === undefined`), the returned node's
+   * `field` is the choice wrapper itself and `choiceField` is `undefined`. {@link createNodeTitle}
+   * recognises this state and returns the member label string (e.g. `"(email | phone)"`), while
+   * {@link NodeTitle} renders it alongside a `<Label>choice</Label>` badge.
+   *
+   * When a member is selected, the returned node's `field` is the selected member and `choiceField`
+   * is set to the choice wrapper. {@link createNodeTitle} returns the member's own display name in
+   * that case, and {@link NodeTitle} renders it as a plain field title without the choice badge.
+   */
   private static doGenerateNodeDataFromChoiceField(
     parent: NodeData,
     field: IField,
@@ -167,6 +179,16 @@ export class VisualizationService {
     return nodes.some((node) => 'mapping' in node && node.mapping === mapping);
   }
 
+  private static resolveChoiceNodeFields(field: IField): IField[] {
+    if (!field.isChoice) {
+      DocumentUtilService.resolveTypeFragment(field);
+      return field.fields;
+    }
+    const selectedMember =
+      field.selectedMemberIndex === undefined ? undefined : field.fields?.[field.selectedMemberIndex];
+    return selectedMember ? [field] : field.fields;
+  }
+
   /**
    * Returns children for choice, field, and mapping nodes (i.e. non-document nodes).
    * Resolves type fragments for complex fields before generating children.
@@ -175,18 +197,9 @@ export class VisualizationService {
    */
   static generateNonDocumentNodeDataChildren(parent: NodeData): NodeData[] {
     if (parent instanceof ChoiceFieldNodeData || parent instanceof TargetChoiceFieldNodeData) {
-      let fields: IField[];
-      if (parent.field.isChoice && parent.field.selectedMemberIndex !== undefined) {
-        fields = [parent.field].filter(Boolean);
-      } else if (parent.field.isChoice) {
-        fields = parent.field.fields;
-      } else {
-        DocumentUtilService.resolveTypeFragment(parent.field);
-        fields = parent.field.fields;
-      }
       return VisualizationService.doGenerateNodeDataFromFields(
         parent,
-        fields,
+        VisualizationService.resolveChoiceNodeFields(parent.field),
         'mapping' in parent ? parent.mapping?.children : undefined,
       );
     }
@@ -570,7 +583,7 @@ export class VisualizationService {
       sourceNode instanceof ChoiceFieldNodeData &&
       (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)
     ) {
-      if (sourceNode.choiceField !== undefined) {
+      if (sourceNode.choiceField) {
         const item = VisualizationService.getOrCreateFieldItem(targetNode);
         MappingService.mapToField(sourceNode.field, item);
       } else {
@@ -591,9 +604,10 @@ export class VisualizationService {
 
   private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
     const targetItem = VisualizationService.getOrCreateFieldItem(targetNode);
+    if (targetItem.children.some((c) => c instanceof ChooseItem)) return;
     const chooseItem = new ChooseItem(targetItem);
 
-    for (const member of sourceField.fields) {
+    for (const member of sourceField.fields ?? []) {
       const whenItem = MappingService.addWhen(chooseItem);
       MappingService.mapToCondition(whenItem, member);
       MappingService.mapToField(member, whenItem);
@@ -617,6 +631,43 @@ export class VisualizationService {
     } catch {
       return rawXml;
     }
+  }
+
+  /**
+   * Returns the member label string (e.g. `"(email | phone | fax)"`) for a choice wrapper node.
+   * Nested choice members are labeled `'choice'` when there is only one nested choice sibling,
+   * or `'choice1'`, `'choice2'`, ... when there are multiple.
+   * @param node - The choice wrapper node whose members should be described.
+   */
+  static getChoiceMemberLabel(node: ChoiceFieldNodeData | TargetChoiceFieldNodeData): string {
+    const members = node.field.fields ?? [];
+    const nestedChoiceCount = members.filter((m) => m.isChoice).length;
+    let choiceIndex = 0;
+    const labels = members.map((m) => {
+      if (!m.isChoice) return m.name;
+      return nestedChoiceCount > 1 ? `choice${++choiceIndex}` : 'choice';
+    });
+    if (labels.length === 0) return '(empty)';
+    const maxVisible = 3;
+    if (labels.length > maxVisible) {
+      return `(${labels.slice(0, maxVisible).join(' | ')} | +${labels.length - maxVisible} more)`;
+    }
+    return `(${labels.join(' | ')})`;
+  }
+
+  /**
+   * Returns the display title for a node, delegating to {@link getChoiceMemberLabel} for
+   * unselected choice wrapper nodes so the member list is rendered separately from the label.
+   * @param nodeData - The node whose title should be resolved.
+   */
+  static createNodeTitle(nodeData: NodeData): string {
+    if (
+      (nodeData instanceof ChoiceFieldNodeData || nodeData instanceof TargetChoiceFieldNodeData) &&
+      !nodeData.choiceField
+    ) {
+      return VisualizationService.getChoiceMemberLabel(nodeData);
+    }
+    return nodeData.title;
   }
 
   /**

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -84,6 +84,106 @@ describe('XmlSchemaDocumentService', () => {
     expect(fields.length > 0).toBeTruthy();
   });
 
+  it('should create a choice wrapper field for xs:choice', () => {
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'testDocument.xsd': getTestDocumentXsd(),
+      },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const testDoc = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+    const fields: XmlSchemaField[] = [];
+    XmlSchemaDocumentService.populateElement(document, fields, testDoc);
+
+    const testDocument = fields[0];
+    const choiceElement = testDocument.fields.find((f) => f.name === 'ChoiceElement')!;
+    expect(choiceElement).toBeDefined();
+
+    // xs:choice should create a single choice wrapper field
+    expect(choiceElement.fields.length).toEqual(1);
+    const choiceWrapper = choiceElement.fields[0];
+    expect(choiceWrapper.isChoice).toBe(true);
+    expect(choiceWrapper.name).toEqual('__choice__');
+    expect(choiceWrapper.displayName).toEqual('choice');
+
+    // Choice1, Choice2, and Group1 (xs:sequence -> Group1Element1, Group1Element2 flattened)
+    expect(choiceWrapper.fields.length).toEqual(4);
+    expect(choiceWrapper.fields.find((f) => f.name === 'Choice1')).toBeDefined();
+    expect(choiceWrapper.fields.find((f) => f.name === 'Choice2')).toBeDefined();
+    expect(choiceWrapper.fields.find((f) => f.name === 'Group1Element1')).toBeDefined();
+    expect(choiceWrapper.fields.find((f) => f.name === 'Group1Element2')).toBeDefined();
+  });
+
+  it('should preserve maxOccurs from xs:choice on the choice wrapper', () => {
+    const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="OptionA" type="xs:string"/>
+        <xs:element name="OptionB" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'root.xsd': xsdContent },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const root = document.fields[0];
+    const choiceWrapper = root.fields.find((f) => f.isChoice);
+    expect(choiceWrapper).toBeDefined();
+    expect(choiceWrapper!.maxOccurs).toEqual('unbounded');
+    expect(choiceWrapper!.maxOccursExplicit).toBe(true);
+    expect(choiceWrapper!.fields.length).toEqual(2);
+  });
+
+  it('should produce two sibling choice wrappers for two sibling xs:choice compositors', () => {
+    const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element name="A1" type="xs:string"/>
+          <xs:element name="A2" type="xs:string"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element name="B1" type="xs:string"/>
+          <xs:element name="B2" type="xs:string"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'root.xsd': xsdContent },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const root = document.fields[0];
+    const choiceWrappers = root.fields.filter((f) => f.isChoice);
+    expect(choiceWrappers.length).toEqual(2);
+    expect(choiceWrappers[0].fields.find((f) => f.name === 'A1')).toBeDefined();
+    expect(choiceWrappers[0].fields.find((f) => f.name === 'A2')).toBeDefined();
+    expect(choiceWrappers[1].fields.find((f) => f.name === 'B1')).toBeDefined();
+    expect(choiceWrappers[1].fields.find((f) => f.name === 'B2')).toBeDefined();
+  });
+
   it('should parse camel-spring.xsd XML schema', () => {
     const definition = new DocumentDefinition(
       DocumentType.TARGET_BODY,
@@ -104,7 +204,8 @@ describe('XmlSchemaDocumentService', () => {
     expect(aggregate.namedTypeFragmentRefs[0]).toEqual('{http://camel.apache.org/schema/spring}aggregateDefinition');
     const aggregateDef = document.namedTypeFragments[aggregate.namedTypeFragmentRefs[0]];
 
-    expect(aggregateDef.fields.length).toBeGreaterThanOrEqual(100);
+    // Many fields; fewer direct children now that xs:choice compositors are wrapped
+    expect(aggregateDef.fields.length).toBeGreaterThanOrEqual(30);
 
     const outputDef = document.namedTypeFragments['{http://camel.apache.org/schema/spring}output'];
     expect(outputDef).toBeDefined();
@@ -301,7 +402,8 @@ describe('XmlSchemaDocumentService', () => {
     const personType = document.namedTypeFragments[person.namedTypeFragmentRefs[0]];
     expect(personType).toBeDefined();
 
-    expect(personType.fields.length).toEqual(11);
+    // name, street, city from AddressGroup, 1 choice wrapper, createdBy, createdDate, @id, @version, @status
+    expect(personType.fields.length).toEqual(9);
 
     const nameField = personType.fields.find((f) => f.name === 'name');
     expect(nameField).toBeDefined();
@@ -311,12 +413,17 @@ describe('XmlSchemaDocumentService', () => {
     const cityField = personType.fields.find((f) => f.name === 'city');
     expect(cityField).toBeDefined();
 
-    const emailField = personType.fields.find((f) => f.name === 'email');
+    // xs:choice wraps into a choice field; ContactGroup is itself xs:choice -> nested wrapper
+    const choiceField = personType.fields.find((f) => f.isChoice);
+    expect(choiceField).toBeDefined();
+    expect(choiceField!.isChoice).toBe(true);
+    const innerChoiceField = choiceField!.fields.find((f) => f.isChoice);
+    expect(innerChoiceField).toBeDefined();
+    const emailField = innerChoiceField!.fields.find((f) => f.name === 'email');
     expect(emailField).toBeDefined();
-    const phoneField = personType.fields.find((f) => f.name === 'phone');
+    const phoneField = innerChoiceField!.fields.find((f) => f.name === 'phone');
     expect(phoneField).toBeDefined();
-
-    const faxField = personType.fields.find((f) => f.name === 'fax');
+    const faxField = choiceField!.fields.find((f) => f.name === 'fax');
     expect(faxField).toBeDefined();
 
     const createdByField = personType.fields.find((f) => f.name === 'createdBy');
@@ -1666,7 +1773,10 @@ describe('XmlSchemaDocumentService', () => {
 
     const bigContainerFragment = document.namedTypeFragments['BigContainer'];
     expect(bigContainerFragment).toBeDefined();
-    const typeA01Field = bigContainerFragment.fields.find((f) => f.name === 'TypeA01');
+    // BigContainer has xs:choice wrapping all TypeA elements
+    const choiceWrapper = bigContainerFragment.fields.find((f) => f.isChoice);
+    expect(choiceWrapper).toBeDefined();
+    const typeA01Field = choiceWrapper!.fields.find((f) => f.name === 'TypeA01');
     expect(typeA01Field).toBeDefined();
     expect(typeA01Field!.type).toEqual(Types.Container);
   });

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -13,7 +13,6 @@ import {
   XmlSchemaAttributeGroupRef,
   XmlSchemaAttributeOrGroupRef,
   XmlSchemaChoice,
-  XmlSchemaChoiceMember,
   XmlSchemaCollection,
   XmlSchemaComplexContentExtension,
   XmlSchemaComplexContentRestriction,
@@ -734,15 +733,45 @@ export class XmlSchemaDocumentService {
     if (groupParticle == null) {
       return;
     }
-    if (groupParticle instanceof XmlSchemaChoice || groupParticle instanceof XmlSchemaSequence) {
+    if (groupParticle instanceof XmlSchemaChoice) {
+      XmlSchemaDocumentService.populateChoice(parent, fields, groupParticle, visitedGroupRefs);
+    } else if (groupParticle instanceof XmlSchemaSequence) {
       for (const member of groupParticle.getItems()) {
-        XmlSchemaDocumentService.populateSequenceOrChoiceMember(parent, fields, member, visitedGroupRefs);
+        XmlSchemaDocumentService.populateSequenceMember(parent, fields, member, visitedGroupRefs);
       }
     } else if (groupParticle instanceof XmlSchemaAll) {
       for (const member of groupParticle.getItems()) {
         XmlSchemaDocumentService.populateAllMember(parent, fields, member, visitedGroupRefs);
       }
     }
+  }
+
+  /**
+   * Creates a choice wrapper {@link XmlSchemaField} with {@link XmlSchemaField.isChoice} set to true,
+   * preserving minOccurs/maxOccurs from the xs:choice particle, and populates its children
+   * from the choice's member items. The `{choice:N}` path index is derived at runtime by
+   * {@link SchemaPathService.getChoiceSiblingIndex} from the field's position among sibling
+   * isChoice fields — no explicit index is stored on the field.
+   */
+  private static populateChoice(
+    parent: XmlSchemaParentType,
+    fields: XmlSchemaField[],
+    choice: XmlSchemaChoice,
+    visitedGroupRefs?: Set<string>,
+  ) {
+    const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;
+    const choiceField = new XmlSchemaField(parent, '__choice__', false);
+    choiceField.isChoice = true;
+    choiceField.minOccurs = choice.getMinOccurs();
+    choiceField.maxOccurs = choice.getMaxOccurs();
+    choiceField.minOccursExplicit = choice.isMinOccursExplicit();
+    choiceField.maxOccursExplicit = choice.isMaxOccursExplicit();
+    fields.push(choiceField);
+    ownerDoc.totalFieldCount++;
+    for (const member of choice.getItems()) {
+      XmlSchemaDocumentService.populateSequenceMember(choiceField, choiceField.fields, member, visitedGroupRefs);
+    }
+    choiceField.displayName = 'choice';
   }
 
   private static populateGroupRef(
@@ -768,10 +797,10 @@ export class XmlSchemaDocumentService {
     visitedGroupRefs.delete(key);
   }
 
-  private static populateSequenceOrChoiceMember(
+  private static populateSequenceMember(
     parent: XmlSchemaParentType,
     fields: XmlSchemaField[],
-    member: XmlSchemaSequenceMember | XmlSchemaChoiceMember,
+    member: XmlSchemaSequenceMember,
     visitedGroupRefs?: Set<string>,
   ) {
     if (member instanceof XmlSchemaGroupRef) {

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -854,5 +854,71 @@ describe('XPathService', () => {
       expect(result.pathSegments[0].name).toBe('ShipOrder');
       expect(result.pathSegments[1].name).toBe('OrderPerson');
     });
+
+    it('should exclude choice wrapper fields from generated XPath', () => {
+      const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="OptionA" type="xs:string"/>
+        <xs:element name="OptionB" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'root.xsd': xsdContent },
+      );
+      const doc = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
+      const rootField = doc.fields.find((f) => f.name === 'Root')!;
+      const choiceWrapper = rootField.fields.find((f) => f.isChoice)!;
+      const optionA = choiceWrapper.fields.find((f) => f.name === 'OptionA')!;
+
+      const result = XPathService.toPathExpression({}, optionA);
+
+      expect(result.pathSegments.every((s) => s.name !== '__choice__')).toBe(true);
+      expect(result.pathSegments.length).toBe(2);
+      expect(result.pathSegments[0].name).toBe('Root');
+      expect(result.pathSegments[1].name).toBe('OptionA');
+    });
+
+    it('should exclude choice wrapper fields from relative XPath when context path is provided', () => {
+      const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="OptionA" type="xs:string"/>
+        <xs:element name="OptionB" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'root.xsd': xsdContent },
+      );
+      const doc = XmlSchemaDocumentService.createXmlSchemaDocument(definition).document!;
+      const rootField = doc.fields.find((f) => f.name === 'Root')!;
+      const choiceWrapper = rootField.fields.find((f) => f.isChoice)!;
+      const optionA = choiceWrapper.fields.find((f) => f.name === 'OptionA')!;
+
+      const contextPath = new PathExpression();
+      contextPath.isRelative = false;
+      contextPath.pathSegments = [new PathSegment('Root', false)];
+
+      const result = XPathService.toPathExpression({}, optionA, contextPath);
+
+      expect(result.pathSegments.every((s) => s.name !== '__choice__')).toBe(true);
+      expect(result.isRelative).toBe(true);
+      expect(result.pathSegments.length).toBe(1);
+      expect(result.pathSegments[0].name).toBe('OptionA');
+    });
   });
 });

--- a/packages/ui/src/services/xpath/xpath.service.ts
+++ b/packages/ui/src/services/xpath/xpath.service.ts
@@ -452,7 +452,9 @@ export class XPathService {
     answer.documentReferenceName = doc.getReferenceId(namespaceMap) || undefined;
 
     const parentAbsPath = contextPath && XPathService.toAbsolutePath(contextPath);
-    const fieldStack = DocumentUtilService.getFieldStack(source, true).reverse();
+    const fieldStack = DocumentUtilService.getFieldStack(source, true)
+      .reverse()
+      .filter((f) => !f.isChoice);
 
     if (!parentAbsPath) {
       return fieldStack.reduce((acc, field) => {

--- a/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
@@ -6,6 +6,13 @@
             <xs:element name="Group1Element2" type="xs:string"/>
         </xs:sequence>
     </xs:group>
+    <!-- A group whose particle is xs:choice, for indirect nested choice testing -->
+    <xs:group name="ChoiceGroup">
+        <xs:choice>
+            <xs:element name="ChoiceGroupEl1" type="xs:string"/>
+            <xs:element name="ChoiceGroupEl2" type="xs:string"/>
+        </xs:choice>
+    </xs:group>
     <xs:attributeGroup name="AttrGroup1">
         <xs:attribute name="AttrGroup1Attr1" type="xs:string"/>
         <xs:attribute name="AttrGroup1Attr2" type="xs:string"/>
@@ -13,12 +20,91 @@
     <xs:element name="TestDocument">
         <xs:complexType>
             <xs:sequence>
+                <!-- Simple xs:choice with elements and group ref -->
                 <xs:element name="ChoiceElement">
                     <xs:complexType>
                         <xs:choice>
                             <xs:element name="Choice1" type="xs:string" />
                             <xs:element name="Choice2" type="xs:string" />
                             <xs:group ref="ns0:Group1"/>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <!-- Two sibling xs:choice compositors in a sequence -->
+                <xs:element name="SiblingChoicesElement">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="SibA1" type="xs:string"/>
+                                <xs:element name="SibA2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="SibB1" type="xs:string"/>
+                                <xs:element name="SibB2" type="xs:string"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <!-- Direct nested xs:choice: a choice directly containing another choice -->
+                <xs:element name="DirectNestedChoiceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="Direct1" type="xs:string"/>
+                            <xs:choice>
+                                <xs:element name="NestedDirect1" type="xs:string"/>
+                                <xs:element name="NestedDirect2" type="xs:string"/>
+                            </xs:choice>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <!-- Two nested xs:choice compositors: produces title 'choice (choice1 | choice2)' -->
+                <xs:element name="MultipleNestedChoicesElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerA1" type="xs:string"/>
+                                <xs:element name="InnerA2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerB1" type="xs:string"/>
+                                <xs:element name="InnerB2" type="xs:string"/>
+                            </xs:choice>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <!-- Five nested xs:choice compositors: produces title 'choice (choice1 | choice2 | choice3 | choice4...)' -->
+                <xs:element name="TooManyNestedChoicesElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerA1" type="xs:string"/>
+                                <xs:element name="InnerA2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerB1" type="xs:string"/>
+                                <xs:element name="InnerB2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerC1" type="xs:string"/>
+                                <xs:element name="InnerC2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerD1" type="xs:string"/>
+                                <xs:element name="InnerD2" type="xs:string"/>
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="InnerE1" type="xs:string"/>
+                                <xs:element name="InnerE2" type="xs:string"/>
+                            </xs:choice>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <!-- Indirect nested xs:choice: an xs:choice containing a group ref whose particle is xs:choice -->
+                <xs:element name="IndirectNestedChoiceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="Indirect1" type="xs:string"/>
+                            <xs:group ref="ns0:ChoiceGroup"/>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>

--- a/packages/ui/src/utils/process-tree-node.test.ts
+++ b/packages/ui/src/utils/process-tree-node.test.ts
@@ -67,7 +67,7 @@ describe('processTreeNodeToDepth', () => {
       processedNodePaths.push(treeNode.path);
     });
 
-    expect(processedNodePaths).toHaveLength(177);
+    expect(processedNodePaths).toHaveLength(105);
   });
 
   it('should not throw an error when processing beyond the DocumentTree parsed level', () => {


### PR DESCRIPTION
https://github.com/KaotoIO/kaoto/pull/3083 should go in before this one

Fixes: https://github.com/KaotoIO/kaoto/issues/2898

Introduces mapping validation when user performs drag and drop to create a data mapping.

Introduces `MappingValidationService` to centralise mapping pair validation rules, replacing `VisualizationService testNodePair()`. `DnDHandler.handleDragEnd()` now returns a `DnDResult` to propagate error message if there is.
 - Invalid cross-side drops (unselected xs:choice, container/terminal mismatch) show an error toast
 - Hovering over an invalid target shows a disabled border and field name style
 - Hovering over a same-side droppable (source→source, target→target) is disabled at DNDKit level, i.e. no visual feedback on hover, silently ignored if dropped

https://github.com/user-attachments/assets/fe42c6c6-4dd8-4b13-ad14-1c5123a71775

Fixes: https://github.com/KaotoIO/kaoto/issues/2814

- Auto-generate choose-when-otherwise mapping when DnD is performed from a choice source to a target field
- MappingValidationService: Skip regular container<>terminal check in `validateContainerRules()` for choice node mapping where `validateChoiceRules()` validates the choice specific rules

Fixes: https://github.com/KaotoIO/kaoto/issues/2814

Handle the case when the source choice is already selected

Fixes: https://github.com/KaotoIO/kaoto/issues/2731

- Instead of flatten all xs:choice members, create a choice field and wrap members as children, making the artificial choice field visible in the document tree
- Skip choice field on XPath generation
- Introduce createNodeTitle() and getChoiceMemberLabel() to generate choice member display label with numbered suffixes (choice1, choice2, …) when multiple nested choice wrappers appear as siblings

### step choice node from camel-spring.xsd
<img width="1206" height="1028" alt="Screenshot From 2026-04-07 23-16-34" src="https://github.com/user-attachments/assets/0495418f-5eb8-4716-864d-f1c4cd673226" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop now returns explicit success/failure results, surfaces danger alerts on failures, and improves drag-preview titles for mapped nodes; visualization now auto-creates choice mapping structures and improved node title formatting.

* **Bug Fixes / UX**
  * Invalid drop zones show disabled styling and not-allowed cursor; same-side drops blocked; choice label text rendered italic; drag preview ignores pointer events.

* **Documentation**
  * Expanded JSDoc for visualization and node models.

* **Tests**
  * Added extensive DnD, mapping-validation, visualization, schema, XPath, and unit tests.

* **Chores**
  * Removed deprecated choice-display helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->