### PR TITLE
fix(3089): restrict dragged container to be dropped into compatible sub-containers within itself

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -1,5 +1,6 @@
 import './CustomGroupExpanded.scss';
 
+import { isDefined } from '@kaoto/forms';
 import { Icon } from '@patternfly/react-core';
 import { BanIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
@@ -160,10 +161,12 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const [dragGroupProps, dragGroupRef] = useDragNode(groupDragSourceSpec);
     const [dndDropProps, dndDropRef] = useDndDrop(customGroupExpandedDropTargetSpec);
     const draggedVizNode = dragGroupProps.node?.getData().vizNode;
+    const draggedVizNodePath = draggedVizNode?.data.path;
     const isDraggingGroup = dragGroupProps.node?.getId() === element.getId();
     const refreshGroup =
       draggedVizNode?.getId() === element.getData().vizNode.getId() &&
-      element.getData().vizNode.data.path.slice(0, draggedVizNode?.data.path.length) === draggedVizNode?.data.path;
+      isDefined(draggedVizNodePath) &&
+      element.getData().vizNode.data.path.startsWith(draggedVizNodePath + '.');
 
     const dropDirection: 'forward' | 'backward' | null =
       dndDropProps.droppable && dndDropProps.canDrop && draggedVizNode

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -1,5 +1,6 @@
 import './CustomNode.scss';
 
+import { isDefined } from '@kaoto/forms';
 import { Icon } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
@@ -242,10 +243,12 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const isDraggingNodeType = dndDropProps.dragItemType === NODE_DRAG_TYPE;
     const isDraggingGroupType = dndDropProps.dragItemType === GROUP_DRAG_TYPE;
     const draggedVizNode = dndDropProps.dragItem?.getData().vizNode;
+    const draggedVizNodePath = draggedVizNode?.data.path;
     const isDraggingWithinGroup =
       isDraggingGroupType &&
       draggedVizNode?.getId() === element.getData().vizNode.getId() &&
-      element.getData().vizNode.data.path.slice(0, draggedVizNode?.data.path.length) === draggedVizNode?.data.path;
+      isDefined(draggedVizNodePath) &&
+      element.getData().vizNode.data.path.startsWith(draggedVizNodePath + '.');
     const isDraggedNode = isDraggingNode || isDraggingWithinGroup;
     const loadGhostNode = dndDropProps.droppable && ((isDraggingGroupType && isDraggingWithinGroup) || isDraggingNode);
     const box = element.getBounds();

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
@@ -241,6 +241,45 @@ describe('CustomNodeUtils', () => {
       const result = checkNodeDropCompatibility(choiceNode, whenBranchPlaceholder, jest.fn());
       expect(result).toBe(false);
     });
+
+    it('should return false when dragged node is a when and target is when-placeholder inside of the same when', () => {
+      const whenNode = getMockVizNode('route.from.steps.0.choice.when.0');
+      (whenNode.getId as jest.Mock).mockReturnValue('test');
+      const whenPlaceholderInsideSameWhen = getMockVizNode('route.from.steps.0.choice.when.0.steps.1.choice.when');
+      whenPlaceholderInsideSameWhen.getId = jest.fn().mockReturnValue('test');
+
+      const result = checkNodeDropCompatibility(whenNode, whenPlaceholderInsideSameWhen, jest.fn());
+      expect(result).toBe(false);
+    });
+
+    it('should return false when dragged node is a when and target is another when inside of the same when', () => {
+      const whenNode = getMockVizNode('route.from.steps.0.choice.when.0');
+      (whenNode.getId as jest.Mock).mockReturnValue('test');
+      const whenInsideSameWhen = getMockVizNode('route.from.steps.0.choice.when.0.steps.1.choice.when.0');
+      whenInsideSameWhen.getId = jest.fn().mockReturnValue('test');
+
+      const result = checkNodeDropCompatibility(whenNode, whenInsideSameWhen, jest.fn());
+      expect(result).toBe(false);
+    });
+
+    it('should return true when dragged node is a when and target is another when not inside of the same when', () => {
+      const mockValidate = jest.fn().mockReturnValue(true);
+      const whenNode = getMockVizNode('route.from.steps.0.choice.when.0');
+      whenNode.getCopiedContent = jest.fn().mockReturnValue({ name: 'when' });
+      (whenNode.getId as jest.Mock).mockReturnValue('test1');
+      const choiceNode = getMockVizNode('route.from.steps.0.choice.when.0.steps.1.choice');
+      const AnotherWhen = getMockVizNode('route.from.steps.0.choice.when.0.steps.1.choice.when.0');
+      AnotherWhen.getId = jest.fn().mockReturnValue('test2');
+      AnotherWhen.getParentNode = jest.fn().mockReturnValue(choiceNode);
+      AnotherWhen.getCopiedContent = jest.fn().mockReturnValue({ name: 'when' });
+      choiceNode.getNodeInteraction = jest.fn().mockReturnValue({
+        canHaveSpecialChildren: true,
+      });
+
+      const result = checkNodeDropCompatibility(whenNode, AnotherWhen, mockValidate);
+      expect(result).toBe(true);
+      expect(mockValidate).toHaveBeenCalled();
+    });
   });
 
   describe('handleValidNodeDrop', () => {

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
@@ -117,6 +117,16 @@ export const checkNodeDropCompatibility = (
   const targetVizNodeContent = droppedVizNode.getCopiedContent();
   if (!isDefined(droppedVizNodeContent) || !isDefined(targetVizNodeContent)) return false;
 
+  // prevent dragged container sub-nodes and sub-containers as dropping targets
+  const draggedPath = draggedVizNode.data.path;
+  const droppedPath = droppedVizNode.data.path;
+  if (
+    isDefined(draggedPath) &&
+    droppedPath?.startsWith(draggedPath + '.') &&
+    droppedVizNode.getId() === draggedVizNode.getId()
+  )
+    return false;
+
   // validation for placeholder nodes
   if (droppedVizNode.data.isPlaceholder) {
     if (droppedVizNode.data.name === draggedVizNode?.data.name) {
@@ -129,12 +139,6 @@ export const checkNodeDropCompatibility = (
       droppedVizNode.data.name === PlaceholderType.Placeholder &&
       droppedVizNode.getPreviousNode() !== draggedVizNode
     ) {
-      if (
-        droppedVizNode.data.path?.includes(draggedVizNode.data.path ?? '') &&
-        droppedVizNode.getId() === draggedVizNode.getId()
-      )
-        return false;
-
       return validate(AddStepMode.ReplaceStep, droppedVizNode, droppedVizNodeContent.name);
     }
 

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
@@ -1,5 +1,6 @@
 import './PlaceholderNode.scss';
 
+import { isDefined } from '@kaoto/forms';
 import { Icon } from '@patternfly/react-core';
 import { CodeBranchIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import type {
@@ -184,11 +185,12 @@ const PlaceholderNodeInner: FunctionComponent<PlaceholderNodeInnerProps> = obser
   const isDraggingGroupType = dndDropProps.dragItemType === GROUP_DRAG_TYPE;
   const isDraggingNodeType = dndDropProps.dragItemType === NODE_DRAG_TYPE;
   const draggedGroupVizNode = dndDropProps.dragItem?.getData().vizNode;
+  const draggedGroupVizNodePath = draggedGroupVizNode?.data.path;
   const isDraggingWithinGroup =
     isDraggingGroupType &&
     draggedGroupVizNode?.getId() === element.getData().vizNode.getId() &&
-    element.getData().vizNode.data.path.slice(0, draggedGroupVizNode?.data.path.length) ===
-      draggedGroupVizNode?.data.path;
+    isDefined(draggedGroupVizNodePath) &&
+    element.getData().vizNode.data.path.startsWith(draggedGroupVizNodePath + '.');
 
   const box = element.getBounds();
   if (!dndDropProps.droppable || !boxRef.current || !boxXRef.current || !boxYRef.current) {


### PR DESCRIPTION
Fixes #3089 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened drag-and-drop validation in the visualization so nodes cannot be dropped into their own subtree; path-prefix matching prevents invalid nested placements.
* **Tests**
  * Added tests covering several "when" node drag/drop scenarios to verify accept/reject behavior and validation callback invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->