### PR TITLE
fix(visualization): update catalog when switching flow types in NewFlow

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -12,7 +12,7 @@ import { CamelRouteVisualEntity } from '../../../models/visualization/flows';
 import { ActionConfirmationModalContextProvider } from '../../../providers/action-confirmation-modal.provider';
 import { SettingsProvider } from '../../../providers/settings.provider';
 import { VisibleFlowsContextResult } from '../../../providers/visible-flows.provider';
-import { TestProvidersWrapper } from '../../../stubs';
+import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../stubs';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { kameletJson } from '../../../stubs/kamelet-route';
 import { Canvas } from './Canvas';
@@ -348,6 +348,7 @@ describe('Canvas', () => {
 
   describe('Empty state', () => {
     it('should render empty state when there is no visual entity', async () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper({
         visibleFlowsContext: { visibleFlows: {} } as unknown as VisibleFlowsContextResult,
       });
@@ -356,11 +357,13 @@ describe('Canvas', () => {
 
       await act(async () => {
         result = render(
-          <Provider>
-            <VisualizationProvider controller={ControllerService.createController()}>
-              <Canvas entities={[]} />
-            </VisualizationProvider>
-          </Provider>,
+          <RuntimeProvider>
+            <Provider>
+              <VisualizationProvider controller={ControllerService.createController()}>
+                <Canvas entities={[]} />
+              </VisualizationProvider>
+            </Provider>
+          </RuntimeProvider>,
         );
       });
 
@@ -373,6 +376,7 @@ describe('Canvas', () => {
     });
 
     it('should render empty state when there is no visible flows', async () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper({
         visibleFlowsContext: { visibleFlows: { ['route-8888']: false } } as unknown as VisibleFlowsContextResult,
       });
@@ -380,11 +384,13 @@ describe('Canvas', () => {
 
       await act(async () => {
         result = render(
-          <Provider>
-            <VisualizationProvider controller={ControllerService.createController()}>
-              <Canvas entities={[entity]} />
-            </VisualizationProvider>
-          </Provider>,
+          <RuntimeProvider>
+            <Provider>
+              <VisualizationProvider controller={ControllerService.createController()}>
+                <Canvas entities={[entity]} />
+              </VisualizationProvider>
+            </Provider>
+          </RuntimeProvider>,
         );
       });
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -1,9 +1,13 @@
-import { act, fireEvent, render } from '@testing-library/react';
+import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
 import { KaotoSchemaDefinition } from '../../../../models';
 import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
+import { KaotoResource } from '../../../../models/kaoto-resource';
+import { RuntimeContext, SourceCodeApiContext } from '../../../../providers';
 import { XmlCamelResourceSerializer } from '../../../../serializers';
 import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../stubs';
+import { CatalogSchemaLoader } from '../../../../utils';
 import { IntegrationTypeSelector } from './IntegrationTypeSelector';
 
 describe('IntegrationTypeSelector.tsx', () => {
@@ -27,6 +31,52 @@ describe('IntegrationTypeSelector.tsx', () => {
   config.config[SourceSchemaType.Test].schema = {
     schema: { name: 'Test', description: 'desc' } as KaotoSchemaDefinition['schema'],
   } as KaotoSchemaDefinition;
+
+  const mockCamelCatalog: CatalogLibraryEntry = {
+    name: 'Camel Main',
+    runtime: 'Main',
+    version: '4.0.0',
+    fileName: 'camel-catalog-4.0.0.json',
+  } as CatalogLibraryEntry;
+
+  const mockCitrusCatalog: CatalogLibraryEntry = {
+    name: 'Citrus',
+    runtime: 'Citrus',
+    version: '4.0.0',
+    fileName: 'citrus-catalog-4.0.0.json',
+  } as CatalogLibraryEntry;
+
+  const mockCatalogLibrary: CatalogLibrary = {
+    definitions: [mockCamelCatalog, mockCitrusCatalog],
+  } as CatalogLibrary;
+
+  const renderWithCustomRuntime = (
+    selectedCatalog: CatalogLibraryEntry = mockCamelCatalog,
+    camelResource?: KaotoResource,
+  ) => {
+    const mockSetSelectedCatalog = jest.fn();
+    const { Provider } = TestProvidersWrapper({ camelResource });
+
+    return {
+      ...render(
+        <RuntimeContext.Provider
+          value={{
+            basePath: CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH,
+            catalogLibrary: mockCatalogLibrary,
+            selectedCatalog,
+            setSelectedCatalog: mockSetSelectedCatalog,
+          }}
+        >
+          <SourceCodeApiContext.Provider value={{ setCodeAndNotify: jest.fn() }}>
+            <Provider>
+              <IntegrationTypeSelector />
+            </Provider>
+          </SourceCodeApiContext.Provider>
+        </RuntimeContext.Provider>,
+      ),
+      mockSetSelectedCatalog,
+    };
+  };
 
   it('should render all of the types', async () => {
     const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
@@ -110,19 +160,9 @@ describe('IntegrationTypeSelector.tsx', () => {
   });
 
   it('should warn the user when selected flow changes the catalog', async () => {
-    const runtimeWrapper = TestRuntimeProviderWrapper();
-    const RuntimeProvider = runtimeWrapper.Provider;
-    const selectedCatalogMock = runtimeWrapper.setSelectedCatalog as jest.Mock;
-    const { Provider } = TestProvidersWrapper();
-    const wrapper = render(
-      <RuntimeProvider>
-        <Provider>
-          <IntegrationTypeSelector />
-        </Provider>
-      </RuntimeProvider>,
-    );
+    const { findByTestId, getByTestId, mockSetSelectedCatalog } = renderWithCustomRuntime(mockCamelCatalog);
 
-    const trigger = await wrapper.findByTestId('integration-type-list-dropdown');
+    const trigger = await findByTestId('integration-type-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -131,26 +171,31 @@ describe('IntegrationTypeSelector.tsx', () => {
 
     /** Select an option */
     act(() => {
-      const element = wrapper.getByTestId('integration-type-Test').firstElementChild; // drop down button
+      const element = getByTestId('integration-type-Test').firstElementChild; // drop down button
       expect(element).toBeTruthy();
       fireEvent.click(element!);
     });
 
-    const modal = await wrapper.findByTestId('confirmation-modal');
+    const modal = await findByTestId('confirmation-modal');
     expect(modal).toBeInTheDocument();
 
-    const modalText = await wrapper.findByTestId('confirmation-modal-text');
+    const modalText = await findByTestId('confirmation-modal-text');
     expect(modalText).toBeInTheDocument();
     expect(modalText.textContent).toContain('This will also change the current selected catalog');
 
     /** Confirm **/
-    const confirmButton = await wrapper.findByTestId('confirmation-modal-confirm');
-    fireEvent.click(confirmButton);
+    const confirmButton = await findByTestId('confirmation-modal-confirm');
 
-    expect(selectedCatalogMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runtime: 'Citrus',
-      }),
-    );
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    await waitFor(() => {
+      expect(mockSetSelectedCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtime: 'Citrus',
+        }),
+      );
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
@@ -1,3 +1,4 @@
+import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render } from '@testing-library/react';
 
 import { KaotoSchemaDefinition } from '../../../../models';
@@ -5,6 +6,7 @@ import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { VisibleFlowsProvider } from '../../../../providers';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { IRuntimeContext, RuntimeContext } from '../../../../providers/runtime.provider';
 import { SourceCodeApiContext } from '../../../../providers/source-code.provider';
 import { NewFlow } from './NewFlow';
 
@@ -26,29 +28,68 @@ describe('NewFlow.tsx', () => {
   config.config[SourceSchemaType.Route].schema = {
     schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
   } as KaotoSchemaDefinition;
+  config.config[SourceSchemaType.Test].schema = {
+    schema: { name: 'Test', description: 'desc' } as KaotoSchemaDefinition['schema'],
+  } as KaotoSchemaDefinition;
 
-  const renderWithContext = () => {
-    return render(
-      <SourceCodeApiContext.Provider
-        value={{
-          setCodeAndNotify: jest.fn(),
-        }}
-      >
-        <EntitiesContext.Provider
-          value={
-            {
-              currentSchemaType: SourceSchemaType.Integration,
-              visualEntities: visualEntities,
-              camelResource: new CamelRouteResource(),
-            } as unknown as EntitiesContextResult
-          }
-        >
-          <VisibleFlowsProvider>
-            <NewFlow />
-          </VisibleFlowsProvider>
-        </EntitiesContext.Provider>
-      </SourceCodeApiContext.Provider>,
-    );
+  const mockCamelCatalog: CatalogLibraryEntry = {
+    name: 'Camel Main',
+    runtime: 'Main',
+    version: '4.0.0',
+    fileName: 'camel-catalog-4.0.0.json',
+  } as CatalogLibraryEntry;
+
+  const mockCitrusCatalog: CatalogLibraryEntry = {
+    name: 'Citrus',
+    runtime: 'Citrus',
+    version: '4.0.0',
+    fileName: 'citrus-catalog-4.0.0.json',
+  } as CatalogLibraryEntry;
+
+  const mockCatalogLibrary: CatalogLibrary = {
+    definitions: [mockCamelCatalog, mockCitrusCatalog],
+  } as CatalogLibrary;
+
+  const renderWithContext = (
+    runtimeContextValue?: Partial<IRuntimeContext>,
+    sourceSchemaType: SourceSchemaType = SourceSchemaType.Integration,
+  ) => {
+    const mockSetSelectedCatalog = jest.fn();
+    const defaultRuntimeContext: IRuntimeContext = {
+      basePath: '',
+      selectedCatalog: mockCamelCatalog,
+      catalogLibrary: mockCatalogLibrary,
+      setSelectedCatalog: mockSetSelectedCatalog,
+    };
+
+    const mergedRuntimeContext = { ...defaultRuntimeContext, ...runtimeContextValue };
+
+    return {
+      ...render(
+        <RuntimeContext.Provider value={mergedRuntimeContext}>
+          <SourceCodeApiContext.Provider
+            value={{
+              setCodeAndNotify: jest.fn(),
+            }}
+          >
+            <EntitiesContext.Provider
+              value={
+                {
+                  currentSchemaType: sourceSchemaType,
+                  visualEntities: visualEntities,
+                  camelResource: new CamelRouteResource(),
+                } as unknown as EntitiesContextResult
+              }
+            >
+              <VisibleFlowsProvider>
+                <NewFlow />
+              </VisibleFlowsProvider>
+            </EntitiesContext.Provider>
+          </SourceCodeApiContext.Provider>
+        </RuntimeContext.Provider>,
+      ),
+      mockSetSelectedCatalog,
+    };
   };
 
   const visualEntities = [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity];
@@ -85,5 +126,73 @@ describe('NewFlow.tsx', () => {
 
     const modal = await wrapper.findByTestId('confirmation-modal');
     expect(modal).toBeInTheDocument();
+  });
+
+  it('should update catalog when switching to Citrus test', async () => {
+    const mockSetSelectedCatalog = jest.fn();
+    const { findByTestId, getByText } = renderWithContext(
+      {
+        selectedCatalog: mockCamelCatalog,
+        catalogLibrary: mockCatalogLibrary,
+        setSelectedCatalog: mockSetSelectedCatalog,
+      },
+      SourceSchemaType.Route,
+    );
+
+    const trigger = await findByTestId('viz-dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select Citrus Test option */
+    act(() => {
+      const element = getByText('Test');
+      fireEvent.click(element);
+    });
+
+    /** Confirm the modal */
+    const confirmButton = await findByTestId('confirmation-modal-confirm');
+    act(() => {
+      fireEvent.click(confirmButton);
+    });
+
+    /** Verify catalog was updated to Citrus */
+    expect(mockSetSelectedCatalog).toHaveBeenCalledWith(mockCitrusCatalog);
+  });
+
+  it('should not update catalog when switching between Camel flow types', async () => {
+    const mockSetSelectedCatalog = jest.fn();
+    const { findByTestId, getByText } = renderWithContext(
+      {
+        selectedCatalog: mockCamelCatalog,
+        catalogLibrary: mockCatalogLibrary,
+        setSelectedCatalog: mockSetSelectedCatalog,
+      },
+      SourceSchemaType.Route,
+    );
+
+    const trigger = await findByTestId('viz-dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select Pipe option (another Camel type) */
+    act(() => {
+      const element = getByText('Pipe');
+      fireEvent.click(element);
+    });
+
+    /** Confirm the modal */
+    const confirmButton = await findByTestId('confirmation-modal-confirm');
+    act(() => {
+      fireEvent.click(confirmButton);
+    });
+
+    /** Verify catalog was NOT updated since both are Camel types */
+    expect(mockSetSelectedCatalog).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
@@ -1,15 +1,19 @@
+import { isDefined } from '@kaoto/forms';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
+import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { ISourceSchema, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
 import { FlowTemplateService } from '../../../../models/visualization/flows/support/flow-templates-service';
 import { SourceCodeApiContext } from '../../../../providers';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
+import { findCatalog, requiresCatalogChange } from '../../../../utils/catalog-helper';
 import { FlowTypeSelector } from './FlowTypeSelector';
 
 export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
+  const runtimeContext = useRuntimeContext();
   const sourceCodeContextApi = useContext(SourceCodeApiContext);
   const { currentSchemaType, camelResource, updateEntitiesFromCamelResource } = useEntityContext();
   const currentFlowType: ISourceSchema = sourceSchemaConfig.config[currentSchemaType];
@@ -80,6 +84,16 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
             onClick={() => {
               if (proposedFlowType) {
                 sourceCodeContextApi.setCodeAndNotify(FlowTemplateService.getFlowYamlTemplate(proposedFlowType));
+
+                // Update catalog if needed when switching flow types
+                const changeCatalog = requiresCatalogChange(proposedFlowType, runtimeContext.selectedCatalog);
+                if (changeCatalog) {
+                  const matchingCatalog = findCatalog(proposedFlowType, runtimeContext.catalogLibrary);
+                  if (isDefined(matchingCatalog)) {
+                    runtimeContext.setSelectedCatalog(matchingCatalog);
+                  }
+                }
+
                 setIsConfirmationModalOpen(false);
               }
             }}

--- a/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
@@ -1,16 +1,19 @@
 import { render } from '@testing-library/react';
 
-import { TestProvidersWrapper } from '../../../stubs';
+import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../stubs';
 import { VisualizationEmptyState } from './VisualizationEmptyState';
 
 describe('VisualizationEmptyState.tsx', () => {
   describe('when there are no routes', () => {
     it('should render the CubesIcon whenever there are no routes', () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <Provider>
-          <VisualizationEmptyState entitiesNumber={0} />
-        </Provider>,
+        <RuntimeProvider>
+          <Provider>
+            <VisualizationEmptyState entitiesNumber={0} />
+          </Provider>
+        </RuntimeProvider>,
       );
 
       const icon = wrapper.getByTestId('cubes-icon');
@@ -19,11 +22,14 @@ describe('VisualizationEmptyState.tsx', () => {
     });
 
     it('should state that there are no routes', () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <Provider>
-          <VisualizationEmptyState entitiesNumber={0} />
-        </Provider>,
+        <RuntimeProvider>
+          <Provider>
+            <VisualizationEmptyState entitiesNumber={0} />
+          </Provider>
+        </RuntimeProvider>,
       );
 
       const noRoutesTitle = wrapper.getByText('There are no routes defined');
@@ -36,11 +42,14 @@ describe('VisualizationEmptyState.tsx', () => {
 
   describe('when there are routes but they are not visible', () => {
     it('should render the EyeSlashIcon whenever there are no routes', () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <Provider>
-          <VisualizationEmptyState entitiesNumber={1} />
-        </Provider>,
+        <RuntimeProvider>
+          <Provider>
+            <VisualizationEmptyState entitiesNumber={1} />
+          </Provider>
+        </RuntimeProvider>,
       );
       const icon = wrapper.getByTestId('eye-slash-icon');
 
@@ -48,11 +57,14 @@ describe('VisualizationEmptyState.tsx', () => {
     });
 
     it('should state that there are no visible routes', () => {
+      const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
       const { Provider } = TestProvidersWrapper();
       const wrapper = render(
-        <Provider>
-          <VisualizationEmptyState entitiesNumber={1} />
-        </Provider>,
+        <RuntimeProvider>
+          <Provider>
+            <VisualizationEmptyState entitiesNumber={1} />
+          </Provider>
+        </RuntimeProvider>,
       );
       const noRoutesTitle = wrapper.getByText('There are no visible routes');
 


### PR DESCRIPTION
### Context
Runtime selector showed wrong catalog after switching from `Camel` to `Citrus` via "New" button.

Added catalog switching logic to `NewFlow` component's confirmation handler, matching `IntegrationTypeSelector`'s implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flow type switching now intelligently updates the runtime catalog when needed (e.g., Camel to Citrus transitions).

* **Tests**
  * Expanded test coverage for runtime context and catalog management across visualization components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->