### PR TITLE
added watcher script to stale/close inactive issues / PRs

### DIFF
--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -1,0 +1,25 @@
+name: Close inactive issues and PRs
+on:
+  schedule:
+    - cron: "30 12 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-label: "stale"
+          days-before-issue-stale: 90
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity. It will be closed if there is no activity in the next 30 days."
+          days-before-issue-close: 30
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale. Please reopen it if you think this was a mistake."
+          stale-pr-label: "stale"
+          days-before-pr-stale: 14
+          stale-pr-message: "This pull request is stale because it has been open for 14 days with no activity. It will be closed if there is no activity in the next 14 days."
+          days-before-pr-close: 14
+          close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale. Please reopen it if you think this was a mistake."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to manage inactive issues and pull requests on a daily schedule. Issues inactive for 90+ days will be marked stale and closed after 30 additional days; pull requests inactive for 14+ days will be marked stale and closed after 14 additional days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->