### PR TITLE
chore: Remove CJS from npm package

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -66,4 +66,4 @@ yarn workspace @kaoto/kaoto lint:style:fix
 
 ### Notes on publishing
 
-This package exposes ESM and CJS builds under `lib/esm` and `lib/cjs`, driven by `build:lib` (which runs `copy-catalog`, `build:esm`, `build:cjs`, and `write-version`). Consumers import from `@kaoto/kaoto`, `@kaoto/kaoto/components`, `@kaoto/kaoto/models`, and `@kaoto/kaoto/testing` via the defined exports map.
+This package ships an ESM-only build under `lib/`, driven by `build:lib` (which runs `tsc --project tsconfig.lib.json`, copies SCSS/assets, and runs `write-version`). Consumers import from `@kaoto/kaoto`, `@kaoto/kaoto/components`, `@kaoto/kaoto/models`, and `@kaoto/kaoto/testing` via the defined exports map.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,27 +10,30 @@
     "access": "public"
   },
   "license": "Apache License v2.0",
-  "types": "./lib/esm/public-api.d.ts",
-  "module": "./lib/esm/public-api.js",
-  "main": "./lib/cjs/public-api.js",
+  "types": "./lib/public-api.d.ts",
+  "module": "./lib/public-api.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/public-api.js",
-      "require": "./lib/cjs/public-api.js"
+      "types": "./lib/public-api.d.ts",
+      "import": "./lib/public-api.js"
     },
     "./components": {
-      "import": "./lib/esm/components-api.js",
-      "require": "./lib/cjs/components-api.js"
+      "types": "./lib/components-api.d.ts",
+      "import": "./lib/components-api.js"
     },
     "./models": {
-      "import": "./lib/esm/models-api.js",
-      "require": "./lib/cjs/models-api.js"
+      "types": "./lib/models-api.d.ts",
+      "import": "./lib/models-api.js"
     },
     "./testing": {
-      "import": "./lib/esm/testing-api.js",
-      "require": "./lib/cjs/testing-api.js"
+      "types": "./lib/testing-api.d.ts",
+      "import": "./lib/testing-api.js"
     }
   },
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "files": [
     "lib"
   ],
@@ -38,9 +41,7 @@
     "start": "vite --mode=dev",
     "build": "tsc && vite build --config vite.config.mjs",
     "build:dev": "tsc && vite build --mode=dev --config vite.config.mjs",
-    "build:lib": "yarn rimraf ./lib && yarn build:esm && yarn build:cjs && yarn write-version",
-    "build:esm": "tsc --project tsconfig.esm.json && copyfiles -u 1 './src/**/*.scss' './src/assets/**' ./lib/esm",
-    "build:cjs": "tsc --project tsconfig.cjs.json && copyfiles -u 1 './src/**/*.scss' './src/assets/**' ./lib/cjs",
+    "build:lib": "yarn rimraf ./lib && tsc --project tsconfig.lib.json && copyfiles -u 1 './src/**/*.scss' './src/assets/**' ./lib && yarn write-version",
     "write-version": "node ./scripts/write-version-file.mjs",
     "preview": "vite preview",
     "test": "jest",

--- a/packages/ui/scripts/write-version-file.mjs
+++ b/packages/ui/scripts/write-version-file.mjs
@@ -22,9 +22,7 @@ const main = async () => {
 
   const VERSION_FILE_CONTENT = JSON.stringify(VERSION_OBJECT, null, 4);
 
-  /** Write the VERSION_FILE_CONTENT into the `lib/XXX/version.json file */
-  await writeFile('lib/esm/version.json', VERSION_FILE_CONTENT);
-  await writeFile('lib/cjs/version.json', VERSION_FILE_CONTENT);
+  await writeFile('lib/version.json', VERSION_FILE_CONTENT);
 };
 
 main();

--- a/packages/ui/tsconfig.cjs.json
+++ b/packages/ui/tsconfig.cjs.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.esm.json",
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "target": "ES2020",
-    "outDir": "lib/cjs",
-  },
-}

--- a/packages/ui/tsconfig.lib.json
+++ b/packages/ui/tsconfig.lib.json
@@ -17,7 +17,7 @@
     "declaration": true,
     "declarationMap": true,
     "jsx": "react-jsx",
-    "outDir": "lib/esm",
+    "outDir": "lib",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build system to produce a single unified ESM output instead of separate ESM and CommonJS builds
  * Updated build scripts and configuration accordingly
  * Consumer import paths via package exports remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->