### PR TITLE
chore(dynamic-catalog): add resolveCatalogLookup()

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -28,6 +28,7 @@ describe('EndpointField', () => {
     getCatalog: jest.fn(),
     setCatalog: jest.fn(),
     clearRegistry: jest.fn(),
+    resolveCatalogLookup: jest.fn(),
   };
 
   const createWrapper = (

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -29,6 +29,7 @@ describe('EndpointListField', () => {
     getCatalog: jest.fn(),
     setCatalog: jest.fn(),
     clearRegistry: jest.fn(),
+    resolveCatalogLookup: jest.fn(),
   };
 
   const createWrapper = (

--- a/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
@@ -21,6 +21,7 @@ describe('CatalogModalProvider', () => {
     getCatalog: jest.fn(),
     setCatalog: jest.fn(),
     clearRegistry: jest.fn(),
+    resolveCatalogLookup: jest.fn(),
   };
 
   const createWrapper = (

--- a/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
@@ -190,6 +190,7 @@ describe('CatalogTilesProvider', () => {
       getCatalog: jest.fn().mockReturnValue(undefined),
       getEntity: jest.fn(),
       clearRegistry: jest.fn(),
+      resolveCatalogLookup: jest.fn(),
     };
 
     const {

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
@@ -358,6 +358,89 @@ describe('DynamicCatalogRegistry', () => {
     });
   });
 
+  describe('resolveCatalogLookup', () => {
+    const timerComponent = {
+      component: { name: 'timer', syntax: 'timer:name' },
+      properties: {},
+      propertiesSchema: {},
+    } as ICamelComponentDefinition;
+
+    const kameletComponent = {
+      component: { name: 'kamelet' },
+      properties: {},
+      propertiesSchema: {},
+    } as ICamelComponentDefinition;
+
+    const chuckNorrisKamelet = {
+      kind: 'Kamelet',
+      metadata: { name: 'chuck-norris-source' },
+      spec: { definition: {} },
+    } as IKameletDefinition;
+
+    beforeEach(() => {
+      const componentCatalog = new DynamicCatalog<ICamelComponentDefinition>({
+        id: 'component-provider',
+        fetch: (key) =>
+          Promise.resolve(
+            ({ timer: timerComponent, kamelet: kameletComponent } as Record<string, ICamelComponentDefinition>)[key],
+          ),
+        fetchAll: () => Promise.resolve({ timer: timerComponent, kamelet: kameletComponent }),
+      });
+
+      const kameletCatalog = new DynamicCatalog<IKameletDefinition>({
+        id: 'kamelet-provider',
+        fetch: (key) =>
+          Promise.resolve(({ 'chuck-norris-source': chuckNorrisKamelet } as Record<string, IKameletDefinition>)[key]),
+        fetchAll: () => Promise.resolve({ 'chuck-norris-source': chuckNorrisKamelet }),
+      });
+
+      registry.setCatalog(CatalogKind.Component, componentCatalog);
+      registry.setCatalog(CatalogKind.Kamelet, kameletCatalog);
+    });
+
+    it('should return undefined for an empty component name', async () => {
+      const lookup = await registry.resolveCatalogLookup('');
+
+      expect(lookup).toBeUndefined();
+    });
+
+    it('should return a component from the catalog lookup', async () => {
+      const lookup = await registry.resolveCatalogLookup('timer');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Component,
+        definition: timerComponent,
+      });
+    });
+
+    it('should return a kamelet from the catalog lookup', async () => {
+      const lookup = await registry.resolveCatalogLookup('kamelet:chuck-norris-source');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Kamelet,
+        definition: chuckNorrisKamelet,
+      });
+    });
+
+    it('should return the kamelet component for unknown kamelets', async () => {
+      const lookup = await registry.resolveCatalogLookup('kamelet:non-existing-kamelet');
+
+      expect(lookup).toEqual({
+        catalogKind: CatalogKind.Component,
+        definition: kameletComponent,
+      });
+    });
+
+    it('should pass forceFresh to underlying catalog lookups', async () => {
+      const componentCatalog = registry.getCatalog(CatalogKind.Component)!;
+      const getSpy = jest.spyOn(componentCatalog, 'get');
+
+      await registry.resolveCatalogLookup('timer', { forceFresh: true });
+
+      expect(getSpy).toHaveBeenCalledWith('timer', { forceFresh: true });
+    });
+  });
+
   it('should maintain a singleton registry', () => {
     const registry1 = DynamicCatalogRegistry.get();
     const registry2 = DynamicCatalogRegistry.get();

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.ts
@@ -1,5 +1,5 @@
 import { CatalogKind } from '../models/catalog-kind';
-import { DynamicCatalogTypeMap, IDynamicCatalog, IDynamicCatalogRegistry } from './models';
+import { CatalogLookupResult, DynamicCatalogTypeMap, IDynamicCatalog, IDynamicCatalogRegistry } from './models';
 
 export class DynamicCatalogRegistry {
   private static instance: CatalogsRegistry;
@@ -31,6 +31,37 @@ class CatalogsRegistry implements IDynamicCatalogRegistry {
   ): Promise<DynamicCatalogTypeMap[K] | undefined> {
     const catalog = this.getCatalog(kind);
     return catalog?.get(key, options) as Promise<DynamicCatalogTypeMap[K] | undefined>;
+  }
+
+  async resolveCatalogLookup(
+    componentName: string,
+    options: { forceFresh?: boolean } = {},
+  ): Promise<CatalogLookupResult | undefined> {
+    if (!componentName) {
+      return undefined;
+    }
+
+    if (componentName.startsWith('kamelet:')) {
+      const kameletName = componentName.replace('kamelet:', '');
+      const definition = await this.getEntity(CatalogKind.Kamelet, kameletName, options);
+
+      if (definition) {
+        return {
+          catalogKind: CatalogKind.Kamelet,
+          definition,
+        };
+      }
+
+      return {
+        catalogKind: CatalogKind.Component,
+        definition: await this.getEntity(CatalogKind.Component, 'kamelet', options),
+      };
+    }
+
+    return {
+      catalogKind: CatalogKind.Component,
+      definition: await this.getEntity(CatalogKind.Component, componentName, options),
+    };
   }
 
   clearRegistry(): void {

--- a/packages/ui/src/dynamic-catalog/models.ts
+++ b/packages/ui/src/dynamic-catalog/models.ts
@@ -43,6 +43,16 @@ export interface IDynamicCatalog<T> {
   clearCache(): void;
 }
 
+export type CatalogLookupResult =
+  | {
+      catalogKind: CatalogKind.Component;
+      definition?: ICamelComponentDefinition;
+    }
+  | {
+      catalogKind: CatalogKind.Kamelet;
+      definition?: IKameletDefinition;
+    };
+
 export interface IDynamicCatalogRegistry {
   setCatalog<K extends CatalogKind>(kind: K, catalog: IDynamicCatalog<DynamicCatalogTypeMap[K]>): void;
   getCatalog<K extends CatalogKind>(kind: K): IDynamicCatalog<DynamicCatalogTypeMap[K]> | undefined;
@@ -52,5 +62,11 @@ export interface IDynamicCatalogRegistry {
     key: string,
     options?: { forceFresh?: boolean },
   ): Promise<DynamicCatalogTypeMap[K] | undefined>;
+
+  resolveCatalogLookup(
+    componentName: string,
+    options?: { forceFresh?: boolean },
+  ): Promise<CatalogLookupResult | undefined>;
+
   clearRegistry(): void;
 }


### PR DESCRIPTION
Added an async version of CamelCatalogService.getCatalogLookup() to the dynamic catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved catalog resolution: lookups now distinguish component vs kamelet entries, handle kamelet: prefixes with fallback behavior, and honor a "force fresh" option when retrieving definitions.

* **Tests**
  * Added tests covering the new lookup behavior and updated test fixtures to include the new lookup API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->