### PR TITLE
feat(DataMapper): wrap collection choice mapping with for-each (#2815)

### DIFF
--- a/packages/ui/src/services/visualization/mapping-action.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.choice.test.ts
@@ -4,7 +4,14 @@ import {
   DocumentDefinitionType,
   DocumentType,
 } from '../../models/datamapper/document';
-import { ChooseItem, FieldItem, MappingTree, OtherwiseItem, ValueSelector } from '../../models/datamapper/mapping';
+import {
+  ChooseItem,
+  FieldItem,
+  ForEachItem,
+  MappingTree,
+  OtherwiseItem,
+  ValueSelector,
+} from '../../models/datamapper/mapping';
 import {
   ChoiceFieldNodeData,
   DocumentNodeData,
@@ -50,6 +57,38 @@ describe('MappingActionService / choice field mappings', () => {
       isChoice: true,
       selectedMemberIndex,
       fields: memberFields,
+    } as unknown as typeof baseField;
+  }
+
+  function createMockCollectionChoiceField(members: { name: string }[], selectedMemberIndex?: number) {
+    const baseField = sourceDoc.fields[0];
+    const memberFields = members.map((m) => ({
+      ...baseField,
+      name: m.name,
+      displayName: m.name,
+      fields: [],
+      isChoice: false,
+      maxOccurs: 1,
+    }));
+    return {
+      ...baseField,
+      name: '__choice__',
+      displayName: 'choice',
+      isChoice: true,
+      wrapperKind: 'choice' as const,
+      selectedMemberIndex,
+      fields: memberFields,
+      maxOccurs: 'unbounded' as const,
+    } as unknown as typeof baseField;
+  }
+
+  function createMockCollectionField() {
+    const baseField = targetDoc.fields[0];
+    return {
+      ...baseField,
+      name: 'collectionField',
+      displayName: 'collectionField',
+      maxOccurs: 'unbounded' as const,
     } as unknown as typeof baseField;
   }
 
@@ -441,6 +480,118 @@ describe('MappingActionService / choice field mappings', () => {
       expect((freshNestedDirect1 as FieldItemNodeData).path.pathSegments).toContain(freshInnerChoice.id);
       expect(nestedDirect1Item.nodePath.pathSegments).not.toContain(freshOuterChoice.id);
       expect(nestedDirect1Item.nodePath.pathSegments).not.toContain(freshInnerChoice.id);
+    });
+  });
+
+  describe('collection choice wrapper mappings (S2 scenario)', () => {
+    let localTargetDocNode: TargetDocumentNodeData;
+
+    beforeEach(() => {
+      localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+    });
+
+    it('should create ForEachItem wrapping ChooseItem when mapping collection choice wrapper to collection field', () => {
+      const collectionChoiceField = createMockCollectionChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, collectionChoiceField);
+      const collectionTargetField = createMockCollectionField();
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, collectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      expect(tree.children.length).toEqual(1);
+      const targetFieldItem = tree.children[0];
+      expect(targetFieldItem).toBeInstanceOf(FieldItem);
+      expect(targetFieldItem.children.length).toEqual(1);
+
+      const forEachItem = targetFieldItem.children[0];
+      expect(forEachItem).toBeInstanceOf(ForEachItem);
+      expect(forEachItem.children.length).toEqual(1);
+
+      const chooseItem = forEachItem.children[0] as ChooseItem;
+      expect(chooseItem).toBeInstanceOf(ChooseItem);
+      expect(chooseItem.when.length).toEqual(2);
+      expect(chooseItem.otherwise).toBeInstanceOf(OtherwiseItem);
+    });
+
+    it('ForEachItem expression should be the XPath of the collection choice wrapper', () => {
+      const collectionChoiceField = createMockCollectionChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, collectionChoiceField);
+      const collectionTargetField = createMockCollectionField();
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, collectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      const forEachItem = tree.children[0].children[0] as ForEachItem;
+      expect(forEachItem.expression).toBeTruthy();
+    });
+
+    it('WhenItem expressions inside ForEachItem should reference the choice members', () => {
+      const collectionChoiceField = createMockCollectionChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, collectionChoiceField);
+      const collectionTargetField = createMockCollectionField();
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, collectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      const forEachItem = tree.children[0].children[0] as ForEachItem;
+      const chooseItem = forEachItem.children[0] as ChooseItem;
+      expect(chooseItem.when[0].expression).toEqual('/ns0:email');
+      expect(chooseItem.when[1].expression).toEqual('/ns0:phone');
+      const emailSelector = chooseItem.when[0].children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      const phoneSelector = chooseItem.when[1].children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      expect(emailSelector.expression).toEqual('/ns0:email');
+      expect(phoneSelector.expression).toEqual('/ns0:phone');
+    });
+
+    it('should create only ChooseItem (no ForEachItem) when mapping collection choice wrapper to non-collection field (S1)', () => {
+      const collectionChoiceField = createMockCollectionChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, collectionChoiceField);
+      const nonCollectionTargetField = targetDoc.fields[0]; // maxOccurs = 1
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, nonCollectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      expect(tree.children.length).toEqual(1);
+      const targetFieldItem = tree.children[0];
+      expect(targetFieldItem).toBeInstanceOf(FieldItem);
+      expect(targetFieldItem.children.length).toEqual(1);
+
+      const chooseItem = targetFieldItem.children[0];
+      expect(chooseItem).toBeInstanceOf(ChooseItem);
+      expect(chooseItem).not.toBeInstanceOf(ForEachItem);
+      expect((chooseItem as ChooseItem).when.length).toEqual(2);
+    });
+
+    it('should create only ChooseItem when mapping non-collection choice wrapper to collection field', () => {
+      const nonCollectionChoiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, nonCollectionChoiceField);
+      const collectionTargetField = createMockCollectionField();
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, collectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      expect(tree.children.length).toEqual(1);
+      const targetFieldItem = tree.children[0];
+      expect(targetFieldItem).toBeInstanceOf(FieldItem);
+      expect(targetFieldItem.children.length).toEqual(1);
+
+      const chooseItem = targetFieldItem.children[0];
+      expect(chooseItem).toBeInstanceOf(ChooseItem);
+      expect(chooseItem).not.toBeInstanceOf(ForEachItem);
+    });
+
+    it('should not create duplicate ForEachItem when mapping the same collection choice source twice', () => {
+      const collectionChoiceField = createMockCollectionChoiceField([{ name: 'email' }, { name: 'phone' }]);
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, collectionChoiceField);
+      const collectionTargetField = createMockCollectionField();
+      const targetFieldNode = new TargetFieldNodeData(localTargetDocNode, collectionTargetField);
+
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+      MappingActionService.engageMapping(tree, choiceNode, targetFieldNode);
+
+      const targetFieldItem = tree.children[0];
+      const forEachItems = targetFieldItem.children.filter((c) => c instanceof ForEachItem);
+      expect(forEachItems.length).toEqual(1);
     });
   });
 });

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -188,6 +188,11 @@ export class MappingActionService {
       if (sourceNode.choiceField) {
         const item = MappingActionService.getOrCreateFieldItem(targetNode);
         MappingService.mapToField(sourceNode.field, item);
+      } else if (
+        VisualizationUtilService.isCollectionField(sourceNode) &&
+        VisualizationUtilService.isCollectionField(targetNode)
+      ) {
+        MappingActionService.createForEachWithChooseFromChoice(sourceNode.field, targetNode);
       } else {
         MappingActionService.createChooseFromChoice(sourceNode.field, targetNode);
       }
@@ -218,16 +223,37 @@ export class MappingActionService {
     const targetItem = MappingActionService.getOrCreateFieldItem(targetNode);
     if (targetItem.children.some((c) => c instanceof ChooseItem)) return;
     targetItem.children = targetItem.children.filter((c) => !(c instanceof ValueSelector));
-    const chooseItem = new ChooseItem(targetItem, targetItem instanceof FieldItem ? targetItem.field : undefined);
 
+    const chooseItem = MappingActionService.buildChooseFromChoiceMembers(targetItem, sourceField, targetItem);
+    targetItem.children.push(chooseItem);
+  }
+
+  private static createForEachWithChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
+    const targetItem = MappingActionService.getOrCreateFieldItem(targetNode);
+    if (targetItem.children.some((c) => c instanceof ForEachItem)) return;
+    targetItem.children = targetItem.children.filter((c) => !(c instanceof ValueSelector));
+
+    const forEachItem = new ForEachItem(targetItem);
+    MappingService.mapToCondition(forEachItem, sourceField);
+
+    const chooseItem = MappingActionService.buildChooseFromChoiceMembers(forEachItem, sourceField, targetItem);
+    forEachItem.children.push(chooseItem);
+    targetItem.children.push(forEachItem);
+  }
+
+  private static buildChooseFromChoiceMembers(
+    parent: MappingItem,
+    sourceField: IField,
+    targetItem: MappingItem,
+  ): ChooseItem {
+    const chooseItem = new ChooseItem(parent, targetItem instanceof FieldItem ? targetItem.field : undefined);
     for (const member of sourceField.fields ?? []) {
       const whenItem = MappingService.addWhen(chooseItem);
       MappingService.mapToCondition(whenItem, member);
       MappingService.mapToField(member, whenItem);
     }
-
     MappingService.addOtherwise(chooseItem);
-    targetItem.children.push(chooseItem);
+    return chooseItem;
   }
 
   private static getOrCreateFieldItem(nodeData: TargetNodeData): MappingItem {

--- a/packages/ui/src/services/visualization/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.test.ts
@@ -379,6 +379,35 @@ describe('MappingValidationService', () => {
       expect(result.isValid).toBe(true);
     });
 
+    it('should reject unselected choice source with container members dropped onto a target field', () => {
+      const containerMember = createMockField({ type: Types.Container, name: 'address' });
+      const choiceField = createMockField({
+        wrapperKind: 'choice',
+        type: Types.Container,
+        fields: [containerMember],
+      });
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+      const targetField = createMockField({ type: Types.String });
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(choiceNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toContain('complex elements');
+    });
+
+    it('should allow unselected choice source with only terminal members dropped onto a target field', () => {
+      const terminalMember = createMockField({ type: Types.String, name: 'email' });
+      const choiceField = createMockField({
+        wrapperKind: 'choice',
+        type: Types.Container,
+        fields: [terminalMember],
+      });
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+      const targetField = createMockField({ type: Types.String });
+      const toNode = new TargetFieldNodeData(targetDocNode, targetField);
+      const result = MappingValidationService.validateMappingPair(choiceNode, toNode);
+      expect(result.isValid).toBe(true);
+    });
+
     it('should reject cross-side drop to unselected abstract target with errorMessage', () => {
       const sourceField = createMockField({ type: Types.String });
       const targetField = createMockField({ wrapperKind: 'abstract', selectedMemberIndex: undefined });

--- a/packages/ui/src/services/visualization/mapping-validation.service.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.ts
@@ -119,14 +119,8 @@ export class MappingValidationService {
     const targetNode = (fromNode.isSource ? toNode : fromNode) as TargetNodeData;
 
     if (sourceNode instanceof ChoiceFieldNodeData && !sourceNode.choiceField) {
-      if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {
-        return {
-          isValid: false,
-          sourceNode,
-          targetNode,
-          errorMessage: 'Drop a choice node onto a target field to create a conditional mapping.',
-        };
-      }
+      const choiceError = MappingValidationService.validateSourceChoiceWrapper(sourceNode, targetNode);
+      if (choiceError) return { ...choiceError, sourceNode, targetNode };
     }
 
     if (targetNode instanceof TargetDocumentNodeData) {
@@ -211,6 +205,25 @@ export class MappingValidationService {
     }
 
     return { isValid: true };
+  }
+
+  private static validateSourceChoiceWrapper(
+    sourceNode: ChoiceFieldNodeData,
+    targetNode: TargetNodeData,
+  ): ValidationResult | undefined {
+    if (!(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)) {
+      return {
+        isValid: false,
+        errorMessage: 'Drop a choice node onto a target field to create a conditional mapping.',
+      };
+    }
+    if (sourceNode.field.fields?.some((m) => MappingValidationService.isContainer(m))) {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map a choice containing complex elements. Map individual members instead.',
+      };
+    }
+    return undefined;
   }
 
   private static isContainer(field: IField) {

--- a/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
@@ -130,6 +130,21 @@
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="ContainerChoiceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="SimpleOption" type="xs:string"/>
+                            <xs:element name="ComplexOption">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="Street" type="xs:string"/>
+                                        <xs:element name="City" type="xs:string"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="AllElement">
                     <xs:complexType>
                         <xs:all>


### PR DESCRIPTION
- Detect collection choice wrapper + collection target and wrap choose/when/otherwise inside a for-each
- Add tests for collection choice scenarios

fixes: #2815 

https://github.com/user-attachments/assets/aed47c6a-ec4f-4d79-bd2c-c94502d19a74



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests for collection-choice-wrapper mapping, covering wrapping behavior, member selection, and deduplication.
  * Added test schema element representing a container choice.

* **Refactor**
  * Improved handling of mappings when mapping choice sources to collection targets, enhancing wrap-and-select behavior.

* **Validation**
  * Drag-and-drop validation now rejects choices containing complex/container members and allows choices with only terminal members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->