### PR TITLE
feat(DataMapper): implement Element Substitution UI

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
@@ -8,7 +8,6 @@ import { FunctionComponent } from 'react';
 import OptIcon from '../../../assets/data-mapper/field-icons/OptIcon';
 import Repeat0Icon from '../../../assets/data-mapper/field-icons/Repeat0Icon';
 import Repeat1Icon from '../../../assets/data-mapper/field-icons/Repeat1Icon';
-import { FieldOverrideVariant } from '../../../models/datamapper/types';
 import {
   AddMappingNodeData,
   ChoiceFieldNodeData,
@@ -20,8 +19,8 @@ import {
   UnknownMappingNodeData,
   VariableNodeData,
 } from '../../../models/datamapper/visualization';
-import { formatQNameWithPrefix } from '../../../services/namespace-util';
 import { VisualizationService } from '../../../services/visualization.service';
+import { getOverrideDisplayInfo } from '../actions/FieldTypeOverride/override-util';
 import { UnknownMappingLabel } from './UnknownMappingLabel';
 
 interface INodeTitle {
@@ -79,15 +78,7 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
     const optionalField = nodeData.field.minOccurs === 0;
     const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
     const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
-    const hasTypeOverride = nodeData.field.typeOverride !== FieldOverrideVariant.NONE;
-
-    // Format type names with namespace prefixes for display
-    const originalTypeDisplay = hasTypeOverride
-      ? formatQNameWithPrefix(nodeData.field.originalField?.typeQName, namespaceMap, nodeData.field.originalField?.type)
-      : '';
-    const overriddenTypeDisplay = hasTypeOverride
-      ? formatQNameWithPrefix(nodeData.field.typeQName, namespaceMap, nodeData.field.type)
-      : '';
+    const overrideDisplay = getOverrideDisplayInfo(nodeData.field, namespaceMap);
 
     return (
       <Popover
@@ -104,15 +95,15 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
               <span className="popover__cell">maxOccurs :&nbsp;</span>
               <span className="popover__cell">{nodeData.field.maxOccurs}</span>
             </div>
-            {hasTypeOverride && (
+            {overrideDisplay && (
               <>
                 <div className="popover__row">
-                  <span className="popover__cell">Original type :&nbsp;</span>
-                  <span className="popover__cell">{originalTypeDisplay}</span>
+                  <span className="popover__cell">{overrideDisplay.originalLabel} :&nbsp;</span>
+                  <span className="popover__cell">{overrideDisplay.original}</span>
                 </div>
                 <div className="popover__row">
-                  <span className="popover__cell">Overridden type :&nbsp;</span>
-                  <span className="popover__cell">{overriddenTypeDisplay}</span>
+                  <span className="popover__cell">{overrideDisplay.currentLabel} :&nbsp;</span>
+                  <span className="popover__cell">{overrideDisplay.current}</span>
                 </div>
               </>
             )}

--- a/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
@@ -17,7 +17,7 @@ describe('FieldContextMenu', () => {
       />,
     );
 
-    expect(screen.getByText('Override Type...')).toBeInTheDocument();
+    expect(screen.getByText('Override Field...')).toBeInTheDocument();
   });
 
   it('should call onOverrideType and onClose when Override type is clicked', () => {
@@ -34,7 +34,7 @@ describe('FieldContextMenu', () => {
       />,
     );
 
-    const overrideButton = screen.getByText('Override Type...');
+    const overrideButton = screen.getByText('Override Field...');
     fireEvent.click(overrideButton);
 
     expect(onOverrideType).toHaveBeenCalled();

--- a/packages/ui/src/components/Document/actions/FieldContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu.tsx
@@ -30,7 +30,7 @@ export const FieldContextMenu: FunctionComponent<IFieldContextMenuProps> = ({
     <Menu className="field-context-menu">
       <MenuContent>
         <MenuList>
-          <MenuItem onClick={handleOverrideType}>Override Type...</MenuItem>
+          <MenuItem onClick={handleOverrideType}>Override Field...</MenuItem>
 
           {hasOverride && (
             <>

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.test.tsx
@@ -6,7 +6,7 @@ import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../../../../models/
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { QName } from '../../../../xml-schema-ts/QName';
-import { FieldTypeOverride, revertTypeOverride } from './FieldTypeOverride';
+import { FieldTypeOverride, revertOverride } from './FieldTypeOverride';
 
 // Mock TypeOverrideModal to expose the onSave/onAttach/onRemove callbacks
 jest.mock('./TypeOverrideModal', () => ({
@@ -14,7 +14,10 @@ jest.mock('./TypeOverrideModal', () => ({
     if (!isOpen) return null;
     return (
       <div data-testid="type-override-modal">
-        <button data-testid="mock-save" onClick={() => onSave(mockSelectedType)}>
+        <button
+          data-testid="mock-save"
+          onClick={() => onSave({ mode: 'type', selectedType: mockSelectedType, selectedKey: 'xs:int' })}
+        >
           Save
         </button>
         <button data-testid="mock-attach" onClick={() => onAttach({ 'custom.xsd': '<xs:schema/>' })}>
@@ -32,7 +35,9 @@ jest.mock('./TypeOverrideModal', () => ({
 jest.mock('../../../../services/field-type-override.service', () => ({
   FieldTypeOverrideService: {
     applyFieldTypeOverride: jest.fn(),
+    applyFieldSubstitution: jest.fn(),
     revertFieldTypeOverride: jest.fn(),
+    revertFieldSubstitution: jest.fn(),
     addSchemaFilesForTypeOverride: jest.fn(),
   },
 }));
@@ -92,7 +97,7 @@ describe('FieldTypeOverride', () => {
     const lastCall = TypeOverrideModalMock.mock.calls[TypeOverrideModalMock.mock.calls.length - 1];
     const onSaveCallback = lastCall[0].onSave;
 
-    onSaveCallback(mockSelectedType);
+    onSaveCallback({ mode: 'type', selectedType: mockSelectedType, selectedKey: 'xs:int' });
 
     expect(FieldTypeOverrideService.applyFieldTypeOverride).toHaveBeenCalledWith(
       field,
@@ -114,7 +119,7 @@ describe('FieldTypeOverride', () => {
     const lastCall = TypeOverrideModalMock.mock.calls[TypeOverrideModalMock.mock.calls.length - 1];
     const onSaveCallback = lastCall[0].onSave;
 
-    onSaveCallback(mockSelectedType);
+    onSaveCallback({ mode: 'type', selectedType: mockSelectedType, selectedKey: 'xs:int' });
 
     expect(FieldTypeOverrideService.addSchemaFilesForTypeOverride).not.toHaveBeenCalled();
     expect(FieldTypeOverrideService.applyFieldTypeOverride).toHaveBeenCalled();
@@ -139,8 +144,30 @@ describe('FieldTypeOverride', () => {
     expect(mockOnClose).not.toHaveBeenCalled();
   });
 
+  it('should call applyFieldSubstitution on save with substitution mode', () => {
+    const field = testTargetDoc.fields[0];
+    render(<FieldTypeOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+
+    const TypeOverrideModalMock = jest.requireMock('./TypeOverrideModal').TypeOverrideModal;
+    const lastCall = TypeOverrideModalMock.mock.calls[TypeOverrideModalMock.mock.calls.length - 1];
+    const onSaveCallback = lastCall[0].onSave;
+
+    onSaveCallback({ mode: 'substitution', selectedKey: 'sub:Cat' });
+
+    expect(FieldTypeOverrideService.applyFieldSubstitution).toHaveBeenCalledWith(
+      field,
+      'sub:Cat',
+      testMappingTree.namespaceMap,
+    );
+    expect(FieldTypeOverrideService.applyFieldTypeOverride).not.toHaveBeenCalled();
+    expect(mockUpdateDocument).toHaveBeenCalled();
+    expect(mockOnComplete).toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
   it('should call revertFieldTypeOverride and updateDocument on remove', () => {
     const field = testTargetDoc.fields[0];
+    field.typeOverride = FieldOverrideVariant.SAFE;
     render(<FieldTypeOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const TypeOverrideModalMock = jest.requireMock('./TypeOverrideModal').TypeOverrideModal;
@@ -171,18 +198,47 @@ describe('FieldTypeOverride', () => {
   });
 });
 
-describe('revertTypeOverride', () => {
+describe('revertOverride', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should call revertFieldSubstitution when field has SUBSTITUTION override', () => {
+    const testTargetDoc = TestUtil.createTargetOrderDoc();
+    const field = testTargetDoc.fields[0];
+    field.typeOverride = FieldOverrideVariant.SUBSTITUTION;
+    const namespaceMap = { xs: 'http://www.w3.org/2001/XMLSchema' };
+    const mockUpdateDocument = jest.fn();
+
+    revertOverride(field, namespaceMap, mockUpdateDocument);
+
+    expect(FieldTypeOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(field, namespaceMap);
+    expect(FieldTypeOverrideService.revertFieldTypeOverride).not.toHaveBeenCalled();
+    expect(mockUpdateDocument).toHaveBeenCalled();
+  });
+
+  it('should not call any service when field has no override', () => {
+    const testTargetDoc = TestUtil.createTargetOrderDoc();
+    const field = testTargetDoc.fields[0];
+    field.typeOverride = FieldOverrideVariant.NONE;
+    const namespaceMap = { xs: 'http://www.w3.org/2001/XMLSchema' };
+    const mockUpdateDocument = jest.fn();
+
+    revertOverride(field, namespaceMap, mockUpdateDocument);
+
+    expect(FieldTypeOverrideService.revertFieldTypeOverride).not.toHaveBeenCalled();
+    expect(FieldTypeOverrideService.revertFieldSubstitution).not.toHaveBeenCalled();
+    expect(mockUpdateDocument).not.toHaveBeenCalled();
   });
 
   it('should call revertFieldTypeOverride and updateDocument', () => {
     const testTargetDoc = TestUtil.createTargetOrderDoc();
     const field = testTargetDoc.fields[0];
+    field.typeOverride = FieldOverrideVariant.SAFE;
     const namespaceMap = { xs: 'http://www.w3.org/2001/XMLSchema' };
     const mockUpdateDocument = jest.fn();
 
-    revertTypeOverride(field, namespaceMap, mockUpdateDocument);
+    revertOverride(field, namespaceMap, mockUpdateDocument);
 
     expect(FieldTypeOverrideService.revertFieldTypeOverride).toHaveBeenCalledWith(field, namespaceMap);
     expect(mockUpdateDocument).toHaveBeenCalledWith(

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
@@ -2,12 +2,12 @@ import { FunctionComponent, useCallback } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
-import { FieldOverrideVariant, IFieldTypeInfo } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
-import { revertTypeOverride } from './revert-type-override';
-import { TypeOverrideModal } from './TypeOverrideModal';
+import { revertOverride } from './revert-type-override';
+import { OverrideSavePayload, TypeOverrideModal } from './TypeOverrideModal';
 
-export { revertTypeOverride } from './revert-type-override';
+export { revertOverride } from './revert-type-override';
 export { TypeOverrideIndicator } from './TypeOverrideIndicator';
 
 type FieldTypeOverrideProps = {
@@ -18,7 +18,7 @@ type FieldTypeOverrideProps = {
 };
 
 /**
- * Dedicated component for field type override operations.
+ * Dedicated component for field override operations (type override and element substitution).
  * Wraps TypeOverrideModal with save/remove handlers, consolidating
  * the override logic that was previously duplicated across
  * SourceDocumentNode, TargetNodeActions, and ConditionMenuAction.
@@ -43,14 +43,22 @@ export const FieldTypeOverride: FunctionComponent<FieldTypeOverrideProps> = ({
   );
 
   const handleSave = useCallback(
-    (selectedType: IFieldTypeInfo | null) => {
+    (payload: OverrideSavePayload) => {
       const document = field.ownerDocument;
       const namespaceMap = mappingTree.namespaceMap;
       const previousRefId = document.getReferenceId(namespaceMap);
 
-      if (selectedType) {
-        FieldTypeOverrideService.applyFieldTypeOverride(field, selectedType, namespaceMap, FieldOverrideVariant.SAFE);
+      if (payload.mode === 'substitution') {
+        FieldTypeOverrideService.applyFieldSubstitution(field, payload.selectedKey, namespaceMap);
+      } else {
+        FieldTypeOverrideService.applyFieldTypeOverride(
+          field,
+          payload.selectedType,
+          namespaceMap,
+          FieldOverrideVariant.SAFE,
+        );
       }
+
       updateDocument(document, document.definition, previousRefId);
       onComplete();
       onClose();
@@ -59,7 +67,7 @@ export const FieldTypeOverride: FunctionComponent<FieldTypeOverrideProps> = ({
   );
 
   const handleRemove = useCallback(() => {
-    revertTypeOverride(field, mappingTree.namespaceMap, updateDocument);
+    revertOverride(field, mappingTree.namespaceMap, updateDocument);
     onComplete();
     onClose();
   }, [field, mappingTree.namespaceMap, updateDocument, onComplete, onClose]);

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideIndicator.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideIndicator.tsx
@@ -1,34 +1,35 @@
 import { Icon } from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons';
+import { ExchangeAltIcon, WrenchIcon } from '@patternfly/react-icons';
 import { FunctionComponent } from 'react';
 
 import { IField } from '../../../../models/datamapper/document';
 import { FieldOverrideVariant } from '../../../../models/datamapper/types';
-import { formatQNameWithPrefix } from '../../../../services/namespace-util';
+import { getOverrideDisplayInfo } from './override-util';
 
 interface TypeOverrideIndicatorProps {
   field: IField | undefined;
   namespaceMap?: Record<string, string>;
 }
 
-/** Wrench icon indicator for a field with a type override. Renders nothing if no override. */
+/** Icon indicator for a field with an override (type or substitution). Renders nothing if no override. */
 export const TypeOverrideIndicator: FunctionComponent<TypeOverrideIndicatorProps> = ({ field, namespaceMap = {} }) => {
-  if (!field || field.typeOverride === FieldOverrideVariant.NONE) return null;
-  const originalDisplay = formatQNameWithPrefix(
-    field.originalField?.typeQName,
-    namespaceMap,
-    field.originalField?.type,
-  );
-  const currentDisplay = formatQNameWithPrefix(field.typeQName, namespaceMap, field.type);
+  if (!field) return null;
+
+  const displayInfo = getOverrideDisplayInfo(field, namespaceMap);
+  if (!displayInfo) return null;
+
+  const isSubstitution = field.typeOverride === FieldOverrideVariant.SUBSTITUTION;
+  const title = `${displayInfo.currentLabel}: ${displayInfo.original} \u2192 ${displayInfo.current}`;
+
   return (
     <Icon
       className="node__spacer node__type-override-indicator"
       size="md"
-      status="warning"
+      status={isSubstitution ? 'info' : 'warning'}
       isInline
-      title={`Type overridden: ${originalDisplay} → ${currentDisplay}`}
+      title={title}
     >
-      <WrenchIcon />
+      {isSubstitution ? <ExchangeAltIcon /> : <WrenchIcon />}
     </Icon>
   );
 };

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
@@ -58,7 +58,7 @@ describe('TypeOverrideModal', () => {
       />,
     );
 
-    expect(screen.getByText(/Type Override:/)).toBeInTheDocument();
+    expect(screen.getByText(/Field Override:/)).toBeInTheDocument();
   });
 
   it('should display field name in modal title', () => {
@@ -73,7 +73,7 @@ describe('TypeOverrideModal', () => {
     );
 
     const fieldName = testField.displayName || testField.name;
-    expect(screen.getByText(new RegExp(`Type Override:.*${fieldName}`))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`Field Override:.*${fieldName}`))).toBeInTheDocument();
   });
 
   it('should open type selector when toggle is clicked', () => {
@@ -279,7 +279,11 @@ describe('TypeOverrideModal', () => {
     });
 
     expect(onSaveMock).toHaveBeenCalledTimes(1);
-    expect(onSaveMock).toHaveBeenCalledWith(mockCandidates['xs:string']);
+    expect(onSaveMock).toHaveBeenCalledWith({
+      mode: 'type',
+      selectedType: mockCandidates['xs:string'],
+      selectedKey: 'xs:string',
+    });
   });
 
   it('should call onRemove when Remove Override button is clicked', () => {
@@ -436,6 +440,291 @@ describe('TypeOverrideModal', () => {
     );
 
     expect(screen.getByRole('button', { name: 'xs:int' })).toBeInTheDocument();
+  });
+
+  describe('Substitution mode', () => {
+    const mockSubstitutionCandidates: Record<string, { displayName: string; qname: QName }> = {
+      'sub:Cat': {
+        displayName: 'Cat',
+        qname: new QName('http://example.com/substitution', 'Cat'),
+      },
+      'sub:Dog': {
+        displayName: 'Dog',
+        qname: new QName('http://example.com/substitution', 'Dog'),
+      },
+    };
+
+    it('should load substitution candidates when Substitute Element radio is selected', () => {
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      const getSubstitutionSpy = jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      const substitutionRadio = screen.getByLabelText('Substitute Element');
+      act(() => {
+        fireEvent.click(substitutionRadio);
+      });
+
+      expect(getSubstitutionSpy).toHaveBeenCalledWith(testField, testMappingTree.namespaceMap);
+    });
+
+    it('should show substitution placeholder when mode is switched', () => {
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Substitute Element'));
+      });
+
+      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+    });
+
+    it('should call onSave with substitution payload when saving in substitution mode', async () => {
+      const onSaveMock = jest.fn();
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={onSaveMock}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Switch to substitution mode
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Substitute Element'));
+      });
+
+      // Open dropdown and select Cat
+      const toggle = screen.getByRole('button', { name: 'Select a substitute element...' });
+      act(() => {
+        fireEvent.click(toggle);
+      });
+
+      const catOption = screen.getAllByText('Cat').find((el) => el.closest('[role="option"]'));
+      if (!catOption) throw new Error('Cat option not found');
+      act(() => {
+        fireEvent.click(catOption);
+      });
+
+      // Save
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      });
+
+      expect(onSaveMock).toHaveBeenCalledTimes(1);
+      expect(onSaveMock).toHaveBeenCalledWith({ mode: 'substitution', selectedKey: 'sub:Cat' });
+    });
+
+    it('should clear selection when switching modes', async () => {
+      const mockTypeCandidates: Record<string, IFieldTypeInfo> = {
+        'xs:string': {
+          typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'string'),
+          displayName: 'string',
+          type: Types.String,
+          isBuiltIn: true,
+        },
+      };
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockTypeCandidates);
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Select a type in type mode
+      const typeToggle = screen.getByRole('button', { name: 'Select a new type...' });
+      act(() => {
+        fireEvent.click(typeToggle);
+      });
+      const stringOption = screen.getAllByText('string').find((el) => el.closest('[role="option"]'));
+      if (!stringOption) throw new Error('string option not found');
+      act(() => {
+        fireEvent.click(stringOption);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+      });
+
+      // Switch to substitution mode — selection should reset, Save should be disabled
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Substitute Element'));
+      });
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+    });
+
+    it('should start in substitution mode when field has existing substitution', () => {
+      testField.typeOverride = FieldOverrideVariant.SUBSTITUTION;
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Should auto-select substitution radio and show substitution placeholder
+      expect(screen.getByLabelText('Substitute Element')).toBeChecked();
+      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+    });
+
+    it('should pre-select the active substitute element when field has existing substitution', () => {
+      const SUB_NS = 'http://example.com/substitution';
+      testMappingTree.namespaceMap = { sub: SUB_NS };
+      testField.typeOverride = FieldOverrideVariant.SUBSTITUTION;
+      testField.name = 'Cat';
+      testField.namespaceURI = SUB_NS;
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // The active substitute 'sub:Cat' should be pre-selected in the dropdown toggle
+      expect(screen.getByRole('button', { name: 'Cat' })).toBeInTheDocument();
+    });
+
+    it('should disable Override Type radio when field has existing substitution', () => {
+      testField.typeOverride = FieldOverrideVariant.SUBSTITUTION;
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Substitution mode is active, so Override Type radio should be disabled
+      expect(screen.getByLabelText('Override Type')).toBeDisabled();
+      // The active mode radio should remain enabled
+      expect(screen.getByLabelText('Substitute Element')).not.toBeDisabled();
+    });
+
+    it('should disable Substitute Element radio when field has existing type override', () => {
+      testField.typeOverride = FieldOverrideVariant.SAFE;
+
+      const mockTypeCandidates: Record<string, IFieldTypeInfo> = {
+        'xs:int': {
+          typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'int'),
+          displayName: 'int',
+          type: Types.Integer,
+          isBuiltIn: true,
+        },
+      };
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockTypeCandidates);
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Type mode is active, so Substitute Element radio should be disabled
+      expect(screen.getByLabelText('Substitute Element')).toBeDisabled();
+      // The active mode radio should remain enabled
+      expect(screen.getByLabelText('Override Type')).not.toBeDisabled();
+    });
+
+    it('should not disable radios when field has no existing override', () => {
+      testField.typeOverride = FieldOverrideVariant.NONE;
+
+      jest.spyOn(FieldTypeOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      jest
+        .spyOn(FieldTypeOverrideService, 'getFieldSubstitutionCandidates')
+        .mockReturnValue(mockSubstitutionCandidates as never);
+
+      render(
+        <TypeOverrideModal
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          onAttach={jest.fn()}
+          onRemove={jest.fn()}
+          field={testField}
+        />,
+      );
+
+      // Both radios should be enabled when there's no override
+      expect(screen.getByLabelText('Override Type')).not.toBeDisabled();
+      expect(screen.getByLabelText('Substitute Element')).not.toBeDisabled();
+    });
   });
 
   describe('Schema upload', () => {

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
@@ -13,25 +13,33 @@ import {
   ModalFooter,
   ModalHeader,
   ModalVariant,
+  Radio,
   Select,
   SelectList,
   SelectOption,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 import { FileImportIcon, WrenchIcon } from '@patternfly/react-icons';
-import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useEffect, useState } from 'react';
+import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField, SCHEMA_FILE_NAME_PATTERN_XML } from '../../../../models/datamapper/document';
 import { FieldOverrideVariant, IFieldTypeInfo } from '../../../../models/datamapper/types';
 import { MetadataContext } from '../../../../providers';
-import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 import { formatQNameWithPrefix } from '../../../../services/namespace-util';
+import { SchemaPathService } from '../../../../services/schema-path.service';
 import { getFileName, pickAndValidateSchemaFiles } from '../utils';
+import { CandidateDisplay, getOverrideCandidates, OverrideMode } from './override-util';
 import { SchemaFileList } from './SchemaFileList';
+
+export type OverrideSavePayload =
+  | { mode: 'type'; selectedType: IFieldTypeInfo; selectedKey: string }
+  | { mode: 'substitution'; selectedKey: string };
 
 export type TypeOverrideModalProps = {
   onClose: () => void;
-  onSave: (selectedType: IFieldTypeInfo | null) => void;
+  onSave: (payload: OverrideSavePayload) => void;
   onAttach: (schemas: Record<string, string>) => void;
   onRemove: () => void;
   field: IField;
@@ -46,45 +54,42 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
 }) => {
   const api = useContext(MetadataContext)!;
   const { mappingTree } = useDataMapper();
-  const [selectedType, setSelectedType] = useState<IFieldTypeInfo | null>(null);
-  const [typeCandidates, setTypeCandidates] = useState<Record<string, IFieldTypeInfo>>({});
+  const initialMode: OverrideMode = field.typeOverride === FieldOverrideVariant.SUBSTITUTION ? 'substitution' : 'type';
+  const initialCandidates = getOverrideCandidates(field, initialMode, mappingTree.namespaceMap);
+  const [overrideMode, setOverrideMode] = useState<OverrideMode>(initialMode);
+  const [selectedKey, setSelectedKey] = useState<string | null>(initialCandidates.selectedKey);
+  const [candidates, setCandidates] = useState<Record<string, CandidateDisplay>>(initialCandidates.candidates);
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [uploadedSchemas, setUploadedSchemas] = useState<Record<string, string>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
 
+  const selectedCandidate = selectedKey ? (candidates[selectedKey] ?? null) : null;
+
   const existingFiles = Object.keys(field?.ownerDocument?.definition?.definitionFiles ?? {});
 
-  const loadTypeCandidates = useCallback(() => {
-    if (!field) return;
+  const reloadCandidates = useCallback(
+    (mode: OverrideMode) => {
+      if (!field) return;
+      const result = getOverrideCandidates(field, mode, mappingTree.namespaceMap);
+      setCandidates(result.candidates);
+      setSelectedKey(result.selectedKey);
+    },
+    [field, mappingTree.namespaceMap],
+  );
 
-    const namespaceMap = mappingTree.namespaceMap;
-
-    // Get safe type candidates (extensions/restrictions of the field's type, or all types for anyType)
-    const candidates = FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
-    setTypeCandidates(candidates);
-
-    // If field has an existing override, pre-select it by matching namespace URI + local part
-    if (field.typeOverride !== FieldOverrideVariant.NONE && field.typeQName) {
-      const typeString = formatQNameWithPrefix(field.typeQName, namespaceMap);
-      setSelectedType(candidates[typeString] || null);
-    } else {
-      setSelectedType(null);
-    }
-  }, [field, mappingTree.namespaceMap]);
-
-  // Reload type candidates on mount and when loadTypeCandidates identity changes
-  // (e.g., field or namespaceMap changed).
-  useEffect(() => {
-    if (field) {
-      loadTypeCandidates();
-    }
-  }, [field, loadTypeCandidates]);
+  const handleModeChange = useCallback(
+    (mode: OverrideMode) => {
+      setOverrideMode(mode);
+      reloadCandidates(mode);
+    },
+    [reloadCandidates],
+  );
 
   // Clean up transient state when modal unmounts
   useEffect(() => {
     return () => {
       setUploadError(null);
-      setSelectedType(null);
+      setSelectedKey(null);
       setIsSelectOpen(false);
       setUploadedSchemas({});
     };
@@ -116,14 +121,13 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
 
   const handleTypeSelect = useCallback(
     (_event: MouseEvent | undefined, value: string | number | undefined) => {
-      const typeString = value as string;
-      const typeInfo = typeCandidates[typeString];
-      if (typeInfo) {
-        setSelectedType(typeInfo);
+      const key = value as string;
+      if (key in candidates) {
+        setSelectedKey(key);
       }
       setIsSelectOpen(false);
     },
-    [typeCandidates],
+    [candidates],
   );
 
   const readSchemaFiles = useCallback(
@@ -169,7 +173,7 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
       try {
         onAttach(newSchemas);
         setUploadedSchemas((prev) => ({ ...prev, ...newSchemas }));
-        loadTypeCandidates();
+        reloadCandidates(overrideMode);
       } catch (attachError: unknown) {
         const message = attachError instanceof Error ? attachError.message : String(attachError);
         setUploadError(`Invalid schema: ${message}`);
@@ -178,23 +182,40 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
       const message = error instanceof Error ? error.message : String(error);
       setUploadError(`Failed to upload: ${message}`);
     }
-  }, [api, uploadedSchemas, field, readSchemaFiles, onAttach, loadTypeCandidates]);
+  }, [api, uploadedSchemas, field, readSchemaFiles, onAttach, reloadCandidates, overrideMode]);
 
   const handleSave = useCallback(() => {
-    onSave(selectedType);
-  }, [selectedType, onSave]);
+    if (!selectedKey) return;
+    if (overrideMode === 'substitution') {
+      onSave({ mode: 'substitution', selectedKey });
+    } else {
+      const selectedType = candidates[selectedKey] as IFieldTypeInfo | undefined;
+      if (selectedType) {
+        onSave({ mode: 'type', selectedType, selectedKey });
+      }
+    }
+  }, [selectedKey, overrideMode, candidates, onSave]);
 
   const handleToggleSelect = useCallback(() => {
-    setIsSelectOpen(!isSelectOpen);
-  }, [isSelectOpen]);
+    setIsSelectOpen((prev) => !prev);
+  }, []);
+
+  const isSubstitutionMode = overrideMode === 'substitution';
+  const selectLabel = isSubstitutionMode ? 'Substitute Element' : 'New Type';
+  const selectPlaceholder = isSubstitutionMode ? 'Select a substitute element...' : 'Select a new type...';
 
   const renderToggle = useCallback(
     (toggleRef: Ref<MenuToggleElement>) => (
       <MenuToggle ref={toggleRef} onClick={handleToggleSelect} isExpanded={isSelectOpen} isFullWidth>
-        {selectedType?.displayName || 'Select a new type...'}
+        {selectedCandidate?.displayName || selectPlaceholder}
       </MenuToggle>
     ),
-    [handleToggleSelect, isSelectOpen, selectedType?.displayName],
+    [handleToggleSelect, isSelectOpen, selectedCandidate?.displayName, selectPlaceholder],
+  );
+
+  const sortedCandidates = useMemo(
+    () => Object.entries(candidates).sort(([, a], [, b]) => a.displayName.localeCompare(b.displayName)),
+    [candidates],
   );
 
   const hasExistingOverride = field?.typeOverride !== FieldOverrideVariant.NONE;
@@ -205,13 +226,13 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
     field?.originalField?.type ?? field?.type ?? 'Unknown',
   );
   const fieldName = field?.displayName || field?.name || 'Field';
-  const fieldPath = field?.path?.toString() || '';
+  const fieldPath = SchemaPathService.build(field, mappingTree.namespaceMap);
   const modalTitle = (
     <>
       <Icon size="md" status="warning" isInline>
         <WrenchIcon />
       </Icon>{' '}
-      Type Override: {fieldName}
+      Field Override: {fieldName}
     </>
   );
 
@@ -238,13 +259,36 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
             </p>
           </FormGroup>
 
-          <FormGroup label="New Type" fieldId="type-select" isRequired>
+          <FormGroup label="Override Mode" fieldId="override-mode" role="radiogroup">
+            <Split hasGutter>
+              <SplitItem>
+                <Radio
+                  id="mode-type"
+                  name="override-mode"
+                  label="Override Type"
+                  isChecked={overrideMode === 'type'}
+                  isDisabled={hasExistingOverride && overrideMode !== 'type'}
+                  onChange={() => handleModeChange('type')}
+                />
+              </SplitItem>
+              <SplitItem>
+                <Radio
+                  id="mode-substitution"
+                  name="override-mode"
+                  label="Substitute Element"
+                  isChecked={overrideMode === 'substitution'}
+                  isDisabled={hasExistingOverride && overrideMode !== 'substitution'}
+                  onChange={() => handleModeChange('substitution')}
+                />
+              </SplitItem>
+            </Split>
+          </FormGroup>
+
+          <FormGroup label={selectLabel} fieldId="type-select" isRequired>
             <Select
               id="type-select"
               isOpen={isSelectOpen}
-              selected={
-                selectedType ? formatQNameWithPrefix(selectedType.typeQName, mappingTree.namespaceMap) : undefined
-              }
+              selected={selectedKey}
               onSelect={handleTypeSelect}
               onOpenChange={(isOpen) => setIsSelectOpen(isOpen)}
               toggle={renderToggle}
@@ -254,19 +298,17 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
               }}
             >
               <SelectList>
-                {Object.entries(typeCandidates)
-                  .sort(([, a], [, b]) => a.displayName.localeCompare(b.displayName))
-                  .map(([typeString, typeInfo]) => (
-                    <SelectOption key={typeString} value={typeString}>
-                      {typeInfo.displayName}
-                    </SelectOption>
-                  ))}
+                {sortedCandidates.map(([key, candidate]) => (
+                  <SelectOption key={key} value={key}>
+                    {candidate.displayName}
+                  </SelectOption>
+                ))}
               </SelectList>
             </Select>
-            {selectedType?.description && (
+            {selectedCandidate?.description && (
               <FormHelperText>
                 <HelperText>
-                  <HelperTextItem>{selectedType.description}</HelperTextItem>
+                  <HelperTextItem>{selectedCandidate.description}</HelperTextItem>
                 </HelperText>
               </FormHelperText>
             )}
@@ -303,7 +345,7 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
         <Button key="cancel" variant="link" onClick={onClose}>
           Cancel
         </Button>
-        <Button key="save" variant="primary" onClick={handleSave} isDisabled={!selectedType}>
+        <Button key="save" variant="primary" onClick={handleSave} isDisabled={!selectedKey}>
           Save
         </Button>
       </ModalFooter>

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/override-util.test.ts
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/override-util.test.ts
@@ -1,0 +1,84 @@
+import { IField } from '../../../../models/datamapper/document';
+import { FieldOverrideVariant, Types } from '../../../../models/datamapper/types';
+import { QName } from '../../../../xml-schema-ts/QName';
+import { getOverrideDisplayInfo } from './override-util';
+
+const NS = 'http://www.w3.org/2001/XMLSchema';
+
+function createField(overrides: Partial<IField> = {}): IField {
+  return {
+    name: 'fieldA',
+    displayName: 'fieldA',
+    type: Types.String,
+    typeQName: new QName(NS, 'string'),
+    typeOverride: FieldOverrideVariant.NONE,
+    ...overrides,
+  } as IField;
+}
+
+describe('getOverrideDisplayInfo', () => {
+  const namespaceMap = { xs: NS };
+
+  it('should return null when field has no override', () => {
+    const field = createField();
+    expect(getOverrideDisplayInfo(field, namespaceMap)).toBeNull();
+  });
+
+  it('should return type override display info for SAFE variant', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: new QName(NS, 'int'),
+      originalField: {
+        name: 'fieldA',
+        displayName: 'fieldA',
+        namespaceURI: null,
+        namespacePrefix: null,
+        type: Types.String,
+        typeQName: new QName(NS, 'string'),
+        namedTypeFragmentRefs: [],
+      },
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    expect(result!.originalLabel).toBe('Original type');
+    expect(result!.currentLabel).toBe('Overridden type');
+    expect(result!.original).toBe('xs:string');
+    expect(result!.current).toBe('xs:int');
+  });
+
+  it('should return substitution display info for SUBSTITUTION variant', () => {
+    const field = createField({
+      name: 'Cat',
+      typeOverride: FieldOverrideVariant.SUBSTITUTION,
+      originalField: {
+        name: 'AbstractAnimal',
+        displayName: 'AbstractAnimal',
+        namespaceURI: null,
+        namespacePrefix: null,
+        type: Types.Container,
+        typeQName: null,
+        namedTypeFragmentRefs: [],
+      },
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    expect(result!.originalLabel).toBe('Original element');
+    expect(result!.currentLabel).toBe('Substituted element');
+    expect(result!.original).toBe('AbstractAnimal');
+    expect(result!.current).toBe('Cat');
+  });
+
+  it('should show "?" when substitution has no originalField', () => {
+    const field = createField({
+      name: 'Cat',
+      typeOverride: FieldOverrideVariant.SUBSTITUTION,
+      originalField: undefined,
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    expect(result!.original).toBe('?');
+  });
+});

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/override-util.ts
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/override-util.ts
@@ -1,0 +1,86 @@
+import { IField } from '../../../../models/datamapper/document';
+import { FieldOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
+import { formatQNameWithPrefix, formatWithPrefix } from '../../../../services/namespace-util';
+
+export interface OverrideDisplayInfo {
+  originalLabel: string;
+  currentLabel: string;
+  original: string;
+  current: string;
+}
+
+/**
+ * Derive the display strings for an overridden field (type override or element substitution).
+ * Returns `null` when the field has no active override.
+ */
+export function getOverrideDisplayInfo(
+  field: IField,
+  namespaceMap: Record<string, string>,
+): OverrideDisplayInfo | null {
+  if (field.typeOverride === FieldOverrideVariant.NONE) return null;
+
+  if (field.typeOverride === FieldOverrideVariant.SUBSTITUTION) {
+    return {
+      originalLabel: 'Original element',
+      currentLabel: 'Substituted element',
+      original: field.originalField?.name ?? '?',
+      current: field.name,
+    };
+  }
+
+  return {
+    originalLabel: 'Original type',
+    currentLabel: 'Overridden type',
+    original: formatQNameWithPrefix(
+      field.originalField?.typeQName ?? field.typeQName,
+      namespaceMap,
+      field.originalField?.typeQName?.toString() || field.originalField?.type || field.type,
+    ),
+    current: formatQNameWithPrefix(field.typeQName, namespaceMap, field.typeQName?.toString() || field.type),
+  };
+}
+
+export type OverrideMode = 'type' | 'substitution';
+
+/** Minimal display shape shared by type and substitution candidates */
+export type CandidateDisplay = { displayName: string; description?: string };
+
+/** Derive the pre-selected key when opening the modal for a field with an existing override. */
+export function derivePreselectedKey(
+  field: IField,
+  mode: OverrideMode,
+  namespaceMap: Record<string, string>,
+  candidates: Record<string, CandidateDisplay>,
+): string | null {
+  if (mode === 'substitution' && field.typeOverride === FieldOverrideVariant.SUBSTITUTION) {
+    const key = formatWithPrefix(field.namespaceURI ?? null, field.name, namespaceMap);
+    return key in candidates ? key : null;
+  }
+  if (
+    mode === 'type' &&
+    field.typeOverride !== FieldOverrideVariant.NONE &&
+    field.typeOverride !== FieldOverrideVariant.SUBSTITUTION &&
+    field.typeQName
+  ) {
+    const key = formatQNameWithPrefix(field.typeQName, namespaceMap);
+    return key in candidates ? key : null;
+  }
+  return null;
+}
+
+/**
+ * Load override candidates for the given mode and derive the pre-selected key.
+ */
+export function getOverrideCandidates(
+  field: IField,
+  mode: OverrideMode,
+  namespaceMap: Record<string, string>,
+): { candidates: Record<string, CandidateDisplay>; selectedKey: string | null } {
+  const candidates =
+    mode === 'substitution'
+      ? FieldTypeOverrideService.getFieldSubstitutionCandidates(field, namespaceMap)
+      : FieldTypeOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+  const selectedKey = derivePreselectedKey(field, mode, namespaceMap, candidates);
+  return { candidates, selectedKey };
+}

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/revert-type-override.ts
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/revert-type-override.ts
@@ -1,17 +1,27 @@
 import { DocumentDefinition, IDocument, IField } from '../../../../models/datamapper/document';
+import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import { FieldTypeOverrideService } from '../../../../services/field-type-override.service';
 
 /**
- * Revert a field type override without opening the modal.
+ * Revert a field override (type override or substitution) without opening the modal.
+ * Dispatches to the correct service method based on the field's current override variant.
  * Used by context menus and dropdown actions for direct reset.
  */
-export function revertTypeOverride(
+export function revertOverride(
   field: IField,
   namespaceMap: Record<string, string>,
   updateDocument: (document: IDocument, definition: DocumentDefinition, previousRefId: string) => void,
 ): void {
+  if (field.typeOverride === FieldOverrideVariant.NONE) return;
+
   const document = field.ownerDocument;
   const previousRefId = document.getReferenceId(namespaceMap);
-  FieldTypeOverrideService.revertFieldTypeOverride(field, namespaceMap);
+
+  if (field.typeOverride === FieldOverrideVariant.SUBSTITUTION) {
+    FieldTypeOverrideService.revertFieldSubstitution(field, namespaceMap);
+  } else {
+    FieldTypeOverrideService.revertFieldTypeOverride(field, namespaceMap);
+  }
+
   updateDocument(document, document.definition, previousRefId);
 }

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.test.tsx
@@ -44,7 +44,7 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${fieldNode.nodeData.id}`));
     });
 
-    expect(screen.getByText('Override Type...')).toBeInTheDocument();
+    expect(screen.getByText('Override Field...')).toBeInTheDocument();
   });
 
   it('should not open context menu in read-only mode', () => {
@@ -64,7 +64,7 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${fieldNode.nodeData.id}`));
     });
 
-    expect(screen.queryByText('Override Type...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Override Field...')).not.toBeInTheDocument();
   });
 
   it('should not open context menu for document nodes', () => {
@@ -86,7 +86,7 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${documentNodeData.id}`));
     });
 
-    expect(screen.queryByText('Override Type...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Override Field...')).not.toBeInTheDocument();
   });
 
   it('should close context menu when clicking outside', () => {
@@ -106,13 +106,13 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${fieldNode.nodeData.id}`));
     });
 
-    expect(screen.getByText('Override Type...')).toBeInTheDocument();
+    expect(screen.getByText('Override Field...')).toBeInTheDocument();
 
     act(() => {
       fireEvent.mouseDown(globalThis.document.body);
     });
 
-    expect(screen.queryByText('Override Type...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Override Field...')).not.toBeInTheDocument();
   });
 
   it('should close context menu when pressing Escape', () => {
@@ -132,16 +132,16 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${fieldNode.nodeData.id}`));
     });
 
-    expect(screen.getByText('Override Type...')).toBeInTheDocument();
+    expect(screen.getByText('Override Field...')).toBeInTheDocument();
 
     act(() => {
       fireEvent.keyDown(globalThis.document, { key: 'Escape' });
     });
 
-    expect(screen.queryByText('Override Type...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Override Field...')).not.toBeInTheDocument();
   });
 
-  it('should open Type Override Modal when clicking Override Type menu item', () => {
+  it('should open Field Override Modal when clicking Override Field menu item', () => {
     const { documentNodeData, fieldNode } = createFieldNode();
 
     render(
@@ -159,10 +159,10 @@ describe('withFieldOverrideContextMenu', () => {
     });
 
     act(() => {
-      fireEvent.click(screen.getByText('Override Type...'));
+      fireEvent.click(screen.getByText('Override Field...'));
     });
 
-    expect(screen.getByText(/Type Override:/)).toBeInTheDocument();
+    expect(screen.getByText(/Field Override:/)).toBeInTheDocument();
   });
 
   it('should show Reset Override menu item when field has type override', () => {
@@ -193,7 +193,7 @@ describe('withFieldOverrideContextMenu', () => {
       fireEvent.contextMenu(screen.getByTestId(`node-source-${fieldNode.nodeData.id}`));
     });
 
-    expect(screen.getByText('Override Type...')).toBeInTheDocument();
+    expect(screen.getByText('Override Field...')).toBeInTheDocument();
     expect(screen.getByText('Reset Override')).toBeInTheDocument();
   });
 
@@ -267,11 +267,11 @@ describe('withFieldOverrideContextMenu', () => {
     });
 
     act(() => {
-      fireEvent.click(screen.getByText('Override Type...'));
+      fireEvent.click(screen.getByText('Override Field...'));
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Type Override:/)).toBeInTheDocument();
+      expect(screen.getByText(/Field Override:/)).toBeInTheDocument();
     });
 
     act(() => {
@@ -323,11 +323,11 @@ describe('withFieldOverrideContextMenu', () => {
     });
 
     act(() => {
-      fireEvent.click(screen.getByText('Override Type...'));
+      fireEvent.click(screen.getByText('Override Field...'));
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Type Override:/)).toBeInTheDocument();
+      expect(screen.getByText(/Field Override:/)).toBeInTheDocument();
     });
 
     act(() => {
@@ -335,7 +335,7 @@ describe('withFieldOverrideContextMenu', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText(/Type Override:/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Field Override:/)).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/withFieldOverrideContextMenu.tsx
@@ -6,7 +6,7 @@ import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import { VisualizationService } from '../../../../services/visualization.service';
 import { FieldContextMenu } from '../FieldContextMenu';
 import { FieldTypeOverride } from './FieldTypeOverride';
-import { revertTypeOverride } from './revert-type-override';
+import { revertOverride } from './revert-type-override';
 
 type WithTreeNode = {
   treeNode: DocumentTreeNode;
@@ -76,7 +76,7 @@ export function withFieldOverrideContextMenu<P extends WithTreeNode>(
 
     const handleResetOverride = useCallback(() => {
       if (field) {
-        revertTypeOverride(field, mappingTree.namespaceMap, updateDocument);
+        revertOverride(field, mappingTree.namespaceMap, updateDocument);
         refreshMappingTree();
       }
     }, [field, mappingTree.namespaceMap, updateDocument, refreshMappingTree]);

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -1011,6 +1011,19 @@ describe('FieldTypeOverrideService', () => {
       expect(abstractAnimalField.typeOverride).toBe(FieldOverrideVariant.SUBSTITUTION);
     });
 
+    it('should register missing namespace and prefix the key when namespace is not in map', () => {
+      const doc = createSubstitutionDoc();
+      const namespaceMap: Record<string, string> = {};
+      const abstractAnimalField = doc.fields[0];
+
+      FieldTypeOverrideService.applyFieldSubstitution(abstractAnimalField, 'ns0:Cat', namespaceMap);
+
+      expect(namespaceMap['ns0']).toBe(NS_SUBSTITUTION);
+      expect(doc.definition.fieldSubstitutions![0].name).toBe('ns0:Cat');
+      expect(abstractAnimalField.typeOverride).toBe(FieldOverrideVariant.SUBSTITUTION);
+      expect(abstractAnimalField.name).toBe('Cat');
+    });
+
     it('should populate children when substituting with an element that has an anonymous complex type', () => {
       const doc = createSubstitutionDoc();
       const namespaceMap = { sub: NS_SUBSTITUTION };


### PR DESCRIPTION
fixes: #2992

Add element substitution support to the Field Override modal, enabling users to substitute XML Schema substitution group members in addition to overriding field types.

- TypeOverrideModal: dual-mode radio toggle (Override Type / Substitute Element) with mode-dependent dropdown labels and candidates
- FieldTypeOverride: dispatch to applyFieldSubstitution for substitution mode
- revert-type-override: dispatch to revertFieldSubstitution for SUBSTITUTION variant
- TypeOverrideIndicator: blue info icon (ExchangeAltIcon) for substitution, amber warning icon (WrenchIcon) for type override
- NodeTitle: substitution-aware popover labels (Original/Substituted element)
- Context menu label: "Override Type..." → "Override Field..."

<img width="999" height="672" alt="Screenshot 2026-04-14 at 11 00 30" src="https://github.com/user-attachments/assets/be2235ee-42a5-43c9-bf7e-a2d65ae8c2ce" />

<img width="342" height="213" alt="Screenshot 2026-04-14 at 11 00 39" src="https://github.com/user-attachments/assets/41d40b3f-f5bc-4401-b7c0-84eff610be26" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Substitute Element" mode to the field override dialog with a radio selector to choose between type override and substitution.
  * Override dialog now requires an explicit selection before saving and preserves/clears selections when switching modes.

* **Improvements**
  * Context menu item renamed to "Override Field..." and modal title updated to "Field Override".
  * Clearer original/current labels and distinct visual indicators for substitutions vs type overrides.
  * Revert behavior correctly handles both override types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->