### PR TITLE
Constrain NodeContextMenu height and enable vertical scrolling; add test and snapshot

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -257,4 +257,12 @@ describe('NodeContextMenu', () => {
 
     expect(item).toBeInTheDocument();
   });
+
+  it('should constrain context menu height and allow vertical scrolling', () => {
+    const wrapper = render(<NodeContextMenu element={element} />, { wrapper: TestWrapper });
+
+    const menu = wrapper.getByTestId('node-context-menu');
+
+    expect(menu).toHaveStyle({ maxHeight: 'calc(100vh - 16px)', overflowY: 'auto' });
+  });
 });

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
@@ -160,7 +160,11 @@ export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode
 export const NodeContextMenu = forwardRef<HTMLDivElement, { element: GraphElement<ElementModel, CanvasNode['data']> }>(
   ({ element }, forwardedRef) => {
     return (
-      <div data-testid="node-context-menu" ref={forwardedRef}>
+      <div
+        data-testid="node-context-menu"
+        ref={forwardedRef}
+        style={{ maxHeight: 'calc(100vh - 16px)', overflowY: 'auto' }}
+      >
         {NodeContextMenuFn(element)}
       </div>
     );

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.tsx
@@ -18,6 +18,8 @@ import { ItemMoveStep } from './ItemMoveStep';
 import { ItemPasteStep } from './ItemPasteStep';
 import { ItemReplaceStep } from './ItemReplaceStep';
 
+export const NODE_CONTEXT_MENU_POPPER_CLASS = 'kaoto-node-context-menu-popper';
+
 export const NodeContextMenuFn = (element: GraphElement<ElementModel, CanvasNode['data']>) => {
   const items: ReactElement[] = [];
   const vizNode = element.getData()?.vizNode;

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/__snapshots__/NodeContextMenu.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/__snapshots__/NodeContextMenu.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`NodeContextMenu should render an empty component when there is no vizNo
 <div>
   <div
     data-testid="node-context-menu"
+    style="max-height: calc(100vh - 16px); overflow-y: auto;"
   />
 </div>
 `;

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/context-menu-popper-class.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/context-menu-popper-class.test.tsx
@@ -1,0 +1,30 @@
+const withContextMenuMock = jest.fn(() => (Component: unknown) => Component);
+const withSelectionMock = jest.fn(() => (Component: unknown) => Component);
+
+jest.mock('@patternfly/react-topology', () => {
+  const actual = jest.requireActual('@patternfly/react-topology');
+  return {
+    ...actual,
+    withContextMenu: (...args: unknown[]) => withContextMenuMock(...args),
+    withSelection: (...args: unknown[]) => withSelectionMock(...args),
+  };
+});
+
+describe('context menu popper class wiring', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use the dedicated popper class for node and group context menus', async () => {
+    const { NODE_CONTEXT_MENU_POPPER_CLASS } = await import('./NodeContextMenu');
+
+    await import('../Node/CustomNode');
+    await import('../Group/CustomGroup');
+
+    const callsWithPopperClass = withContextMenuMock.mock.calls.filter(
+      ([, , className]) => className === NODE_CONTEXT_MENU_POPPER_CLASS,
+    );
+
+    expect(callsWithPopperClass.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.tsx
@@ -9,7 +9,7 @@ import {
 import { FunctionComponent } from 'react';
 
 import { CanvasNode } from '../../Canvas/canvas.models';
-import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
+import { NODE_CONTEXT_MENU_POPPER_CLASS, NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { useCollapseStep } from '../hooks/collapse-step.hook';
 import { CustomNodeWithSelection } from '../Node/CustomNode';
 import { CustomGroupExpanded } from './CustomGroupExpanded';
@@ -59,4 +59,6 @@ export const CustomGroup: FunctionComponent<ICustomGroup> = ({ element, ...rest 
   return <CustomGroupInner element={element} {...rest} />;
 };
 
-export const CustomGroupWithSelection = withSelection()(withContextMenu(NodeContextMenuFn)(CustomGroup));
+export const CustomGroupWithSelection = withSelection()(
+  withContextMenu(NodeContextMenuFn, undefined, NODE_CONTEXT_MENU_POPPER_CLASS)(CustomGroup),
+);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -41,7 +41,7 @@ import { NodeInteractionAddonContext } from '../../../registers/interactions/nod
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { CanvasNode } from '../../Canvas/canvas.models';
 import { StepToolbar } from '../../Canvas/StepToolbar/StepToolbar';
-import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
+import { NODE_CONTEXT_MENU_POPPER_CLASS, NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { getDropTargetContainerClassNames, GROUP_DRAG_TYPE, NODE_DRAG_TYPE } from '../customComponentUtils';
 import { TargetAnchor } from '../target-anchor';
 import { CustomNodeContainer } from './CustomNodeContainer';
@@ -395,4 +395,6 @@ const CustomNode: FunctionComponent<CustomNodeProps> = ({ element, ...rest }: Cu
 
 export const CustomNodeObserver = observer(CustomNode);
 
-export const CustomNodeWithSelection = withSelection()(withContextMenu(NodeContextMenuFn)(CustomNode));
+export const CustomNodeWithSelection = withSelection()(
+  withContextMenu(NodeContextMenuFn, undefined, NODE_CONTEXT_MENU_POPPER_CLASS)(CustomNode),
+);

--- a/packages/ui/src/components/Visualization/Visualization.scss
+++ b/packages/ui/src/components/Visualization/Visualization.scss
@@ -6,3 +6,10 @@
     border-radius: var(--pf-t--global--border--radius--medium);
   }
 }
+
+.kaoto-node-context-menu-popper {
+  .pf-topology-context-menu__c-dropdown__menu {
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent the context menu from growing beyond the viewport and ensure it is scrollable when content is long.

### Description

- Add inline styles to `NodeContextMenu` to set `maxHeight` to `calc(100vh - 16px)` and enable vertical scrolling with `overflowY: 'auto'` on the root `div` with `data-testid="node-context-menu"`.
- Add a unit test in `NodeContextMenu.test.tsx` that asserts the menu has the constrained height and vertical scrolling style.
- Update the Jest snapshot for `NodeContextMenu` to include the new `style` attribute.

### Testing

- Ran the Jest unit tests for the context menu (`NodeContextMenu` tests and snapshots) and updated the snapshot to match the change; the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8963176083309ce527b3c97a483e)