### PR TITLE
fix(gh_actions): build UI only once

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
 
       - name: Build packages
-        run: yarn workspaces foreach --verbose --all --topological-dev run build:dev
+        run: yarn workspace @kaoto/kaoto run build:dev
 
       # Build lib
       - name: Build @kaoto/kaoto package in lib mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced E2E test workflow by refining the build process to execute targeted package builds instead of broader monorepo operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->