### PR TITLE
fix(datamapper): highlight selected document row

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.scss
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.scss
@@ -61,6 +61,7 @@
   &__row[data-selected='true'] {
     color: var(--pf-t--global--color--brand--default) !important;
     font-weight: bold;
+    outline: 1px dotted var(--pf-t--global--color--brand--default);
   }
 
   &__expand {


### PR DESCRIPTION
Fixes #3225

## Summary
- Adds a visible outline to selected DataMapper document rows.
- Preserves the existing selected text color and font weight.
- Uses `outline` so row dimensions do not shift.

## Verification
- `node .yarn/releases/yarn-4.13.0.cjs install --immutable`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto lint:style`
- `env HOME=/private/tmp node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto build:lib`
- `env HOME=/private/tmp node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto-tests build:storybook`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto test src/components/Document/Nodes/BaseNode.test.tsx --runInBand`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual distinction for selected nodes with an added dotted outline in brand color, improving selection clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->