### PR TITLE
fix(DataMapper): render concrete substitution when choice selects already-substituted abstract field

### DIFF
--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -589,4 +589,53 @@ describe('VisualizationService / abstract fields', () => {
       expect(candidateChildren.map((c) => c.title)).toEqual(['catName']);
     });
   });
+
+  describe('choice-selected abstract wrapper with existing substitution (#3201)', () => {
+    it('should render concrete substitution on source side when choice selects an already-substituted abstract field', () => {
+      const abstractField = createMockAbstractField([{ name: 'AgmtsUpd' }, { name: 'OtherType' }], 0);
+      const baseField = sourceDoc.fields[0];
+      const choiceField = {
+        ...baseField,
+        wrapperKind: 'choice' as const,
+        selectedMemberIndex: 0,
+        fields: [abstractField],
+      } as unknown as typeof baseField;
+      const parentField = {
+        ...sourceDoc.fields[0],
+        fields: [choiceField],
+      };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+
+      expect(children.length).toEqual(1);
+      expect(children[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(children[0].title).toEqual('AgmtsUpd');
+      expect((children[0] as AbstractFieldNodeData).abstractField).toBeDefined();
+    });
+
+    it('should render concrete substitution on target side when choice selects an already-substituted abstract field', () => {
+      const abstractField = createMockAbstractField([{ name: 'AgmtsUpd' }, { name: 'OtherType' }], 0);
+      const baseField = targetDoc.fields[0];
+      const choiceField = {
+        ...baseField,
+        wrapperKind: 'choice' as const,
+        selectedMemberIndex: 0,
+        fields: [abstractField],
+      } as unknown as typeof baseField;
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [choiceField],
+      };
+      const localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const parentNode = new TargetFieldNodeData(localTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+
+      expect(children.length).toEqual(1);
+      expect(children[0]).toBeInstanceOf(TargetAbstractFieldNodeData);
+      expect(children[0].title).toEqual('AgmtsUpd');
+      expect((children[0] as TargetAbstractFieldNodeData).abstractField).toBeDefined();
+    });
+  });
 });

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -143,6 +143,18 @@ export class VisualizationService {
     const selectedMember =
       field.selectedMemberIndex === undefined ? undefined : field.fields?.[field.selectedMemberIndex];
     const nodeField = selectedMember ?? field;
+    if (
+      spec === CHOICE_WRAPPER &&
+      selectedMember?.wrapperKind === 'abstract' &&
+      selectedMember.selectedMemberIndex !== undefined
+    ) {
+      return VisualizationService.doGenerateNodeDataFromWrapperField(
+        parent,
+        selectedMember,
+        mappings,
+        ABSTRACT_WRAPPER,
+      );
+    }
     if (parent.isSource) {
       const node = spec.createSourceNode(parent, nodeField);
       if (selectedMember) spec.setWrapperRef(node, field);


### PR DESCRIPTION
## Summary

When a choice wrapper (`xs:choice`) selects a member that is itself an abstract field (`xs:element` with substitution group) **and that abstract field already has a substitution selected**, the visualization was discarding the substitution and rendering the abstract element as a plain regular field — with no abstract badge, no field-substitution context menu, and broken mapping lines.

## Root Cause

In `doGenerateNodeDataFromWrapperField`, when called with `CHOICE_WRAPPER`, the code resolved `selectedMember` (the choice's selected child) and passed it directly to `CHOICE_WRAPPER.createSourceNode`. When `selectedMember` was an abstract field with its own `selectedMemberIndex` already set, that substitution was silently ignored, producing a `ChoiceFieldNodeData` instead of the correct `AbstractFieldNodeData`.

## Fix

Added a guard in `doGenerateNodeDataFromWrapperField`: when `CHOICE_WRAPPER` selects an abstract member that already has its own `selectedMemberIndex` set, recurse with `ABSTRACT_WRAPPER` and the abstract member as the field. This allows the existing abstract wrapper resolution logic to naturally produce `AbstractFieldNodeData` with the correct `field` (concrete substitution) and `abstractField` (abstract wrapper) references.

## Tests

Added 2 test cases to `visualization.service.abstract.test.ts`:
- Source side: choice selecting an already-substituted abstract field produces `AbstractFieldNodeData` with the concrete substitution as title
- Target side: same scenario produces `TargetAbstractFieldNodeData`

Fixes #3201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved visualization rendering issues for field selections involving pre-existing substitutions. The fix ensures that complex nested field scenarios now display accurately across all visualization views, improving data presentation integrity.

* **Tests**
  * Added comprehensive test coverage for advanced field selection scenarios to validate correct visualization behavior with substitutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->