### PR TITLE
fix(DataMapper): abstract field indentation

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
@@ -7,13 +7,7 @@ import { FunctionComponent } from 'react';
 import OptIcon from '../../../assets/data-mapper/field-icons/OptIcon';
 import Repeat0Icon from '../../../assets/data-mapper/field-icons/Repeat0Icon';
 import Repeat1Icon from '../../../assets/data-mapper/field-icons/Repeat1Icon';
-import {
-  AbstractFieldNodeData,
-  AddMappingNodeData,
-  FieldItemNodeData,
-  FieldNodeData,
-  TargetAbstractFieldNodeData,
-} from '../../../models/datamapper/visualization';
+import { AddMappingNodeData, FieldItemNodeData, FieldNodeData } from '../../../models/datamapper/visualization';
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
 import { getOverrideDisplayInfo } from '../actions/FieldOverride/override-util';
 
@@ -34,9 +28,7 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({
 }) => {
   const isChoiceWrapper = VisualizationUtilService.isUnselectedChoiceField(nodeData);
   const isSelectedChoiceWrapper = VisualizationUtilService.isSelectedNestedChoice(nodeData);
-  const isAbstractWrapper =
-    (nodeData instanceof AbstractFieldNodeData || nodeData instanceof TargetAbstractFieldNodeData) &&
-    !nodeData.abstractField;
+  const isAbstractWrapper = VisualizationUtilService.isUnselectedAbstractField(nodeData);
   const hasNoCandidates = isAbstractWrapper && (nodeData.field.fields ?? []).length === 0;
   const optionalField = nodeData.field.minOccurs === 0;
   const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
@@ -73,7 +65,7 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({
         </div>
       }
     >
-      <div className="node-title-container">
+      <div className={clsx('node-title-container', { 'node-title-container__abstract': isAbstractWrapper })}>
         {isChoiceWrapper && <Label>choice</Label>}
         {isSelectedChoiceWrapper && (
           <Label color="green" icon={<CheckIcon />}>

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
@@ -32,6 +32,10 @@ div.node-title-container {
   align-items: center;
   overflow: hidden;
   min-width: 0;
+
+  &__abstract {
+    margin-left: calc(0.875rem + 2 * var(--pf-t--global--spacer--sm));
+  }
 }
 
 .datamapper-marker-field {

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -139,6 +139,16 @@ export class VisualizationUtilService {
   }
 
   /**
+   * Returns `true` if the node is an abstract field without a selected substitution member
+   * @param nodeData - The node to test.
+   */
+  static isUnselectedAbstractField(
+    nodeData: NodeData,
+  ): nodeData is AbstractFieldNodeData | TargetAbstractFieldNodeData {
+    return VisualizationUtilService.isAbstractField(nodeData) && !nodeData.abstractField;
+  }
+
+  /**
    * Returns `true` if the node represents a recursive field reference (self-referencing type).
    * @param nodeData - The node to test.
    */


### PR DESCRIPTION
Resolves: [#3199](https://github.com/KaotoIO/kaoto/issues/3199)

<img width="689" height="582" alt="Screenshot 2026-05-22 at 15 50 52" src="https://github.com/user-attachments/assets/0be11964-66ed-408f-b101-3384d56b9b95" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for abstract field titles so indented abstract titles align consistently.

* **Refactor**
  * Simplified abstract-field detection and reduced internal imports.
  * Component now applies abstract styling only when the field is an unselected abstract, ensuring correct title rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->