### PR TITLE
chore(Resource): KaotoResource tells what catalogs need

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.test.tsx
@@ -1,15 +1,18 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
-import { TestRuntimeProviderWrapper } from '../../../../stubs';
+import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../stubs';
 import { RuntimeSelector } from './RuntimeSelector';
 
 describe('RuntimeSelector', () => {
   it('component renders', () => {
-    const { Provider } = TestRuntimeProviderWrapper();
+    const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+    const { Provider: EntitiesProvider } = TestProvidersWrapper();
     const wrapper = render(
-      <Provider>
-        <RuntimeSelector />
-      </Provider>,
+      <RuntimeProvider>
+        <EntitiesProvider>
+          <RuntimeSelector />
+        </EntitiesProvider>
+      </RuntimeProvider>,
     );
 
     const toggle = wrapper.queryByTestId('runtime-selector-list-dropdown');
@@ -17,11 +20,14 @@ describe('RuntimeSelector', () => {
   });
 
   it('should call `setSelectedCatalog` when selecting an item', async () => {
-    const { Provider, setSelectedCatalog } = TestRuntimeProviderWrapper();
+    const { Provider: RuntimeProvider, setSelectedCatalog } = TestRuntimeProviderWrapper();
+    const { Provider: EntitiesProvider } = TestProvidersWrapper();
     const wrapper = render(
-      <Provider>
-        <RuntimeSelector />
-      </Provider>,
+      <RuntimeProvider>
+        <EntitiesProvider>
+          <RuntimeSelector />
+        </EntitiesProvider>
+      </RuntimeProvider>,
     );
 
     /** Click on toggle */
@@ -50,11 +56,14 @@ describe('RuntimeSelector', () => {
   });
 
   it('should toggle list of Runtimes', async () => {
-    const { Provider } = TestRuntimeProviderWrapper();
+    const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+    const { Provider: EntitiesProvider } = TestProvidersWrapper();
     const wrapper = render(
-      <Provider>
-        <RuntimeSelector />
-      </Provider>,
+      <RuntimeProvider>
+        <EntitiesProvider>
+          <RuntimeSelector />
+        </EntitiesProvider>
+      </RuntimeProvider>,
     );
 
     const toggle = await wrapper.findByTestId('runtime-selector-list-dropdown');
@@ -78,11 +87,14 @@ describe('RuntimeSelector', () => {
   });
 
   it('should close Select when pressing ESC', async () => {
-    const { Provider } = TestRuntimeProviderWrapper();
+    const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+    const { Provider: EntitiesProvider } = TestProvidersWrapper();
     const wrapper = render(
-      <Provider>
-        <RuntimeSelector />
-      </Provider>,
+      <RuntimeProvider>
+        <EntitiesProvider>
+          <RuntimeSelector />
+        </EntitiesProvider>
+      </RuntimeProvider>,
     );
 
     const toggle = await wrapper.findByTestId('runtime-selector-list-dropdown');
@@ -105,6 +117,104 @@ describe('RuntimeSelector', () => {
     await waitFor(async () => {
       /** The close panel is an async process */
       expect(menu).not.toBeInTheDocument();
+    });
+  });
+
+  describe('runtime filtering based on compatible runtimes', () => {
+    it('should display only compatible runtimes for Camel Route resources', async () => {
+      const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+      const { Provider: EntitiesProvider } = TestProvidersWrapper();
+      const wrapper = render(
+        <RuntimeProvider>
+          <EntitiesProvider>
+            <RuntimeSelector />
+          </EntitiesProvider>
+        </RuntimeProvider>,
+      );
+
+      const toggle = await wrapper.findByTestId('runtime-selector-list-dropdown');
+
+      /** Open Select */
+      act(() => {
+        fireEvent.click(toggle);
+      });
+
+      /** Should show Main, Quarkus, and Spring Boot for Camel resources */
+      const mainRuntime = await wrapper.findByTestId('runtime-selector-Main');
+      expect(mainRuntime).toBeInTheDocument();
+
+      const quarkusRuntime = await wrapper.findByTestId('runtime-selector-Quarkus');
+      expect(quarkusRuntime).toBeInTheDocument();
+
+      const springBootRuntime = await wrapper.findByTestId('runtime-selector-Spring Boot');
+      expect(springBootRuntime).toBeInTheDocument();
+
+      /** Should not show Citrus runtime for Camel resources */
+      const citrusRuntime = wrapper.queryByTestId('runtime-selector-Citrus');
+      expect(citrusRuntime).not.toBeInTheDocument();
+    });
+
+    it('should group runtimes correctly based on compatible runtimes', async () => {
+      const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+      const { Provider: EntitiesProvider } = TestProvidersWrapper();
+      const wrapper = render(
+        <RuntimeProvider>
+          <EntitiesProvider>
+            <RuntimeSelector />
+          </EntitiesProvider>
+        </RuntimeProvider>,
+      );
+
+      const toggle = await wrapper.findByTestId('runtime-selector-list-dropdown');
+
+      /** Open Select */
+      act(() => {
+        fireEvent.click(toggle);
+      });
+
+      /** Verify that runtime groups are present */
+      const menuList = await wrapper.findByTestId('runtime-selector-list');
+      expect(menuList).toBeInTheDocument();
+
+      /** Check that Main group exists */
+      const mainGroup = await wrapper.findByTestId('runtime-selector-Main');
+      expect(mainGroup).toBeInTheDocument();
+    });
+
+    it('should filter out incompatible runtime groups', async () => {
+      const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
+      const { Provider: EntitiesProvider } = TestProvidersWrapper();
+      const wrapper = render(
+        <RuntimeProvider>
+          <EntitiesProvider>
+            <RuntimeSelector />
+          </EntitiesProvider>
+        </RuntimeProvider>,
+      );
+
+      const toggle = await wrapper.findByTestId('runtime-selector-list-dropdown');
+
+      /** Open Select */
+      act(() => {
+        fireEvent.click(toggle);
+      });
+
+      /** Verify that only compatible runtime groups are shown */
+      const menuList = await wrapper.findByTestId('runtime-selector-list');
+      expect(menuList).toBeInTheDocument();
+
+      /** For Camel resources, should have Main, Quarkus, Spring Boot groups */
+      const mainRuntime = wrapper.queryByTestId('runtime-selector-Main');
+      const quarkusRuntime = wrapper.queryByTestId('runtime-selector-Quarkus');
+      const springBootRuntime = wrapper.queryByTestId('runtime-selector-Spring Boot');
+
+      expect(mainRuntime).toBeInTheDocument();
+      expect(quarkusRuntime).toBeInTheDocument();
+      expect(springBootRuntime).toBeInTheDocument();
+
+      /** Citrus should not be in the list for Camel resources */
+      const citrusRuntime = wrapper.queryByTestId('runtime-selector-Citrus');
+      expect(citrusRuntime).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
@@ -12,7 +12,6 @@ import springBootLogo from '../../../../assets/springboot-logo.svg';
 import { useLocalStorage } from '../../../../hooks';
 import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { LocalStorageKeys } from '../../../../models';
-import { SourceSchemaType } from '../../../../models/camel';
 import { EntitiesContext } from '../../../../providers';
 
 const SPACE_REGEX = /\s/g;
@@ -56,20 +55,14 @@ export const RuntimeSelector: FunctionComponent = () => {
   const toggleRef = useRef<HTMLButtonElement>(null);
   const runtimeContext = useRuntimeContext();
   const entitiesContext = useContext(EntitiesContext);
-  const currentSchemaType = entitiesContext?.currentSchemaType;
+  const compatibleRuntimes = entitiesContext?.camelResource.getCompatibleRuntimes() ?? [];
   const [_, setSelectedCatalogLocalStorage] = useLocalStorage(
     LocalStorageKeys.SelectedCatalog,
     runtimeContext.selectedCatalog,
   );
   const groupedRuntimes =
     runtimeContext.catalogLibrary?.definitions
-      .filter((catalog) => {
-        if (currentSchemaType && currentSchemaType === SourceSchemaType.Test) {
-          return catalog.runtime === 'Citrus';
-        } else {
-          return catalog.runtime !== 'Citrus';
-        }
-      })
+      .filter((catalog) => compatibleRuntimes.includes(catalog.runtime))
       .reduce(
         (acc, catalog) => {
           if (acc[catalog.runtime]) {

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -95,6 +95,11 @@ export abstract class CamelKResource implements KaotoResource {
   getCompatibleComponents(_mode: AddStepMode, _visualEntityData: IVisualizationNodeData): TileFilter | undefined {
     return undefined;
   }
+
+  getCompatibleRuntimes(): string[] {
+    return ['Main', 'Quarkus', 'Spring Boot'];
+  }
+
   getSerializerType() {
     return this.serializer.getType();
   }

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -820,6 +820,29 @@ describe('CamelRouteResource', () => {
     });
   });
 
+  describe('getCompatibleRuntimes', () => {
+    it('should return the correct list of compatible runtimes', () => {
+      const resource = new CamelRouteResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+
+    it('should return the same list regardless of resource content', () => {
+      const emptyResource = new CamelRouteResource();
+      const resourceWithRoutes = new CamelRouteResource([camelRouteJson, camelFromJson]);
+
+      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithRoutes.getCompatibleRuntimes());
+    });
+
+    it('should return an array with three runtime names', () => {
+      const resource = new CamelRouteResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+  });
+
   describe('edge cases and error handling', () => {
     it('should handle empty entities array in constructor', () => {
       const resource = new CamelRouteResource([]);

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -279,6 +279,10 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     return CamelComponentFilterService.getCamelCompatibleComponents(mode, visualEntityData, definition);
   }
 
+  getCompatibleRuntimes(): string[] {
+    return ['Main', 'Quarkus', 'Spring Boot'];
+  }
+
   private getEntity(rawItem: unknown): BaseEntity | undefined {
     if (!isDefined(rawItem) || Array.isArray(rawItem)) {
       return undefined;

--- a/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
@@ -14,6 +14,29 @@ describe('KameletBindingResource', () => {
     expect(resource.getEntities().length).toEqual(2);
   });
 
+  describe('getCompatibleRuntimes', () => {
+    it('should return the correct list of compatible runtimes', () => {
+      const resource = new KameletBindingResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+
+    it('should return the same list regardless of resource content', () => {
+      const emptyResource = new KameletBindingResource();
+      const resourceWithBinding = new KameletBindingResource(kameletBindingJson);
+
+      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithBinding.getCompatibleRuntimes());
+    });
+
+    it('should return an array with three runtime names', () => {
+      const resource = new KameletBindingResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+  });
+
   it('should initialize KameletBinding if no args is specified', () => {
     const resource = new KameletBindingResource(undefined);
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -101,6 +101,29 @@ describe('KameletResource', () => {
     });
   });
 
+  describe('getCompatibleRuntimes', () => {
+    it('should return the correct list of compatible runtimes', () => {
+      const kameletResource = new KameletResource();
+      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+
+    it('should return the same list regardless of resource content', () => {
+      const emptyResource = new KameletResource();
+      const resourceWithKamelet = new KameletResource(kameletJson);
+
+      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
+    });
+
+    it('should return an array with three runtime names', () => {
+      const kameletResource = new KameletResource();
+      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+  });
+
   it('should support RouteTemplateBeansAwareResource methods', () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -29,6 +29,29 @@ describe('PipeResource', () => {
     expect(vis.pipe.spec?.sink).toBeUndefined();
   });
 
+  describe('getCompatibleRuntimes', () => {
+    it('should return the correct list of compatible runtimes', () => {
+      const resource = new PipeResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+
+    it('should return the same list regardless of resource content', () => {
+      const emptyResource = new PipeResource();
+      const resourceWithPipe = new PipeResource(pipeJson);
+
+      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithPipe.getCompatibleRuntimes());
+    });
+
+    it('should return an array with three runtime names', () => {
+      const resource = new PipeResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+  });
+
   it('should create/delete entities', () => {
     const resource = new PipeResource();
     expect(resource.getEntities().length).toEqual(0);

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -220,6 +220,29 @@ describe('CitrusTestResource', () => {
     });
   });
 
+  describe('getCompatibleRuntimes', () => {
+    it('should return the correct list of compatible runtimes', () => {
+      const resource = new CitrusTestResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Citrus']);
+    });
+
+    it('should return the same list regardless of resource content', () => {
+      const emptyResource = new CitrusTestResource();
+      const resourceWithTest = new CitrusTestResource(citrusTestJson);
+
+      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithTest.getCompatibleRuntimes());
+    });
+
+    it('should return an array with one runtime name', () => {
+      const resource = new CitrusTestResource();
+      const compatibleRuntimes = resource.getCompatibleRuntimes();
+
+      expect(compatibleRuntimes).toEqual(['Citrus']);
+    });
+  });
+
   describe('getCompatibleComponents', () => {
     it('should get compatible types', () => {
       const resource = new CitrusTestResource(citrusTestJson);

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -219,6 +219,10 @@ export class CitrusTestResource implements KaotoResource {
     };
   }
 
+  getCompatibleRuntimes(): string[] {
+    return ['Citrus'];
+  }
+
   /**
    * Converts a raw item to a BaseCamelEntity.
    *

--- a/packages/ui/src/models/kaoto-resource.ts
+++ b/packages/ui/src/models/kaoto-resource.ts
@@ -28,6 +28,13 @@ export interface KaotoResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter | undefined;
+
+  /**
+   * Returns the list of compatible runtime catalog names for this resource type.
+   * For example, CamelRouteResource returns ["Main", "Quarkus", "Spring Boot"],
+   * while CitrusTestResource returns ["Citrus"].
+   */
+  getCompatibleRuntimes(): string[];
 }
 
 export enum SerializerType {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime selector now filters available runtimes by resource compatibility, showing appropriate runtimes for Camel routes, Camel K resources, and Citrus tests.

* **Tests**
  * Expanded and updated test coverage to validate runtime compatibility filtering and provider setup, including new unit tests asserting expected runtime lists for resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->