### PR TITLE
fix(canvas): route created from an empty canvas doesn’t align centrally

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -48,7 +48,6 @@ import { FlowService } from './flow.service';
 interface CanvasProps {
   vizNodes: IVisualizationNode[];
   entitiesCount: number;
-  /** When true, root viz nodes are not ready yet; avoid empty-state for "all flows hidden" during async resolution. */
   isVizNodesResolving?: boolean;
   contextToolbar?: ReactNode;
 }
@@ -81,9 +80,9 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   const controller = useVisualizationController();
   const shouldShowEmptyState = useMemo(() => {
     const areNoFlows = entitiesCount === 0;
-    const areAllFlowsHidden = vizNodes.length === 0 && entitiesCount > 0 && !isVizNodesResolving;
+    const areAllFlowsHidden = vizNodes.length === 0 && entitiesCount > 0;
     return areNoFlows || areAllFlowsHidden;
-  }, [entitiesCount, vizNodes.length, isVizNodesResolving]);
+  }, [entitiesCount, vizNodes.length]);
 
   const wasEmptyStateVisible = usePrevious(shouldShowEmptyState);
   const clearSelection = useCallback(() => {
@@ -96,6 +95,11 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   /** Draw graph */
   useEffect(() => {
     clearSelection();
+
+    if (isVizNodesResolving) {
+      return;
+    }
+
     const nodes: CanvasNode[] = [];
     const edges: CanvasEdge[] = [];
 
@@ -118,7 +122,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
       },
     };
 
-    if ((!initialized && !isVizNodesResolving) || wasEmptyStateVisible) {
+    if (!initialized || wasEmptyStateVisible) {
       controller.fromModel(model, false);
       setInitialized(true);
 
@@ -132,7 +136,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
     applyCollapseState(controller);
     controller.getGraph().layout();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [controller, vizNodes]);
+  }, [controller, vizNodes, isVizNodesResolving]);
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, setSelectedIds);
 
@@ -233,6 +237,10 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   );
 
   const isSidebarOpen = useMemo(() => selectedIds.length > 0, [selectedIds.length]);
+
+  if (isVizNodesResolving) {
+    return null;
+  }
 
   return (
     <TopologyView


### PR DESCRIPTION
Fixes #3239 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty-state detection so visualizations correctly show when all flows are hidden during loading.
  * Suspended the canvas while data is resolving to avoid partial or unstable graph rendering.
  * Prevented rendering of the topology view during resolution to reduce flicker.
  * Simplified initialization/update behavior for smoother, more reliable topology updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->