### PR TITLE
fix(DataMapper): parent node is collapsed when choice node chevron is clicked

### DIFF
--- a/packages/ui/src/models/datamapper/document-tree-node.test.ts
+++ b/packages/ui/src/models/datamapper/document-tree-node.test.ts
@@ -440,6 +440,73 @@ describe('DocumentTreeNode', () => {
     });
   });
 
+  describe('choice wrapper path uniqueness', () => {
+    it('should give choice wrapper nodes a unique path distinct from parent', () => {
+      const rootNode = new DocumentTreeNode(mockNodeData);
+
+      const parentData: NodeData = {
+        title: 'Parent',
+        id: 'parent-1',
+        path: NodePath.childOf(mockNodeData.path, 'parent-1'),
+        isSource: false,
+        isPrimitive: false,
+      };
+      const parentNode = rootNode.addChild(parentData);
+
+      const choiceData: NodeData = {
+        title: 'choice',
+        id: 'choice-1',
+        path: NodePath.childOf(parentData.path, 'choice-1'),
+        isSource: false,
+        isPrimitive: false,
+      };
+      const choiceNode = parentNode.addChild(choiceData);
+
+      expect(parentNode.path).not.toEqual(choiceNode.path);
+      expect(rootNode.findByPath(parentNode.path)).toBe(parentNode);
+      expect(rootNode.findByPath(choiceNode.path)).toBe(choiceNode);
+    });
+
+    it('should give nested choice wrappers unique paths at each level', () => {
+      const rootNode = new DocumentTreeNode(mockNodeData);
+
+      const parentData: NodeData = {
+        title: 'Parent',
+        id: 'parent-1',
+        path: NodePath.childOf(mockNodeData.path, 'parent-1'),
+        isSource: false,
+        isPrimitive: false,
+      };
+      const parentNode = rootNode.addChild(parentData);
+
+      const outerChoiceData: NodeData = {
+        title: 'outer-choice',
+        id: 'outer-choice-1',
+        path: NodePath.childOf(parentData.path, 'outer-choice-1'),
+        isSource: false,
+        isPrimitive: false,
+      };
+      const outerChoiceNode = parentNode.addChild(outerChoiceData);
+
+      const innerChoiceData: NodeData = {
+        title: 'inner-choice',
+        id: 'inner-choice-1',
+        path: NodePath.childOf(outerChoiceData.path, 'inner-choice-1'),
+        isSource: false,
+        isPrimitive: false,
+      };
+      const innerChoiceNode = outerChoiceNode.addChild(innerChoiceData);
+
+      expect(parentNode.path).not.toEqual(outerChoiceNode.path);
+      expect(outerChoiceNode.path).not.toEqual(innerChoiceNode.path);
+      expect(parentNode.path).not.toEqual(innerChoiceNode.path);
+
+      expect(rootNode.findByPath(parentNode.path)).toBe(parentNode);
+      expect(rootNode.findByPath(outerChoiceNode.path)).toBe(outerChoiceNode);
+      expect(rootNode.findByPath(innerChoiceNode.path)).toBe(innerChoiceNode);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle primitive document nodes', () => {
       const primitiveNodeData: NodeData = {

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -43,6 +43,12 @@ export abstract class MappingItem {
   /** The root {@link MappingTree} this item belongs to. */
   mappingTree: MappingTree;
   children: MappingItem[] = [];
+  /**
+   * {@link NodePath} representing this item's position in the **mapping tree** (XSLT output
+   * structure). `xs:choice` is a schema compositor — not an XML element — so choice wrapper
+   * segments are never included. Use {@link MappingLinksService.computeVisualTargetNodePath}
+   * to obtain the corresponding visual document tree path that includes choice wrapper segments.
+   */
   get nodePath(): NodePath {
     return NodePath.childOf(this.parent.nodePath, this.id);
   }

--- a/packages/ui/src/models/datamapper/nodepath.ts
+++ b/packages/ui/src/models/datamapper/nodepath.ts
@@ -1,13 +1,19 @@
 import { DocumentType } from './document';
 
 /**
- * The internal path representation which uses {@link IField.id} for source and {@link MappingItem.id} for target
- * to represent the node, and use '/' as a path separator.
- * In order to distinguish all the nodes at the target side, we needed to use ID. While document field nodes are all
- * unique with its path (when namespace is taken care) at the same level, e.g. it is guaranteed that `/ns0:ShipOrder/ns0:ShipTo`
- * is unique, it is not the case at the target side once the mappings are overlaid. For example there could be
- * multiple `for-each` element at the same level, for example `/ns0:ShipOrder/for-each` is ambiguous when there're
- * multiple `for-each` at the same level, such as `/ns0:ShipOrder/for-each[0]` and `/ns0:ShipOrder/for-each[1]`.
+ * Generic path identifier for a node within a tree structure, using '/' as a segment separator.
+ * Each segment is the node's `id`, which ensures uniqueness even when multiple mapping instructions
+ * (e.g. `for-each`) share the same name at the same level.
+ *
+ * `NodePath` is used in two distinct tree structures:
+ *
+ * - **Mapping tree** ({@link MappingItem.nodePath}): represents the node's position in the XSLT
+ *   output structure. `xs:choice` is a schema compositor with no XSLT counterpart, so choice
+ *   wrapper segments are absent from these paths.
+ *
+ * - **Visual document tree** ({@link NodeData.path}): represents the node's position among
+ *   rendered document nodes. Unselected choice wrappers ARE rendered nodes and therefore have
+ *   their own path segments, even though they won't appear in XPath or the XSLT output.
  */
 export class NodePath {
   documentType: DocumentType = DocumentType.SOURCE_BODY;

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -27,7 +27,13 @@ export interface NodeData {
   type?: Types;
   /** Stable identifier used for keying and DnD operations. */
   id: string;
-  /** Full path from the document root to this node. */
+  /**
+   * {@link NodePath} representing this node's position in the **visual document tree**.
+   * Unselected choice wrappers are rendered nodes and have their own path segment,
+   * unlike in the mapping tree where `xs:choice` has no counterpart.
+   * See {@link MappingLinksService.computeVisualTargetNodePath} for the bridge between
+   * mapping tree and visual tree paths.
+   */
   path: NodePath;
   /** `true` for source-side nodes, `false` for target-side nodes. */
   isSource: boolean;
@@ -147,19 +153,18 @@ export class ChoiceFieldNodeData extends FieldNodeData {
  * Target-side counterpart of {@link ChoiceFieldNodeData}.
  * Carries the same selected/unselected semantics; see that class for details.
  *
- * When unselected (`field.isChoice === true`), the wrapper is **path-transparent**:
- * its {@link path} equals its parent's path so that children compute paths matching
- * the mapping tree hierarchy (which has no choice wrapper nodes). This ensures
- * {@link MappingLinksService} can match visual node paths to mapping node paths
- * for line rendering.
+ * The {@link path} is a {@link NodePath} representing this node's position in the
+ * **visual document tree**. When unselected (`field.isChoice === true`), the choice
+ * wrapper IS a rendered node and therefore has its own path segment — even though
+ * `xs:choice` is a schema compositor (not an XML element) that won't appear in XPath
+ * or the XSLT output structure.
+ *
+ * Note: the mapping tree ({@link MappingItem.nodePath}) does not include choice wrapper
+ * segments because the mapping tree mirrors the XSLT output structure. The bridge between
+ * visual and mapping tree paths is handled by
+ * {@link MappingLinksService.computeVisualTargetNodePath}.
  */
 export class TargetChoiceFieldNodeData extends TargetFieldNodeData {
-  constructor(parent: TargetNodeData, field: IField, mapping?: FieldItem) {
-    super(parent, field, mapping);
-    if (field.isChoice) {
-      this.path = parent.path;
-    }
-  }
   /** The choice wrapper field when a member is selected; `undefined` for the unselected wrapper itself. */
   choiceField?: IField;
 }

--- a/packages/ui/src/services/mapping-links.service.test.ts
+++ b/packages/ui/src/services/mapping-links.service.test.ts
@@ -4,8 +4,9 @@ import {
   DocumentDefinitionType,
   DocumentType,
   IDocument,
+  IField,
 } from '../models/datamapper/document';
-import { MappingTree } from '../models/datamapper/mapping';
+import { FieldItem, MappingTree, ValueSelector } from '../models/datamapper/mapping';
 import { useDocumentTreeStore } from '../store';
 import { mockRandomValues } from '../stubs';
 import {
@@ -15,6 +16,7 @@ import {
   getMessage837Xsd,
   getOrgToContactsXslt,
   getOrgXsd,
+  getSchemaTestXsd,
   getShipOrderJsonSchema,
   getShipOrderToShipOrderCollectionIndexXslt,
   getShipOrderToShipOrderMultipleForEachXslt,
@@ -26,6 +28,7 @@ import {
   getX12850ForEachXslt,
   TestUtil,
 } from '../stubs/datamapper/data-mapper';
+import { DocumentUtilService } from './document-util.service';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
 import { MappingLinksService } from './mapping-links.service';
 import { MappingSerializerService } from './mapping-serializer.service';
@@ -282,6 +285,139 @@ describe('MappingLinksService', () => {
 
       expect(selectedLinks.length).toBeGreaterThan(0);
       expect(selectedLinks.every((l) => l.targetNodePath === firstTargetPath)).toBeTruthy();
+    });
+  });
+
+  describe('choice wrapper target paths', () => {
+    it('should include choice wrapper segments in target paths for fields inside choice', () => {
+      const targetDefinition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'schemaTest.xsd': getSchemaTestXsd() },
+      );
+      const choiceTargetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
+      const choiceTree = new MappingTree(
+        choiceTargetDoc.documentType,
+        choiceTargetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+
+      const rootField = choiceTargetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(rootField);
+      const personField = rootField.fields.find((f: IField) => f.name === 'person')!;
+      DocumentUtilService.resolveTypeFragment(personField);
+      const outerChoiceField = personField.fields.find((f: IField) => f.isChoice)!;
+      const innerChoiceField = outerChoiceField.fields.find((f: IField) => f.isChoice)!;
+      const emailField = innerChoiceField.fields.find((f: IField) => f.name === 'email')!;
+
+      outerChoiceField.id = 'outer-choice';
+      innerChoiceField.id = 'inner-choice';
+
+      choiceTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+      const rootItem = new FieldItem(choiceTree, rootField);
+      choiceTree.children.push(rootItem);
+      const personItem = new FieldItem(rootItem, personField);
+      rootItem.children.push(personItem);
+      const emailItem = new FieldItem(personItem, emailField);
+      personItem.children.push(emailItem);
+      const valueSelector = new ValueSelector(emailItem);
+      valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      emailItem.children.push(valueSelector);
+
+      const links = MappingLinksService.extractMappingLinks(choiceTree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(1);
+      expect(links[0].targetNodePath).toEqual(
+        `targetBody:Body://${rootItem.id}/${personItem.id}/outer-choice/inner-choice/${emailItem.id}`,
+      );
+      expect(emailItem.nodePath.toString()).not.toContain('outer-choice');
+    });
+
+    it('should exclude selected choice wrapper segments from target paths', () => {
+      const targetDefinition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'schemaTest.xsd': getSchemaTestXsd() },
+      );
+      const choiceTargetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
+      const choiceTree = new MappingTree(
+        choiceTargetDoc.documentType,
+        choiceTargetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+
+      const rootField = choiceTargetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(rootField);
+      const personField = rootField.fields.find((f: IField) => f.name === 'person')!;
+      DocumentUtilService.resolveTypeFragment(personField);
+      const outerChoiceField = personField.fields.find((f: IField) => f.isChoice)!;
+      const innerChoiceField = outerChoiceField.fields.find((f: IField) => f.isChoice)!;
+      const emailField = innerChoiceField.fields.find((f: IField) => f.name === 'email')!;
+
+      outerChoiceField.id = 'outer-choice';
+      innerChoiceField.id = 'inner-choice';
+      outerChoiceField.selectedMemberIndex = 0;
+      innerChoiceField.selectedMemberIndex = 0;
+
+      choiceTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+      const rootItem = new FieldItem(choiceTree, rootField);
+      choiceTree.children.push(rootItem);
+      const personItem = new FieldItem(rootItem, personField);
+      rootItem.children.push(personItem);
+      const emailItem = new FieldItem(personItem, emailField);
+      personItem.children.push(emailItem);
+      const valueSelector = new ValueSelector(emailItem);
+      valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      emailItem.children.push(valueSelector);
+
+      const links = MappingLinksService.extractMappingLinks(choiceTree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(1);
+      expect(links[0].targetNodePath).toEqual(`targetBody:Body://${rootItem.id}/${personItem.id}/${emailItem.id}`);
+    });
+
+    it('should only include unselected choice wrapper segments when mixed', () => {
+      const targetDefinition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'schemaTest.xsd': getSchemaTestXsd() },
+      );
+      const choiceTargetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
+      const choiceTree = new MappingTree(
+        choiceTargetDoc.documentType,
+        choiceTargetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+
+      const rootField = choiceTargetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(rootField);
+      const personField = rootField.fields.find((f: IField) => f.name === 'person')!;
+      DocumentUtilService.resolveTypeFragment(personField);
+      const outerChoiceField = personField.fields.find((f: IField) => f.isChoice)!;
+      const innerChoiceField = outerChoiceField.fields.find((f: IField) => f.isChoice)!;
+      const emailField = innerChoiceField.fields.find((f: IField) => f.name === 'email')!;
+
+      outerChoiceField.id = 'outer-choice';
+      innerChoiceField.id = 'inner-choice';
+      outerChoiceField.selectedMemberIndex = 0;
+
+      choiceTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+      const rootItem = new FieldItem(choiceTree, rootField);
+      choiceTree.children.push(rootItem);
+      const personItem = new FieldItem(rootItem, personField);
+      rootItem.children.push(personItem);
+      const emailItem = new FieldItem(personItem, emailField);
+      personItem.children.push(emailItem);
+      const valueSelector = new ValueSelector(emailItem);
+      valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      emailItem.children.push(valueSelector);
+
+      const links = MappingLinksService.extractMappingLinks(choiceTree, paramsMap, sourceDoc);
+      expect(links.length).toEqual(1);
+      expect(links[0].targetNodePath).toEqual(
+        `targetBody:Body://${rootItem.id}/${personItem.id}/inner-choice/${emailItem.id}`,
+      );
     });
   });
 

--- a/packages/ui/src/services/mapping-links.service.ts
+++ b/packages/ui/src/services/mapping-links.service.ts
@@ -4,10 +4,12 @@ import {
   FieldItem,
   IDocument,
   IExpressionHolder,
+  IField,
   IMappingLink,
   isExpressionHolder,
   MappingItem,
   MappingTree,
+  NodePath,
   PrimitiveDocument,
   ValueSelector,
 } from '../models/datamapper';
@@ -26,7 +28,7 @@ export class MappingLinksService {
     selectedNodeIsSource: boolean = false,
   ): IMappingLink[] {
     const answer = [] as IMappingLink[];
-    const targetNodePath = item.nodePath.toString();
+    const targetNodePath = MappingLinksService.computeVisualTargetNodePath(item).toString();
     if (item instanceof MappingItem && isExpressionHolder(item)) {
       const links = MappingLinksService.doExtractMappingLinks(
         item,
@@ -135,5 +137,51 @@ export class MappingLinksService {
     return !!mappingLinks
       .filter((link) => link.isSelected)
       .some((link) => link.sourceNodePath === nodePath || link.targetNodePath === nodePath);
+  }
+
+  /**
+   * Bridges a mapping tree {@link NodePath} (no choice wrapper segments) to the
+   * visual document tree {@link NodePath} (with choice wrapper segments) by inserting
+   * intermediate choice wrapper IDs from the {@link IField} parent chain.
+   *
+   * The mapping tree mirrors the XSLT output structure where `xs:choice` has no counterpart,
+   * while the visual tree renders choice wrappers as nodes with their own path segments.
+   * This method reconciles the two so that mapping link target paths match the connection
+   * port paths registered in the DOM.
+   */
+  private static computeVisualTargetNodePath(item: MappingTree | MappingItem): NodePath {
+    if (item instanceof MappingTree) {
+      return item.nodePath;
+    }
+    const parentPath = MappingLinksService.computeVisualTargetNodePath(item.parent);
+    if (item instanceof FieldItem) {
+      const choiceSegments = MappingLinksService.getIntermediateChoiceSegments(item.field);
+      let path = parentPath;
+      for (const segment of choiceSegments) {
+        path = NodePath.childOf(path, segment);
+      }
+      return NodePath.childOf(path, item.id);
+    }
+    return NodePath.childOf(parentPath, item.id);
+  }
+
+  /**
+   * Collects the IDs of consecutive `isChoice` ancestor fields, ordered from
+   * outermost to innermost. Only includes **unselected** choice wrappers
+   * (`selectedMemberIndex` is `undefined`) because selected wrappers are not
+   * rendered as visual nodes — the selected member replaces them in the tree.
+   * Returns an empty array when the field has no unselected choice wrapper ancestors.
+   */
+  private static getIntermediateChoiceSegments(field: IField): string[] {
+    const segments: string[] = [];
+    let current = field.parent;
+    while ('isChoice' in current && current.isChoice) {
+      if (current.selectedMemberIndex === undefined) {
+        segments.push(current.id);
+      }
+      current = current.parent;
+    }
+    segments.reverse();
+    return segments;
   }
 }

--- a/packages/ui/src/services/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization.service.test.ts
@@ -1971,8 +1971,7 @@ describe('VisualizationService', () => {
         expect(contactEmailNode).toBeInstanceOf(FieldItemNodeData);
       });
 
-      it('FieldItemNodeData.path should match FieldItem.nodePath so mapping lines render correctly', () => {
-        // Create a mapping for a member field inside the choice wrapper
+      it('FieldItemNodeData.path should include choice wrapper segment while FieldItem.nodePath should not', () => {
         const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
         const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
         const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
@@ -1983,12 +1982,9 @@ describe('VisualizationService', () => {
 
         VisualizationService.engageMapping(tree, sourceChildren[0] as FieldNodeData, memberNode);
 
-        // Re-render the visual tree using FieldItemNodeData for the parent (as the
-        // real rendering pipeline would, since it has a mapping)
         const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
         const parentItem = tree.children[0] as FieldItem;
         const freshParentNode = new FieldItemNodeData(freshTargetDocNode, parentItem);
-        // Override field to include the choice member
         freshParentNode.field = {
           ...freshParentNode.field,
           fields: [choiceField],
@@ -1998,11 +1994,13 @@ describe('VisualizationService', () => {
         const choiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshChoiceNode);
         const contactEmailNode = choiceChildren.find((c) => c.title === 'contactEmail') as FieldItemNodeData;
 
-        // The visual node path must match the mapping tree nodePath for line rendering
         const mappingFieldItem = parentItem.children.find(
           (c) => c instanceof FieldItem && c.field === memberField,
         ) as FieldItem;
-        expect(contactEmailNode.path.toString()).toEqual(mappingFieldItem.nodePath.toString());
+        // Visual path includes choice wrapper segment; mapping path does not.
+        // MappingLinksService.computeVisualTargetNodePath bridges this gap for line rendering.
+        expect(contactEmailNode.path.pathSegments).toContain(choiceField.id);
+        expect(mappingFieldItem.nodePath.pathSegments).not.toContain(choiceField.id);
       });
 
       it('should work for nested fields inside choice member (mapping + rendering + path)', () => {
@@ -2091,10 +2089,10 @@ describe('VisualizationService', () => {
         expect(freshEmailAddressNode).toBeDefined();
         expect(freshEmailAddressNode).toBeInstanceOf(FieldItemNodeData);
 
-        // Path must match mapping tree nodePath for line rendering
-        expect((freshEmailAddressNode as FieldItemNodeData).path.toString()).toEqual(
-          emailAddressItem.nodePath.toString(),
-        );
+        // Visual path includes choice wrapper segment; mapping path does not.
+        // MappingLinksService.computeVisualTargetNodePath bridges this gap for line rendering.
+        expect((freshEmailAddressNode as FieldItemNodeData).path.pathSegments).toContain(nestedChoiceField.id);
+        expect(emailAddressItem.nodePath.pathSegments).not.toContain(nestedChoiceField.id);
       });
     });
 
@@ -2196,10 +2194,12 @@ describe('VisualizationService', () => {
         expect(freshNestedDirect1).toBeDefined();
         expect(freshNestedDirect1).toBeInstanceOf(FieldItemNodeData);
 
-        // Path must match mapping tree nodePath
-        expect((freshNestedDirect1 as FieldItemNodeData).path.toString()).toEqual(
-          nestedDirect1Item.nodePath.toString(),
-        );
+        // Visual path includes both choice wrapper segments; mapping path includes neither.
+        // MappingLinksService.computeVisualTargetNodePath bridges this gap for line rendering.
+        expect((freshNestedDirect1 as FieldItemNodeData).path.pathSegments).toContain(freshOuterChoice.id);
+        expect((freshNestedDirect1 as FieldItemNodeData).path.pathSegments).toContain(freshInnerChoice.id);
+        expect(nestedDirect1Item.nodePath.pathSegments).not.toContain(freshOuterChoice.id);
+        expect(nestedDirect1Item.nodePath.pathSegments).not.toContain(freshInnerChoice.id);
       });
     });
   });


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3108

By simply skipping the choice wrapper node for the NodeData node path, despite the choice node actually being rendered, its NodeData node path become exactly same with the parent node. NodeData node path should represent the choice node segment when it's not selected. With this taken into account, MappingItem node path and NodeData node path no longer matches, since choice node is only a visual representation but it won't appear in the MappingTree (thus XSLT). On the other hand, once choice selection is made (which will be introduced by following sub-issue https://github.com/KaotoIO/kaoto/issues/2817), the choice node is skipped rendering and the chosen member is directly rendered. MappingLinksService.computeVisualTargetNodePath() is introduced to calculate this gap when rendering mapping lines.


https://github.com/user-attachments/assets/273f7021-ecd0-4007-bce5-f266cb662394



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path computation for unselected choice wrappers to display with distinct visual path segments.

* **Documentation**
  * Clarified distinction between mapping tree paths (excluding choice wrappers) and visual document tree paths (including unselected choice wrapper segments).

* **Tests**
  * Added comprehensive tests for choice wrapper path uniqueness and visual target path computation across nested wrapper scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->