### PR TITLE
feat(DataMapper): Allow editing mapping fields via double-click

### DIFF
--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -768,6 +768,7 @@ describe('TargetDocumentNode', () => {
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
+      const allowSpy = jest.spyOn(VisualizationService, 'allowValueSelector').mockReturnValue(true);
       const applyValueSelectorSpy = jest.spyOn(VisualizationService, 'applyValueSelector');
 
       act(() => {
@@ -781,9 +782,39 @@ describe('TargetDocumentNode', () => {
         fireEvent.doubleClick(nodeContainer);
       });
 
+      expect(allowSpy).toHaveBeenCalledWith(documentNodeData);
       expect(applyValueSelectorSpy).toHaveBeenCalledWith(documentNodeData);
       expect(applyValueSelectorSpy).toHaveBeenCalledTimes(1);
 
+      allowSpy.mockRestore();
+      applyValueSelectorSpy.mockRestore();
+    });
+
+    it('should not call applyValueSelector when allowValueSelector is false', () => {
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      const allowSpy = jest.spyOn(VisualizationService, 'allowValueSelector').mockReturnValue(false);
+      const applyValueSelectorSpy = jest.spyOn(VisualizationService, 'applyValueSelector');
+
+      act(() => {
+        render(<TargetDocumentNode treeNode={tree.root} documentId={documentNodeData.id} rank={0} />, { wrapper });
+      });
+
+      const nodeContainer = screen.getByTestId(`node-target-${documentNodeData.id}`);
+      expect(nodeContainer).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.doubleClick(nodeContainer);
+      });
+
+      expect(allowSpy).toHaveBeenCalledWith(documentNodeData);
+      expect(applyValueSelectorSpy).not.toHaveBeenCalled();
+
+      allowSpy.mockRestore();
       applyValueSelectorSpy.mockRestore();
     });
   });

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -14,6 +14,7 @@ import { MappingTree, VariableItem } from '../../models/datamapper/mapping';
 import {
   AddMappingNodeData,
   DocumentNodeData,
+  MappingActionKind,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
   VariableNodeData,
@@ -22,7 +23,7 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { TreeParsingService } from '../../services/tree-parsing.service';
 import { TreeUIService } from '../../services/tree-ui.service';
-import { VisualizationService } from '../../services/visualization.service';
+import { MappingActionService, VisualizationService } from '../../services/visualization.service';
 import { useDocumentTreeStore } from '../../store';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
 import { TargetDocumentNode } from './TargetDocumentNode';
@@ -768,7 +769,9 @@ describe('TargetDocumentNode', () => {
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
-      const allowSpy = jest.spyOn(VisualizationService, 'allowValueSelector').mockReturnValue(true);
+      const getAllowedActionsSpy = jest
+        .spyOn(MappingActionService, 'getAllowedActions')
+        .mockReturnValue([MappingActionKind.ValueSelector]);
       const applyValueSelectorSpy = jest.spyOn(VisualizationService, 'applyValueSelector');
 
       act(() => {
@@ -782,11 +785,11 @@ describe('TargetDocumentNode', () => {
         fireEvent.doubleClick(nodeContainer);
       });
 
-      expect(allowSpy).toHaveBeenCalledWith(documentNodeData);
+      expect(getAllowedActionsSpy).toHaveBeenCalledWith(documentNodeData);
       expect(applyValueSelectorSpy).toHaveBeenCalledWith(documentNodeData);
       expect(applyValueSelectorSpy).toHaveBeenCalledTimes(1);
 
-      allowSpy.mockRestore();
+      getAllowedActionsSpy.mockRestore();
       applyValueSelectorSpy.mockRestore();
     });
 
@@ -797,7 +800,7 @@ describe('TargetDocumentNode', () => {
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
-      const allowSpy = jest.spyOn(VisualizationService, 'allowValueSelector').mockReturnValue(false);
+      const getAllowedActionsSpy = jest.spyOn(MappingActionService, 'getAllowedActions').mockReturnValue([]);
       const applyValueSelectorSpy = jest.spyOn(VisualizationService, 'applyValueSelector');
 
       act(() => {
@@ -811,10 +814,10 @@ describe('TargetDocumentNode', () => {
         fireEvent.doubleClick(nodeContainer);
       });
 
-      expect(allowSpy).toHaveBeenCalledWith(documentNodeData);
+      expect(getAllowedActionsSpy).toHaveBeenCalledWith(documentNodeData);
       expect(applyValueSelectorSpy).not.toHaveBeenCalled();
 
-      allowSpy.mockRestore();
+      getAllowedActionsSpy.mockRestore();
       applyValueSelectorSpy.mockRestore();
     });
   });

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -760,6 +760,32 @@ describe('TargetDocumentNode', () => {
       // Node should be selected
       expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
+
+    it('should call applyValueSelector and handleUpdate on double click', () => {
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+
+      const applyValueSelectorSpy = jest.spyOn(VisualizationService, 'applyValueSelector');
+
+      act(() => {
+        render(<TargetDocumentNode treeNode={tree.root} documentId={documentNodeData.id} rank={0} />, { wrapper });
+      });
+
+      const nodeContainer = screen.getByTestId(`node-target-${documentNodeData.id}`);
+      expect(nodeContainer).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.doubleClick(nodeContainer);
+      });
+
+      expect(applyValueSelectorSpy).toHaveBeenCalledWith(documentNodeData);
+      expect(applyValueSelectorSpy).toHaveBeenCalledTimes(1);
+
+      applyValueSelectorSpy.mockRestore();
+    });
   });
 
   describe('Keyboard Selection', () => {

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -70,6 +70,11 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
       [toggleSelectedNode, nodePathString],
     );
 
+    const handleDoubleClickField = useCallback(() => {
+      VisualizationService.applyValueSelector(nodeData as TargetNodeData);
+      handleUpdate();
+    }, [nodeData, handleUpdate]);
+
     const handleKeyDown = useCallback(
       (event: KeyboardEvent) => handleNodeKeyDown(event, () => toggleSelectedNode(nodePathString, false)),
       [nodePathString, toggleSelectedNode],
@@ -88,6 +93,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
         data-selected={isSelected}
         className="node__container"
         onClick={handleClickField}
+        onDoubleClick={handleDoubleClickField}
         onKeyDown={handleKeyDown}
         onContextMenu={onContextMenu}
       >

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -4,9 +4,14 @@ import { FunctionComponent, KeyboardEvent, memo, MouseEvent, MouseEventHandler, 
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
 import { MappingItem } from '../../models/datamapper/mapping';
-import { AddMappingNodeData, TargetDocumentNodeData, TargetNodeData } from '../../models/datamapper/visualization';
+import {
+  AddMappingNodeData,
+  MappingActionKind,
+  TargetDocumentNodeData,
+  TargetNodeData,
+} from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/tree-ui.service';
-import { VisualizationService } from '../../services/visualization.service';
+import { MappingActionService, VisualizationService } from '../../services/visualization.service';
 import { useDocumentTreeStore } from '../../store';
 import { DocumentActions } from './actions/DocumentActions';
 import { OverrideIndicator } from './actions/FieldOverride/OverrideIndicator';
@@ -71,7 +76,9 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
     );
 
     const handleDoubleClickField = useCallback(() => {
-      const allowValueSelector = VisualizationService.allowValueSelector(nodeData);
+      const allowValueSelector = MappingActionService.getAllowedActions(nodeData).includes(
+        MappingActionKind.ValueSelector,
+      );
 
       if (!allowValueSelector) {
         return;

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -71,7 +71,13 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
     );
 
     const handleDoubleClickField = useCallback(() => {
-      VisualizationService.applyValueSelector(nodeData as TargetNodeData);
+      const allowValueSelector = VisualizationService.allowValueSelector(nodeData);
+
+      if (!allowValueSelector) {
+        return;
+      }
+
+      VisualizationService.applyValueSelector(nodeData);
       handleUpdate();
     }, [nodeData, handleUpdate]);
 

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
@@ -28,7 +28,7 @@ export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({ c
     <ActionListGroup key={`target-node-actions-${nodeData.id}`} onKeyDown={handleStopPropagation} className={className}>
       {expressionItem && (
         <>
-          <XPathInputAction mapping={expressionItem} onUpdate={onUpdate} />
+          <XPathInputAction nodeData={nodeData} mapping={expressionItem} onUpdate={onUpdate} />
           <XPathEditorAction nodeData={nodeData} mapping={expressionItem} onUpdate={onUpdate} />
         </>
       )}

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -2,20 +2,30 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
 import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';
+import { TargetDocumentNodeData } from '../../../models/datamapper/visualization';
+import { XmlSchemaDocument } from '../../../services/xml-schema-document.model';
+import { useDocumentTreeStore } from '../../../store/document-tree.store';
+import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { XPathInputAction } from './XPathInputAction';
 
 describe('XPathInputAction', () => {
   let tree: MappingTree;
   let mapping: ValueSelector;
+  let doc: XmlSchemaDocument;
+  let docData: TargetDocumentNodeData;
 
   beforeEach(() => {
+    doc = TestUtil.createTargetOrderDoc();
     tree = new MappingTree(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     mapping = new ValueSelector(tree);
+    docData = new TargetDocumentNodeData(doc, tree);
+    // Reset store state before each test
+    useDocumentTreeStore.getState().clearXPathInputFocusRequest();
   });
 
   it('should update xpath', () => {
     const onUpdateMock = jest.fn();
-    render(<XPathInputAction mapping={mapping} onUpdate={onUpdateMock} />);
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={onUpdateMock} />);
     expect(mapping.expression).toBeFalsy();
     const input = screen.getByTestId('transformation-xpath-input');
     act(() => {
@@ -28,14 +38,14 @@ describe('XPathInputAction', () => {
   it('should show error popover button if xpath has a parse error', async () => {
     mapping.expression = '{{';
     const onUpdateMock = jest.fn();
-    render(<XPathInputAction mapping={mapping} onUpdate={onUpdateMock} />);
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={onUpdateMock} />);
     const btn = await screen.findByTestId('xpath-input-error-btn');
     expect(btn).toBeInTheDocument();
   });
 
   it('should stop event propagation on handleXPathChange', () => {
     const stopPropagationSpy = jest.fn();
-    const wrapper = render(<XPathInputAction mapping={mapping} onUpdate={jest.fn()} />);
+    const wrapper = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     act(() => {
       const input = wrapper.getByTestId('transformation-xpath-input');
@@ -45,27 +55,67 @@ describe('XPathInputAction', () => {
     waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
   });
 
-  it('should focus input on mount when expression is empty', async () => {
-    const emptyMapping = { ...mapping, expression: '' };
-    render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+  it('should focus input when store indicates focus is needed for nodeData path', async () => {
+    mapping.expression = '';
+
+    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
+
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     const input = await screen.findByTestId('transformation-xpath-input');
 
     expect(input).toHaveFocus();
+    expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
   });
 
-  it('should NOT focus input on mount if expression already exists', async () => {
-    const filledMapping = { ...mapping, expression: 'existing/xpath' };
-    render(<XPathInputAction mapping={filledMapping} onUpdate={jest.fn()} />);
+  it('should focus input when stored path matches nodeData path after stable normalization', async () => {
+    mapping.expression = '';
+
+    useDocumentTreeStore
+      .getState()
+      .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
+
+    docData.path.pathSegments = ['fj-map-1255-1111', 'fj-map-Address-6894-3333', 'fj-string-City-1404-5555'];
+
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+
+    expect(input).toHaveFocus();
+    expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
+  });
+
+  it('should focus input when stored target field path matches field item path for the same field', async () => {
+    mapping.expression = '';
+
+    useDocumentTreeStore.getState().requestXPathInputFocus('targetBody:Body://fj-map-Address-6894/fj-string-City-8276');
+
+    docData.path.pathSegments = ['fj-map-Address-6894', 'fj-string-City-8276-4288'];
+
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+
+    expect(input).toHaveFocus();
+    expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
+  });
+
+  it('should NOT focus input when store does not indicate focus', async () => {
+    mapping.expression = 'existing/xpath';
+
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     const input = await screen.findByTestId('transformation-xpath-input');
 
     expect(input).not.toHaveFocus();
   });
 
-  it('should only focus once and respect the hasFocusedRef guard', async () => {
-    const emptyMapping = { ...mapping, expression: '' };
-    const { rerender } = render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+  it('should only focus when store flag is set', async () => {
+    mapping.expression = '';
+
+    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
+
+    const { rerender } = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     const input = await screen.findByTestId('transformation-xpath-input');
     expect(input).toHaveFocus();
@@ -75,14 +125,17 @@ describe('XPathInputAction', () => {
     });
     expect(input).not.toHaveFocus();
 
-    rerender(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+    rerender(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     expect(input).not.toHaveFocus();
   });
 
-  it('should not focus when expression changes if already focused once', async () => {
-    const emptyMapping = { ...mapping, expression: '' };
-    const { rerender } = render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+  it('should not focus when expression changes without store flag', async () => {
+    mapping.expression = '';
+
+    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
+
+    const { rerender } = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     const input = await screen.findByTestId('transformation-xpath-input');
     expect(input).toHaveFocus();
@@ -91,8 +144,8 @@ describe('XPathInputAction', () => {
       input.blur();
     });
 
-    const newMapping = { ...mapping, expression: 'new/path' };
-    rerender(<XPathInputAction mapping={newMapping} onUpdate={jest.fn()} />);
+    mapping.expression = 'new/path';
+    rerender(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
     expect(input).not.toHaveFocus();
   });

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -44,4 +44,56 @@ describe('XPathInputAction', () => {
 
     waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
   });
+
+  it('should focus input on mount when expression is empty', async () => {
+    const emptyMapping = { ...mapping, expression: '' };
+    render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+
+    expect(input).toHaveFocus();
+  });
+
+  it('should NOT focus input on mount if expression already exists', async () => {
+    const filledMapping = { ...mapping, expression: 'existing/xpath' };
+    render(<XPathInputAction mapping={filledMapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+
+    expect(input).not.toHaveFocus();
+  });
+
+  it('should only focus once and respect the hasFocusedRef guard', async () => {
+    const emptyMapping = { ...mapping, expression: '' };
+    const { rerender } = render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+    expect(input).toHaveFocus();
+
+    act(() => {
+      input.blur();
+    });
+    expect(input).not.toHaveFocus();
+
+    rerender(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+
+    expect(input).not.toHaveFocus();
+  });
+
+  it('should not focus when expression changes if already focused once', async () => {
+    const emptyMapping = { ...mapping, expression: '' };
+    const { rerender } = render(<XPathInputAction mapping={emptyMapping} onUpdate={jest.fn()} />);
+
+    const input = await screen.findByTestId('transformation-xpath-input');
+    expect(input).toHaveFocus();
+
+    act(() => {
+      input.blur();
+    });
+
+    const newMapping = { ...mapping, expression: 'new/path' };
+    rerender(<XPathInputAction mapping={newMapping} onUpdate={jest.fn()} />);
+
+    expect(input).not.toHaveFocus();
+  });
 });

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -55,42 +55,11 @@ describe('XPathInputAction', () => {
     waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
   });
 
-  it('should focus input when store indicates focus is needed for nodeData path', async () => {
+  it('should focus input when store indicates focus is needed for mapping node path', async () => {
     mapping.expression = '';
 
-    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
-
-    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
-
-    const input = await screen.findByTestId('transformation-xpath-input');
-
-    expect(input).toHaveFocus();
-    expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
-  });
-
-  it('should focus input when stored path matches nodeData path after stable normalization', async () => {
-    mapping.expression = '';
-
-    useDocumentTreeStore
-      .getState()
-      .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
-
-    docData.path.pathSegments = ['fj-map-1255-1111', 'fj-map-Address-6894-3333', 'fj-string-City-1404-5555'];
-
-    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
-
-    const input = await screen.findByTestId('transformation-xpath-input');
-
-    expect(input).toHaveFocus();
-    expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
-  });
-
-  it('should focus input when stored target field path matches field item path for the same field', async () => {
-    mapping.expression = '';
-
-    useDocumentTreeStore.getState().requestXPathInputFocus('targetBody:Body://fj-map-Address-6894/fj-string-City-8276');
-
-    docData.path.pathSegments = ['fj-map-Address-6894', 'fj-string-City-8276-4288'];
+    // Request focus using the tree's nodePath (which is what nodeData.mapping.nodePath refers to)
+    useDocumentTreeStore.getState().requestXPathInputFocus(tree.nodePath.toString());
 
     render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
@@ -113,7 +82,7 @@ describe('XPathInputAction', () => {
   it('should only focus when store flag is set', async () => {
     mapping.expression = '';
 
-    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
+    useDocumentTreeStore.getState().requestXPathInputFocus(tree.nodePath.toString());
 
     const { rerender } = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 
@@ -133,7 +102,7 @@ describe('XPathInputAction', () => {
   it('should not focus when expression changes without store flag', async () => {
     mapping.expression = '';
 
-    useDocumentTreeStore.getState().requestXPathInputFocus(docData.path.toString());
+    useDocumentTreeStore.getState().requestXPathInputFocus(tree.nodePath.toString());
 
     const { rerender } = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={jest.fn()} />);
 

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -16,17 +16,24 @@ import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/reac
 import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { IExpressionHolder } from '../../../models/datamapper/mapping';
+import { TargetNodeData } from '../../../models/datamapper/visualization';
 import { XPathService } from '../../../services/xpath/xpath.service';
 import { ValidatedXPathParseResult } from '../../../services/xpath/xpath-model';
+import { useDocumentTreeStore } from '../../../store/document-tree.store';
 
 type XPathInputProps = {
+  nodeData: TargetNodeData;
   mapping: IExpressionHolder;
   onUpdate: () => void;
 };
-export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, onUpdate }) => {
+export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ nodeData, mapping, onUpdate }) => {
   const [validationResult, setValidationResult] = useState<ValidatedXPathParseResult>();
   const inputRef = useRef<HTMLInputElement>(null);
-  const hasFocusedRef = useRef(false);
+  const nodePathString = nodeData.path.toString();
+
+  // Check if this mapping should receive focus from the store
+  const shouldFocus = useDocumentTreeStore((state) => state.shouldFocusXPathInput(nodePathString));
+  const clearFocusRequest = useDocumentTreeStore((state) => state.clearXPathInputFocusRequest);
 
   const validateXPath = useCallback(() => {
     const result = XPathService.validate(mapping.expression);
@@ -37,19 +44,13 @@ export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, 
     validateXPath();
   }, [validateXPath]);
 
-  // Focus on creation of mapping input field (only once on mount and if mapping.expression is empty)
+  // Focus input field when store indicates this mapping should be focused
   useEffect(() => {
-    if (hasFocusedRef.current) {
-      return;
+    if (shouldFocus && inputRef.current) {
+      inputRef.current.focus();
+      clearFocusRequest();
     }
-
-    if (mapping.expression && mapping.expression.length > 0) {
-      return;
-    }
-
-    inputRef.current?.focus();
-    hasFocusedRef.current = true;
-  }, [mapping.expression]);
+  }, [shouldFocus, clearFocusRequest]);
 
   const handleXPathChange = useCallback(
     (event: FormEvent, value: string) => {

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -29,10 +29,10 @@ type XPathInputProps = {
 export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ nodeData, mapping, onUpdate }) => {
   const [validationResult, setValidationResult] = useState<ValidatedXPathParseResult>();
   const inputRef = useRef<HTMLInputElement>(null);
-  const nodePathString = nodeData.path.toString();
+  const mappingNodePath = nodeData.mapping?.nodePath.toString() ?? '';
 
   // Check if this mapping should receive focus from the store
-  const shouldFocus = useDocumentTreeStore((state) => state.shouldFocusXPathInput(nodePathString));
+  const shouldFocus = useDocumentTreeStore((state) => state.shouldFocusXPathInput(mappingNodePath));
   const clearFocusRequest = useDocumentTreeStore((state) => state.clearXPathInputFocusRequest);
 
   const validateXPath = useCallback(() => {

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { IExpressionHolder } from '../../../models/datamapper/mapping';
 import { XPathService } from '../../../services/xpath/xpath.service';
@@ -25,6 +25,8 @@ type XPathInputProps = {
 };
 export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, onUpdate }) => {
   const [validationResult, setValidationResult] = useState<ValidatedXPathParseResult>();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasFocusedRef = useRef(false);
 
   const validateXPath = useCallback(() => {
     const result = XPathService.validate(mapping.expression);
@@ -34,6 +36,20 @@ export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, 
   useEffect(() => {
     validateXPath();
   }, [validateXPath]);
+
+  // Focus on creation of mapping input field (only once on mount and if mapping.expression is empty)
+  useEffect(() => {
+    if (hasFocusedRef.current) {
+      return;
+    }
+
+    if (mapping.expression && mapping.expression.length > 0) {
+      return;
+    }
+
+    inputRef.current?.focus();
+    hasFocusedRef.current = true;
+  }, [mapping.expression]);
 
   const handleXPathChange = useCallback(
     (event: FormEvent, value: string) => {
@@ -68,6 +84,7 @@ export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ mapping, 
       <InputGroup>
         <InputGroupItem className="input-group__text">
           <TextInput
+            ref={inputRef}
             data-testid="transformation-xpath-input"
             id="xpath"
             type="text"

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -112,7 +112,12 @@ export const TargetPanel: FunctionComponent = () => {
     // XPath actions for primitive target body with mapping
     if (expressionItem) {
       actions.push(
-        <XPathInputAction key="xpath-input" mapping={expressionItem} onUpdate={handleUpdate} />,
+        <XPathInputAction
+          key="xpath-input"
+          nodeData={targetBodyNodeData}
+          mapping={expressionItem}
+          onUpdate={handleUpdate}
+        />,
         <XPathEditorAction
           key="xpath-editor"
           nodeData={targetBodyNodeData}

--- a/packages/ui/src/services/path-util.ts
+++ b/packages/ui/src/services/path-util.ts
@@ -16,42 +16,6 @@ export class PathUtil {
     return normalized.join('/');
   }
 
-  /**
-   * Converts a DataMapper node path into a stable identifier by removing only
-   * the trailing random 4-digit suffix from each path segment.
-   *
-   * Examples:
-   * - `fj-map-1255-2922` -> `fj-map-1255`
-   * - `fj-string-City-8276-4288` -> `fj-string-City-8276`
-   * - `fj-string-City-8276` -> `fj-string-City-8276`
-   */
-  static toStableNodePath(path: string): string {
-    const parts = path.split('://');
-    if (parts.length !== 2) {
-      return path;
-    }
-
-    const [prefix, rawSegments] = parts;
-
-    if (!rawSegments) {
-      return `${prefix}://`;
-    }
-
-    const stableSegments = rawSegments.split('/').map((segment) => {
-      const tokens = segment.split('-');
-      if (tokens.length >= 3 && /^\d{4}$/.test(tokens.at(-1) ?? '') && /^\d{4}$/.test(tokens.at(-2) ?? '')) {
-        return tokens.slice(0, -1).join('-');
-      }
-      return segment;
-    });
-
-    return `${prefix}://${stableSegments.join('/')}`;
-  }
-
-  static isSameStableNodePath(left: string, right: string): boolean {
-    return PathUtil.toStableNodePath(left) === PathUtil.toStableNodePath(right);
-  }
-
   static extractDirectory(path: string): string | null {
     const lastSlash = path.lastIndexOf('/');
     if (lastSlash === -1) {

--- a/packages/ui/src/services/path-util.ts
+++ b/packages/ui/src/services/path-util.ts
@@ -16,6 +16,42 @@ export class PathUtil {
     return normalized.join('/');
   }
 
+  /**
+   * Converts a DataMapper node path into a stable identifier by removing only
+   * the trailing random 4-digit suffix from each path segment.
+   *
+   * Examples:
+   * - `fj-map-1255-2922` -> `fj-map-1255`
+   * - `fj-string-City-8276-4288` -> `fj-string-City-8276`
+   * - `fj-string-City-8276` -> `fj-string-City-8276`
+   */
+  static toStableNodePath(path: string): string {
+    const parts = path.split('://');
+    if (parts.length !== 2) {
+      return path;
+    }
+
+    const [prefix, rawSegments] = parts;
+
+    if (!rawSegments) {
+      return `${prefix}://`;
+    }
+
+    const stableSegments = rawSegments.split('/').map((segment) => {
+      const tokens = segment.split('-');
+      if (tokens.length >= 3 && /^\d{4}$/.test(tokens.at(-1) ?? '') && /^\d{4}$/.test(tokens.at(-2) ?? '')) {
+        return tokens.slice(0, -1).join('-');
+      }
+      return segment;
+    });
+
+    return `${prefix}://${stableSegments.join('/')}`;
+  }
+
+  static isSameStableNodePath(left: string, right: string): boolean {
+    return PathUtil.toStableNodePath(left) === PathUtil.toStableNodePath(right);
+  }
+
   static extractDirectory(path: string): string | null {
     const lastSlash = path.lastIndexOf('/');
     if (lastSlash === -1) {

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -37,6 +37,7 @@ import {
   UnknownMappingNodeData,
   VariableNodeData,
 } from '../models/datamapper/visualization';
+import { useDocumentTreeStore } from '../store/document-tree.store';
 import { DocumentService } from './document.service';
 import { DocumentUtilService } from './document-util.service';
 import { MappingService } from './mapping.service';
@@ -505,6 +506,7 @@ export class VisualizationService {
     if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
       const valueSelector = MappingService.createValueSelector(mapping);
       mapping.children.push(valueSelector);
+      useDocumentTreeStore.getState().requestXPathInputFocus(nodeData.path.toString());
     }
   }
 

--- a/packages/ui/src/services/visualization.service.ts
+++ b/packages/ui/src/services/visualization.service.ts
@@ -506,7 +506,7 @@ export class VisualizationService {
     if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
       const valueSelector = MappingService.createValueSelector(mapping);
       mapping.children.push(valueSelector);
-      useDocumentTreeStore.getState().requestXPathInputFocus(nodeData.path.toString());
+      useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
     }
   }
 

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -29,6 +29,7 @@ describe('useDocumentTreeStore', () => {
       nodesConnectionPorts: {},
       selectedNodePath: null,
       selectedNodeIsSource: false,
+      targetXPathInputForFocus: null,
     });
   });
 
@@ -229,6 +230,61 @@ describe('useDocumentTreeStore', () => {
       const state = useDocumentTreeStore.getState();
 
       expect(state.expansionState[documentId][nodePath]).toBe(true);
+    });
+  });
+
+  describe('XPath input focus management', () => {
+    it('should match XPath input focus paths with different random suffixes', () => {
+      useDocumentTreeStore
+        .getState()
+        .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
+        'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404',
+      );
+      expect(
+        useDocumentTreeStore
+          .getState()
+          .shouldFocusXPathInput(
+            'targetBody:Body://fj-map-1255-9999/fj-map-Address-6894-1111/fj-string-City-1404-2222',
+          ),
+      ).toBe(true);
+    });
+
+    it('should match target field and field item paths for the same field', () => {
+      useDocumentTreeStore
+        .getState()
+        .requestXPathInputFocus('targetBody:Body://fj-map-Address-6894/fj-string-City-8276');
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
+        'targetBody:Body://fj-map-Address-6894/fj-string-City-8276',
+      );
+      expect(
+        useDocumentTreeStore
+          .getState()
+          .shouldFocusXPathInput('targetBody:Body://fj-map-Address-6894/fj-string-City-8276-4288'),
+      ).toBe(true);
+    });
+
+    it('should clear XPath input focus request', () => {
+      useDocumentTreeStore
+        .getState()
+        .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
+        'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404',
+      );
+
+      useDocumentTreeStore.getState().clearXPathInputFocusRequest();
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
+      expect(
+        useDocumentTreeStore
+          .getState()
+          .shouldFocusXPathInput(
+            'targetBody:Body://fj-map-1255-9999/fj-map-Address-6894-1111/fj-string-City-1404-2222',
+          ),
+      ).toBe(false);
     });
   });
 

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -234,57 +234,37 @@ describe('useDocumentTreeStore', () => {
   });
 
   describe('XPath input focus management', () => {
-    it('should match XPath input focus paths with different random suffixes', () => {
-      useDocumentTreeStore
-        .getState()
-        .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
+    it('should request focus for exact mapping node path', () => {
+      const mappingNodePath = 'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404';
 
-      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
-        'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404',
-      );
-      expect(
-        useDocumentTreeStore
-          .getState()
-          .shouldFocusXPathInput(
-            'targetBody:Body://fj-map-1255-9999/fj-map-Address-6894-1111/fj-string-City-1404-2222',
-          ),
-      ).toBe(true);
+      useDocumentTreeStore.getState().requestXPathInputFocus(mappingNodePath);
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(mappingNodePath);
+      expect(useDocumentTreeStore.getState().shouldFocusXPathInput(mappingNodePath)).toBe(true);
     });
 
-    it('should match target field and field item paths for the same field', () => {
-      useDocumentTreeStore
-        .getState()
-        .requestXPathInputFocus('targetBody:Body://fj-map-Address-6894/fj-string-City-8276');
+    it('should not match different mapping node paths', () => {
+      const mappingNodePath1 = 'targetBody:Body://fj-map-Address-6894/fj-string-City-8276';
+      const mappingNodePath2 = 'targetBody:Body://fj-map-Address-6894/fj-string-Name-1234';
 
-      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
-        'targetBody:Body://fj-map-Address-6894/fj-string-City-8276',
-      );
-      expect(
-        useDocumentTreeStore
-          .getState()
-          .shouldFocusXPathInput('targetBody:Body://fj-map-Address-6894/fj-string-City-8276-4288'),
-      ).toBe(true);
+      useDocumentTreeStore.getState().requestXPathInputFocus(mappingNodePath1);
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(mappingNodePath1);
+      expect(useDocumentTreeStore.getState().shouldFocusXPathInput(mappingNodePath1)).toBe(true);
+      expect(useDocumentTreeStore.getState().shouldFocusXPathInput(mappingNodePath2)).toBe(false);
     });
 
     it('should clear XPath input focus request', () => {
-      useDocumentTreeStore
-        .getState()
-        .requestXPathInputFocus('targetBody:Body://fj-map-1255-2922/fj-map-Address-6894-3031/fj-string-City-1404-3876');
+      const mappingNodePath = 'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404';
 
-      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(
-        'targetBody:Body://fj-map-1255/fj-map-Address-6894/fj-string-City-1404',
-      );
+      useDocumentTreeStore.getState().requestXPathInputFocus(mappingNodePath);
+
+      expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(mappingNodePath);
 
       useDocumentTreeStore.getState().clearXPathInputFocusRequest();
 
       expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBeNull();
-      expect(
-        useDocumentTreeStore
-          .getState()
-          .shouldFocusXPathInput(
-            'targetBody:Body://fj-map-1255-9999/fj-map-Address-6894-1111/fj-string-City-1404-2222',
-          ),
-      ).toBe(false);
+      expect(useDocumentTreeStore.getState().shouldFocusXPathInput(mappingNodePath)).toBe(false);
     });
   });
 

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -3,7 +3,6 @@ import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 
 import { DocumentTree } from '../models/datamapper/document-tree';
-import { PathUtil } from '../services/path-util';
 import { processTreeNode } from '../utils';
 
 /** [NodePath]: expansion state */
@@ -26,9 +25,9 @@ export interface DocumentTreeState {
   selectedNodeIsSource: boolean;
 
   /**
-   * Stable node path of the XPath input field that should receive focus.
-   * Uses stable paths (via PathUtil.toStableNodePath) to match nodes reliably
-   * across re-renders. Automatically cleared after the input receives focus.
+   * Mapping-tree node path of the XPath input field that should receive focus.
+   * Matched by exact equality against the mapping's {@link MappingItem.nodePath}.
+   * Automatically cleared after the input receives focus.
    */
   targetXPathInputForFocus: string | null;
 
@@ -50,23 +49,13 @@ export interface DocumentTreeState {
   clearSelection: () => void;
   isNodeSelected: (nodePath: string, isSource: boolean) => boolean;
 
-  /**
-   * Request focus on the XPath input field for the specified target node.
-   * Converts the node path to a stable identifier to ensure reliable matching
-   * even if the component re-renders with different random suffixes.
-   */
+  /** Request focus on the XPath input for the given mapping-tree node path. */
   requestXPathInputFocus: (nodePath: string) => void;
 
-  /**
-   * Clear the XPath input focus request after it has been applied.
-   * Should be called immediately after the input field receives focus.
-   */
+  /** Clear the focus request after the input has received focus. */
   clearXPathInputFocusRequest: () => void;
 
-  /**
-   * Check if the XPath input for this node path should receive focus.
-   * Compares stable node paths to handle random suffix variations.
-   */
+  /** Check if the XPath input for this mapping-tree node path should receive focus. */
   shouldFocusXPathInput: (nodePath: string) => boolean;
 }
 
@@ -152,18 +141,16 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
         return get().selectedNodePath === nodePath && get().selectedNodeIsSource === isSource;
       },
 
-      requestXPathInputFocus: (nodePath: string) => {
-        set({ targetXPathInputForFocus: PathUtil.toStableNodePath(nodePath) });
+      requestXPathInputFocus: (mappingNodePath: string) => {
+        set({ targetXPathInputForFocus: mappingNodePath });
       },
 
       clearXPathInputFocusRequest: () => {
         set({ targetXPathInputForFocus: null });
       },
 
-      shouldFocusXPathInput: (nodePath: string) => {
-        const storedPath = get().targetXPathInputForFocus;
-        if (!storedPath) return false;
-        return PathUtil.isSameStableNodePath(storedPath, nodePath);
+      shouldFocusXPathInput: (mappingNodePath: string) => {
+        return get().targetXPathInputForFocus === mappingNodePath;
       },
     }),
     { name: 'Document Tree Store' },

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -3,6 +3,7 @@ import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 
 import { DocumentTree } from '../models/datamapper/document-tree';
+import { PathUtil } from '../services/path-util';
 import { processTreeNode } from '../utils';
 
 /** [NodePath]: expansion state */
@@ -24,6 +25,13 @@ export interface DocumentTreeState {
   selectedNodePath: string | null;
   selectedNodeIsSource: boolean;
 
+  /**
+   * Stable node path of the XPath input field that should receive focus.
+   * Uses stable paths (via PathUtil.toStableNodePath) to match nodes reliably
+   * across re-renders. Automatically cleared after the input receives focus.
+   */
+  targetXPathInputForFocus: string | null;
+
   /** Set the document's connection ports map with fresh data */
   setNodesConnectionPorts: (documentId: string, ports: TreeConnectionPorts) => void;
 
@@ -41,6 +49,25 @@ export interface DocumentTreeState {
   toggleSelectedNode: (nodePath: string, isSource: boolean) => void;
   clearSelection: () => void;
   isNodeSelected: (nodePath: string, isSource: boolean) => boolean;
+
+  /**
+   * Request focus on the XPath input field for the specified target node.
+   * Converts the node path to a stable identifier to ensure reliable matching
+   * even if the component re-renders with different random suffixes.
+   */
+  requestXPathInputFocus: (nodePath: string) => void;
+
+  /**
+   * Clear the XPath input focus request after it has been applied.
+   * Should be called immediately after the input field receives focus.
+   */
+  clearXPathInputFocusRequest: () => void;
+
+  /**
+   * Check if the XPath input for this node path should receive focus.
+   * Compares stable node paths to handle random suffix variations.
+   */
+  shouldFocusXPathInput: (nodePath: string) => boolean;
 }
 
 export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
@@ -52,6 +79,7 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
       nodesConnectionPortsArray: {},
       selectedNodePath: null,
       selectedNodeIsSource: false,
+      targetXPathInputForFocus: null,
 
       setNodesConnectionPorts: (documentId: string, ports: TreeConnectionPorts) => {
         set((state) => ({
@@ -122,6 +150,20 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
 
       isNodeSelected: (nodePath, isSource) => {
         return get().selectedNodePath === nodePath && get().selectedNodeIsSource === isSource;
+      },
+
+      requestXPathInputFocus: (nodePath: string) => {
+        set({ targetXPathInputForFocus: PathUtil.toStableNodePath(nodePath) });
+      },
+
+      clearXPathInputFocusRequest: () => {
+        set({ targetXPathInputForFocus: null });
+      },
+
+      shouldFocusXPathInput: (nodePath: string) => {
+        const storedPath = get().targetXPathInputForFocus;
+        if (!storedPath) return false;
+        return PathUtil.isSameStableNodePath(storedPath, nodePath);
       },
     }),
     { name: 'Document Tree Store' },


### PR DESCRIPTION
Resolves: [#2550](https://github.com/KaotoIO/kaoto/issues/2550)

## Description

This PR adds double-click functionality to target document nodes in the data mapper, allowing users to quickly apply value selectors without needing to use the context menu.

## Changes

- **Added double-click handler** to [`TargetDocumentNode`](packages/ui/src/components/Document/TargetDocumentNode.tsx:73-76) component that calls `applyValueSelector` and triggers an update
- **Implemented test coverage** for the new double-click behavior in [`TargetDocumentNode.test.tsx`](packages/ui/src/components/Document/TargetDocumentNode.test.tsx:764-788)

## Technical Details

The implementation adds a `handleDoubleClickField` callback that:
1. Applies the value selector to the target node data using `VisualizationService.applyValueSelector()`
2. Triggers a UI update via `handleUpdate()`

This provides a more intuitive user experience by enabling a common interaction pattern (double-click) for a frequently used action.

## Testing

- Added unit test verifying that double-clicking a target node calls `applyValueSelector` with the correct node data
- Existing tests continue to pass, ensuring no regression in click behavior


https://github.com/user-attachments/assets/1a987de4-0738-4541-92f4-c03ba9bd570a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced double-click functionality on document nodes to apply value selector actions when permitted by mapping action policies
  * Implemented automatic focus management for XPath input fields, enabling seamless focus transitions during mapping operations
  * Added intelligent focus state tracking to the document tree store to coordinate UI interactions across mapping nodes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->