### PR TITLE
refactor(DataMapper): extract common modal DnD event isolation into DataMapperModal

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperModal.test.tsx
@@ -1,0 +1,148 @@
+import { ModalVariant } from '@patternfly/react-core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  FunctionComponent,
+  KeyboardEvent,
+  MouseEvent,
+  PointerEvent,
+  PropsWithChildren,
+  TouchEvent,
+  useCallback,
+} from 'react';
+
+import { DataMapperModal } from './DataMapperModal';
+
+/**
+ * Test helper that simulates a DnD-aware parent component.
+ * Uses a native interactive element (button) to capture events
+ * that would normally reach @dnd-kit's useDraggable listeners.
+ */
+const DnDParent: FunctionComponent<
+  PropsWithChildren<{
+    onMouseDown?: (e: MouseEvent) => void;
+    onPointerDown?: (e: PointerEvent) => void;
+    onKeyDown?: (e: KeyboardEvent) => void;
+    onTouchStart?: (e: TouchEvent) => void;
+  }>
+> = ({ children, ...handlers }) => {
+  useCallback(() => {}, []);
+  return (
+    <div style={{ all: 'unset' }} {...handlers}>
+      {children}
+    </div>
+  );
+};
+
+describe('DataMapperModal', () => {
+  it('should render children inside the modal', () => {
+    render(
+      <DataMapperModal isOpen data-testid="test-modal" aria-label="Test Modal">
+        <button data-testid="modal-content">Content</button>
+      </DataMapperModal>,
+    );
+    expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(
+      <DataMapperModal isOpen={false} aria-label="Test Modal">
+        <button data-testid="modal-content">Content</button>
+      </DataMapperModal>,
+    );
+    expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument();
+  });
+
+  it('should stop mousedown propagation to parent DnD handlers', () => {
+    const outerHandler = jest.fn();
+    render(
+      <DnDParent onMouseDown={outerHandler}>
+        <DataMapperModal isOpen aria-label="Test Modal">
+          <button data-testid="inner-btn">Click me</button>
+        </DataMapperModal>
+      </DnDParent>,
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('inner-btn'));
+    expect(outerHandler).not.toHaveBeenCalled();
+  });
+
+  it('should stop pointerdown propagation to parent DnD handlers', () => {
+    const outerHandler = jest.fn();
+    render(
+      <DnDParent onPointerDown={outerHandler}>
+        <DataMapperModal isOpen aria-label="Test Modal">
+          <button data-testid="inner-btn">Click me</button>
+        </DataMapperModal>
+      </DnDParent>,
+    );
+
+    fireEvent.pointerDown(screen.getByTestId('inner-btn'));
+    expect(outerHandler).not.toHaveBeenCalled();
+  });
+
+  it('should stop keydown propagation to parent DnD handlers', () => {
+    const outerHandler = jest.fn();
+    render(
+      <DnDParent onKeyDown={outerHandler}>
+        <DataMapperModal isOpen aria-label="Test Modal">
+          <input data-testid="inner-input" />
+        </DataMapperModal>
+      </DnDParent>,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('inner-input'), { key: 'Enter' });
+    expect(outerHandler).not.toHaveBeenCalled();
+  });
+
+  it('should stop touchstart propagation to parent DnD handlers', () => {
+    const outerHandler = jest.fn();
+    render(
+      <DnDParent onTouchStart={outerHandler}>
+        <DataMapperModal isOpen aria-label="Test Modal">
+          <button data-testid="inner-btn">Click me</button>
+        </DataMapperModal>
+      </DnDParent>,
+    );
+
+    fireEvent.touchStart(screen.getByTestId('inner-btn'));
+    expect(outerHandler).not.toHaveBeenCalled();
+  });
+
+  it('should still allow interaction with inner elements', () => {
+    const innerClickHandler = jest.fn();
+    render(
+      <DataMapperModal isOpen aria-label="Test Modal">
+        <button data-testid="inner-btn" onClick={innerClickHandler}>
+          Click me
+        </button>
+      </DataMapperModal>,
+    );
+
+    fireEvent.click(screen.getByTestId('inner-btn'));
+    expect(innerClickHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClose when the modal close mechanism is triggered', () => {
+    const onClose = jest.fn();
+    render(
+      <DataMapperModal isOpen onClose={onClose} aria-label="Test Modal">
+        <button>Content</button>
+      </DataMapperModal>,
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass through modal props to underlying Modal', () => {
+    render(
+      <DataMapperModal isOpen aria-label="Custom Label" data-testid="custom-modal" variant={ModalVariant.small}>
+        <button>Content</button>
+      </DataMapperModal>,
+    );
+
+    const modalBox = screen.getByRole('dialog');
+    expect(modalBox).toHaveAttribute('aria-label', 'Custom Label');
+  });
+});

--- a/packages/ui/src/components/DataMapper/DataMapperModal.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperModal.tsx
@@ -1,0 +1,34 @@
+import { Modal, ModalProps } from '@patternfly/react-core';
+import { FunctionComponent, KeyboardEvent, MouseEvent, PointerEvent, TouchEvent, useCallback } from 'react';
+
+/**
+ * A wrapper around PatternFly Modal that prevents mouse/pointer/keyboard events
+ * from propagating through the React tree to the DataMapper canvas DnD handlers.
+ *
+ * PatternFly Modal renders via a portal to document.body, but React synthetic
+ * events still bubble through the React tree (not the DOM tree). Since DataMapper
+ * modals are rendered as children of draggable components, events from the modal
+ * would reach useDraggable listeners and trigger unintended drag operations.
+ *
+ * The wrapper div sits above the Modal in the React tree, so it intercepts
+ * synthetic events from the entire portal — including the backdrop, modal box,
+ * and all children. Inner draggable listeners (e.g., XPath editor's DnD) fire
+ * before the event reaches this wrapper, so they are not affected.
+ */
+export const DataMapperModal: FunctionComponent<Omit<ModalProps, 'ref'>> = (props) => {
+  const stopPropagation = useCallback((e: MouseEvent | PointerEvent | KeyboardEvent | TouchEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  return (
+    <div // NOSONAR - intentional non-interactive event barrier for DnD isolation, not a user-facing element
+      style={{ display: 'contents' }}
+      onPointerDown={stopPropagation}
+      onMouseDown={stopPropagation}
+      onKeyDown={stopPropagation}
+      onTouchStart={stopPropagation}
+    >
+      <Modal {...props} />
+    </div>
+  );
+};

--- a/packages/ui/src/components/Document/actions/Comment/CommentModal.tsx
+++ b/packages/ui/src/components/Document/actions/Comment/CommentModal.tsx
@@ -1,16 +1,8 @@
-import {
-  Button,
-  FormGroup,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  ModalVariant,
-  TextArea,
-} from '@patternfly/react-core';
-import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useState } from 'react';
+import { Button, FormGroup, ModalBody, ModalFooter, ModalHeader, ModalVariant, TextArea } from '@patternfly/react-core';
+import { FormEvent, FunctionComponent, useCallback, useEffect, useState } from 'react';
 
 import { MappingItem } from '../../../../models/datamapper/mapping';
+import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
 
 interface CommentModalProps {
   /** Controls whether the modal is open */
@@ -64,31 +56,6 @@ export const CommentModal: FunctionComponent<CommentModalProps> = ({
     onUpdate();
     handleClose();
   }, [mapping, onUpdate, handleClose]);
-
-  const stopPropagation = useCallback((event: MouseEvent) => {
-    event.stopPropagation();
-  }, []);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleMouseDownCapture = (e: Event) => {
-      const target = e.target as HTMLElement | null;
-      if (!target) return;
-      // Stop propagation for any click on backdrop or modal content
-      if (target.closest('.pf-v6-c-backdrop') || target.closest('.pf-v6-c-modal-box')) {
-        e.stopPropagation();
-      }
-    };
-
-    // Capture phase (third parameter = true) runs before React synthetic events
-    document.addEventListener('mousedown', handleMouseDownCapture, true);
-    document.addEventListener('pointerdown', handleMouseDownCapture, true);
-
-    return () => {
-      document.removeEventListener('mousedown', handleMouseDownCapture, true);
-      document.removeEventListener('pointerdown', handleMouseDownCapture, true);
-    };
-  }, [isOpen]);
 
   const textAreaElement = (
     <TextArea
@@ -147,7 +114,7 @@ export const CommentModal: FunctionComponent<CommentModalProps> = ({
   };
 
   return (
-    <Modal
+    <DataMapperModal
       isOpen={isOpen}
       variant={ModalVariant.small}
       onClose={handleClose}
@@ -155,7 +122,7 @@ export const CommentModal: FunctionComponent<CommentModalProps> = ({
       aria-label="Comment Editor Modal"
     >
       <ModalHeader title={isEditingExistingComment ? 'Edit Comment' : 'Add Comment'} />
-      <ModalBody onClick={stopPropagation}>
+      <ModalBody>
         {withFormGroup ? (
           <FormGroup label="Comment" fieldId="comment-textarea">
             {textAreaElement}
@@ -165,6 +132,6 @@ export const CommentModal: FunctionComponent<CommentModalProps> = ({
         )}
       </ModalBody>
       <ModalFooter>{renderFooterButtons()}</ModalFooter>
-    </Modal>
+    </DataMapperModal>
   );
 };

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.tsx
@@ -8,7 +8,6 @@ import {
   Icon,
   MenuToggle,
   MenuToggleElement,
-  Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -29,6 +28,7 @@ import { FieldOverrideVariant, IFieldTypeInfo } from '../../../../models/datamap
 import { MetadataContext } from '../../../../providers';
 import { formatQNameWithPrefix } from '../../../../services/namespace-util';
 import { SchemaPathService } from '../../../../services/schema-path.service';
+import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
 import { getFileName, pickAndValidateSchemaFiles } from '../utils';
 import { CandidateDisplay, getOverrideCandidates, OverrideMode } from './override-util';
 import { SchemaFileList } from './SchemaFileList';
@@ -92,30 +92,6 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
       setSelectedKey(null);
       setIsSelectOpen(false);
       setUploadedSchemas({});
-    };
-  }, []);
-
-  // Prevent @dnd-kit drag activation when modal is open.
-  // React synthetic events from portals bubble through the React tree, not DOM tree.
-  // Since this modal is rendered inside a draggable component, mousedown events
-  // would bubble to the useDraggable listeners. We use native capture-phase listeners
-  // to intercept events BEFORE they reach React's synthetic event system.
-  useEffect(() => {
-    const handleMouseDownCapture = (e: Event) => {
-      const target = e.target as HTMLElement;
-      // Stop propagation for any click on backdrop or modal content
-      if (target.closest('.pf-v6-c-backdrop') || target.closest('.pf-v6-c-modal-box')) {
-        e.stopPropagation();
-      }
-    };
-
-    // Capture phase (third parameter = true) runs before React synthetic events
-    document.addEventListener('mousedown', handleMouseDownCapture, true);
-    document.addEventListener('pointerdown', handleMouseDownCapture, true);
-
-    return () => {
-      document.removeEventListener('mousedown', handleMouseDownCapture, true);
-      document.removeEventListener('pointerdown', handleMouseDownCapture, true);
     };
   }, []);
 
@@ -237,7 +213,7 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
   );
 
   return (
-    <Modal
+    <DataMapperModal
       variant={ModalVariant.medium}
       isOpen
       onClose={onClose}
@@ -349,6 +325,6 @@ export const TypeOverrideModal: FunctionComponent<TypeOverrideModalProps> = ({
           Save
         </Button>
       </ModalFooter>
-    </Modal>
+    </DataMapperModal>
   );
 };

--- a/packages/ui/src/components/XPath/XPathEditorModal.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorModal.tsx
@@ -5,7 +5,6 @@ import {
   ButtonVariant,
   List,
   ListItem,
-  Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -19,6 +18,7 @@ import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 're
 import { IExpressionHolder, MappingItem } from '../../models/datamapper';
 import { XPathService } from '../../services/xpath/xpath.service';
 import { ValidatedXPathParseResult } from '../../services/xpath/xpath-model';
+import { DataMapperModal } from '../DataMapper/DataMapperModal';
 import { XPathEditorLayout } from './XPathEditorLayout';
 
 type XPathEditorModalProps = {
@@ -92,7 +92,7 @@ export const XPathEditorModal: FunctionComponent<XPathEditorModalProps> = ({
   );
 
   return (
-    <Modal
+    <DataMapperModal
       aria-label="XPath Editor Modal"
       className="xpath-editor-modal"
       position="top"
@@ -111,6 +111,6 @@ export const XPathEditorModal: FunctionComponent<XPathEditorModalProps> = ({
           Close
         </Button>
       </ModalFooter>
-    </Modal>
+    </DataMapperModal>
   );
 };


### PR DESCRIPTION
DataMapper modals rendered inside draggable components cause unintended drag activation because React synthetic events from portals bubble through the React tree. Extract a shared DataMapperModal wrapper that stops mousedown, pointerdown, and keydown propagation at the modal boundary, replacing duplicated native capture-phase event listeners in CommentModal and TypeOverrideModal, and adding the same protection to XPathEditorModal.

Closes #3120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new modal component that isolates certain input events while rendering existing modal content and attributes.

* **Bug Fixes**
  * Prevented specific event propagation from modal content to parent layers to avoid unintended interactions with surrounding UI.

* **Tests**
  * Added tests covering open/close behavior, event isolation (mouse/pointer/key/touch), inner element interaction, and accessibility label propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->