### PR TITLE
fix(DataMapper): reserve drag handle space for abstract wrappers

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.scss
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.scss
@@ -86,6 +86,10 @@
     }
   }
 
+  &__drag-placeholder {
+    visibility: hidden;
+  }
+
   &__override-indicator {
     padding: var(--pf-t--global--spacer--sm);
     cursor: help;

--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../models/datamapper/document';
 import { MappingTree, UnknownMappingItem, ValueSelector, VariableItem } from '../../../models/datamapper/mapping';
 import {
+  AbstractFieldNodeData,
   AddMappingNodeData,
   DocumentNodeData,
   FieldNodeData,
@@ -137,6 +138,43 @@ const createAddMappingNodeData = (): AddMappingNodeData => {
   return new AddMappingNodeData(targetDocNodeData, mockField);
 };
 
+const createAbstractFieldNodeData = (): AbstractFieldNodeData => {
+  const mockDocument = new PrimitiveDocument(
+    new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.Primitive, 'test-doc'),
+  );
+  const docNodeData = new DocumentNodeData(mockDocument);
+
+  const mockField: IField = {
+    parent: mockDocument,
+    ownerDocument: mockDocument,
+    id: 'abstract-field',
+    name: 'abstractField',
+    displayName: 'Abstract Field',
+    type: Types.Container,
+    typeQName: new QName('', Types.Container),
+    originalType: Types.Container,
+    originalTypeQName: new QName('', Types.Container),
+    path: new NodePath('abstractField'),
+    fields: [],
+    isAttribute: false,
+    defaultValue: null,
+    minOccurs: 1,
+    maxOccurs: 1,
+    nillable: false,
+    typeOverride: FieldOverrideVariant.NONE,
+    namespacePrefix: null,
+    namespaceURI: '',
+    namedTypeFragmentRefs: [],
+    predicates: [],
+    wrapperKind: 'abstract',
+    adopt: () => mockField,
+    getExpression: () => '',
+    isIdentical: () => false,
+  } as IField;
+
+  return new AbstractFieldNodeData(docNodeData, mockField);
+};
+
 describe('BaseNode', () => {
   describe('Basic Rendering', () => {
     it('should render title as string', () => {
@@ -248,6 +286,14 @@ describe('BaseNode', () => {
       const { container } = render(<BaseNode nodeData={addMappingNodeData} title="Title" data-testid="test-node" />);
       const dragHandler = container.querySelector('[data-drag-handler]');
       expect(dragHandler).not.toBeInTheDocument();
+    });
+
+    it('should reserve drag icon space for unselected abstract wrapper fields', () => {
+      const abstractNodeData = createAbstractFieldNodeData();
+      const { container } = render(<BaseNode nodeData={abstractNodeData} title="Title" data-testid="test-node" />);
+
+      expect(container.querySelector('[data-drag-handler]')).not.toBeInTheDocument();
+      expect(screen.getByTestId('drag-handler-spacer')).toBeInTheDocument();
     });
 
     it('should show drag icon for VariableNodeData', () => {

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -72,6 +72,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
   const isAttributeField = VisualizationUtilService.isAttributeField(nodeData);
   const isVariableNode = nodeData instanceof VariableNodeData;
   const isDraggable = MappingValidationService.isDraggable(nodeData);
+  const shouldReserveDragHandleSpace = !isDraggable && isAbstractField && !isSelectedAbstract;
   const isSource = nodeData.isSource;
   const [isCommentModalOpen, setIsCommentModalOpen] = useState(false);
 
@@ -117,6 +118,11 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
 
       {isDraggable && (
         <Icon className="node__spacer" data-drag-handler>
+          <Draggable />
+        </Icon>
+      )}
+      {shouldReserveDragHandleSpace && (
+        <Icon className="node__spacer node__drag-placeholder" data-testid="drag-handler-spacer" aria-hidden="true">
           <Draggable />
         </Icon>
       )}


### PR DESCRIPTION
## Summary
- reserve the drag handle width for unselected abstract wrapper fields without making them draggable
- add a regression test for the non-draggable abstract wrapper placeholder

Fixes #3199.

## Validation
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto test src/components/Document/Nodes/BaseNode.test.tsx --runInBand`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto lint`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto lint:style`
- `./node_modules/.bin/prettier --check packages/ui/src/components/Document/Nodes/BaseNode.tsx packages/ui/src/components/Document/Nodes/BaseNode.scss packages/ui/src/components/Document/Nodes/BaseNode.test.tsx`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto build`
- `node .yarn/releases/yarn-4.13.0.cjs workspace @kaoto/kaoto test --runInBand`
- `npm audit signatures`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual consistency in the document editor by maintaining proper spacing for abstract field elements.
* **Tests**
  * Added comprehensive test coverage for drag handler placeholder rendering and spacing on abstract wrapper fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->