### PR TITLE
fix(DataMapper): Add service methods for applying xsl:for-each-group

### DIFF
--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -11,6 +11,7 @@ export enum MappingActionKind {
   If = 'if',
   Choose = 'choose',
   ForEach = 'forEach',
+  ForEachGroup = 'forEachGroup',
   Delete = 'delete',
   When = 'when',
   Otherwise = 'otherwise',

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -2,6 +2,7 @@ import { DocumentType, IDocument, IField, PrimitiveDocument } from '../../models
 import {
   ChooseItem,
   FieldItem,
+  ForEachGroupItem,
   ForEachItem,
   IExpressionHolder,
   IfItem,
@@ -46,7 +47,8 @@ export class MappingService {
       mapping instanceof IfItem ||
       mapping instanceof WhenItem ||
       mapping instanceof OtherwiseItem ||
-      mapping instanceof ForEachItem
+      mapping instanceof ForEachItem ||
+      mapping instanceof ForEachGroupItem
     ) {
       return mapping.children.reduce((acc, child) => {
         if (child instanceof FieldItem) {
@@ -258,6 +260,10 @@ export class MappingService {
 
   static wrapWithForEach(wrapped: MappingItem) {
     MappingService.wrapWithItem(wrapped, new ForEachItem(wrapped.parent));
+  }
+
+  static wrapWithForEachGroup(wrapped: MappingItem) {
+    MappingService.wrapWithItem(wrapped, new ForEachGroupItem(wrapped.parent));
   }
 
   static wrapWithIf(wrapped: MappingItem) {

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   ChooseItem,
   FieldItem,
+  ForEachGroupItem,
   ForEachItem,
   IfItem,
   MappingTree,
@@ -322,6 +323,25 @@ describe('MappingActionService', () => {
         const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(shipOrderChildren[3]);
         expect(forEachChildren.length).toEqual(1);
         expect(forEachChildren[0].title).toEqual('Item');
+      });
+    });
+
+    describe('applyForEachGroup()', () => {
+      it('should add for-each-group', () => {
+        let docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        expect(docChildren.length).toEqual(1);
+        let shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        expect(shipOrderChildren.length).toEqual(4);
+        expect(shipOrderChildren[3].title).toEqual('Item');
+        MappingActionService.applyForEachGroup(shipOrderChildren[3] as TargetFieldNodeData);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        expect(shipOrderChildren[3].title).toEqual('for-each-group');
+        const forEachGroupChildren = VisualizationService.generateNonDocumentNodeDataChildren(shipOrderChildren[3]);
+        expect(forEachGroupChildren.length).toEqual(1);
+        expect(forEachGroupChildren[0].title).toEqual('Item');
       });
     });
 
@@ -768,10 +788,45 @@ describe('MappingActionService', () => {
         expect(addMappingNode.title).toEqual('Item');
         expect(addMappingNode.id).toContain('add-mapping-fx-Item');
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEach);
+        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEachGroup);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.If);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.Choose);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ContextMenu);
         expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.ValueSelector);
+      });
+
+      it('should allow ContextMenu and Sort but exclude ValueSelector for for-each-group nodes', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const itemNode = shipOrderChildren[3] as MappingNodeData;
+        expect(itemNode.title).toEqual('for-each');
+
+        const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(itemNode);
+        const fieldInsideForEach = forEachChildren[0] as FieldItemNodeData;
+        expect(fieldInsideForEach.title).toEqual('Item');
+        expect(MappingActionService.getAllowedActions(fieldInsideForEach)).not.toContain(MappingActionKind.ContextMenu);
+
+        MappingActionService.applyForEachGroup(shipOrderChildren[4] as AddMappingNodeData);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+
+        const forEachGroupNode = updatedShipOrderChildren[4] as MappingNodeData;
+        expect(forEachGroupNode.title).toEqual('for-each-group');
+        expect(forEachGroupNode.mapping instanceof ForEachGroupItem).toBeTruthy();
+        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(MappingActionKind.Sort);
+        expect(MappingActionService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.ValueSelector);
+
+        const forEachGroupChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachGroupNode);
+        const fieldInsideForEachGroup = forEachGroupChildren[0] as FieldItemNodeData;
+        expect(fieldInsideForEachGroup.title).toEqual('Item');
+        expect(MappingActionService.getAllowedActions(fieldInsideForEachGroup)).not.toContain(
+          MappingActionKind.ContextMenu,
+        );
       });
     });
 

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -29,6 +29,8 @@ import { useDocumentTreeStore } from '../../store/document-tree.store';
 import { MappingService } from '../mapping/mapping.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
+type ForEachCapableNodeData = TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData;
+
 /**
  * Static service for mapping mutations and the action registry in the
  * DataMapper visualization layer.
@@ -134,9 +136,19 @@ export class MappingActionService {
    * Creates the field item first if it does not yet exist.
    * @param nodeData - The target field node to wrap.
    */
-  static applyForEach(nodeData: TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData) {
+  static applyForEach(nodeData: ForEachCapableNodeData) {
     const fieldItem = MappingActionService.getOrCreateFieldItem(nodeData);
     MappingService.wrapWithForEach(fieldItem);
+  }
+
+  /**
+   * Wraps the target field's mapping item with a {@link ForEachGroupItem}.
+   * Creates the field item first if it does not yet exist.
+   * @param nodeData - The target field node to wrap.
+   */
+  static applyForEachGroup(nodeData: ForEachCapableNodeData) {
+    const fieldItem = MappingActionService.getOrCreateFieldItem(nodeData);
+    MappingService.wrapWithForEachGroup(fieldItem);
   }
 
   /**
@@ -252,6 +264,14 @@ export class MappingActionService {
     );
   }
 
+  private static isFieldInsideForEachGroup(n: TargetNodeData): boolean {
+    return (
+      MappingActionService.isFieldNode(n) &&
+      n.parent instanceof MappingNodeData &&
+      n.parent.mapping instanceof ForEachGroupItem
+    );
+  }
+
   private static isContextMenuAction(def: IMappingAction): def is IMappingContextMenuAction {
     return 'getLabel' in def;
   }
@@ -261,7 +281,8 @@ export class MappingActionService {
       key: MappingActionKind.ContextMenu,
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData || n instanceof TargetDocumentNodeData) return true;
-        if (MappingActionService.isFieldNode(n)) return !MappingActionService.isFieldInsideForEach(n);
+        if (MappingActionService.isFieldNode(n))
+          return !MappingActionService.isFieldInsideForEach(n) && !MappingActionService.isFieldInsideForEachGroup(n);
         return (
           MappingActionService.isMappingNode(n) &&
           !MappingActionService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, UnknownMappingItem)(n)
@@ -308,7 +329,13 @@ export class MappingActionService {
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
         if (!MappingActionService.isMappingNode(n)) return true;
-        return !MappingActionService.mappingIsOneOf(ValueSelector, ForEachItem, ChooseItem, UnknownMappingItem)(n);
+        return !MappingActionService.mappingIsOneOf(
+          ValueSelector,
+          ForEachItem,
+          ForEachGroupItem,
+          ChooseItem,
+          UnknownMappingItem,
+        )(n);
       },
       isDisabled: (n) => MappingActionService.hasValueSelector(n),
     },
@@ -339,6 +366,18 @@ export class MappingActionService {
       getLabel: () => 'Wrap with "for-each"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyForEach(n as TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        n instanceof AddMappingNodeData ||
+        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
+    },
+    {
+      key: MappingActionKind.ForEachGroup,
+      testId: 'transformation-actions-foreachgroup',
+      getLabel: () => 'Wrap with "for-each-group"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyForEachGroup(n as TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData);
         onUpdate();
       },
       isAllowed: (n) =>


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/2863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "For Each Group" mapping action that can be applied to collection fields and mapping nodes, enabling group-based iteration functionality within the mapping interface.

* **Tests**
  * Extended test coverage for the new For Each Group action, verifying allowed actions and interaction patterns for grouped mapping configurations and contained field nodes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->