### PR TITLE
chore(vscode): Remove RuntimeSelector from VS Code

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -271,7 +271,7 @@ Cypress.Commands.add('checkCatalogVersion', (version?: string) => {
 
 Cypress.Commands.add('switchCodeToXml', () => {
   cy.get('[data-testid="serializer-list-dropdown"]').click();
-  cy.get('[data-testid="serializer-yaml"]').contains('XML').click();
+  cy.get('[data-testid="serializer-xml"]').contains('XML').click();
 });
 
 Cypress.Commands.add('switchCodeToYaml', () => {

--- a/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
@@ -6,17 +6,15 @@ import {
   ContextToolbar,
   ControllerService,
   EntitiesProvider,
-  IntegrationTypeSelector,
   kameletYaml,
   pipeYaml,
   RuntimeProvider,
   SchemasLoaderProvider,
-  SerializerSelector,
   SourceCodeApiContext,
   SourceCodeProvider,
   VisibleFlowsProvider,
 } from '@kaoto/kaoto/testing';
-import { Divider, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Divider, Toolbar, ToolbarContent, ToolbarGroup } from '@patternfly/react-core';
 import { VisualizationProvider } from '@patternfly/react-topology';
 import { Meta, StoryFn } from '@storybook/react';
 import { useContext, useMemo } from 'react';
@@ -56,18 +54,12 @@ export default {
 const Template: StoryFn<{ sourceCode: string }> = (props: { sourceCode: string }) => {
   const sourceCodeApi = useContext(SourceCodeApiContext);
   sourceCodeApi.setCodeAndNotify(props.sourceCode);
-  const additionalControls = [
-    <ToolbarItem key="toolbar-integration-type-selector">
-      <IntegrationTypeSelector />
-    </ToolbarItem>,
-    <SerializerSelector key="toolbar-serializer-selector" />,
-  ];
 
   return (
     <Toolbar>
       <ToolbarContent>
         <ToolbarGroup className="pf-topology-view__project-toolbar">
-          <ContextToolbar additionalControls={additionalControls} />
+          <ContextToolbar />
         </ToolbarGroup>
       </ToolbarContent>
       <Divider />

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
@@ -45,6 +45,14 @@ jest.mock('./RuntimeSelector/RuntimeSelector', () => ({
   RuntimeSelector: () => <div data-testid="runtime-selector">RuntimeSelector</div>,
 }));
 
+jest.mock('./IntegrationTypeSelector/IntegrationTypeSelector', () => ({
+  IntegrationTypeSelector: () => <div data-testid="integration-type-selector">IntegrationTypeSelector</div>,
+}));
+
+jest.mock('./SerializerSelector/SerializerSelector', () => ({
+  SerializerSelector: () => <div data-testid="serializer-selector">SerializerSelector</div>,
+}));
+
 describe('ContextToolbar', () => {
   describe('when using multipleRoute configuration', () => {
     it('should include NewEntity component for Route schema type', () => {
@@ -207,27 +215,8 @@ describe('ContextToolbar', () => {
 
       expect(screen.getByTestId('runtime-selector')).toBeInTheDocument();
     });
-  });
 
-  describe('additional controls', () => {
-    it('should render additional controls when provided', () => {
-      const { Provider } = TestProvidersWrapper();
-      const additionalControls = [
-        <div key="test-control" data-testid="additional-control">
-          Test Control
-        </div>,
-      ];
-
-      render(
-        <Provider>
-          <ContextToolbar additionalControls={additionalControls} />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('additional-control')).toBeInTheDocument();
-    });
-
-    it('should work without additional controls', () => {
+    it('should render IntegrationTypeSelector component', () => {
       const { Provider } = TestProvidersWrapper();
 
       render(
@@ -236,9 +225,108 @@ describe('ContextToolbar', () => {
         </Provider>,
       );
 
-      // Should render basic components without additional controls
+      expect(screen.getByTestId('integration-type-selector')).toBeInTheDocument();
+    });
+
+    it('should render SerializerSelector component', () => {
+      const { Provider } = TestProvidersWrapper();
+
+      render(
+        <Provider>
+          <ContextToolbar />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('serializer-selector')).toBeInTheDocument();
+    });
+  });
+
+  describe('SerializerSelector visibility', () => {
+    it('should render SerializerSelector for CamelRouteResource (Route schema)', () => {
+      const camelResource = new CamelRouteResource([]);
+      const { Provider } = TestProvidersWrapper({ camelResource });
+
+      render(
+        <Provider>
+          <ContextToolbar />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('serializer-selector')).toBeInTheDocument();
+    });
+
+    it.each([
+      ['IntegrationResource', () => new IntegrationResource()],
+      ['KameletResource', () => new KameletResource()],
+      ['PipeResource', () => new PipeResource()],
+      ['KameletBindingResource', () => new KameletBindingResource()],
+    ])('should not render SerializerSelector for %s (non-Route schema)', (_name, createResource) => {
+      const camelResource = createResource();
+      const { Provider } = TestProvidersWrapper({ camelResource });
+
+      render(
+        <Provider>
+          <ContextToolbar />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('serializer-selector')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when isSimplified is true', () => {
+    it('should not render SerializerSelector even for Route schema', () => {
+      const { Provider } = TestProvidersWrapper();
+
+      render(
+        <Provider>
+          <ContextToolbar isSimplified />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('serializer-selector')).not.toBeInTheDocument();
+    });
+
+    it('should not render IntegrationTypeSelector', () => {
+      const { Provider } = TestProvidersWrapper();
+
+      render(
+        <Provider>
+          <ContextToolbar isSimplified />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('integration-type-selector')).not.toBeInTheDocument();
+    });
+
+    it('should not render RuntimeSelector', () => {
+      const { Provider } = TestProvidersWrapper();
+
+      render(
+        <Provider>
+          <ContextToolbar isSimplified />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('runtime-selector')).not.toBeInTheDocument();
+    });
+
+    it('should still render the core toolbar items', () => {
+      const { Provider } = TestProvidersWrapper();
+
+      render(
+        <Provider>
+          <ContextToolbar isSimplified />
+        </Provider>,
+      );
+
       expect(screen.getByTestId('flows-menu')).toBeInTheDocument();
+      expect(screen.getByTestId('new-entity')).toBeInTheDocument();
+      expect(screen.getByTestId('flow-clipboard')).toBeInTheDocument();
+      expect(screen.getByTestId('flow-export-image')).toBeInTheDocument();
+      expect(screen.getByTestId('export-document')).toBeInTheDocument();
       expect(screen.getByLabelText('Undo')).toBeInTheDocument();
+      expect(screen.getByLabelText('Redo')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.tsx
@@ -2,67 +2,80 @@ import './ContextToolbar.scss';
 
 import { Button, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { RedoIcon, UndoIcon } from '@patternfly/react-icons';
-import { FunctionComponent, JSX, useContext } from 'react';
+import { FunctionComponent } from 'react';
 
 import { useUndoRedo } from '../../../hooks/undo-redo.hook';
-import { sourceSchemaConfig } from '../../../models/camel';
-import { EntitiesContext } from '../../../providers/entities.provider';
+import { useEntityContext } from '../../../hooks/useEntityContext/useEntityContext';
+import { sourceSchemaConfig, SourceSchemaType } from '../../../models/camel';
 import { ExportDocument } from './ExportDocument/ExportDocument';
 import { FlowClipboard } from './FlowClipboard/FlowClipboard';
 import { FlowExportImage } from './FlowExportImage/FlowExportImage';
 import { FlowsMenu } from './Flows/FlowsMenu';
+import { IntegrationTypeSelector } from './IntegrationTypeSelector/IntegrationTypeSelector';
 import { NewEntity } from './NewEntity/NewEntity';
 import { RuntimeSelector } from './RuntimeSelector/RuntimeSelector';
+import { SerializerSelector } from './SerializerSelector/SerializerSelector';
 
-export const ContextToolbar: FunctionComponent<{ additionalControls?: JSX.Element[] }> = ({ additionalControls }) => {
-  const { currentSchemaType } = useContext(EntitiesContext)!;
+interface ContextToolbarProps {
+  isSimplified?: boolean;
+}
+
+export const ContextToolbar: FunctionComponent<ContextToolbarProps> = ({ isSimplified }) => {
+  const { currentSchemaType } = useEntityContext();
+  const doesSupportSerializers = !isSimplified && currentSchemaType === SourceSchemaType.Route;
   const isMultipleRoutes = sourceSchemaConfig.config[currentSchemaType].multipleRoute;
   const { undo, redo, canUndo, canRedo } = useUndoRedo();
-
-  const toolbarItems: JSX.Element[] = [
-    <ToolbarItem key="toolbar-flows-list">
-      <FlowsMenu />
-    </ToolbarItem>,
-  ];
-
-  if (isMultipleRoutes) {
-    toolbarItems.push(
-      <ToolbarItem key="toolbar-new-route">
-        <NewEntity />
-      </ToolbarItem>,
-    );
-  }
-  //Currently adding only SerializerSelector at the beginning of the toolbar,
-  if (additionalControls) {
-    additionalControls.forEach((control) => toolbarItems.unshift(control));
-  }
 
   return (
     <Toolbar className="context-toolbar">
       <ToolbarContent>
-        {toolbarItems.concat([
-          <ToolbarItem key="toolbar-undo">
-            <Button aria-label="Undo" title="Undo" variant="plain" isDisabled={!canUndo} onClick={undo}>
-              <UndoIcon />
-            </Button>
-          </ToolbarItem>,
-          <ToolbarItem key="toolbar-redo">
-            <Button aria-label="Redo" title="Redo" variant="plain" isDisabled={!canRedo} onClick={redo}>
-              <RedoIcon />
-            </Button>
-          </ToolbarItem>,
-          <ToolbarItem key="toolbar-clipboard">
-            <FlowClipboard />
-          </ToolbarItem>,
-          <ToolbarItem key="toolbar-export-image">
-            <FlowExportImage />
-          </ToolbarItem>,
-          <ToolbarItem key="toolbar-export-document">
-            <ExportDocument />
-          </ToolbarItem>,
+        {doesSupportSerializers && (
+          <ToolbarItem key="toolbar-item-serializer-selector">
+            <SerializerSelector key="toolbar-serializer-selector" />
+          </ToolbarItem>
+        )}
 
-          <RuntimeSelector key="runtime-selector" />,
-        ])}
+        {!isSimplified && (
+          <ToolbarItem key="toolbar-dsl-selector">
+            <IntegrationTypeSelector />
+          </ToolbarItem>
+        )}
+
+        <ToolbarItem key="toolbar-flows-list">
+          <FlowsMenu />
+        </ToolbarItem>
+
+        {isMultipleRoutes && (
+          <ToolbarItem key="toolbar-new-route">
+            <NewEntity />
+          </ToolbarItem>
+        )}
+
+        <ToolbarItem key="toolbar-undo">
+          <Button aria-label="Undo" title="Undo" variant="plain" isDisabled={!canUndo} onClick={undo}>
+            <UndoIcon />
+          </Button>
+        </ToolbarItem>
+
+        <ToolbarItem key="toolbar-redo">
+          <Button aria-label="Redo" title="Redo" variant="plain" isDisabled={!canRedo} onClick={redo}>
+            <RedoIcon />
+          </Button>
+        </ToolbarItem>
+
+        <ToolbarItem key="toolbar-clipboard">
+          <FlowClipboard />
+        </ToolbarItem>
+
+        <ToolbarItem key="toolbar-export-image">
+          <FlowExportImage />
+        </ToolbarItem>
+
+        <ToolbarItem key="toolbar-export-document">
+          <ExportDocument />
+        </ToolbarItem>
+
+        {!isSimplified && <RuntimeSelector key="runtime-selector" />}
       </ToolbarContent>
     </Toolbar>
   );

--- a/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.test.tsx
@@ -1,0 +1,130 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
+import { SerializerType } from '../../../../models/kaoto-resource';
+import { TestProvidersWrapper } from '../../../../stubs';
+import { camelRouteJson } from '../../../../stubs/camel-route';
+import { SerializerSelector } from './SerializerSelector';
+
+describe('SerializerSelector', () => {
+  it('renders the toggle', () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    expect(wrapper.queryByTestId('serializer-list-dropdown')).toBeInTheDocument();
+  });
+
+  it('shows the current serializer type as the toggle label', () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    const toggle = wrapper.getByTestId('serializer-list-dropdown');
+    expect(toggle).toHaveTextContent(SerializerType.YAML);
+  });
+
+  it('reveals both XML and YAML options when opened', async () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    const toggle = wrapper.getByTestId('serializer-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(await wrapper.findByRole('option', { name: 'XML' })).toBeInTheDocument();
+    expect(await wrapper.findByRole('option', { name: 'YAML' })).toBeInTheDocument();
+  });
+
+  it('calls setSerializer and updateSourceCodeFromEntities when a different serializer is selected', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const setSerializerSpy = jest.spyOn(camelResource, 'setSerializer');
+    const { Provider, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({ camelResource });
+
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    const toggle = wrapper.getByTestId('serializer-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const xmlOption = await wrapper.findByRole('option', { name: 'XML' });
+    await act(async () => {
+      fireEvent.click(xmlOption);
+    });
+
+    expect(setSerializerSpy).toHaveBeenCalledTimes(1);
+    expect(setSerializerSpy).toHaveBeenCalledWith(SerializerType.XML);
+    expect(updateSourceCodeFromEntitiesSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(wrapper.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not call setSerializer when the already-selected serializer is clicked', async () => {
+    const camelResource = new CamelRouteResource([camelRouteJson]);
+    const setSerializerSpy = jest.spyOn(camelResource, 'setSerializer');
+    const { Provider, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({ camelResource });
+
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    const toggle = wrapper.getByTestId('serializer-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const yamlOption = await wrapper.findByRole('option', { name: 'YAML' });
+    await act(async () => {
+      fireEvent.click(yamlOption);
+    });
+
+    expect(setSerializerSpy).not.toHaveBeenCalled();
+    expect(updateSourceCodeFromEntitiesSpy).not.toHaveBeenCalled();
+  });
+
+  it('closes the dropdown when ESC is pressed', async () => {
+    const { Provider } = TestProvidersWrapper();
+    const wrapper = render(
+      <Provider>
+        <SerializerSelector />
+      </Provider>,
+    );
+
+    const toggle = wrapper.getByTestId('serializer-list-dropdown');
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const listbox = await wrapper.findByRole('listbox');
+    expect(listbox).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.focus(listbox);
+      fireEvent.keyDown(listbox, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    await waitFor(() => {
+      expect(wrapper.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.tsx
@@ -1,9 +1,8 @@
 import './SerializerSelector.scss';
 
-import { MenuToggle, Select, SelectList, SelectOption, ToolbarItem } from '@patternfly/react-core';
+import { MenuToggle, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import { FunctionComponent, RefObject, useContext, useState } from 'react';
 
-import { SourceSchemaType } from '../../../../models/camel';
 import { SerializerType } from '../../../../models/kaoto-resource';
 import { EntitiesContext } from '../../../../providers';
 
@@ -35,41 +34,37 @@ export const SerializerSelector: FunctionComponent = () => {
   );
 
   return (
-    camelResource.getType() === SourceSchemaType.Route && (
-      <ToolbarItem key="toolbar-item-serializer-selector">
-        <Select
-          id="serializer-list-select"
-          isOpen={isOpen}
-          onSelect={(_event, value) => {
-            onSelect(value as SerializerType);
-          }}
-          onOpenChange={(isOpen) => {
-            setIsOpen(isOpen);
-          }}
-          toggle={toggle}
+    <Select
+      id="serializer-list-select"
+      isOpen={isOpen}
+      onSelect={(_event, value) => {
+        onSelect(value as SerializerType);
+      }}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+      }}
+      toggle={toggle}
+    >
+      <SelectList>
+        <SelectOption
+          key="serializer-xml"
+          data-testid="serializer-xml"
+          itemId="XML"
+          value={SerializerType.XML}
+          isDisabled={selected === SerializerType.XML}
         >
-          <SelectList>
-            <SelectOption
-              key="serializer-yaml"
-              data-testid="serializer-yaml"
-              itemId="XML"
-              value={SerializerType.XML}
-              isDisabled={selected === SerializerType.XML}
-            >
-              XML
-            </SelectOption>
-            <SelectOption
-              key="serializer-xml"
-              data-testid="serializer-yaml"
-              itemId="YAML"
-              value={SerializerType.YAML}
-              isDisabled={selected === SerializerType.YAML}
-            >
-              YAML
-            </SelectOption>
-          </SelectList>
-        </Select>
-      </ToolbarItem>
-    )
+          XML
+        </SelectOption>
+        <SelectOption
+          key="serializer-yaml"
+          data-testid="serializer-yaml"
+          itemId="YAML"
+          value={SerializerType.YAML}
+          isDisabled={selected === SerializerType.YAML}
+        >
+          YAML
+        </SelectOption>
+      </SelectList>
+    </Select>
   );
 };

--- a/packages/ui/src/components/Visualization/ContextToolbar/index.ts
+++ b/packages/ui/src/components/Visualization/ContextToolbar/index.ts
@@ -1,3 +1,1 @@
 export * from './ContextToolbar';
-export * from './IntegrationTypeSelector/IntegrationTypeSelector';
-export * from './SerializerSelector/SerializerSelector';

--- a/packages/ui/src/components/Visualization/Visualization.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.tsx
@@ -1,7 +1,7 @@
 import './Visualization.scss';
 
 import { CanvasFormTabsProvider } from '@kaoto/forms';
-import { FunctionComponent, JSX, PropsWithChildren, ReactNode, useContext } from 'react';
+import { FunctionComponent, PropsWithChildren, ReactNode, useContext } from 'react';
 
 import { useVisibleVizNodes } from '../../hooks/use-visible-viz-nodes';
 import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
@@ -9,20 +9,19 @@ import { VisibleFlowsContext } from '../../providers/visible-flows.provider';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Canvas } from './Canvas';
 import { CanvasFallback } from './CanvasFallback';
-import { ContextToolbar } from './ContextToolbar/ContextToolbar';
 
 interface VisualizationProps {
   className?: string;
   entities: BaseVisualEntity[];
   fallback?: ReactNode;
-  additionalToolbarControls?: JSX.Element[];
+  contextToolbar?: ReactNode;
 }
 
 export const Visualization: FunctionComponent<PropsWithChildren<VisualizationProps>> = ({
   className,
   entities,
   fallback,
-  additionalToolbarControls,
+  contextToolbar,
 }) => {
   const { visibleFlows } = useContext(VisibleFlowsContext)!;
   const { vizNodes, isResolving } = useVisibleVizNodes(entities, visibleFlows);
@@ -32,7 +31,7 @@ export const Visualization: FunctionComponent<PropsWithChildren<VisualizationPro
       <CanvasFormTabsProvider>
         <ErrorBoundary fallback={fallback ?? <CanvasFallback />}>
           <Canvas
-            contextToolbar={<ContextToolbar additionalControls={additionalToolbarControls} />}
+            contextToolbar={contextToolbar}
             vizNodes={vizNodes}
             entitiesCount={entities.length}
             isVizNodesResolving={isResolving}

--- a/packages/ui/src/pages/Design/DesignPage.tsx
+++ b/packages/ui/src/pages/Design/DesignPage.tsx
@@ -1,15 +1,13 @@
 import './DesignPage.scss';
 
-import { FunctionComponent, JSX, ReactNode, useContext } from 'react';
+import { FunctionComponent, ReactNode, useContext } from 'react';
 
 import { Visualization } from '../../components/Visualization';
 import { CatalogModalProvider } from '../../dynamic-catalog/catalog-modal.provider';
 import { ActionConfirmationModalContextProvider } from '../../providers/action-confirmation-modal.provider';
 import { EntitiesContext } from '../../providers/entities.provider';
 
-export const DesignPage: FunctionComponent<{ fallback?: ReactNode; additionalToolbarControls?: JSX.Element[] }> = (
-  props,
-) => {
+export const DesignPage: FunctionComponent<{ fallback?: ReactNode; contextToolbar?: ReactNode }> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
   const visualEntities = entitiesContext?.visualEntities ?? [];
 
@@ -20,7 +18,7 @@ export const DesignPage: FunctionComponent<{ fallback?: ReactNode; additionalToo
           className="canvas-page"
           entities={visualEntities}
           fallback={props.fallback}
-          additionalToolbarControls={props.additionalToolbarControls}
+          contextToolbar={props.contextToolbar}
         />
       </ActionConfirmationModalContextProvider>
     </CatalogModalProvider>

--- a/packages/ui/src/pages/Design/router-exports-multiplying-architecture.tsx
+++ b/packages/ui/src/pages/Design/router-exports-multiplying-architecture.tsx
@@ -1,3 +1,4 @@
+import { ContextToolbar } from '../../components/Visualization/ContextToolbar';
 import { DesignPage } from './DesignPage';
 
-export const element = <DesignPage />;
+export const element = <DesignPage contextToolbar={<ContextToolbar isSimplified />} />;

--- a/packages/ui/src/pages/Design/router-exports.tsx
+++ b/packages/ui/src/pages/Design/router-exports.tsx
@@ -1,17 +1,7 @@
-import { ToolbarItem } from '@patternfly/react-core';
-
-import { IntegrationTypeSelector } from '../../components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector';
-import { SerializerSelector } from '../../components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector';
+import { ContextToolbar } from '../../components/Visualization/ContextToolbar/ContextToolbar';
 import { DesignPage } from './DesignPage';
 import { ReturnToSourceCodeFallback } from './ReturnToSourceCodeFallback';
 
-const additionalControls = [
-  <ToolbarItem key="toolbar-dsl-selector">
-    <IntegrationTypeSelector />
-  </ToolbarItem>,
-  <SerializerSelector key="toolbar-serializer-selector" />,
-];
-
 export const Component = () => (
-  <DesignPage fallback={<ReturnToSourceCodeFallback />} additionalToolbarControls={additionalControls} />
+  <DesignPage fallback={<ReturnToSourceCodeFallback />} contextToolbar={<ContextToolbar />} />
 );


### PR DESCRIPTION
### Context
With the upcoming introduction of the Camel Launcher, we need to revisit how the runtime information is propagated from the VS Code host to the Kaoto UI. The first step is to remove the `RuntimeSelector` component from the toolbar in VS Code Kaoto.

<img width="1621" height="1003" alt="Screenshot From 2026-05-11 11-44-22" src="https://github.com/user-attachments/assets/4feb8404-f4e0-4247-8717-097b35c27e11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a simplified context toolbar mode and a pluggable contextToolbar prop for visualization pages.

* **Bug Fixes**
  * Refines toolbar rendering so selectors and controls appear only when appropriate (simplified mode and resource type).

* **Tests**
  * Adds/updates tests covering serializer selection, toolbar visibility rules, and related UI interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3204)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->