### PR TITLE
fix(DataMapper): xsl:variable: XSLT serialization/deserialization

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
@@ -13,7 +13,7 @@ type ImportMappingFileDropdownItemProps = {
 export const ImportMappingFileDropdownItem: FunctionComponent<ImportMappingFileDropdownItemProps> = ({
   onComplete,
 }) => {
-  const { mappingTree, sourceParameterMap, targetBodyDocument, refreshMappingTree } = useDataMapper();
+  const { mappingTree, sourceParameterMap, targetBodyDocument, refreshMappingTree, sendAlert } = useDataMapper();
   const fileInputRef = createRef<HTMLInputElement>();
 
   const onClick = useCallback(() => {
@@ -24,13 +24,29 @@ export const ImportMappingFileDropdownItem: FunctionComponent<ImportMappingFileD
     (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.item(0);
       if (!file) return;
-      readFileAsString(file).then((content) => {
-        MappingSerializerService.deserialize(content, targetBodyDocument, mappingTree, sourceParameterMap);
-        refreshMappingTree();
-        onComplete();
-      });
+      readFileAsString(file)
+        .then((content) => {
+          const { messages } = MappingSerializerService.deserialize(
+            content,
+            targetBodyDocument,
+            mappingTree,
+            sourceParameterMap,
+          );
+          for (const msg of messages) {
+            sendAlert(msg);
+          }
+          refreshMappingTree();
+          onComplete();
+        })
+        .catch((error: unknown) => {
+          sendAlert({
+            variant: 'danger',
+            title: 'Failed to import mapping file',
+            description: error instanceof Error ? error.message : String(error),
+          });
+        });
     },
-    [mappingTree, onComplete, refreshMappingTree, sourceParameterMap, targetBodyDocument],
+    [mappingTree, onComplete, refreshMappingTree, sendAlert, sourceParameterMap, targetBodyDocument],
   );
 
   return (

--- a/packages/ui/src/models/datamapper/index.ts
+++ b/packages/ui/src/models/datamapper/index.ts
@@ -1,10 +1,10 @@
 export * from './document';
 export * from './mapping';
 export * from './nodepath';
+export * from './serialization';
 export { NS_XSL } from './standard-namespaces';
 export * from './types';
 export * from './view';
 export * from './visualization';
 export { PathExpression } from './xpath';
 export { PathSegment } from './xpath';
-export * from './xslt-item-handler';

--- a/packages/ui/src/models/datamapper/serialization.ts
+++ b/packages/ui/src/models/datamapper/serialization.ts
@@ -1,21 +1,34 @@
 import { IParentType } from './document';
-import { MappingItem, MappingParentType } from './mapping';
+import { MappingItem, MappingParentType, MappingTree } from './mapping';
+import { SendAlertProps } from './visualization';
 
 /**
  * Constructor type for any class that extends {@link MappingItem}.
- * Used as the key type in the serialize handler table.
+ * Used as the key type in the serialize handler lookup table.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type MappingItemClass = abstract new (...args: any[]) => MappingItem;
 
 /**
- * Result of deserializing an XSLT element into a mapping model node.
+ * Per-handler result for a single XSLT element.
+ * {@link mappingItem} is absent when the element is skipped (e.g. reserved variable names)
+ * but the handler still needs to report {@link messages}.
  * {@link fieldItem} is non-null only when the handler resolves a target field
  * (e.g. `xsl:attribute` or a target element).
  */
-export interface DeserializeResult {
-  mappingItem: MappingItem;
+export interface DeserializeItemResult<T extends MappingItem> {
+  mappingItem?: T;
   fieldItem: IParentType | null;
+  messages?: SendAlertProps[];
+}
+
+/**
+ * Top-level result returned by {@link MappingSerializerService.deserialize}.
+ * Collects all {@link SendAlertProps} emitted during the full deserialization pass.
+ */
+export interface DeserializeResult {
+  mappingTree: MappingTree;
+  messages: SendAlertProps[];
 }
 
 /**
@@ -32,5 +45,9 @@ export interface XsltItemHandler<T extends MappingItem = MappingItem> {
   /** Create XSLT DOM element(s) for the given mapping item and append to `parent`. */
   serialize(parent: Element, mapping: T): Element | null;
   /** Create a {@link MappingItem} from the given XSLT DOM element, or null to skip. */
-  deserialize(element: Element, parentField: IParentType, parentMapping: MappingParentType): DeserializeResult | null;
+  deserialize(
+    element: Element,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<T> | null;
 }

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -362,4 +362,5 @@ export type LineProps = LineCoord & {
 };
 
 /** Props passed to the alert notification handler. */
-export type SendAlertProps = Partial<AlertProps & { description: string }>;
+export type SendAlertProps = Required<Pick<AlertProps, 'variant' | 'title'>> &
+  Partial<Pick<AlertProps, 'key'>> & { description?: string };

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-import { Alert, AlertActionCloseButton, AlertGroup, AlertProps, AlertVariant } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertGroup } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Loading } from '../components/Loading';
@@ -148,13 +148,16 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     mappingTree.documentDefinitionType = latestTargetBodyDocument.definitionType;
 
     if (initialXsltFile) {
-      const loaded = MappingSerializerService.deserialize(
+      const { mappingTree: loaded, messages } = MappingSerializerService.deserialize(
         initialXsltFile,
         latestTargetBodyDocument,
         mappingTree,
         latestSourceParameterMap,
       );
       setMappingTree(loaded);
+      for (const msg of messages) {
+        sendAlert(msg);
+      }
     }
     setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -291,24 +294,13 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     [onUpdateDocument, refreshMappingTree, removeStaleMappings, setNewDocument],
   );
 
-  const sendAlert = useCallback(
-    (option: SendAlertProps) => {
-      alerts.push(option);
-      setAlerts([...alerts]);
-    },
-    [alerts],
-  );
+  const sendAlert = useCallback((option: SendAlertProps) => {
+    setAlerts((prev) => [...prev, option]);
+  }, []);
 
-  const closeAlert = useCallback(
-    (option: Partial<AlertProps>) => {
-      const index = alerts.indexOf(option);
-      if (index > -1) {
-        alerts.splice(index, 1);
-        setAlerts([...alerts]);
-      }
-    },
-    [alerts],
-  );
+  const closeAlert = useCallback((option: SendAlertProps) => {
+    setAlerts((prev) => prev.filter((a) => a !== option));
+  }, []);
 
   const value = useMemo(() => {
     return {
@@ -367,13 +359,13 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
             {alerts.map((option, index) => (
               <Alert
                 key={option.key ?? `alert-key-${index}`}
-                variant={option.variant ?? AlertVariant.danger}
-                title={option.title ?? 'Unknown Error'}
-                timeout={option.timeout ?? true}
+                variant={option.variant}
+                title={option.title}
+                timeout={true}
                 onTimeout={() => closeAlert(option)}
                 actionClose={<AlertActionCloseButton onClose={() => closeAlert(option)} />}
               >
-                {option.description && <>option.description</>}
+                {option.description && <>{option.description}</>}
               </Alert>
             ))}
           </AlertGroup>

--- a/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
@@ -58,12 +58,12 @@ describe('MappingSerializerService / JSON', () => {
   describe('deserialize()', () => {
     it('should deserialize XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderJsonXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       expect(targetDoc.fields[0].fields[3].fields[0].fields.length).toEqual(3);
       const namespaces = mappingTree.namespaceMap;
       expect(mappingTree.children.length).toBe(1);
@@ -205,12 +205,12 @@ describe('MappingSerializerService / JSON', () => {
 
     it('should serialize JSON mappings', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderJsonXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const xsltString = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(xsltString, 'text/xml');
 

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -13,6 +13,7 @@ import {
   OtherwiseItem,
   UnknownMappingItem,
   ValueSelector,
+  VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
@@ -30,6 +31,11 @@ import {
   getUnknownApplyTemplateAfterFieldXslt,
   getUnknownApplyTemplateBeforeFieldXslt,
   getUnknownApplyTemplateXslt,
+  getVariableBeforeFieldXslt,
+  getVariableEmptyNameXslt,
+  getVariableNestedInForEachXslt,
+  getVariableReservedNamesXslt,
+  getVariableSimpleXslt,
   getWhitespaceTextNodeXslt,
   getX12850ForEachXslt,
   getXslTextNodeXslt,
@@ -58,22 +64,22 @@ describe('MappingSerializerService', () => {
   describe('deserialize()', () => {
     it('should return an empty MappingTree', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(EMPTY_XSL, targetDoc, mappingTree, sourceParameterMap);
+      ({ mappingTree } = MappingSerializerService.deserialize(EMPTY_XSL, targetDoc, mappingTree, sourceParameterMap));
       expect(mappingTree.children.length).toEqual(0);
       mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize('', targetDoc, mappingTree, sourceParameterMap);
+      ({ mappingTree } = MappingSerializerService.deserialize('', targetDoc, mappingTree, sourceParameterMap));
       expect(mappingTree.children.length).toEqual(0);
     });
 
     it('should deserialize XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
       expect(Object.keys(mappingTree.namespaceMap).length).toEqual(0);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       expect(Object.keys(mappingTree.namespaceMap).length).toEqual(1);
       expect(mappingTree.namespaceMap['ns0']).toEqual('io.kaoto.datamapper.poc.test');
       expect(mappingTree.children.length).toEqual(1);
@@ -194,7 +200,7 @@ describe('MappingSerializerService', () => {
         BODY_DOCUMENT_ID,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      const result = MappingSerializerService.deserialize(
+      const { mappingTree: result } = MappingSerializerService.deserialize(
         getRawTextNodeXslt(),
         targetDoc,
         mappingTree,
@@ -212,7 +218,7 @@ describe('MappingSerializerService', () => {
         BODY_DOCUMENT_ID,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      const result = MappingSerializerService.deserialize(
+      const { mappingTree: result } = MappingSerializerService.deserialize(
         getXslTextNodeXslt(),
         targetDoc,
         mappingTree,
@@ -230,7 +236,7 @@ describe('MappingSerializerService', () => {
         BODY_DOCUMENT_ID,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      const result = MappingSerializerService.deserialize(
+      const { mappingTree: result } = MappingSerializerService.deserialize(
         getWhitespaceTextNodeXslt(),
         targetDoc,
         mappingTree,
@@ -241,12 +247,12 @@ describe('MappingSerializerService', () => {
 
     it('should deserialize incomplete XSLT', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderInvalidForEachXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const forEachItem = mappingTree.children[0].children[0] as ForEachItem;
       expect(forEachItem.expression).toEqual('');
       const itemSelector = forEachItem.children[0].children[0] as ValueSelector;
@@ -264,12 +270,12 @@ describe('MappingSerializerService', () => {
       expect(result.validationStatus).toBe('success');
       const targetDoc850 = result.document!;
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getX12850ForEachXslt(),
         targetDoc850,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const itemsFieldItem = mappingTree.children[0].children[0] as FieldItem;
       expect(itemsFieldItem.children.length).toEqual(1);
       const forEachItem = itemsFieldItem.children[0] as ForEachItem;
@@ -282,12 +288,12 @@ describe('MappingSerializerService', () => {
 
     it('should deserialize multiple for-each mappings on a same target collection', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderMultipleForEachXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       expect(mappingTree.children[0].children.length).toEqual(2);
       const forEach1 = mappingTree.children[0].children[0] as ForEachItem;
       expect(forEach1.expression).toEqual('/ns0:ShipOrder/Item');
@@ -303,12 +309,12 @@ describe('MappingSerializerService', () => {
 
     it('should clone UnknownMappingItem with a deep copy of the element', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getUnknownApplyTemplateXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const shipOrderItem = mappingTree.children[0];
       const unknownItem = shipOrderItem.children[0] as UnknownMappingItem;
 
@@ -325,7 +331,7 @@ describe('MappingSerializerService', () => {
     it('should capture unrecognized XSL elements as UnknownMappingItem', () => {
       const xslt = getUnknownApplyTemplateXslt();
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap);
+      ({ mappingTree } = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap));
       expect(mappingTree.children.length).toEqual(1);
       const shipOrderItem = mappingTree.children[0] as FieldItem;
       expect(shipOrderItem.field.name).toEqual('ShipOrder');
@@ -342,12 +348,12 @@ describe('MappingSerializerService', () => {
       const mockCrypto = { getRandomValues: () => [Math.random() * 10000] };
       jest.spyOn(globalThis, 'crypto', 'get').mockImplementation(() => mockCrypto as unknown as Crypto);
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderCollectionIndexXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       expect(mappingTree.children[0].children.length).toEqual(2);
       const item1 = mappingTree.children[0].children[0] as FieldItem;
       expect(item1.children.length).toEqual(4);
@@ -374,12 +380,12 @@ describe('MappingSerializerService', () => {
 
     it('should serialize mappings', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(xslt, 'text/xml');
       expect(xsltDocument.documentElement.getAttribute('xmlns:ns0')).toEqual('io.kaoto.datamapper.poc.test');
@@ -469,7 +475,7 @@ describe('MappingSerializerService', () => {
     it('should round-trip UnknownMappingItem verbatim including nested children', () => {
       const xslt = getUnknownApplyTemplateXslt();
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap);
+      ({ mappingTree } = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap));
       const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
       const applyTemplates = xsltDocument
@@ -503,12 +509,12 @@ describe('MappingSerializerService', () => {
 
     it('should preserve original order when UnknownMappingItem appears after a FieldItem', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getUnknownApplyTemplateAfterFieldXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
       const children = xsltDocument.evaluate(
@@ -525,12 +531,12 @@ describe('MappingSerializerService', () => {
 
     it('should preserve original order when UnknownMappingItem appears before a FieldItem', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getUnknownApplyTemplateBeforeFieldXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
       const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
       const children = xsltDocument.evaluate(
@@ -547,12 +553,12 @@ describe('MappingSerializerService', () => {
 
     it('should serialize mappings with respecting Document field order', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const shipOrderItem = mappingTree.children[0];
       shipOrderItem.children.reverse();
       const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
@@ -577,12 +583,12 @@ describe('MappingSerializerService', () => {
 
     it('should serialize mapping with comment', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const shipOrderItem = mappingTree.children[0];
       shipOrderItem.comment = 'This is a test comment';
       const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
@@ -603,12 +609,12 @@ describe('MappingSerializerService', () => {
 
     it('should serialize mapping with nested comments', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const shipOrderItem = mappingTree.children[0];
       shipOrderItem.comment = 'Root element comment';
       const ifItem = shipOrderItem.children[1] as IfItem;
@@ -620,12 +626,12 @@ describe('MappingSerializerService', () => {
 
     it('should deserialize mapping with comment', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderWithCommentXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       expect(mappingTree.children.length).toEqual(1);
       const shipOrderItem = mappingTree.children[0];
       expect(shipOrderItem.comment).toEqual('This is a test comment');
@@ -633,12 +639,12 @@ describe('MappingSerializerService', () => {
 
     it('should preserve comments through serialize/deserialize cycle', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
       const shipOrderItem = mappingTree.children[0];
       shipOrderItem.comment = 'Root comment';
       const ifItem = shipOrderItem.children[1] as IfItem;
@@ -651,7 +657,12 @@ describe('MappingSerializerService', () => {
 
       // Deserialize
       let mappingTree2 = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree2 = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree2, sourceParameterMap);
+      ({ mappingTree: mappingTree2 } = MappingSerializerService.deserialize(
+        xslt,
+        targetDoc,
+        mappingTree2,
+        sourceParameterMap,
+      ));
 
       // Verify comments are preserved
       const shipOrderItem2 = mappingTree2.children[0];
@@ -664,12 +675,12 @@ describe('MappingSerializerService', () => {
 
     it('should deserialize complex XSL with multiple comments at different levels', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderWithMultipleCommentsXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
 
       expect(mappingTree.children.length).toEqual(1);
       const shipOrderItem = mappingTree.children[0] as FieldItem;
@@ -692,27 +703,157 @@ describe('MappingSerializerService', () => {
 
     it('should handle XSL without comments gracefully', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
+      ({ mappingTree } = MappingSerializerService.deserialize(
         getShipOrderToShipOrderXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
-      );
+      ));
 
       expect(mappingTree.children.length).toBeGreaterThan(0);
       const shipOrderItem = mappingTree.children[0];
       expect(shipOrderItem.comment).toBeUndefined();
     });
 
-    it('should deserialize external XSL file with comments correctly', () => {
-      // This simulates importing an XSL file that was manually edited with comments
+    it('should deserialize a simple variable with select attribute', () => {
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mappingTree = MappingSerializerService.deserialize(
-        getShipOrderManuallyEditedXslt(),
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getVariableSimpleXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
+      const shipOrderItem = mappingTree.children[0] as FieldItem;
+      expect(shipOrderItem.children.length).toEqual(2);
+      const variableItem = shipOrderItem.children[0] as VariableItem;
+      expect(variableItem).toBeInstanceOf(VariableItem);
+      expect(variableItem.name).toEqual('orderRef');
+      expect(variableItem.expression).toEqual('/ns0:ShipOrder/@OrderId');
+    });
+
+    it('should filter reserved variable names during deserialization', () => {
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const { messages } = MappingSerializerService.deserialize(
+        getVariableReservedNamesXslt(),
         targetDoc,
         mappingTree,
         sourceParameterMap,
       );
+      const shipOrderItem = mappingTree.children[0] as FieldItem;
+      expect(shipOrderItem.children.length).toEqual(1);
+      const variableItem = shipOrderItem.children[0] as VariableItem;
+      expect(variableItem).toBeInstanceOf(VariableItem);
+      expect(variableItem.name).toEqual('myVar');
+      expect(messages).toHaveLength(2);
+      expect(messages[0].variant).toEqual('danger');
+      expect(messages[0].title).toContain('reserved variable name');
+    });
+
+    it('should skip xsl:variable with empty name and emit danger message', () => {
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const { messages } = MappingSerializerService.deserialize(
+        getVariableEmptyNameXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      );
+      const shipOrderItem = mappingTree.children[0] as FieldItem;
+      expect(shipOrderItem.children.length).toEqual(1);
+      const variableItem = shipOrderItem.children[0] as VariableItem;
+      expect(variableItem).toBeInstanceOf(VariableItem);
+      expect(variableItem.name).toEqual('myVar');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].variant).toEqual('danger');
+      expect(messages[0].title).toContain('without a name');
+    });
+
+    it('should deserialize a variable nested inside for-each', () => {
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getVariableNestedInForEachXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
+      const shipOrderItem = mappingTree.children[0] as FieldItem;
+      const forEachItem = shipOrderItem.children[0] as ForEachItem;
+      const itemFieldItem = forEachItem.children[0] as FieldItem;
+      expect(itemFieldItem.children.length).toEqual(2);
+      const variableItem = itemFieldItem.children[0] as VariableItem;
+      expect(variableItem).toBeInstanceOf(VariableItem);
+      expect(variableItem.name).toEqual('itemTitle');
+      expect(variableItem.expression).toEqual('Title');
+    });
+
+    it('should round-trip a simple variable', () => {
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getVariableSimpleXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
+      const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
+      const variableName = xsltDocument
+        .evaluate(
+          '/xsl:stylesheet/xsl:template/ShipOrder/xsl:variable/@name',
+          xsltDocument,
+          null,
+          XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+        )
+        .iterateNext();
+      expect(variableName?.nodeValue).toEqual('orderRef');
+      const variableSelect = xsltDocument
+        .evaluate(
+          '/xsl:stylesheet/xsl:template/ShipOrder/xsl:variable/@select',
+          xsltDocument,
+          null,
+          XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+        )
+        .iterateNext();
+      expect(variableSelect?.nodeValue).toEqual('/ns0:ShipOrder/@OrderId');
+    });
+
+    it('should sort variables before other children during serialization', () => {
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getVariableBeforeFieldXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
+      const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
+      const children = xsltDocument.evaluate(
+        '/xsl:stylesheet/xsl:template/ShipOrder/*',
+        xsltDocument,
+        null,
+        XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+      );
+      const first = children.iterateNext() as Element;
+      expect(first.nodeName).toEqual('xsl:variable');
+      const second = children.iterateNext() as Element;
+      expect(second.nodeName).toEqual('xsl:attribute');
+    });
+
+    it('should deserialize external XSL file with comments correctly', () => {
+      // This simulates importing an XSL file that was manually edited with comments
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getShipOrderManuallyEditedXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
 
       expect(mappingTree.children.length).toEqual(1);
       const shipOrderItem = mappingTree.children[0];
@@ -723,6 +864,26 @@ describe('MappingSerializerService', () => {
 
       const ifItem = shipOrderItem.children[1] as IfItem;
       expect(ifItem.comment).toEqual('TODO: Add validation for OrderPerson');
+    });
+
+    it('should serialize stably when two InstructionItems resolve to empty fields', () => {
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const shipOrder = new FieldItem(mappingTree, targetDoc.fields[0]);
+      const if1 = new IfItem(shipOrder);
+      if1.expression = 'true()';
+      const if2 = new IfItem(shipOrder);
+      if2.expression = 'false()';
+      shipOrder.children = [if1, if2];
+      mappingTree.children = [shipOrder];
+      const xslt1 = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      shipOrder.children = [if2, if1];
+      const xslt2 = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      expect(xslt1).toContain('xsl:if');
+      expect(xslt2).toContain('xsl:if');
     });
   });
 });

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -19,9 +19,11 @@ import {
   UnknownMappingItem,
   ValueSelector,
   ValueType,
+  VariableItem,
 } from '../../models/datamapper/mapping';
+import { DeserializeItemResult, DeserializeResult, MappingItemClass } from '../../models/datamapper/serialization';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
-import { MappingItemClass } from '../../models/datamapper/xslt-item-handler';
+import { SendAlertProps } from '../../models/datamapper/visualization';
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
 import { MappingService } from './mapping.service';
 import { MappingSerializerJsonAddon } from './mapping-serializer-json-addon';
@@ -45,14 +47,18 @@ export class MappingSerializerService {
   }
 
   private static sortMappingItem(left: MappingItem, right: MappingItem) {
+    if (left instanceof VariableItem && right instanceof VariableItem) return 0;
+    if (left instanceof VariableItem) return -1;
+    if (right instanceof VariableItem) return 1;
     if (left instanceof UnknownMappingItem || right instanceof UnknownMappingItem) return 0;
     const leftFields =
       left instanceof FieldItem ? [left.field] : MappingService.getInstructionFields(left as InstructionItem);
-    if (leftFields.length === 0) return 1;
-    if (leftFields.find((f) => f.isAttribute)) return -1;
     const rightFields =
       right instanceof FieldItem ? [right.field] : MappingService.getInstructionFields(right as InstructionItem);
+    if (leftFields.length === 0 && rightFields.length === 0) return 0;
+    if (leftFields.length === 0) return 1;
     if (rightFields.length === 0) return -1;
+    if (leftFields.find((f) => f.isAttribute)) return -1;
     if (rightFields.find((f) => f.isAttribute)) return 1;
     const leftFirst = leftFields.sort(MappingSerializerService.sortFields)[0];
     const rightFirst = rightFields.sort(MappingSerializerService.sortFields)[0];
@@ -159,18 +165,19 @@ export class MappingSerializerService {
     targetDocument: IDocument,
     mappingTree: MappingTree,
     sourceParameterMap: Map<string, IDocument>,
-  ): MappingTree {
+  ): DeserializeResult {
     mappingTree.children = [];
+    const messages: SendAlertProps[] = [];
     const xsltDoc = new DOMParser().parseFromString(xslt, 'application/xml');
     const template = xsltDoc.getElementsByTagNameNS(NS_XSL, 'template')[0];
-    if (!template?.children) return mappingTree;
+    if (!template?.children) return { mappingTree, messages };
     MappingSerializerService.restoreNamespaces(xsltDoc, mappingTree);
     MappingSerializerService.restoreParam(xsltDoc, sourceParameterMap);
     const root = MappingSerializerJsonAddon.getJsonTargetBase(xsltDoc, mappingTree) ?? template;
-    Array.from(root.childNodes).forEach((item) =>
-      MappingSerializerService.restoreMapping(item, targetDocument, mappingTree),
-    );
-    return mappingTree;
+    for (const item of Array.from(root.childNodes)) {
+      MappingSerializerService.restoreMapping(item, targetDocument, mappingTree, messages);
+    }
+    return { mappingTree, messages };
   }
 
   private static restoreNamespaces(xsltDocument: Document, mappingTree: MappingTree) {
@@ -204,11 +211,16 @@ export class MappingSerializerService {
     }
   }
 
-  private static restoreMapping(item: Node, parentField: IParentType, parentMapping: MappingParentType) {
+  private static restoreMapping(
+    item: Node,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+    messages: SendAlertProps[],
+  ) {
     if (item.nodeType === Node.TEXT_NODE) {
       MappingSerializerService.restoreTextNode(item, parentMapping);
     } else if (item.nodeType === Node.ELEMENT_NODE) {
-      MappingSerializerService.restoreElementNode(item as Element, parentField, parentMapping);
+      MappingSerializerService.restoreElementNode(item as Element, parentField, parentMapping, messages);
     }
   }
 
@@ -232,21 +244,31 @@ export class MappingSerializerService {
     }
   }
 
-  private static restoreElementNode(element: Element, parentField: IParentType, parentMapping: MappingParentType) {
+  private static restoreElementNode(
+    element: Element,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+    messages: SendAlertProps[],
+  ) {
     const result =
       element.namespaceURI === NS_XSL
-        ? MappingSerializerService.restoreXslElement(element, parentField, parentMapping)
+        ? MappingSerializerService.restoreXslElement(element, parentField, parentMapping, messages)
         : MappingSerializerService.restoreNonXslElement(element, parentField, parentMapping);
 
-    if (!result) return;
+    if (!result?.mappingItem) return;
 
     parentMapping.children.push(result.mappingItem);
 
     const isXslText = element.namespaceURI === NS_XSL && element.localName === 'text';
     if (!(result.mappingItem instanceof UnknownMappingItem) && !isXslText) {
-      Array.from(element.childNodes).forEach((childItem) =>
-        MappingSerializerService.restoreMapping(childItem, result.fieldItem ?? parentField, result.mappingItem),
-      );
+      for (const childItem of Array.from(element.childNodes)) {
+        MappingSerializerService.restoreMapping(
+          childItem,
+          result.fieldItem ?? parentField,
+          result.mappingItem,
+          messages,
+        );
+      }
     }
   }
 
@@ -267,13 +289,32 @@ export class MappingSerializerService {
     element: Element,
     parentField: IParentType,
     parentMapping: MappingParentType,
-  ): { mappingItem: MappingItem; fieldItem: IParentType | null } | null {
+    messages: SendAlertProps[],
+  ): DeserializeItemResult<MappingItem> | null {
     const handler = deserializeHandlers.get(element.localName);
-    const result = handler
-      ? handler.deserialize(element, parentField, parentMapping)
-      : { mappingItem: new UnknownMappingItem(parentMapping, element), fieldItem: null };
+    let result: DeserializeItemResult<MappingItem> | null;
+    if (handler) {
+      result = handler.deserialize(element, parentField, parentMapping);
+    } else {
+      result = {
+        mappingItem: new UnknownMappingItem(parentMapping, element),
+        fieldItem: null,
+        messages: [
+          {
+            variant: 'warning',
+            title: `Unrecognized XSLT element: "xsl:${element.localName}"`,
+            description: new XMLSerializer().serializeToString(element),
+          },
+        ],
+      };
+    }
     if (!result) return null;
-    MappingSerializerService.restoreCommentFromPreviousSibling(element, result.mappingItem);
+    if (result.messages) {
+      messages.push(...result.messages);
+    }
+    if (result.mappingItem) {
+      MappingSerializerService.restoreCommentFromPreviousSibling(element, result.mappingItem);
+    }
     return result;
   }
 

--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -161,12 +161,12 @@ describe('ForEachGroupItemHandler', () => {
 
   it('should round-trip for-each-group with group-starting-with', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-    mappingTree = MappingSerializerService.deserialize(
+    ({ mappingTree } = MappingSerializerService.deserialize(
       getForEachGroupStartingWithToShipOrderXslt(),
       targetDoc,
       mappingTree,
       sourceParameterMap,
-    );
+    ));
     const forEachGroup = mappingTree.children[0].children[0] as ForEachGroupItem;
     expect(forEachGroup.expression).toBe('/ns0:ShipOrder/Item');
     expect(forEachGroup.groupingStrategy).toBe(GroupingStrategy.GROUP_STARTING_WITH);
@@ -182,12 +182,12 @@ describe('ForEachGroupItemHandler', () => {
 
   it('should round-trip for-each-group with group-ending-with', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-    mappingTree = MappingSerializerService.deserialize(
+    ({ mappingTree } = MappingSerializerService.deserialize(
       getForEachGroupEndingWithToShipOrderXslt(),
       targetDoc,
       mappingTree,
       sourceParameterMap,
-    );
+    ));
     const forEachGroup = mappingTree.children[0].children[0] as ForEachGroupItem;
     expect(forEachGroup.expression).toBe('/ns0:ShipOrder/Item');
     expect(forEachGroup.groupingStrategy).toBe(GroupingStrategy.GROUP_ENDING_WITH);
@@ -203,12 +203,12 @@ describe('ForEachGroupItemHandler', () => {
 
   it('should round-trip for-each-group with group-by', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-    mappingTree = MappingSerializerService.deserialize(
+    ({ mappingTree } = MappingSerializerService.deserialize(
       getForEachGroupToShipOrderXslt(),
       targetDoc,
       mappingTree,
       sourceParameterMap,
-    );
+    ));
     const forEachGroup = mappingTree.children[0].children[0] as ForEachGroupItem;
     expect(forEachGroup.expression).toBe('/ns0:ShipOrder/Item');
     expect(forEachGroup.groupingStrategy).toBe(GroupingStrategy.GROUP_BY);

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -11,12 +11,14 @@ import {
   UnknownMappingItem,
   ValueSelector,
   ValueType,
+  VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
+import { DeserializeItemResult, MappingItemClass, XsltItemHandler } from '../../models/datamapper/serialization';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
-import { DeserializeResult, MappingItemClass, XsltItemHandler } from '../../models/datamapper/xslt-item-handler';
+import { FROM_JSON_SOURCE_SUFFIX } from '../document/json-schema/json-schema-document.model';
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
-import { MappingSerializerJsonAddon } from './mapping-serializer-json-addon';
+import { MappingSerializerJsonAddon, TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 /** Handles {@link ValueSelector} — maps to `xsl:copy-of`, `xsl:value-of`, or `xsl:text`. */
 export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
@@ -37,7 +39,11 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
     return valueOf;
   }
 
-  deserialize(element: Element, parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<ValueSelector> {
     switch (element.localName) {
       case 'copy-of': {
         const selector = new ValueSelector(parentMapping, ValueType.CONTAINER);
@@ -86,7 +92,11 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
     return element;
   }
 
-  deserialize(element: Element, parentField: IParentType, parentMapping: MappingParentType): DeserializeResult | null {
+  deserialize(
+    element: Element,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<FieldItem> | null {
     if (parentField instanceof PrimitiveDocument) return null;
     const field = FieldItemHandler.getOrCreateAttributeField(element, parentField);
     if (!field) return null;
@@ -123,7 +133,11 @@ export class IfItemHandler implements XsltItemHandler<IfItem> {
     return xslIf;
   }
 
-  deserialize(element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<IfItem> {
     const ifItem = new IfItem(parentMapping);
     ifItem.expression = element.getAttribute('test') || '';
     return { mappingItem: ifItem, fieldItem: null };
@@ -141,7 +155,11 @@ export class ChooseItemHandler implements XsltItemHandler<ChooseItem> {
     return xslChoose;
   }
 
-  deserialize(_element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    _element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<ChooseItem> {
     return { mappingItem: new ChooseItem(parentMapping), fieldItem: null };
   }
 }
@@ -158,7 +176,11 @@ export class WhenItemHandler implements XsltItemHandler<WhenItem> {
     return xslWhen;
   }
 
-  deserialize(element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<WhenItem> {
     const whenItem = new WhenItem(parentMapping);
     whenItem.expression = element.getAttribute('test') || '';
     return { mappingItem: whenItem, fieldItem: null };
@@ -176,7 +198,11 @@ export class OtherwiseItemHandler implements XsltItemHandler<OtherwiseItem> {
     return xslOtherwise;
   }
 
-  deserialize(_element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    _element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<OtherwiseItem> {
     return { mappingItem: new OtherwiseItem(parentMapping), fieldItem: null };
   }
 }
@@ -193,7 +219,11 @@ export class ForEachItemHandler implements XsltItemHandler<ForEachItem> {
     return xslForEach;
   }
 
-  deserialize(element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<ForEachItem> {
     const forEachItem = new ForEachItem(parentMapping);
     forEachItem.expression = element.getAttribute('select') || '';
     return { mappingItem: forEachItem, fieldItem: null };
@@ -213,7 +243,11 @@ export class ForEachGroupItemHandler implements XsltItemHandler<ForEachGroupItem
     return el;
   }
 
-  deserialize(element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<ForEachGroupItem> {
     const item = new ForEachGroupItem(parentMapping);
     item.expression = element.getAttribute('select') || '';
     for (const strategy of Object.values(GroupingStrategy)) {
@@ -225,6 +259,55 @@ export class ForEachGroupItemHandler implements XsltItemHandler<ForEachGroupItem
       }
     }
     return { mappingItem: item, fieldItem: null };
+  }
+}
+
+/** Handles {@link VariableItem} — maps to `xsl:variable` with a `select` XPath expression. */
+export class VariableItemHandler implements XsltItemHandler<VariableItem> {
+  readonly itemClass = VariableItem;
+  readonly xsltElementNames = ['variable'];
+
+  serialize(parent: Element, mapping: VariableItem): Element {
+    const xslVariable = parent.ownerDocument.createElementNS(NS_XSL, 'variable');
+    xslVariable.setAttribute('name', mapping.name);
+    xslVariable.setAttribute('select', mapping.expression);
+    parent.appendChild(xslVariable);
+    return xslVariable;
+  }
+
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<VariableItem> | null {
+    const varName = element.getAttribute('name')?.trim() || '';
+    if (!varName) {
+      return {
+        fieldItem: null,
+        messages: [
+          {
+            variant: 'danger',
+            title: 'Skipping xsl:variable without a name',
+            description: new XMLSerializer().serializeToString(element),
+          },
+        ],
+      };
+    }
+    if (varName.endsWith(FROM_JSON_SOURCE_SUFFIX) || varName === TO_JSON_TARGET_VARIABLE) {
+      return {
+        fieldItem: null,
+        messages: [
+          {
+            variant: 'danger',
+            title: `Skipping reserved variable name: "${varName}"`,
+            description: new XMLSerializer().serializeToString(element),
+          },
+        ],
+      };
+    }
+    const variableItem = new VariableItem(parentMapping, varName);
+    variableItem.expression = element.getAttribute('select') || '';
+    return { mappingItem: variableItem, fieldItem: null };
   }
 }
 
@@ -243,7 +326,11 @@ export class UnknownMappingItemHandler implements XsltItemHandler<UnknownMapping
     return imported;
   }
 
-  deserialize(element: Element, _parentField: IParentType, parentMapping: MappingParentType): DeserializeResult {
+  deserialize(
+    element: Element,
+    _parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<UnknownMappingItem> {
     return { mappingItem: new UnknownMappingItem(parentMapping, element), fieldItem: null };
   }
 }
@@ -258,6 +345,7 @@ export const allHandlers: XsltItemHandler[] = [
   new OtherwiseItemHandler(),
   new ForEachItemHandler(),
   new ForEachGroupItemHandler(),
+  new VariableItemHandler(),
   new UnknownMappingItemHandler(),
 ];
 

--- a/packages/ui/src/services/visualization/visualization.service.json.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.json.test.ts
@@ -148,12 +148,12 @@ describe('VisualizationService / JSON', () => {
 
   it('should render deserialized mappings', () => {
     let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);
-    mappingTree = MappingSerializerService.deserialize(
+    ({ mappingTree } = MappingSerializerService.deserialize(
       getShipOrderJsonXslt(),
       targetDoc,
       mappingTree,
       sourceParameterMap,
-    );
+    ));
     expect(mappingTree.children.length).toEqual(1);
 
     targetDocNode = new TargetDocumentNodeData(targetDoc, mappingTree);

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -307,6 +307,21 @@ export function getShipOrderWithMultipleCommentsXslt(): string {
 export function getShipOrderManuallyEditedXslt(): string {
   return readStubFile('./xml/ShipOrderManuallyEdited.xsl');
 }
+export function getVariableSimpleXslt(): string {
+  return readStubFile('./xml/VariableSimple.xsl');
+}
+export function getVariableReservedNamesXslt(): string {
+  return readStubFile('./xml/VariableReservedNames.xsl');
+}
+export function getVariableBeforeFieldXslt(): string {
+  return readStubFile('./xml/VariableBeforeField.xsl');
+}
+export function getVariableEmptyNameXslt(): string {
+  return readStubFile('./xml/VariableEmptyName.xsl');
+}
+export function getVariableNestedInForEachXslt(): string {
+  return readStubFile('./xml/VariableNestedInForEach.xsl');
+}
 
 export class TestUtil {
   static createSourceOrderDoc() {

--- a/packages/ui/src/stubs/datamapper/xml/VariableBeforeField.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/VariableBeforeField.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:attribute name="OrderId">
+                <xsl:value-of select="/ns0:ShipOrder/@OrderId"/>
+            </xsl:attribute>
+            <xsl:variable name="orderRef" select="/ns0:ShipOrder/@OrderId"/>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/stubs/datamapper/xml/VariableEmptyName.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/VariableEmptyName.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:variable name="" select="/ns0:ShipOrder/@OrderId"/>
+            <xsl:variable name="myVar" select="/ns0:ShipOrder/@OrderId"/>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/stubs/datamapper/xml/VariableNestedInForEach.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/VariableNestedInForEach.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:for-each select="/ns0:ShipOrder/Item">
+                <Item xmlns="">
+                    <xsl:variable name="itemTitle" select="Title"/>
+                    <Title>
+                        <xsl:value-of select="$itemTitle"/>
+                    </Title>
+                </Item>
+            </xsl:for-each>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/stubs/datamapper/xml/VariableReservedNames.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/VariableReservedNames.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:param name="sourceParam1"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:variable name="sourceParam1-x" select="json-to-xml($sourceParam1)"/>
+            <xsl:variable name="mapped-xml" select="/ns0:ShipOrder"/>
+            <xsl:variable name="myVar" select="/ns0:ShipOrder/@OrderId"/>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packages/ui/src/stubs/datamapper/xml/VariableSimple.xsl
+++ b/packages/ui/src/stubs/datamapper/xml/VariableSimple.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ns0="io.kaoto.datamapper.poc.test">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:template match="/">
+        <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+            <xsl:variable name="orderRef" select="/ns0:ShipOrder/@OrderId"/>
+            <xsl:attribute name="OrderId">
+                <xsl:value-of select="$orderRef"/>
+            </xsl:attribute>
+        </ShipOrder>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2841

* Add VariableItemHandler
* Refactor deserializer to be able to return gathered error messages, which is now shown in toast notification

<img width="1350" height="375" alt="Screenshot From 2026-04-28 16-43-20" src="https://github.com/user-attachments/assets/bab663d6-eab2-437e-b76a-ce7570ae9230" />

<img width="1350" height="375" alt="Screenshot From 2026-04-28 21-29-15" src="https://github.com/user-attachments/assets/bc4af2d3-198c-41dd-baeb-1c514497f659" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XSLT variable support in the data mapper, including nested variables and round-trip serialization/deserialization.

* **Improvements**
  * Import now surfaces consolidated deserialization messages as alerts (warnings/errors) including unrecognized elements and skipped/reserved variables.
  * Variables are ordered deterministically during serialization.

* **Tests**
  * Expanded tests for variable handling, reserved/empty-name reporting, message propagation, and serialization round-trip stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->