### PR TITLE
chore(DataMapper): Add ForEachGroupItem and GroupingStrategy

### DIFF
--- a/packages/ui/src/models/datamapper/mapping.test.ts
+++ b/packages/ui/src/models/datamapper/mapping.test.ts
@@ -1,7 +1,9 @@
 import { DocumentDefinitionType, DocumentType } from './document';
 import {
   ChooseItem,
+  ForEachGroupItem,
   ForEachItem,
+  GroupingStrategy,
   IfItem,
   isExpressionHolder,
   MappingTree,
@@ -25,6 +27,7 @@ describe('mapping.ts', () => {
       expect(isExpressionHolder(new IfItem(tree))).toBe(true);
       expect(isExpressionHolder(new WhenItem(tree))).toBe(true);
       expect(isExpressionHolder(new ForEachItem(tree))).toBe(true);
+      expect(isExpressionHolder(new ForEachGroupItem(tree))).toBe(true);
       expect(isExpressionHolder(new ValueSelector(tree))).toBe(true);
       expect(isExpressionHolder(new VariableItem(tree, 'myVar'))).toBe(true);
     });
@@ -137,17 +140,71 @@ describe('mapping.ts', () => {
       const item = new ForEachItem(tree);
       item.expression = '/Order/Items/Item';
 
-      // Get contextPath twice
       const firstCall = item.contextPath;
       const secondCall = item.contextPath;
 
-      // Both calls should return different object instances (not mutated)
       expect(firstCall).not.toBe(secondCall);
 
-      // But they should have the same values
-      if (firstCall && secondCall) {
-        expect(firstCall.contextPath).toEqual(secondCall.contextPath);
-      }
+      expect(firstCall?.pathSegments).toEqual(secondCall?.pathSegments);
+      expect(firstCall?.isRelative).toBe(secondCall?.isRelative);
+      expect(firstCall?.documentReferenceName).toBe(secondCall?.documentReferenceName);
+    });
+  });
+
+  describe('ForEachGroupItem', () => {
+    it('should default to GROUP_BY strategy with empty expressions', () => {
+      const item = new ForEachGroupItem(tree);
+      expect(item.groupingStrategy).toBe(GroupingStrategy.GROUP_BY);
+      expect(item.groupingExpression).toBe('');
+      expect(item.expression).toBe('');
+    });
+
+    it('doClone() should copy sortItems', () => {
+      const item = new ForEachGroupItem(tree);
+      const sort = new SortItem();
+      sort.expression = '@price';
+      sort.order = 'descending';
+      item.sortItems = [sort];
+
+      const cloned = item.clone();
+
+      expect(cloned.sortItems).toHaveLength(1);
+      expect(cloned.sortItems[0].expression).toBe('@price');
+      expect(cloned.sortItems[0].order).toBe('descending');
+      expect(cloned.sortItems[0]).not.toBe(sort);
+    });
+
+    it('clone() should copy expression, groupingStrategy, groupingExpression, and children', () => {
+      const item = new ForEachGroupItem(tree);
+      item.expression = '/Order/Items/Item';
+      item.groupingStrategy = GroupingStrategy.GROUP_ADJACENT;
+      item.groupingExpression = 'Category';
+      const child = new ValueSelector(item);
+      child.expression = 'ItemId';
+      item.children = [child];
+
+      const cloned = item.clone();
+
+      expect(cloned.expression).toBe('/Order/Items/Item');
+      expect(cloned.groupingStrategy).toBe(GroupingStrategy.GROUP_ADJACENT);
+      expect(cloned.groupingExpression).toBe('Category');
+      expect(cloned.children).toHaveLength(1);
+      expect((cloned.children[0] as ValueSelector).expression).toBe('ItemId');
+      expect(cloned).not.toBe(item);
+    });
+
+    it('contextPath getter should not mutate the original PathExpression', () => {
+      const item = new ForEachGroupItem(tree);
+      item.expression = '/Order/Items/Item';
+
+      const firstCall = item.contextPath;
+      const secondCall = item.contextPath;
+
+      expect(firstCall).not.toBe(secondCall);
+
+      expect(firstCall?.pathSegments).toEqual(secondCall?.pathSegments);
+      expect(firstCall?.isRelative).toBe(secondCall?.isRelative);
+      expect(firstCall?.documentReferenceName).toBe(secondCall?.documentReferenceName);
     });
   });
 

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -184,6 +184,17 @@ export class OtherwiseItem extends InstructionItem {
   }
 }
 
+const extractContextPath = (item: ForEachItem | ForEachGroupItem) => {
+  const answer = XPathService.extractFieldPaths(item.expression)[0];
+  if (answer) {
+    const pathExpr = new PathExpression(item.parent.contextPath, answer.isRelative);
+    pathExpr.pathSegments = answer.pathSegments;
+    pathExpr.documentReferenceName = answer.documentReferenceName;
+    return pathExpr;
+  }
+  return item.parent.contextPath;
+};
+
 /**
  * Represents an `xsl:for-each` instruction.
  * {@link expression} selects the node-set to iterate over.
@@ -198,14 +209,7 @@ export class ForEachItem extends InstructionItem implements IExpressionHolder {
   expression = '';
 
   get contextPath(): PathExpression | undefined {
-    const answer = XPathService.extractFieldPaths(this.expression)[0];
-    if (answer) {
-      const pathExpr = new PathExpression(this.parent.contextPath, answer.isRelative);
-      pathExpr.pathSegments = answer.pathSegments;
-      pathExpr.documentReferenceName = answer.documentReferenceName;
-      return pathExpr;
-    }
-    return this.parent.contextPath;
+    return extractContextPath(this);
   }
 
   sortItems: SortItem[] = [];
@@ -224,6 +228,56 @@ export class ForEachItem extends InstructionItem implements IExpressionHolder {
   clone() {
     const cloned = super.clone() as ForEachItem;
     cloned.expression = this.expression;
+    return cloned;
+  }
+}
+
+/** Selects which grouping attribute is emitted on `xsl:for-each-group`. */
+export enum GroupingStrategy {
+  GROUP_BY = 'group-by',
+  GROUP_ADJACENT = 'group-adjacent',
+  GROUP_STARTING_WITH = 'group-starting-with',
+  GROUP_ENDING_WITH = 'group-ending-with',
+}
+
+/**
+ * Represents an `xsl:for-each-group` instruction.
+ * {@link expression} selects the population to group; {@link groupingStrategy}
+ * and {@link groupingExpression} control the grouping attribute.
+ * Overrides {@link contextPath} so that descendant XPath expressions
+ * are evaluated relative to each group.
+ */
+export class ForEachGroupItem extends InstructionItem implements IExpressionHolder {
+  constructor(public parent: MappingParentType) {
+    super(parent, 'for-each-group');
+  }
+
+  expression = '';
+  groupingStrategy: GroupingStrategy = GroupingStrategy.GROUP_BY;
+  groupingExpression = '';
+
+  get contextPath(): PathExpression | undefined {
+    return extractContextPath(this);
+  }
+
+  sortItems: SortItem[] = [];
+
+  doClone() {
+    const cloned = new ForEachGroupItem(this.parent);
+    cloned.sortItems = this.sortItems.map((sort) => {
+      return {
+        expression: sort.expression,
+        order: sort.order,
+      } as SortItem;
+    });
+    return cloned;
+  }
+
+  clone() {
+    const cloned = super.clone() as ForEachGroupItem;
+    cloned.expression = this.expression;
+    cloned.groupingStrategy = this.groupingStrategy;
+    cloned.groupingExpression = this.groupingExpression;
     return cloned;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for for-each-group mapping constructs with four configurable grouping strategies: group-by, group-adjacent, group-starting-with, and group-ending-with
  * Grouping expressions can now be specified per for-each-group item

* **Tests**
  * Comprehensive test coverage for for-each-group functionality
  * Enhanced regression tests for path resolution in for-each items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->