### PR TITLE
fix(DataMapper): Fix tree node indentation for non-expandable children (#3172)

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.scss
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.scss
@@ -2,7 +2,8 @@
 
 .node {
   &__row {
-    --rank-margin: calc(var(--node-rank, 0) * 0.85rem);
+    --rank-step: 0.85rem;
+    --rank-margin: calc(var(--node-rank, 0) * var(--rank-step));
 
     display: flex;
     flex-flow: row nowrap;
@@ -11,7 +12,7 @@
     font-size: var(--datamapper-node-font-size, 0.875rem);
     position: relative;
 
-    // Rank-based indentation - expand icon + margins = ~1.5rem per level
+    // Rank-based indentation
     margin-left: var(--rank-margin);
 
     &[data-draggable='true'] {
@@ -21,8 +22,16 @@
     // Leaf nodes (no children) have grey font color
     &:not([data-expandable='true']) {
       color: var(--pf-t--global--color--text--subtle);
-      border-left: 1px dotted gray;
-      padding-left: var(--pf-t--global--spacer--sm);
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: calc(var(--pf-t--global--spacer--sm) + 0.5rem * var(--datamapper-scale-factor, 1) - var(--rank-step));
+        top: 0;
+        bottom: 0;
+        border-left: 1px dotted var(--pf-t--global--border--color--default);
+        pointer-events: none;
+      }
     }
 
     // Make inputs/buttons fit within row height
@@ -56,6 +65,10 @@
 
   &__expand {
     margin-left: var(--pf-t--global--spacer--sm);
+    display: inline-flex;
+    align-items: center;
+    width: calc(1rem * var(--datamapper-scale-factor, 1));
+    flex-shrink: 0;
 
     svg {
       width: calc(1rem * var(--datamapper-scale-factor, 1));

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -105,11 +105,13 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
         />
       )}
 
-      {isExpandable && (
+      {isExpandable ? (
         <Icon className="node__expand" onClick={onExpandChange}>
           {isExpanded && <ChevronDown data-testid={`expand-icon-${dataTestId}`} />}
           {!isExpanded && <ChevronRight data-testid={`collapse-icon-${dataTestId}`} />}
         </Icon>
+      ) : (
+        <span className="node__expand" aria-hidden="true" />
       )}
 
       {isDraggable && (


### PR DESCRIPTION
Always render the expand slot (chevron area) so leaf and expandable siblings align consistently. Position the guide line under the parent's chevron via a ::before pseudo-element.

Fixes: #3172
<img width="994" height="836" alt="Screenshot 2026-05-06 at 10 46 38" src="https://github.com/user-attachments/assets/a18abc87-ea32-4567-a3f8-9eef58b0260d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * More consistent indentation spacing across hierarchy levels for improved visual rhythm.
  * Leaf nodes use a visually separated dotted border rendered for clearer alignment without affecting clickability.
  * Expansion control sizing and alignment refined for a cleaner, balanced appearance.

* **Refactor**
  * Expansion controls now render consistently (interactive when available; inert placeholders otherwise) to preserve stable layout across node types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->