### PR TITLE
fix(DataMapper): Do not remove InstructionItem targeted field item

### DIFF
--- a/packages/ui/src/services/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping.service.test.ts
@@ -300,6 +300,18 @@ describe('MappingService', () => {
       consoleSpy.mockRestore();
       extractSpy.mockRestore();
     });
+
+    it("should not remove for-each targeted field when it doesn't have children", () => {
+      const shipOrderItem = tree.children[0];
+      const forEachItem = shipOrderItem.children[3];
+      expect(forEachItem).toBeInstanceOf(ForEachItem);
+      shipOrderItem.children = [forEachItem];
+      const itemItem = forEachItem.children[0];
+      itemItem.children = [];
+      MappingService.removeAllMappingsForDocument(tree, DocumentType.PARAM, 'newParam');
+      expect(forEachItem.children.length).toEqual(1);
+      expect(forEachItem.children[0]).toBe(itemItem);
+    });
   });
 
   describe('renameParameterInMappings()', () => {

--- a/packages/ui/src/services/mapping.service.ts
+++ b/packages/ui/src/services/mapping.service.ts
@@ -102,7 +102,8 @@ export class MappingService {
       ) {
         return acc;
       }
-      if (child instanceof FieldItem && child.children.length === 0) return acc;
+      if (!(child.parent instanceof InstructionItem) && child instanceof FieldItem && child.children.length === 0)
+        return acc;
       acc.push(child);
       return acc;
     }, [] as MappingItem[]);


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3149


https://github.com/user-attachments/assets/d808f34b-ed77-4b4d-8236-785650760424



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined mapping removal logic to properly preserve nested structural elements when removing document mappings, ensuring data integrity in complex hierarchical structures.

* **Tests**
  * Added comprehensive test coverage for mapping removal scenarios with nested elements to validate correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->