### PR TITLE
fix: updated dynamic catalog to accept cache partially filled

### DIFF
--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
@@ -303,6 +303,25 @@ describe('DynamicCatalog', () => {
       expect(result).toEqual({ entity2: entities.entity2 });
       expect(fetchAllSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should fetch all entities even if cache was partially populated by get()', async () => {
+      const singleEntity: TestEntity = { id: '1', name: 'single', value: 10 };
+      const allEntities = {
+        entity1: singleEntity,
+        entity2: { id: '2', name: 'second', value: 20 },
+        entity3: { id: '3', name: 'third', value: 30 },
+      };
+      const fetchSpy = jest.spyOn(mockProvider, 'fetch').mockResolvedValue(singleEntity);
+      const fetchAllSpy = jest.spyOn(mockProvider, 'fetchAll').mockResolvedValue(allEntities);
+
+      await catalog.get('entity1');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      const result = await catalog.getAll();
+      expect(result).toEqual(allEntities);
+      expect(fetchAllSpy).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result)).toHaveLength(3);
+    });
   });
 
   describe('clearCache', () => {

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.ts
@@ -4,6 +4,7 @@ import { ICatalogProvider, IDynamicCatalog } from './models';
 
 export class DynamicCatalog<T = unknown> implements IDynamicCatalog<T> {
   protected readonly cache: Record<string, T> = {};
+  private fetchedAll = false;
 
   constructor(protected readonly provider: ICatalogProvider<T>) {}
 
@@ -23,7 +24,8 @@ export class DynamicCatalog<T = unknown> implements IDynamicCatalog<T> {
   async getAll(
     options: { forceFresh?: boolean; filterFn?: (key: string, entity: T) => boolean } = {},
   ): Promise<Record<string, T>> {
-    if (options.forceFresh || Object.keys(this.cache).length === 0) {
+    if (options.forceFresh || !this.fetchedAll) {
+      this.fetchedAll = true;
       const entities = await this.provider.fetchAll();
       Object.entries(entities).forEach(([key, entity]) => {
         this.cache[key] = entity;
@@ -50,5 +52,6 @@ export class DynamicCatalog<T = unknown> implements IDynamicCatalog<T> {
     Object.keys(this.cache).forEach((key) => {
       delete this.cache[key];
     });
+    this.fetchedAll = false;
   }
 }


### PR DESCRIPTION
Fix dynamic catalog cache management                                                                                                
 
Fixes an issue where getAll() would skip fetching all entities if the cache was partially populated from a previous get() call.     
                  
Changes:                                                                                                                            
- Adds fetchedAll flag to track whether all entities have been fetched
- Updates getAll() to fetch all entities unless fetchedAll is true (instead of checking if cache is empty)                          
- Resets fetchedAll flag in clearCache()                                                                  
- Adds test coverage for the partial cache scenario                                                                                 
                                                   
Before: Calling get('entity1') then getAll() would return only the cached entity                                                    
After: getAll() always fetches all entities on first call, regardless of partial cache state

fix: https://github.com/KaotoIO/kaoto/issues/3175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the `getAll()` method to reliably return complete catalog data regardless of prior cache state, ensuring consistent results across different usage patterns.

* **Tests**
  * Added comprehensive test coverage for `getAll()` behavior when the cache contains partial data, verifying proper refresh and complete data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->