### PR TITLE
feat(DataMapper): Allow to collapse the function list in XPath editor…

### DIFF
--- a/packages/ui/src/components/XPath/XPathEditorLayout.scss
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.scss
@@ -15,6 +15,18 @@
       display: block;
       flex: 1 1 auto;
       overflow: scroll;
+
+      &__group-toggle {
+        width: 100%;
+        justify-content: flex-start;
+        text-align: left;
+        font-weight: var(--pf-t--global--font--weight--body--bold);
+        padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+
+        &:hover {
+          background-color: var(--pf-t--global--background--color--action--hover--default);
+        }
+      }
     }
   }
 

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -6,25 +6,34 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { XPathEditorLayout } from './XPathEditorLayout';
 
-describe('XPathEditorLayout - Search Field', () => {
-  globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-    disconnect: jest.fn(),
-  }));
+// Shared test setup
+globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+const createTestMapping = () => {
   const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
   const mapping: IExpressionHolder & MappingItem = new ValueSelector(tree);
   mapping.expression = '/to/some/field';
+  return mapping;
+};
+
+const setupComponent = (mapping: IExpressionHolder & MappingItem, onUpdate: jest.Mock) => {
+  return render(
+    <DataMapperProvider>
+      <MappingLinksProvider>
+        <XPathEditorLayout mapping={mapping} onUpdate={onUpdate} />
+      </MappingLinksProvider>
+    </DataMapperProvider>,
+  );
+};
+
+describe('XPathEditorLayout - Search Field', () => {
+  const mapping = createTestMapping();
   const onUpdate = jest.fn();
-  const setup = () => {
-    return render(
-      <DataMapperProvider>
-        <MappingLinksProvider>
-          <XPathEditorLayout mapping={mapping} onUpdate={onUpdate} />
-        </MappingLinksProvider>
-      </DataMapperProvider>,
-    );
-  };
+  const setup = () => setupComponent(mapping, onUpdate);
 
   it('renders the search field', () => {
     setup();
@@ -71,5 +80,97 @@ describe('XPathEditorLayout - Search Field', () => {
     expect(screen.getByText('Substring Before')).toBeInTheDocument();
     expect(screen.getByText('Substring After')).toBeInTheDocument();
     expect(screen.queryByText('Translate')).not.toBeInTheDocument();
+  });
+});
+
+describe('XPathEditorLayout - Collapsible MenuGroups', () => {
+  const mapping = createTestMapping();
+  const onUpdate = jest.fn();
+  const setup = () => setupComponent(mapping, onUpdate);
+
+  beforeEach(() => {
+    // Switch to the Function tab before each test
+    setup();
+    const tab = screen.getByTestId('xpath-editor-tab-function');
+    act(() => {
+      fireEvent.click(tab);
+    });
+  });
+
+  it('renders function groups with toggle buttons', () => {
+    // Check that group toggle buttons exist
+    expect(screen.getByTestId('function-group-toggle-String')).toBeInTheDocument();
+    expect(screen.getByTestId('function-group-toggle-Numeric')).toBeInTheDocument();
+    expect(screen.getByTestId('function-group-toggle-Boolean')).toBeInTheDocument();
+  });
+
+  it('groups are initially expanded and show functions', () => {
+    // String group should be expanded and show its functions
+    const stringToggle = screen.getByTestId('function-group-toggle-String');
+    expect(stringToggle).toBeInTheDocument();
+
+    // Check that some functions from String group are visible
+    expect(screen.getByText('String Length')).toBeInTheDocument();
+    expect(screen.getByText('Concatenate')).toBeInTheDocument();
+  });
+
+  it('collapses a group when toggle button is clicked', () => {
+    // String group functions should be visible initially
+    expect(screen.getByText('String Length')).toBeInTheDocument();
+    expect(screen.getByText('Concatenate')).toBeInTheDocument();
+
+    // Click the String group toggle to collapse it
+    const stringToggle = screen.getByTestId('function-group-toggle-String');
+    act(() => {
+      fireEvent.click(stringToggle);
+    });
+
+    // Functions should not be visible after collapse
+    expect(screen.queryByText('String Length')).not.toBeInTheDocument();
+    expect(screen.queryByText('Concatenate')).not.toBeInTheDocument();
+  });
+
+  it('expands a collapsed group when toggle button is clicked again', () => {
+    const stringToggle = screen.getByTestId('function-group-toggle-String');
+
+    // Collapse the group first
+    act(() => {
+      fireEvent.click(stringToggle);
+    });
+    expect(screen.queryByText('String Length')).not.toBeInTheDocument();
+
+    // Expand the group again
+    act(() => {
+      fireEvent.click(stringToggle);
+    });
+    expect(screen.getByText('String Length')).toBeInTheDocument();
+    expect(screen.getByText('Concatenate')).toBeInTheDocument();
+  });
+
+  it('allows collapsing groups while searching', () => {
+    const searchInput = screen.getByTestId('functions-menu-search-input').querySelector('input');
+    const stringToggle = screen.getByTestId('function-group-toggle-String');
+
+    // Enter search text
+    fireEvent.change(searchInput!, { target: { value: 'concat' } });
+
+    // Verify function is visible initially
+    expect(screen.getByText('Concatenate')).toBeInTheDocument();
+
+    // Collapse the group while search is active
+    act(() => {
+      fireEvent.click(stringToggle);
+    });
+
+    // Function should not be visible after collapse, even with search text
+    expect(screen.queryByText('Concatenate')).not.toBeInTheDocument();
+
+    // Expand again
+    act(() => {
+      fireEvent.click(stringToggle);
+    });
+
+    // Function should be visible again
+    expect(screen.getByText('Concatenate')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/XPath/XPathEditorLayout.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.tsx
@@ -1,6 +1,7 @@
 import './XPathEditorLayout.scss';
 
 import {
+  Button,
   Grid,
   GridItem,
   Menu,
@@ -13,6 +14,7 @@ import {
   Tabs,
   TabTitleText,
 } from '@patternfly/react-core';
+import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import { FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { EditorNodeData, FunctionNodeData, IExpressionHolder, MappingItem } from '../../models/datamapper';
@@ -48,9 +50,25 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({ m
   };
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchValue, setSearchValue] = useState('');
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => {
+    // Initialize with all groups expanded
+    return new Set(Object.keys(functionDefinitions));
+  });
 
   const handleOnSearchChange = useCallback((_event: unknown, value: string) => {
     setSearchValue(value);
+  }, []);
+
+  const toggleGroup = useCallback((groupName: string) => {
+    setExpandedGroups((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(groupName)) {
+        newSet.delete(groupName);
+      } else {
+        newSet.add(groupName);
+      }
+      return newSet;
+    });
   }, []);
 
   useEffect(() => {
@@ -95,35 +113,51 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({ m
                 />
                 <Menu className="xpath-editor__tab__functions-list">
                   <MenuContent>
-                    {Object.keys(functionDefinitions).map((value) => (
-                      <MenuGroup
-                        key={value}
-                        label={value}
-                        hidden={
-                          !functionDefinitions[value as FunctionGroup].some((func) =>
-                            func.displayName.toLocaleLowerCase().includes(getSearchValue),
-                          )
-                        }
-                      >
-                        {functionDefinitions[value as FunctionGroup]
-                          .filter((func) => func.displayName.toLocaleLowerCase().includes(getSearchValue))
-                          .map((func) => (
-                            <DraggableContainer
-                              key={`${value}-${func.name}`}
-                              id={`${value}-${func.name}`}
-                              nodeData={new FunctionNodeData(func)}
+                    {Object.keys(functionDefinitions).map((value) => {
+                      const isExpanded = expandedGroups.has(value);
+                      const hasVisibleItems = functionDefinitions[value as FunctionGroup].some((func) =>
+                        func.displayName.toLocaleLowerCase().includes(getSearchValue),
+                      );
+
+                      if (!hasVisibleItems) return null;
+
+                      return (
+                        <MenuGroup
+                          key={value}
+                          label={
+                            <Button
+                              aria-expanded={isExpanded}
+                              variant="plain"
+                              onClick={() => toggleGroup(value)}
+                              className="xpath-editor__tab__functions-list__group-toggle"
+                              icon={isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
+                              data-testid={`function-group-toggle-${value}`}
                             >
-                              <MenuItem
-                                className="menu-item-drag"
-                                key={`${value}-${func.name}`}
-                                description={func.description}
-                              >
-                                {func.displayName}
-                              </MenuItem>
-                            </DraggableContainer>
-                          ))}
-                      </MenuGroup>
-                    ))}
+                              {value}
+                            </Button>
+                          }
+                        >
+                          {isExpanded &&
+                            functionDefinitions[value as FunctionGroup]
+                              .filter((func) => func.displayName.toLocaleLowerCase().includes(getSearchValue))
+                              .map((func) => (
+                                <DraggableContainer
+                                  key={`${value}-${func.name}`}
+                                  id={`${value}-${func.name}`}
+                                  nodeData={new FunctionNodeData(func)}
+                                >
+                                  <MenuItem
+                                    className="menu-item-drag"
+                                    key={`${value}-${func.name}`}
+                                    description={func.description}
+                                  >
+                                    {func.displayName}
+                                  </MenuItem>
+                                </DraggableContainer>
+                              ))}
+                        </MenuGroup>
+                      );
+                    })}
                   </MenuContent>
                 </Menu>
               </TabContent>


### PR DESCRIPTION
… for each category

fixes https://github.com/KaotoIO/kaoto/issues/1810
<img width="492" height="701" alt="Screenshot From 2026-04-23 14-16-00" src="https://github.com/user-attachments/assets/c7357252-73b1-4609-85cd-88f8d591da32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Function groups in the XPath editor are now collapsible with toggle buttons; collapse/expand continues to work while filtering.

* **Style**
  * Updated function list toggle styling: full-width layout, left-aligned bold text, themed padding and hover background.

* **Tests**
  * Added and refactored tests validating collapsible group behavior, toggle state, and interaction with the search filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->