### PR TITLE
feat: introduce topology view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ storybook-static
 
 .bob/notes
 .codex
+.claude/

--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -22,6 +22,7 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
         children: [
           { title: 'Design', to: Links.Home },
           { title: 'Source Code', to: Links.SourceCode },
+          { title: 'Topology', to: Links.Topology },
         ],
       },
       {

--- a/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
+++ b/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-37"
+                  data-ouia-component-id="OUIA-Generated-NavItem-41"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -82,7 +82,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-38"
+                  data-ouia-component-id="OUIA-Generated-NavItem-42"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -93,6 +93,21 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
                     href="/code"
                   >
                     Source Code
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-43"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-discover="true"
+                    data-testid="Topology"
+                    href="/topology"
+                  >
+                    Topology
                   </a>
                 </li>
               </ul>
@@ -143,7 +158,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-39"
+                  data-ouia-component-id="OUIA-Generated-NavItem-44"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -158,7 +173,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-40"
+                  data-ouia-component-id="OUIA-Generated-NavItem-45"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -176,7 +191,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-41"
+            data-ouia-component-id="OUIA-Generated-NavItem-46"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -191,7 +206,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-42"
+            data-ouia-component-id="OUIA-Generated-NavItem-47"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -206,7 +221,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-43"
+            data-ouia-component-id="OUIA-Generated-NavItem-48"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -221,7 +236,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-44"
+            data-ouia-component-id="OUIA-Generated-NavItem-49"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -236,7 +251,7 @@ exports[`Navigation Component navigation sidebar for: Integration 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-45"
+            data-ouia-component-id="OUIA-Generated-NavItem-50"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -322,7 +337,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-10"
+                  data-ouia-component-id="OUIA-Generated-NavItem-11"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -338,7 +353,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-11"
+                  data-ouia-component-id="OUIA-Generated-NavItem-12"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -349,6 +364,21 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
                     href="/code"
                   >
                     Source Code
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-13"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-discover="true"
+                    data-testid="Topology"
+                    href="/topology"
+                  >
+                    Topology
                   </a>
                 </li>
               </ul>
@@ -400,7 +430,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-12"
+                  data-ouia-component-id="OUIA-Generated-NavItem-14"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -415,7 +445,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-13"
+                  data-ouia-component-id="OUIA-Generated-NavItem-15"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -433,7 +463,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-14"
+            data-ouia-component-id="OUIA-Generated-NavItem-16"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -448,7 +478,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-15"
+            data-ouia-component-id="OUIA-Generated-NavItem-17"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -463,7 +493,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-16"
+            data-ouia-component-id="OUIA-Generated-NavItem-18"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -478,7 +508,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-17"
+            data-ouia-component-id="OUIA-Generated-NavItem-19"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -493,7 +523,7 @@ exports[`Navigation Component navigation sidebar for: Kamelet 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-18"
+            data-ouia-component-id="OUIA-Generated-NavItem-20"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -579,7 +609,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-28"
+                  data-ouia-component-id="OUIA-Generated-NavItem-31"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -595,7 +625,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-29"
+                  data-ouia-component-id="OUIA-Generated-NavItem-32"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -606,6 +636,21 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
                     href="/code"
                   >
                     Source Code
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-33"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-discover="true"
+                    data-testid="Topology"
+                    href="/topology"
+                  >
+                    Topology
                   </a>
                 </li>
               </ul>
@@ -657,7 +702,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-30"
+                  data-ouia-component-id="OUIA-Generated-NavItem-34"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -672,7 +717,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-31"
+                  data-ouia-component-id="OUIA-Generated-NavItem-35"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -690,7 +735,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-32"
+            data-ouia-component-id="OUIA-Generated-NavItem-36"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -705,7 +750,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-33"
+            data-ouia-component-id="OUIA-Generated-NavItem-37"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -720,7 +765,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-34"
+            data-ouia-component-id="OUIA-Generated-NavItem-38"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -735,7 +780,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-35"
+            data-ouia-component-id="OUIA-Generated-NavItem-39"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -750,7 +795,7 @@ exports[`Navigation Component navigation sidebar for: KameletBinding 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-36"
+            data-ouia-component-id="OUIA-Generated-NavItem-40"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -836,7 +881,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-19"
+                  data-ouia-component-id="OUIA-Generated-NavItem-21"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -852,7 +897,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-20"
+                  data-ouia-component-id="OUIA-Generated-NavItem-22"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -863,6 +908,21 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
                     href="/code"
                   >
                     Source Code
+                  </a>
+                </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-23"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-discover="true"
+                    data-testid="Topology"
+                    href="/topology"
+                  >
+                    Topology
                   </a>
                 </li>
               </ul>
@@ -914,7 +974,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-21"
+                  data-ouia-component-id="OUIA-Generated-NavItem-24"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -929,7 +989,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-22"
+                  data-ouia-component-id="OUIA-Generated-NavItem-25"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -947,7 +1007,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-23"
+            data-ouia-component-id="OUIA-Generated-NavItem-26"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -962,7 +1022,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-24"
+            data-ouia-component-id="OUIA-Generated-NavItem-27"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -977,7 +1037,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-25"
+            data-ouia-component-id="OUIA-Generated-NavItem-28"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -992,7 +1052,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-26"
+            data-ouia-component-id="OUIA-Generated-NavItem-29"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1007,7 +1067,7 @@ exports[`Navigation Component navigation sidebar for: Pipe 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-27"
+            data-ouia-component-id="OUIA-Generated-NavItem-30"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1122,6 +1182,21 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
                     Source Code
                   </a>
                 </li>
+                <li
+                  class="pf-v6-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-3"
+                  data-ouia-component-type="PF6/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-v6-c-nav__link"
+                    data-discover="true"
+                    data-testid="Topology"
+                    href="/topology"
+                  >
+                    Topology
+                  </a>
+                </li>
               </ul>
             </section>
           </li>
@@ -1170,7 +1245,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
               >
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-3"
+                  data-ouia-component-id="OUIA-Generated-NavItem-4"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -1185,7 +1260,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
                 </li>
                 <li
                   class="pf-v6-c-nav__item"
-                  data-ouia-component-id="OUIA-Generated-NavItem-4"
+                  data-ouia-component-id="OUIA-Generated-NavItem-5"
                   data-ouia-component-type="PF6/NavItem"
                   data-ouia-safe="true"
                 >
@@ -1203,7 +1278,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-5"
+            data-ouia-component-id="OUIA-Generated-NavItem-6"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1218,7 +1293,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-6"
+            data-ouia-component-id="OUIA-Generated-NavItem-7"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1233,7 +1308,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item pf-v6-u-hidden"
-            data-ouia-component-id="OUIA-Generated-NavItem-7"
+            data-ouia-component-id="OUIA-Generated-NavItem-8"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1248,7 +1323,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-8"
+            data-ouia-component-id="OUIA-Generated-NavItem-9"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >
@@ -1263,7 +1338,7 @@ exports[`Navigation Component navigation sidebar for: Route 1`] = `
           </li>
           <li
             class="pf-v6-c-nav__item"
-            data-ouia-component-id="OUIA-Generated-NavItem-9"
+            data-ouia-component-id="OUIA-Generated-NavItem-10"
             data-ouia-component-type="PF6/NavItem"
             data-ouia-safe="true"
           >

--- a/packages/ui/src/pages/Topology/OrthogonalBendpointsEdge.test.ts
+++ b/packages/ui/src/pages/Topology/OrthogonalBendpointsEdge.test.ts
@@ -1,0 +1,56 @@
+import { Point } from '@patternfly/react-topology';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { OrthogonalBendpointsEdge } from './OrthogonalBendpointsEdge';
+
+const node = (pos: { x: number; y: number }, size: { width: number; height: number }) => ({
+  getPosition: () => pos,
+  getDimensions: () => size,
+});
+
+const wireEdge = (edge: OrthogonalBendpointsEdge, layout: string, source: unknown, target: unknown) => {
+  jest.spyOn(edge, 'getSource').mockReturnValue(source as never);
+  jest.spyOn(edge, 'getTarget').mockReturnValue(target as never);
+  jest.spyOn(edge, 'getGraph').mockReturnValue({ getLayout: () => layout } as never);
+};
+
+describe('OrthogonalBendpointsEdge', () => {
+  let edge: OrthogonalBendpointsEdge;
+
+  beforeEach(() => {
+    edge = new OrthogonalBendpointsEdge();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns no bendpoints for a self-loop', () => {
+    const self = {};
+    wireEdge(edge, LayoutType.DagreHorizontal, self, self);
+    expect(edge.getBendpoints()).toEqual([]);
+  });
+
+  it('returns no bendpoints when source or target is missing', () => {
+    wireEdge(edge, LayoutType.DagreHorizontal, undefined, node({ x: 0, y: 0 }, { width: 10, height: 10 }));
+    expect(edge.getBendpoints()).toEqual([]);
+  });
+
+  it('produces a horizontal step (same Y as source) and a vertical step at midX in horizontal layout', () => {
+    const source = node({ x: 0, y: 0 }, { width: 100, height: 50 });
+    const target = node({ x: 300, y: 200 }, { width: 100, height: 50 });
+    wireEdge(edge, LayoutType.DagreHorizontal, source, target);
+
+    // Centers: source = (50, 25), target = (350, 225). midX = 200.
+    expect(edge.getBendpoints()).toEqual([new Point(200, 25), new Point(200, 225)]);
+  });
+
+  it('produces a vertical step (same X as source) and a horizontal step at midY in vertical layout', () => {
+    const source = node({ x: 0, y: 0 }, { width: 100, height: 50 });
+    const target = node({ x: 300, y: 200 }, { width: 100, height: 50 });
+    wireEdge(edge, LayoutType.DagreVertical, source, target);
+
+    // Centers: source = (50, 25), target = (350, 225). midY = 125.
+    expect(edge.getBendpoints()).toEqual([new Point(50, 125), new Point(350, 125)]);
+  });
+});

--- a/packages/ui/src/pages/Topology/OrthogonalBendpointsEdge.ts
+++ b/packages/ui/src/pages/Topology/OrthogonalBendpointsEdge.ts
@@ -1,0 +1,40 @@
+import { BaseEdge, Point } from '@patternfly/react-topology';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+
+/**
+ * Edge element that bends twice to produce orthogonal (stepped) lines:
+ * one segment along the layout's primary axis, a perpendicular step in the
+ * middle, then another segment along the primary axis to the target.
+ */
+export class OrthogonalBendpointsEdge extends BaseEdge {
+  getBendpoints(): Point[] {
+    const source = this.getSource();
+    const target = this.getTarget();
+    if (!source || !target || source === target) {
+      return [];
+    }
+
+    const sourcePos = source.getPosition();
+    const sourceSize = source.getDimensions();
+    const targetPos = target.getPosition();
+    const targetSize = target.getDimensions();
+
+    const startX = sourcePos.x + sourceSize.width / 2;
+    const startY = sourcePos.y + sourceSize.height / 2;
+    const endX = targetPos.x + targetSize.width / 2;
+    const endY = targetPos.y + targetSize.height / 2;
+
+    // Edges may briefly be queried before they're attached to the graph. Default to
+    // horizontal so we always return a sensible bend pair even in that window.
+    const graph = this.getGraph?.();
+    const isHorizontal = graph?.getLayout?.() !== LayoutType.DagreVertical;
+
+    if (isHorizontal) {
+      const midX = (startX + endX) / 2;
+      return [new Point(midX, startY), new Point(midX, endY)];
+    }
+    const midY = (startY + endY) / 2;
+    return [new Point(startX, midY), new Point(endX, midY)];
+  }
+}

--- a/packages/ui/src/pages/Topology/TopologyPage.scss
+++ b/packages/ui/src/pages/Topology/TopologyPage.scss
@@ -1,0 +1,64 @@
+.topology-page {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+
+  .pf-topology-container {
+    flex: 1 1 auto;
+  }
+
+  // Stepped edge paths enclose an area, which the browser would fill in black
+  // without an explicit fill: none.
+  .custom-edge {
+    &__background,
+    &__body {
+      fill: none;
+    }
+
+    &__body {
+      stroke-width: 2;
+    }
+
+    &__connector {
+      stroke-width: 2;
+    }
+  }
+
+  // Let the node labels blend with the canvas background instead of using the
+  // default solid background coming from CustomNode.scss.
+  .custom-node {
+    &__label {
+      &__text {
+        background-color: transparent;
+      }
+    }
+  }
+}
+
+.topology-collapsed-route {
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.05);
+  }
+}
+
+.topology-external-endpoint,
+.topology-dynamic-endpoint {
+  // External and dynamic endpoints are read-only — make the visual cue obvious
+  // by using a dashed border on the container.
+  .custom-node {
+    &__container {
+      &__image {
+        border-style: dashed;
+      }
+    }
+  }
+
+  &__badge {
+    right: -12px;
+  }
+}

--- a/packages/ui/src/pages/Topology/TopologyPage.test.tsx
+++ b/packages/ui/src/pages/Topology/TopologyPage.test.tsx
@@ -1,0 +1,373 @@
+import { act, fireEvent, render, RenderResult, waitFor } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { CamelRouteResource } from '../../models/camel';
+import { VisualFlowsApi } from '../../models/visualization/flows/support/flows-visibility';
+import { TestProvidersWrapper } from '../../stubs';
+import { camelRouteJson } from '../../stubs/camel-route';
+import { TopologyPage } from './TopologyPage';
+
+const buildVisibleFlowsContext = (entityIds: string[], dispatch: jest.Mock = jest.fn()) => ({
+  visibleFlows: entityIds.reduce<Record<string, boolean>>((acc, id) => ({ ...acc, [id]: true }), {}),
+  allFlowsVisible: true,
+  visualFlowsApi: new VisualFlowsApi(dispatch),
+});
+
+const Router: FunctionComponent<PropsWithChildren> = ({ children }) => (
+  <MemoryRouter initialEntries={['/topology']}>{children}</MemoryRouter>
+);
+
+describe('TopologyPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render without entities', async () => {
+    const { Provider } = TestProvidersWrapper({ camelResource: new CamelRouteResource([]) });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    expect(result?.container.querySelector('.topology-page')).toBeInTheDocument();
+  });
+
+  it('should render a collapsed node for each visual entity', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(visualEntities.map((e) => e.id)),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    expect(result?.container.querySelector('.pf-topology-visualization-surface')).toBeInTheDocument();
+
+    await waitFor(() => {
+      visualEntities.forEach((entity) => {
+        const scope = entity.getId() ?? entity.id;
+        // FlowService scopes ids as `${scope}|...`. Each route has at least one node sharing this scope prefix.
+        const nodes = result?.container.querySelectorAll(`[data-id^="${scope}|"]`);
+        expect(nodes?.length ?? 0).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('should render every route even when the global visibleFlows hides them', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const hiddenFlows = visualEntities.reduce<Record<string, boolean>>((acc, e) => ({ ...acc, [e.id]: false }), {});
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        visibleFlows: hiddenFlows,
+        allFlowsVisible: false,
+        visualFlowsApi: new VisualFlowsApi(jest.fn()),
+      },
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      visualEntities.forEach((entity) => {
+        const scope = entity.getId() ?? entity.id;
+        const nodes = result?.container.querySelectorAll(`[data-id^="${scope}|"]`);
+        expect(nodes?.length ?? 0).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  // JSDOM renders the route group as an empty <g/> when external endpoint nodes are
+  // present in the model. The same flow works in the real browser. Skipped until a
+  // deterministic way to flush PatternFly Topology's mobx-driven layout in JSDOM is in place.
+  it.skip('should hide all but the clicked route and dispatch a navigation when a route node is double-clicked', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const dispatch = jest.fn();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(
+        visualEntities.map((e) => e.id),
+        dispatch,
+      ),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    const targetEntity = visualEntities[0];
+    const routeId = targetEntity.getId() ?? targetEntity.id;
+
+    let clickable: Element | null | undefined;
+    await waitFor(() => {
+      clickable = result?.container.querySelector('.topology-collapsed-route');
+      expect(clickable).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent.doubleClick(clickable!);
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'hideFlows', flowIds: undefined });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'showFlows', flowIds: [routeId] });
+  });
+
+  // See note above — JSDOM/external-node interaction.
+  it.skip('should show an Open context menu item that triggers the same action as double-click', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const dispatch = jest.fn();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(
+        visualEntities.map((e) => e.id),
+        dispatch,
+      ),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    const targetEntity = visualEntities[0];
+    const routeId = targetEntity.getId() ?? targetEntity.id;
+
+    let target: Element | null | undefined;
+    await waitFor(() => {
+      target = result?.container.querySelector('.topology-collapsed-route');
+      expect(target).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent.contextMenu(target!);
+    });
+
+    let openItem: HTMLElement | null | undefined;
+    await waitFor(() => {
+      openItem = result?.queryByText('Open');
+      expect(openItem).toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(openItem!);
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'hideFlows', flowIds: undefined });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'showFlows', flowIds: [routeId] });
+  });
+
+  // See note above — JSDOM/external-node interaction.
+  it.skip('should not navigate on a single click', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const dispatch = jest.fn();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(
+        visualEntities.map((e) => e.id),
+        dispatch,
+      ),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    let clickable: Element | null | undefined;
+    await waitFor(() => {
+      clickable = result?.container.querySelector('.topology-collapsed-route');
+      expect(clickable).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent.click(clickable!);
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('should render an edge between routes connected via a direct: endpoint', async () => {
+    const producer = {
+      route: {
+        id: 'route-producer',
+        from: {
+          uri: 'timer:tick',
+          parameters: { period: '1000' },
+          steps: [{ to: { uri: 'direct:my-consumer' } }],
+        },
+      },
+    };
+    const consumer = {
+      route: {
+        id: 'route-consumer',
+        from: {
+          uri: 'direct:my-consumer',
+          steps: [{ log: { message: 'hello' } }],
+        },
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const camelResource = new CamelRouteResource([producer, consumer] as any);
+    const visualEntities = camelResource.getVisualEntities();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(visualEntities.map((e) => e.id)),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      const edges = result?.container.querySelectorAll<HTMLElement>('[data-kind="edge"]');
+      const crossRouteEdges = Array.from(edges ?? []).filter((edge) => {
+        const id = edge.dataset.id ?? '';
+        return id.includes('route-producer') && id.includes('route-consumer') && id.includes('direct:my-consumer');
+      });
+      expect(crossRouteEdges.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should render an external-endpoint node when a producer references an unknown direct: target', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const visualEntities = camelResource.getVisualEntities();
+    const { Provider } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: buildVisibleFlowsContext(visualEntities.map((e) => e.id)),
+    });
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      const externalNode = result?.container.querySelector<HTMLElement>('[data-id="external::direct:my-route"]');
+      expect(externalNode).toBeInTheDocument();
+      expect(externalNode?.dataset.type).toBe('external-endpoint');
+    });
+  });
+
+  it('should render the topology control bar buttons', async () => {
+    const { Provider } = TestProvidersWrapper();
+
+    let result: RenderResult | undefined;
+    await act(async () => {
+      result = render(
+        <Router>
+          <Provider>
+            <TopologyPage />
+          </Provider>
+        </Router>,
+      );
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(result?.getByRole('button', { name: /reset view/i })).toBeInTheDocument();
+      expect(result?.getByRole('button', { name: /zoom in/i })).toBeInTheDocument();
+      expect(result?.getByRole('button', { name: /zoom out/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/Topology/TopologyPage.tsx
+++ b/packages/ui/src/pages/Topology/TopologyPage.tsx
@@ -1,0 +1,56 @@
+import './TopologyPage.scss';
+
+import {
+  TopologyControlBar,
+  TopologyView,
+  useVisualizationController,
+  VisualizationProvider,
+  VisualizationSurface,
+} from '@patternfly/react-topology';
+import { FunctionComponent, useContext, useMemo } from 'react';
+
+import { useVisibleVizNodes } from '../../hooks/use-visible-viz-nodes';
+import { EntitiesContext } from '../../providers/entities.provider';
+import { SettingsContext } from '../../providers/settings.provider';
+import { useApplyTopologyModel } from './topology-apply-model.hook';
+import { useTopologyControlButtons } from './topology-control-buttons.hook';
+import { TopologyControllerService } from './topology-controller.service';
+import { useTopologyLayoutPreference } from './topology-layout-preference.hook';
+import { useTopologyModel } from './topology-model.hook';
+
+const TopologyVisualization: FunctionComponent = () => {
+  const controller = useVisualizationController();
+  const entitiesContext = useContext(EntitiesContext);
+  const settingsAdapter = useContext(SettingsContext);
+
+  const visualEntities = useMemo(() => entitiesContext?.visualEntities ?? [], [entitiesContext?.visualEntities]);
+  // Topology shows every route regardless of the global visible-flows filter applied on the Design canvas.
+  const allFlowsVisible = useMemo(
+    () => visualEntities.reduce<Record<string, boolean>>((acc, entity) => ({ ...acc, [entity.id]: true }), {}),
+    [visualEntities],
+  );
+  const { vizNodes } = useVisibleVizNodes(visualEntities, allFlowsVisible);
+
+  const { activeLayout } = useTopologyLayoutPreference(settingsAdapter);
+  const { model, topLevelGroupIds } = useTopologyModel(vizNodes, visualEntities, activeLayout);
+  useApplyTopologyModel(controller, model, topLevelGroupIds);
+  const controlButtons = useTopologyControlButtons(controller, settingsAdapter);
+
+  return (
+    <TopologyView controlBar={<TopologyControlBar controlButtons={controlButtons} />}>
+      <VisualizationSurface />
+    </TopologyView>
+  );
+};
+
+export const TopologyPage: FunctionComponent = () => {
+  const controller = useMemo(() => TopologyControllerService.createController(), []);
+
+  return (
+    <div className="topology-page">
+      <VisualizationProvider controller={controller}>
+        <TopologyVisualization />
+      </VisualizationProvider>
+    </div>
+  );
+};

--- a/packages/ui/src/pages/Topology/components/TopologyCollapsedGroup.test.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyCollapsedGroup.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
+import { VisualFlowsApi } from '../../../models/visualization/flows/support/flows-visibility';
+import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../providers';
+import { TopologyCollapsedGroup } from './TopologyCollapsedGroup';
+
+jest.mock('@patternfly/react-topology', () => {
+  const actual = jest.requireActual('@patternfly/react-topology');
+  return { ...actual, isNode: () => true };
+});
+
+interface MockNodeOverrides {
+  routeId?: string;
+  fallbackLabel?: string;
+  description?: string;
+  disabled?: boolean;
+  childCount?: number;
+  bounds?: { width: number; height: number };
+}
+
+const mockVizNode = (overrides: MockNodeOverrides) =>
+  ({
+    id: overrides.routeId ?? 'route-1234',
+    getId: () => overrides.routeId ?? 'route-1234',
+    getNodeLabel: () => overrides.fallbackLabel ?? 'route-1234',
+    getNodeDefinition: () => ({ disabled: overrides.disabled, description: overrides.description }),
+    data: {
+      iconUrl: 'http://example.com/route.svg',
+      description: 'Catalog description',
+      processorIconTooltip: '',
+      processorName: 'route',
+    },
+  }) as unknown as IVisualizationNode;
+
+const mockNodeElement = (overrides: MockNodeOverrides = {}) =>
+  ({
+    getData: () => ({ vizNode: mockVizNode(overrides) }),
+    getAllNodeChildren: () => Array.from({ length: overrides.childCount ?? 0 }, (_, i) => i),
+    getBounds: () => overrides.bounds ?? { width: 90, height: 75 },
+  }) as never;
+
+const buildVisibleFlowsContext = (dispatch: jest.Mock = jest.fn()): VisibleFlowsContextResult => ({
+  visibleFlows: { 'route-1234': true, 'route-5678': true },
+  allFlowsVisible: true,
+  visualFlowsApi: new VisualFlowsApi(dispatch),
+});
+
+const Wrapper: FunctionComponent<PropsWithChildren<{ dispatch?: jest.Mock }>> = ({ children, dispatch }) => (
+  <MemoryRouter initialEntries={['/topology']}>
+    <VisibleFlowsContext.Provider value={buildVisibleFlowsContext(dispatch)}>
+      <Routes>
+        <Route path="/topology" element={<svg>{children}</svg>} />
+        <Route path="/" element={<div data-testid="design-page">design</div>} />
+      </Routes>
+    </VisibleFlowsContext.Provider>
+  </MemoryRouter>
+);
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+describe('TopologyCollapsedGroup', () => {
+  it('uses the route description as the visible label when set', () => {
+    const { container } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={mockNodeElement({ description: 'Sammelt Timer-Events' })} />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector('.custom-node__label__text')?.textContent).toBe('Sammelt Timer-Events');
+    expect(container.querySelector('[data-nodelabel="Sammelt Timer-Events"]')).toBeInTheDocument();
+  });
+
+  it('falls back to vizNode.getNodeLabel() when no description is set', () => {
+    const { container } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={mockNodeElement({ fallbackLabel: 'route-9999' })} />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector('.custom-node__label__text')?.textContent).toBe('route-9999');
+  });
+
+  it('treats a whitespace-only description as missing and uses the fallback label', () => {
+    const { container } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={mockNodeElement({ description: '   ', fallbackLabel: 'route-blank' })} />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector('.custom-node__label__text')?.textContent).toBe('route-blank');
+  });
+
+  it('renders nothing for an element without a vizNode', () => {
+    const elementWithoutViz = {
+      getData: () => ({}),
+      getBounds: () => ({ width: 90, height: 75 }),
+    } as never;
+
+    const { container } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={elementWithoutViz} />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector('.topology-collapsed-route')).not.toBeInTheDocument();
+  });
+
+  it('exposes the disabled state on the outer <g> when the route definition has disabled: true', () => {
+    const { container } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={mockNodeElement({ disabled: true })} />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector<SVGGElement>('.topology-collapsed-route')?.dataset.disabled).toBe('true');
+  });
+
+  it('navigates Home and focuses the route on double-click', () => {
+    const dispatch = jest.fn();
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/topology']}>
+        <VisibleFlowsContext.Provider value={buildVisibleFlowsContext(dispatch)}>
+          <Routes>
+            <Route
+              path="/topology"
+              element={
+                <svg>
+                  <TopologyCollapsedGroup element={mockNodeElement({ routeId: 'route-clicked' })} />
+                </svg>
+              }
+            />
+            <Route path="/" element={<LocationProbe />} />
+          </Routes>
+        </VisibleFlowsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.doubleClick(getByTestId('topology-route__route-clicked'));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'hideFlows', flowIds: undefined });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'showFlows', flowIds: ['route-clicked'] });
+    expect(getByTestId('location').textContent).toBe('/');
+  });
+
+  it('forwards onContextMenu to the outer <g>', () => {
+    const onContextMenu = jest.fn();
+    const { getByTestId } = render(
+      <Wrapper>
+        <TopologyCollapsedGroup element={mockNodeElement()} onContextMenu={onContextMenu} />
+      </Wrapper>,
+    );
+
+    fireEvent.contextMenu(getByTestId('topology-route__route-1234'));
+    expect(onContextMenu).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/Topology/components/TopologyCollapsedGroup.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyCollapsedGroup.tsx
@@ -1,0 +1,88 @@
+import { DefaultGroup, ElementModel, GraphElement, isNode, observer } from '@patternfly/react-topology';
+import { FunctionComponent, useCallback, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { CanvasDefaults } from '../../../components/Visualization/Canvas/canvas.defaults';
+import { CanvasNode } from '../../../components/Visualization/Canvas/canvas.models';
+import { CustomNodeContainer } from '../../../components/Visualization/Custom/Node/CustomNodeContainer';
+import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
+import { CamelRouteVisualEntityData } from '../../../models/visualization/flows/support/camel-component-types';
+import { VisibleFlowsContext } from '../../../providers/visible-flows.provider';
+import { Links } from '../../../router/links.models';
+import { getProcessorIcon } from '../../../utils/processor-icon';
+import { TopologyNodeLabel } from './TopologyNodeLabel';
+
+type IDefaultGroup = Parameters<typeof DefaultGroup>[0];
+
+interface TopologyCollapsedGroupProps extends IDefaultGroup {
+  element: GraphElement<ElementModel, CanvasNode['data']>;
+}
+
+/**
+ * Renders a route as a single collapsed-group node. Reacts to:
+ *  - double-click → hide every other flow and navigate to the Design view
+ *  - right-click → show the topology context menu (Open)
+ */
+export const TopologyCollapsedGroup: FunctionComponent<TopologyCollapsedGroupProps> = observer(
+  ({ element, onContextMenu }) => {
+    if (!isNode(element)) {
+      throw new Error('TopologyCollapsedGroup must be used only on Node elements');
+    }
+
+    const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
+    const visibleFlowsContext = useContext(VisibleFlowsContext);
+    const navigate = useNavigate();
+
+    const handleDoubleClick = useCallback(() => {
+      const routeId = vizNode?.getId();
+      if (!routeId || !visibleFlowsContext) {
+        return;
+      }
+      visibleFlowsContext.visualFlowsApi.hideFlows();
+      visibleFlowsContext.visualFlowsApi.showFlows([routeId]);
+      navigate(Links.Home);
+    }, [navigate, visibleFlowsContext, vizNode]);
+
+    if (!vizNode) {
+      return null;
+    }
+
+    const processorName = (vizNode.data as CamelRouteVisualEntityData).processorName;
+    const ProcessorIcon = getProcessorIcon(processorName);
+    const processorDescription = vizNode.data.processorIconTooltip ?? '';
+    const definition = vizNode.getNodeDefinition() as { disabled?: boolean; description?: string } | undefined;
+    const isDisabled = !!definition?.disabled;
+    // Prefer the user-supplied route description as the visible label; otherwise fall back
+    // to the regular node label (typically the route id).
+    const label = definition?.description?.trim() || vizNode.getNodeLabel();
+    const childCount = element.getAllNodeChildren?.()?.length ?? 0;
+    const bounds = element.getBounds?.();
+    const width = bounds?.width ?? CanvasDefaults.DEFAULT_NODE_WIDTH;
+    const height = bounds?.height ?? CanvasDefaults.DEFAULT_NODE_HEIGHT;
+
+    return (
+      <g
+        className="custom-node topology-collapsed-route"
+        data-testid={`topology-route__${vizNode.id}`}
+        data-nodelabel={label}
+        data-disabled={isDisabled}
+        onDoubleClick={handleDoubleClick}
+        onContextMenu={onContextMenu}
+      >
+        <CustomNodeContainer
+          width={width}
+          height={height}
+          dataNodelabel={label}
+          dataTestId={vizNode.id}
+          containerClassNames={{ 'custom-node__container': true }}
+          vizNode={vizNode}
+          childCount={childCount}
+          ProcessorIcon={ProcessorIcon}
+          processorDescription={processorDescription}
+          isDisabled={isDisabled}
+        />
+        <TopologyNodeLabel label={label} nodeWidth={width} nodeHeight={height} />
+      </g>
+    );
+  },
+);

--- a/packages/ui/src/pages/Topology/components/TopologyDynamicEndpoint.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyDynamicEndpoint.tsx
@@ -1,0 +1,23 @@
+import { BoltIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+import { TopologySyntheticEndpoint, TopologySyntheticEndpointProps } from './TopologySyntheticEndpoint';
+
+interface TopologyDynamicEndpointProps {
+  element: TopologySyntheticEndpointProps['element'];
+}
+
+/**
+ * Renders an endpoint whose URI contains a Camel expression like
+ * `${header.foo}` that can't be resolved at design time. Uses the same
+ * BoltIcon badge that the Design view's `toD` step shows.
+ */
+export const TopologyDynamicEndpoint: FunctionComponent<TopologyDynamicEndpointProps> = ({ element }) => (
+  <TopologySyntheticEndpoint
+    element={element}
+    className="topology-dynamic-endpoint"
+    testIdPrefix="topology-dynamic"
+    titlePrefix="Dynamic endpoint"
+    BadgeIcon={BoltIcon}
+  />
+);

--- a/packages/ui/src/pages/Topology/components/TopologyEdge.test.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyEdge.test.tsx
@@ -1,0 +1,88 @@
+import { getClosestVisibleParent, Point } from '@patternfly/react-topology';
+import { render } from '@testing-library/react';
+
+import { TopologyEdge } from './TopologyEdge';
+
+jest.mock('@patternfly/react-topology', () => {
+  const actual = jest.requireActual('@patternfly/react-topology');
+  return {
+    ...actual,
+    isEdge: () => true,
+    getClosestVisibleParent: jest.fn(),
+  };
+});
+
+const mockGetClosestVisibleParent = getClosestVisibleParent as jest.Mock;
+
+const mockEdgeElement = (overrides?: {
+  startPoint?: Point;
+  endPoint?: Point;
+  bendpoints?: Point[];
+  source?: unknown;
+  target?: unknown;
+}) =>
+  ({
+    getStartPoint: () => overrides?.startPoint ?? new Point(0, 0),
+    getEndPoint: () => overrides?.endPoint ?? new Point(100, 100),
+    getBendpoints: () => overrides?.bendpoints ?? [new Point(50, 0), new Point(50, 100)],
+    getSource: () => overrides?.source ?? {},
+    getTarget: () => overrides?.target ?? {},
+  }) as never;
+
+const renderInSvg = (ui: React.ReactNode) => render(<svg>{ui}</svg>);
+
+describe('TopologyEdge', () => {
+  beforeEach(() => {
+    mockGetClosestVisibleParent.mockReset();
+  });
+
+  it('renders background path, body path and a connector arrow when source and target are visible', () => {
+    mockGetClosestVisibleParent.mockReturnValue({ isCollapsed: () => false });
+
+    const { container } = renderInSvg(<TopologyEdge element={mockEdgeElement()} />);
+
+    expect(container.querySelector('.custom-edge')).toBeInTheDocument();
+    expect(container.querySelector('.custom-edge__background')).toBeInTheDocument();
+    expect(container.querySelector('.custom-edge__body')).toBeInTheDocument();
+    expect(container.querySelector('.custom-edge__connector')).toBeInTheDocument();
+  });
+
+  it('returns null when source and target share a collapsed parent (edge inside a collapsed group)', () => {
+    const parent = { isCollapsed: () => true };
+    mockGetClosestVisibleParent.mockReturnValue(parent);
+
+    const { container } = renderInSvg(<TopologyEdge element={mockEdgeElement()} />);
+
+    expect(container.querySelector('.custom-edge')).not.toBeInTheDocument();
+  });
+
+  it('still draws the edge when source and target have different parents (cross-route edge)', () => {
+    const parentA = { isCollapsed: () => true };
+    const parentB = { isCollapsed: () => true };
+    mockGetClosestVisibleParent.mockReturnValueOnce(parentA).mockReturnValueOnce(parentB);
+
+    const { container } = renderInSvg(<TopologyEdge element={mockEdgeElement()} />);
+
+    expect(container.querySelector('.custom-edge')).toBeInTheDocument();
+  });
+
+  it('generates a straight-line path when the edge has no bendpoints', () => {
+    mockGetClosestVisibleParent.mockReturnValue({ isCollapsed: () => false });
+
+    const { container } = renderInSvg(
+      <TopologyEdge
+        element={mockEdgeElement({
+          startPoint: new Point(10, 20),
+          endPoint: new Point(110, 20),
+          bendpoints: [],
+        })}
+      />,
+    );
+
+    const body = container.querySelector('.custom-edge__body');
+    expect(body).not.toBeNull();
+    // Direct line: M10 20 L110 20 (no bezier curves needed).
+    expect(body!.getAttribute('d')).toBe('M10 20 L110 20');
+    expect(container.querySelector('.custom-edge__connector')).not.toBeNull();
+  });
+});

--- a/packages/ui/src/pages/Topology/components/TopologyEdge.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyEdge.tsx
@@ -1,0 +1,53 @@
+import {
+  ConnectorArrow,
+  EdgeModel,
+  getClosestVisibleParent,
+  GraphElement,
+  isEdge,
+  observer,
+} from '@patternfly/react-topology';
+import { FunctionComponent } from 'react';
+
+import { buildRoundedPath } from '../rounded-path';
+
+interface TopologyEdgeProps {
+  element: GraphElement<EdgeModel, unknown>;
+}
+
+const CORNER_RADIUS = 12;
+
+/**
+ * Edge renderer that draws the path defined by start + bendpoints + end with
+ * rounded corners. Bendpoints are produced by the edge element factory
+ * (see OrthogonalBendpointsEdge), this component only handles the rendering.
+ */
+export const TopologyEdge: FunctionComponent<TopologyEdgeProps> = observer(({ element }) => {
+  if (!isEdge(element)) {
+    throw new Error('TopologyEdge must be used only on Edge elements');
+  }
+
+  // Hide edges between nodes that are inside a collapsed group (route children).
+  const sourceParent = getClosestVisibleParent(element.getSource());
+  const targetParent = getClosestVisibleParent(element.getTarget());
+  if (sourceParent?.isCollapsed() && sourceParent === targetParent) {
+    return null;
+  }
+
+  const startPoint = element.getStartPoint();
+  const endPoint = element.getEndPoint();
+  const bendpoints = element.getBendpoints();
+  const points = [startPoint, ...bendpoints, endPoint];
+  const d = buildRoundedPath(points, CORNER_RADIUS);
+
+  // The arrow direction must match the last segment so it points along the
+  // approach to the target node.
+  const arrowStart = bendpoints.length > 0 ? bendpoints[bendpoints.length - 1] : startPoint;
+
+  return (
+    <g className="custom-edge topology-edge">
+      <path className="custom-edge__background" d={d} />
+      <path className="custom-edge__body" d={d} />
+      <ConnectorArrow isTarget className="custom-edge__connector" startPoint={arrowStart} endPoint={endPoint} />
+    </g>
+  );
+});

--- a/packages/ui/src/pages/Topology/components/TopologyExternalEndpoint.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyExternalEndpoint.tsx
@@ -1,0 +1,23 @@
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+import { TopologySyntheticEndpoint, TopologySyntheticEndpointProps } from './TopologySyntheticEndpoint';
+
+interface TopologyExternalEndpointProps {
+  element: TopologySyntheticEndpointProps['element'];
+}
+
+/**
+ * Renders an endpoint that is referenced by a route in this file but isn't
+ * defined here — typically a `direct:`/`seda:` target that lives in another
+ * file or module.
+ */
+export const TopologyExternalEndpoint: FunctionComponent<TopologyExternalEndpointProps> = ({ element }) => (
+  <TopologySyntheticEndpoint
+    element={element}
+    className="topology-external-endpoint"
+    testIdPrefix="topology-external"
+    titlePrefix="External endpoint"
+    BadgeIcon={ExternalLinkAltIcon}
+  />
+);

--- a/packages/ui/src/pages/Topology/components/TopologyNodeLabel.test.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyNodeLabel.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+
+import { TopologyNodeLabel } from './TopologyNodeLabel';
+
+const renderInSvg = (ui: React.ReactNode) => render(<svg>{ui}</svg>);
+
+describe('TopologyNodeLabel', () => {
+  it('renders the label inside a foreignObject', () => {
+    const { container } = renderInSvg(<TopologyNodeLabel label="my-route" nodeWidth={90} nodeHeight={75} />);
+
+    const foreignObject = container.querySelector('foreignObject');
+    expect(foreignObject).toBeInTheDocument();
+    expect(foreignObject?.textContent).toBe('my-route');
+  });
+
+  it('returns null and renders nothing when the label is empty', () => {
+    const { container } = renderInSvg(<TopologyNodeLabel label="" nodeWidth={90} nodeHeight={75} />);
+
+    expect(container.querySelector('foreignObject')).not.toBeInTheDocument();
+  });
+
+  it('positions the label centered horizontally and just below the node', () => {
+    const { container } = renderInSvg(<TopologyNodeLabel label="abc" nodeWidth={120} nodeHeight={60} />);
+    const foreignObject = container.querySelector('foreignObject');
+
+    // labelX = (nodeWidth - DEFAULT_LABEL_WIDTH) / 2 with DEFAULT_LABEL_WIDTH=150 → -15
+    expect(foreignObject?.getAttribute('x')).toBe('-15');
+    // y = nodeHeight - 1
+    expect(foreignObject?.getAttribute('y')).toBe('59');
+  });
+
+  it('exposes the label as a hover title for tooltips', () => {
+    const { getByTitle } = renderInSvg(<TopologyNodeLabel label="hover-me" nodeWidth={90} nodeHeight={75} />);
+    expect(getByTitle('hover-me')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/pages/Topology/components/TopologyNodeLabel.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologyNodeLabel.tsx
@@ -1,0 +1,38 @@
+import { FunctionComponent } from 'react';
+
+import { CanvasDefaults } from '../../../components/Visualization/Canvas/canvas.defaults';
+
+interface TopologyNodeLabelProps {
+  label: string;
+  /** Width of the node (used to center the label horizontally). */
+  nodeWidth: number;
+  /** Height of the node (used to position the label below it). */
+  nodeHeight: number;
+}
+
+/**
+ * Renders the label below a topology node — positioned identically to the
+ * design canvas labels so the route group, external endpoint and dynamic
+ * endpoint share a consistent look.
+ */
+export const TopologyNodeLabel: FunctionComponent<TopologyNodeLabelProps> = ({ label, nodeWidth, nodeHeight }) => {
+  if (!label) {
+    return null;
+  }
+
+  const labelX = (nodeWidth - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
+
+  return (
+    <foreignObject
+      className="custom-node__label"
+      x={labelX}
+      y={nodeHeight - 1}
+      width={CanvasDefaults.DEFAULT_LABEL_WIDTH}
+      height={CanvasDefaults.DEFAULT_LABEL_HEIGHT}
+    >
+      <div className="custom-node__label__text">
+        <span title={label}>{label}</span>
+      </div>
+    </foreignObject>
+  );
+};

--- a/packages/ui/src/pages/Topology/components/TopologySyntheticEndpoint.test.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologySyntheticEndpoint.test.tsx
@@ -1,0 +1,111 @@
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { render } from '@testing-library/react';
+
+import { TopologySyntheticEndpoint } from './TopologySyntheticEndpoint';
+
+jest.mock('@patternfly/react-topology', () => {
+  const actual = jest.requireActual('@patternfly/react-topology');
+  return { ...actual, isNode: () => true };
+});
+
+const mockNodeElement = (
+  overrides: { label?: string; iconUrl?: string; bounds?: { width: number; height: number } } = {},
+) =>
+  ({
+    getLabel: () => overrides.label ?? 'direct:foo',
+    getData: () => ({ iconUrl: overrides.iconUrl ?? 'http://example.com/icon.svg' }),
+    getBounds: () => overrides.bounds ?? { width: 90, height: 75 },
+  }) as never;
+
+const renderInSvg = (ui: React.ReactNode) => render(<svg>{ui}</svg>);
+
+describe('TopologySyntheticEndpoint', () => {
+  it('renders the label, icon image and badge in the route container layout', () => {
+    const { container, getByTitle, getByAltText } = renderInSvg(
+      <TopologySyntheticEndpoint
+        element={mockNodeElement()}
+        className="topology-external-endpoint"
+        testIdPrefix="topology-external"
+        titlePrefix="External endpoint"
+        BadgeIcon={ExternalLinkAltIcon}
+      />,
+    );
+
+    // Outer <g> with the kind-specific class and data-testid.
+    const outer = container.querySelector<SVGGElement>('.topology-external-endpoint');
+    expect(outer).toBeInTheDocument();
+    expect(outer?.dataset.testid).toBe('topology-external__direct:foo');
+
+    // Container tooltip uses the configured title prefix + label.
+    expect(getByTitle('External endpoint: direct:foo')).toBeInTheDocument();
+
+    // Routes-icon image rendered with the iconUrl from the node data.
+    const img = getByAltText('direct:foo') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('http://example.com/icon.svg');
+
+    // FloatingCircle badge with the kind-specific class.
+    expect(container.querySelector('.topology-external-endpoint__badge')).toBeInTheDocument();
+  });
+
+  it('falls back to default node dimensions when getBounds() yields nothing', () => {
+    const elementWithoutBounds = {
+      getLabel: () => 'direct:foo',
+      getData: () => ({ iconUrl: '' }),
+      getBounds: () => undefined,
+    } as never;
+
+    const { container } = renderInSvg(
+      <TopologySyntheticEndpoint
+        element={elementWithoutBounds}
+        className="topology-external-endpoint"
+        testIdPrefix="topology-external"
+        titlePrefix="External endpoint"
+        BadgeIcon={ExternalLinkAltIcon}
+      />,
+    );
+
+    const foreignObject = container.querySelector('foreignObject');
+    expect(foreignObject?.getAttribute('width')).toBe('90'); // CanvasDefaults.DEFAULT_NODE_WIDTH
+    expect(foreignObject?.getAttribute('height')).toBe('75'); // CanvasDefaults.DEFAULT_NODE_HEIGHT
+  });
+
+  it('omits the <img> when no iconUrl is available', () => {
+    const noIconElement = {
+      getLabel: () => 'direct:foo',
+      getData: () => ({ iconUrl: '' }),
+      getBounds: () => ({ width: 90, height: 75 }),
+    } as never;
+
+    const { container } = renderInSvg(
+      <TopologySyntheticEndpoint
+        element={noIconElement}
+        className="topology-external-endpoint"
+        testIdPrefix="topology-external"
+        titlePrefix="External endpoint"
+        BadgeIcon={ExternalLinkAltIcon}
+      />,
+    );
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+  });
+
+  it('falls back to an empty label when getLabel is missing', () => {
+    const noLabelElement = {
+      getData: () => ({}),
+      getBounds: () => ({ width: 90, height: 75 }),
+    } as never;
+
+    const { container } = renderInSvg(
+      <TopologySyntheticEndpoint
+        element={noLabelElement}
+        className="topology-external-endpoint"
+        testIdPrefix="topology-external"
+        titlePrefix="External endpoint"
+        BadgeIcon={ExternalLinkAltIcon}
+      />,
+    );
+
+    // No label foreignObject (TopologyNodeLabel returns null on empty)
+    expect(container.querySelectorAll('foreignObject').length).toBe(1);
+  });
+});

--- a/packages/ui/src/pages/Topology/components/TopologySyntheticEndpoint.tsx
+++ b/packages/ui/src/pages/Topology/components/TopologySyntheticEndpoint.tsx
@@ -1,0 +1,58 @@
+import { ElementModel, GraphElement, isNode, observer } from '@patternfly/react-topology';
+import { ComponentType, FunctionComponent } from 'react';
+
+import { CanvasDefaults } from '../../../components/Visualization/Canvas/canvas.defaults';
+import { CanvasNode } from '../../../components/Visualization/Canvas/canvas.models';
+import { FloatingCircle } from '../../../components/Visualization/Custom/FloatingCircle/FloatingCircle';
+import { TopologyNodeLabel } from './TopologyNodeLabel';
+
+export type SyntheticEndpointData = CanvasNode['data'] & { iconUrl?: string };
+
+export interface TopologySyntheticEndpointProps {
+  element: GraphElement<ElementModel, SyntheticEndpointData>;
+  /** Extra class added on the outer `<g>`; also used as prefix for the badge class. */
+  className: string;
+  /** Used to build `data-testid` on the outer `<g>`. */
+  testIdPrefix: string;
+  /** Tooltip prefix shown on hover ("<prefix>: <label>"). */
+  titlePrefix: string;
+  /** Icon rendered in the FloatingCircle badge above the node. */
+  BadgeIcon: ComponentType;
+}
+
+/**
+ * Renderer for synthetic endpoint nodes (external and dynamic). Visually
+ * identical to a collapsed route node — same container, same route icon and
+ * label position — but read-only: no double-click, no context menu, no
+ * pointer interactions. The badge in the top-right corner indicates the kind
+ * of synthetic endpoint.
+ */
+export const TopologySyntheticEndpoint: FunctionComponent<TopologySyntheticEndpointProps> = observer(
+  ({ element, className, testIdPrefix, titlePrefix, BadgeIcon }) => {
+    if (!isNode(element)) {
+      throw new Error('TopologySyntheticEndpoint must be used only on Node elements');
+    }
+
+    const label = element.getLabel?.() ?? '';
+    const iconUrl = element.getData?.()?.iconUrl ?? '';
+    const bounds = element.getBounds?.();
+    const width = bounds?.width ?? CanvasDefaults.DEFAULT_NODE_WIDTH;
+    const height = bounds?.height ?? CanvasDefaults.DEFAULT_NODE_HEIGHT;
+
+    return (
+      <g className={`custom-node ${className}`} data-testid={`${testIdPrefix}__${label}`} data-label={label}>
+        <foreignObject width={width} height={height}>
+          <div className="custom-node__container" title={`${titlePrefix}: ${label}`}>
+            <div className="custom-node__container__image">
+              {iconUrl && <img src={iconUrl} alt={label} />}
+              <FloatingCircle className={`step-icon ${className}__badge`}>
+                <BadgeIcon />
+              </FloatingCircle>
+            </div>
+          </div>
+        </foreignObject>
+        <TopologyNodeLabel label={label} nodeWidth={width} nodeHeight={height} />
+      </g>
+    );
+  },
+);

--- a/packages/ui/src/pages/Topology/index.ts
+++ b/packages/ui/src/pages/Topology/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/packages/ui/src/pages/Topology/rounded-path.test.ts
+++ b/packages/ui/src/pages/Topology/rounded-path.test.ts
@@ -1,0 +1,46 @@
+import { Point } from '@patternfly/react-topology';
+
+import { buildRoundedPath } from './rounded-path';
+
+const p = (x: number, y: number) => new Point(x, y);
+
+describe('buildRoundedPath', () => {
+  it('returns an empty string for fewer than two points', () => {
+    expect(buildRoundedPath([], 10)).toBe('');
+    expect(buildRoundedPath([p(0, 0)], 10)).toBe('');
+  });
+
+  it('returns a straight line segment for exactly two points', () => {
+    expect(buildRoundedPath([p(0, 0), p(50, 0)], 10)).toBe('M0 0 L50 0');
+  });
+
+  it('rounds a single right-angle corner with a quadratic bezier', () => {
+    // Horizontal-then-vertical L shape: (0,0) → (100,0) → (100,80)
+    const d = buildRoundedPath([p(0, 0), p(100, 0), p(100, 80)], 10);
+    expect(d).toContain('M0 0');
+    expect(d).toContain('L90 0');
+    expect(d).toContain('Q100 0');
+    expect(d).toContain('100 10');
+    expect(d).toContain('L100 80');
+  });
+
+  it('rounds multiple corners along a stepped path', () => {
+    // Two bend points, like the orthogonal edge
+    const d = buildRoundedPath([p(0, 0), p(50, 0), p(50, 100), p(120, 100)], 8);
+    // Approach + control + exit for each bend
+    expect(d.split('Q').length - 1).toBe(2);
+  });
+
+  it('clamps the corner radius to half of the shorter adjacent segment', () => {
+    // Segments of length 4 and 100 with requested radius 50 — should clamp to 2.
+    const d = buildRoundedPath([p(0, 0), p(4, 0), p(4, 100)], 50);
+    // The approach point sits at distance min(50, 4/2) = 2 from the bend, so x=2.
+    expect(d).toContain('L2 0');
+    // The exit point sits at distance min(50, 100/2) = 50 from the bend, so y=50.
+    expect(d).toContain('4 50');
+  });
+
+  it('does not divide by zero when consecutive points coincide', () => {
+    expect(() => buildRoundedPath([p(0, 0), p(0, 0), p(10, 10)], 5)).not.toThrow();
+  });
+});

--- a/packages/ui/src/pages/Topology/rounded-path.ts
+++ b/packages/ui/src/pages/Topology/rounded-path.ts
@@ -1,0 +1,45 @@
+import { Point } from '@patternfly/react-topology';
+
+/**
+ * Build an SVG path that connects all given points and rounds every corner
+ * with a quadratic Bezier curve of the given radius. The first and last
+ * points act as the path endpoints, every intermediate point becomes a
+ * control point of the smoothing curve.
+ */
+export const buildRoundedPath = (points: Point[], radius: number): string => {
+  if (points.length < 2) {
+    return '';
+  }
+  if (points.length === 2) {
+    return `M${points[0].x} ${points[0].y} L${points[1].x} ${points[1].y}`;
+  }
+
+  let d = `M${points[0].x} ${points[0].y}`;
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    const next = points[i + 1];
+
+    const dxIn = curr.x - prev.x;
+    const dyIn = curr.y - prev.y;
+    const lenIn = Math.hypot(dxIn, dyIn) || 1;
+    const rIn = Math.min(radius, lenIn / 2);
+
+    const dxOut = next.x - curr.x;
+    const dyOut = next.y - curr.y;
+    const lenOut = Math.hypot(dxOut, dyOut) || 1;
+    const rOut = Math.min(radius, lenOut / 2);
+
+    const approachX = curr.x - (dxIn / lenIn) * rIn;
+    const approachY = curr.y - (dyIn / lenIn) * rIn;
+    const exitX = curr.x + (dxOut / lenOut) * rOut;
+    const exitY = curr.y + (dyOut / lenOut) * rOut;
+
+    d += ` L${approachX} ${approachY} Q${curr.x} ${curr.y} ${exitX} ${exitY}`;
+  }
+
+  const last = points[points.length - 1];
+  d += ` L${last.x} ${last.y}`;
+  return d;
+};

--- a/packages/ui/src/pages/Topology/router-exports.tsx
+++ b/packages/ui/src/pages/Topology/router-exports.tsx
@@ -1,0 +1,1 @@
+export { TopologyPage as Component } from './TopologyPage';

--- a/packages/ui/src/pages/Topology/topology-apply-model.hook.ts
+++ b/packages/ui/src/pages/Topology/topology-apply-model.hook.ts
@@ -1,0 +1,34 @@
+import { Controller, Dimensions, isNode, Model, Node } from '@patternfly/react-topology';
+import { useEffect } from 'react';
+
+import { CanvasDefaults } from '../../components/Visualization/Canvas/canvas.defaults';
+
+const FIT_PADDING = 80;
+
+/**
+ * Synchronizes the topology controller with the model: replaces the model,
+ * collapses every top-level group (so each route shows as a single node),
+ * triggers a layout pass and fits the result to the viewport. The fit() runs
+ * inside a requestAnimationFrame so the layout has a chance to settle before
+ * we measure; the RAF handle is cleaned up on re-run/unmount.
+ */
+export const useApplyTopologyModel = (controller: Controller, model: Model, topLevelGroupIds: string[]): void => {
+  useEffect(() => {
+    controller.fromModel(model, false);
+
+    topLevelGroupIds.forEach((id) => {
+      const element = controller.getNodeById(id);
+      if (element && isNode(element)) {
+        const node = element as Node;
+        node.setCollapsed(true);
+        node.setDimensions(new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT));
+      }
+    });
+
+    controller.getGraph().layout();
+    const fitHandle = requestAnimationFrame(() => {
+      controller.getGraph().fit(FIT_PADDING);
+    });
+    return () => cancelAnimationFrame(fitHandle);
+  }, [controller, model, topLevelGroupIds]);
+};

--- a/packages/ui/src/pages/Topology/topology-connections.test.ts
+++ b/packages/ui/src/pages/Topology/topology-connections.test.ts
@@ -1,0 +1,344 @@
+import { EdgeStyle } from '@patternfly/react-topology';
+
+import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
+import {
+  buildRouteConnectionExtras,
+  DYNAMIC_ENDPOINT_ID_PREFIX,
+  DYNAMIC_ENDPOINT_NODE_TYPE,
+  EXTERNAL_ENDPOINT_ID_PREFIX,
+  EXTERNAL_ENDPOINT_NODE_TYPE,
+} from './topology-connections';
+
+const mockEntity = (id: string, json: unknown): BaseVisualEntity =>
+  ({
+    id,
+    toJSON: () => json,
+  }) as unknown as BaseVisualEntity;
+
+describe('buildRouteConnectionExtras', () => {
+  it('returns empty extras when there are no routes', () => {
+    expect(buildRouteConnectionExtras([], new Map())).toEqual({ edges: [], externalNodes: [], dynamicNodes: [] });
+  });
+
+  it('connects a producer to a consumer that share a direct: endpoint', () => {
+    const producer = mockEntity('route-a', {
+      route: {
+        id: 'route-a',
+        from: { uri: 'timer:tick' },
+        steps: [{ to: { uri: 'direct:foo' } }],
+      },
+    });
+    const consumer = mockEntity('route-b', {
+      route: {
+        id: 'route-b',
+        from: { uri: 'direct:foo' },
+        steps: [{ log: { message: 'hi' } }],
+      },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges, externalNodes } = buildRouteConnectionExtras([producer, consumer], map);
+
+    expect(externalNodes).toEqual([]);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: 'A|route',
+      target: 'B|route',
+      label: 'direct:foo',
+      edgeStyle: EdgeStyle.solid,
+    });
+  });
+
+  it('strips query parameters when matching endpoints', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:foo?block=true' } }] },
+    });
+    const consumer = mockEntity('route-b', {
+      route: { from: { uri: 'direct:foo' }, steps: [] },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges, externalNodes } = buildRouteConnectionExtras([producer, consumer], map);
+    expect(externalNodes).toEqual([]);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].label).toBe('direct:foo');
+  });
+
+  it('matches seda, vm and direct-vm endpoints in addition to direct', () => {
+    const entities = [
+      mockEntity('a', { route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'seda:x' } }] } }),
+      mockEntity('b', { route: { from: { uri: 'seda:x' }, steps: [] } }),
+      mockEntity('c', { route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'vm:y' } }] } }),
+      mockEntity('d', { route: { from: { uri: 'vm:y' }, steps: [] } }),
+      mockEntity('e', { route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct-vm:z' } }] } }),
+      mockEntity('f', { route: { from: { uri: 'direct-vm:z' }, steps: [] } }),
+    ];
+    const map = new Map([
+      ['a', 'A|route'],
+      ['b', 'B|route'],
+      ['c', 'C|route'],
+      ['d', 'D|route'],
+      ['e', 'E|route'],
+      ['f', 'F|route'],
+    ]);
+
+    const { edges, externalNodes } = buildRouteConnectionExtras(entities, map);
+    expect(externalNodes).toEqual([]);
+    expect(edges).toHaveLength(3);
+    expect(edges.map((e: { label?: string }) => e.label ?? '').sort((a, b) => a.localeCompare(b))).toEqual([
+      'direct-vm:z',
+      'seda:x',
+      'vm:y',
+    ]);
+  });
+
+  it('ignores non-VM endpoints like http or amqp', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'http://example.com' } }] },
+    });
+    const consumer = mockEntity('route-b', {
+      route: { from: { uri: 'http://example.com' }, steps: [] },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    expect(buildRouteConnectionExtras([producer, consumer], map)).toEqual({
+      edges: [],
+      externalNodes: [],
+      dynamicNodes: [],
+    });
+  });
+
+  it('detects to inside choice/when branches', () => {
+    const producer = mockEntity('route-a', {
+      route: {
+        from: {
+          uri: 'timer:t',
+          steps: [
+            {
+              choice: {
+                when: [{ simple: '${header.x}', steps: [{ to: { uri: 'direct:branch-a' } }] }],
+                otherwise: { steps: [{ to: { uri: 'direct:branch-b' } }] },
+              },
+            },
+          ],
+        },
+      },
+    });
+    const consumerA = mockEntity('route-b', { route: { from: { uri: 'direct:branch-a' }, steps: [] } });
+    const consumerB = mockEntity('route-c', { route: { from: { uri: 'direct:branch-b' }, steps: [] } });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+      ['route-c', 'C|route'],
+    ]);
+
+    const { edges } = buildRouteConnectionExtras([producer, consumerA, consumerB], map);
+    expect(edges).toHaveLength(2);
+    expect(edges.map((e: { label?: string }) => e.label ?? '').sort((a, b) => a.localeCompare(b))).toEqual([
+      'direct:branch-a',
+      'direct:branch-b',
+    ]);
+  });
+
+  it('also detects toD, wireTap, enrich and pollEnrich URIs', () => {
+    const producer = mockEntity('route-a', {
+      route: {
+        from: {
+          uri: 'timer:t',
+          steps: [
+            { toD: { uri: 'direct:dyn' } },
+            { wireTap: { uri: 'direct:wire' } },
+            { enrich: { uri: 'direct:rich' } },
+            { pollEnrich: { uri: 'direct:poll' } },
+          ],
+        },
+      },
+    });
+    const consumers = ['dyn', 'wire', 'rich', 'poll'].map((name, i) =>
+      mockEntity(`c-${i}`, { route: { from: { uri: `direct:${name}` }, steps: [] } }),
+    );
+    const map = new Map<string, string>([
+      ['route-a', 'A|route'],
+      ['c-0', 'C0|route'],
+      ['c-1', 'C1|route'],
+      ['c-2', 'C2|route'],
+      ['c-3', 'C3|route'],
+    ]);
+
+    const { edges } = buildRouteConnectionExtras([producer, ...consumers], map);
+    expect(edges.map((e: { label?: string }) => e.label ?? '').sort((a, b) => a.localeCompare(b))).toEqual([
+      'direct:dyn',
+      'direct:poll',
+      'direct:rich',
+      'direct:wire',
+    ]);
+  });
+
+  it('skips a route that calls itself via direct (and emits no external node)', () => {
+    const entity = mockEntity('route-a', {
+      route: { from: { uri: 'direct:loop' }, steps: [{ to: { uri: 'direct:loop' } }] },
+    });
+    const map = new Map([['route-a', 'A|route']]);
+    expect(buildRouteConnectionExtras([entity], map)).toEqual({ edges: [], externalNodes: [], dynamicNodes: [] });
+  });
+
+  it('treats uri: "direct" with parameters.name as equivalent to "direct:name"', () => {
+    const producer = mockEntity('route-a', {
+      route: {
+        from: { uri: 'timer:t' },
+        steps: [{ to: { uri: 'direct', parameters: { name: 'route2' } } }],
+      },
+    });
+    const consumer = mockEntity('route-b', {
+      route: { from: { uri: 'direct', parameters: { name: 'route2' } } },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges } = buildRouteConnectionExtras([producer, consumer], map);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].label).toBe('direct:route2');
+  });
+
+  it('matches the canonical form (uri: direct:foo) against the parametric form (uri: direct + parameters.name)', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:route2' } }] },
+    });
+    const consumer = mockEntity('route-b', {
+      route: { from: { uri: 'direct', parameters: { name: 'route2' } } },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges } = buildRouteConnectionExtras([producer, consumer], map);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].label).toBe('direct:route2');
+  });
+
+  it('handles shorthand string form (to: "direct:foo")', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: 'direct:foo' }] },
+    });
+    const consumer = mockEntity('route-b', { route: { from: 'direct:foo', steps: [] } });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges } = buildRouteConnectionExtras([producer, consumer], map);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].label).toBe('direct:foo');
+  });
+
+  it('emits an external-endpoint node and dashed edge when no consumer matches', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:externalOne' } }] },
+    });
+    const map = new Map([['route-a', 'A|route']]);
+
+    const { edges, externalNodes } = buildRouteConnectionExtras([producer], map);
+
+    expect(externalNodes).toHaveLength(1);
+    expect(externalNodes[0]).toMatchObject({
+      id: `${EXTERNAL_ENDPOINT_ID_PREFIX}direct:externalOne`,
+      type: EXTERNAL_ENDPOINT_NODE_TYPE,
+      label: 'direct:externalOne',
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: 'A|route',
+      target: `${EXTERNAL_ENDPOINT_ID_PREFIX}direct:externalOne`,
+      label: 'direct:externalOne',
+      edgeStyle: EdgeStyle.dashed,
+    });
+  });
+
+  it('reuses the same external-endpoint node when multiple producers reference it', () => {
+    const producerA = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:shared' } }] },
+    });
+    const producerB = mockEntity('route-b', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:shared' } }] },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges, externalNodes } = buildRouteConnectionExtras([producerA, producerB], map);
+
+    expect(externalNodes).toHaveLength(1);
+    expect(edges).toHaveLength(2);
+    expect(edges.map((e) => e.source).sort((a, b) => a.localeCompare(b))).toEqual(['A|route', 'B|route']);
+    expect(edges.every((e) => e.target === `${EXTERNAL_ENDPOINT_ID_PREFIX}direct:shared`)).toBe(true);
+  });
+
+  it('emits a dynamic-endpoint node for a toD with an expression URI', () => {
+    const producer = mockEntity('route-a', {
+      route: {
+        from: { uri: 'timer:t', steps: [{ toD: { uri: '${header.foo}' } }] },
+      },
+    });
+    const map = new Map([['route-a', 'A|route']]);
+
+    const { edges, externalNodes, dynamicNodes } = buildRouteConnectionExtras([producer], map);
+
+    expect(externalNodes).toEqual([]);
+    expect(dynamicNodes).toHaveLength(1);
+    expect(dynamicNodes[0]).toMatchObject({
+      id: `${DYNAMIC_ENDPOINT_ID_PREFIX}\${header.foo}`,
+      type: DYNAMIC_ENDPOINT_NODE_TYPE,
+      label: '${header.foo}',
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: 'A|route',
+      target: `${DYNAMIC_ENDPOINT_ID_PREFIX}\${header.foo}`,
+      label: '${header.foo}',
+    });
+  });
+
+  it('reuses the same dynamic-endpoint node when the same expression is referenced twice', () => {
+    const producerA = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t', steps: [{ toD: { uri: '${header.target}' } }] } },
+    });
+    const producerB = mockEntity('route-b', {
+      route: { from: { uri: 'timer:t', steps: [{ toD: { uri: '${header.target}' } }] } },
+    });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { edges, dynamicNodes } = buildRouteConnectionExtras([producerA, producerB], map);
+    expect(dynamicNodes).toHaveLength(1);
+    expect(edges).toHaveLength(2);
+  });
+
+  it('does not emit an external node for a producer when at least one internal consumer matches', () => {
+    const producer = mockEntity('route-a', {
+      route: { from: { uri: 'timer:t' }, steps: [{ to: { uri: 'direct:foo' } }] },
+    });
+    const consumer = mockEntity('route-b', { route: { from: { uri: 'direct:foo' }, steps: [] } });
+    const map = new Map([
+      ['route-a', 'A|route'],
+      ['route-b', 'B|route'],
+    ]);
+
+    const { externalNodes } = buildRouteConnectionExtras([producer, consumer], map);
+    expect(externalNodes).toEqual([]);
+  });
+});

--- a/packages/ui/src/pages/Topology/topology-connections.ts
+++ b/packages/ui/src/pages/Topology/topology-connections.ts
@@ -1,0 +1,243 @@
+import { EdgeStyle } from '@patternfly/react-topology';
+
+import { CanvasDefaults } from '../../components/Visualization/Canvas/canvas.defaults';
+import { CanvasEdge, CanvasNode } from '../../components/Visualization/Canvas/canvas.models';
+import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
+
+export const EXTERNAL_ENDPOINT_NODE_TYPE = 'external-endpoint';
+export const EXTERNAL_ENDPOINT_ID_PREFIX = 'external::';
+
+export const DYNAMIC_ENDPOINT_NODE_TYPE = 'dynamic-endpoint';
+export const DYNAMIC_ENDPOINT_ID_PREFIX = 'dynamic::';
+
+const IN_VM_ENDPOINT_PREFIXES = ['direct:', 'seda:', 'vm:', 'direct-vm:'];
+
+const PRODUCER_KEYS = ['to', 'toD', 'wireTap', 'enrich', 'pollEnrich'] as const;
+
+const EXPRESSION_PATTERN = /\$\{[^}]+\}/;
+
+const isDynamicUri = (uri: string): boolean => EXPRESSION_PATTERN.test(uri);
+
+const normalizeEndpoint = (uri: string | undefined): string | undefined => {
+  if (!uri) {
+    return undefined;
+  }
+  const stripped = uri.split('?')[0];
+  return IN_VM_ENDPOINT_PREFIXES.some((p) => stripped.startsWith(p)) ? stripped : undefined;
+};
+
+const getUri = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as { uri?: unknown; parameters?: { name?: unknown } };
+    const rawUri = obj.uri;
+    if (typeof rawUri === 'string') {
+      // Camel allows `uri: direct` + `parameters.name: foo` as an equivalent of `uri: direct:foo`.
+      // Compose the canonical form here so endpoint matching works for both spellings.
+      if (!rawUri.includes(':')) {
+        const name = obj.parameters?.name;
+        if (typeof name === 'string') {
+          return `${rawUri}:${name}`;
+        }
+      }
+      return rawUri;
+    }
+  }
+  return undefined;
+};
+
+interface RouteEndpoints {
+  from?: string;
+  outgoing: string[];
+  /** URIs that contain a Camel expression like `${header.foo}` and can't be resolved at design time. */
+  dynamic: string[];
+}
+
+const extractRouteEndpoints = (json: unknown): RouteEndpoints => {
+  if (!json || typeof json !== 'object' || !('route' in json)) {
+    return { outgoing: [], dynamic: [] };
+  }
+  const route = (json as { route?: { from?: unknown } }).route;
+  const from = normalizeEndpoint(getUri(route?.from));
+  const outgoing: string[] = [];
+  const dynamic: string[] = [];
+
+  const walk = (obj: unknown): void => {
+    if (!obj || typeof obj !== 'object') {
+      return;
+    }
+    if (Array.isArray(obj)) {
+      obj.forEach(walk);
+      return;
+    }
+    const record = obj as Record<string, unknown>;
+    for (const key of PRODUCER_KEYS) {
+      if (key in record) {
+        const rawUri = getUri(record[key]);
+        if (rawUri && isDynamicUri(rawUri)) {
+          dynamic.push(rawUri);
+        } else {
+          const endpoint = normalizeEndpoint(rawUri);
+          if (endpoint) {
+            outgoing.push(endpoint);
+          }
+        }
+      }
+    }
+    Object.values(record).forEach(walk);
+  };
+
+  walk(route);
+
+  return { from, outgoing, dynamic };
+};
+
+export interface RouteConnectionExtras {
+  edges: CanvasEdge[];
+  externalNodes: CanvasNode[];
+  dynamicNodes: CanvasNode[];
+}
+
+const buildSyntheticNode = (id: string, label: string, type: string, iconUrl: string | undefined): CanvasNode => {
+  const node: CanvasNode = {
+    id,
+    type,
+    label,
+    width: CanvasDefaults.DEFAULT_NODE_WIDTH,
+    height: CanvasDefaults.DEFAULT_NODE_HEIGHT,
+  };
+  if (iconUrl) {
+    // CanvasNode['data'] is typed for vizNode-backed nodes; widen here so the renderer
+    // can pull the icon URL out of the synthetic node's data.
+    (node as { data?: Record<string, unknown> }).data = { iconUrl };
+  }
+  return node;
+};
+
+export const buildRouteConnectionExtras = (
+  visualEntities: BaseVisualEntity[],
+  entityToTopLevelId: Map<string, string>,
+  endpointIconUrl?: string,
+): RouteConnectionExtras => {
+  const consumersByEndpoint = new Map<string, string[]>();
+  const outgoingByEntity = new Map<string, string[]>();
+  const dynamicByEntity = new Map<string, string[]>();
+
+  visualEntities.forEach((entity) => {
+    const { from, outgoing, dynamic } = extractRouteEndpoints(entity.toJSON());
+    if (from) {
+      const consumers = consumersByEndpoint.get(from) ?? [];
+      consumers.push(entity.id);
+      consumersByEndpoint.set(from, consumers);
+    }
+    if (outgoing.length > 0) {
+      outgoingByEntity.set(entity.id, outgoing);
+    }
+    if (dynamic.length > 0) {
+      dynamicByEntity.set(entity.id, dynamic);
+    }
+  });
+
+  const edges: CanvasEdge[] = [];
+  const seenEdges = new Set<string>();
+  const externalNodes: CanvasNode[] = [];
+  const seenExternals = new Set<string>();
+  const dynamicNodes: CanvasNode[] = [];
+  const seenDynamics = new Set<string>();
+
+  const addEdge = (edge: CanvasEdge): void => {
+    if (seenEdges.has(edge.id)) {
+      return;
+    }
+    seenEdges.add(edge.id);
+    edges.push(edge);
+  };
+
+  /** Add a synthetic node + dashed edge from the given producer (deduped by node id). */
+  const addSyntheticEndpoint = (
+    producerTop: string,
+    label: string,
+    idPrefix: string,
+    nodeType: string,
+    targetNodes: CanvasNode[],
+    seenNodes: Set<string>,
+  ): void => {
+    const nodeId = `${idPrefix}${label}`;
+    if (!seenNodes.has(nodeId)) {
+      seenNodes.add(nodeId);
+      targetNodes.push(buildSyntheticNode(nodeId, label, nodeType, endpointIconUrl));
+    }
+    addEdge({
+      id: `${producerTop} >>> ${nodeId}`,
+      type: 'edge',
+      source: producerTop,
+      target: nodeId,
+      edgeStyle: EdgeStyle.dashed,
+      label,
+    });
+  };
+
+  outgoingByEntity.forEach((endpoints, producerId) => {
+    const producerTop = entityToTopLevelId.get(producerId);
+    if (!producerTop) {
+      return;
+    }
+    endpoints.forEach((endpoint) => {
+      const consumerIds = consumersByEndpoint.get(endpoint);
+
+      // The endpoint is consumed somewhere in this file (possibly only by the producer itself).
+      // Don't treat it as external; emit edges to any non-self consumer.
+      if (consumerIds && consumerIds.length > 0) {
+        consumerIds.forEach((consumerId) => {
+          if (consumerId === producerId) {
+            return;
+          }
+          const consumerTop = entityToTopLevelId.get(consumerId);
+          if (!consumerTop) {
+            return;
+          }
+          addEdge({
+            id: `${producerTop} >>> ${consumerTop} :: ${endpoint}`,
+            type: 'edge',
+            source: producerTop,
+            target: consumerTop,
+            edgeStyle: EdgeStyle.solid,
+            label: endpoint,
+          });
+        });
+        return;
+      }
+
+      // No consumer in this file → render a synthetic external endpoint node.
+      addSyntheticEndpoint(
+        producerTop,
+        endpoint,
+        EXTERNAL_ENDPOINT_ID_PREFIX,
+        EXTERNAL_ENDPOINT_NODE_TYPE,
+        externalNodes,
+        seenExternals,
+      );
+    });
+  });
+
+  dynamicByEntity.forEach((uris, producerId) => {
+    const producerTop = entityToTopLevelId.get(producerId);
+    if (!producerTop) {
+      return;
+    }
+    uris.forEach((uri) => {
+      addSyntheticEndpoint(
+        producerTop,
+        uri,
+        DYNAMIC_ENDPOINT_ID_PREFIX,
+        DYNAMIC_ENDPOINT_NODE_TYPE,
+        dynamicNodes,
+        seenDynamics,
+      );
+    });
+  });
+
+  return { edges, externalNodes, dynamicNodes };
+};

--- a/packages/ui/src/pages/Topology/topology-context-menu.test.tsx
+++ b/packages/ui/src/pages/Topology/topology-context-menu.test.tsx
@@ -1,0 +1,74 @@
+import { ElementModel, GraphElement } from '@patternfly/react-topology';
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { CanvasNode } from '../../components/Visualization/Canvas/canvas.models';
+import { IVisualizationNode } from '../../models/visualization/base-visual-entity';
+import { VisualFlowsApi } from '../../models/visualization/flows/support/flows-visibility';
+import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../providers';
+import { topologyContextMenuFn } from './topology-context-menu';
+
+type MenuElement = GraphElement<ElementModel, CanvasNode['data']>;
+
+const buildVisibleFlowsContext = (dispatch: jest.Mock): VisibleFlowsContextResult => ({
+  visibleFlows: { 'route-1234': true, 'route-5678': true },
+  allFlowsVisible: true,
+  visualFlowsApi: new VisualFlowsApi(dispatch),
+});
+
+const mockElement = (vizNode: Partial<IVisualizationNode> | undefined): MenuElement =>
+  ({
+    getData: () => (vizNode ? { vizNode: vizNode as IVisualizationNode } : ({} as CanvasNode['data'])),
+  }) as MenuElement;
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+const renderItems = (items: ReturnType<typeof topologyContextMenuFn>, dispatch: jest.Mock) =>
+  render(
+    <MemoryRouter initialEntries={['/topology']}>
+      <VisibleFlowsContext.Provider value={buildVisibleFlowsContext(dispatch)}>
+        <Routes>
+          <Route path="/topology" element={<>{items}</>} />
+          <Route path="/" element={<LocationProbe />} />
+        </Routes>
+      </VisibleFlowsContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('topologyContextMenuFn', () => {
+  it('returns an empty array when the element has no vizNode', () => {
+    expect(topologyContextMenuFn(mockElement(undefined))).toEqual([]);
+  });
+
+  it('returns a single Open menu item for a vizNode', () => {
+    const items = topologyContextMenuFn(mockElement({ getId: () => 'route-1234' } as Partial<IVisualizationNode>));
+    expect(items).toHaveLength(1);
+  });
+
+  it('clicking Open hides every other flow, shows only this one and navigates Home', () => {
+    const dispatch = jest.fn();
+    const items = topologyContextMenuFn(mockElement({ getId: () => 'route-1234' } as Partial<IVisualizationNode>));
+    const { getByText, getByTestId } = renderItems(items, dispatch);
+
+    fireEvent.click(getByText('Open'));
+
+    // Order matters: hide all flows first, then re-show the producer.
+    expect(dispatch).toHaveBeenNthCalledWith(1, { type: 'hideFlows', flowIds: undefined });
+    expect(dispatch).toHaveBeenNthCalledWith(2, { type: 'showFlows', flowIds: ['route-1234'] });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(getByTestId('location').textContent).toBe('/');
+  });
+
+  it('does nothing when the vizNode has no id', () => {
+    const dispatch = jest.fn();
+    const items = topologyContextMenuFn(mockElement({ getId: () => undefined } as Partial<IVisualizationNode>));
+    const { getByText } = renderItems(items, dispatch);
+
+    fireEvent.click(getByText('Open'));
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/Topology/topology-context-menu.tsx
+++ b/packages/ui/src/pages/Topology/topology-context-menu.tsx
@@ -1,0 +1,42 @@
+import { ArrowRightIcon } from '@patternfly/react-icons';
+import { ContextMenuItem, ElementModel, GraphElement } from '@patternfly/react-topology';
+import { FunctionComponent, ReactElement, useCallback, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { CanvasNode } from '../../components/Visualization/Canvas/canvas.models';
+import { IVisualizationNode } from '../../models/visualization/base-visual-entity';
+import { VisibleFlowsContext } from '../../providers/visible-flows.provider';
+import { Links } from '../../router/links.models';
+
+interface OpenInDesignItemProps {
+  vizNode: IVisualizationNode;
+}
+
+const OpenInDesignItem: FunctionComponent<OpenInDesignItemProps> = ({ vizNode }) => {
+  const visibleFlowsContext = useContext(VisibleFlowsContext);
+  const navigate = useNavigate();
+
+  const onClick = useCallback(() => {
+    const routeId = vizNode.getId();
+    if (!routeId || !visibleFlowsContext) {
+      return;
+    }
+    visibleFlowsContext.visualFlowsApi.hideFlows();
+    visibleFlowsContext.visualFlowsApi.showFlows([routeId]);
+    navigate(Links.Home);
+  }, [navigate, visibleFlowsContext, vizNode]);
+
+  return (
+    <ContextMenuItem onClick={onClick} data-testid="topology-context-menu-open">
+      <ArrowRightIcon /> Open
+    </ContextMenuItem>
+  );
+};
+
+export const topologyContextMenuFn = (element: GraphElement<ElementModel, CanvasNode['data']>): ReactElement[] => {
+  const vizNode = element.getData()?.vizNode;
+  if (!vizNode) {
+    return [];
+  }
+  return [<OpenInDesignItem key="topology-context-menu-open" vizNode={vizNode} />];
+};

--- a/packages/ui/src/pages/Topology/topology-control-buttons.hook.test.tsx
+++ b/packages/ui/src/pages/Topology/topology-control-buttons.hook.test.tsx
@@ -1,0 +1,120 @@
+import { Controller } from '@patternfly/react-topology';
+import { renderHook } from '@testing-library/react';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { LocalStorageKeys } from '../../models';
+import { AbstractSettingsAdapter, CanvasLayoutDirection, ISettingsModel } from '../../models/settings/settings.model';
+import { useTopologyControlButtons } from './topology-control-buttons.hook';
+
+const FIT_PADDING = 80;
+
+const buildController = () => {
+  const graph = {
+    scaleBy: jest.fn(),
+    fit: jest.fn(),
+    reset: jest.fn(),
+    layout: jest.fn(),
+    setLayout: jest.fn(),
+  };
+  return {
+    controller: { getGraph: () => graph } as unknown as Controller,
+    graph,
+  };
+};
+
+const buildAdapter = (canvasLayoutDirection: CanvasLayoutDirection): AbstractSettingsAdapter => ({
+  getSettings: () => ({ canvasLayoutDirection }) as ISettingsModel,
+  saveSettings: jest.fn(),
+});
+
+describe('useTopologyControlButtons', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('omits the layout-toggle buttons when the global setting forces a direction', () => {
+    const { controller } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.Horizontal);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+
+    const ids = result.current.map((b) => b.id);
+    expect(ids).not.toContain('topology-control-bar-h_layout-button');
+    expect(ids).not.toContain('topology-control-bar-v_layout-button');
+  });
+
+  it('includes the horizontal/vertical layout buttons when the user picks per-canvas', () => {
+    const { controller } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.SelectInCanvas);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+
+    const ids = result.current.map((b) => b.id);
+    expect(ids).toContain('topology-control-bar-h_layout-button');
+    expect(ids).toContain('topology-control-bar-v_layout-button');
+  });
+
+  it('horizontal layout button persists the choice and re-runs the layout', () => {
+    const { controller, graph } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.SelectInCanvas);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+    const button = result.current.find((b) => b.id === 'topology-control-bar-h_layout-button');
+    button!.callback?.(button!.id);
+
+    expect(localStorage.getItem(LocalStorageKeys.CanvasLayout)).toBe(LayoutType.DagreHorizontal);
+    expect(graph.setLayout).toHaveBeenCalledWith(LayoutType.DagreHorizontal);
+    expect(graph.layout).toHaveBeenCalled();
+  });
+
+  it('vertical layout button persists the choice and re-runs the layout', () => {
+    const { controller, graph } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.SelectInCanvas);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+    const button = result.current.find((b) => b.id === 'topology-control-bar-v_layout-button');
+    button!.callback?.(button!.id);
+
+    expect(localStorage.getItem(LocalStorageKeys.CanvasLayout)).toBe(LayoutType.DagreVertical);
+    expect(graph.setLayout).toHaveBeenCalledWith(LayoutType.DagreVertical);
+    expect(graph.layout).toHaveBeenCalled();
+  });
+
+  it('zoom-in and zoom-out scale the graph by 4/3 and 3/4 respectively', () => {
+    const { controller, graph } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.Horizontal);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+    const zoomIn = result.current.find((b) => b.id === 'zoom-in');
+    const zoomOut = result.current.find((b) => b.id === 'zoom-out');
+    zoomIn!.callback?.(zoomIn!.id);
+    zoomOut!.callback?.(zoomOut!.id);
+
+    expect(graph.scaleBy).toHaveBeenNthCalledWith(1, 4 / 3);
+    expect(graph.scaleBy).toHaveBeenNthCalledWith(2, 3 / 4);
+  });
+
+  it('fit-to-screen calls graph.fit with the topology padding', () => {
+    const { controller, graph } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.Horizontal);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+    const fit = result.current.find((b) => b.id === 'fit-to-screen');
+    fit!.callback?.(fit!.id);
+
+    expect(graph.fit).toHaveBeenCalledWith(FIT_PADDING);
+  });
+
+  it('reset-view resets the graph, re-runs the layout and fits the result', () => {
+    const { controller, graph } = buildController();
+    const adapter = buildAdapter(CanvasLayoutDirection.Horizontal);
+
+    const { result } = renderHook(() => useTopologyControlButtons(controller, adapter));
+    const reset = result.current.find((b) => b.id === 'reset-view');
+    reset!.callback?.(reset!.id);
+
+    expect(graph.reset).toHaveBeenCalled();
+    expect(graph.layout).toHaveBeenCalled();
+    expect(graph.fit).toHaveBeenCalledWith(FIT_PADDING);
+  });
+});

--- a/packages/ui/src/pages/Topology/topology-control-buttons.hook.tsx
+++ b/packages/ui/src/pages/Topology/topology-control-buttons.hook.tsx
@@ -1,0 +1,75 @@
+import {
+  action,
+  Controller,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+  TopologyControlButton,
+} from '@patternfly/react-topology';
+import { useMemo } from 'react';
+
+import { HorizontalLayoutIcon } from '../../components/Icons/HorizontalLayout';
+import { VerticalLayoutIcon } from '../../components/Icons/VerticalLayout';
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { LocalStorageKeys } from '../../models';
+import { AbstractSettingsAdapter, CanvasLayoutDirection } from '../../models/settings/settings.model';
+
+const FIT_PADDING = 80;
+
+/**
+ * Build the topology control bar: zoom in/out, fit-to-screen, reset and (when
+ * the user opted into per-canvas layout selection) horizontal/vertical layout
+ * toggles. The chosen layout is persisted in the same localStorage key used
+ * by the design canvas so both views stay in sync.
+ */
+export const useTopologyControlButtons = (
+  controller: Controller,
+  settingsAdapter: AbstractSettingsAdapter,
+): TopologyControlButton[] =>
+  useMemo(() => {
+    const customButtons: TopologyControlButton[] = [];
+
+    if (settingsAdapter.getSettings().canvasLayoutDirection === CanvasLayoutDirection.SelectInCanvas) {
+      customButtons.push(
+        {
+          id: 'topology-control-bar-h_layout-button',
+          icon: <HorizontalLayoutIcon />,
+          tooltip: 'Horizontal Layout',
+          callback: action(() => {
+            localStorage.setItem(LocalStorageKeys.CanvasLayout, LayoutType.DagreHorizontal);
+            controller.getGraph().setLayout(LayoutType.DagreHorizontal);
+            controller.getGraph().layout();
+          }),
+        },
+        {
+          id: 'topology-control-bar-v_layout-button',
+          icon: <VerticalLayoutIcon />,
+          tooltip: 'Vertical Layout',
+          callback: action(() => {
+            localStorage.setItem(LocalStorageKeys.CanvasLayout, LayoutType.DagreVertical);
+            controller.getGraph().setLayout(LayoutType.DagreVertical);
+            controller.getGraph().layout();
+          }),
+        },
+      );
+    }
+
+    return createTopologyControlButtons({
+      ...defaultControlButtonsOptions,
+      zoomInCallback: action(() => {
+        controller.getGraph().scaleBy(4 / 3);
+      }),
+      zoomOutCallback: action(() => {
+        controller.getGraph().scaleBy(3 / 4);
+      }),
+      fitToScreenCallback: action(() => {
+        controller.getGraph().fit(FIT_PADDING);
+      }),
+      resetViewCallback: action(() => {
+        controller.getGraph().reset();
+        controller.getGraph().layout();
+        controller.getGraph().fit(FIT_PADDING);
+      }),
+      legend: false,
+      customButtons,
+    });
+  }, [controller, settingsAdapter]);

--- a/packages/ui/src/pages/Topology/topology-controller.service.test.ts
+++ b/packages/ui/src/pages/Topology/topology-controller.service.test.ts
@@ -1,0 +1,89 @@
+import { DagreGroupsLayout, GraphComponent, ModelKind, Visualization } from '@patternfly/react-topology';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { TopologyCollapsedGroup } from './components/TopologyCollapsedGroup';
+import { TopologyDynamicEndpoint } from './components/TopologyDynamicEndpoint';
+import { TopologyEdge } from './components/TopologyEdge';
+import { TopologyExternalEndpoint } from './components/TopologyExternalEndpoint';
+import { OrthogonalBendpointsEdge } from './OrthogonalBendpointsEdge';
+import { DYNAMIC_ENDPOINT_NODE_TYPE, EXTERNAL_ENDPOINT_NODE_TYPE } from './topology-connections';
+import { TopologyControllerService } from './topology-controller.service';
+
+describe('TopologyControllerService', () => {
+  describe('createController', () => {
+    it('returns a Visualization with factories registered and a graph already in the model', () => {
+      const controller = TopologyControllerService.createController();
+      expect(controller).toBeInstanceOf(Visualization);
+      // After fromModel({ graph }), getGraph() must succeed.
+      expect(controller.getGraph().getId()).toBe('topology-graph');
+    });
+  });
+
+  describe('layoutFactory', () => {
+    // DagreGroupsLayout requires a real Graph (it calls graph.getController()), so we exercise
+    // the factory through a real controller instead of building a mock graph from scratch.
+    it('produces a DagreGroupsLayout for the horizontal layout type', () => {
+      const controller = TopologyControllerService.createController();
+      const layout = TopologyControllerService.layoutFactory(
+        LayoutType.DagreHorizontal,
+        controller.getGraph(),
+      ) as DagreGroupsLayout;
+      expect(layout).toBeInstanceOf(DagreGroupsLayout);
+    });
+
+    it('produces a DagreGroupsLayout for the vertical layout type', () => {
+      const controller = TopologyControllerService.createController();
+      const layout = TopologyControllerService.layoutFactory(
+        LayoutType.DagreVertical,
+        controller.getGraph(),
+      ) as DagreGroupsLayout;
+      expect(layout).toBeInstanceOf(DagreGroupsLayout);
+    });
+  });
+
+  describe('componentFactory', () => {
+    it('routes external-endpoint nodes to TopologyExternalEndpoint', () => {
+      expect(TopologyControllerService.componentFactory(ModelKind.node, EXTERNAL_ENDPOINT_NODE_TYPE)).toBe(
+        TopologyExternalEndpoint,
+      );
+    });
+
+    it('routes dynamic-endpoint nodes to TopologyDynamicEndpoint', () => {
+      expect(TopologyControllerService.componentFactory(ModelKind.node, DYNAMIC_ENDPOINT_NODE_TYPE)).toBe(
+        TopologyDynamicEndpoint,
+      );
+    });
+
+    it('routes group nodes to the context-menu-wrapped TopologyCollapsedGroup', () => {
+      const Component = TopologyControllerService.componentFactory(ModelKind.node, 'group');
+      expect(Component).toBeDefined();
+      // The wrapped component is created by withContextMenu; it isn't === TopologyCollapsedGroup
+      // but the displayName chain hints at the wrapped target.
+      expect(Component).not.toBe(TopologyCollapsedGroup);
+    });
+
+    it('returns the default GraphComponent for the graph kind', () => {
+      expect(TopologyControllerService.componentFactory(ModelKind.graph, 'graph')).toBe(GraphComponent);
+    });
+
+    it('routes generic edges to TopologyEdge', () => {
+      expect(TopologyControllerService.componentFactory(ModelKind.edge, 'edge')).toBe(TopologyEdge);
+    });
+
+    it('returns undefined for unknown node types so PatternFly falls back to its default', () => {
+      expect(TopologyControllerService.componentFactory(ModelKind.node, 'something-unknown')).toBeUndefined();
+    });
+  });
+
+  describe('elementFactory', () => {
+    it('returns an OrthogonalBendpointsEdge for the edge kind', () => {
+      const element = TopologyControllerService.elementFactory(ModelKind.edge);
+      expect(element).toBeInstanceOf(OrthogonalBendpointsEdge);
+    });
+
+    it('returns undefined for non-edge kinds (PatternFly uses its defaults)', () => {
+      expect(TopologyControllerService.elementFactory(ModelKind.node)).toBeUndefined();
+      expect(TopologyControllerService.elementFactory(ModelKind.graph)).toBeUndefined();
+    });
+  });
+});

--- a/packages/ui/src/pages/Topology/topology-controller.service.ts
+++ b/packages/ui/src/pages/Topology/topology-controller.service.ts
@@ -1,0 +1,85 @@
+import {
+  ComponentFactory,
+  DagreGroupsLayout,
+  Graph,
+  GraphComponent,
+  GraphElement,
+  Layout,
+  LEFT_TO_RIGHT,
+  ModelKind,
+  TOP_TO_BOTTOM,
+  Visualization,
+  withContextMenu,
+} from '@patternfly/react-topology';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { TopologyCollapsedGroup } from './components/TopologyCollapsedGroup';
+import { TopologyDynamicEndpoint } from './components/TopologyDynamicEndpoint';
+import { TopologyEdge } from './components/TopologyEdge';
+import { TopologyExternalEndpoint } from './components/TopologyExternalEndpoint';
+import { OrthogonalBendpointsEdge } from './OrthogonalBendpointsEdge';
+import { DYNAMIC_ENDPOINT_NODE_TYPE, EXTERNAL_ENDPOINT_NODE_TYPE } from './topology-connections';
+import { topologyContextMenuFn } from './topology-context-menu';
+
+const TopologyCollapsedGroupWithMenu = withContextMenu(topologyContextMenuFn)(TopologyCollapsedGroup);
+
+export class TopologyControllerService {
+  static createController(): Visualization {
+    const controller = new Visualization();
+
+    controller.registerLayoutFactory(this.layoutFactory);
+    controller.registerComponentFactory(this.componentFactory);
+    controller.registerElementFactory(this.elementFactory);
+    controller.fromModel({
+      graph: {
+        id: 'topology-graph',
+        type: 'graph',
+      },
+    });
+
+    return controller;
+  }
+
+  static layoutFactory(type: string, graph: Graph): Layout | undefined {
+    const isHorizontal = type === LayoutType.DagreHorizontal;
+    return new DagreGroupsLayout(graph, {
+      rankdir: isHorizontal ? LEFT_TO_RIGHT : TOP_TO_BOTTOM,
+      nodeDistance: 60,
+      ranker: 'network-simplex',
+      nodesep: 30,
+      edgesep: 20,
+      ranksep: 60,
+    });
+  }
+
+  static componentFactory(kind: ModelKind, type: string): ReturnType<ComponentFactory> {
+    // Intentional "type before kind" precedence: external/dynamic endpoint nodes and the
+    // collapsed-route group must resolve to their dedicated renderers regardless of their
+    // ModelKind. Generic ModelKind.graph / ModelKind.edge handling lives in the switch
+    // below — don't reorder these checks.
+    if (type === EXTERNAL_ENDPOINT_NODE_TYPE) {
+      return TopologyExternalEndpoint;
+    }
+    if (type === DYNAMIC_ENDPOINT_NODE_TYPE) {
+      return TopologyDynamicEndpoint;
+    }
+    if (type === 'group') {
+      return TopologyCollapsedGroupWithMenu;
+    }
+    switch (kind) {
+      case ModelKind.graph:
+        return GraphComponent;
+      case ModelKind.edge:
+        return TopologyEdge;
+      default:
+        return undefined;
+    }
+  }
+
+  static elementFactory(kind: ModelKind): GraphElement | undefined {
+    if (kind === ModelKind.edge) {
+      return new OrthogonalBendpointsEdge();
+    }
+    return undefined;
+  }
+}

--- a/packages/ui/src/pages/Topology/topology-layout-preference.hook.ts
+++ b/packages/ui/src/pages/Topology/topology-layout-preference.hook.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { LocalStorageKeys } from '../../models';
+import { AbstractSettingsAdapter } from '../../models/settings/settings.model';
+import { getInitialLayout } from '../../utils/get-initial-layout';
+
+export interface TopologyLayoutPreference {
+  /** Forced layout from the global setting, or `undefined` when the user picks per-canvas. */
+  settingsLayout: LayoutType | undefined;
+  /** The layout that should be applied right now. */
+  activeLayout: LayoutType;
+}
+
+// LayoutType is a `const enum`, so its values can't be enumerated at runtime —
+// list them explicitly for the validation check.
+const VALID_LAYOUTS = new Set<string>([LayoutType.DagreHorizontal, LayoutType.DagreVertical]);
+
+const isValidLayout = (value: string | null): value is LayoutType => value !== null && VALID_LAYOUTS.has(value);
+
+/**
+ * Resolves the layout direction for the topology view. Honors the global
+ * `canvasLayoutDirection` setting first, then the user's last per-canvas
+ * choice (persisted in localStorage), and finally falls back to horizontal.
+ */
+export const useTopologyLayoutPreference = (settingsAdapter: AbstractSettingsAdapter): TopologyLayoutPreference => {
+  // Depend on the actual setting value rather than the adapter reference so a
+  // saveSettings() on the same adapter still triggers a recompute.
+  const canvasLayoutDirection = settingsAdapter.getSettings().canvasLayoutDirection;
+  const settingsLayout = useMemo(() => getInitialLayout(canvasLayoutDirection), [canvasLayoutDirection]);
+  const activeLayout = useMemo(() => {
+    if (settingsLayout) {
+      return settingsLayout;
+    }
+    const stored = localStorage.getItem(LocalStorageKeys.CanvasLayout);
+    return isValidLayout(stored) ? stored : LayoutType.DagreHorizontal;
+  }, [settingsLayout]);
+
+  return { settingsLayout, activeLayout };
+};

--- a/packages/ui/src/pages/Topology/topology-model.hook.ts
+++ b/packages/ui/src/pages/Topology/topology-model.hook.ts
@@ -1,0 +1,73 @@
+import { Model } from '@patternfly/react-topology';
+import { useMemo } from 'react';
+
+import { CanvasEdge, CanvasNode, LayoutType } from '../../components/Visualization/Canvas/canvas.models';
+import { FlowService } from '../../components/Visualization/Canvas/flow.service';
+import { BaseVisualEntity, IVisualizationNode } from '../../models/visualization/base-visual-entity';
+import { buildRouteConnectionExtras } from './topology-connections';
+
+export interface TopologyModelResult {
+  /** PatternFly Topology model: nodes (route groups + synthetic endpoints) + edges. */
+  model: Model;
+  /** IDs of every top-level group (one per route); used to mark them as collapsed. */
+  topLevelGroupIds: string[];
+}
+
+/**
+ * Build the topology model from the resolved viz nodes and the underlying
+ * visual entities. Combines:
+ *   - the per-route flow diagrams produced by FlowService (used as collapsed groups)
+ *   - cross-route edges from in-VM endpoint references
+ *   - synthetic external/dynamic endpoint nodes for unresolved producers
+ */
+export const useTopologyModel = (
+  vizNodes: IVisualizationNode[],
+  visualEntities: BaseVisualEntity[],
+  activeLayout: LayoutType,
+): TopologyModelResult =>
+  useMemo(() => {
+    const nodes: CanvasNode[] = [];
+    const edges: CanvasEdge[] = [];
+    const topLevelGroupIds: string[] = [];
+    const entityToTopLevelId = new Map<string, string>();
+
+    vizNodes.forEach((vizNode) => {
+      const scope = vizNode.getId() ?? vizNode.id;
+      const { nodes: childNodes, edges: childEdges } = FlowService.getFlowDiagram(scope, vizNode, {
+        removePlaceholder: true,
+      });
+      nodes.push(...childNodes);
+      edges.push(...childEdges);
+
+      const topLevel = childNodes.find((node) => node.type === 'group' && !node.parentNode);
+      if (topLevel) {
+        topLevelGroupIds.push(topLevel.id);
+        entityToTopLevelId.set(scope, topLevel.id);
+      }
+    });
+
+    // Use the same icon URL as the route nodes so external/dynamic endpoints look consistent.
+    const routeIconUrl = (vizNodes[0]?.data.iconUrl as string | undefined) ?? '';
+    const {
+      edges: connectionEdges,
+      externalNodes,
+      dynamicNodes,
+    } = buildRouteConnectionExtras(visualEntities, entityToTopLevelId, routeIconUrl);
+    // Insert synthetic endpoint nodes before route children so PatternFly Topology lays them out
+    // without colliding with collapsed groups.
+    nodes.unshift(...externalNodes, ...dynamicNodes);
+    edges.push(...connectionEdges);
+
+    return {
+      model: {
+        nodes,
+        edges,
+        graph: {
+          id: 'topology-graph',
+          type: 'graph',
+          layout: activeLayout,
+        },
+      } satisfies Model,
+      topLevelGroupIds,
+    };
+  }, [vizNodes, visualEntities, activeLayout]);

--- a/packages/ui/src/router.tsx
+++ b/packages/ui/src/router.tsx
@@ -24,6 +24,10 @@ export const router = createHashRouter([
         lazy: async () => import('./pages/SourceCode'),
       },
       {
+        path: Links.Topology,
+        lazy: async () => import('./pages/Topology'),
+      },
+      {
         path: Links.RestImport,
         lazy: async () => import('./pages/RestDslImport'),
       },

--- a/packages/ui/src/router/links.models.ts
+++ b/packages/ui/src/router/links.models.ts
@@ -1,6 +1,7 @@
 export const enum Links {
   Home = '/', // Flows visualization
   SourceCode = '/code', // Flows source code
+  Topology = '/topology', // Routes topology overview
   DataMapper = '/datamapper',
   About = '/about',
   Beans = '/beans',


### PR DESCRIPTION
first draft of the topology view. for the moment we can only show it for a single file.

fixes #769 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Topology view accessible from Visualization in navigation
  * Interactive topology visualization with zoom, pan, fit/reset controls and layout toggles
  * Visualized route connections, external and dynamic endpoints, node badges/icons, and collapsed-route rendering
  * Right-click context menu entry to open a route

* **Style**
  * Topology-specific styling improvements for nodes, edges, labels, and hover/badge visuals

* **Tests**
  * Extensive test coverage added for topology components and utilities

* **Chore**
  * Updated .gitignore to ignore .claude/
<!-- end of auto-generated comment: release notes by coderabbit.ai -->