### PR TITLE
fix(DataMapper): Use solid line for primitive params without schema

### DIFF
--- a/packages/ui/src/utils/get-nearest-visible-port.test.ts
+++ b/packages/ui/src/utils/get-nearest-visible-port.test.ts
@@ -133,6 +133,22 @@ describe('getNearestVisiblePort', () => {
     expect(result).toEqual({ connectionTarget: 'parent', position: [120, 220] });
   });
 
+  it('should return node for primitive parameter without child attachment', () => {
+    const options: NearestVisiblePortOptions = {
+      nodesConnectionPorts: {
+        'p:EDGE:top': [0, 0],
+        'p:EDGE:bottom': [0, 500],
+      },
+      nodesConnectionPortsArray: [],
+      expansionState: {},
+      expansionStateArray: [],
+    };
+
+    const result = getNearestVisiblePort('param:p://', options);
+
+    expect(result).toEqual({ connectionTarget: 'node', position: [0, 500] });
+  });
+
   it('should prefer closer ancestors over distant ones', () => {
     const options: NearestVisiblePortOptions = {
       nodesConnectionPorts: {

--- a/packages/ui/src/utils/get-nearest-visible-port.ts
+++ b/packages/ui/src/utils/get-nearest-visible-port.ts
@@ -1,3 +1,4 @@
+import { DocumentType } from '../models/datamapper/document';
 import { NodePath } from '../models/datamapper/nodepath';
 import { TreeConnectionPorts, TreeExpansionState } from '../store/document-tree.store';
 
@@ -48,6 +49,14 @@ export function getNearestVisiblePort(
     if (nodesConnectionPorts[parentPath] && !expansionState[parentPath]) {
       return { connectionTarget: 'parent', position: nodesConnectionPorts[parentPath] };
     }
+  }
+
+  if (
+    nodePath.documentType === DocumentType.PARAM &&
+    nodesConnectionPortsArray.length === 0 &&
+    expansionStateArray.length === 0
+  ) {
+    return { connectionTarget: 'node', position: nodesConnectionPorts[edgeBottomKey] };
   }
 
   const firstVisiblePath = nodesConnectionPortsArray.at(0);

--- a/packages/ui/src/utils/get-nearest-visible-port.ts
+++ b/packages/ui/src/utils/get-nearest-visible-port.ts
@@ -1,4 +1,3 @@
-import { DocumentType } from '../models/datamapper/document';
 import { NodePath } from '../models/datamapper/nodepath';
 import { TreeConnectionPorts, TreeExpansionState } from '../store/document-tree.store';
 
@@ -51,11 +50,8 @@ export function getNearestVisiblePort(
     }
   }
 
-  if (
-    nodePath.documentType === DocumentType.PARAM &&
-    nodesConnectionPortsArray.length === 0 &&
-    expansionStateArray.length === 0
-  ) {
+  // no ports && no expansion states, means it's a primitive document (including header and params)
+  if (nodesConnectionPortsArray.length === 0 && expansionStateArray.length === 0) {
     return { connectionTarget: 'node', position: nodesConnectionPorts[edgeBottomKey] };
   }
 


### PR DESCRIPTION
Resolves: [#3075](https://github.com/KaotoIO/kaoto/issues/3075)

# Summary

Fix nearest visible port resolution for primitive source parameters without an attached schema.

# Changes Made

- Updated [`getNearestVisiblePort()`](packages/ui/src/utils/get-nearest-visible-port.ts:22) to treat primitive param documents with no visible child ports as a `node` target instead of falling back to an `edge`.
- Added regression coverage in [`get-nearest-visible-port.test.ts`](packages/ui/src/utils/get-nearest-visible-port.test.ts) for a no-schema source param using the runtime-correct [`param:`](packages/ui/src/models/datamapper/nodepath.ts:34) path format.
- No breaking changes expected.

# Testing

- Added a focused unit test for primitive parameter port resolution.
- Existing behavior for exact node, parent, and edge fallback cases remains covered by the test suite.

# Additional Notes

This change is based on the runtime shape of primitive source params, where only edge ports are registered and both [`nodesConnectionPortsArray`](packages/ui/src/utils/get-nearest-visible-port.ts) and [`expansionStateArray`](packages/ui/src/utils/get-nearest-visible-port.ts) are empty.

<img width="1198" height="741" alt="Screenshot 2026-04-24 at 08 13 42" src="https://github.com/user-attachments/assets/3cd7f275-bc21-4d34-a889-e491008256ae" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit to verify parameter/primitive nodes resolve connections to their bottom edge when child-attachment metadata and port registrations are absent.

* **Bug Fixes**
  * UI now resolves connections for primitives to the node’s bottom-edge position (treated as a node) when no connection ports or expansion state exist, preventing incorrect parent/edge fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->