### PR TITLE
chore(DataMapper): for-each-group: S.3, S.6: Add tests for group-star…

### DIFF
--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -1,7 +1,12 @@
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IParentType } from '../../models/datamapper/document';
 import { ForEachGroupItem, GroupingStrategy, MappingTree, UnknownMappingItem } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
-import { getForEachGroupToShipOrderXslt, TestUtil } from '../../stubs/datamapper/data-mapper';
+import {
+  getForEachGroupEndingWithToShipOrderXslt,
+  getForEachGroupStartingWithToShipOrderXslt,
+  getForEachGroupToShipOrderXslt,
+  TestUtil,
+} from '../../stubs/datamapper/data-mapper';
 import { MappingSerializerService } from './mapping-serializer.service';
 import * as handlerModule from './xslt-item-handlers';
 import {
@@ -126,7 +131,77 @@ describe('ForEachGroupItemHandler', () => {
     expect(item.groupingExpression).toBe('@type');
   });
 
-  it('should round-trip for-each-group through serialize/deserialize', () => {
+  it('should serialize for-each-group with group-starting-with', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const item = new ForEachGroupItem(mappingTree);
+    item.expression = '/data/record';
+    item.groupingStrategy = GroupingStrategy.GROUP_STARTING_WITH;
+    item.groupingExpression = 'self::ns0:Header';
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const el = handler.serialize(parent, item);
+    expect(el.getAttribute('select')).toBe('/data/record');
+    expect(el.getAttribute('group-starting-with')).toBe('self::ns0:Header');
+  });
+
+  it('should serialize for-each-group with group-ending-with', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const item = new ForEachGroupItem(mappingTree);
+    item.expression = '/data/record';
+    item.groupingStrategy = GroupingStrategy.GROUP_ENDING_WITH;
+    item.groupingExpression = 'self::ns0:Footer';
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const el = handler.serialize(parent, item);
+    expect(el.getAttribute('select')).toBe('/data/record');
+    expect(el.getAttribute('group-ending-with')).toBe('self::ns0:Footer');
+  });
+
+  it('should round-trip for-each-group with group-starting-with', () => {
+    let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree = MappingSerializerService.deserialize(
+      getForEachGroupStartingWithToShipOrderXslt(),
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+    const forEachGroup = mappingTree.children[0].children[0] as ForEachGroupItem;
+    expect(forEachGroup.expression).toBe('/ns0:ShipOrder/Item');
+    expect(forEachGroup.groupingStrategy).toBe(GroupingStrategy.GROUP_STARTING_WITH);
+    expect(forEachGroup.groupingExpression).toBe('self::*[Note]');
+
+    const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    const dom = new DOMParser().parseFromString(serialized, 'application/xml');
+    const el = dom.getElementsByTagNameNS(NS_XSL, 'for-each-group')[0];
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('select')).toBe('/ns0:ShipOrder/Item');
+    expect(el.getAttribute('group-starting-with')).toBe('self::*[Note]');
+  });
+
+  it('should round-trip for-each-group with group-ending-with', () => {
+    let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree = MappingSerializerService.deserialize(
+      getForEachGroupEndingWithToShipOrderXslt(),
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+    const forEachGroup = mappingTree.children[0].children[0] as ForEachGroupItem;
+    expect(forEachGroup.expression).toBe('/ns0:ShipOrder/Item');
+    expect(forEachGroup.groupingStrategy).toBe(GroupingStrategy.GROUP_ENDING_WITH);
+    expect(forEachGroup.groupingExpression).toBe('self::*[Price > 100]');
+
+    const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    const dom = new DOMParser().parseFromString(serialized, 'application/xml');
+    const el = dom.getElementsByTagNameNS(NS_XSL, 'for-each-group')[0];
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('select')).toBe('/ns0:ShipOrder/Item');
+    expect(el.getAttribute('group-ending-with')).toBe('self::*[Price > 100]');
+  });
+
+  it('should round-trip for-each-group with group-by', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     mappingTree = MappingSerializerService.deserialize(
       getForEachGroupToShipOrderXslt(),

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -100,6 +100,12 @@ export function getShipOrderToShipOrderMultipleForEachXslt(): string {
 export function getForEachGroupToShipOrderXslt(): string {
   return readStubFile('./xml/ForEachGroupToShipOrder.xsl');
 }
+export function getForEachGroupStartingWithToShipOrderXslt(): string {
+  return readStubFile('./xml/ForEachGroupStartingWithToShipOrder.xsl');
+}
+export function getForEachGroupEndingWithToShipOrderXslt(): string {
+  return readStubFile('./xml/ForEachGroupEndingWithToShipOrder.xsl');
+}
 export function getShipOrderToShipOrderCollectionIndexXslt(): string {
   return readStubFile('./xml/ShipOrderToShipOrderCollectionIndex.xsl');
 }

--- a/packages/ui/src/stubs/datamapper/xml/ForEachGroupEndingWithToShipOrder.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/ForEachGroupEndingWithToShipOrder.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ShipOrder>
+      <xsl:for-each-group select="/ns0:ShipOrder/Item" group-ending-with="self::*[Price > 100]">
+        <Batch>
+          <ItemCount><xsl:value-of select="count(current-group())"/></ItemCount>
+          <TotalPrice><xsl:value-of select="sum(current-group()/Price)"/></TotalPrice>
+        </Batch>
+      </xsl:for-each-group>
+    </ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/stubs/datamapper/xml/ForEachGroupStartingWithToShipOrder.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/ForEachGroupStartingWithToShipOrder.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ShipOrder>
+      <xsl:for-each-group select="/ns0:ShipOrder/Item" group-starting-with="self::*[Note]">
+        <Section>
+          <xsl:for-each select="current-group()">
+            <Item>
+              <Title><xsl:value-of select="Title"/></Title>
+              <Price><xsl:value-of select="Price"/></Price>
+            </Item>
+          </xsl:for-each>
+        </Section>
+      </xsl:for-each-group>
+    </ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
…ting-with and group-ending-with

Fixes: https://github.com/KaotoIO/kaoto/issues/2862
Fixes: https://github.com/KaotoIO/kaoto/issues/2868

The implementation was already done by: https://github.com/KaotoIO/kaoto/pull/3159 Add missing tests for group-starting-with and group-ending-with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for for-each-group operations with multiple grouping strategies.

* **Documentation**
  * Added example XSLT stylesheets demonstrating data transformation and grouping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->