### PR TITLE
chore(canvas): refactor title and tooltip resolvers

### DIFF
--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
@@ -92,4 +92,43 @@ describe('NodeEnrichmentService', () => {
     expect(vizNode.data.title).toBe('Log EIP');
     expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('should pass processorName to getTitleRequest for Processor catalog kind', async () => {
+    mockGetIconRequest.mockResolvedValue({ icon: 'when-icon.svg', alt: 'When icon' });
+    mockGetTooltipRequest.mockResolvedValue('Conditional routing');
+    mockGetProcessorIconTooltipRequest.mockResolvedValue('When: Routes based on condition');
+    mockGetTitleRequest.mockResolvedValue('When EIP');
+
+    const vizNode = createMockVizNode();
+    // Set name to a condition expression (different from processorName)
+    vizNode.data.name = "${header.foo} == 'bar'";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vizNode.data as any).processorName = 'when';
+
+    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Processor);
+
+    // Verify getTitleRequest was called with processorName, not name
+    expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Processor, 'when', undefined);
+    expect(vizNode.data.title).toBe('When EIP');
+  });
+
+  it('should pass name to getTitleRequest for Component catalog kind', async () => {
+    mockGetIconRequest.mockResolvedValue({ icon: 'timer-icon.svg', alt: 'Timer icon' });
+    mockGetTooltipRequest.mockResolvedValue('Timer component');
+    mockGetProcessorIconTooltipRequest.mockResolvedValue('From: Consumes messages');
+    mockGetTitleRequest.mockResolvedValue('Timer');
+
+    const vizNode = createMockVizNode();
+    vizNode.data.name = 'timer';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vizNode.data as any).processorName = 'from';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vizNode.data as any).componentName = 'timer';
+
+    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Component);
+
+    // Verify getTitleRequest was called with name (not processorName) for Component kind
+    expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Component, 'timer', 'timer');
+    expect(vizNode.data.title).toBe('Timer');
+  });
 });

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
@@ -21,11 +21,16 @@ export class NodeEnrichmentService {
     const processorName = routeData.processorName;
     const componentName = routeData.componentName;
 
+    // For Processor/Pattern catalog kinds, use processorName as the identifier
+    // For other kinds (Component, Kamelet, etc.), use vizNode.data.name
+    const titleIdentifier =
+      catalogKind === CatalogKind.Processor || catalogKind === CatalogKind.Pattern ? processorName : vizNode.data.name;
+
     const results = await Promise.allSettled([
       getIconRequest(catalogKind, vizNode.data.name),
       getTooltipRequest(catalogKind, vizNode.data.name, vizNode.data.description),
       getProcessorIconTooltipRequest(processorName),
-      getTitleRequest(catalogKind, vizNode.data.name, componentName),
+      getTitleRequest(catalogKind, titleIdentifier, componentName),
     ]);
 
     // Handle icon result

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.test.ts
@@ -1,0 +1,150 @@
+import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../../../catalog-kind';
+import { CatalogResolverFactory } from './catalog-resolver.factory';
+
+jest.mock('../../../../../dynamic-catalog/dynamic-catalog-registry');
+
+describe('CatalogResolverFactory', () => {
+  const mockGetEntity = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(DynamicCatalogRegistry.get).mockReturnValue({
+      getEntity: mockGetEntity,
+    } as unknown as ReturnType<typeof DynamicCatalogRegistry.get>);
+  });
+
+  describe('resolveProperty', () => {
+    it('should resolve property when found', async () => {
+      mockGetEntity.mockResolvedValue({ component: { title: 'Timer' } });
+
+      const result = await CatalogResolverFactory.resolveProperty(
+        CatalogKind.Component,
+        'timer',
+        (def) => def?.component?.title,
+      );
+
+      expect(result).toBe('Timer');
+    });
+
+    it('should return fallback when property not found', async () => {
+      mockGetEntity.mockResolvedValue(null);
+
+      const result = await CatalogResolverFactory.resolveProperty(
+        CatalogKind.Component,
+        'unknown',
+        (def) => def?.component?.title,
+        'Fallback',
+      );
+
+      expect(result).toBe('Fallback');
+    });
+
+    it('should return undefined when no fallback provided', async () => {
+      mockGetEntity.mockResolvedValue(null);
+
+      const result = await CatalogResolverFactory.resolveProperty(
+        CatalogKind.Component,
+        'unknown',
+        (def) => def?.component?.title,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle errors and return fallback', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockGetEntity.mockRejectedValue(new Error('Catalog error'));
+
+      const result = await CatalogResolverFactory.resolveProperty(
+        CatalogKind.Component,
+        'timer',
+        (def) => def?.component?.title,
+        'Fallback',
+      );
+
+      expect(result).toBe('Fallback');
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should accept empty string as valid value', async () => {
+      mockGetEntity.mockResolvedValue({ component: { title: '' } });
+
+      const result = await CatalogResolverFactory.resolveProperty(
+        CatalogKind.Component,
+        'timer',
+        (def) => def?.component?.title,
+        'Fallback',
+      );
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('resolvePropertyWithFallbacks', () => {
+    it('should return value from first matching catalog', async () => {
+      mockGetEntity.mockResolvedValue({ model: { title: 'Log' } });
+
+      const result = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+        [CatalogKind.Processor, CatalogKind.Pattern],
+        'log',
+        (def) => def?.model?.title,
+      );
+
+      expect(result).toBe('Log');
+      expect(mockGetEntity).toHaveBeenCalledTimes(1);
+    });
+
+    it('should try next catalog when first fails', async () => {
+      mockGetEntity.mockResolvedValueOnce(null).mockResolvedValueOnce({ model: { title: 'Pattern' } });
+
+      const result = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+        [CatalogKind.Processor, CatalogKind.Pattern],
+        'log',
+        (def) => def?.model?.title,
+      );
+
+      expect(result).toBe('Pattern');
+      expect(mockGetEntity).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return fallback when all catalogs fail', async () => {
+      mockGetEntity.mockResolvedValue(null);
+
+      const result = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+        [CatalogKind.Processor, CatalogKind.Pattern],
+        'unknown',
+        (def) => def?.model?.title,
+        'Fallback',
+      );
+
+      expect(result).toBe('Fallback');
+    });
+
+    it('should return undefined when no fallback provided', async () => {
+      mockGetEntity.mockResolvedValue(null);
+
+      const result = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+        [CatalogKind.Processor, CatalogKind.Pattern],
+        'unknown',
+        (def) => def?.model?.title,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should continue after catalog errors', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockGetEntity.mockRejectedValueOnce(new Error('Error')).mockResolvedValueOnce({ model: { title: 'Success' } });
+
+      const result = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+        [CatalogKind.Processor, CatalogKind.Pattern],
+        'log',
+        (def) => def?.model?.title,
+      );
+
+      expect(result).toBe('Success');
+      consoleWarnSpy.mockRestore();
+    });
+  });
+});

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.ts
@@ -1,0 +1,64 @@
+import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../../../catalog-kind';
+
+/**
+ * Generic catalog property resolver factory.
+ * Eliminates duplication between title and tooltip resolvers.
+ */
+export class CatalogResolverFactory {
+  /**
+   * Resolves a property from the catalog based on catalog kind and name.
+   *
+   * @param catalogKind - The type of catalog item
+   * @param name - The name/identifier of the catalog item
+   * @param propertyExtractor - Function to extract the desired property from the catalog definition
+   * @param fallback - Optional fallback value if resolution fails
+   * @returns Promise resolving to the property value or fallback
+   */
+  static async resolveProperty<T>(
+    catalogKind: CatalogKind,
+    name: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    propertyExtractor: (definition: any) => T | undefined,
+    fallback?: T,
+  ): Promise<T | undefined> {
+    try {
+      const definition = await DynamicCatalogRegistry.get().getEntity(catalogKind, name);
+      if (definition) {
+        const value = propertyExtractor(definition);
+        if (value !== undefined && value !== null) {
+          return value;
+        }
+      }
+    } catch (error) {
+      console.warn(`Failed to fetch property from ${catalogKind} catalog for "${name}"`, error);
+    }
+    return fallback;
+  }
+
+  /**
+   * Resolves a property by trying multiple catalog kinds in order.
+   * Useful for processors that might be in Processor or Pattern catalogs.
+   *
+   * @param catalogKinds - Array of catalog kinds to try in order
+   * @param name - The name/identifier of the catalog item
+   * @param propertyExtractor - Function to extract the desired property from the catalog definition
+   * @param fallback - Optional fallback value if all resolutions fail
+   * @returns Promise resolving to the first successful property value or fallback
+   */
+  static async resolvePropertyWithFallbacks<T>(
+    catalogKinds: CatalogKind[],
+    name: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    propertyExtractor: (definition: any) => T | undefined,
+    fallback?: T,
+  ): Promise<T | undefined> {
+    for (const kind of catalogKinds) {
+      const value = await this.resolveProperty(kind, name, propertyExtractor);
+      if (value !== undefined && value !== null) {
+        return value;
+      }
+    }
+    return fallback;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.test.ts
@@ -20,7 +20,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.Component, 'timer');
 
-    expect(mockGetComponentTitle).toHaveBeenCalledWith('timer');
+    expect(mockGetComponentTitle).toHaveBeenCalledWith('timer', CatalogKind.Component, undefined);
     expect(result).toBe('Timer Component');
   });
 
@@ -29,7 +29,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.Kamelet, 'kafka-source');
 
-    expect(mockGetKameletTitle).toHaveBeenCalledWith('kafka-source');
+    expect(mockGetKameletTitle).toHaveBeenCalledWith('kafka-source', CatalogKind.Kamelet, undefined);
     expect(result).toBe('Kafka Source');
   });
 
@@ -38,7 +38,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.Processor, 'log');
 
-    expect(mockGetProcessorTitle).toHaveBeenCalledWith('log', undefined);
+    expect(mockGetProcessorTitle).toHaveBeenCalledWith('log', CatalogKind.Processor, undefined);
     expect(result).toBe('Log EIP');
   });
 
@@ -47,7 +47,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.Processor, 'from', 'timer');
 
-    expect(mockGetProcessorTitle).toHaveBeenCalledWith('from', 'timer');
+    expect(mockGetProcessorTitle).toHaveBeenCalledWith('from', CatalogKind.Processor, 'timer');
     expect(result).toBe('Timer');
   });
 
@@ -56,7 +56,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.Entity, 'errorHandler');
 
-    expect(mockGetEntityTitle).toHaveBeenCalledWith('errorHandler');
+    expect(mockGetEntityTitle).toHaveBeenCalledWith('errorHandler', CatalogKind.Entity, undefined);
     expect(result).toBe('Error Handler');
   });
 
@@ -65,7 +65,7 @@ describe('getTitleRequest', () => {
 
     const result = await getTitleRequest(CatalogKind.TestAction, 'send');
 
-    expect(mockGetTestActionTitle).toHaveBeenCalledWith('send');
+    expect(mockGetTestActionTitle).toHaveBeenCalledWith('send', CatalogKind.TestAction, undefined);
     expect(result).toBe('Send Action');
   });
 

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.ts
@@ -2,6 +2,25 @@ import { CatalogKind } from '../../../../../catalog-kind';
 import { NodeTitleResolver } from './node-title-resolver';
 
 /**
+ * Mapping of catalog kinds to their respective resolver methods.
+ */
+const TITLE_RESOLVER_MAP: Partial<
+  Record<CatalogKind, (name: string, catalogKind: CatalogKind, componentName?: string) => Promise<string>>
+> = {
+  [CatalogKind.Entity]: NodeTitleResolver.getEntityTitle,
+  [CatalogKind.Kamelet]: NodeTitleResolver.getKameletTitle,
+  [CatalogKind.Component]: NodeTitleResolver.getComponentTitle,
+  [CatalogKind.Processor]: NodeTitleResolver.getProcessorTitle,
+  [CatalogKind.Pattern]: NodeTitleResolver.getProcessorTitle,
+  [CatalogKind.TestAction]: NodeTitleResolver.getTestActionTitle,
+  [CatalogKind.TestActionGroup]: NodeTitleResolver.getTestActionTitle,
+  [CatalogKind.TestContainer]: NodeTitleResolver.getTestActionTitle,
+  [CatalogKind.TestEndpoint]: NodeTitleResolver.getTestActionTitle,
+  [CatalogKind.TestFunction]: NodeTitleResolver.getTestActionTitle,
+  [CatalogKind.TestValidationMatcher]: NodeTitleResolver.getTestActionTitle,
+};
+
+/**
  * Requests the display title for a node based on its catalog kind and name.
  * This function resolves titles from the catalog asynchronously.
  *
@@ -11,33 +30,12 @@ import { NodeTitleResolver } from './node-title-resolver';
  * @returns Promise resolving to the human-readable title
  */
 export async function getTitleRequest(catalogKind: CatalogKind, name: string, componentName?: string): Promise<string> {
-  let title: string;
+  const resolver = TITLE_RESOLVER_MAP[catalogKind];
 
-  switch (catalogKind) {
-    case CatalogKind.Entity:
-      title = await NodeTitleResolver.getEntityTitle(name);
-      break;
-    case CatalogKind.Kamelet:
-      title = await NodeTitleResolver.getKameletTitle(name);
-      break;
-    case CatalogKind.Component:
-      title = await NodeTitleResolver.getComponentTitle(name);
-      break;
-    case CatalogKind.Processor:
-    case CatalogKind.Pattern:
-      title = await NodeTitleResolver.getProcessorTitle(name, componentName);
-      break;
-    case CatalogKind.TestAction:
-    case CatalogKind.TestActionGroup:
-    case CatalogKind.TestContainer:
-    case CatalogKind.TestEndpoint:
-    case CatalogKind.TestFunction:
-    case CatalogKind.TestValidationMatcher:
-      title = await NodeTitleResolver.getTestActionTitle(name);
-      break;
-    default:
-      title = name;
+  if (resolver) {
+    const title = await resolver(name, catalogKind, componentName);
+    return title || name;
   }
 
-  return title || name;
+  return name;
 }

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.test.ts
@@ -62,7 +62,7 @@ describe('NodeTitleResolver', () => {
         component: { title: 'Timer' },
       });
 
-      const title = await NodeTitleResolver.getProcessorTitle('from', 'timer');
+      const title = await NodeTitleResolver.getProcessorTitle('from', CatalogKind.Processor, 'timer');
 
       expect(mockRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.Component, 'timer');
       expect(title).toBe('Timer');
@@ -73,7 +73,7 @@ describe('NodeTitleResolver', () => {
         spec: { definition: { title: 'Kafka Source' } },
       });
 
-      const title = await NodeTitleResolver.getProcessorTitle('from', 'kamelet:kafka-source');
+      const title = await NodeTitleResolver.getProcessorTitle('from', CatalogKind.Processor, 'kamelet:kafka-source');
 
       expect(mockRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.Kamelet, 'kafka-source');
       expect(title).toBe('Kafka Source');
@@ -84,7 +84,7 @@ describe('NodeTitleResolver', () => {
         model: { title: 'Log EIP' },
       });
 
-      const title = await NodeTitleResolver.getProcessorTitle('log');
+      const title = await NodeTitleResolver.getProcessorTitle('log', CatalogKind.Processor);
 
       expect(mockRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.Processor, 'log');
       expect(title).toBe('Log EIP');
@@ -93,7 +93,7 @@ describe('NodeTitleResolver', () => {
     it('should fallback to processor name if not found', async () => {
       mockRegistry.getEntity.mockResolvedValue(undefined);
 
-      const title = await NodeTitleResolver.getProcessorTitle('missing');
+      const title = await NodeTitleResolver.getProcessorTitle('missing', CatalogKind.Processor);
 
       expect(title).toBe('missing');
     });
@@ -126,16 +126,28 @@ describe('NodeTitleResolver', () => {
         title: 'Send Action',
       });
 
-      const title = await NodeTitleResolver.getTestActionTitle('send');
+      const title = await NodeTitleResolver.getTestActionTitle('send', CatalogKind.TestAction);
 
       expect(mockRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.TestAction, 'send');
       expect(title).toBe('Send Action');
     });
 
+    it('should prioritize requested catalog kind (TestActionGroup)', async () => {
+      mockRegistry.getEntity.mockResolvedValue({
+        title: 'Test Action Group Title',
+      });
+
+      const title = await NodeTitleResolver.getTestActionTitle('myGroup', CatalogKind.TestActionGroup);
+
+      // Should try TestActionGroup first since it was requested
+      expect(mockRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.TestActionGroup, 'myGroup');
+      expect(title).toBe('Test Action Group Title');
+    });
+
     it('should fallback to name if test action not found', async () => {
       mockRegistry.getEntity.mockResolvedValue(undefined);
 
-      const title = await NodeTitleResolver.getTestActionTitle('missing');
+      const title = await NodeTitleResolver.getTestActionTitle('missing', CatalogKind.TestAction);
 
       expect(title).toBe('missing');
     });

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.ts
@@ -1,5 +1,5 @@
-import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../catalog-kind';
+import { CatalogResolverFactory } from '../catalog-resolver.factory';
 
 /**
  * Service for resolving node titles from the catalog.
@@ -10,8 +10,12 @@ export class NodeTitleResolver {
    * Resolves the title for a Camel component.
    */
   static async getComponentTitle(name: string): Promise<string> {
-    const component = await DynamicCatalogRegistry.get().getEntity<CatalogKind.Component>(CatalogKind.Component, name);
-    return component?.component.title ?? name;
+    const title = await CatalogResolverFactory.resolveProperty(
+      CatalogKind.Component,
+      name,
+      (def) => def?.component?.title,
+    );
+    return title ?? name;
   }
 
   /**
@@ -20,15 +24,23 @@ export class NodeTitleResolver {
   static async getKameletTitle(name: string): Promise<string> {
     // Remove 'kamelet:' prefix if present
     const cleanName = name.replace('kamelet:', '');
-    const kamelet = await DynamicCatalogRegistry.get().getEntity<CatalogKind.Kamelet>(CatalogKind.Kamelet, cleanName);
-    return kamelet?.spec.definition.title ?? name;
+    const title = await CatalogResolverFactory.resolveProperty(
+      CatalogKind.Kamelet,
+      cleanName,
+      (def) => def?.spec?.definition?.title,
+    );
+    return title ?? name;
   }
 
   /**
    * Resolves the title for a processor.
    * If a component name is provided, tries to get the component title first.
    */
-  static async getProcessorTitle(processorName: string, componentName?: string): Promise<string> {
+  static async getProcessorTitle(
+    processorName: string,
+    _catalogKind: CatalogKind,
+    componentName?: string,
+  ): Promise<string> {
     // If there's a component name, get the component/kamelet title
     if (componentName) {
       if (componentName.startsWith('kamelet:')) {
@@ -38,23 +50,24 @@ export class NodeTitleResolver {
       return this.getComponentTitle(componentName);
     }
 
-    // Otherwise get processor title
-    const processor = await DynamicCatalogRegistry.get().getEntity<CatalogKind.Processor>(
-      CatalogKind.Processor,
+    // Try processor catalog, fallback to pattern catalog
+    const title = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+      [CatalogKind.Processor, CatalogKind.Pattern],
       processorName,
+      (def) => def?.model?.title,
     );
-    return processor?.model.title ?? processorName;
+    return title ?? processorName;
   }
 
   /**
    * Resolves the title for an entity (route, errorHandler, etc.).
    */
   static async getEntityTitle(name: string): Promise<string> {
-    const entity = await DynamicCatalogRegistry.get().getEntity<CatalogKind.Entity>(CatalogKind.Entity, name);
+    const title = await CatalogResolverFactory.resolveProperty(CatalogKind.Entity, name, (def) => def?.model?.title);
 
     // If catalog has a title, use it
-    if (entity?.model?.title) {
-      return entity.model.title;
+    if (title) {
+      return title;
     }
 
     // Otherwise, format camelCase to spaced title
@@ -69,12 +82,23 @@ export class NodeTitleResolver {
 
   /**
    * Resolves the title for a test action.
+   * Searches across all test catalog kinds, prioritizing the requested kind.
    */
-  static async getTestActionTitle(name: string): Promise<string> {
-    const testAction = await DynamicCatalogRegistry.get().getEntity<CatalogKind.TestAction>(
+  static async getTestActionTitle(name: string, requestedKind: CatalogKind, _componentName?: string): Promise<string> {
+    // All possible test catalog kinds
+    const allTestKinds = [
       CatalogKind.TestAction,
-      name,
-    );
-    return testAction?.title ?? name;
+      CatalogKind.TestActionGroup,
+      CatalogKind.TestContainer,
+      CatalogKind.TestEndpoint,
+      CatalogKind.TestFunction,
+      CatalogKind.TestValidationMatcher,
+    ];
+
+    // Try requested kind first, then all other test kinds
+    const catalogKinds = [requestedKind, ...allTestKinds.filter((kind) => kind !== requestedKind)];
+
+    const title = await CatalogResolverFactory.resolvePropertyWithFallbacks(catalogKinds, name, (def) => def?.title);
+    return title ?? name;
   }
 }

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getTooltipRequest.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getTooltipRequest.ts
@@ -2,42 +2,43 @@ import { CatalogKind } from '../../../../../catalog-kind';
 import { NodeTooltipResolver } from './node-tooltip-resolver';
 
 /**
+ * Mapping of catalog kinds to their respective resolver methods.
+ */
+const TOOLTIP_RESOLVER_MAP: Partial<Record<CatalogKind, (name: string, catalogKind: CatalogKind) => Promise<string>>> =
+  {
+    [CatalogKind.Entity]: NodeTooltipResolver.getEntityTooltip,
+    [CatalogKind.Kamelet]: NodeTooltipResolver.getKameletTooltip,
+    [CatalogKind.Component]: NodeTooltipResolver.getComponentTooltip,
+    [CatalogKind.Processor]: NodeTooltipResolver.getProcessorTooltip,
+    [CatalogKind.Pattern]: NodeTooltipResolver.getProcessorTooltip,
+    [CatalogKind.TestAction]: NodeTooltipResolver.getTestActionTooltip,
+    [CatalogKind.TestActionGroup]: NodeTooltipResolver.getTestActionTooltip,
+    [CatalogKind.TestContainer]: NodeTooltipResolver.getTestActionTooltip,
+    [CatalogKind.TestEndpoint]: NodeTooltipResolver.getTestActionTooltip,
+    [CatalogKind.TestFunction]: NodeTooltipResolver.getTestActionTooltip,
+    [CatalogKind.TestValidationMatcher]: NodeTooltipResolver.getTestActionTooltip,
+  };
+
+/**
  * Requests a tooltip description for a given catalog item.
  * This function resolves tooltip content from the catalog asynchronously.
  *
  * @param catalogKind - The type of catalog item (Component, Processor, Kamelet, etc.)
  * @param name - The name/identifier of the catalog item
- * @returns Promise resolving to the tooltip description text
+ * @param description - Fallback description if catalog lookup fails
+ * @returns Promise resolving to the tooltip description text in format "name: description"
  */
 export async function getTooltipRequest(catalogKind: CatalogKind, name: string, description: string): Promise<string> {
+  const resolver = TOOLTIP_RESOLVER_MAP[catalogKind];
   let tooltip: string;
 
-  switch (catalogKind) {
-    case CatalogKind.Entity:
-      tooltip = await NodeTooltipResolver.getEntityTooltip(name);
-      break;
-    case CatalogKind.Kamelet:
-      tooltip = await NodeTooltipResolver.getKameletTooltip(name);
-      break;
-    case CatalogKind.Component:
-      tooltip = await NodeTooltipResolver.getComponentTooltip(name);
-      break;
-    case CatalogKind.Processor:
-    case CatalogKind.Pattern:
-      tooltip = await NodeTooltipResolver.getProcessorTooltip(name);
-      break;
-    case CatalogKind.TestAction:
-    case CatalogKind.TestActionGroup:
-    case CatalogKind.TestContainer:
-    case CatalogKind.TestEndpoint:
-    case CatalogKind.TestFunction:
-    case CatalogKind.TestValidationMatcher:
-      tooltip = await NodeTooltipResolver.getTestActionTooltip(name, catalogKind);
-      break;
-    default:
-      tooltip = name;
+  if (resolver) {
+    tooltip = await resolver(name, catalogKind);
+  } else {
+    tooltip = name;
   }
 
+  // Use description as fallback if tooltip is empty or same as name
   if (!tooltip || tooltip === name) {
     tooltip = description || name;
   }

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/node-tooltip-resolver.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/node-tooltip-resolver.ts
@@ -1,23 +1,19 @@
-import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
-import { ICamelComponentDefinition } from '../../../../../camel/camel-components-catalog';
-import { ICamelProcessorDefinition } from '../../../../../camel/camel-processors-catalog';
-import { IKameletDefinition } from '../../../../../camel/kamelets-catalog';
 import { CatalogKind } from '../../../../../catalog-kind';
-import { ICitrusComponentDefinition } from '../../../../../citrus/citrus-catalog';
+import { CatalogResolverFactory } from '../catalog-resolver.factory';
 
 /**
  * Service for resolving tooltip descriptions from various catalogs.
- * This follows the same pattern as NodeIconResolver but for tooltip content.
+ * Uses the CatalogResolverFactory to eliminate code duplication.
  */
 export class NodeTooltipResolver {
   /**
    * Get tooltip for a Camel component
    */
   static async getComponentTooltip(componentName: string): Promise<string> {
-    const tooltip = await this.fetchTooltipFromCatalog(
+    const tooltip = await CatalogResolverFactory.resolveProperty(
       CatalogKind.Component,
       componentName,
-      (def: ICamelComponentDefinition) => def.component.description,
+      (def) => def?.component?.description,
     );
     return tooltip ?? componentName;
   }
@@ -26,22 +22,12 @@ export class NodeTooltipResolver {
    * Get tooltip for a Camel processor/pattern
    */
   static async getProcessorTooltip(processorName: string): Promise<string> {
-    // Try processor catalog first
-    let tooltip = await this.fetchTooltipFromCatalog(
-      CatalogKind.Processor,
+    // Try processor catalog first, fallback to pattern catalog
+    const tooltip = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+      [CatalogKind.Processor, CatalogKind.Pattern],
       processorName,
-      (def: ICamelProcessorDefinition) => def.model.description,
+      (def) => def?.model?.description,
     );
-
-    // Fallback to pattern catalog
-    if (!tooltip) {
-      tooltip = await this.fetchTooltipFromCatalog(
-        CatalogKind.Pattern,
-        processorName,
-        (def: ICamelProcessorDefinition) => def.model.description,
-      );
-    }
-
     return tooltip ?? processorName;
   }
 
@@ -51,10 +37,10 @@ export class NodeTooltipResolver {
   static async getKameletTooltip(kameletName: string): Promise<string> {
     // Remove 'kamelet:' prefix if present
     const cleanName = kameletName.replace('kamelet:', '');
-    const tooltip = await this.fetchTooltipFromCatalog(
+    const tooltip = await CatalogResolverFactory.resolveProperty(
       CatalogKind.Kamelet,
       cleanName,
-      (def: IKameletDefinition) => def.spec.definition.description,
+      (def) => def?.spec?.definition?.description,
     );
     return tooltip ?? kameletName;
   }
@@ -63,10 +49,10 @@ export class NodeTooltipResolver {
    * Get tooltip for an entity (route, rest, etc.)
    */
   static async getEntityTooltip(entityName: string): Promise<string> {
-    const tooltip = await this.fetchTooltipFromCatalog(
+    const tooltip = await CatalogResolverFactory.resolveProperty(
       CatalogKind.Entity,
       entityName,
-      (def: ICamelProcessorDefinition) => def.model.description,
+      (def) => def?.model?.description,
     );
     return tooltip ?? entityName;
   }
@@ -85,39 +71,14 @@ export class NodeTooltipResolver {
       CatalogKind.TestValidationMatcher,
     ];
 
+    // Try requested kind first, then all other test kinds
     const catalogKinds = [requestedKind, ...allTestKinds.filter((kind) => kind !== requestedKind)];
 
-    for (const kind of catalogKinds) {
-      const tooltip = await this.fetchTooltipFromCatalog(
-        kind,
-        actionName,
-        (def: ICitrusComponentDefinition) => def.description,
-      );
-      if (tooltip) {
-        return tooltip;
-      }
-    }
-
-    return actionName;
-  }
-
-  /**
-   * Common helper to fetch tooltip from catalog with proper error handling.
-   */
-  private static async fetchTooltipFromCatalog(
-    catalogKind: CatalogKind,
-    name: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    descriptionExtractor: (definition: any) => string | undefined,
-  ): Promise<string | undefined> {
-    try {
-      const definition = await DynamicCatalogRegistry.get().getEntity(catalogKind, name);
-      if (definition) {
-        return descriptionExtractor(definition) ?? undefined;
-      }
-    } catch (error) {
-      console.warn('Failed to fetch description tooltip', error);
-    }
-    return undefined;
+    const tooltip = await CatalogResolverFactory.resolvePropertyWithFallbacks(
+      catalogKinds,
+      actionName,
+      (def) => def?.description,
+    );
+    return tooltip ?? actionName;
   }
 }


### PR DESCRIPTION
## Summary

This PR refactors the node title and tooltip resolution system to improve code maintainability and fix a bug where processor nodes displayed incorrect titles.

### Key Changes

**Bug Fix:**
- Fixed processor node title resolution to use `processorName` instead of `name` for Processor/Pattern catalog kinds (e.g., "when" nodes now correctly show "When EIP" instead of displaying the condition expression)

**Refactoring:**
- Introduced [`CatalogResolverFactory`](packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.ts:1) to centralize catalog property resolution logic
- Replaced switch statements with resolver maps in [`getTitleRequest`](packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.ts:7) and [`getTooltipRequest`](packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getTooltipRequest.ts:7)
- Refactored [`NodeTitleResolver`](packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.ts:8) and [`NodeTooltipResolver`](packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/node-tooltip-resolver.ts:8) to use the factory pattern
- Eliminated code duplication across resolver methods

**Testing:**
- Added comprehensive test coverage for [`CatalogResolverFactory`](packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.test.ts:1) (150 lines)
- Added tests verifying correct identifier usage for different catalog kinds in [`node-enrichment.service.test.ts`](packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts:95)

### Impact
- Improves code maintainability by reducing duplication
- Ensures processor nodes display correct titles based on their type
- Better separation of concerns with centralized catalog resolution

fix: https://github.com/KaotoIO/kaoto/issues/3181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved title and tooltip resolution for flow visualization nodes by centralizing catalog property lookup mechanisms
  * Enhanced handling of different catalog types with more robust fallback resolution strategies

* **Tests**
  * Expanded test coverage for node enrichment, title resolution, and catalog resolver functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->