### PR TITLE
fix(DataMapper): Reduce dragged item size to improve usability

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "@carbon/icons-react": "^11.67.0",
     "@carbon/react": "^1.102.0",
     "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@kaoto/forms": "^1.7.1",
     "@kie-tools-core/editor": "^10.0.0",
     "@kie-tools-core/notifications": "^10.0.0",

--- a/packages/ui/src/providers/datamapper-dnd.provider.scss
+++ b/packages/ui/src/providers/datamapper-dnd.provider.scss
@@ -1,22 +1,5 @@
 @use '../styles/dnd';
 
-.dragging-container {
-  display: inline-block; // Make it only as wide as the content
-  padding: 2px 6px; // Smaller, tighter padding
-  font-weight: bold;
-  font-size: calc(0.875rem * var(--datamapper-scale-factor, 1)); // Scale with DataMapper scale factor
-  color: var(--pf-t--global--icon--color--brand--default);
-  border-style: solid;
-  border-width: 2px;
-  border-color: var(--pf-v6-c-draggable--m-dragging--after--BorderColor);
-  background-color: var(--pf-t--global--background--color--100);
-  border-radius: var(--pf-v6-c-draggable--m-dragging--after--BorderRadius);
-  box-shadow: var(--pf-v6-c-draggable--m-dragging--BoxShadow);
-
-  // Override the node__row class height to keep it compact
-  height: auto !important;
-}
-
-.pf-v6-c-draggable.dragging-container {
+.drag-overlay {
   cursor: grabbing;
 }

--- a/packages/ui/src/providers/datamapper-dnd.provider.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.tsx
@@ -16,6 +16,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import { AlertVariant, Label } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, useCallback, useMemo, useRef, useState } from 'react';
 
@@ -212,14 +213,8 @@ export const DatamapperDndProvider: FunctionComponent<DataMapperDndContextProps>
         onDragCancel={clearActiveDrag}
       >
         {props.children}
-        <DragOverlay dropAnimation={null}>
-          <div
-            className={'pf-v6-c-draggable node__row dragging-container'}
-            data-dnd-dragging={draggingLabel}
-            style={{ pointerEvents: 'none' }}
-          >
-            <Label>{draggingLabel}</Label>
-          </div>
+        <DragOverlay className="drag-overlay" modifiers={[snapCenterToCursor]} dropAnimation={null}>
+          <Label data-dnd-dragging={draggingLabel}>{draggingLabel}</Label>
         </DragOverlay>
       </DndContext>
     </DataMapperDndContext.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/modifiers@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@dnd-kit/modifiers@npm:9.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10/2ae238a1b787029e95d92319d7e4a0e2ffba8fceed56c4b58dfee7ed6890df207bf89ce522d4126411051121954222bd8e1444fae321485b594ae518c7c4397d
+  languageName: node
+  linkType: hard
+
 "@dnd-kit/utilities@npm:^3.2.2":
   version: 3.2.2
   resolution: "@dnd-kit/utilities@npm:3.2.2"
@@ -3548,6 +3561,7 @@ __metadata:
     "@carbon/icons-react": "npm:^11.67.0"
     "@carbon/react": "npm:^1.102.0"
     "@dnd-kit/core": "npm:^6.1.0"
+    "@dnd-kit/modifiers": "npm:^9.0.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.4.4"
     "@kaoto/forms": "npm:^1.7.1"


### PR DESCRIPTION
Resolves: [#1931](https://github.com/KaotoIO/kaoto/issues/1931)

## Improve DataMapper Drag Overlay UX

This PR enhances the drag-and-drop experience in the DataMapper by implementing cursor-snapping behavior and simplifying the drag overlay styling. The dragged label now follows the cursor more naturally, providing better visual feedback during field mapping operations.

### Changes

- **Added `@dnd-kit/modifiers` dependency** to enable cursor-snapping behavior during drag operations
- **Simplified drag overlay styling** by removing custom `.dragging-container` styles in favor of a minimal `.drag-overlay` class
- **Enhanced drag experience** by implementing `snapCenterToCursor` modifier, making the dragged label follow the cursor more naturally
- **Streamlined overlay component** by removing unnecessary wrapper div and styling, now using just a PatternFly `Label` component

### Technical Details

- Updated [`packages/ui/package.json`](packages/ui/package.json) to include `@dnd-kit/modifiers@^9.0.0`
- Refactored [`datamapper-dnd.provider.tsx`](packages/ui/src/providers/datamapper-dnd.provider.tsx) to use the new modifier
- Cleaned up [`datamapper-dnd.provider.scss`](packages/ui/src/providers/datamapper-dnd.provider.scss) by removing 20+ lines of custom drag styling

### Benefits

- More intuitive drag-and-drop behavior with cursor-centered dragging
- Cleaner, more maintainable code with less custom styling
- Better alignment with `@dnd-kit` best practices


https://github.com/user-attachments/assets/ebc1233a-d84c-48d7-aeae-7dbef6270d4c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined drag-and-drop overlay behavior for smoother interaction, including centering the overlay on the cursor for more accurate dragging.

* **Style**
  * Simplified overlay styling and updated cursor to "grabbing" for clearer visual feedback during drag operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->