### PR TITLE
fix: use true() instead of true in XPath test

### DIFF
--- a/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-cst-visitor.test.ts
+++ b/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-cst-visitor.test.ts
@@ -415,7 +415,7 @@ describe('CstVisitor', () => {
 
 describe('Logical expressions in if-then-else', () => {
   it('should handle if with logical condition and traverse all path expressions', () => {
-    const xpath = 'if (status = "active" and verified = true) then "ok" else "nok"';
+    const xpath = 'if (status = "active" and verified = true()) then "ok" else "nok"';
     const ast = XPathService.parse(xpath).exprNode;
     expect(ast).toBeDefined();
     if (!ast) return;


### PR DESCRIPTION
Fixes #2983

This PR corrects the XPath boolean literal syntax in the test case. In XPath, `true` without parentheses is interpreted as a node name (PathExpr), not a boolean literal. This can hide bugs in field extraction logic and may create phantom mapping lines in the datamapper.

**Changes:**
- Updated `verified = true` to `verified = true()` in the XPath test expression

**Verification:**
- Checked the entire codebase and confirmed this was the only occurrence of this issue
- All tests pass successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved XPath parser test to better verify handling of logical expressions and operand parsing, increasing confidence in expression evaluation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->