### PR TITLE
fix(DataMapper): Avoid state update in useDataMapperDeleteHotKey hook…

### DIFF
--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
@@ -1,8 +1,9 @@
 import { renderHook } from '@testing-library/react';
 import hotkeys from 'hotkeys-js';
 
+import { IDocument } from '../models/datamapper';
 import { MappingActionKind } from '../models/datamapper/mapping-action';
-import { TargetDocumentNodeData } from '../models/datamapper/visualization';
+import { DocumentNodeData, TargetDocumentNodeData } from '../models/datamapper/visualization';
 import { MappingActionService } from '../services/visualization/mapping-action.service';
 import { TreeUIService } from '../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../store/document-tree.store';
@@ -23,10 +24,9 @@ describe('useDataMapperDeleteHotkey', () => {
   let mockUseDataMapper: jest.MockedFunction<typeof useDataMapper>;
   let mockGetAllowedActions: jest.Mock;
   let mockDeleteMappingItem: jest.Mock;
-  let mockCreateTree: jest.Mock;
+  let mockGetTree: jest.Mock;
   let mockFindNodeByPath: jest.Mock;
-  let mockTargetBodyDocument: { id: string };
-  let mockMappingTree: { mappings: unknown[] };
+  let mockTargetBodyDocument: { id: string; documentType: string; documentId: string };
   let mockTreeNode: { nodeData: TargetDocumentNodeData };
   let mockTargetDocumentNodeData: TargetDocumentNodeData;
 
@@ -40,7 +40,7 @@ describe('useDataMapperDeleteHotkey', () => {
     mockHotkeysUnbind = jest.fn();
     mockGetAllowedActions = jest.fn();
     mockDeleteMappingItem = jest.fn();
-    mockCreateTree = jest.fn();
+    mockGetTree = jest.fn();
     mockFindNodeByPath = jest.fn();
 
     // Mock hotkeys
@@ -48,12 +48,10 @@ describe('useDataMapperDeleteHotkey', () => {
     mockHotkeys.unbind = mockHotkeysUnbind;
 
     // Mock useDataMapper
-    mockTargetBodyDocument = { id: 'target-doc' };
-    mockMappingTree = { mappings: [] };
+    mockTargetBodyDocument = { id: 'target-doc', documentType: 'targetBody', documentId: 'Body' };
     mockUseDataMapper = useDataMapper as jest.MockedFunction<typeof useDataMapper>;
     mockUseDataMapper.mockReturnValue({
       targetBodyDocument: mockTargetBodyDocument,
-      mappingTree: mockMappingTree,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
@@ -62,7 +60,7 @@ describe('useDataMapperDeleteHotkey', () => {
     (MappingActionService.deleteMappingItem as jest.Mock) = mockDeleteMappingItem;
 
     // Mock TreeUIService
-    (TreeUIService.createTree as jest.Mock) = mockCreateTree;
+    (TreeUIService.getTree as jest.Mock) = mockGetTree;
 
     // Setup mock node data
     mockTargetDocumentNodeData = { id: 'test-node' } as TargetDocumentNodeData;
@@ -71,7 +69,7 @@ describe('useDataMapperDeleteHotkey', () => {
     };
 
     mockFindNodeByPath = jest.fn();
-    mockCreateTree.mockReturnValue({
+    mockGetTree.mockReturnValue({
       findNodeByPath: mockFindNodeByPath,
     });
 
@@ -241,47 +239,51 @@ describe('useDataMapperDeleteHotkey', () => {
       expect(mockOnUpdate).not.toHaveBeenCalled();
     });
   });
-  describe('tree creation and memoization', () => {
-    it('should create TargetDocumentNodeData with correct parameters', () => {
+
+  describe('tree lookup', () => {
+    it('should not call getTree during render', () => {
       renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
 
-      // The hook creates a TargetDocumentNodeData internally
-      // We can verify TreeUIService.createTree was called
-      expect(mockCreateTree).toHaveBeenCalled();
+      expect(mockGetTree).not.toHaveBeenCalled();
     });
 
-    it('should recreate tree when targetBodyDocument changes', () => {
-      const { rerender } = renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+    it('should call getTree when handling keypress', () => {
+      useDocumentTreeStore.setState({
+        selectedNodePath: 'test-path',
+        selectedNodeIsSource: false,
+        clearSelection: mockClearSelection,
+      });
 
-      const callCountBefore = mockCreateTree.mock.calls.length;
+      mockFindNodeByPath.mockReturnValue(mockTreeNode);
+      mockGetAllowedActions.mockReturnValue([MappingActionKind.Delete]);
 
-      // Change targetBodyDocument
-      mockUseDataMapper.mockReturnValue({
-        targetBodyDocument: { id: 'new-target-doc' },
-        mappingTree: mockMappingTree,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
 
-      rerender();
+      const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
+      const mockEvent = { preventDefault: jest.fn() } as unknown as KeyboardEvent;
+      hotkeyCallback(mockEvent);
 
-      expect(mockCreateTree.mock.calls.length).toBeGreaterThan(callCountBefore);
+      expect(mockGetTree).toHaveBeenCalledWith(DocumentNodeData.getId(mockTargetBodyDocument as unknown as IDocument));
     });
 
-    it('should recreate tree when mappingTree changes', () => {
-      const { rerender } = renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+    it('should not delete when getTree returns undefined', () => {
+      useDocumentTreeStore.setState({
+        selectedNodePath: 'test-path',
+        selectedNodeIsSource: false,
+        clearSelection: mockClearSelection,
+      });
 
-      const callCountBefore = mockCreateTree.mock.calls.length;
+      mockGetTree.mockReturnValue(undefined);
 
-      // Change mappingTree
-      mockUseDataMapper.mockReturnValue({
-        targetBodyDocument: mockTargetBodyDocument,
-        mappingTree: { mappings: [{ id: 'new-mapping' }] },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
 
-      rerender();
+      const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
+      const mockEvent = { preventDefault: jest.fn() } as unknown as KeyboardEvent;
+      hotkeyCallback(mockEvent);
 
-      expect(mockCreateTree.mock.calls.length).toBeGreaterThan(callCountBefore);
+      expect(mockDeleteMappingItem).not.toHaveBeenCalled();
+      expect(mockClearSelection).not.toHaveBeenCalled();
+      expect(mockOnUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.tsx
@@ -1,9 +1,8 @@
 import hotkeys from 'hotkeys-js';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 
-import { DocumentTree } from '../models/datamapper/document-tree';
 import { MappingActionKind } from '../models/datamapper/mapping-action';
-import { TargetDocumentNodeData } from '../models/datamapper/visualization';
+import { DocumentNodeData, TargetDocumentNodeData } from '../models/datamapper/visualization';
 import { MappingActionService } from '../services/visualization/mapping-action.service';
 import { TreeUIService } from '../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../store/document-tree.store';
@@ -20,21 +19,14 @@ export function useDataMapperDeleteHotkey(onUpdate: () => void) {
   const selectedNodePath = useDocumentTreeStore((state) => state.selectedNodePath);
   const selectedNodeIsSource = useDocumentTreeStore((state) => state.selectedNodeIsSource);
   const clearSelection = useDocumentTreeStore((state) => state.clearSelection);
-  const { targetBodyDocument, mappingTree } = useDataMapper();
-
-  // Create the target document tree
-  const targetBodyNodeData = useMemo(
-    () => new TargetDocumentNodeData(targetBodyDocument, mappingTree),
-    [targetBodyDocument, mappingTree],
-  );
-
-  const targetBodyTree = useMemo<DocumentTree | undefined>(() => {
-    return TreeUIService.createTree(targetBodyNodeData);
-  }, [targetBodyNodeData]);
+  const { targetBodyDocument } = useDataMapper();
 
   const handleKeyDown = useCallback(() => {
     // Only handle deletions on target nodes (not source nodes)
-    if (!selectedNodePath || selectedNodeIsSource || !targetBodyTree) return;
+    if (!selectedNodePath || selectedNodeIsSource) return;
+
+    const targetBodyTree = TreeUIService.getTree(DocumentNodeData.getId(targetBodyDocument));
+    if (!targetBodyTree) return;
 
     // Find the selected tree node by path
     const treeNode = targetBodyTree.findNodeByPath(selectedNodePath);
@@ -54,7 +46,7 @@ export function useDataMapperDeleteHotkey(onUpdate: () => void) {
     // Clear selection and trigger update
     clearSelection();
     onUpdate();
-  }, [selectedNodePath, selectedNodeIsSource, targetBodyTree, clearSelection, onUpdate]);
+  }, [selectedNodePath, selectedNodeIsSource, targetBodyDocument, clearSelection, onUpdate]);
 
   useEffect(() => {
     hotkeys.filter = (event) => {

--- a/packages/ui/src/models/datamapper/document-tree.test.ts
+++ b/packages/ui/src/models/datamapper/document-tree.test.ts
@@ -30,7 +30,7 @@ describe('document-tree.ts', () => {
         const tree = new DocumentTree(mockDocumentNodeData);
 
         expect(tree).toBeInstanceOf(DocumentTree);
-        expect(tree.documentId).toEqual(mockDocumentNodeData.id);
+        expect(tree.documentNodeDataId).toEqual(mockDocumentNodeData.id);
         expect(tree.documentNodeData).toBe(mockDocumentNodeData);
         expect(tree.root).toBeInstanceOf(DocumentTreeNode);
         expect(tree.root.nodeData).toBe(mockDocumentNodeData);

--- a/packages/ui/src/models/datamapper/document-tree.ts
+++ b/packages/ui/src/models/datamapper/document-tree.ts
@@ -28,13 +28,13 @@ export interface FlattenedNode {
  * from {@link flatten} output to avoid duplicating the panel header in the tree.
  */
 export class DocumentTree {
-  readonly documentId: string;
+  readonly documentNodeDataId: string;
   readonly documentNodeData: DocumentNodeData;
   readonly root: DocumentTreeNode;
 
   constructor(documentNodeData: DocumentNodeData) {
     this.documentNodeData = documentNodeData;
-    this.documentId = documentNodeData.id;
+    this.documentNodeDataId = documentNodeData.id;
     this.root = new DocumentTreeNode(documentNodeData);
   }
 

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -67,9 +67,13 @@ export type TargetNodeDataType =
  * Its `title` is set to the document's `documentId`.
  */
 export class DocumentNodeData implements NodeData {
+  static getId(document: IDocument): string {
+    return `doc-${document.documentType}-${document.documentId}`;
+  }
+
   constructor(document: IDocument) {
     this.title = document.documentId;
-    this.id = `doc-${document.documentType}-${document.documentId}`;
+    this.id = DocumentNodeData.getId(document);
     this.path = NodePath.fromDocument(document.documentType, document.documentId);
     this.document = document;
     this.isSource = document.documentType !== DocumentType.TARGET_BODY;

--- a/packages/ui/src/services/visualization/tree-ui.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.test.ts
@@ -120,6 +120,35 @@ describe('TreeUIService', () => {
     });
   });
 
+  describe('getTree', () => {
+    it('should return undefined when no tree exists for the given ID', () => {
+      expect(TreeUIService.getTree('non-existent-id')).toBeUndefined();
+    });
+
+    it('should return the cached tree after createTree()', () => {
+      TreeUIService.createTree(sourceDocNode);
+
+      const retrieved = TreeUIService.getTree(sourceDocNode.id);
+
+      expect(retrieved).toBeInstanceOf(DocumentTree);
+      expect(retrieved!.root.nodeData).toBe(sourceDocNode);
+    });
+
+    it('should return different trees for different document IDs', () => {
+      TreeUIService.createTree(sourceDocNode);
+
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const targetDocNode = new DocumentNodeData(targetDoc);
+      TreeUIService.createTree(targetDocNode);
+
+      const sourceTree = TreeUIService.getTree(sourceDocNode.id);
+      const targetTree = TreeUIService.getTree(targetDocNode.id);
+
+      expect(sourceTree).not.toBe(targetTree);
+      expect(sourceTree!.root.nodeData.id).not.toBe(targetTree!.root.nodeData.id);
+    });
+  });
+
   describe('toggleNode', () => {
     let tree: DocumentTree;
     let documentId: string;

--- a/packages/ui/src/services/visualization/tree-ui.service.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.ts
@@ -17,10 +17,14 @@ export class TreeUIService {
     const tree = new DocumentTree(documentNodeData);
     TreeParsingService.parseTree(tree);
 
-    this.trees.set(tree.documentId, tree);
+    this.trees.set(tree.documentNodeDataId, tree);
     useDocumentTreeStore.getState().updateTreeExpansion(tree);
 
     return tree;
+  }
+
+  static getTree(documentNodeDataId: string): DocumentTree | undefined {
+    return this.trees.get(documentNodeDataId);
   }
 
   /**

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -60,7 +60,7 @@ describe('useDocumentTreeStore', () => {
 
       useDocumentTreeStore.getState().updateTreeExpansion(tree);
       const state = useDocumentTreeStore.getState().expansionState;
-      const keys = Object.keys(state[tree.documentId]);
+      const keys = Object.keys(state[tree.documentNodeDataId]);
 
       expect(keys).toEqual([
         // DFS order: ShipOrder -> children -> grandchildren (maxFields extends beyond maxDepth)
@@ -94,7 +94,7 @@ describe('useDocumentTreeStore', () => {
 
       useDocumentTreeStore.getState().updateTreeExpansion(primitiveTree);
       const state = useDocumentTreeStore.getState().expansionState;
-      const keys = Object.keys(state[primitiveTree.documentId]);
+      const keys = Object.keys(state[primitiveTree.documentNodeDataId]);
 
       expect(keys).toEqual([]);
     });
@@ -118,13 +118,13 @@ describe('useDocumentTreeStore', () => {
 
       useDocumentTreeStore.getState().updateTreeExpansion(primitiveTree);
       const state = useDocumentTreeStore.getState().expansionState;
-      const keys = Object.keys(state[primitiveTree.documentId]);
+      const keys = Object.keys(state[primitiveTree.documentNodeDataId]);
 
       // The 'if' instruction item and its ValueSelector child should appear in expansion state
       expect(keys.length).toBeGreaterThan(0);
 
       // Content roots should be flattened for rendering
-      const flattened = primitiveTree.flatten(state[primitiveTree.documentId]);
+      const flattened = primitiveTree.flatten(state[primitiveTree.documentNodeDataId]);
       expect(flattened.length).toBeGreaterThan(0);
       expect(flattened[0].treeNode.nodeData.title).toBe('if');
     });
@@ -135,7 +135,7 @@ describe('useDocumentTreeStore', () => {
       useDocumentTreeStore.getState().updateTreeExpansion(tree);
 
       // Get the actual paths from the tree after initial expansion
-      const initialState = useDocumentTreeStore.getState().expansionState[tree.documentId];
+      const initialState = useDocumentTreeStore.getState().expansionState[tree.documentNodeDataId];
       const paths = Object.keys(initialState);
 
       const firstContentRoot = paths[0];
@@ -144,7 +144,7 @@ describe('useDocumentTreeStore', () => {
       // Set custom expansion state: first content root expanded (true), second collapsed (false)
       useDocumentTreeStore.setState({
         expansionState: {
-          [tree.documentId]: {
+          [tree.documentNodeDataId]: {
             [firstContentRoot]: true,
             [secondPath]: false,
           },
@@ -153,7 +153,7 @@ describe('useDocumentTreeStore', () => {
 
       // Call updateTreeExpansion again - should preserve existing states
       useDocumentTreeStore.getState().updateTreeExpansion(tree);
-      const state = useDocumentTreeStore.getState().expansionState[tree.documentId];
+      const state = useDocumentTreeStore.getState().expansionState[tree.documentNodeDataId];
 
       expect(state[firstContentRoot]).toBe(true);
       expect(state[secondPath]).toBe(false);
@@ -212,7 +212,7 @@ describe('useDocumentTreeStore', () => {
 
   describe('toggleExpansion', () => {
     it('should toggle expansion state from false to true', () => {
-      const documentId = tree.documentId;
+      const documentId = tree.documentNodeDataId;
       const nodePath = 'sourceBody:Body://';
 
       // Set initial state to false
@@ -231,7 +231,7 @@ describe('useDocumentTreeStore', () => {
     });
 
     it('should toggle expansion state from true to false', () => {
-      const documentId = tree.documentId;
+      const documentId = tree.documentNodeDataId;
       const nodePath = 'sourceBody:Body://';
 
       // Set initial state to true
@@ -297,7 +297,7 @@ describe('useDocumentTreeStore', () => {
 
   describe('isExpanded', () => {
     it('should return true for expanded node', () => {
-      const documentId = tree.documentId;
+      const documentId = tree.documentNodeDataId;
       const nodePath = 'sourceBody:Body://';
 
       useDocumentTreeStore.setState({
@@ -314,7 +314,7 @@ describe('useDocumentTreeStore', () => {
     });
 
     it('should return false for collapsed node', () => {
-      const documentId = tree.documentId;
+      const documentId = tree.documentNodeDataId;
       const nodePath = 'sourceBody:Body://';
 
       useDocumentTreeStore.setState({

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -97,7 +97,7 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
       },
 
       updateTreeExpansion: (documentTree: DocumentTree) => {
-        const currentExpansionState: TreeExpansionState = get().expansionState[documentTree.documentId] ?? {};
+        const currentExpansionState: TreeExpansionState = get().expansionState[documentTree.documentNodeDataId] ?? {};
         const newExpansionState: TreeExpansionState = {};
 
         for (const contentRoot of documentTree.contentRoots) {
@@ -110,11 +110,11 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
         set((state) => ({
           expansionState: {
             ...state.expansionState,
-            [documentTree.documentId]: newExpansionState,
+            [documentTree.documentNodeDataId]: newExpansionState,
           },
           expansionStateArray: {
             ...state.expansionStateArray,
-            [documentTree.documentId]: Object.keys(newExpansionState),
+            [documentTree.documentNodeDataId]: Object.keys(newExpansionState),
           },
         }));
       },


### PR DESCRIPTION
… initialization

Fixes: https://github.com/KaotoIO/kaoto/issues/3220

* TreeUIService.createTree() mutates React states, which is not allowed while rendering (initialization), fixed by:
  * Let useDataMapperDeleteHotKey hook access existing tree instead of creating a duplicate document tree
  * Add TreeUIService.getTree() to access existing tree
* Rename DocumentTree.documentId to documentNodeDataId to avoid confusion with IDocument.id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal document tree identification and retrieval mechanisms to improve system performance and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->