### PR TITLE
feat(DataMapper): Members of collection choice inherit collection sem…

### DIFF
--- a/packages/ui/src/services/document/document.service.test.ts
+++ b/packages/ui/src/services/document/document.service.test.ts
@@ -14,7 +14,12 @@ import { IFieldSubstitution } from '../../models/datamapper/metadata';
 import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { PathExpression } from '../../models/datamapper/xpath';
 import { IMetadataApi } from '../../providers';
-import { getCartJsonSchema, getMultipleElementsXsd, TestUtil } from '../../stubs/datamapper/data-mapper';
+import {
+  getCartJsonSchema,
+  getMultipleElementsXsd,
+  getTestDocumentXsd,
+  TestUtil,
+} from '../../stubs/datamapper/data-mapper';
 import { DocumentService } from './document.service';
 import { JsonSchemaDocument } from './json-schema/json-schema-document.model';
 import { XmlSchemaDocument, XmlSchemaField } from './xml-schema/xml-schema-document.model';
@@ -496,7 +501,7 @@ describe('DocumentService', () => {
   });
 
   describe('isCollectionField()', () => {
-    it('', () => {
+    it('should identify collection fields by maxOccurs', () => {
       expect(DocumentService.isCollectionField(sourceDoc.fields[0])).toBeFalsy();
       expect(DocumentService.isCollectionField(targetDoc.fields[0])).toBeFalsy();
       expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[0])).toBeFalsy();
@@ -507,6 +512,136 @@ describe('DocumentService', () => {
       expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[2])).toBeFalsy();
       expect(DocumentService.isCollectionField(sourceDoc.fields[0].fields[3])).toBeTruthy();
       expect(DocumentService.isCollectionField(targetDoc.fields[0].fields[3])).toBeTruthy();
+    });
+
+    it('should identify members of collection choice as collection fields', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(getTestDocumentXsd()),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'TestDocument',
+        ['TestDocument.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const testDocument = doc.fields[0];
+      expect(testDocument.name).toBe('TestDocument');
+
+      const collectionChoiceElement = testDocument.fields.find((f) => f.name === 'CollectionChoiceElement');
+      expect(collectionChoiceElement).toBeDefined();
+
+      const choiceWrapper = collectionChoiceElement!.fields[0];
+      expect(choiceWrapper.wrapperKind).toBe('choice');
+      expect(choiceWrapper.maxOccurs).toBe('unbounded');
+      expect(DocumentService.isCollectionField(choiceWrapper)).toBeTruthy();
+
+      const emailField = choiceWrapper.fields.find((f) => f.name === 'Email');
+      const phoneField = choiceWrapper.fields.find((f) => f.name === 'Phone');
+      const faxField = choiceWrapper.fields.find((f) => f.name === 'Fax');
+
+      expect(emailField).toBeDefined();
+      expect(phoneField).toBeDefined();
+      expect(faxField).toBeDefined();
+
+      expect(emailField!.maxOccurs).toBe(1);
+      expect(DocumentService.isCollectionField(emailField!)).toBeTruthy();
+      expect(DocumentService.isCollectionField(phoneField!)).toBeTruthy();
+      expect(DocumentService.isCollectionField(faxField!)).toBeTruthy();
+
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(emailField!)).toBeTruthy();
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(phoneField!)).toBeTruthy();
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(faxField!)).toBeTruthy();
+    });
+
+    it('should not treat members of non-collection choice as collection fields', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(getTestDocumentXsd()),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'TestDocument',
+        ['TestDocument.xsd'],
+      );
+
+      expect(result.validationStatus).toBe('success');
+      const doc = result.document!;
+      const testDocument = doc.fields[0];
+
+      const choiceElement = testDocument.fields.find((f) => f.name === 'ChoiceElement');
+      expect(choiceElement).toBeDefined();
+
+      const choiceWrapper = choiceElement!.fields[0];
+      expect(choiceWrapper.wrapperKind).toBe('choice');
+      expect(choiceWrapper.maxOccurs).toBe(1);
+      expect(DocumentService.isCollectionField(choiceWrapper)).toBeFalsy();
+
+      const choice1Field = choiceWrapper.fields.find((f) => f.name === 'Choice1');
+      const choice2Field = choiceWrapper.fields.find((f) => f.name === 'Choice2');
+
+      expect(choice1Field).toBeDefined();
+      expect(choice2Field).toBeDefined();
+
+      expect(DocumentService.isCollectionField(choice1Field!)).toBeFalsy();
+      expect(DocumentService.isCollectionField(choice2Field!)).toBeFalsy();
+    });
+  });
+
+  describe('isFieldInsideCollectionChoiceWrapper()', () => {
+    it('should return true for fields inside collection choice wrapper', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(getTestDocumentXsd()),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'TestDocument',
+        ['TestDocument.xsd'],
+      );
+
+      const doc = result.document!;
+      const testDocument = doc.fields[0];
+      const collectionChoiceElement = testDocument.fields.find((f) => f.name === 'CollectionChoiceElement')!;
+      const choiceWrapper = collectionChoiceElement.fields[0];
+      const emailField = choiceWrapper.fields.find((f) => f.name === 'Email')!;
+
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(emailField)).toBeTruthy();
+    });
+
+    it('should return false for fields inside non-collection choice wrapper', async () => {
+      const mockApi = {
+        getResourceContent: jest.fn().mockResolvedValue(getTestDocumentXsd()),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'TestDocument',
+        ['TestDocument.xsd'],
+      );
+
+      const doc = result.document!;
+      const testDocument = doc.fields[0];
+      const choiceElement = testDocument.fields.find((f) => f.name === 'ChoiceElement')!;
+      const choiceWrapper = choiceElement.fields[0];
+      const choice1Field = choiceWrapper.fields.find((f) => f.name === 'Choice1')!;
+
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(choice1Field)).toBeFalsy();
+    });
+
+    it('should return false for fields not inside any choice wrapper', () => {
+      const regularField = sourceDoc.fields[0].fields[0];
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(regularField)).toBeFalsy();
     });
   });
 

--- a/packages/ui/src/services/document/document.service.ts
+++ b/packages/ui/src/services/document/document.service.ts
@@ -485,12 +485,33 @@ export class DocumentService {
   }
 
   /**
+   * Returns true if the field's parent is a collection choice wrapper.
+   * A collection choice wrapper is an xs:choice with maxOccurs > 1, meaning its members
+   * can repeat across choice instances and should be treated as collection fields.
+   * @param field - The field to inspect
+   * @returns true if the field is a direct child of a collection choice wrapper, false otherwise
+   */
+  static isFieldInsideCollectionChoiceWrapper(field: IField): boolean {
+    if (!('wrapperKind' in field.parent)) return false;
+    return (
+      field.parent.wrapperKind === 'choice' &&
+      (field.parent.maxOccurs === 'unbounded' || Number(field.parent.maxOccurs) > 1)
+    );
+  }
+
+  /**
    * Returns true if the field represents a collection (maxOccurs is 'unbounded' or greater than 1).
+   * Also returns true if the field is a member of a collection choice wrapper, as members inherit
+   * the repeating nature from the choice wrapper.
    * @param field - The field to inspect
    * @returns true if the field is a collection, false otherwise
    */
   static isCollectionField(field: IField) {
-    return field.maxOccurs === 'unbounded' || Number(field.maxOccurs) > 1;
+    return (
+      field.maxOccurs === 'unbounded' ||
+      Number(field.maxOccurs) > 1 ||
+      DocumentService.isFieldInsideCollectionChoiceWrapper(field)
+    );
   }
 
   /**

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -23,6 +23,8 @@ export class VisualizationUtilService {
   /**
    * Returns `true` if the node's field is a collection (array/repeating element).
    * Also checks the choice wrapper field for collection status when the node is a selected choice member.
+   * For unselected choice members (children of a collection choice wrapper), the collection status
+   * is inherited from the parent wrapper via DocumentService.isCollectionField().
    * @param nodeData - The node to test.
    */
   static isCollectionField(nodeData: NodeData) {


### PR DESCRIPTION
…antics (#3167)

- Add isFieldInsideCollectionChoiceWrapper() helper to check if field is inside collection choice
- Update DocumentService.isCollectionField() to consider collection choice inheritance
- Update VisualizationUtilService.isCollectionField() documentation
- Add comprehensive tests for collection choice inheritance
- Add tests using TestDocument.xsd CollectionChoiceElement
- Verify non-collection choice members are unaffected (no regression)

Fixes #3167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved detection of collection fields within choice wrappers to ensure proper handling of repeated field groups.

* **Tests**
  - Added comprehensive test coverage for collection field detection, including choice wrapper scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->