### PR TITLE
fix(DataMapper): Restored panel headers (Source and Target)

### DIFF
--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -831,7 +831,7 @@ describe('ParametersSection', () => {
       );
 
       // Header should exist
-      expect(screen.getByText('Parameters')).toBeInTheDocument();
+      expect(screen.getByText('Source Parameters')).toBeInTheDocument();
 
       // Add button should exist
       expect(await screen.findByTestId('add-parameter-button')).toBeInTheDocument();
@@ -858,7 +858,7 @@ describe('ParametersSection', () => {
       );
 
       // Header should exist
-      expect(screen.getByText('Parameters')).toBeInTheDocument();
+      expect(screen.getByText('Source Parameters')).toBeInTheDocument();
 
       // Add button should not exist in read-only
       expect(screen.queryByTestId('add-parameter-button')).not.toBeInTheDocument();

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -54,7 +54,7 @@ export const ParametersHeader: FunctionComponent<ParametersHeaderProps> = ({
   actionItems,
 }) => (
   <div className="parameters-header" data-testid="source-parameters-header">
-    <span className="parameters-header__title panel-header-text">Parameters</span>
+    <span className="parameters-header__title panel-header-text">Source Parameters</span>
     <ActionList isIconList className="parameters-header__actions">
       {!isReadOnly && (
         <>

--- a/packages/ui/src/components/View/SourcePanel.scss
+++ b/packages/ui/src/components/View/SourcePanel.scss
@@ -2,8 +2,4 @@
   position: relative;
   overflow: auto;
   height: 100%;
-
-  &__header {
-    padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm) 0;
-  }
 }

--- a/packages/ui/src/components/View/SourcePanel.test.tsx
+++ b/packages/ui/src/components/View/SourcePanel.test.tsx
@@ -76,4 +76,15 @@ describe('SourcePanel', () => {
 
     jest.useRealTimers();
   });
+
+  it('should render the h3 with the "Source" text', () => {
+    const { container } = render(
+      <DataMapperProvider>
+        <MappingLinksProvider>
+          <SourcePanel />
+        </MappingLinksProvider>
+      </DataMapperProvider>,
+    );
+    expect(container.querySelector('.source-panel__header')).toHaveTextContent('Source');
+  });
 });

--- a/packages/ui/src/components/View/SourcePanel.test.tsx
+++ b/packages/ui/src/components/View/SourcePanel.test.tsx
@@ -56,7 +56,7 @@ describe('SourcePanel', () => {
     );
 
     // Find the Body panel summary and click to collapse
-    const bodyPanel = screen.getByText('Body').closest('.expansion-panel__summary') as HTMLElement;
+    const bodyPanel = screen.getByText('Source Body').closest('.expansion-panel__summary') as HTMLElement;
     expect(bodyPanel).toBeInTheDocument();
 
     act(() => {
@@ -70,21 +70,10 @@ describe('SourcePanel', () => {
 
     // The panel should now be collapsed (data-expanded=false)
     await waitFor(() => {
-      const panel = screen.getByText('Body').closest('.expansion-panel');
+      const panel = screen.getByText('Source Body').closest('.expansion-panel');
       expect(panel).toHaveAttribute('data-expanded', 'false');
     });
 
     jest.useRealTimers();
-  });
-
-  it('should render the h3 with the "Source" text', () => {
-    const { container } = render(
-      <DataMapperProvider>
-        <MappingLinksProvider>
-          <SourcePanel />
-        </MappingLinksProvider>
-      </DataMapperProvider>,
-    );
-    expect(container.querySelector('.source-panel__header')).toHaveTextContent('Source');
   });
 });

--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -1,5 +1,6 @@
 import './SourcePanel.scss';
 
+import { Content, ContentVariants, Truncate } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -95,6 +96,9 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
 
   return (
     <div id="panel-source" className="source-panel">
+      <Content component={ContentVariants.h3}>
+        <Truncate content="Source" className="source-panel__header" />
+      </Content>
       <ExpansionPanels firstPanelId="parameters-header" lastPanelId="source-body">
         {/* Parameters section - self-contained component that manages all parameter state */}
         <ParametersSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} actionItems={actionItems} />

--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -1,6 +1,5 @@
 import './SourcePanel.scss';
 
-import { Content, ContentVariants, Truncate } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -96,9 +95,6 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
 
   return (
     <div id="panel-source" className="source-panel">
-      <Content component={ContentVariants.h3}>
-        <Truncate content="Source" className="source-panel__header" />
-      </Content>
       <ExpansionPanels firstPanelId="parameters-header" lastPanelId="source-body">
         {/* Parameters section - self-contained component that manages all parameter state */}
         <ParametersSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} actionItems={actionItems} />
@@ -112,7 +108,7 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
           minHeight={PANEL_MIN_HEIGHT}
           summary={
             <DocumentHeader
-              header={<span className="panel-header-text">Body</span>}
+              header={<span className="panel-header-text">Source Body</span>}
               document={sourceBodyDocument}
               documentType={DocumentType.SOURCE_BODY}
               isReadOnly={isReadOnly}

--- a/packages/ui/src/components/View/TargetPanel.scss
+++ b/packages/ui/src/components/View/TargetPanel.scss
@@ -2,8 +2,4 @@
   position: relative;
   overflow: auto;
   height: 100%;
-
-  &__header {
-    padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm) 0;
-  }
 }

--- a/packages/ui/src/components/View/TargetPanel.test.tsx
+++ b/packages/ui/src/components/View/TargetPanel.test.tsx
@@ -50,7 +50,7 @@ describe('TargetPanel', () => {
 
   it('should render the Target panel with Body header', () => {
     render(<TargetPanel />, { wrapper });
-    expect(screen.getByText('Body')).toBeInTheDocument();
+    expect(screen.getByText('Target Body')).toBeInTheDocument();
   });
 
   it('should render the panel with correct id', () => {
@@ -61,7 +61,7 @@ describe('TargetPanel', () => {
   it('should hide the grab icon when the target body has a schema attached', async () => {
     const { container } = render(<TargetPanel />, { wrapper: schemaWrapper });
 
-    expect(await screen.findByText('Body')).toBeInTheDocument();
+    expect(await screen.findByText('Target Body')).toBeInTheDocument();
 
     const header = container.querySelector('[data-testid="document-doc-targetBody-Body"]');
     expect(header).toBeInTheDocument();
@@ -79,10 +79,5 @@ describe('TargetPanel', () => {
     const panel = container.querySelector('.expansion-panel');
     // Target body starts as primitive (no schema), so it should be collapsed
     expect(panel).toHaveAttribute('data-expanded', 'false');
-  });
-
-  it('should render the h3 with the "Target" text', () => {
-    const { container } = render(<TargetPanel />, { wrapper });
-    expect(container.querySelector('.target-panel__header')).toHaveTextContent('Target');
   });
 });

--- a/packages/ui/src/components/View/TargetPanel.test.tsx
+++ b/packages/ui/src/components/View/TargetPanel.test.tsx
@@ -80,4 +80,9 @@ describe('TargetPanel', () => {
     // Target body starts as primitive (no schema), so it should be collapsed
     expect(panel).toHaveAttribute('data-expanded', 'false');
   });
+
+  it('should render the h3 with the "Target" text', () => {
+    const { container } = render(<TargetPanel />, { wrapper });
+    expect(container.querySelector('.target-panel__header')).toHaveTextContent('Target');
+  });
 });

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -1,6 +1,5 @@
 import './TargetPanel.scss';
 
-import { Content, ContentVariants, Truncate } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -151,9 +150,6 @@ export const TargetPanel: FunctionComponent = () => {
 
   return (
     <div id="panel-target" className="target-panel">
-      <Content component={ContentVariants.h3}>
-        <Truncate content="Target" className="target-panel__header" />
-      </Content>
       <ExpansionPanels lastPanelId="target-body">
         <ExpansionPanel
           id="target-body"
@@ -163,7 +159,7 @@ export const TargetPanel: FunctionComponent = () => {
           collapsible={false}
           summary={
             <DocumentHeader
-              header={<span className="panel-header-text">Body</span>}
+              header={<span className="panel-header-text">Target Body</span>}
               document={targetBodyDocument}
               documentType={DocumentType.TARGET_BODY}
               isReadOnly={false}

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -1,5 +1,6 @@
 import './TargetPanel.scss';
 
+import { Content, ContentVariants, Truncate } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -150,6 +151,9 @@ export const TargetPanel: FunctionComponent = () => {
 
   return (
     <div id="panel-target" className="target-panel">
+      <Content component={ContentVariants.h3}>
+        <Truncate content="Target" className="target-panel__header" />
+      </Content>
       <ExpansionPanels lastPanelId="target-body">
         <ExpansionPanel
           id="target-body"


### PR DESCRIPTION
Resolves: [#3169](https://github.com/KaotoIO/kaoto/issues/3169)

## Description

Restored the Source and Target headers on SourcePanel and TargetPanel. 

<img width="1440" height="716" alt="Screenshot 2026-04-30 at 08 26 04" src="https://github.com/user-attachments/assets/628ffcb2-6358-438e-84da-5924c2d82f85" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header labels updated to "Source Body", "Target Body", and "Source Parameters".

* **Style**
  * Adjusted header spacing for source and target panels.

* **Tests**
  * Updated tests to assert the new header labels and related panel rendering/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->