### PR TITLE
fix(DataMapper): Fix primitive document content and document root ren…

### DIFF
--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -59,6 +59,8 @@ export const TargetPanel: FunctionComponent = () => {
   }, [flattenedNodes.length, mappingTree, syncConnectionPorts]);
 
   const hasSchema = !targetBodyNodeData.isPrimitive;
+  const hasTreeContent = (targetBodyTree?.contentRoots.length ?? 0) > 0;
+  const shouldRenderTree = hasSchema || hasTreeContent;
 
   const handleUpdate = useCallback(() => {
     refreshMappingTree();
@@ -151,8 +153,8 @@ export const TargetPanel: FunctionComponent = () => {
       <ExpansionPanels lastPanelId="target-body">
         <ExpansionPanel
           id="target-body"
-          defaultExpanded={hasSchema}
-          defaultHeight={hasSchema ? TARGET_PANEL_DEFAULT_HEIGHT : PANEL_COLLAPSED_HEIGHT}
+          defaultExpanded={shouldRenderTree}
+          defaultHeight={shouldRenderTree ? TARGET_PANEL_DEFAULT_HEIGHT : PANEL_COLLAPSED_HEIGHT}
           minHeight={TARGET_PANEL_MIN_HEIGHT}
           collapsible={false}
           summary={
@@ -168,7 +170,7 @@ export const TargetPanel: FunctionComponent = () => {
           }
           onLayoutChange={syncConnectionPorts}
         >
-          {hasSchema && targetBodyTree && (
+          {shouldRenderTree && targetBodyTree && (
             <Virtuoso
               totalCount={flattenedNodes.length}
               components={virtuosoComponents}

--- a/packages/ui/src/models/datamapper/document-tree.test.ts
+++ b/packages/ui/src/models/datamapper/document-tree.test.ts
@@ -31,8 +31,10 @@ describe('document-tree.ts', () => {
 
         expect(tree).toBeInstanceOf(DocumentTree);
         expect(tree.documentId).toEqual(mockDocumentNodeData.id);
+        expect(tree.documentNodeData).toBe(mockDocumentNodeData);
         expect(tree.root).toBeInstanceOf(DocumentTreeNode);
         expect(tree.root.nodeData).toBe(mockDocumentNodeData);
+        expect(tree.contentRoots).toEqual([]);
       });
 
       it('should initialize root node with correct properties', () => {
@@ -334,51 +336,18 @@ describe('document-tree.ts', () => {
     });
 
     describe('flatten', () => {
-      it('should flatten a tree with only root node', () => {
+      it('should return empty array for tree with no content roots', () => {
         const tree = new DocumentTree(mockDocumentNodeData);
 
         const flattened = tree.flatten({});
 
-        expect(flattened).toHaveLength(1);
-        expect(flattened[0].treeNode).toBe(tree.root);
-        expect(flattened[0].depth).toBe(0);
-        expect(flattened[0].index).toBe(0);
-        expect(flattened[0].path).toBe('sourceBody:testDoc://');
+        expect(flattened).toHaveLength(0);
       });
 
-      it('should only include root when no nodes are expanded', () => {
+      it('should include content roots at depth 0', () => {
         const tree = new DocumentTree(mockDocumentNodeData);
 
         // Add children
-        const child1NodeData = {
-          title: 'Child 1',
-          id: 'child-1',
-          path: NodePath.childOf(mockDocumentNodeData.path, 'child-1'),
-          isSource: true,
-          isPrimitive: false,
-          isDocument: false,
-        };
-        tree.root.addChild(child1NodeData);
-
-        const child2NodeData = {
-          title: 'Child 2',
-          id: 'child-2',
-          path: NodePath.childOf(mockDocumentNodeData.path, 'child-2'),
-          isSource: true,
-          isPrimitive: false,
-          isDocument: false,
-        };
-        tree.root.addChild(child2NodeData);
-
-        const flattened = tree.flatten({});
-
-        expect(flattened).toHaveLength(1);
-        expect(flattened[0].treeNode).toBe(tree.root);
-      });
-
-      it('should include children when root is expanded', () => {
-        const tree = new DocumentTree(mockDocumentNodeData);
-
         const child1NodeData = {
           title: 'Child 1',
           id: 'child-1',
@@ -399,19 +368,49 @@ describe('document-tree.ts', () => {
         };
         const child2 = tree.root.addChild(child2NodeData);
 
+        const flattened = tree.flatten({});
+
+        expect(flattened).toHaveLength(2);
+        expect(flattened[0].treeNode).toBe(child1);
+        expect(flattened[0].depth).toBe(0);
+        expect(flattened[1].treeNode).toBe(child2);
+        expect(flattened[1].depth).toBe(0);
+      });
+
+      it('should include grandchildren when content root is expanded', () => {
+        const tree = new DocumentTree(mockDocumentNodeData);
+
+        const child1NodeData = {
+          title: 'Child 1',
+          id: 'child-1',
+          path: NodePath.childOf(mockDocumentNodeData.path, 'child-1'),
+          isSource: true,
+          isPrimitive: false,
+          isDocument: false,
+        };
+        const child1 = tree.root.addChild(child1NodeData);
+
+        const grandchildNodeData = {
+          title: 'Grandchild',
+          id: 'grandchild-1',
+          path: NodePath.childOf(child1NodeData.path, 'grandchild-1'),
+          isSource: true,
+          isPrimitive: false,
+          isDocument: false,
+        };
+        const grandchild = child1.addChild(grandchildNodeData);
+
         const expansionState = {
-          'sourceBody:testDoc://': true,
+          'sourceBody:testDoc://child-1': true,
         };
 
         const flattened = tree.flatten(expansionState);
 
-        expect(flattened).toHaveLength(3);
-        expect(flattened[0].treeNode).toBe(tree.root);
+        expect(flattened).toHaveLength(2);
+        expect(flattened[0].treeNode).toBe(child1);
         expect(flattened[0].depth).toBe(0);
-        expect(flattened[1].treeNode).toBe(child1);
+        expect(flattened[1].treeNode).toBe(grandchild);
         expect(flattened[1].depth).toBe(1);
-        expect(flattened[2].treeNode).toBe(child2);
-        expect(flattened[2].depth).toBe(1);
       });
 
       it('should handle nested expansion correctly', () => {
@@ -448,22 +447,19 @@ describe('document-tree.ts', () => {
         const level3 = level2.addChild(level3NodeData);
 
         const expansionState = {
-          'sourceBody:testDoc://': true,
           'sourceBody:testDoc://level1': true,
           'sourceBody:testDoc://level1/level2': true,
         };
 
         const flattened = tree.flatten(expansionState);
 
-        expect(flattened).toHaveLength(4);
-        expect(flattened[0].treeNode).toBe(tree.root);
+        expect(flattened).toHaveLength(3);
+        expect(flattened[0].treeNode).toBe(level1);
         expect(flattened[0].depth).toBe(0);
-        expect(flattened[1].treeNode).toBe(level1);
+        expect(flattened[1].treeNode).toBe(level2);
         expect(flattened[1].depth).toBe(1);
-        expect(flattened[2].treeNode).toBe(level2);
+        expect(flattened[2].treeNode).toBe(level3);
         expect(flattened[2].depth).toBe(2);
-        expect(flattened[3].treeNode).toBe(level3);
-        expect(flattened[3].depth).toBe(3);
       });
 
       it('should stop at collapsed nodes', () => {
@@ -499,20 +495,18 @@ describe('document-tree.ts', () => {
         };
         level2.addChild(level3NodeData);
 
-        // Expand root and level1, but NOT level2
+        // Expand level1, but NOT level2
         const expansionState = {
-          'sourceBody:testDoc://': true,
           'sourceBody:testDoc://level1': true,
           'sourceBody:testDoc://level1/level2': false,
         };
 
         const flattened = tree.flatten(expansionState);
 
-        // Should only include root, level1, and level2 (but not level3)
-        expect(flattened).toHaveLength(3);
-        expect(flattened[0].treeNode).toBe(tree.root);
-        expect(flattened[1].treeNode).toBe(level1);
-        expect(flattened[2].treeNode).toBe(level2);
+        // Should include level1 and level2 (but not level3)
+        expect(flattened).toHaveLength(2);
+        expect(flattened[0].treeNode).toBe(level1);
+        expect(flattened[1].treeNode).toBe(level2);
       });
 
       it('should handle mixed expansion states with siblings', () => {
@@ -558,44 +552,18 @@ describe('document-tree.ts', () => {
         };
         branch2.addChild(leaf2NodeData);
 
-        // Expand root and branch1, but NOT branch2
+        // Expand branch1, but NOT branch2
         const expansionState = {
-          'sourceBody:testDoc://': true,
           'sourceBody:testDoc://branch1': true,
           'sourceBody:testDoc://branch2': false,
         };
 
         const flattened = tree.flatten(expansionState);
 
-        expect(flattened).toHaveLength(4);
-        expect(flattened[0].treeNode).toBe(tree.root);
-        expect(flattened[1].treeNode).toBe(branch1);
-        expect(flattened[2].treeNode).toBe(leaf1);
-        expect(flattened[3].treeNode).toBe(branch2);
-      });
-
-      it('should use custom startDepth parameter', () => {
-        const tree = new DocumentTree(mockDocumentNodeData);
-
-        const childNodeData = {
-          title: 'Child',
-          id: 'child-1',
-          path: NodePath.childOf(mockDocumentNodeData.path, 'child-1'),
-          isSource: true,
-          isPrimitive: false,
-          isDocument: false,
-        };
-        tree.root.addChild(childNodeData);
-
-        const expansionState = {
-          'sourceBody:testDoc://': true,
-        };
-
-        const flattened = tree.flatten(expansionState, 5);
-
-        expect(flattened).toHaveLength(2);
-        expect(flattened[0].depth).toBe(5);
-        expect(flattened[1].depth).toBe(6);
+        expect(flattened).toHaveLength(3);
+        expect(flattened[0].treeNode).toBe(branch1);
+        expect(flattened[1].treeNode).toBe(leaf1);
+        expect(flattened[2].treeNode).toBe(branch2);
       });
 
       it('should assign correct index values', () => {
@@ -621,18 +589,13 @@ describe('document-tree.ts', () => {
         };
         tree.root.addChild(child2NodeData);
 
-        const expansionState = {
-          'sourceBody:testDoc://': true,
-        };
-
-        const flattened = tree.flatten(expansionState);
+        const flattened = tree.flatten({});
 
         expect(flattened[0].index).toBe(0);
         expect(flattened[1].index).toBe(1);
-        expect(flattened[2].index).toBe(2);
       });
 
-      it('should handle undefined expansion state (defaults to false)', () => {
+      it('should not include grandchildren when content root is collapsed', () => {
         const tree = new DocumentTree(mockDocumentNodeData);
 
         const childNodeData = {
@@ -643,16 +606,22 @@ describe('document-tree.ts', () => {
           isPrimitive: false,
           isDocument: false,
         };
-        tree.root.addChild(childNodeData);
+        const child = tree.root.addChild(childNodeData);
 
-        // Pass expansion state without the root path
-        const expansionState = {};
+        const grandchildNodeData = {
+          title: 'Grandchild',
+          id: 'grandchild-1',
+          path: NodePath.childOf(childNodeData.path, 'grandchild-1'),
+          isSource: true,
+          isPrimitive: false,
+          isDocument: false,
+        };
+        child.addChild(grandchildNodeData);
 
-        const flattened = tree.flatten(expansionState);
+        const flattened = tree.flatten({});
 
-        // Should only include root since expansion state defaults to false
         expect(flattened).toHaveLength(1);
-        expect(flattened[0].treeNode).toBe(tree.root);
+        expect(flattened[0].treeNode).toBe(child);
       });
 
       it('should preserve path strings in flattened nodes', () => {
@@ -668,14 +637,33 @@ describe('document-tree.ts', () => {
         };
         tree.root.addChild(childNodeData);
 
+        const flattened = tree.flatten({});
+
+        expect(flattened[0].path).toBe('sourceBody:testDoc://child-1');
+      });
+
+      it('should not include document root node in flattened result', () => {
+        const tree = new DocumentTree(mockDocumentNodeData);
+
+        const childNodeData = {
+          title: 'Child',
+          id: 'child-1',
+          path: NodePath.childOf(mockDocumentNodeData.path, 'child-1'),
+          isSource: true,
+          isPrimitive: false,
+          isDocument: false,
+        };
+        tree.root.addChild(childNodeData);
+
         const expansionState = {
           'sourceBody:testDoc://': true,
+          'sourceBody:testDoc://child-1': true,
         };
 
         const flattened = tree.flatten(expansionState);
 
-        expect(flattened[0].path).toBe('sourceBody:testDoc://');
-        expect(flattened[1].path).toBe('sourceBody:testDoc://child-1');
+        const rootInResult = flattened.find((f) => f.treeNode === tree.root);
+        expect(rootInResult).toBeUndefined();
       });
     });
 

--- a/packages/ui/src/models/datamapper/document-tree.ts
+++ b/packages/ui/src/models/datamapper/document-tree.ts
@@ -14,39 +14,59 @@ export interface FlattenedNode {
 }
 
 /**
- * Document tree for managing pre-parsed schema structure
- * Handles the root node and provides tree-level operations
+ * Pre-parsed tree structure for a document in the DataMapper.
+ *
+ * A document tree separates the document identity from its internal structure:
+ * - {@link documentNodeData} represents the document itself (name, type, schema attachment)
+ *   and is rendered by the panel header ({@link DocumentHeader}).
+ * - {@link contentRoots} / {@link flatten} represent the document's internal structure
+ *   (schema fields, mapping items) and are rendered in the panel's virtual-scroll tree.
+ *
+ * The internal {@link root} `DocumentTreeNode` remains the structural parent of all nodes
+ * and is used by {@link TreeParsingService} for tree construction and by
+ * {@link TreeUIService} for node lookup and invalidation. It is intentionally excluded
+ * from {@link flatten} output to avoid duplicating the panel header in the tree.
  */
 export class DocumentTree {
-  public readonly documentId: string;
-  public root: DocumentTreeNode;
+  readonly documentId: string;
+  readonly documentNodeData: DocumentNodeData;
+  readonly root: DocumentTreeNode;
 
   constructor(documentNodeData: DocumentNodeData) {
+    this.documentNodeData = documentNodeData;
     this.documentId = documentNodeData.id;
     this.root = new DocumentTreeNode(documentNodeData);
   }
 
   /**
-   * Find a node by path in the entire tree
+   * The first-level content nodes (schema fields for structured documents,
+   * mapping items for primitive documents). These are the roots of the
+   * renderable tree content.
    */
+  get contentRoots(): readonly DocumentTreeNode[] {
+    return this.root.children;
+  }
+
+  /** Find a node by path in the entire tree */
   findNodeByPath(path: string): DocumentTreeNode | undefined {
     return this.root.findByPath(path);
   }
 
   /**
-   * Flattens the tree into an array of visible nodes based on expansion state
+   * Flattens the content tree into an array of visible nodes for virtual-scroll rendering.
+   *
+   * Starts from {@link contentRoots} (not the document root), since the document node
+   * is represented by the panel header.
    *
    * Key behavior:
-   * - Always includes the root node
    * - Only includes children if parent is expanded
    * - Recursively checks expansion state down the tree
    * - Calculates correct depth for indentation
    *
    * @param expansionState - Record mapping node paths to their expansion state
-   * @param startDepth - Starting depth for the root node (default: 0)
    * @returns Array of flattened nodes with depth and index information
    */
-  flatten(expansionState: Record<string, boolean>, startDepth = 0): FlattenedNode[] {
+  flatten(expansionState: Record<string, boolean>): FlattenedNode[] {
     const result: FlattenedNode[] = [];
 
     const traverse = (node: DocumentTreeNode, depth: number) => {
@@ -62,13 +82,16 @@ export class DocumentTree {
       // 1. Node has children
       // 2. Node is expanded (checked via expansion state)
       if (node.children.length > 0 && (expansionState[node.path] ?? false)) {
-        node.children.forEach((child) => {
+        for (const child of node.children) {
           traverse(child, depth + 1);
-        });
+        }
       }
     };
 
-    traverse(this.root, startDepth);
+    for (const contentRoot of this.contentRoots) {
+      traverse(contentRoot, 0);
+    }
+
     return result;
   }
 }

--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -1,4 +1,4 @@
-import { TargetNodeData } from './visualization';
+import type { TargetNodeData } from './visualization';
 
 /**
  * Enumeration of actions that can be performed on a target mapping node.

--- a/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
@@ -17,8 +17,9 @@ import {
 import { NodePath } from '../../../models/datamapper/nodepath';
 import { NS_XPATH_FUNCTIONS } from '../../../models/datamapper/standard-namespaces';
 import { Predicate, PredicateOperator } from '../../../models/datamapper/xpath';
-import { FROM_JSON_SOURCE_SUFFIX } from '../../mapping/mapping-serializer-json-addon';
 import { JsonSchemaDocumentUtilService } from './json-schema-document-util.service';
+
+export const FROM_JSON_SOURCE_SUFFIX = '-x';
 
 export interface CreateJsonSchemaDocumentResult extends CreateDocumentResult {
   document?: JsonSchemaDocument;

--- a/packages/ui/src/services/mapping/mapping-serializer-json-addon.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer-json-addon.test.ts
@@ -9,15 +9,15 @@ import {
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentType } from '../../models/datamapper/document';
 import { NS_XPATH_FUNCTIONS } from '../../models/datamapper/standard-namespaces';
 import { getCartToShipOrderJsonXslt, getShipOrderXsd, TestUtil } from '../../stubs/datamapper/data-mapper';
-import { JsonSchemaDocument, JsonSchemaField } from '../document/json-schema/json-schema-document.model';
+import {
+  FROM_JSON_SOURCE_SUFFIX,
+  JsonSchemaDocument,
+  JsonSchemaField,
+} from '../document/json-schema/json-schema-document.model';
 import { XmlSchemaField } from '../document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
 import { MappingSerializerService } from './mapping-serializer.service';
-import {
-  FROM_JSON_SOURCE_SUFFIX,
-  MappingSerializerJsonAddon,
-  TO_JSON_TARGET_VARIABLE,
-} from './mapping-serializer-json-addon';
+import { MappingSerializerJsonAddon, TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 describe('mappingSerializerJsonAddon', () => {
   describe('populateXmlToJsonVariable()', () => {

--- a/packages/ui/src/services/mapping/mapping-serializer-json-addon.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer-json-addon.ts
@@ -10,13 +10,12 @@ import {
 } from '../../models/datamapper';
 import { NS_XPATH_FUNCTIONS } from '../../models/datamapper/standard-namespaces';
 import {
+  FROM_JSON_SOURCE_SUFFIX,
   JsonSchemaDocument,
   JsonSchemaField,
   JsonSchemaParentType,
 } from '../document/json-schema/json-schema-document.model';
 import { JsonSchemaDocumentUtilService } from '../document/json-schema/json-schema-document-util.service';
-
-export const FROM_JSON_SOURCE_SUFFIX = '-x';
 export const TO_JSON_TARGET_VARIABLE = 'mapped-xml';
 
 /**

--- a/packages/ui/src/services/visualization/tree-parsing.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-parsing.service.test.ts
@@ -8,9 +8,16 @@ import {
 } from '../../models/datamapper/document';
 import { DocumentTree, INITIAL_PARSE_DEPTH } from '../../models/datamapper/document-tree';
 import { DocumentTreeNode } from '../../models/datamapper/document-tree-node';
-import { DocumentNodeData, FieldNodeData } from '../../models/datamapper/visualization';
+import { MappingTree } from '../../models/datamapper/mapping';
+import {
+  DocumentNodeData,
+  FieldNodeData,
+  MappingNodeData,
+  TargetDocumentNodeData,
+} from '../../models/datamapper/visualization';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
+import { MappingActionService } from './mapping-action.service';
 import { TreeParsingService } from './tree-parsing.service';
 import { VisualizationService } from './visualization.service';
 
@@ -57,6 +64,33 @@ describe('TreeParsingService', () => {
 
       expect(primitiveTree.root.isParsed).toBe(false);
       expect(primitiveTree.root.children).toHaveLength(0);
+    });
+
+    it('should parse primitive target document with instruction items into content roots', () => {
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const mappingTree = new MappingTree(
+        primitiveDoc.documentType,
+        primitiveDoc.documentId,
+        DocumentDefinitionType.Primitive,
+      );
+      const targetDocNode = new TargetDocumentNodeData(primitiveDoc, mappingTree);
+
+      // Add an 'if' instruction item to the primitive target
+      MappingActionService.applyIf(targetDocNode);
+
+      const primitiveTree = new DocumentTree(targetDocNode);
+      TreeParsingService.parseTree(primitiveTree);
+
+      // The 'if' instruction item should appear as a content root
+      expect(primitiveTree.contentRoots.length).toBe(1);
+      expect(primitiveTree.contentRoots[0].nodeData).toBeInstanceOf(MappingNodeData);
+      expect(primitiveTree.contentRoots[0].nodeData.title).toBe('if');
+
+      // The content root should be parsed and have its own children (ValueSelector)
+      expect(primitiveTree.contentRoots[0].isParsed).toBe(true);
+      expect(primitiveTree.contentRoots[0].children.length).toBeGreaterThan(0);
     });
 
     it('should handle empty document (no fields)', () => {

--- a/packages/ui/src/services/visualization/tree-ui.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.test.ts
@@ -50,7 +50,7 @@ describe('TreeUIService', () => {
       const expansionState = store.expansionState[documentId];
 
       expect(expansionState).toBeDefined();
-      expect(expansionState[tree.root.path]).toBe(true);
+      expect(expansionState[tree.contentRoots[0].path]).toBe(true);
     });
 
     it('should initialize expansion state for all nodes up to INITIAL_PARSE_DEPTH', () => {
@@ -61,9 +61,9 @@ describe('TreeUIService', () => {
       const expansionState = store.expansionState[documentId];
 
       const expandedNodeCount = Object.keys(expansionState).length;
-      expect(expandedNodeCount).toBeGreaterThan(1); // At least root and some children
+      expect(expandedNodeCount).toBeGreaterThan(1); // At least content root and some children
 
-      expect(store.isExpanded(documentId, tree.root.path)).toBe(true);
+      expect(store.isExpanded(documentId, tree.contentRoots[0].path)).toBe(true);
     });
 
     it('should store the tree internally and make it accessible via toggleNode', () => {
@@ -263,20 +263,21 @@ describe('TreeUIService', () => {
     const documentId = sourceDocNode.id;
     const store = useDocumentTreeStore.getState();
 
-    // Initial state: root should be expanded
-    expect(store.isExpanded(documentId, tree.root.path)).toBe(true);
+    // Initial state: first content root should be expanded
+    const firstContentRoot = tree.contentRoots[0];
+    expect(store.isExpanded(documentId, firstContentRoot.path)).toBe(true);
 
-    // Toggle root
-    TreeUIService.toggleNode(documentId, tree.root.path);
-    expect(store.isExpanded(documentId, tree.root.path)).toBe(false);
+    // Toggle content root
+    TreeUIService.toggleNode(documentId, firstContentRoot.path);
+    expect(store.isExpanded(documentId, firstContentRoot.path)).toBe(false);
 
-    // Toggle root again
-    TreeUIService.toggleNode(documentId, tree.root.path);
-    expect(store.isExpanded(documentId, tree.root.path)).toBe(true);
+    // Toggle content root again
+    TreeUIService.toggleNode(documentId, firstContentRoot.path);
+    expect(store.isExpanded(documentId, firstContentRoot.path)).toBe(true);
 
-    // Toggle a child - we know tree has children from our fixture
-    expect(tree.root.children.length).toBeGreaterThan(0);
-    const firstChildPath = tree.root.children[0].path;
+    // Toggle a child - we know content root has children from our fixture
+    expect(firstContentRoot.children.length).toBeGreaterThan(0);
+    const firstChildPath = firstContentRoot.children[0].path;
     const initialChildState = store.isExpanded(documentId, firstChildPath);
 
     TreeUIService.toggleNode(documentId, firstChildPath);
@@ -293,23 +294,25 @@ describe('TreeUIService', () => {
     const targetDocId = targetDocNode.id;
     const store = useDocumentTreeStore.getState();
 
-    // Both roots should be expanded initially
-    expect(store.isExpanded(sourceDocId, sourceTree.root.path)).toBe(true);
-    expect(store.isExpanded(targetDocId, targetTree.root.path)).toBe(true);
+    // Both content roots should be expanded initially
+    const sourceContentRoot = sourceTree.contentRoots[0];
+    const targetContentRoot = targetTree.contentRoots[0];
+    expect(store.isExpanded(sourceDocId, sourceContentRoot.path)).toBe(true);
+    expect(store.isExpanded(targetDocId, targetContentRoot.path)).toBe(true);
 
-    // Toggle source root
-    TreeUIService.toggleNode(sourceDocId, sourceTree.root.path);
-    expect(store.isExpanded(sourceDocId, sourceTree.root.path)).toBe(false);
-    expect(store.isExpanded(targetDocId, targetTree.root.path)).toBe(true);
+    // Toggle source content root
+    TreeUIService.toggleNode(sourceDocId, sourceContentRoot.path);
+    expect(store.isExpanded(sourceDocId, sourceContentRoot.path)).toBe(false);
+    expect(store.isExpanded(targetDocId, targetContentRoot.path)).toBe(true);
 
-    // Toggle target root
-    TreeUIService.toggleNode(targetDocId, targetTree.root.path);
-    expect(store.isExpanded(sourceDocId, sourceTree.root.path)).toBe(false);
-    expect(store.isExpanded(targetDocId, targetTree.root.path)).toBe(false);
+    // Toggle target content root
+    TreeUIService.toggleNode(targetDocId, targetContentRoot.path);
+    expect(store.isExpanded(sourceDocId, sourceContentRoot.path)).toBe(false);
+    expect(store.isExpanded(targetDocId, targetContentRoot.path)).toBe(false);
   });
 
   it('should handle creating tree, toggling, and verifying expansion state', () => {
-    expect.assertions(6);
+    expect.assertions(5);
     TreeUIService.createTree(sourceDocNode);
     const documentId = sourceDocNode.id;
     const store = useDocumentTreeStore.getState();
@@ -318,13 +321,13 @@ describe('TreeUIService', () => {
     const initialExpansionState = { ...store.expansionState[documentId] };
 
     const initialKeys = Object.keys(initialExpansionState);
-    expect(initialKeys.length).toEqual(14);
+    expect(initialKeys.length).toEqual(13);
 
     const expandedPaths = Object.entries(initialExpansionState).reduce((acc, [path, isExpanded]) => {
       if (isExpanded) acc.push(path);
       return acc;
     }, [] as string[]);
-    expect(expandedPaths.length).toEqual(4);
+    expect(expandedPaths.length).toEqual(3);
 
     // Toggle all initially expanded nodes
     for (const nodePath of expandedPaths) {

--- a/packages/ui/src/services/visualization/visualization-util.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.test.ts
@@ -1,9 +1,10 @@
-import { DocumentDefinitionType } from '../../models/datamapper/document';
-import { MappingTree } from '../../models/datamapper/mapping';
+import { DocumentDefinitionType, IField } from '../../models/datamapper/document';
+import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
 import {
   AbstractFieldNodeData,
   ChoiceFieldNodeData,
   DocumentNodeData,
+  FieldItemNodeData,
   FieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
@@ -38,7 +39,7 @@ describe('VisualizationUtilService', () => {
           { ...sourceDoc.fields[0], name: 'email' },
           { ...sourceDoc.fields[0], name: 'phone' },
         ],
-      } as unknown as (typeof sourceDoc.fields)[0];
+      } as unknown as IField;
       const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
       expect(VisualizationUtilService.isChoiceField(choiceNode)).toBe(true);
     });
@@ -53,7 +54,7 @@ describe('VisualizationUtilService', () => {
           { ...sourceDoc.fields[0], name: 'email' },
           { ...sourceDoc.fields[0], name: 'phone' },
         ],
-      } as unknown as (typeof sourceDoc.fields)[0];
+      } as unknown as IField;
       const choiceNode = new TargetChoiceFieldNodeData(targetDocNode, choiceField);
       expect(VisualizationUtilService.isChoiceField(choiceNode)).toBe(true);
     });
@@ -79,7 +80,7 @@ describe('VisualizationUtilService', () => {
           { ...sourceDoc.fields[0], name: 'Cat' },
           { ...sourceDoc.fields[0], name: 'Dog' },
         ],
-      } as unknown as (typeof sourceDoc.fields)[0];
+      } as unknown as IField;
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
       expect(VisualizationUtilService.isAbstractField(abstractNode)).toBe(true);
     });
@@ -94,7 +95,7 @@ describe('VisualizationUtilService', () => {
           { ...sourceDoc.fields[0], name: 'Cat' },
           { ...sourceDoc.fields[0], name: 'Dog' },
         ],
-      } as unknown as (typeof sourceDoc.fields)[0];
+      } as unknown as IField;
       const abstractNode = new TargetAbstractFieldNodeData(targetDocNode, abstractField);
       expect(VisualizationUtilService.isAbstractField(abstractNode)).toBe(true);
     });
@@ -106,6 +107,83 @@ describe('VisualizationUtilService', () => {
 
     it('should return false for DocumentNodeData', () => {
       expect(VisualizationUtilService.isAbstractField(sourceDocNode)).toBe(false);
+    });
+  });
+
+  describe('isCollectionField', () => {
+    it('should return false for non-collection FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isCollectionField(fieldNode)).toBe(false);
+    });
+
+    it('should return false for DocumentNodeData', () => {
+      expect(VisualizationUtilService.isCollectionField(sourceDocNode)).toBe(false);
+    });
+  });
+
+  describe('isAttributeField', () => {
+    it('should return true for FieldNodeData with attribute field', () => {
+      const attrField = { ...sourceDoc.fields[0], isAttribute: true } as unknown as IField;
+      const fieldNode = new FieldNodeData(sourceDocNode, attrField);
+      expect(VisualizationUtilService.isAttributeField(fieldNode)).toBe(true);
+    });
+
+    it('should return false for FieldNodeData with non-attribute field', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isAttributeField(fieldNode)).toBe(false);
+    });
+
+    it('should return true for FieldItemNodeData with attribute field', () => {
+      const attrField = { ...sourceDoc.fields[0], isAttribute: true } as unknown as IField;
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, attrField);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isAttributeField(fieldItemNode)).toBe(true);
+    });
+
+    it('should return false for FieldItemNodeData with non-attribute field', () => {
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, sourceDoc.fields[0]);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isAttributeField(fieldItemNode)).toBe(false);
+    });
+
+    it('should return false for DocumentNodeData', () => {
+      expect(VisualizationUtilService.isAttributeField(sourceDocNode)).toBe(false);
+    });
+  });
+
+  describe('isRecursiveField', () => {
+    it('should return false for non-recursive FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isRecursiveField(fieldNode)).toBe(false);
+    });
+
+    it('should return false for non-recursive FieldItemNodeData', () => {
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, sourceDoc.fields[0]);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isRecursiveField(fieldItemNode)).toBe(false);
+    });
+
+    it('should return false for DocumentNodeData', () => {
+      expect(VisualizationUtilService.isRecursiveField(sourceDocNode)).toBe(false);
+    });
+  });
+
+  describe('getField', () => {
+    it('should return field for FieldNodeData', () => {
+      const field = sourceDoc.fields[0];
+      const fieldNode = new FieldNodeData(sourceDocNode, field);
+      expect(VisualizationUtilService.getField(fieldNode)).toBe(field);
+    });
+
+    it('should return field for FieldItemNodeData', () => {
+      const field = sourceDoc.fields[0];
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, field);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.getField(fieldItemNode)).toBe(field);
+    });
+
+    it('should return undefined for DocumentNodeData', () => {
+      expect(VisualizationUtilService.getField(sourceDocNode)).toBeUndefined();
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -36,7 +36,7 @@ export class VisualizationUtilService {
    * @param nodeData - The node to test.
    */
   static isAttributeField(nodeData: NodeData) {
-    return nodeData instanceof FieldNodeData && nodeData.field.isAttribute;
+    return VisualizationUtilService.getField(nodeData)?.isAttribute ?? false;
   }
 
   /**
@@ -60,7 +60,8 @@ export class VisualizationUtilService {
    * @param nodeData - The node to test.
    */
   static isRecursiveField(nodeData: NodeData) {
-    return nodeData instanceof FieldNodeData && DocumentService.isRecursiveField(nodeData.field);
+    const field = VisualizationUtilService.getField(nodeData);
+    return field ? DocumentService.isRecursiveField(field) : false;
   }
 
   /**

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -289,7 +289,7 @@ describe('VisualizationService', () => {
     const forEach1Children = VisualizationService.generateNonDocumentNodeDataChildren(forEach1Node);
     expect(forEach1Children.length).toEqual(1);
     expect(forEach1Children[0].title).toEqual('Item');
-    expect(VisualizationUtilService.isCollectionField(forEach1Children[0]));
+    expect(VisualizationUtilService.isCollectionField(forEach1Children[0])).toBeTruthy();
     const forEach1ItemChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEach1Children[0]);
     expect(forEach1ItemChildren.length).toEqual(4);
     expect(forEach1ItemChildren[0].title).toEqual('Title');
@@ -301,7 +301,7 @@ describe('VisualizationService', () => {
     const forEach2Children = VisualizationService.generateNonDocumentNodeDataChildren(forEach2Node);
     expect(forEach2Children.length).toEqual(1);
     expect(forEach2Children[0].title).toEqual('Item');
-    expect(VisualizationUtilService.isCollectionField(forEach2Children[0]));
+    expect(VisualizationUtilService.isCollectionField(forEach2Children[0])).toBeTruthy();
     const forEach2ItemChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEach2Children[0]);
     expect(forEach2ItemChildren.length).toEqual(4);
     expect(forEach2ItemChildren[0].title).toEqual('Title');

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -6,8 +6,10 @@ import {
   PrimitiveDocument,
 } from '../models/datamapper/document';
 import { DocumentTree } from '../models/datamapper/document-tree';
-import { DocumentNodeData } from '../models/datamapper/visualization';
+import { MappingTree } from '../models/datamapper/mapping';
+import { DocumentNodeData, TargetDocumentNodeData } from '../models/datamapper/visualization';
 import { XmlSchemaDocument } from '../services/document/xml-schema/xml-schema-document.model';
+import { MappingActionService } from '../services/visualization/mapping-action.service';
 import { TreeParsingService } from '../services/visualization/tree-parsing.service';
 import { TestUtil } from '../stubs/datamapper/data-mapper';
 import { TreeConnectionPorts, useDocumentTreeStore } from './document-tree.store';
@@ -40,14 +42,12 @@ describe('useDocumentTreeStore', () => {
   });
 
   describe('updateTreeExpansion', () => {
-    it('should set first level state to false for an unparsed tree', () => {
+    it('should produce empty expansion state for an unparsed tree', () => {
       useDocumentTreeStore.getState().updateTreeExpansion(tree);
       const state = useDocumentTreeStore.getState().expansionState;
 
       expect(state).toEqual({
-        ['doc-sourceBody-Body']: {
-          ['sourceBody:Body://']: false,
-        },
+        ['doc-sourceBody-Body']: {},
       });
       expect(Object.keys(state)).toHaveLength(1);
     });
@@ -63,8 +63,7 @@ describe('useDocumentTreeStore', () => {
       const keys = Object.keys(state[tree.documentId]);
 
       expect(keys).toEqual([
-        // DFS order: Root -> ShipOrder -> children -> grandchildren (maxFields extends beyond maxDepth)
-        'targetBody:Body://',
+        // DFS order: ShipOrder -> children -> grandchildren (maxFields extends beyond maxDepth)
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderId-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-OrderPerson-\d{4}$/),
@@ -81,7 +80,7 @@ describe('useDocumentTreeStore', () => {
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Quantity-\d{4}$/),
         expect.stringMatching(/^targetBody:Body:\/\/fx-ShipOrder-\d{4}\/fx-Item-\d{4}\/fx-Price-\d{4}$/),
       ]);
-      expect(keys).toHaveLength(14);
+      expect(keys).toHaveLength(13);
     });
 
     it('should not include primitive nodes in expansion state', () => {
@@ -93,11 +92,41 @@ describe('useDocumentTreeStore', () => {
 
       TreeParsingService.parseTree(primitiveTree);
 
-      useDocumentTreeStore.getState().updateTreeExpansion(tree);
+      useDocumentTreeStore.getState().updateTreeExpansion(primitiveTree);
       const state = useDocumentTreeStore.getState().expansionState;
-      const keys = Object.keys(state[tree.documentId]);
+      const keys = Object.keys(state[primitiveTree.documentId]);
 
-      expect(keys).toEqual(['sourceBody:Body://']);
+      expect(keys).toEqual([]);
+    });
+
+    it('should track expansion state for primitive target document with instruction items', () => {
+      const primitiveDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const mappingTree = new MappingTree(
+        primitiveDoc.documentType,
+        primitiveDoc.documentId,
+        DocumentDefinitionType.Primitive,
+      );
+      const targetDocNode = new TargetDocumentNodeData(primitiveDoc, mappingTree);
+
+      // Add an 'if' instruction item to the primitive target
+      MappingActionService.applyIf(targetDocNode);
+
+      const primitiveTree = new DocumentTree(targetDocNode);
+      TreeParsingService.parseTree(primitiveTree);
+
+      useDocumentTreeStore.getState().updateTreeExpansion(primitiveTree);
+      const state = useDocumentTreeStore.getState().expansionState;
+      const keys = Object.keys(state[primitiveTree.documentId]);
+
+      // The 'if' instruction item and its ValueSelector child should appear in expansion state
+      expect(keys.length).toBeGreaterThan(0);
+
+      // Content roots should be flattened for rendering
+      const flattened = primitiveTree.flatten(state[primitiveTree.documentId]);
+      expect(flattened.length).toBeGreaterThan(0);
+      expect(flattened[0].treeNode.nodeData.title).toBe('if');
     });
 
     it('should keep the existing expansion state for matching keys', () => {
@@ -109,16 +138,15 @@ describe('useDocumentTreeStore', () => {
       const initialState = useDocumentTreeStore.getState().expansionState[tree.documentId];
       const paths = Object.keys(initialState);
 
-      // Find a path that has children (not root or leaf)
-      const rootPath = paths[0]; // 'sourceBody:Body://'
-      const childPath = paths[1]; // First child path (with random ID)
+      const firstContentRoot = paths[0];
+      const secondPath = paths[1];
 
-      // Set custom expansion state: root expanded (true), child collapsed (false)
+      // Set custom expansion state: first content root expanded (true), second collapsed (false)
       useDocumentTreeStore.setState({
         expansionState: {
           [tree.documentId]: {
-            [rootPath]: true,
-            [childPath]: false,
+            [firstContentRoot]: true,
+            [secondPath]: false,
           },
         },
       });
@@ -127,9 +155,8 @@ describe('useDocumentTreeStore', () => {
       useDocumentTreeStore.getState().updateTreeExpansion(tree);
       const state = useDocumentTreeStore.getState().expansionState[tree.documentId];
 
-      // Verify that the custom states were preserved for matching keys
-      expect(state[rootPath]).toBe(true);
-      expect(state[childPath]).toBe(false);
+      expect(state[firstContentRoot]).toBe(true);
+      expect(state[secondPath]).toBe(false);
     });
   });
 

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -100,10 +100,12 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
         const currentExpansionState: TreeExpansionState = get().expansionState[documentTree.documentId] ?? {};
         const newExpansionState: TreeExpansionState = {};
 
-        processTreeNode(documentTree.root, (treeNode) => {
-          const isNodeParsed = treeNode.isParsed;
-          newExpansionState[treeNode.path] = isNodeParsed && (currentExpansionState[treeNode.path] ?? true);
-        });
+        for (const contentRoot of documentTree.contentRoots) {
+          processTreeNode(contentRoot, (treeNode) => {
+            const isNodeParsed = treeNode.isParsed;
+            newExpansionState[treeNode.path] = isNodeParsed && (currentExpansionState[treeNode.path] ?? true);
+          });
+        }
 
         set((state) => ({
           expansionState: {

--- a/packages/ui/src/utils/process-tree-node.ts
+++ b/packages/ui/src/utils/process-tree-node.ts
@@ -18,7 +18,7 @@ export const processTreeNode = (
   let totalFieldsProcessed = 0;
 
   const visit = (node: DocumentTreeNode, depth: number): void => {
-    if ((depth >= maxDepth && totalFieldsProcessed >= maxFields) || node.nodeData.isPrimitive) {
+    if (depth >= maxDepth && totalFieldsProcessed >= maxFields) {
       return;
     }
 


### PR DESCRIPTION
…dering

Fixes: https://github.com/KaotoIO/kaoto/issues/3156

Render XSLT instruction items such as if/choose-when-otherwise for the primitive target document

Fixes: https://github.com/KaotoIO/kaoto/issues/3132

DocumentTree header/content architecture: DocumentTree now explicitly separates the document identity (consumed by panel header) from the content structure (rendered in the tree) which eliminate the duplicate "Body" node that appeared in both the header and the tree.

Fixes: https://github.com/KaotoIO/kaoto/issues/3153

Following up PR #3152 for coderabbitai findings:
  * isAttributeField/isRecursiveField now handle FieldItemNodeData via getField()
  * FROM_JSON_SOURCE_SUFFIX moved to json-schema-document.model.ts
  * mapping-action.ts uses import type
  * Missing .toBeTruthy() matchers added in visualization.service.test.ts

https://github.com/user-attachments/assets/70f21809-da4b-419a-9b82-02aae38f8e48



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for instruction items on primitive target documents.

* **Bug Fixes**
  * Improved expansion panel behavior to recognize all content states.
  * Enhanced attribute field detection in tree visualization.
  * Refined tree expansion state tracking for better persistence.

* **Tests**
  * Expanded test coverage for instruction items and field attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->