### PR TITLE
fix(canvas): restrict container drag area to header only

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/DnD/dragAndDrop.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/DnD/dragAndDrop.cy.ts
@@ -84,7 +84,7 @@ describe('Canvas nodes Drag and Drop', () => {
     cy.uploadFixture('flows/camelRoute/complexMultiFlow.yaml');
     cy.openDesignPage();
 
-    cy.DnDOnNode('route-1|route.from.steps.0.choice.when.0', 'route-2|route.from.steps.0.choice.when.0');
+    cy.DnDOnNode('route-1|route.from.steps.0.choice.when.0|drag-handle', 'route-2|route.from.steps.0.choice.when.0');
 
     cy.get('[data-testid="Source Code"]').click({ force: true });
     cy.openSourceCode();
@@ -96,7 +96,7 @@ describe('Canvas nodes Drag and Drop', () => {
     cy.openDesignPage();
 
     cy.DnDOnEdge(
-      'doTry-route|route.from.steps.2.doTry',
+      'doTry-route|route.from.steps.2.doTry|drag-handle',
       'doTry-route|route.from.steps.0.setHeader >>> route.from.steps.1.marshal',
     );
 

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                                 >
                                   <div
                                     class="custom-group__container__text"
+                                    data-testid="route-8888|route|drag-handle"
                                     title="route"
                                   >
                                     <img
@@ -145,7 +146,8 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                                   data-testid="route-8888|route.from.steps.1.choice"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice|drag-handle"
                                     title="choice"
                                   >
                                     <img
@@ -189,7 +191,8 @@ exports[`Canvas Catalog button should NOT be present if \`CatalogModalContext\` 
                                   data-testid="route-8888|route.from.steps.1.choice.when.0"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice.when.0|drag-handle"
                                     title="when"
                                   >
                                     <img
@@ -1071,6 +1074,7 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                                 >
                                   <div
                                     class="custom-group__container__text"
+                                    data-testid="route-8888|route|drag-handle"
                                     title="route"
                                   >
                                     <img
@@ -1136,7 +1140,8 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                                   data-testid="route-8888|route.from.steps.1.choice"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice|drag-handle"
                                     title="choice"
                                   >
                                     <img
@@ -1180,7 +1185,8 @@ exports[`Canvas Catalog button should be present if \`CatalogModalContext\` is p
                                   data-testid="route-8888|route.from.steps.1.choice.when.0"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice.when.0|drag-handle"
                                     title="when"
                                   >
                                     <img
@@ -2949,6 +2955,7 @@ exports[`Canvas should render correctly 1`] = `
                                 >
                                   <div
                                     class="custom-group__container__text"
+                                    data-testid="route-8888|route|drag-handle"
                                     title="route"
                                   >
                                     <img
@@ -3014,7 +3021,8 @@ exports[`Canvas should render correctly 1`] = `
                                   data-testid="route-8888|route.from.steps.1.choice"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice|drag-handle"
                                     title="choice"
                                   >
                                     <img
@@ -3058,7 +3066,8 @@ exports[`Canvas should render correctly 1`] = `
                                   data-testid="route-8888|route.from.steps.1.choice.when.0"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice.when.0|drag-handle"
                                     title="when"
                                   >
                                     <img
@@ -3940,6 +3949,7 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                 >
                                   <div
                                     class="custom-group__container__text"
+                                    data-testid="route-8888|route|drag-handle"
                                     title="route"
                                   >
                                     <img
@@ -4005,7 +4015,8 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                   data-testid="route-8888|route.from.steps.1.choice"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice|drag-handle"
                                     title="choice"
                                   >
                                     <img
@@ -4049,7 +4060,8 @@ exports[`Canvas should render correctly with more routes  1`] = `
                                   data-testid="route-8888|route.from.steps.1.choice.when.0"
                                 >
                                   <div
-                                    class="custom-group__container__text"
+                                    class="custom-group__container__text custom-group__container__text__draggable"
+                                    data-testid="route-8888|route.from.steps.1.choice.when.0|drag-handle"
                                     title="when"
                                   >
                                     <img

--- a/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.tsx
@@ -11,10 +11,8 @@ import {
   GraphElement,
   GraphElementProps,
   isEdge,
-  Layer,
   observer,
   Point,
-  TOP_LAYER,
   useDndDrop,
 } from '@patternfly/react-topology';
 import { clsx } from 'clsx';
@@ -93,14 +91,6 @@ export const CustomEdge: FunctionComponent<CustomEdgeProps> = observer(({ elemen
   );
 
   const [dndDropProps, dndDropRef] = useDndDrop(customNodeDropTargetSpec);
-  const dragItemType = dndDropProps.dragItemType;
-  const dragItem = dndDropProps.dragItem;
-  const edgeSourceParent = element.getSource().getParent()?.getId();
-  const edgeTargetParent = element.getTarget().getParent()?.getId();
-  const refreshEdge =
-    dragItemType === GROUP_DRAG_TYPE &&
-    edgeSourceParent.slice(0, dragItem?.getId().length) === dragItem?.getId() &&
-    edgeTargetParent.slice(0, dragItem?.getId().length) === dragItem?.getId();
 
   /* If the edge connects to nodes in a collapsed group don't draw */
   const sourceParent = getClosestVisibleParent(element.getSource());
@@ -142,50 +132,48 @@ export const CustomEdge: FunctionComponent<CustomEdgeProps> = observer(({ elemen
   }
 
   return (
-    <Layer id={refreshEdge ? TOP_LAYER : undefined}>
-      <g className="custom-edge" ref={dndDropRef}>
-        <path className="custom-edge__background" d={edgeDRef.current} />
-        <path
-          className={clsx('custom-edge__body', {
-            'custom-edge__body__validDropTarget': dndDropProps.droppable && dndDropProps.hover && dndDropProps.canDrop,
-            'custom-edge__body__possibleDropTargets':
-              dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
-          })}
-          d={edgeDRef.current}
-        />
-        <ConnectorArrow
-          isTarget
-          className={clsx('custom-edge__connector', {
-            'custom-edge__connector__validDropTarget':
-              dndDropProps.droppable && dndDropProps.hover && dndDropProps.canDrop,
-            'custom-edge__connector__possibleDropTargets':
-              dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
-          })}
-          startPoint={startPointRef.current}
-          endPoint={endPointRef.current}
-        />
+    <g className="custom-edge" ref={dndDropRef}>
+      <path className="custom-edge__background" d={edgeDRef.current} />
+      <path
+        className={clsx('custom-edge__body', {
+          'custom-edge__body__validDropTarget': dndDropProps.droppable && dndDropProps.hover && dndDropProps.canDrop,
+          'custom-edge__body__possibleDropTargets':
+            dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
+        })}
+        d={edgeDRef.current}
+      />
+      <ConnectorArrow
+        isTarget
+        className={clsx('custom-edge__connector', {
+          'custom-edge__connector__validDropTarget':
+            dndDropProps.droppable && dndDropProps.hover && dndDropProps.canDrop,
+          'custom-edge__connector__possibleDropTargets':
+            dndDropProps.canDrop && dndDropProps.droppable && !dndDropProps.hover,
+        })}
+        startPoint={startPointRef.current}
+        endPoint={endPointRef.current}
+      />
 
-        {/** Add Step Icon, appears when nothing is dragging and user hovers over the edge */}
-        {!dndDropProps.droppable && shouldShowPrepend && (
-          <EdgeAddStepIconSlot x={x} y={y} vizNode={vizNode} className="custom-edge__add-step" />
-        )}
+      {/** Add Step Icon, appears when nothing is dragging and user hovers over the edge */}
+      {!dndDropProps.droppable && shouldShowPrepend && (
+        <EdgeAddStepIconSlot x={x} y={y} vizNode={vizNode} className="custom-edge__add-step" />
+      )}
 
-        {/** Add Step Icon, appears when a compatible node/group is being dragged over the edge */}
-        {dndDropProps.droppable && shouldShowPrepend && dndDropProps.hover && dndDropProps.canDrop && (
-          <EdgeAddStepIconSlot
-            x={
-              startPointRef.current.x +
-              (endPointRef.current.x - startPointRef.current.x - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2
-            }
-            y={
-              startPointRef.current.y +
-              (endPointRef.current.y - startPointRef.current.y - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2
-            }
-            vizNode={vizNode}
-            className="add-step-icon__icon__validDropTarget"
-          />
-        )}
-      </g>
-    </Layer>
+      {/** Add Step Icon, appears when a compatible node/group is being dragged over the edge */}
+      {dndDropProps.droppable && shouldShowPrepend && dndDropProps.hover && dndDropProps.canDrop && (
+        <EdgeAddStepIconSlot
+          x={
+            startPointRef.current.x +
+            (endPointRef.current.x - startPointRef.current.x - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2
+          }
+          y={
+            startPointRef.current.y +
+            (endPointRef.current.y - startPointRef.current.y - CanvasDefaults.ADD_STEP_ICON_SIZE) / 2
+          }
+          vizNode={vizNode}
+          className="add-step-icon__icon__validDropTarget"
+        />
+      )}
+    </g>
   );
 });

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.scss
@@ -1,4 +1,5 @@
 @use '../custom';
+@use '../../../../styles/dnd';
 
 .custom-group {
   @include custom.highligth {
@@ -92,6 +93,12 @@
 
       &__possibleDropTarget-left {
         border-left: var(--custom-component-border-possibleDropTarget);
+      }
+
+      & &__text {
+        &__draggable {
+          @include dnd.cursor-grab;
+        }
       }
     }
 

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -4,7 +4,6 @@ import { Icon } from '@patternfly/react-core';
 import { BanIcon, ExclamationCircleIcon, PauseIcon, PlayIcon } from '@patternfly/react-icons';
 import {
   AnchorEnd,
-  DEFAULT_LAYER,
   DragEvent,
   DragObjectWithType,
   DragSourceSpec,
@@ -21,7 +20,6 @@ import {
   Rect,
   TOP_LAYER,
   useAnchor,
-  useCombineRefs,
   useDndDrop,
   useDragNode,
   useHover,
@@ -164,7 +162,6 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const refreshGroup =
       draggedVizNode?.getId() === element.getData().vizNode.getId() &&
       element.getData().vizNode.data.path.slice(0, draggedVizNode?.data.path.length) === draggedVizNode?.data.path;
-    const gCombinedRef = useCombineRefs<SVGGElement>(gHoverRef, dragGroupRef);
 
     const dropDirection: 'forward' | 'backward' | null =
       dndDropProps.droppable && dndDropProps.canDrop && draggedVizNode
@@ -185,9 +182,9 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const toolbarY = boxRef.current.y - CanvasDefaults.STEP_TOOLBAR_HEIGHT;
 
     return (
-      <Layer id={refreshGroup ? DEFAULT_LAYER : GROUPS_LAYER} data-lastupdate={lastUpdate}>
+      <Layer id={GROUPS_LAYER} data-lastupdate={lastUpdate}>
         <g
-          ref={gCombinedRef}
+          ref={gHoverRef}
           className="custom-group"
           data-testid={`custom-group__${groupVizNode.id}`}
           data-grouplabel={label}
@@ -211,7 +208,14 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
               data-testid={`${groupVizNode.getId()}|${groupVizNode.id}`}
               className={clsx('custom-group__container', mainContainerClassNames)}
             >
-              <div className="custom-group__container__text" title={tooltipContent}>
+              <div
+                ref={dragGroupRef}
+                data-testid={`${groupVizNode.getId()}|${groupVizNode.id}|drag-handle`}
+                className={clsx('custom-group__container__text', {
+                  'custom-group__container__text__draggable': canDragGroup(groupVizNode),
+                })}
+                title={tooltipContent}
+              >
                 {doesHaveWarnings ? (
                   <div className="custom-group__container__icon-placeholder" />
                 ) : (
@@ -240,22 +244,25 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
 
           {/** This is the dragged node which is being moved */}
           {dndDropProps.droppable && isDraggingGroup && (
-            <CustomNodeContainer
-              width={CanvasDefaults.DEFAULT_NODE_WIDTH}
-              height={CanvasDefaults.DEFAULT_NODE_HEIGHT}
-              dataNodelabel={label}
-              transform={`translate(${dragGroupProps.dragEvent!.x - 20}, ${dragGroupProps.dragEvent!.y - 20})`}
-              dataTestId={groupVizNode.id}
-              vizNode={groupVizNode}
-              tooltipContent={tooltipContent}
-              childCount={childCount}
-              containerClassNames={{
-                'custom-node__container__draggedNode': true,
-              }}
-              ProcessorIcon={ProcessorIcon}
-              processorDescription={processorDescription}
-              isDisabled={isDisabled}
-            />
+            <Layer id={TOP_LAYER}>
+              <CustomNodeContainer
+                width={CanvasDefaults.DEFAULT_NODE_WIDTH}
+                height={CanvasDefaults.DEFAULT_NODE_HEIGHT}
+                dataNodelabel={label}
+                transform={`translate(${dragGroupProps.dragEvent!.x - 20}, ${dragGroupProps.dragEvent!.y - 20})`}
+                dataTestId={groupVizNode.id}
+                vizNode={groupVizNode}
+                tooltipContent={tooltipContent}
+                childCount={childCount}
+                containerClassNames={{
+                  'custom-node__container__draggedNode': true,
+                  'custom-node__container__grabbing-cursor': true,
+                }}
+                ProcessorIcon={ProcessorIcon}
+                processorDescription={processorDescription}
+                isDisabled={isDisabled}
+              />
+            </Layer>
           )}
 
           {doesHaveWarnings && !isDisabled && (

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.scss
@@ -32,6 +32,11 @@
         @include dnd.cursor-grab;
       }
 
+      // Drag preview under the pointer (already dragging — use grabbing, not grab).
+      &__grabbing-cursor {
+        @include dnd.cursor-grabbing;
+      }
+
       &__draggedNode {
         @include custom.drag-node;
       }

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -267,7 +267,6 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const showLabelWhenDragging =
       (isDraggingNodeType && !isDraggingNode) || (isDraggingGroupType && !isDraggingWithinGroup);
     const showToolbarSection = !dndDropProps.droppable && shouldShowToolbar && hasSomeInteractions;
-    const layerId = isDraggingWithinGroup ? TOP_LAYER : DEFAULT_LAYER;
 
     const mainContainerClassNames = {
       ...getDropTargetContainerClassNames('custom-node__container', dropDirection, dndDropProps.hover),
@@ -276,7 +275,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     };
 
     return (
-      <Layer id={layerId} data-lastupdate={lastUpdate}>
+      <Layer id={DEFAULT_LAYER} data-lastupdate={lastUpdate}>
         <g
           ref={gCombinedRef}
           className="custom-node"

--- a/packages/ui/src/styles/_dnd.scss
+++ b/packages/ui/src/styles/_dnd.scss
@@ -7,3 +7,7 @@
     cursor: grabbing;
   }
 }
+
+@mixin cursor-grabbing {
+  cursor: grabbing;
+}


### PR DESCRIPTION
Fixes #3071 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated drag-and-drop operation test selectors for improved test reliability.

* **Style**
  * Enhanced drag-and-drop visual feedback with improved cursor behavior during node and group dragging.

* **Refactor**
  * Streamlined internal component rendering for drag-and-drop operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->