### PR TITLE
feat(Settings): Add hidden runtime and testing versions to the Settings form

### DIFF
--- a/packages/ui/src/assets/settingsSchema.json
+++ b/packages/ui/src/assets/settingsSchema.json
@@ -11,6 +11,18 @@
       "type": "string",
       "format": "uri"
     },
+    "runtimeCatalogName": {
+      "title": "Integrations runtime version",
+      "description": "Integration runtime version. f.i. 'Camel Main 4.14.5', 'Camel Quarkus 3.15.0.redhat-00010' or 'Camel Spring Boot 4.14.5'",
+      "default": "<empty string>",
+      "type": "string"
+    },
+    "testingCatalogName": {
+      "title": "Testing runtime version",
+      "description": "Testing runtime version. f.i. 'Citrus 4.10.0'",
+      "default": "<empty string>",
+      "type": "string"
+    },
     "nodeLabel": {
       "title": "Node label to display in canvas",
       "description": "Node label, which will be used for nodes in the canvas. Can be either `description` or `id`. If `description` is selected, it will be displayed only if it is available, otherwise `id` will be displayed by default.",

--- a/packages/ui/src/components/Icons/RuntimeIcon.scss
+++ b/packages/ui/src/components/Icons/RuntimeIcon.scss
@@ -1,0 +1,12 @@
+.runtime-icon {
+  margin-top: 2px;
+
+  > [class^='pf-v6-c-icon'] {
+    display: inline-flex;
+    align-items: center;
+    width: 14px;
+    height: 14px;
+    line-height: 1;
+    padding-top: 2px;
+  }
+}

--- a/packages/ui/src/components/Icons/RuntimeIcon.test.tsx
+++ b/packages/ui/src/components/Icons/RuntimeIcon.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+
+import { getRuntimeIcon } from './RuntimeIcon';
+
+describe('getRuntimeIcon', () => {
+  it.each([
+    ['Main', 'Apache Camel logo'],
+    ['Camel Main 4.0.0', 'Apache Camel logo'],
+    ['Unknown Runtime', 'Apache Camel logo'],
+    ['Citrus', 'Citrus logo'],
+    ['Citrus 1.0.0', 'Citrus logo'],
+    ['Quarkus', 'Quarkus logo'],
+    ['Camel Quarkus 3.0.0', 'Quarkus logo'],
+    ['Spring Boot', 'Spring Boot logo'],
+    ['CamelSpringBoot3.0.0', 'Spring Boot logo'],
+    ['Camel Main 4.0.0.redhat-00001', 'Red Hat logo'],
+    ['anything-with-redhat-in-name', 'Red Hat logo'],
+  ])('returns correct icon for "%s"', (input, expectedAlt) => {
+    render(getRuntimeIcon(input));
+    expect(screen.getByAltText(expectedAlt)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Icons/RuntimeIcon.tsx
+++ b/packages/ui/src/components/Icons/RuntimeIcon.tsx
@@ -1,0 +1,58 @@
+import './RuntimeIcon.scss';
+
+import { Icon } from '@patternfly/react-core';
+
+import camelLogo from '../../assets/camel-logo.svg';
+import citrusLogo from '../../assets/citrus-logo.png';
+import quarkusLogo from '../../assets/quarkus-logo.svg';
+import redhatLogo from '../../assets/redhat-logo.svg';
+import springBootLogo from '../../assets/springboot-logo.svg';
+
+/**
+ * Returns the appropriate icon for a given runtime or catalog name.
+ *
+ * Matches are case-insensitive and whitespace-agnostic for flexibility.
+ * @param runtimeOrName - Runtime type (e.g., "Main", "Quarkus") or catalog name (e.g., "Camel Main 4.0.0.redhat-00001")
+ * @returns Icon component with the appropriate logo
+ */
+export const getRuntimeIcon = (runtimeOrName: string = '') => {
+  const normalized = runtimeOrName.toLowerCase().replace(/\s/g, '');
+
+  if (normalized.includes('redhat')) {
+    return (
+      <Icon className="runtime-icon">
+        <img src={redhatLogo} alt="Red Hat logo" />
+      </Icon>
+    );
+  }
+
+  if (normalized.includes('citrus')) {
+    return (
+      <Icon className="runtime-icon">
+        <img src={citrusLogo} alt="Citrus logo" />
+      </Icon>
+    );
+  }
+
+  if (normalized.includes('quarkus')) {
+    return (
+      <Icon className="runtime-icon">
+        <img src={quarkusLogo} alt="Quarkus logo" />
+      </Icon>
+    );
+  }
+
+  if (normalized.includes('springboot')) {
+    return (
+      <Icon className="runtime-icon">
+        <img src={springBootLogo} alt="Spring Boot logo" />
+      </Icon>
+    );
+  }
+
+  return (
+    <Icon className="runtime-icon">
+      <img src={camelLogo} alt="Apache Camel logo" />
+    </Icon>
+  );
+};

--- a/packages/ui/src/components/Settings/SettingsForm.scss
+++ b/packages/ui/src/components/Settings/SettingsForm.scss
@@ -5,8 +5,22 @@
     overflow: hidden auto;
   }
 
+  .alert-catalog-url {
+    margin-bottom: 24px;
+
+    /* stylelint-disable-next-line selector-class-pattern */
+    .pf-v6-c-alert__icon {
+      align-content: center;
+    }
+  }
+
   /* stylelint-disable-next-line selector-class-pattern */
   .pf-v6-c-card__footer {
     padding-block-start: var(--pf-v6-c-card--first-child--PaddingBlockStart);
+  }
+
+  [data-testid='#.runtimeCatalogName__field-wrapper'],
+  [data-testid='#.testingCatalogName__field-wrapper'] {
+    display: none;
   }
 }

--- a/packages/ui/src/components/Settings/SettingsForm.test.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.test.tsx
@@ -1,19 +1,26 @@
+import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { AbstractSettingsAdapter, DefaultSettingsAdapter } from '../../models/settings';
 import { ReloadContext, SettingsProvider } from '../../providers';
+import { TestRuntimeProviderWrapper } from '../../stubs/TestRuntimeProviderWrapper';
 import { SettingsForm } from './SettingsForm';
 
 describe('SettingsForm', () => {
   let reloadPage: jest.Mock;
   let settingsAdapter: AbstractSettingsAdapter;
+  const { Provider: RuntimeProvider } = TestRuntimeProviderWrapper();
 
   const wrapper = ({ children }: { children: React.ReactNode }) => {
     return (
       <MemoryRouter>
         <ReloadContext.Provider value={{ reloadPage, lastRender: 0 }}>
-          <SettingsProvider adapter={settingsAdapter}>{children}</SettingsProvider>
+          <RuntimeProvider>
+            <SettingsProvider adapter={settingsAdapter}>
+              <SuggestionRegistryProvider>{children}</SuggestionRegistryProvider>
+            </SettingsProvider>
+          </RuntimeProvider>
         </ReloadContext.Provider>
       </MemoryRouter>
     );
@@ -52,12 +59,29 @@ describe('SettingsForm', () => {
     expect(settingsAdapter.getSettings().catalogUrl).not.toBe('http://localhost:8080');
   });
 
-  it('should reload the page upon clicking save', () => {
-    act(() => {
+  it('should reload the page upon clicking save', async () => {
+    await act(async () => {
       const button = screen.getByTestId('settings-form-save-btn');
       fireEvent.click(button);
     });
 
     expect(reloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display error alert when save fails', async () => {
+    // Mock saveSettings to throw an error
+    const errorMessage = 'Failed to save settings to storage';
+    settingsAdapter.saveSettings = jest.fn().mockRejectedValue(new Error(errorMessage));
+
+    await act(async () => {
+      const button = screen.getByTestId('settings-form-save-btn');
+      fireEvent.click(button);
+    });
+
+    // Wait for error alert to appear
+    const errorAlert = await screen.findByText('Failed to save settings.');
+    expect(errorAlert).toBeInTheDocument();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    expect(reloadPage).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/Settings/SettingsForm.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.tsx
@@ -1,7 +1,7 @@
 import './SettingsForm.scss';
 
 import { CanvasFormTabsContext, CanvasFormTabsContextResult, KaotoForm } from '@kaoto/forms';
-import { Button, Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
+import { Alert, Button, Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import { FunctionComponent, useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -22,15 +22,27 @@ export const SettingsForm: FunctionComponent = () => {
   const navigate = useNavigate();
   const { lastRender, reloadPage } = useReloadContext();
   const [settings, setSettings] = useState(settingsAdapter.getSettings());
+  const [saveError, setSaveError] = useState<string | undefined>(undefined);
+  const initialCatalogUrl = useMemo(() => settingsAdapter.getSettings().catalogUrl, [settingsAdapter]);
 
   const onChangeModel = (value: unknown) => {
     setSettings(value as SettingsModel);
+    setSaveError(undefined);
   };
 
-  const onSave = () => {
-    settingsAdapter.saveSettings(settings);
-    reloadPage();
-    navigate(Links.Home);
+  const hasPendingCatalogUrlChange = settings.catalogUrl !== initialCatalogUrl;
+
+  const onSave = async () => {
+    try {
+      await settingsAdapter.saveSettings(settings);
+      reloadPage();
+
+      if (!hasPendingCatalogUrlChange) {
+        navigate(Links.Home);
+      }
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Unable to save settings');
+    }
   };
 
   return (
@@ -38,6 +50,22 @@ export const SettingsForm: FunctionComponent = () => {
       <CardTitle>Settings</CardTitle>
 
       <CardBody>
+        {hasPendingCatalogUrlChange && (
+          <Alert
+            className="alert-catalog-url"
+            isInline
+            variant="info"
+            title="Catalog versions will be recomputed after saving a custom catalog."
+          >
+            Runtime selector versions still reflect the currently saved catalog URL. Save the settings to recompute the
+            available Camel and testing catalogs options from the new catalog URL.
+          </Alert>
+        )}
+        {saveError && (
+          <Alert className="alert-catalog-url" isInline variant="danger" title="Failed to save settings.">
+            {saveError}
+          </Alert>
+        )}
         <CanvasFormTabsContext.Provider value={formTabsValue}>
           <KaotoForm
             data-testid="settings-form"

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -151,6 +151,230 @@ exports[`SettingsForm should render 1`] = `
   </div>
   <div
     class="pf-v6-c-form__group"
+    data-testid="#.runtimeCatalogName__field-wrapper"
+  >
+    <div
+      class="pf-v6-c-form__group-label"
+    >
+      <label
+        class="pf-v6-c-form__label"
+        for="#.runtimeCatalogName"
+      >
+        <span
+          class="pf-v6-c-form__label-text"
+        >
+          Integrations runtime version
+        </span>
+      </label>
+        
+      <span
+        class="pf-v6-c-form__group-label-help"
+      >
+        <div
+          style="display: contents;"
+        >
+          <span
+            aria-label="More info for Integrations runtime version field"
+            class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+            data-ouia-component-id="OUIA-Generated-Button-plain-3"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </span>
+    </div>
+    <div
+      class="pf-v6-c-form__group-control"
+    >
+      <button
+        aria-expanded="false"
+        class="pf-v6-c-menu-toggle pf-m-full-width"
+        data-ouia-component-id="OUIA-Generated-MenuToggle-1"
+        data-ouia-component-type="PF6/MenuToggle"
+        data-ouia-safe="true"
+        data-testid="#.runtimeCatalogName-catalog-selector-toggle"
+        type="button"
+      >
+        <span
+          class="pf-v6-c-menu-toggle__text"
+        >
+          <span
+            class="pf-v6-c-icon runtime-icon"
+          >
+            <span
+              class="pf-v6-c-icon__content"
+            >
+              <img
+                alt="Red Hat logo"
+                src="file-mock-data"
+              />
+            </span>
+          </span>
+          <span
+            class="runtime-selector pf-v6-u-m-sm"
+          >
+            Camel Main 4.14.2.redhat-00019
+          </span>
+        </span>
+        <span
+          class="pf-v6-c-menu-toggle__controls"
+        >
+          <span
+            class="pf-v6-c-menu-toggle__toggle-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    class="pf-v6-c-form__group"
+    data-testid="#.testingCatalogName__field-wrapper"
+  >
+    <div
+      class="pf-v6-c-form__group-label"
+    >
+      <label
+        class="pf-v6-c-form__label"
+        for="#.testingCatalogName"
+      >
+        <span
+          class="pf-v6-c-form__label-text"
+        >
+          Testing runtime version
+        </span>
+      </label>
+        
+      <span
+        class="pf-v6-c-form__group-label-help"
+      >
+        <div
+          style="display: contents;"
+        >
+          <span
+            aria-label="More info for Testing runtime version field"
+            class="pf-v6-c-button pf-m-plain pf-m-no-padding"
+            data-ouia-component-id="OUIA-Generated-Button-plain-4"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </span>
+    </div>
+    <div
+      class="pf-v6-c-form__group-control"
+    >
+      <button
+        aria-expanded="false"
+        class="pf-v6-c-menu-toggle pf-m-full-width"
+        data-ouia-component-id="OUIA-Generated-MenuToggle-2"
+        data-ouia-component-type="PF6/MenuToggle"
+        data-ouia-safe="true"
+        data-testid="#.testingCatalogName-catalog-selector-toggle"
+        type="button"
+      >
+        <span
+          class="pf-v6-c-menu-toggle__text"
+        >
+          <span
+            class="pf-v6-c-icon runtime-icon"
+          >
+            <span
+              class="pf-v6-c-icon__content"
+            >
+              <img
+                alt="Citrus logo"
+                src="file-mock-data"
+              />
+            </span>
+          </span>
+          <span
+            class="runtime-selector pf-v6-u-m-sm"
+          >
+            Citrus 4.10.0
+          </span>
+        </span>
+        <span
+          class="pf-v6-c-menu-toggle__controls"
+        >
+          <span
+            class="pf-v6-c-menu-toggle__toggle-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    class="pf-v6-c-form__group"
     data-testid="#.nodeLabel__field-wrapper"
   >
     <div
@@ -176,7 +400,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Node label to display in canvas field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-3"
+            data-ouia-component-id="OUIA-Generated-Button-plain-5"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -238,7 +462,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeLabel__clear"
@@ -326,7 +550,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Open Node toolbar field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
+            data-ouia-component-id="OUIA-Generated-Button-plain-7"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -388,7 +612,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.nodeToolbarTrigger__clear"
@@ -476,7 +700,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Color scheme field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-7"
+            data-ouia-component-id="OUIA-Generated-Button-plain-9"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -538,7 +762,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.colorScheme__clear"
@@ -626,7 +850,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             aria-label="More info for Canvas layout direction field"
             class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-            data-ouia-component-id="OUIA-Generated-Button-plain-9"
+            data-ouia-component-id="OUIA-Generated-Button-plain-11"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             role="button"
@@ -688,7 +912,7 @@ exports[`SettingsForm should render 1`] = `
             <button
               aria-label="Clear input value"
               class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-id="OUIA-Generated-Button-plain-12"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               data-testid="#.canvasLayoutDirection__clear"
@@ -766,7 +990,7 @@ exports[`SettingsForm should render 1`] = `
         <button
           aria-label="Remove object"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-11"
+          data-ouia-component-id="OUIA-Generated-Button-plain-13"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           data-testid="#.rest__remove"
@@ -810,7 +1034,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Rest configuration field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-id="OUIA-Generated-Button-plain-14"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -871,7 +1095,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Apicurio Registry URL field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"
@@ -930,7 +1154,7 @@ exports[`SettingsForm should render 1`] = `
               <button
                 aria-label="Open suggestions"
                 class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
-                data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                data-ouia-component-id="OUIA-Generated-Button-plain-16"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 data-testid="#.rest.apicurioRegistryUrl__open-suggestions-button"
@@ -1014,7 +1238,7 @@ exports[`SettingsForm should render 1`] = `
               <span
                 aria-label="More info for Custom media types field"
                 class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-                data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                data-ouia-component-id="OUIA-Generated-Button-plain-17"
                 data-ouia-component-type="PF6/Button"
                 data-ouia-safe="true"
                 role="button"

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.scss
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.scss
@@ -1,0 +1,11 @@
+.cat-select-field {
+  .dropdown-title {
+    flex-direction: row;
+    gap: 6px;
+    font-weight: bold;
+  }
+}
+
+.runtime-selector.pf-v6-u-m-sm {
+  margin-left: 6px;
+}

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.test.tsx
@@ -1,0 +1,510 @@
+import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { KaotoSchemaDefinition } from '../../../../../../models';
+import { RuntimeContext } from '../../../../../../providers/runtime.provider';
+import { RuntimeCatalogNameField, TestingCatalogNameField } from './CatalogSelectorField';
+
+describe('CatalogSelectorField', () => {
+  const mockCatalogLibrary: CatalogLibrary = {
+    definitions: [
+      {
+        name: 'Camel Main 4.14.5',
+        version: '4.14.5',
+        runtime: 'Main',
+        catalogs: {},
+      },
+      {
+        name: 'Camel Quarkus 3.8.0',
+        version: '3.8.0',
+        runtime: 'Quarkus',
+        catalogs: {},
+      },
+      {
+        name: 'Camel Spring Boot 4.10.0',
+        version: '4.10.0',
+        runtime: 'Spring Boot',
+        catalogs: {},
+      },
+      {
+        name: 'Citrus 4.10.1',
+        version: '4.10.1',
+        runtime: 'Citrus',
+        catalogs: {},
+      },
+    ] as unknown as CatalogLibraryEntry[],
+    version: 0,
+    name: '',
+  };
+
+  const mockSchema: KaotoSchemaDefinition['schema'] = {
+    title: 'Catalog Name',
+    description: 'Select a catalog',
+    type: 'string',
+  };
+
+  const createRuntimeContext = (catalogLibrary?: CatalogLibrary, selectedCatalog?: CatalogLibraryEntry) => ({
+    basePath: '/catalogs',
+    catalogLibrary,
+    selectedCatalog,
+    setSelectedCatalog: jest.fn(),
+  });
+
+  const renderWithProviders = (
+    component: React.ReactElement,
+    model = {},
+    onPropertyChange = jest.fn(),
+    runtimeContext = createRuntimeContext(mockCatalogLibrary),
+  ) => {
+    return render(
+      <RuntimeContext.Provider value={runtimeContext}>
+        <ModelContextProvider model={model} onPropertyChange={onPropertyChange}>
+          <SchemaProvider schema={mockSchema}>{component}</SchemaProvider>
+        </ModelContextProvider>
+      </RuntimeContext.Provider>,
+    );
+  };
+
+  describe('RuntimeCatalogNameField', () => {
+    describe('Rendering', () => {
+      it('should render loading state when catalog library is not available', () => {
+        renderWithProviders(
+          <RuntimeCatalogNameField propName="runtimeCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(),
+        );
+
+        expect(screen.getByText('Loading catalogs...')).toBeInTheDocument();
+      });
+
+      it('should render with default catalog value', () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        expect(toggle).toBeInTheDocument();
+        expect(toggle).toHaveTextContent('Camel Main 4.14.5');
+      });
+
+      it('should render with stored value from model', () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />, {
+          runtimeCatalogName: 'Camel Quarkus 3.8.0',
+        });
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        expect(toggle).toHaveTextContent('Camel Quarkus 3.8.0');
+      });
+
+      it('should render schema title and description', () => {
+        const { container } = renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        expect(container.querySelector('label')).toHaveTextContent('Catalog Name');
+      });
+
+      it('should filter to only show integration runtimes', () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Should show Main, Quarkus, Spring Boot
+        expect(screen.getByText('Main')).toBeInTheDocument();
+        expect(screen.getByText('Quarkus')).toBeInTheDocument();
+        expect(screen.getByText('Spring Boot')).toBeInTheDocument();
+
+        // Should NOT show Citrus (testing runtime)
+        expect(screen.queryByText('Citrus')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Menu Interactions', () => {
+      it('should open menu when clicking toggle', async () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+          expect(screen.getByText('Camel Quarkus 3.8.0')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Camel Spring Boot 4.10.0')).toBeInTheDocument();
+      });
+
+      it('should close menu when clicking toggle again', async () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+
+        // Open menu
+        fireEvent.click(toggle);
+        await waitFor(() => {
+          expect(screen.getByText('Camel Quarkus 3.8.0')).toBeInTheDocument();
+        });
+
+        // Close menu
+        fireEvent.click(toggle);
+        await waitFor(() => {
+          expect(screen.queryByText('Camel Quarkus 3.8.0')).not.toBeInTheDocument();
+        });
+      });
+
+      it('should select catalog when clicking menu item', () => {
+        const onPropertyChange = jest.fn();
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />, {}, onPropertyChange);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        const quarkusOption = screen.getByText('Camel Quarkus 3.8.0');
+        fireEvent.click(quarkusOption);
+
+        expect(onPropertyChange).toHaveBeenCalledWith('runtimeCatalogName', 'Camel Quarkus 3.8.0');
+      });
+
+      it('should close menu after selecting an item', async () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        const quarkusOption = screen.getByText('Camel Quarkus 3.8.0');
+        fireEvent.click(quarkusOption);
+
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        });
+      });
+
+      it('should mark selected catalog in menu', async () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />, {
+          runtimeCatalogName: 'Camel Quarkus 3.8.0',
+        });
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+          const menuItems = screen.getAllByRole('menuitem');
+          expect(menuItems.length).toBeGreaterThan(0);
+        });
+
+        const menuItems = screen.getAllByRole('menuitem');
+        const quarkusOption = menuItems.find((item) => item.textContent === 'Camel Quarkus 3.8.0');
+        expect(quarkusOption).toBeDefined();
+        expect(quarkusOption).toHaveClass('pf-m-selected');
+
+        // Verify CheckIcon is present for selected item
+        const selectIcon = quarkusOption?.querySelector('.pf-v6-c-menu__item-select-icon svg');
+        expect(selectIcon).toBeInTheDocument();
+      });
+    });
+
+    describe('Runtime Grouping', () => {
+      it('should group catalogs by runtime', () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Check that runtime headers are present
+        expect(screen.getByText('Main')).toBeInTheDocument();
+        expect(screen.getByText('Quarkus')).toBeInTheDocument();
+        expect(screen.getByText('Spring Boot')).toBeInTheDocument();
+      });
+
+      it('should display catalogs under their runtime group', () => {
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Verify catalog items are present
+        expect(screen.getAllByText('Camel Main 4.14.5').length).toBeGreaterThan(0);
+        expect(screen.getByText('Camel Quarkus 3.8.0')).toBeInTheDocument();
+        expect(screen.getByText('Camel Spring Boot 4.10.0')).toBeInTheDocument();
+      });
+    });
+
+    describe('Edge Cases', () => {
+      it('should handle empty catalog library', () => {
+        const emptyCatalogLibrary: CatalogLibrary = {
+          definitions: [],
+          version: 0,
+          name: '',
+        };
+
+        renderWithProviders(
+          <RuntimeCatalogNameField propName="runtimeCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(emptyCatalogLibrary),
+        );
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Menu should be empty
+        expect(screen.queryByText('Main')).not.toBeInTheDocument();
+        expect(screen.queryByText('Quarkus')).not.toBeInTheDocument();
+      });
+
+      it('should handle catalog library with no matching runtimes', () => {
+        const nonMatchingCatalogLibrary: CatalogLibrary = {
+          definitions: [
+            {
+              name: 'Other Runtime 1.0.0',
+              version: '1.0.0',
+              runtime: 'Other',
+              catalogs: {},
+            } as unknown as CatalogLibraryEntry,
+          ],
+          version: 0,
+          name: '',
+        };
+
+        renderWithProviders(
+          <RuntimeCatalogNameField propName="runtimeCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(nonMatchingCatalogLibrary),
+        );
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Should not show the non-matching runtime
+        expect(screen.queryByText('Other')).not.toBeInTheDocument();
+      });
+
+      it('should not call onChange when selecting invalid catalog', async () => {
+        const onPropertyChange = jest.fn();
+        renderWithProviders(<RuntimeCatalogNameField propName="runtimeCatalogName" />, {}, onPropertyChange);
+
+        const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+          expect(screen.getByText('Camel Quarkus 3.8.0')).toBeInTheDocument();
+        });
+
+        // Click on the toggle again to close without selecting
+        fireEvent.click(toggle);
+
+        expect(onPropertyChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('TestingCatalogNameField', () => {
+    describe('Rendering', () => {
+      it('should render loading state when catalog library is not available', () => {
+        renderWithProviders(
+          <TestingCatalogNameField propName="testingCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(),
+        );
+
+        expect(screen.getByText('Loading catalogs...')).toBeInTheDocument();
+      });
+
+      it('should render with default catalog value', () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        expect(toggle).toBeInTheDocument();
+        expect(toggle).toHaveTextContent('Citrus 4.10.1');
+      });
+
+      it('should render with stored value from model', () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />, {
+          testingCatalogName: 'Citrus 4.10.1',
+        });
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        expect(toggle).toHaveTextContent('Citrus 4.10.1');
+      });
+
+      it('should filter to only show testing runtimes', () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Should show Citrus
+        expect(screen.getByText('Citrus')).toBeInTheDocument();
+
+        // Should NOT show integration runtimes
+        expect(screen.queryByText('Main')).not.toBeInTheDocument();
+        expect(screen.queryByText('Quarkus')).not.toBeInTheDocument();
+        expect(screen.queryByText('Spring Boot')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Menu Interactions', () => {
+      it('should open menu when clicking toggle', async () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+          expect(screen.getAllByText('Citrus 4.10.1').length).toBeGreaterThan(0);
+        });
+      });
+
+      it('should select catalog when clicking menu item', () => {
+        const onPropertyChange = jest.fn();
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />, {}, onPropertyChange);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        const [citrusOption] = screen.getAllByRole('menuitem', { name: 'Citrus 4.10.1' });
+        fireEvent.click(citrusOption);
+
+        expect(onPropertyChange).toHaveBeenCalledWith('testingCatalogName', 'Citrus 4.10.1');
+      });
+
+      it('should mark selected catalog in menu', async () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />, {
+          testingCatalogName: 'Citrus 4.10.1',
+        });
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+          expect(screen.getAllByText('Citrus 4.10.1').length).toBeGreaterThan(0);
+        });
+
+        const menuItems = screen.getAllByRole('menuitem');
+        const citrusOption = menuItems.find((item) => item.textContent === 'Citrus 4.10.1');
+        expect(citrusOption).toBeDefined();
+        expect(citrusOption).toHaveClass('pf-m-selected');
+
+        // Verify CheckIcon is present for selected item
+        const selectIcon = citrusOption?.querySelector('.pf-v6-c-menu__item-select-icon svg');
+        expect(selectIcon).toBeInTheDocument();
+      });
+    });
+
+    describe('Runtime Grouping', () => {
+      it('should group catalogs by runtime', () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Check that Citrus runtime header is present
+        expect(screen.getByText('Citrus')).toBeInTheDocument();
+      });
+
+      it('should display catalogs under their runtime group', () => {
+        renderWithProviders(<TestingCatalogNameField propName="testingCatalogName" />);
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Verify catalog item is present
+        expect(screen.getAllByText('Citrus 4.10.1').length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('Edge Cases', () => {
+      it('should handle empty catalog library', () => {
+        const emptyCatalogLibrary: CatalogLibrary = {
+          definitions: [],
+          version: 0,
+          name: '',
+        };
+
+        renderWithProviders(
+          <TestingCatalogNameField propName="testingCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(emptyCatalogLibrary),
+        );
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Menu should be empty
+        expect(screen.queryByText('Citrus')).not.toBeInTheDocument();
+      });
+
+      it('should handle catalog library with no matching runtimes', () => {
+        const nonMatchingCatalogLibrary: CatalogLibrary = {
+          definitions: [
+            {
+              name: 'Camel Main 4.14.5',
+              version: '4.14.5',
+              runtime: 'Main',
+              catalogs: {},
+            } as unknown as CatalogLibraryEntry,
+          ],
+          version: 0,
+          name: '',
+        };
+
+        renderWithProviders(
+          <TestingCatalogNameField propName="testingCatalogName" />,
+          {},
+          jest.fn(),
+          createRuntimeContext(nonMatchingCatalogLibrary),
+        );
+
+        const toggle = screen.getByTestId('testingCatalogName-catalog-selector-toggle');
+        fireEvent.click(toggle);
+
+        // Should not show the non-matching runtime
+        expect(screen.queryByText('Main')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Multiple Catalogs per Runtime', () => {
+    it('should display multiple catalogs for the same runtime', () => {
+      const multiCatalogLibrary: CatalogLibrary = {
+        definitions: [
+          {
+            name: 'Camel Main 4.14.5',
+            version: '4.14.5',
+            runtime: 'Main',
+            catalogs: {},
+          },
+          {
+            name: 'Camel Main 4.13.0',
+            version: '4.13.0',
+            runtime: 'Main',
+            catalogs: {},
+          },
+          {
+            name: 'Camel Main 4.12.0',
+            version: '4.12.0',
+            runtime: 'Main',
+            catalogs: {},
+          },
+        ] as unknown as CatalogLibraryEntry[],
+        version: 0,
+        name: '',
+      };
+
+      renderWithProviders(
+        <RuntimeCatalogNameField propName="runtimeCatalogName" />,
+        {},
+        jest.fn(),
+        createRuntimeContext(multiCatalogLibrary),
+      );
+
+      const toggle = screen.getByTestId('runtimeCatalogName-catalog-selector-toggle');
+      fireEvent.click(toggle);
+
+      // All three versions should be displayed under Main runtime
+      expect(screen.getAllByText('Camel Main 4.14.5').length).toBeGreaterThan(0);
+      expect(screen.getByText('Camel Main 4.13.0')).toBeInTheDocument();
+      expect(screen.getByText('Camel Main 4.12.0')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.tsx
@@ -1,0 +1,146 @@
+import './CatalogSelectorField.scss';
+
+import { CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { FieldProps, FieldWrapper, SchemaContext, useFieldValue } from '@kaoto/forms';
+import { Menu, MenuContainer, MenuContent, MenuGroup, MenuItem, MenuToggle } from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useContext, useMemo, useRef, useState } from 'react';
+
+import { useRuntimeContext } from '../../../../../../hooks/useRuntimeContext/useRuntimeContext';
+import { SourceSchemaType } from '../../../../../../models/camel/source-schema-type';
+import { findCatalog } from '../../../../../../utils/catalog-helper';
+import { getRuntimeIcon } from '../../../../../Icons/RuntimeIcon';
+
+interface ICatalogSelectorField extends FieldProps {
+  schemaType: SourceSchemaType;
+  validRuntimes: string[];
+}
+
+const CatalogSelectorField: FunctionComponent<ICatalogSelectorField> = ({
+  propName,
+  required,
+  schemaType,
+  validRuntimes,
+}) => {
+  const { schema } = useContext(SchemaContext);
+  const { value: storedValue, onChange, disabled } = useFieldValue<string | undefined>(propName);
+  const { catalogLibrary } = useRuntimeContext();
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  const catalogOptions = useMemo(() => {
+    return (catalogLibrary?.definitions ?? []).filter((catalog) => validRuntimes.includes(catalog.runtime));
+  }, [catalogLibrary?.definitions, validRuntimes]);
+
+  const value = storedValue || findCatalog(schemaType, catalogLibrary)?.name;
+
+  // Group catalogs by runtime
+  const groupedCatalogs = useMemo(() => {
+    return catalogOptions.reduce(
+      (acc, catalog) => {
+        if (!acc[catalog.runtime]) {
+          acc[catalog.runtime] = [];
+        }
+        acc[catalog.runtime].push(catalog);
+        return acc;
+      },
+      {} as Record<string, CatalogLibraryEntry[]>,
+    );
+  }, [catalogOptions]);
+
+  const onSelect = useCallback(
+    (_event: unknown, catalogName: string | number | undefined) => {
+      if (!catalogName || typeof catalogName !== 'string') return;
+
+      onChange(catalogName);
+      setIsOpen(false);
+    },
+    [onChange],
+  );
+
+  // Handle loading state
+  if (!catalogLibrary) {
+    return (
+      <FieldWrapper
+        propName={propName}
+        required={required}
+        title={schema.title}
+        type="object"
+        description={schema.description}
+      >
+        <div>Loading catalogs...</div>
+      </FieldWrapper>
+    );
+  }
+
+  return (
+    <FieldWrapper
+      propName={propName}
+      required={required}
+      title={schema.title}
+      type="string"
+      description={schema.description}
+    >
+      <MenuContainer
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        menu={
+          <Menu ref={menuRef} onSelect={onSelect} className="cat-select-field">
+            <MenuContent>
+              {Object.entries(groupedCatalogs).map(([runtime, catalogs]) => (
+                <MenuGroup
+                  key={runtime}
+                  label={
+                    <li className="pf-v6-c-menu__list-item dropdown-title pf-v6-c-menu__item" role="none">
+                      {getRuntimeIcon(runtime)} {runtime}
+                    </li>
+                  }
+                >
+                  {catalogs.map((catalog) => (
+                    <MenuItem
+                      key={catalog.name}
+                      itemId={catalog.name}
+                      isSelected={value === catalog.name}
+                      selected={value === catalog.name}
+                    >
+                      {catalog.name}
+                    </MenuItem>
+                  ))}
+                </MenuGroup>
+              ))}
+            </MenuContent>
+          </Menu>
+        }
+        menuRef={menuRef}
+        toggle={
+          <MenuToggle
+            ref={toggleRef}
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            isDisabled={disabled}
+            isFullWidth
+            data-testid={`${propName}-catalog-selector-toggle`}
+          >
+            {getRuntimeIcon(value)}
+            <span className="runtime-selector pf-v6-u-m-sm">{value}</span>
+          </MenuToggle>
+        }
+        toggleRef={toggleRef}
+        popperProps={{
+          minWidth: 'trigger',
+          width: 'max-content',
+        }}
+      />
+    </FieldWrapper>
+  );
+};
+
+const INTEGRATION_RUNTIMES = ['Main', 'Quarkus', 'Spring Boot'];
+export const RuntimeCatalogNameField: FunctionComponent<FieldProps> = (props) => (
+  <CatalogSelectorField schemaType={SourceSchemaType.Route} validRuntimes={INTEGRATION_RUNTIMES} {...props} />
+);
+
+const TESTING_RUNTIMES = ['Citrus'];
+export const TestingCatalogNameField: FunctionComponent<FieldProps> = (props) => (
+  <CatalogSelectorField schemaType={SourceSchemaType.Test} validRuntimes={TESTING_RUNTIMES} {...props} />
+);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
@@ -1,5 +1,4 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { EnumField, TextAreaField } from '@kaoto/forms';
 
 import { ICamelComponentDefinition } from '../../../../../models/camel/camel-components-catalog';
@@ -9,6 +8,7 @@ import { CamelCatalogService } from '../../../../../models/visualization/flows/c
 import { getFirstCatalogMap } from '../../../../../stubs/test-load-catalog';
 import { CustomMediaTypes } from './ArrayBadgesField/CustomMediaTypes';
 import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
+import { RuntimeCatalogNameField, TestingCatalogNameField } from './CatalogSelectorField/CatalogSelectorField';
 import { customFieldsFactoryfactory } from './custom-fields-factory';
 import { DirectEndpointNameField } from './DirectEndpointNameField';
 import { EndpointField } from './EndpointField/EndpointField';
@@ -22,7 +22,7 @@ describe('customFieldsFactoryfactory', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
 
   beforeEach(async () => {
-    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary);
     componentCatalogMap = catalogsMap.componentCatalogMap;
 
     CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
@@ -238,5 +238,21 @@ describe('customFieldsFactoryfactory', () => {
     };
     const result = customFieldsFactoryfactory(schema);
     expect(result).toBe(EndpointListField);
+  });
+
+  it('returns RuntimeCatalogNameField for runtime field', () => {
+    const result = customFieldsFactoryfactory({
+      type: 'string',
+      title: 'Integrations runtime version',
+    });
+    expect(result).toBe(RuntimeCatalogNameField);
+  });
+
+  it('returns TestingCatalogNameField for runtime field', () => {
+    const result = customFieldsFactoryfactory({
+      type: 'string',
+      title: 'Testing runtime version',
+    });
+    expect(result).toBe(TestingCatalogNameField);
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -2,6 +2,7 @@ import { CustomFieldsFactory, EnumField, TextAreaField } from '@kaoto/forms';
 
 import { CustomMediaTypes } from './ArrayBadgesField/CustomMediaTypes';
 import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './BeanField/BeanField';
+import { RuntimeCatalogNameField, TestingCatalogNameField } from './CatalogSelectorField/CatalogSelectorField';
 import { DirectEndpointNameField } from './DirectEndpointNameField';
 import { EndpointField } from './EndpointField/EndpointField';
 import { EndpointListField } from './EndpointField/EndpointListField';
@@ -77,10 +78,26 @@ const isTextAreaField = (schema: Parameters<CustomFieldsFactory>[0]): boolean =>
   );
 };
 
+const isIntegrationRuntimeSelectorField = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {
+  return schema.type === 'string' && schema.title === 'Integrations runtime version';
+};
+
+const isTestingRuntimeSelectorField = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {
+  return schema.type === 'string' && schema.title === 'Testing runtime version';
+};
+
 export const customFieldsFactoryfactory: CustomFieldsFactory = (schema) => {
   /* Workaround for https://github.com/KaotoIO/kaoto/issues/2565 since the SNMP component has the wrong type */
   if (Array.isArray(schema.enum) && schema.enum.length > 0) {
     return EnumField;
+  }
+
+  if (isIntegrationRuntimeSelectorField(schema)) {
+    return RuntimeCatalogNameField;
+  }
+
+  if (isTestingRuntimeSelectorField(schema)) {
+    return TestingCatalogNameField;
   }
 
   if (isDirectEndpointName(schema)) {

--- a/packages/ui/src/utils/catalog-helper.test.ts
+++ b/packages/ui/src/utils/catalog-helper.test.ts
@@ -30,12 +30,17 @@ describe('CatalogHelper', () => {
           fileName: 'citrus/1.0.0/index.js',
         },
       ],
-    } as CatalogLibrary;
+    };
   });
 
   it('should handle no matching Camel catalog', () => {
     const entry = findCatalog(SourceSchemaType.Route, catalogLibrary);
-    expect(entry).toBeUndefined();
+    expect(entry).toEqual({
+      fileName: 'camel-main/index.js',
+      name: 'Camel Main 1.0.0',
+      runtime: 'Main',
+      version: '1.0.0',
+    });
   });
 
   it('should find matching Camel catalog', () => {

--- a/packages/ui/src/utils/catalog-helper.ts
+++ b/packages/ui/src/utils/catalog-helper.ts
@@ -30,7 +30,16 @@ export const findCatalog = (sourceType: SourceSchemaType, catalogLibrary?: Catal
         versionCompare(c1.version.split('.redhat')[0], c2.version.split('.redhat')[0]),
       );
 
-    return redhatMainCatalogs.length > 0 ? redhatMainCatalogs[0] : undefined;
+    if (redhatMainCatalogs.length > 0) {
+      return redhatMainCatalogs[0];
+    }
+
+    // Fallback to any Main catalog if no redhat catalog is found
+    const mainCatalogs = catalogLibrary.definitions
+      .filter((c: CatalogLibraryEntry) => c.runtime === 'Main')
+      .sort((c1: CatalogLibraryEntry, c2: CatalogLibraryEntry) => versionCompare(c1.version, c2.version));
+
+    return mainCatalogs.length > 0 ? mainCatalogs[0] : undefined;
   }
 };
 


### PR DESCRIPTION
### Context
As part of migrating the catalog version settings from LocalStorage to the Settings infrastructure, we need to add 2 additional fields to the settings schema.

Based on https://github.com/KaotoIO/kaoto/pull/3218 from @PVinaches, we're extracting the Settings components and related logic to this pull request.

Considering this is a multi pull request process, the fist step is to add the fields hidden and leverage them in an upcoming PR.

### Screenshots
<img width="1374" height="175" alt="image" src="https://github.com/user-attachments/assets/728b4b74-e894-470a-8c13-4d48ad77da11" />


relates: https://github.com/KaotoIO/kaoto/issues/3230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime and testing catalog configuration options in settings
  * New catalog selector fields with runtime filtering and visual icons for easier catalog selection

* **Improvements**
  * Enhanced error handling in settings with on-screen error alerts for save failures
  * Improved visual styling for runtime icons and catalog selector UI
  * Added informational alerts for pending catalog URL changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->