### PR TITLE
feat: Drag and drop: show collections in collapsed state

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
@@ -14,7 +14,7 @@
   border: 1px solid var(--custom-node-BorderColor);
   box-shadow: var(--custom-node-Shadow);
 
-  &.step-icon__collection {
+  &.step-icon-collection {
     gap: 4px;
   }
 

--- a/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
+++ b/packages/ui/src/components/Visualization/Custom/FloatingCircle/FloatingCircle.scss
@@ -5,11 +5,18 @@
   align-items: center;
   justify-content: center;
   background-color: var(--custom-node-BackgroundColor);
-  width: 25px;
-  height: 25px;
-  border-radius: 50%;
+  min-width: 25px;
+  min-height: 25px;
+  width: fit-content;
+  height: fit-content;
+  padding: 0 6px;
+  border-radius: 12.5px;
   border: 1px solid var(--custom-node-BorderColor);
   box-shadow: var(--custom-node-Shadow);
+
+  &.step-icon__collection {
+    gap: 4px;
+  }
 
   [data-selected='true'] & {
     @include custom.selected;

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -47,7 +47,12 @@ import {
 } from '../customComponentUtils';
 import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
 import { CustomNodeContainer } from '../Node/CustomNodeContainer';
-import { checkNodeDropCompatibility, getNodeDragAndDropDirection, handleValidNodeDrop } from '../Node/CustomNodeUtils';
+import {
+  checkNodeDropCompatibility,
+  getNodeDragAndDropDirection,
+  getVizNodeChildrenInfo,
+  handleValidNodeDrop,
+} from '../Node/CustomNodeUtils';
 import { TargetAnchor } from '../target-anchor';
 import { CustomGroupProps } from './Group.models';
 
@@ -70,7 +75,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const isDisabled = !!groupVizNode?.getNodeDefinition()?.disabled;
     const validationText = groupVizNode?.getNodeValidationText();
     const doesHaveWarnings = !isDisabled && !!validationText;
-    const childCount = element.getAllNodeChildren().length;
+    const { childCount, hasGroupChildren } = getVizNodeChildrenInfo(groupVizNode);
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
       CanvasDefaults.HOVER_DELAY_IN,
@@ -256,6 +261,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
                 vizNode={groupVizNode}
                 isCollapsed={element.isCollapsed()}
                 childCount={childCount}
+                hasGroupChildren={hasGroupChildren}
                 containerClassNames={{
                   'custom-node__container__draggedNode': true,
                   'custom-node__container__grabbing-cursor': true,

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -254,6 +254,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
                 dataTestId={groupVizNode.id}
                 vizNode={groupVizNode}
                 tooltipContent={tooltipContent}
+                isCollapsed={element.isCollapsed()}
                 childCount={childCount}
                 containerClassNames={{
                   'custom-node__container__draggedNode': true,

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -254,6 +254,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
                 transform={`translate(${dragGroupProps.dragEvent!.x - 20}, ${dragGroupProps.dragEvent!.y - 20})`}
                 dataTestId={groupVizNode.id}
                 vizNode={groupVizNode}
+                isCollapsed={element.isCollapsed()}
                 childCount={childCount}
                 containerClassNames={{
                   'custom-node__container__draggedNode': true,

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -45,7 +45,12 @@ import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { getDropTargetContainerClassNames, GROUP_DRAG_TYPE, NODE_DRAG_TYPE } from '../customComponentUtils';
 import { TargetAnchor } from '../target-anchor';
 import { CustomNodeContainer } from './CustomNodeContainer';
-import { checkNodeDropCompatibility, getNodeDragAndDropDirection, handleValidNodeDrop } from './CustomNodeUtils';
+import {
+  checkNodeDropCompatibility,
+  getNodeDragAndDropDirection,
+  getVizNodeChildrenInfo,
+  handleValidNodeDrop,
+} from './CustomNodeUtils';
 
 type DefaultNodeProps = Parameters<typeof DefaultNode>[0];
 
@@ -135,8 +140,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       CanvasDefaults.HOVER_DELAY_IN,
       CanvasDefaults.HOVER_DELAY_OUT,
     );
-    const childCount = element.getAllNodeChildren().length;
-    const hasGroupChildren = element.getAllNodeChildren().some((node) => node.getData()?.vizNode?.data?.isGroup);
+    const { childCount, hasGroupChildren, isCollapsedGroup } = getVizNodeChildrenInfo(vizNode);
     const shouldShowToolbar = getShouldShowToolbar(
       settingsAdapter.getSettings().nodeToolbarTrigger,
       isGHover,
@@ -304,7 +308,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               dataTestId={vizNode.id}
               containerClassNames={mainContainerClassNames}
               vizNode={vizNode}
-              isCollapsed={element.isCollapsed()}
+              isCollapsed={element.isCollapsed() || isCollapsedGroup}
               childCount={childCount}
               hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
@@ -323,7 +327,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               dataTestId={`${vizNode.id}-dummy`}
               containerClassNames={{ 'custom-node__container__draggedNode': isDraggedNode }}
               vizNode={vizNode}
-              isCollapsed={element.isCollapsed()}
+              isCollapsed={element.isCollapsed() || isCollapsedGroup}
               childCount={childCount}
               hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
@@ -377,7 +381,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
                 <StepToolbar
                   data-testid="step-toolbar"
                   vizNode={vizNode}
-                  isCollapsed={element.isCollapsed()}
+                  isCollapsed={element.isCollapsed() || isCollapsedGroup}
                   onCollapseToggle={onCollapseToggle}
                 />
               </foreignObject>

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -136,6 +136,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       CanvasDefaults.HOVER_DELAY_OUT,
     );
     const childCount = element.getAllNodeChildren().length;
+    const hasGroupChildren = element.getAllNodeChildren().some((node) => node.getData()?.vizNode?.data?.isGroup);
     const shouldShowToolbar = getShouldShowToolbar(
       settingsAdapter.getSettings().nodeToolbarTrigger,
       isGHover,
@@ -304,7 +305,9 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               containerClassNames={mainContainerClassNames}
               vizNode={vizNode}
               tooltipContent={tooltipContent}
+              isCollapsed={element.isCollapsed()}
               childCount={childCount}
+              hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
               processorDescription={processorDescription}
               isDisabled={isDisabled}
@@ -322,7 +325,9 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               containerClassNames={{ 'custom-node__container__draggedNode': isDraggedNode }}
               vizNode={vizNode}
               tooltipContent={tooltipContent}
+              isCollapsed={element.isCollapsed()}
               childCount={childCount}
+              hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
               processorDescription={processorDescription}
               isDisabled={isDisabled}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -136,6 +136,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       CanvasDefaults.HOVER_DELAY_OUT,
     );
     const childCount = element.getAllNodeChildren().length;
+    const hasGroupChildren = element.getAllNodeChildren().some((node) => node.getData()?.vizNode?.data?.isGroup);
     const shouldShowToolbar = getShouldShowToolbar(
       settingsAdapter.getSettings().nodeToolbarTrigger,
       isGHover,
@@ -303,7 +304,9 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               dataTestId={vizNode.id}
               containerClassNames={mainContainerClassNames}
               vizNode={vizNode}
+              isCollapsed={element.isCollapsed()}
               childCount={childCount}
+              hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
               processorDescription={processorDescription}
               isDisabled={isDisabled}
@@ -320,7 +323,9 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
               dataTestId={`${vizNode.id}-dummy`}
               containerClassNames={{ 'custom-node__container__draggedNode': isDraggedNode }}
               vizNode={vizNode}
+              isCollapsed={element.isCollapsed()}
               childCount={childCount}
+              hasGroupChildren={hasGroupChildren}
               ProcessorIcon={ProcessorIcon}
               processorDescription={processorDescription}
               isDisabled={isDisabled}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -26,6 +26,7 @@ describe('CustomNodeContainer', () => {
     width: 90,
     height: 75,
     dataTestId: 'test-node',
+    isCollapsed: true,
   };
 
   it('should render IconResolver with correct props', () => {
@@ -59,6 +60,7 @@ describe('CustomNodeContainer', () => {
         {...defaultContainerProps}
         vizNode={vizNode}
         tooltipContent={undefined}
+        isCollapsed={true}
         childCount={5}
         ProcessorIcon={null}
         processorDescription={undefined}
@@ -69,6 +71,25 @@ describe('CustomNodeContainer', () => {
     const childCountElement = screen.getByTitle('5');
     expect(childCountElement).toBeInTheDocument();
     expect(childCountElement).toHaveTextContent('5');
+  });
+
+  it('should not render child count when isCollapsed is false', () => {
+    const vizNode = createMockVizNode();
+
+    render(
+      <CustomNodeContainer
+        {...defaultContainerProps}
+        vizNode={vizNode}
+        tooltipContent={undefined}
+        isCollapsed={false}
+        childCount={5}
+        ProcessorIcon={null}
+        processorDescription={undefined}
+        isDisabled={false}
+      />,
+    );
+
+    expect(screen.queryByTitle('5')).not.toBeInTheDocument();
   });
 
   it('should not render child count when childCount is 0', () => {
@@ -206,5 +227,27 @@ describe('CustomNodeContainer', () => {
     expect(screen.getByTitle('3')).toBeInTheDocument();
     expect(screen.getByTestId('processor-icon')).toBeInTheDocument();
     expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('should render Layers icon when hasGroupChildren is true', () => {
+    const vizNode = createMockVizNode();
+
+    const { container } = render(
+      <CustomNodeContainer
+        {...defaultContainerProps}
+        vizNode={vizNode}
+        tooltipContent={undefined}
+        isCollapsed={true}
+        childCount={1}
+        hasGroupChildren={true}
+        ProcessorIcon={null}
+        processorDescription={undefined}
+        isDisabled={false}
+      />,
+    );
+
+    expect(container.querySelector('.step-icon__collection')).toBeInTheDocument();
+    // Carbon icon is rendered inside PF Icon
+    expect(container.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -23,6 +23,7 @@ describe('CustomNodeContainer', () => {
     width: 90,
     height: 75,
     dataTestId: 'test-node',
+    isCollapsed: true,
   };
 
   it('should render the CustomNodeContainer correctly', () => {
@@ -49,6 +50,7 @@ describe('CustomNodeContainer', () => {
       <CustomNodeContainer
         {...defaultContainerProps}
         vizNode={vizNode}
+        isCollapsed={true}
         childCount={5}
         ProcessorIcon={null}
         processorDescription={''}
@@ -59,6 +61,42 @@ describe('CustomNodeContainer', () => {
     const childCountElement = screen.getByTitle('5');
     expect(childCountElement).toBeInTheDocument();
     expect(childCountElement).toHaveTextContent('5');
+  });
+
+  it('should not render child count when isCollapsed is false', () => {
+    const vizNode = createMockVizNode();
+
+    render(
+      <CustomNodeContainer
+        {...defaultContainerProps}
+        vizNode={vizNode}
+        tooltipContent={undefined}
+        isCollapsed={false}
+        childCount={5}
+        ProcessorIcon={null}
+        processorDescription={undefined}
+        isDisabled={false}
+      />,
+    );
+
+    expect(screen.queryByTitle('5')).not.toBeInTheDocument();
+  });
+
+  it('should not render child count when isCollapsed is false', () => {
+    const vizNode = createMockVizNode();
+
+    render(
+      <CustomNodeContainer
+        {...defaultContainerProps}
+        vizNode={vizNode}
+        childCount={0}
+        ProcessorIcon={null}
+        processorDescription={''}
+        isDisabled={false}
+      />,
+    );
+
+    expect(screen.queryByTitle('5')).not.toBeInTheDocument();
   });
 
   it('should not render child count when childCount is 0', () => {
@@ -185,5 +223,27 @@ describe('CustomNodeContainer', () => {
     expect(screen.getByTitle('3')).toBeInTheDocument();
     expect(screen.getByTestId('processor-icon')).toBeInTheDocument();
     expect(container.querySelector('.step-icon__disabled')).toBeInTheDocument();
+  });
+
+  it('should render Layers icon when hasGroupChildren is true', () => {
+    const vizNode = createMockVizNode();
+
+    const { container } = render(
+      <CustomNodeContainer
+        {...defaultContainerProps}
+        vizNode={vizNode}
+        tooltipContent={undefined}
+        isCollapsed={true}
+        childCount={1}
+        hasGroupChildren={true}
+        ProcessorIcon={null}
+        processorDescription={undefined}
+        isDisabled={false}
+      />,
+    );
+
+    expect(container.querySelector('.step-icon__collection')).toBeInTheDocument();
+    // Carbon icon is rendered inside PF Icon
+    expect(container.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -242,7 +242,7 @@ describe('CustomNodeContainer', () => {
       />,
     );
 
-    expect(container.querySelector('.step-icon__collection')).toBeInTheDocument();
+    expect(container.querySelector('.step-icon-collection')).toBeInTheDocument();
     // Carbon icon is rendered inside PF Icon
     expect(container.querySelector('svg')).toBeInTheDocument();
   });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -246,7 +246,7 @@ describe('CustomNodeContainer', () => {
       />,
     );
 
-    expect(container.querySelector('.step-icon__collection')).toBeInTheDocument();
+    expect(container.querySelector('.step-icon-collection')).toBeInTheDocument();
     // Carbon icon is rendered inside PF Icon
     expect(container.querySelector('svg')).toBeInTheDocument();
   });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -70,7 +70,6 @@ describe('CustomNodeContainer', () => {
       <CustomNodeContainer
         {...defaultContainerProps}
         vizNode={vizNode}
-        tooltipContent={undefined}
         isCollapsed={false}
         childCount={5}
         ProcessorIcon={null}
@@ -232,7 +231,6 @@ describe('CustomNodeContainer', () => {
       <CustomNodeContainer
         {...defaultContainerProps}
         vizNode={vizNode}
-        tooltipContent={undefined}
         isCollapsed={true}
         childCount={1}
         hasGroupChildren={true}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -1,3 +1,4 @@
+import { Layers } from '@carbon/icons-react';
 import { Icon } from '@patternfly/react-core';
 import { BanIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
@@ -15,7 +16,9 @@ export interface CustomNodeContainerProps {
   dataTestId: string;
   containerClassNames?: Record<string, boolean>;
   vizNode: IVisualizationNode;
+  isCollapsed: boolean;
   childCount: number;
+  hasGroupChildren?: boolean;
   ProcessorIcon: ElementType | null;
   processorDescription: string;
   isDisabled: boolean;
@@ -30,7 +33,9 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
   dataTestId,
   containerClassNames = {},
   vizNode,
+  isCollapsed,
   childCount,
+  hasGroupChildren,
   ProcessorIcon,
   processorDescription,
   isDisabled,
@@ -46,8 +51,15 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
       <div title={vizNode.data.description} className="custom-node__container__image">
         <img src={vizNode.data.iconUrl} alt={vizNode.data.description?.trim() || (vizNode.data.iconAlt as string)} />
 
-        {childCount > 0 && (
-          <FloatingCircle className="step-icon step-icon__processor">
+        {isCollapsed && childCount > 0 && (
+          <FloatingCircle
+            className={clsx('step-icon step-icon__processor', { 'step-icon__collection': hasGroupChildren })}
+          >
+            {hasGroupChildren && (
+              <Icon size="sm">
+                <Layers />
+              </Icon>
+            )}
             <span title={`${childCount}`}>{childCount}</span>
           </FloatingCircle>
         )}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -56,7 +56,7 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
 
         {isCollapsed && childCount > 0 && (
           <FloatingCircle
-            className={clsx('step-icon step-icon__processor', { 'step-icon__collection': hasGroupChildren })}
+            className={clsx('step-icon step-icon__processor', { 'step-icon-collection': hasGroupChildren })}
           >
             {hasGroupChildren && (
               <Icon size="sm">

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -1,3 +1,4 @@
+import { Layers } from '@carbon/icons-react';
 import { Icon } from '@patternfly/react-core';
 import { BanIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
@@ -17,7 +18,9 @@ export interface CustomNodeContainerProps {
   containerClassNames?: Record<string, boolean>;
   vizNode: IVisualizationNode;
   tooltipContent: string | undefined;
+  isCollapsed: boolean;
   childCount: number;
+  hasGroupChildren?: boolean;
   ProcessorIcon: ElementType | null;
   processorDescription: string | undefined;
   isDisabled: boolean;
@@ -33,7 +36,9 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
   containerClassNames = {},
   vizNode,
   tooltipContent,
+  isCollapsed,
   childCount,
+  hasGroupChildren,
   ProcessorIcon,
   processorDescription,
   isDisabled,
@@ -49,8 +54,15 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
       <div title={tooltipContent} className="custom-node__container__image">
         <IconResolver alt={tooltipContent} catalogKind={vizNode.data.catalogKind} name={vizNode.data.name} />
 
-        {childCount > 0 && (
-          <FloatingCircle className="step-icon step-icon__processor">
+        {isCollapsed && childCount > 0 && (
+          <FloatingCircle
+            className={clsx('step-icon step-icon__processor', { 'step-icon__collection': hasGroupChildren })}
+          >
+            {hasGroupChildren && (
+              <Icon size="sm">
+                <Layers />
+              </Icon>
+            )}
             <span title={`${childCount}`}>{childCount}</span>
           </FloatingCircle>
         )}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -53,10 +53,10 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
 
         {isCollapsed && childCount > 0 && (
           <FloatingCircle
-            className={clsx('step-icon step-icon__processor', { 'step-icon__collection': hasGroupChildren })}
+            className={clsx('step-icon step-icon__processor', { 'step-icon-collection': hasGroupChildren })}
           >
             {hasGroupChildren && (
-              <Icon size="sm">
+              <Icon size="sm" aria-label="contains nested collections">
                 <Layers />
               </Icon>
             )}

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -20,7 +20,7 @@ export interface CustomNodeContainerProps {
   childCount: number;
   hasGroupChildren?: boolean;
   ProcessorIcon: ElementType | null;
-  processorDescription: string;
+  processorDescription?: string;
   isDisabled: boolean;
 }
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
@@ -4,6 +4,8 @@ import { ElementModel, GraphElement, Node } from '@patternfly/react-topology';
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardCopyObject } from '../../../../models/visualization/clipboard';
+import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
@@ -173,4 +175,26 @@ const performForwardDrop = (
     const flowId = draggedVizNode?.getId();
     entitiesContext.camelResource.removeEntity(flowId ? [flowId] : undefined);
   }
+};
+
+export interface VizNodeChildrenInfo {
+  childCount: number;
+  hasGroupChildren: boolean;
+  isCollapsedGroup: boolean;
+}
+
+export const getVizNodeChildrenInfo = (vizNode: IVisualizationNode | undefined): VizNodeChildrenInfo => {
+  const processorName = (vizNode?.data as CamelRouteVisualEntityData)?.processorName;
+  const vizNodeChildren = vizNode?.getChildren() ?? [];
+  const childCount = vizNodeChildren.filter((c) => !c.data.isPlaceholder).length;
+  const hasGroupChildren = vizNodeChildren.some((child) => {
+    const childProcessorName = (child.data as CamelRouteVisualEntityData)?.processorName;
+    return childProcessorName
+      ? CamelComponentSchemaService.getProcessorStepsProperties(childProcessorName).length > 0
+      : false;
+  });
+  const isContainerType =
+    !!processorName && CamelComponentSchemaService.getProcessorStepsProperties(processorName).length > 0;
+  const isCollapsedGroup = isContainerType && childCount > 0;
+  return { childCount, hasGroupChildren, isCollapsedGroup };
 };


### PR DESCRIPTION
Closes: #2958 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Child-count badge changed to a content-adaptive pill with horizontal padding and spacing for multi-icon collections.

* **Bug Fixes**
  * Badge now renders only when a node is collapsed; collapse state is respected.

* **New Features**
  * Small Layers/collection icon can appear inside the badge for nodes containing nested groups.
  * Improved detection of collapsed/group children for more accurate UI indicators.

* **Tests**
  * Added tests for collapse-state badge behavior and group-child visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->