### PR TITLE
fix: DataMapper: Grabbing icon shows even after the schema is attached

### DIFF
--- a/packages/ui/src/components/View/TargetPanel.test.tsx
+++ b/packages/ui/src/components/View/TargetPanel.test.tsx
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentInitializationModel,
+  DocumentType,
+} from '../../models/datamapper/document';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
+import { getShipOrderJsonSchema } from '../../stubs/datamapper/data-mapper';
 import { TargetPanel } from './TargetPanel';
 
 // Mock ResizeObserver for ExpansionPanels
@@ -27,6 +34,20 @@ describe('TargetPanel', () => {
     </DataMapperProvider>
   );
 
+  const schemaWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
+    const sourceDocDef = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'Body', {});
+    const targetDocDef = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.JSON_SCHEMA, 'Body', {
+      ShipOrder: getShipOrderJsonSchema(),
+    });
+    const documentInitializationModel = new DocumentInitializationModel({}, sourceDocDef, targetDocDef);
+
+    return (
+      <DataMapperProvider documentInitializationModel={documentInitializationModel}>
+        <MappingLinksProvider>{children}</MappingLinksProvider>
+      </DataMapperProvider>
+    );
+  };
+
   it('should render the Target panel with Body header', () => {
     render(<TargetPanel />, { wrapper });
     expect(screen.getByText('Body')).toBeInTheDocument();
@@ -35,6 +56,16 @@ describe('TargetPanel', () => {
   it('should render the panel with correct id', () => {
     const { container } = render(<TargetPanel />, { wrapper });
     expect(container.querySelector('#panel-target')).toBeInTheDocument();
+  });
+
+  it('should hide the grab icon when the target body has a schema attached', async () => {
+    const { container } = render(<TargetPanel />, { wrapper: schemaWrapper });
+
+    expect(await screen.findByText('Body')).toBeInTheDocument();
+
+    const header = container.querySelector('[data-testid="document-doc-targetBody-Body"]');
+    expect(header).toBeInTheDocument();
+    expect(header?.querySelector('[data-drag-handler]')).not.toBeInTheDocument();
   });
 
   it('should render using ExpansionPanels', () => {

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -152,7 +152,7 @@ export const TargetPanel: FunctionComponent = () => {
               documentType={DocumentType.TARGET_BODY}
               isReadOnly={false}
               additionalActions={documentActions}
-              enableDnD={true}
+              enableDnD={!hasSchema}
               nodeData={targetBodyNodeData}
             />
           }


### PR DESCRIPTION
Fixes: #3133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag-and-drop behavior in the target panel. The feature is now disabled when a schema is attached and enabled only for primitive types without schema definitions.

* **Tests**
  * Added test coverage verifying that the drag handler is not rendered when a schema is present on the target body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->