### PR TITLE
fix(Catalog): Select appropriate Catalog for Resource

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/ChangeIntegrationTypeModal/ChangeIntegrationTypeModal.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/ChangeIntegrationTypeModal/ChangeIntegrationTypeModal.tsx
@@ -3,7 +3,6 @@ import { FunctionComponent } from 'react';
 
 interface ChangeIntegrationTypeModalProps {
   isOpen: boolean;
-  changesCatalog?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -14,8 +13,7 @@ export const ChangeIntegrationTypeModal: FunctionComponent<ChangeIntegrationType
       <ModalHeader title="Warning" titleIconVariant="warning" />
       <ModalBody>
         <p data-testid={'confirmation-modal-text'}>
-          Changing the source type will remove any existing integration and you will lose your current work.{' '}
-          {props.changesCatalog && 'This will also change the current selected catalog.'}
+          Changing the source type will remove any existing integration and you will lose your current work.
         </p>
         <p>Are you sure you would like to proceed?</p>
       </ModalBody>

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -55,6 +55,7 @@ describe('IntegrationTypeSelector.tsx', () => {
     camelResource?: KaotoResource,
   ) => {
     const mockSetSelectedCatalog = jest.fn();
+    const mockSetCodeAndNotify = jest.fn();
     const { Provider } = TestProvidersWrapper({ camelResource });
 
     return {
@@ -67,7 +68,7 @@ describe('IntegrationTypeSelector.tsx', () => {
             setSelectedCatalog: mockSetSelectedCatalog,
           }}
         >
-          <SourceCodeApiContext.Provider value={{ setCodeAndNotify: jest.fn() }}>
+          <SourceCodeApiContext.Provider value={{ setCodeAndNotify: mockSetCodeAndNotify }}>
             <Provider>
               <IntegrationTypeSelector />
             </Provider>
@@ -75,6 +76,7 @@ describe('IntegrationTypeSelector.tsx', () => {
         </RuntimeContext.Provider>,
       ),
       mockSetSelectedCatalog,
+      mockSetCodeAndNotify,
     };
   };
 
@@ -159,8 +161,9 @@ describe('IntegrationTypeSelector.tsx', () => {
     expect(modalText.textContent).not.toContain('This will also change the current selected catalog');
   });
 
-  it('should warn the user when selected flow changes the catalog', async () => {
-    const { findByTestId, getByTestId, mockSetSelectedCatalog } = renderWithCustomRuntime(mockCamelCatalog);
+  it('should warn the user when selecting a flow type that previously changed the catalog', async () => {
+    const { findByTestId, getByTestId, mockSetSelectedCatalog, mockSetCodeAndNotify } =
+      renderWithCustomRuntime(mockCamelCatalog);
 
     const trigger = await findByTestId('integration-type-list-dropdown');
 
@@ -181,7 +184,7 @@ describe('IntegrationTypeSelector.tsx', () => {
 
     const modalText = await findByTestId('confirmation-modal-text');
     expect(modalText).toBeInTheDocument();
-    expect(modalText.textContent).toContain('This will also change the current selected catalog');
+    expect(modalText.textContent).not.toContain('This will also change the current selected catalog');
 
     /** Confirm **/
     const confirmButton = await findByTestId('confirmation-modal-confirm');
@@ -191,11 +194,8 @@ describe('IntegrationTypeSelector.tsx', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetSelectedCatalog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          runtime: 'Citrus',
-        }),
-      );
+      expect(mockSetCodeAndNotify).toHaveBeenCalled();
+      expect(mockSetSelectedCatalog).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.tsx
@@ -1,45 +1,27 @@
-import { isDefined } from '@kaoto/forms';
 import { FunctionComponent, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
-import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { SourceSchemaType } from '../../../../models/camel';
 import { FlowTemplateService } from '../../../../models/visualization/flows/support/flow-templates-service';
 import { SourceCodeApiContext } from '../../../../providers';
-import { findCatalog } from '../../../../utils/catalog-helper';
 import { ChangeIntegrationTypeModal } from './ChangeIntegrationTypeModal/ChangeIntegrationTypeModal';
 import { IntegrationTypeSelectorToggle } from './IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle';
 
 export const IntegrationTypeSelector: FunctionComponent<PropsWithChildren> = () => {
-  const runtimeContext = useRuntimeContext();
   const sourceCodeContextApi = useContext(SourceCodeApiContext);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const [proposedFlowType, setProposedFlowType] = useState<SourceSchemaType>();
-  const [changeCatalog, setChangeCatalog] = useState<boolean>();
 
-  const checkBeforeAddNewFlow = useCallback((flowType: SourceSchemaType, changeCatalog: boolean) => {
-    /**
-     * If it is not the same integration type, this operation might result in
-     * removing the existing flows, so then we warn the user first
-     */
+  const checkBeforeAddNewFlow = useCallback((flowType: SourceSchemaType) => {
     setProposedFlowType(flowType);
-    setChangeCatalog(changeCatalog);
     setIsConfirmationModalOpen(true);
   }, []);
 
   const onConfirm = useCallback(() => {
     if (proposedFlowType) {
       sourceCodeContextApi.setCodeAndNotify(FlowTemplateService.getFlowYamlTemplate(proposedFlowType));
-
-      if (changeCatalog) {
-        const matchingCatalog = findCatalog(proposedFlowType, runtimeContext.catalogLibrary);
-        if (isDefined(matchingCatalog)) {
-          runtimeContext.setSelectedCatalog(matchingCatalog);
-        }
-      }
-
       setIsConfirmationModalOpen(false);
     }
-  }, [proposedFlowType, runtimeContext, sourceCodeContextApi, changeCatalog]);
+  }, [proposedFlowType, sourceCodeContextApi]);
 
   const onCancel = useCallback(() => {
     setIsConfirmationModalOpen(false);
@@ -48,12 +30,7 @@ export const IntegrationTypeSelector: FunctionComponent<PropsWithChildren> = () 
   return (
     <>
       <IntegrationTypeSelectorToggle onSelect={checkBeforeAddNewFlow} />
-      <ChangeIntegrationTypeModal
-        isOpen={isConfirmationModalOpen}
-        changesCatalog={changeCatalog}
-        onConfirm={onConfirm}
-        onCancel={onCancel}
-      />
+      <ChangeIntegrationTypeModal isOpen={isConfirmationModalOpen} onConfirm={onConfirm} onCancel={onCancel} />
     </>
   );
 };

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.tsx
@@ -1,19 +1,15 @@
 import { MenuToggle, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import { FunctionComponent, MouseEvent, RefObject, useCallback, useContext, useState } from 'react';
 
-import { useRuntimeContext } from '../../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { ISourceSchema, sourceSchemaConfig, SourceSchemaType } from '../../../../../models/camel';
 import { EntitiesContext } from '../../../../../providers/entities.provider';
 import { getSupportedDsls } from '../../../../../serializers/serializer-dsl-lists';
-import { requiresCatalogChange } from '../../../../../utils/catalog-helper';
 
 interface ISourceTypeSelector {
-  onSelect?: (value: SourceSchemaType, changeCatalog: boolean) => void;
+  onSelect?: (value: SourceSchemaType) => void;
 }
 
 export const IntegrationTypeSelectorToggle: FunctionComponent<ISourceTypeSelector> = (props) => {
-  const runtimeContext = useRuntimeContext();
-  const { selectedCatalog } = runtimeContext;
   const { currentSchemaType, camelResource } = useContext(EntitiesContext)!;
   const currentFlowType: ISourceSchema = sourceSchemaConfig.config[currentSchemaType];
   const [isOpen, setIsOpen] = useState(false);
@@ -21,29 +17,22 @@ export const IntegrationTypeSelectorToggle: FunctionComponent<ISourceTypeSelecto
 
   const onSelect = useCallback(
     (_event: MouseEvent | undefined, flowType: string | number | undefined) => {
-      if (!flowType) {
-        return;
-      }
+      if (!flowType) return;
       const integrationType = sourceSchemaConfig.config[flowType as SourceSchemaType];
 
       setIsOpen(false);
       if (integrationType !== undefined) {
-        props.onSelect?.(
-          flowType as SourceSchemaType,
-          requiresCatalogChange(flowType as SourceSchemaType, selectedCatalog),
-        );
+        props.onSelect?.(flowType as SourceSchemaType);
       }
     },
-    [props, selectedCatalog],
+    [props],
   );
 
   const toggle = (toggleRef: RefObject<HTMLButtonElement>) => (
     <MenuToggle
       data-testid="integration-type-list-dropdown"
       ref={toggleRef}
-      onClick={() => {
-        setIsOpen(!isOpen);
-      }}
+      onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
     >
       {sourceSchemaConfig.config[currentSchemaType].name}
@@ -64,7 +53,6 @@ export const IntegrationTypeSelectorToggle: FunctionComponent<ISourceTypeSelecto
         {dslEntries.map((sourceType, index) => {
           const sourceSchema = sourceSchemaConfig.config[sourceType];
           const isCurrentType = sourceSchema.name === currentFlowType.name;
-          const changeCatalog = requiresCatalogChange(sourceType, selectedCatalog);
 
           return (
             <SelectOption
@@ -79,7 +67,6 @@ export const IntegrationTypeSelectorToggle: FunctionComponent<ISourceTypeSelecto
               isDisabled={isCurrentType}
             >
               {sourceSchema.name}
-              {changeCatalog && !isCurrentType && ' (in different catalog)'}
               {isCurrentType && ' (current integration type)'}
             </SelectOption>
           );

--- a/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
+import { LocalStorageKeys } from '../../../../models';
 import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../stubs';
 import { RuntimeSelector } from './RuntimeSelector';
 
@@ -53,6 +54,14 @@ describe('RuntimeSelector', () => {
     await waitFor(async () => {
       expect(setSelectedCatalog).toHaveBeenCalled();
     });
+
+    const raw = localStorage.getItem(LocalStorageKeys.SelectedCatalog);
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      expect(parsed).toEqual(expect.any(Object));
+      expect((parsed as Record<string, unknown>).name).toBeUndefined();
+      expect((parsed as Record<string, unknown>).version).toBeUndefined();
+    }
   });
 
   it('should toggle list of Runtimes', async () => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/RuntimeSelector/RuntimeSelector.tsx
@@ -9,9 +9,9 @@ import citrusLogo from '../../../../assets/citrus-logo.png';
 import quarkusLogo from '../../../../assets/quarkus-logo.svg';
 import redhatLogo from '../../../../assets/redhat-logo.svg';
 import springBootLogo from '../../../../assets/springboot-logo.svg';
-import { useLocalStorage } from '../../../../hooks';
 import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
-import { LocalStorageKeys } from '../../../../models';
+import { SourceSchemaType } from '../../../../models/camel';
+import { COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE } from '../../../../models/camel/compatible-runtimes';
 import { EntitiesContext } from '../../../../providers';
 
 const SPACE_REGEX = /\s/g;
@@ -55,11 +55,8 @@ export const RuntimeSelector: FunctionComponent = () => {
   const toggleRef = useRef<HTMLButtonElement>(null);
   const runtimeContext = useRuntimeContext();
   const entitiesContext = useContext(EntitiesContext);
-  const compatibleRuntimes = entitiesContext?.camelResource.getCompatibleRuntimes() ?? [];
-  const [_, setSelectedCatalogLocalStorage] = useLocalStorage(
-    LocalStorageKeys.SelectedCatalog,
-    runtimeContext.selectedCatalog,
-  );
+  const currentSchemaType = entitiesContext?.currentSchemaType ?? SourceSchemaType.Route;
+  const compatibleRuntimes = COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[currentSchemaType];
   const groupedRuntimes =
     runtimeContext.catalogLibrary?.definitions
       .filter((catalog) => compatibleRuntimes.includes(catalog.runtime))
@@ -88,12 +85,11 @@ export const RuntimeSelector: FunctionComponent = () => {
 
       if (isDefined(selectedCatalog)) {
         runtimeContext.setSelectedCatalog(selectedCatalog);
-        setSelectedCatalogLocalStorage(selectedCatalog);
       }
 
       setIsOpen(false);
     },
-    [runtimeContext, setSelectedCatalogLocalStorage],
+    [runtimeContext],
   );
 
   const getMenuItem = useCallback(

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
@@ -55,6 +55,7 @@ describe('NewFlow.tsx', () => {
     sourceSchemaType: SourceSchemaType = SourceSchemaType.Integration,
   ) => {
     const mockSetSelectedCatalog = jest.fn();
+    const mockSetCodeAndNotify = jest.fn();
     const defaultRuntimeContext: IRuntimeContext = {
       basePath: '',
       selectedCatalog: mockCamelCatalog,
@@ -69,7 +70,7 @@ describe('NewFlow.tsx', () => {
         <RuntimeContext.Provider value={mergedRuntimeContext}>
           <SourceCodeApiContext.Provider
             value={{
-              setCodeAndNotify: jest.fn(),
+              setCodeAndNotify: mockSetCodeAndNotify,
             }}
           >
             <EntitiesContext.Provider
@@ -89,6 +90,7 @@ describe('NewFlow.tsx', () => {
         </RuntimeContext.Provider>,
       ),
       mockSetSelectedCatalog,
+      mockSetCodeAndNotify,
     };
   };
 
@@ -128,13 +130,11 @@ describe('NewFlow.tsx', () => {
     expect(modal).toBeInTheDocument();
   });
 
-  it('should update catalog when switching to Citrus test', async () => {
-    const mockSetSelectedCatalog = jest.fn();
-    const { findByTestId, getByText } = renderWithContext(
+  it('should call setCodeAndNotify and not directly call setSelectedCatalog when switching flow types', async () => {
+    const { findByTestId, getByText, mockSetCodeAndNotify, mockSetSelectedCatalog } = renderWithContext(
       {
         selectedCatalog: mockCamelCatalog,
         catalogLibrary: mockCatalogLibrary,
-        setSelectedCatalog: mockSetSelectedCatalog,
       },
       SourceSchemaType.Route,
     );
@@ -158,41 +158,8 @@ describe('NewFlow.tsx', () => {
       fireEvent.click(confirmButton);
     });
 
-    /** Verify catalog was updated to Citrus */
-    expect(mockSetSelectedCatalog).toHaveBeenCalledWith(mockCitrusCatalog);
-  });
-
-  it('should not update catalog when switching between Camel flow types', async () => {
-    const mockSetSelectedCatalog = jest.fn();
-    const { findByTestId, getByText } = renderWithContext(
-      {
-        selectedCatalog: mockCamelCatalog,
-        catalogLibrary: mockCatalogLibrary,
-        setSelectedCatalog: mockSetSelectedCatalog,
-      },
-      SourceSchemaType.Route,
-    );
-
-    const trigger = await findByTestId('viz-dsl-list-dropdown');
-
-    /** Open Select */
-    act(() => {
-      fireEvent.click(trigger);
-    });
-
-    /** Select Pipe option (another Camel type) */
-    act(() => {
-      const element = getByText('Pipe');
-      fireEvent.click(element);
-    });
-
-    /** Confirm the modal */
-    const confirmButton = await findByTestId('confirmation-modal-confirm');
-    act(() => {
-      fireEvent.click(confirmButton);
-    });
-
-    /** Verify catalog was NOT updated since both are Camel types */
+    /** Verify the reactive chain is triggered via setCodeAndNotify, not directly via setSelectedCatalog */
+    expect(mockSetCodeAndNotify).toHaveBeenCalled();
     expect(mockSetSelectedCatalog).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
@@ -1,19 +1,15 @@
-import { isDefined } from '@kaoto/forms';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, PropsWithChildren, useCallback, useContext, useState } from 'react';
 
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
-import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { ISourceSchema, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
 import { FlowTemplateService } from '../../../../models/visualization/flows/support/flow-templates-service';
 import { SourceCodeApiContext } from '../../../../providers';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
-import { findCatalog, requiresCatalogChange } from '../../../../utils/catalog-helper';
 import { FlowTypeSelector } from './FlowTypeSelector';
 
 export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
-  const runtimeContext = useRuntimeContext();
   const sourceCodeContextApi = useContext(SourceCodeApiContext);
   const { currentSchemaType, camelResource, updateEntitiesFromCamelResource } = useEntityContext();
   const currentFlowType: ISourceSchema = sourceSchemaConfig.config[currentSchemaType];
@@ -84,16 +80,6 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
             onClick={() => {
               if (proposedFlowType) {
                 sourceCodeContextApi.setCodeAndNotify(FlowTemplateService.getFlowYamlTemplate(proposedFlowType));
-
-                // Update catalog if needed when switching flow types
-                const changeCatalog = requiresCatalogChange(proposedFlowType, runtimeContext.selectedCatalog);
-                if (changeCatalog) {
-                  const matchingCatalog = findCatalog(proposedFlowType, runtimeContext.catalogLibrary);
-                  if (isDefined(matchingCatalog)) {
-                    runtimeContext.setSelectedCatalog(matchingCatalog);
-                  }
-                }
-
                 setIsConfirmationModalOpen(false);
               }
             }}

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -96,10 +96,6 @@ export abstract class CamelKResource implements KaotoResource {
     return undefined;
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Main', 'Quarkus', 'Spring Boot'];
-  }
-
   getSerializerType() {
     return this.serializer.getType();
   }

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -820,29 +820,6 @@ describe('CamelRouteResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new CamelRouteResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new CamelRouteResource();
-      const resourceWithRoutes = new CamelRouteResource([camelRouteJson, camelFromJson]);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithRoutes.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new CamelRouteResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   describe('edge cases and error handling', () => {
     it('should handle empty entities array in constructor', () => {
       const resource = new CamelRouteResource([]);

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -832,29 +832,6 @@ describe('CamelRouteResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new CamelRouteResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new CamelRouteResource();
-      const resourceWithRoutes = new CamelRouteResource([camelRouteJson, camelFromJson]);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithRoutes.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new CamelRouteResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   describe('edge cases and error handling', () => {
     it('should handle empty entities array in constructor', () => {
       const resource = new CamelRouteResource([]);

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -279,10 +279,6 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     return CamelComponentFilterService.getCamelCompatibleComponents(mode, visualEntityData, definition);
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Main', 'Quarkus', 'Spring Boot'];
-  }
-
   private getEntity(rawItem: unknown): BaseEntity | undefined {
     if (!isDefined(rawItem) || Array.isArray(rawItem)) {
       return undefined;

--- a/packages/ui/src/models/camel/compatible-runtimes.test.ts
+++ b/packages/ui/src/models/camel/compatible-runtimes.test.ts
@@ -1,0 +1,30 @@
+import { COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE } from './compatible-runtimes';
+import { SourceSchemaType } from './source-schema-type';
+
+describe('COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE', () => {
+  it('has a non-empty entry for every SourceSchemaType enum value', () => {
+    for (const type of Object.values(SourceSchemaType)) {
+      const entry = COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[type];
+      expect(entry).toBeDefined();
+      expect(entry.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('maps Test to Citrus only', () => {
+    expect(COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[SourceSchemaType.Test]).toEqual(['Citrus']);
+  });
+
+  it('maps Camel-family types to the same set of runtimes', () => {
+    const camelFamily = [
+      SourceSchemaType.Route,
+      SourceSchemaType.Integration,
+      SourceSchemaType.Kamelet,
+      SourceSchemaType.Pipe,
+      SourceSchemaType.KameletBinding,
+    ];
+    const expected = ['Main', 'Quarkus', 'Spring Boot'];
+    for (const type of camelFamily) {
+      expect(COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[type]).toEqual(expected);
+    }
+  });
+});

--- a/packages/ui/src/models/camel/compatible-runtimes.ts
+++ b/packages/ui/src/models/camel/compatible-runtimes.ts
@@ -1,0 +1,18 @@
+import { SourceSchemaType } from './source-schema-type';
+
+/**
+ * Registry mapping each resource schema type to the catalog runtimes it is
+ * compatible with. This is the single source of truth for the "which catalog
+ * goes with which resource" decision.
+ *
+ * Runtime strings match `CatalogLibraryEntry.runtime` values used by the
+ * catalog library index.
+ */
+export const COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE: Record<SourceSchemaType, readonly string[]> = {
+  [SourceSchemaType.Route]: ['Main', 'Quarkus', 'Spring Boot'],
+  [SourceSchemaType.Integration]: ['Main', 'Quarkus', 'Spring Boot'],
+  [SourceSchemaType.Kamelet]: ['Main', 'Quarkus', 'Spring Boot'],
+  [SourceSchemaType.Pipe]: ['Main', 'Quarkus', 'Spring Boot'],
+  [SourceSchemaType.KameletBinding]: ['Main', 'Quarkus', 'Spring Boot'],
+  [SourceSchemaType.Test]: ['Citrus'],
+};

--- a/packages/ui/src/models/camel/detect-schema-type.test.ts
+++ b/packages/ui/src/models/camel/detect-schema-type.test.ts
@@ -1,0 +1,99 @@
+import { CamelResourceFactory } from './camel-resource-factory';
+import { detectSchemaType } from './detect-schema-type';
+import { SourceSchemaType } from './source-schema-type';
+
+const ROUTE_YAML = `
+- route:
+    id: demo-route
+    from:
+      uri: timer:hello
+      steps:
+        - log: hello
+`;
+
+const KAMELET_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: my-kamelet
+spec: {}
+`;
+
+const PIPE_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: my-pipe
+`;
+
+const INTEGRATION_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: my-integration
+`;
+
+const KAMELET_BINDING_YAML = `
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: my-binding
+`;
+
+const CITRUS_YAML = `
+name: sample-test
+actions:
+  - echo:
+      message: hello
+`;
+
+const XML_ROUTE = `<camel>
+  <route id="demo-route">
+    <from uri="timer:hello"/>
+    <log message="hello"/>
+  </route>
+</camel>`;
+
+describe('detectSchemaType', () => {
+  describe('parity with CamelResourceFactory', () => {
+    const cases: Array<{ name: string; source?: string; path?: string }> = [
+      { name: 'empty source, no path', source: '', path: undefined },
+      { name: 'empty source, .kamelet.yaml path', source: '', path: 'foo.kamelet.yaml' },
+      { name: 'empty source, .pipe.yaml path', source: '', path: 'foo.pipe.yaml' },
+      { name: 'empty source, .integration.yaml path', source: '', path: 'foo.integration.yaml' },
+      { name: 'empty source, .kamelet-binding.yaml path', source: '', path: 'foo.kamelet-binding.yaml' },
+      { name: 'empty source, .citrus.yaml path', source: '', path: 'foo.citrus.yaml' },
+      { name: 'empty source, .yaml path', source: '', path: 'foo.yaml' },
+      { name: 'route yaml, no path', source: ROUTE_YAML, path: undefined },
+      { name: 'kamelet yaml, no path', source: KAMELET_YAML, path: undefined },
+      { name: 'pipe yaml, no path', source: PIPE_YAML, path: undefined },
+      { name: 'integration yaml, no path', source: INTEGRATION_YAML, path: undefined },
+      { name: 'kamelet-binding yaml, no path', source: KAMELET_BINDING_YAML, path: undefined },
+      { name: 'citrus yaml, no path', source: CITRUS_YAML, path: undefined },
+      { name: 'xml route, no path', source: XML_ROUTE, path: undefined },
+      { name: 'xml route, .xml path', source: XML_ROUTE, path: 'foo.xml' },
+    ];
+
+    for (const testCase of cases) {
+      it(testCase.name, () => {
+        const factoryType = CamelResourceFactory.createCamelResource(testCase.source, {
+          path: testCase.path,
+        }).getType();
+        const detectedType = detectSchemaType(testCase.source, testCase.path);
+        expect(detectedType).toEqual(factoryType);
+      });
+    }
+  });
+
+  it('returns Route for undefined source and no path', () => {
+    expect(detectSchemaType()).toEqual(SourceSchemaType.Route);
+  });
+
+  it('prefers path-based Test detection over content', () => {
+    expect(detectSchemaType(ROUTE_YAML, 'foo.citrus.yaml')).toEqual(SourceSchemaType.Test);
+  });
+
+  it('falls back to content-based Citrus detection when path is ambiguous', () => {
+    expect(detectSchemaType(CITRUS_YAML, 'foo.yaml')).toEqual(SourceSchemaType.Test);
+  });
+});

--- a/packages/ui/src/models/camel/detect-schema-type.test.ts
+++ b/packages/ui/src/models/camel/detect-schema-type.test.ts
@@ -1,0 +1,99 @@
+import { CamelResourceFactory } from './camel-resource-factory';
+import { detectSchemaType } from './detect-schema-type';
+import { SourceSchemaType } from './source-schema-type';
+
+const ROUTE_YAML = `
+- route:
+    id: demo-route
+    from:
+      uri: timer:hello
+      steps:
+        - log: hello
+`;
+
+const KAMELET_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: my-kamelet
+spec: {}
+`;
+
+const PIPE_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: my-pipe
+`;
+
+const INTEGRATION_YAML = `
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: my-integration
+`;
+
+const KAMELET_BINDING_YAML = `
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: my-binding
+`;
+
+const CITRUS_YAML = `
+name: sample-test
+actions:
+  - echo:
+      message: hello
+`;
+
+const XML_ROUTE = `<camel>
+  <route id="demo-route">
+    <from uri="timer:hello"/>
+    <log message="hello"/>
+  </route>
+</camel>`;
+
+describe('detectSchemaType', () => {
+  describe('parity with CamelResourceFactory', () => {
+    const cases: Array<{ name: string; source?: string; path?: string }> = [
+      { name: 'empty source, no path', source: '', path: undefined },
+      { name: 'empty source, .kamelet.yaml path', source: '', path: 'foo.kamelet.yaml' },
+      { name: 'empty source, .pipe.yaml path', source: '', path: 'foo.pipe.yaml' },
+      { name: 'empty source, .integration.yaml path', source: '', path: 'foo.integration.yaml' },
+      { name: 'empty source, .kamelet-binding.yaml path', source: '', path: 'foo.kamelet-binding.yaml' },
+      { name: 'empty source, .citrus.yaml path', source: '', path: 'foo.citrus.yaml' },
+      { name: 'empty source, .yaml path', source: '', path: 'foo.yaml' },
+      { name: 'route yaml, no path', source: ROUTE_YAML, path: undefined },
+      { name: 'kamelet yaml, no path', source: KAMELET_YAML, path: undefined },
+      { name: 'pipe yaml, no path', source: PIPE_YAML, path: undefined },
+      { name: 'integration yaml, no path', source: INTEGRATION_YAML, path: undefined },
+      { name: 'kamelet-binding yaml, no path', source: KAMELET_BINDING_YAML, path: undefined },
+      { name: 'citrus yaml, no path', source: CITRUS_YAML, path: undefined },
+      { name: 'xml route, no path', source: XML_ROUTE, path: undefined },
+      { name: 'xml route, .xml path', source: XML_ROUTE, path: 'foo.xml' },
+    ];
+
+    for (const testCase of cases) {
+      it(testCase.name, () => {
+        const factoryType = CamelResourceFactory.createCamelResource(testCase.source, {
+          path: testCase.path,
+        }).getType();
+        const detectedType = detectSchemaType(testCase.source, testCase.path);
+        expect(detectedType).toEqual(factoryType);
+      });
+    }
+  });
+
+  it('returns Route for undefined source and no path', () => {
+    expect(detectSchemaType(undefined, undefined)).toEqual(SourceSchemaType.Route);
+  });
+
+  it('prefers path-based Test detection over content', () => {
+    expect(detectSchemaType(ROUTE_YAML, 'foo.citrus.yaml')).toEqual(SourceSchemaType.Test);
+  });
+
+  it('falls back to content-based Citrus detection when path is ambiguous', () => {
+    expect(detectSchemaType(CITRUS_YAML, 'foo.yaml')).toEqual(SourceSchemaType.Test);
+  });
+});

--- a/packages/ui/src/models/camel/detect-schema-type.ts
+++ b/packages/ui/src/models/camel/detect-schema-type.ts
@@ -1,0 +1,90 @@
+import { isDefined } from '@kaoto/forms';
+
+import { XmlCamelResourceSerializer, YamlCamelResourceSerializer } from '../../serializers';
+import { KaotoResourceSerializer } from '../kaoto-resource';
+import { getResourceTypeFromPath, SourceSchemaType } from './source-schema-type';
+
+/**
+ * Detects the resource schema type of a given source without instantiating a
+ * full `KaotoResource`. Used where the schema type is needed but constructing
+ * the resource would be wasteful or premature (for example, when selecting a
+ * catalog before the entities provider has mounted).
+ *
+ * Detection mirrors the precedence used by `CamelResourceFactory.createCamelResource`:
+ * 1. Path-based hint (extensions such as `.kamelet.yaml`, `.citrus.yaml`, etc.).
+ * 2. Content inspection: Citrus tests via an `actions` array, Camel-K resources
+ *    via the `kind` field, otherwise fall back to `Route`.
+ *
+ * A parity test asserts this function agrees with
+ * `CamelResourceFactory.createCamelResource(...).getType()` across all known
+ * shapes.
+ */
+export const detectSchemaType = (source?: string, path?: string): SourceSchemaType => {
+  const pathType = getResourceTypeFromPath(path);
+
+  if (pathType === SourceSchemaType.Test) {
+    return SourceSchemaType.Test;
+  }
+
+  const parsed = parseSource(source, path);
+
+  if (isCitrusShape(parsed, pathType)) {
+    return SourceSchemaType.Test;
+  }
+
+  const camelKType = detectCamelKKind(parsed, pathType);
+  if (camelKType) {
+    return camelKType;
+  }
+
+  return pathType ?? SourceSchemaType.Route;
+};
+
+const parseSource = (source?: string, path?: string): unknown => {
+  if (typeof source !== 'string' || source.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const serializer = pickSerializer(source, path);
+    return serializer.parse(source);
+  } catch {
+    return undefined;
+  }
+};
+
+const pickSerializer = (source: string, path?: string): KaotoResourceSerializer => {
+  if (!path) {
+    return XmlCamelResourceSerializer.isApplicable(source)
+      ? new XmlCamelResourceSerializer()
+      : new YamlCamelResourceSerializer();
+  }
+
+  return path.endsWith('.xml') ? new XmlCamelResourceSerializer() : new YamlCamelResourceSerializer();
+};
+
+const isCitrusShape = (parsed: unknown, pathType?: SourceSchemaType): boolean => {
+  if (pathType === SourceSchemaType.Test) return true;
+  if (!isDefined(parsed) || Array.isArray(parsed) || typeof parsed !== 'object') return false;
+  const actions = (parsed as { actions?: unknown }).actions;
+  return Array.isArray(actions);
+};
+
+const detectCamelKKind = (parsed: unknown, pathType?: SourceSchemaType): SourceSchemaType | undefined => {
+  const record =
+    isDefined(parsed) && !Array.isArray(parsed) && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : {};
+  const kind = record['kind'] ?? pathType;
+
+  if (
+    kind === SourceSchemaType.Integration ||
+    kind === SourceSchemaType.Kamelet ||
+    kind === SourceSchemaType.KameletBinding ||
+    kind === SourceSchemaType.Pipe
+  ) {
+    return kind;
+  }
+
+  return undefined;
+};

--- a/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
@@ -14,29 +14,6 @@ describe('KameletBindingResource', () => {
     expect(resource.getEntities().length).toEqual(2);
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new KameletBindingResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new KameletBindingResource();
-      const resourceWithBinding = new KameletBindingResource(kameletBindingJson);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithBinding.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new KameletBindingResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should initialize KameletBinding if no args is specified', () => {
     const resource = new KameletBindingResource(undefined);
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -101,29 +101,6 @@ describe('KameletResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const kameletResource = new KameletResource();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new KameletResource();
-      const resourceWithKamelet = new KameletResource(kameletJson);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const kameletResource = new KameletResource();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should support RouteTemplateBeansAwareResource methods', () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -113,29 +113,6 @@ describe('KameletResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const kameletResource = new KameletResource();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new KameletResource();
-      const resourceWithKamelet = new KameletResource(kameletJson);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const kameletResource = new KameletResource();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should support RouteTemplateBeansAwareResource methods', () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -29,29 +29,6 @@ describe('PipeResource', () => {
     expect(vis.pipe.spec?.sink).toBeUndefined();
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new PipeResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new PipeResource();
-      const resourceWithPipe = new PipeResource(pipeJson);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithPipe.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new PipeResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should create/delete entities', () => {
     const resource = new PipeResource();
     expect(resource.getEntities().length).toEqual(0);

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -220,29 +220,6 @@ describe('CitrusTestResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new CitrusTestResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Citrus']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new CitrusTestResource();
-      const resourceWithTest = new CitrusTestResource(citrusTestJson);
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithTest.getCompatibleRuntimes());
-    });
-
-    it('should return an array with one runtime name', () => {
-      const resource = new CitrusTestResource();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Citrus']);
-    });
-  });
-
   describe('getCompatibleComponents', () => {
     it('should get compatible types', () => {
       const resource = new CitrusTestResource(citrusTestJson);

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -219,10 +219,6 @@ export class CitrusTestResource implements KaotoResource {
     };
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Citrus'];
-  }
-
   /**
    * Converts a raw item to a BaseCamelEntity.
    *

--- a/packages/ui/src/models/kaoto-resource.ts
+++ b/packages/ui/src/models/kaoto-resource.ts
@@ -28,13 +28,6 @@ export interface KaotoResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter | undefined;
-
-  /**
-   * Returns the list of compatible runtime catalog names for this resource type.
-   * For example, CamelRouteResource returns ["Main", "Quarkus", "Spring Boot"],
-   * while CitrusTestResource returns ["Citrus"].
-   */
-  getCompatibleRuntimes(): string[];
 }
 
 export enum SerializerType {

--- a/packages/ui/src/providers/runtime.provider.test.tsx
+++ b/packages/ui/src/providers/runtime.provider.test.tsx
@@ -1,11 +1,45 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { act, render, screen } from '@testing-library/react';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
+import { SourceSchemaType } from '../models/camel';
+import { LocalStorageKeys } from '../models/local-storage-keys';
+import { useSourceCodeStore } from '../store';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
 import { ReloadContext } from './reload.provider';
-import { RuntimeProvider } from './runtime.provider';
+import { RuntimeContext, RuntimeProvider } from './runtime.provider';
+import { SourceCodeProvider } from './source-code.provider';
 
-describe('RuntimeProvider', () => {
+const camelEntry = {
+  name: 'Camel Main 1.0.0.redhat-00001',
+  runtime: 'Main',
+  version: '1.0.0.redhat-00001',
+  fileName: 'camel-main/index.js',
+};
+
+const citrusEntry = {
+  name: 'Citrus 1.0.0',
+  runtime: 'Citrus',
+  version: '1.0.0',
+  fileName: 'citrus/1.0.0/index.js',
+};
+
+const mockCatalogLibrary: CatalogLibrary = {
+  name: 'Catalog',
+  version: 1,
+  definitions: [camelEntry, citrusEntry],
+} as unknown as CatalogLibrary;
+
+/**
+ * A valid Citrus YAML: the root object must have an 'actions' array
+ * (not wrapped in an array) for CitrusTestResourceFactory to detect it.
+ */
+const CITRUS_YAML = `
+name: sample-test
+actions: []
+`;
+
+describe('RuntimeProvider — loading states (existing tests)', () => {
   let fetchMock: jest.SpyInstance;
   let fetchResolve: () => void;
   let fetchReject: () => void;
@@ -92,5 +126,84 @@ describe('RuntimeProvider', () => {
     });
 
     expect(screen.getByTestId('library-loaded')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Integration tests for compatibility-based catalog selection.
+ *
+ * The hierarchy here matches production: SourceCodeProvider wraps
+ * RuntimeProvider. RuntimeProvider derives the compatible-runtimes signal
+ * by calling `detectSchemaType` on the source code + path, then looking
+ * up the static `COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE` registry.
+ */
+describe('RuntimeProvider — catalog selection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSourceCodeStore.getState().setSourceCode('');
+    useSourceCodeStore.getState().setPath(undefined);
+    (global as unknown as { fetch: jest.Mock }).fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve(mockCatalogLibrary) });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderWithSource = (sourceCode: string) => {
+    const captured: { selectedCatalog?: { name: string } } = {};
+    const Capture = () => (
+      <RuntimeContext.Consumer>
+        {(ctx) => {
+          if (ctx?.selectedCatalog) {
+            captured.selectedCatalog = ctx.selectedCatalog as { name: string };
+          }
+          return null;
+        }}
+      </RuntimeContext.Consumer>
+    );
+    render(
+      <SourceCodeProvider initialSourceCode={sourceCode}>
+        <RuntimeProvider catalogUrl="http://fake/index.json">
+          <Capture />
+        </RuntimeProvider>
+      </SourceCodeProvider>,
+    );
+    return captured;
+  };
+
+  it('picks a compatible catalog when no value is persisted', async () => {
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('uses the persisted catalog when it is compatible with the current resource', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: camelEntry }));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('ignores an incompatible persisted catalog and falls back to findCatalog', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: citrusEntry }));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('ignores the legacy single-entry shape and selects the compatible catalog', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(citrusEntry));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('selects the Citrus catalog when loading a Citrus resource', async () => {
+    const captured = renderWithSource(CITRUS_YAML);
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(citrusEntry.name));
+  });
+
+  it('selects the Citrus catalog for a Citrus resource even when a Camel catalog is persisted', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: camelEntry }));
+    const captured = renderWithSource(CITRUS_YAML);
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(citrusEntry.name));
   });
 });

--- a/packages/ui/src/providers/runtime.provider.test.tsx
+++ b/packages/ui/src/providers/runtime.provider.test.tsx
@@ -1,23 +1,57 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { act, render, screen } from '@testing-library/react';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
+import { SourceSchemaType } from '../models/camel';
+import { LocalStorageKeys } from '../models/local-storage-keys';
+import { useSourceCodeStore } from '../store';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
 import { ReloadContext } from './reload.provider';
-import { RuntimeProvider } from './runtime.provider';
+import { RuntimeContext, RuntimeProvider } from './runtime.provider';
+import { SourceCodeProvider } from './source-code.provider';
 
-describe('RuntimeProvider', () => {
+const camelEntry = {
+  name: 'Camel Main 1.0.0.redhat-00001',
+  runtime: 'Main',
+  version: '1.0.0.redhat-00001',
+  fileName: 'camel-main/index.js',
+};
+
+const citrusEntry = {
+  name: 'Citrus 1.0.0',
+  runtime: 'Citrus',
+  version: '1.0.0',
+  fileName: 'citrus/1.0.0/index.js',
+};
+
+const mockCatalogLibrary: CatalogLibrary = {
+  name: 'Catalog',
+  version: 1,
+  definitions: [camelEntry, citrusEntry],
+} as unknown as CatalogLibrary;
+
+/**
+ * A valid Citrus YAML: the root object must have an 'actions' array
+ * (not wrapped in an array) for CitrusTestResourceFactory to detect it.
+ */
+const CITRUS_YAML = `
+name: sample-test
+actions: []
+`;
+
+describe('RuntimeProvider — loading states (existing tests)', () => {
   let fetchMock: jest.SpyInstance;
   let fetchResolve: () => void;
   let fetchReject: () => void;
 
   beforeEach(() => {
-    fetchMock = jest.spyOn(window, 'fetch');
+    fetchMock = jest.spyOn(globalThis, 'fetch');
     fetchMock.mockImplementationOnce((file) => {
       return new Promise((resolve, reject) => {
         fetchResolve = () => {
           resolve({
             json: () => catalogLibrary,
-            url: `http://localhost/${file}`,
+            url: `https://localhost/${file}`,
           } as unknown as Response);
         };
         fetchReject = () => {
@@ -92,5 +126,84 @@ describe('RuntimeProvider', () => {
     });
 
     expect(screen.getByTestId('library-loaded')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Integration tests for compatibility-based catalog selection.
+ *
+ * The hierarchy here matches production: SourceCodeProvider wraps
+ * RuntimeProvider. RuntimeProvider derives the compatible-runtimes signal
+ * by calling `detectSchemaType` on the source code + path, then looking
+ * up the static `COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE` registry.
+ */
+describe('RuntimeProvider — catalog selection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSourceCodeStore.getState().setSourceCode('');
+    useSourceCodeStore.getState().setPath(undefined);
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve(mockCatalogLibrary) });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderWithSource = (sourceCode: string) => {
+    const captured: { selectedCatalog?: { name: string } } = {};
+    const Capture = () => (
+      <RuntimeContext.Consumer>
+        {(ctx) => {
+          if (ctx?.selectedCatalog) {
+            captured.selectedCatalog = ctx.selectedCatalog as { name: string };
+          }
+          return null;
+        }}
+      </RuntimeContext.Consumer>
+    );
+    render(
+      <SourceCodeProvider initialSourceCode={sourceCode}>
+        <RuntimeProvider catalogUrl="https://fake/index.json">
+          <Capture />
+        </RuntimeProvider>
+      </SourceCodeProvider>,
+    );
+    return captured;
+  };
+
+  it('picks a compatible catalog when no value is persisted', async () => {
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('uses the persisted catalog when it is compatible with the current resource', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: camelEntry }));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('ignores an incompatible persisted catalog and falls back to findCatalog', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: citrusEntry }));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('ignores the legacy single-entry shape and selects the compatible catalog', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(citrusEntry));
+    const captured = renderWithSource('');
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(camelEntry.name));
+  });
+
+  it('selects the Citrus catalog when loading a Citrus resource', async () => {
+    const captured = renderWithSource(CITRUS_YAML);
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(citrusEntry.name));
+  });
+
+  it('selects the Citrus catalog for a Citrus resource even when a Camel catalog is persisted', async () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Route]: camelEntry }));
+    const captured = renderWithSource(CITRUS_YAML);
+    await waitFor(() => expect(captured.selectedCatalog?.name).toEqual(citrusEntry.name));
   });
 });

--- a/packages/ui/src/providers/runtime.provider.tsx
+++ b/packages/ui/src/providers/runtime.provider.tsx
@@ -1,14 +1,26 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { Content, ContentVariants } from '@patternfly/react-core';
-import { createContext, FunctionComponent, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import { LoadDefaultCatalog } from '../components/LoadDefaultCatalog';
 import { Loading } from '../components/Loading';
-import { LoadingStatus, LocalStorageKeys } from '../models';
-import { SourceSchemaType } from '../models/camel';
-import { findCatalog } from '../utils/catalog-helper';
-import { EntitiesContext } from './entities.provider';
+import { LoadingStatus } from '../models';
+import { COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE } from '../models/camel/compatible-runtimes';
+import { detectSchemaType } from '../models/camel/detect-schema-type';
+import { useSourceCodeStore } from '../store';
+import { findCatalog, isCatalogCompatible } from '../utils/catalog-helper';
+import { getPersistedCatalog, setPersistedCatalog } from '../utils/catalog-storage';
+import { SourceCodeContext } from './source-code.provider';
 
 export interface IRuntimeContext {
   basePath: string;
@@ -21,23 +33,38 @@ export const RuntimeContext = createContext<IRuntimeContext | undefined>(undefin
 
 /**
  * Loader for the available Catalog library.
+ *
+ * The compatible-runtimes signal is derived from the current source code and
+ * path via `detectSchemaType` + the static compatible-runtimes registry. This
+ * keeps `RuntimeProvider` independent of `EntitiesContext`, allowing the
+ * existing provider hierarchy (EntitiesProvider nested inside the catalog
+ * loaders) to remain in place so visual entities are always computed against
+ * a populated `CamelCatalogService`.
  */
 export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: string }>> = (props) => {
   const [loadingStatus, setLoadingStatus] = useState(LoadingStatus.Loading);
   const [errorMessage, setErrorMessage] = useState('');
   const [catalogLibrary, setCatalogLibrary] = useState<CatalogLibrary | undefined>(undefined);
-  const entitiesContext = useContext(EntitiesContext);
-  const currentSchemaType = entitiesContext?.currentSchemaType || SourceSchemaType.Route;
-  let localSelectedCatalog: CatalogLibraryEntry | undefined = undefined;
 
-  try {
-    localSelectedCatalog = JSON.parse(localStorage.getItem(LocalStorageKeys.SelectedCatalog) ?? 'undefined');
-  } catch (error) {
-    localSelectedCatalog = undefined;
-  }
+  const sourceCode = useContext(SourceCodeContext);
+  const path = useSourceCodeStore((state) => state.path);
 
-  const [selectedCatalog, setSelectedCatalog] = useState<CatalogLibraryEntry | undefined>(localSelectedCatalog);
+  const schemaType = useMemo(() => detectSchemaType(sourceCode, path), [sourceCode, path]);
+  const compatibleRuntimes = COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[schemaType];
+  const compatibleRuntimesKey = [...compatibleRuntimes].sort().join('|');
+
+  const [selectedCatalog, setSelectedCatalogState] = useState<CatalogLibraryEntry | undefined>(undefined);
   const basePath = props.catalogUrl.substring(0, props.catalogUrl.lastIndexOf('/'));
+
+  const setSelectedCatalog = useCallback(
+    (catalog: CatalogLibraryEntry | undefined) => {
+      setSelectedCatalogState(catalog);
+      if (isDefined(catalog)) {
+        setPersistedCatalog(schemaType, catalog);
+      }
+    },
+    [schemaType],
+  );
 
   useEffect(() => {
     fetch(props.catalogUrl)
@@ -45,20 +72,23 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
         setLoadingStatus(LoadingStatus.Loading);
         return response.json();
       })
-      .then((catalogLibrary: CatalogLibrary) => {
-        let catalogLibraryEntry: CatalogLibraryEntry | undefined = undefined;
-        if (isDefined(selectedCatalog)) {
-          catalogLibraryEntry = catalogLibrary.definitions.find(
-            (c: CatalogLibraryEntry) => c.name === selectedCatalog.name,
-          );
-        }
-        if (!isDefined(catalogLibraryEntry)) {
-          catalogLibraryEntry = findCatalog(currentSchemaType, catalogLibrary);
+      .then((library: CatalogLibrary) => {
+        const persisted = getPersistedCatalog(schemaType);
+
+        let resolved: CatalogLibraryEntry | undefined;
+        if (
+          isDefined(persisted) &&
+          isCatalogCompatible(persisted, compatibleRuntimes) &&
+          library.definitions.some((c) => c.name === persisted.name)
+        ) {
+          resolved = persisted;
+        } else {
+          resolved = findCatalog(compatibleRuntimes, library);
         }
 
-        setCatalogLibrary(catalogLibrary);
-        if (isDefined(catalogLibraryEntry)) {
-          setSelectedCatalog(catalogLibraryEntry);
+        setCatalogLibrary(library);
+        if (isDefined(resolved)) {
+          setSelectedCatalogState(resolved);
         }
       })
       .then(() => {
@@ -69,7 +99,7 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
         setLoadingStatus(LoadingStatus.Error);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentSchemaType]);
+  }, [schemaType, compatibleRuntimesKey]);
 
   const runtimeContext: IRuntimeContext = useMemo(
     () => ({
@@ -78,7 +108,7 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
       selectedCatalog,
       setSelectedCatalog,
     }),
-    [basePath, catalogLibrary, selectedCatalog],
+    [basePath, catalogLibrary, selectedCatalog, setSelectedCatalog],
   );
 
   return (

--- a/packages/ui/src/providers/runtime.provider.tsx
+++ b/packages/ui/src/providers/runtime.provider.tsx
@@ -1,14 +1,26 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { Content, ContentVariants } from '@patternfly/react-core';
-import { createContext, FunctionComponent, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import { LoadDefaultCatalog } from '../components/LoadDefaultCatalog';
 import { Loading } from '../components/Loading';
-import { LoadingStatus, LocalStorageKeys } from '../models';
-import { SourceSchemaType } from '../models/camel';
-import { findCatalog } from '../utils/catalog-helper';
-import { EntitiesContext } from './entities.provider';
+import { LoadingStatus } from '../models';
+import { COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE } from '../models/camel/compatible-runtimes';
+import { detectSchemaType } from '../models/camel/detect-schema-type';
+import { useSourceCodeStore } from '../store';
+import { findCatalog, isCatalogCompatible } from '../utils/catalog-helper';
+import { getPersistedCatalog, setPersistedCatalog } from '../utils/catalog-storage';
+import { SourceCodeContext } from './source-code.provider';
 
 export interface IRuntimeContext {
   basePath: string;
@@ -21,23 +33,38 @@ export const RuntimeContext = createContext<IRuntimeContext | undefined>(undefin
 
 /**
  * Loader for the available Catalog library.
+ *
+ * The compatible-runtimes signal is derived from the current source code and
+ * path via `detectSchemaType` + the static compatible-runtimes registry. This
+ * keeps `RuntimeProvider` independent of `EntitiesContext`, allowing the
+ * existing provider hierarchy (EntitiesProvider nested inside the catalog
+ * loaders) to remain in place so visual entities are always computed against
+ * a populated `CamelCatalogService`.
  */
 export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: string }>> = (props) => {
   const [loadingStatus, setLoadingStatus] = useState(LoadingStatus.Loading);
   const [errorMessage, setErrorMessage] = useState('');
   const [catalogLibrary, setCatalogLibrary] = useState<CatalogLibrary | undefined>(undefined);
-  const entitiesContext = useContext(EntitiesContext);
-  const currentSchemaType = entitiesContext?.currentSchemaType || SourceSchemaType.Route;
-  let localSelectedCatalog: CatalogLibraryEntry | undefined = undefined;
 
-  try {
-    localSelectedCatalog = JSON.parse(localStorage.getItem(LocalStorageKeys.SelectedCatalog) ?? 'undefined');
-  } catch (error) {
-    localSelectedCatalog = undefined;
-  }
+  const sourceCode = useContext(SourceCodeContext);
+  const path = useSourceCodeStore((state) => state.path);
 
-  const [selectedCatalog, setSelectedCatalog] = useState<CatalogLibraryEntry | undefined>(localSelectedCatalog);
+  const schemaType = useMemo(() => detectSchemaType(sourceCode, path), [sourceCode, path]);
+  const compatibleRuntimes = COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE[schemaType];
+  const compatibleRuntimesKey = [...compatibleRuntimes].sort((a, b) => a.localeCompare(b)).join('|');
+
+  const [selectedCatalog, setSelectedCatalog] = useState<CatalogLibraryEntry | undefined>(undefined);
   const basePath = props.catalogUrl.substring(0, props.catalogUrl.lastIndexOf('/'));
+
+  const setCatalog = useCallback(
+    (catalog: CatalogLibraryEntry | undefined) => {
+      setSelectedCatalog(catalog);
+      if (isDefined(catalog)) {
+        setPersistedCatalog(schemaType, catalog);
+      }
+    },
+    [schemaType],
+  );
 
   useEffect(() => {
     fetch(props.catalogUrl)
@@ -45,20 +72,23 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
         setLoadingStatus(LoadingStatus.Loading);
         return response.json();
       })
-      .then((catalogLibrary: CatalogLibrary) => {
-        let catalogLibraryEntry: CatalogLibraryEntry | undefined = undefined;
-        if (isDefined(selectedCatalog)) {
-          catalogLibraryEntry = catalogLibrary.definitions.find(
-            (c: CatalogLibraryEntry) => c.name === selectedCatalog.name,
-          );
-        }
-        if (!isDefined(catalogLibraryEntry)) {
-          catalogLibraryEntry = findCatalog(currentSchemaType, catalogLibrary);
+      .then((library: CatalogLibrary) => {
+        const persisted = getPersistedCatalog(schemaType);
+
+        let resolved: CatalogLibraryEntry | undefined;
+        if (
+          isDefined(persisted) &&
+          isCatalogCompatible(persisted, compatibleRuntimes) &&
+          library.definitions.some((c) => c.name === persisted.name)
+        ) {
+          resolved = persisted;
+        } else {
+          resolved = findCatalog(compatibleRuntimes, library);
         }
 
-        setCatalogLibrary(catalogLibrary);
-        if (isDefined(catalogLibraryEntry)) {
-          setSelectedCatalog(catalogLibraryEntry);
+        setCatalogLibrary(library);
+        if (isDefined(resolved)) {
+          setSelectedCatalog(resolved);
         }
       })
       .then(() => {
@@ -69,16 +99,16 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
         setLoadingStatus(LoadingStatus.Error);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentSchemaType]);
+  }, [schemaType, compatibleRuntimesKey]);
 
   const runtimeContext: IRuntimeContext = useMemo(
     () => ({
       basePath,
       catalogLibrary,
       selectedCatalog,
-      setSelectedCatalog,
+      setSelectedCatalog: setCatalog,
     }),
-    [basePath, catalogLibrary, selectedCatalog],
+    [basePath, catalogLibrary, selectedCatalog, setCatalog],
   );
 
   return (

--- a/packages/ui/src/utils/catalog-helper.test.ts
+++ b/packages/ui/src/utils/catalog-helper.test.ts
@@ -1,9 +1,8 @@
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { SourceSchemaType } from '../models/camel';
-import { findCatalog } from './catalog-helper';
+import { findCatalog, isCatalogCompatible } from './catalog-helper';
 
-describe('CatalogHelper', () => {
+describe('CatalogHelper — findCatalog', () => {
   let catalogLibrary: CatalogLibrary;
 
   beforeEach(() => {
@@ -11,34 +10,22 @@ describe('CatalogHelper', () => {
       name: 'Catalog',
       version: 1,
       definitions: [
-        {
-          name: 'Camel Main 1.0.0',
-          runtime: 'Main',
-          version: '1.0.0',
-          fileName: 'camel-main/index.js',
-        },
-        {
-          name: 'Camel Quarkus 1.0.0',
-          runtime: 'Quarkus',
-          version: '1.0.0',
-          fileName: 'camel-quarkus/index.js',
-        },
-        {
-          name: 'Citrus 1.0.0',
-          runtime: 'Citrus',
-          version: '1.0.0',
-          fileName: 'citrus/1.0.0/index.js',
-        },
+        { name: 'Camel Main 1.0.0', runtime: 'Main', version: '1.0.0', fileName: 'camel-main/index.js' },
+        { name: 'Camel Quarkus 1.0.0', runtime: 'Quarkus', version: '1.0.0', fileName: 'camel-quarkus/index.js' },
+        { name: 'Citrus 1.0.0', runtime: 'Citrus', version: '1.0.0', fileName: 'citrus/1.0.0/index.js' },
       ],
     } as CatalogLibrary;
   });
 
-  it('should handle no matching Camel catalog', () => {
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeUndefined();
+  it('returns undefined when catalogLibrary is missing', () => {
+    expect(findCatalog(['Main'], undefined)).toBeUndefined();
   });
 
-  it('should find matching Camel catalog', () => {
+  it('returns undefined when no candidate matches the compatible runtimes', () => {
+    expect(findCatalog(['Spring Boot'], catalogLibrary)).toBeUndefined();
+  });
+
+  it('finds a matching Camel catalog when a redhat build is present', () => {
     catalogLibrary.definitions.push({
       name: 'Camel Main 1.0.0.redhat-00001',
       runtime: 'Main',
@@ -46,13 +33,12 @@ describe('CatalogHelper', () => {
       fileName: 'camel-main-redhat/index.js',
     });
 
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Main', 'Quarkus', 'Spring Boot'], catalogLibrary);
     expect(entry?.name).toEqual('Camel Main 1.0.0.redhat-00001');
     expect(entry?.runtime).toEqual('Main');
   });
 
-  it('should find matching Camel catalog latest version', () => {
+  it('prefers the latest version among redhat candidates', () => {
     catalogLibrary.definitions.push(
       {
         name: 'Camel Main 1.0.2.redhat-00002',
@@ -68,38 +54,50 @@ describe('CatalogHelper', () => {
       },
     );
 
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Main', 'Quarkus', 'Spring Boot'], catalogLibrary);
     expect(entry?.name).toEqual('Camel Main 1.0.3.redhat-00003');
-    expect(entry?.runtime).toEqual('Main');
   });
 
-  it('should find Citrus catalog', () => {
-    const entry = findCatalog(SourceSchemaType.Test, catalogLibrary);
-    expect(entry).toBeDefined();
+  it('falls back to non-redhat candidates when no redhat build exists for any compatible runtime', () => {
+    const entry = findCatalog(['Quarkus'], catalogLibrary);
+    expect(entry?.name).toEqual('Camel Quarkus 1.0.0');
+    expect(entry?.runtime).toEqual('Quarkus');
+  });
+
+  it('finds a Citrus catalog via the Citrus runtime', () => {
+    const entry = findCatalog(['Citrus'], catalogLibrary);
     expect(entry?.name).toEqual('Citrus 1.0.0');
     expect(entry?.runtime).toEqual('Citrus');
   });
 
-  it('should find matching Citrus catalog latest version', () => {
+  it('prefers the latest Citrus version', () => {
     catalogLibrary.definitions.push(
-      {
-        name: 'Citrus 1.0.2',
-        runtime: 'Citrus',
-        version: '1.0.2',
-        fileName: 'citrus/1.0.2/index.js',
-      },
-      {
-        name: 'Citrus 1.0.3',
-        runtime: 'Citrus',
-        version: '1.0.3',
-        fileName: 'citrus/1.0.3/index.js',
-      },
+      { name: 'Citrus 1.0.2', runtime: 'Citrus', version: '1.0.2', fileName: 'citrus/1.0.2/index.js' },
+      { name: 'Citrus 1.0.3', runtime: 'Citrus', version: '1.0.3', fileName: 'citrus/1.0.3/index.js' },
     );
 
-    const entry = findCatalog(SourceSchemaType.Test, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Citrus'], catalogLibrary);
     expect(entry?.name).toEqual('Citrus 1.0.3');
-    expect(entry?.runtime).toEqual('Citrus');
+  });
+});
+
+describe('CatalogHelper — isCatalogCompatible', () => {
+  const camel = { runtime: 'Main' } as never;
+  const citrus = { runtime: 'Citrus' } as never;
+
+  it('returns false when the catalog is undefined', () => {
+    expect(isCatalogCompatible(undefined, ['Main'])).toBe(false);
+  });
+
+  it('returns true when the catalog runtime is in the compatible list', () => {
+    expect(isCatalogCompatible(camel, ['Main', 'Quarkus', 'Spring Boot'])).toBe(true);
+  });
+
+  it('returns false when the catalog runtime is not in the compatible list', () => {
+    expect(isCatalogCompatible(citrus, ['Main', 'Quarkus', 'Spring Boot'])).toBe(false);
+  });
+
+  it('returns false when the compatible list is empty', () => {
+    expect(isCatalogCompatible(camel, [])).toBe(false);
   });
 });

--- a/packages/ui/src/utils/catalog-helper.test.ts
+++ b/packages/ui/src/utils/catalog-helper.test.ts
@@ -1,9 +1,8 @@
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { SourceSchemaType } from '../models/camel';
-import { findCatalog } from './catalog-helper';
+import { findCatalog, isCatalogCompatible } from './catalog-helper';
 
-describe('CatalogHelper', () => {
+describe('CatalogHelper — findCatalog', () => {
   let catalogLibrary: CatalogLibrary;
 
   beforeEach(() => {
@@ -11,34 +10,22 @@ describe('CatalogHelper', () => {
       name: 'Catalog',
       version: 1,
       definitions: [
-        {
-          name: 'Camel Main 1.0.0',
-          runtime: 'Main',
-          version: '1.0.0',
-          fileName: 'camel-main/index.js',
-        },
-        {
-          name: 'Camel Quarkus 1.0.0',
-          runtime: 'Quarkus',
-          version: '1.0.0',
-          fileName: 'camel-quarkus/index.js',
-        },
-        {
-          name: 'Citrus 1.0.0',
-          runtime: 'Citrus',
-          version: '1.0.0',
-          fileName: 'citrus/1.0.0/index.js',
-        },
+        { name: 'Camel Main 1.0.0', runtime: 'Main', version: '1.0.0', fileName: 'camel-main/index.js' },
+        { name: 'Camel Quarkus 1.0.0', runtime: 'Quarkus', version: '1.0.0', fileName: 'camel-quarkus/index.js' },
+        { name: 'Citrus 1.0.0', runtime: 'Citrus', version: '1.0.0', fileName: 'citrus/1.0.0/index.js' },
       ],
     } as CatalogLibrary;
   });
 
-  it('should handle no matching Camel catalog', () => {
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeUndefined();
+  it('returns undefined when catalogLibrary is missing', () => {
+    expect(findCatalog(['Main'])).toBeUndefined();
   });
 
-  it('should find matching Camel catalog', () => {
+  it('returns undefined when no candidate matches the compatible runtimes', () => {
+    expect(findCatalog(['Spring Boot'], catalogLibrary)).toBeUndefined();
+  });
+
+  it('finds a matching Camel catalog when a redhat build is present', () => {
     catalogLibrary.definitions.push({
       name: 'Camel Main 1.0.0.redhat-00001',
       runtime: 'Main',
@@ -46,13 +33,12 @@ describe('CatalogHelper', () => {
       fileName: 'camel-main-redhat/index.js',
     });
 
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Main', 'Quarkus', 'Spring Boot'], catalogLibrary);
     expect(entry?.name).toEqual('Camel Main 1.0.0.redhat-00001');
     expect(entry?.runtime).toEqual('Main');
   });
 
-  it('should find matching Camel catalog latest version', () => {
+  it('prefers the latest version among redhat candidates', () => {
     catalogLibrary.definitions.push(
       {
         name: 'Camel Main 1.0.2.redhat-00002',
@@ -68,38 +54,50 @@ describe('CatalogHelper', () => {
       },
     );
 
-    const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Main', 'Quarkus', 'Spring Boot'], catalogLibrary);
     expect(entry?.name).toEqual('Camel Main 1.0.3.redhat-00003');
-    expect(entry?.runtime).toEqual('Main');
   });
 
-  it('should find Citrus catalog', () => {
-    const entry = findCatalog(SourceSchemaType.Test, catalogLibrary);
-    expect(entry).toBeDefined();
+  it('falls back to non-redhat candidates when no redhat build exists for any compatible runtime', () => {
+    const entry = findCatalog(['Quarkus'], catalogLibrary);
+    expect(entry?.name).toEqual('Camel Quarkus 1.0.0');
+    expect(entry?.runtime).toEqual('Quarkus');
+  });
+
+  it('finds a Citrus catalog via the Citrus runtime', () => {
+    const entry = findCatalog(['Citrus'], catalogLibrary);
     expect(entry?.name).toEqual('Citrus 1.0.0');
     expect(entry?.runtime).toEqual('Citrus');
   });
 
-  it('should find matching Citrus catalog latest version', () => {
+  it('prefers the latest Citrus version', () => {
     catalogLibrary.definitions.push(
-      {
-        name: 'Citrus 1.0.2',
-        runtime: 'Citrus',
-        version: '1.0.2',
-        fileName: 'citrus/1.0.2/index.js',
-      },
-      {
-        name: 'Citrus 1.0.3',
-        runtime: 'Citrus',
-        version: '1.0.3',
-        fileName: 'citrus/1.0.3/index.js',
-      },
+      { name: 'Citrus 1.0.2', runtime: 'Citrus', version: '1.0.2', fileName: 'citrus/1.0.2/index.js' },
+      { name: 'Citrus 1.0.3', runtime: 'Citrus', version: '1.0.3', fileName: 'citrus/1.0.3/index.js' },
     );
 
-    const entry = findCatalog(SourceSchemaType.Test, catalogLibrary);
-    expect(entry).toBeDefined();
+    const entry = findCatalog(['Citrus'], catalogLibrary);
     expect(entry?.name).toEqual('Citrus 1.0.3');
-    expect(entry?.runtime).toEqual('Citrus');
+  });
+});
+
+describe('CatalogHelper — isCatalogCompatible', () => {
+  const camel = { runtime: 'Main' } as never;
+  const citrus = { runtime: 'Citrus' } as never;
+
+  it('returns false when the catalog is undefined', () => {
+    expect(isCatalogCompatible(undefined, ['Main'])).toBe(false);
+  });
+
+  it('returns true when the catalog runtime is in the compatible list', () => {
+    expect(isCatalogCompatible(camel, ['Main', 'Quarkus', 'Spring Boot'])).toBe(true);
+  });
+
+  it('returns false when the catalog runtime is not in the compatible list', () => {
+    expect(isCatalogCompatible(citrus, ['Main', 'Quarkus', 'Spring Boot'])).toBe(false);
+  });
+
+  it('returns false when the compatible list is empty', () => {
+    expect(isCatalogCompatible(camel, [])).toBe(false);
   });
 });

--- a/packages/ui/src/utils/catalog-helper.ts
+++ b/packages/ui/src/utils/catalog-helper.ts
@@ -1,50 +1,41 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 
-import { SourceSchemaType } from '../models/camel';
 import { versionCompare } from './version-compare';
 
 /**
- * Finds the appropriate catalog for a given source schema type.
+ * Returns the best catalog matching the given compatible runtimes.
  *
- * For Citrus tests (SourceSchemaType.Test), returns the first available Citrus catalog sorted by version.
- * For other source types, returns the first available RedHat Main catalog sorted by version.
- *
- * @param sourceType - The source schema type to find a catalog for
- * @param catalogLibrary - The catalog library containing available catalogs
- * @returns The matching catalog entry or undefined if not found or library is unavailable
+ * Preference order: redhat builds win across all compatible runtimes (if any
+ * redhat candidate exists in the compat-filtered pool, non-redhat candidates
+ * are excluded regardless of runtime), then highest version among the pool.
  */
-export const findCatalog = (sourceType: SourceSchemaType, catalogLibrary?: CatalogLibrary) => {
-  if (!catalogLibrary) {
-    return undefined;
-  }
+export const findCatalog = (
+  compatibleRuntimes: readonly string[],
+  catalogLibrary?: CatalogLibrary,
+): CatalogLibraryEntry | undefined => {
+  if (!catalogLibrary) return undefined;
 
-  if (sourceType === SourceSchemaType.Test) {
-    const citrusCatalogs = catalogLibrary.definitions
-      .filter((c: CatalogLibraryEntry) => c.runtime === 'Citrus')
-      .sort((c1: CatalogLibraryEntry, c2: CatalogLibraryEntry) => versionCompare(c1.version, c2.version));
-    return citrusCatalogs.length > 0 ? citrusCatalogs[0] : undefined;
-  } else {
-    const redhatMainCatalogs = catalogLibrary.definitions
-      .filter((c: CatalogLibraryEntry) => c.runtime === 'Main' && c.name.includes('redhat'))
-      .sort((c1: CatalogLibraryEntry, c2: CatalogLibraryEntry) =>
-        versionCompare(c1.version.split('.redhat')[0], c2.version.split('.redhat')[0]),
-      );
+  const candidates = catalogLibrary.definitions.filter((c: CatalogLibraryEntry) =>
+    compatibleRuntimes.includes(c.runtime),
+  );
 
-    return redhatMainCatalogs.length > 0 ? redhatMainCatalogs[0] : undefined;
-  }
+  const preferred = candidates.filter((c) => c.name.includes('redhat'));
+  const pool = preferred.length > 0 ? preferred : candidates;
+
+  if (pool.length === 0) return undefined;
+
+  return pool
+    .slice()
+    .sort((a: CatalogLibraryEntry, b: CatalogLibraryEntry) =>
+      versionCompare(a.version.split('.redhat')[0], b.version.split('.redhat')[0]),
+    )[0];
 };
 
 /**
- * Determines if a catalog change is required based on the source type and current catalog.
- *
- * A catalog change is required when:
- * - The current catalog is Citrus but the source type is not Test
- * - The current catalog is not Citrus but the source type is Test
- *
- * @param sourceType - The source schema type being used
- * @param catalog - The currently active catalog
- * @returns True if a catalog change is required, false otherwise
+ * Returns true if the given catalog's runtime is in the resource's
+ * compatible runtimes list.
  */
-export const requiresCatalogChange = (sourceType: SourceSchemaType, catalog?: CatalogLibraryEntry) => {
-  return catalog?.runtime === 'Citrus' ? sourceType !== SourceSchemaType.Test : sourceType === SourceSchemaType.Test;
-};
+export const isCatalogCompatible = (
+  catalog: CatalogLibraryEntry | undefined,
+  compatibleRuntimes: readonly string[],
+): boolean => catalog !== undefined && compatibleRuntimes.includes(catalog.runtime);

--- a/packages/ui/src/utils/catalog-storage.test.ts
+++ b/packages/ui/src/utils/catalog-storage.test.ts
@@ -1,0 +1,114 @@
+import { CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+
+import { SourceSchemaType } from '../models/camel';
+import { LocalStorageKeys } from '../models/local-storage-keys';
+import { getPersistedCatalog, readCatalogMap, setPersistedCatalog, writeCatalogMap } from './catalog-storage';
+
+const camelEntry: CatalogLibraryEntry = {
+  name: 'Camel Main 1.0.0',
+  runtime: 'Main',
+  version: '1.0.0',
+  fileName: 'camel-main/index.js',
+};
+
+const citrusEntry: CatalogLibraryEntry = {
+  name: 'Citrus 1.0.0',
+  runtime: 'Citrus',
+  version: '1.0.0',
+  fileName: 'citrus/index.js',
+};
+
+describe('catalog-storage — readCatalogMap', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns an empty map when localStorage is empty', () => {
+    expect(readCatalogMap()).toEqual({});
+  });
+
+  it('returns an empty map when the stored JSON is malformed', () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, '{not-json');
+    expect(readCatalogMap()).toEqual({});
+  });
+
+  it('returns an empty map when the stored value is the legacy single-entry shape', () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(camelEntry));
+    expect(readCatalogMap()).toEqual({});
+  });
+
+  it('returns the stored map when the value is the new shape', () => {
+    const stored = {
+      [SourceSchemaType.Route]: camelEntry,
+      [SourceSchemaType.Test]: citrusEntry,
+    };
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(stored));
+    expect(readCatalogMap()).toEqual(stored);
+  });
+});
+
+describe('catalog-storage — getPersistedCatalog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns undefined when no entry exists for the requested type', () => {
+    expect(getPersistedCatalog(SourceSchemaType.Route)).toBeUndefined();
+  });
+
+  it('returns the stored entry for the requested type', () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify({ [SourceSchemaType.Test]: citrusEntry }));
+    expect(getPersistedCatalog(SourceSchemaType.Test)).toEqual(citrusEntry);
+  });
+
+  it('returns undefined when the legacy single-entry shape is stored', () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(camelEntry));
+    expect(getPersistedCatalog(SourceSchemaType.Route)).toBeUndefined();
+  });
+});
+
+describe('catalog-storage — writeCatalogMap', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('serializes the map to localStorage', () => {
+    writeCatalogMap({ [SourceSchemaType.Route]: camelEntry });
+    expect(localStorage.getItem(LocalStorageKeys.SelectedCatalog)).toEqual(
+      JSON.stringify({ [SourceSchemaType.Route]: camelEntry }),
+    );
+  });
+});
+
+describe('catalog-storage — setPersistedCatalog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('creates the map when none exists', () => {
+    setPersistedCatalog(SourceSchemaType.Route, camelEntry);
+    expect(readCatalogMap()).toEqual({ [SourceSchemaType.Route]: camelEntry });
+  });
+
+  it('merges into the existing map without clobbering other keys', () => {
+    setPersistedCatalog(SourceSchemaType.Route, camelEntry);
+    setPersistedCatalog(SourceSchemaType.Test, citrusEntry);
+    expect(readCatalogMap()).toEqual({
+      [SourceSchemaType.Route]: camelEntry,
+      [SourceSchemaType.Test]: citrusEntry,
+    });
+  });
+
+  it('overwrites an existing entry for the same type', () => {
+    const olderCamel: CatalogLibraryEntry = { ...camelEntry, version: '0.9.0', name: 'Camel Main 0.9.0' };
+    setPersistedCatalog(SourceSchemaType.Route, olderCamel);
+    setPersistedCatalog(SourceSchemaType.Route, camelEntry);
+    expect(readCatalogMap()).toEqual({ [SourceSchemaType.Route]: camelEntry });
+  });
+
+  it('overwrites the legacy single-entry shape when writing a new entry', () => {
+    localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(camelEntry));
+    setPersistedCatalog(SourceSchemaType.Route, camelEntry);
+    expect(readCatalogMap()).toEqual({ [SourceSchemaType.Route]: camelEntry });
+  });
+});

--- a/packages/ui/src/utils/catalog-storage.ts
+++ b/packages/ui/src/utils/catalog-storage.ts
@@ -1,0 +1,42 @@
+import { CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+
+import { SourceSchemaType } from '../models/camel';
+import { LocalStorageKeys } from '../models/local-storage-keys';
+
+export type CatalogMap = Partial<Record<SourceSchemaType, CatalogLibraryEntry>>;
+
+const isLegacyEntry = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.name === 'string' && typeof candidate.version === 'string';
+};
+
+export const readCatalogMap = (): CatalogMap => {
+  const raw = localStorage.getItem(LocalStorageKeys.SelectedCatalog);
+  if (raw === null) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return {};
+  if (isLegacyEntry(parsed)) return {};
+
+  return parsed as CatalogMap;
+};
+
+export const getPersistedCatalog = (sourceType: SourceSchemaType): CatalogLibraryEntry | undefined => {
+  return readCatalogMap()[sourceType];
+};
+
+export const writeCatalogMap = (map: CatalogMap): void => {
+  localStorage.setItem(LocalStorageKeys.SelectedCatalog, JSON.stringify(map));
+};
+
+export const setPersistedCatalog = (sourceType: SourceSchemaType, entry: CatalogLibraryEntry): void => {
+  const current = readCatalogMap();
+  writeCatalogMap({ ...current, [sourceType]: entry });
+};


### PR DESCRIPTION
### Changes
Pick the catalog based on the resource's schema type so opening a Citrus test no longer loads a Camel catalog (and vice-versa).

- Add `detectSchemaType()` to infer the schema from source/path without constructing a full `KaotoResource`, avoiding a chicken-and-egg problem at provider mount time.
- Add `COMPATIBLE_RUNTIMES_BY_SCHEMA_TYPE` as the single source of truth for resource→runtime compatibility, replacing the per-resource `getCompatibleRuntimes()` methods.
- Persist the selected catalog per schema type via `catalog-storage.ts` (keyed map) instead of one global entry, with legacy-format detection to discard old values.
- Simplify `IntegrationTypeSelector`, `RuntimeSelector`, and `NewFlow` now that runtime filtering lives in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of integration resource types (Camel Routes, Integrations, Kamelet Bindings, Citrus Tests, etc.) based on content and file path.

* **Bug Fixes**
  * Fixed catalog selection persistence to properly handle legacy stored data and ensure compatibility across resource types.

* **Refactor**
  * Simplified integration type selection by removing automatic catalog switching behavior.
  * Centralized runtime compatibility mappings for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->