### PR TITLE
chore(DataMapper): Abstract field UX redesign: UI mockup

### DIFF
--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.scss
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.scss
@@ -1,0 +1,92 @@
+.abstract-config-modal {
+  &__mode-options {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__mode-option {
+    padding: 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--pf-v6-global--palette--black-300);
+
+    &:hover {
+      background-color: var(--pf-v6-global--palette--black-150);
+    }
+
+    &--selected {
+      border-color: var(--pf-v6-global--palette--blue-300);
+      background-color: rgba(0, 102, 204, 0.04);
+    }
+  }
+
+  &__candidate-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  &__candidate-item {
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--pf-v6-global--palette--black-300);
+
+    &:hover {
+      background-color: var(--pf-v6-global--palette--black-150);
+    }
+  }
+
+  &__candidate-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__candidate-name {
+    font-weight: 500;
+    color: var(--pf-v6-global--palette--black-900);
+  }
+
+  &__candidate-type {
+    font-size: 0.75rem;
+    color: var(--pf-v6-global--palette--black-600);
+    font-family: var(--pf-t--global--font--family--mono);
+    padding: 0.125rem 0.5rem;
+    background-color: var(--pf-v6-global--palette--black-200);
+    border-radius: 3px;
+  }
+
+  &__candidate-description {
+    margin-top: 0.25rem;
+    margin-left: 1.5rem;
+    font-size: 0.8125rem;
+    color: var(--pf-v6-global--palette--black-600);
+  }
+
+  &__candidate-children {
+    margin-top: 0.125rem;
+    margin-left: 1.5rem;
+    font-size: 0.75rem;
+    color: var(--pf-v6-global--palette--black-500);
+    font-style: italic;
+  }
+
+  &__search {
+    margin-bottom: 0.5rem;
+  }
+
+  &__select-all {
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid var(--pf-v6-global--palette--black-300);
+  }
+
+  &__no-results {
+    font-style: italic;
+    color: var(--pf-v6-global--palette--black-500);
+    padding: 1rem;
+    text-align: center;
+  }
+}

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.tsx
@@ -1,0 +1,225 @@
+import './AbstractConfigModal.scss';
+
+import {
+  Button,
+  Checkbox,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Radio,
+  SearchInput,
+} from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+
+import { AbstractConfig, MockAbstractNode, MockFieldNode } from './mockAbstractData';
+
+interface AbstractConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (config: AbstractConfig) => void;
+  abstractNode: MockAbstractNode;
+  'data-testid'?: string;
+}
+
+interface CandidateItemProps {
+  candidate: MockFieldNode;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  selectionType: 'radio' | 'checkbox';
+}
+
+const CandidateItem: FunctionComponent<CandidateItemProps> = ({ candidate, isSelected, onSelect, selectionType }) => {
+  const childrenPreview = candidate.children
+    ? candidate.children.map((c) => ('displayName' in c ? c.displayName : '')).join(', ')
+    : undefined;
+
+  const label = (
+    <div className="abstract-config-modal__candidate-label">
+      <span className="abstract-config-modal__candidate-name">{candidate.displayName}</span>
+      <span className="abstract-config-modal__candidate-type">{candidate.type}</span>
+    </div>
+  );
+
+  return (
+    <div className="abstract-config-modal__candidate-item" data-testid={`candidate-${candidate.id}`}>
+      {selectionType === 'radio' ? (
+        <Radio
+          isChecked={isSelected}
+          name="candidate-selection"
+          onChange={() => onSelect(candidate.id)}
+          label={label}
+          id={`radio-${candidate.id}`}
+          data-testid={`radio-${candidate.id}`}
+        />
+      ) : (
+        <Checkbox
+          isChecked={isSelected}
+          onChange={() => onSelect(candidate.id)}
+          label={label}
+          id={`checkbox-${candidate.id}`}
+          data-testid={`checkbox-${candidate.id}`}
+        />
+      )}
+      {candidate.description && (
+        <div className="abstract-config-modal__candidate-description">{candidate.description}</div>
+      )}
+      {childrenPreview && <div className="abstract-config-modal__candidate-children">Fields: {childrenPreview}</div>}
+    </div>
+  );
+};
+
+export const AbstractConfigModal: FunctionComponent<AbstractConfigModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  abstractNode,
+  'data-testid': dataTestId = 'abstract-config-modal',
+}) => {
+  const [selectedSingle, setSelectedSingle] = useState<string | undefined>(undefined);
+  const [selectedMultiple, setSelectedMultiple] = useState<Set<string>>(new Set());
+  const [searchFilter, setSearchFilter] = useState('');
+
+  const isCollection = abstractNode.maxOccurs === -1 || abstractNode.maxOccurs > 1;
+  const useRadio = !isCollection;
+  const showSearch = abstractNode.candidates.length > 10;
+
+  const filteredCandidates = useMemo(() => {
+    if (!searchFilter) return abstractNode.candidates;
+    const lower = searchFilter.toLowerCase();
+    return abstractNode.candidates.filter((c) => c.displayName.toLowerCase().includes(lower));
+  }, [abstractNode.candidates, searchFilter]);
+
+  const handleSingleSelect = useCallback((id: string) => {
+    setSelectedSingle(id);
+  }, []);
+
+  const handleMultipleToggle = useCallback((id: string) => {
+    setSelectedMultiple((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(id)) {
+        newSet.delete(id);
+      } else {
+        newSet.add(id);
+      }
+      return newSet;
+    });
+  }, []);
+
+  const allFilteredSelected = useMemo(
+    () => filteredCandidates.length > 0 && filteredCandidates.every((c) => selectedMultiple.has(c.id)),
+    [filteredCandidates, selectedMultiple],
+  );
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedMultiple((prev) => {
+      const newSet = new Set(prev);
+      if (allFilteredSelected) {
+        for (const c of filteredCandidates) {
+          newSet.delete(c.id);
+        }
+      } else {
+        for (const c of filteredCandidates) {
+          newSet.add(c.id);
+        }
+      }
+      return newSet;
+    });
+  }, [allFilteredSelected, filteredCandidates]);
+
+  const handleConfirm = useCallback(() => {
+    if (useRadio && selectedSingle) {
+      onConfirm({ mode: 'static', selectedCandidateIds: [selectedSingle] });
+    } else if (!useRadio && selectedMultiple.size >= 1) {
+      onConfirm({ mode: 'static', selectedCandidateIds: Array.from(selectedMultiple) });
+    }
+  }, [useRadio, selectedSingle, selectedMultiple, onConfirm]);
+
+  const handleClose = useCallback(() => {
+    setSelectedSingle(undefined);
+    setSelectedMultiple(new Set());
+    setSearchFilter('');
+    onClose();
+  }, [onClose]);
+
+  const isConfirmDisabled = useRadio ? !selectedSingle : selectedMultiple.size < 1;
+
+  const title = isCollection ? 'Add Field(s)' : 'Add Field';
+  const description = isCollection
+    ? `Choose one or more concrete elements to place under ${abstractNode.elementName}`
+    : `Choose a concrete element to replace ${abstractNode.elementName}`;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      variant={ModalVariant.medium}
+      onClose={handleClose}
+      data-testid={dataTestId}
+      ouiaId="AbstractConfigModal"
+    >
+      <ModalHeader title={title} description={description} />
+      <ModalBody>
+        {showSearch && (
+          <div className="abstract-config-modal__search">
+            <SearchInput
+              placeholder="Filter candidates..."
+              value={searchFilter}
+              onChange={(_event, value) => setSearchFilter(value)}
+              onClear={() => setSearchFilter('')}
+              data-testid={`${dataTestId}-search`}
+            />
+          </div>
+        )}
+        {!useRadio && (
+          <div className="abstract-config-modal__select-all">
+            <Checkbox
+              isChecked={allFilteredSelected}
+              onChange={handleSelectAll}
+              label={showSearch && searchFilter ? `Select all matching (${filteredCandidates.length})` : 'Select all'}
+              id="select-all"
+              data-testid={`${dataTestId}-select-all`}
+            />
+          </div>
+        )}
+        <div className="abstract-config-modal__candidate-list">
+          {filteredCandidates.map((candidate) => (
+            <CandidateItem
+              key={candidate.id}
+              candidate={candidate}
+              isSelected={useRadio ? selectedSingle === candidate.id : selectedMultiple.has(candidate.id)}
+              onSelect={useRadio ? handleSingleSelect : handleMultipleToggle}
+              selectionType={useRadio ? 'radio' : 'checkbox'}
+            />
+          ))}
+          {filteredCandidates.length === 0 && (
+            <p className="abstract-config-modal__no-results">No candidates match the filter.</p>
+          )}
+        </div>
+        {!useRadio && (
+          <HelperText>
+            <HelperTextItem variant={selectedMultiple.size < 1 ? 'warning' : 'default'}>
+              Select at least 1 candidate ({selectedMultiple.size} selected)
+            </HelperTextItem>
+          </HelperText>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="confirm"
+          variant="primary"
+          onClick={handleConfirm}
+          isDisabled={isConfirmDisabled}
+          data-testid={`${dataTestId}-confirm-btn`}
+        >
+          Confirm
+        </Button>
+        <Button key="cancel" variant="link" onClick={handleClose} data-testid={`${dataTestId}-cancel-btn`}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractMockup.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractMockup.stories.tsx
@@ -1,0 +1,240 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { FunctionComponent, useCallback, useRef, useState } from 'react';
+
+import { AbstractInstance, AbstractTreeMock } from './AbstractTreeMock';
+import {
+  MockAbstractTreeNode,
+  MockInstruction,
+  mockManyRoot,
+  mockZooCollection,
+  mockZooSingle,
+} from './mockAbstractData';
+
+export default {
+  title: 'UI Mockups/DataMapper/Abstract Field Mockup',
+  component: AbstractTreeMock,
+} as Meta<typeof AbstractTreeMock>;
+
+interface TemplateArgs {
+  mockData: MockAbstractTreeNode;
+  initialSubstitutions?: Record<string, AbstractInstance[]>;
+}
+
+const Template: FunctionComponent<TemplateArgs> = (args) => {
+  const [substitutions, setSubstitutions] = useState<Record<string, AbstractInstance[]>>(
+    args.initialSubstitutions || {},
+  );
+  const [instructions, setInstructions] = useState<Record<string, MockInstruction[]>>({});
+  const instructionCounterRef = useRef(0);
+
+  const handleSelectSubstitute = useCallback((abstractId: string, instanceId: string, candidateId: string) => {
+    setSubstitutions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      const updated = existing.map((inst) => (inst.instanceId === instanceId ? { ...inst, candidateId } : inst));
+      const found = updated.some((inst) => inst.instanceId === instanceId);
+      if (!found) {
+        updated.push({ instanceId, candidateId });
+      }
+      return { ...prev, [abstractId]: updated };
+    });
+  }, []);
+
+  const handleClearSubstitution = useCallback((abstractId: string, instanceId: string) => {
+    setSubstitutions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      if (existing.length === 1 && existing[0].instanceId === instanceId) {
+        const newSubs = { ...prev };
+        delete newSubs[abstractId];
+        return newSubs;
+      }
+      return {
+        ...prev,
+        [abstractId]: existing.map((inst) =>
+          inst.instanceId === instanceId ? { ...inst, candidateId: undefined } : inst,
+        ),
+      };
+    });
+  }, []);
+
+  const handleDuplicate = useCallback((abstractId: string, sourceInstanceId?: string) => {
+    setSubstitutions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      if (!sourceInstanceId) {
+        return {
+          ...prev,
+          [abstractId]: [
+            ...existing,
+            { instanceId: `inst-orig-${Date.now()}` },
+            { instanceId: `inst-dup-${Date.now() + 1}` },
+          ],
+        };
+      }
+      const source = existing.find((inst) => inst.instanceId === sourceInstanceId);
+      return {
+        ...prev,
+        [abstractId]: [...existing, { instanceId: `inst-dup-${Date.now()}`, candidateId: source?.candidateId }],
+      };
+    });
+  }, []);
+
+  const handleRemoveInstance = useCallback((abstractId: string, instanceId: string) => {
+    setSubstitutions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      const updated = existing.filter((inst) => inst.instanceId !== instanceId);
+      if (updated.length === 0) {
+        const newSubs = { ...prev };
+        delete newSubs[abstractId];
+        return newSubs;
+      }
+      return { ...prev, [abstractId]: updated };
+    });
+  }, []);
+
+  const handleAddInstruction = useCallback((abstractId: string, kind: string, initialFieldIds?: string[]) => {
+    const uid = `${Date.now()}-${instructionCounterRef.current++}`;
+    let newInstruction: MockInstruction;
+    const showAbstract = initialFieldIds !== undefined && initialFieldIds.length === 0;
+    if (kind === 'choose') {
+      newInstruction = {
+        id: `choose-${uid}`,
+        kind: 'choose',
+        children: [
+          { id: `when-${uid}`, kind: 'when', initialFieldIds, showAbstractField: showAbstract },
+          { id: `otherwise-${uid}`, kind: 'otherwise' },
+        ],
+      };
+    } else {
+      newInstruction = {
+        id: `${kind}-${uid}`,
+        kind: kind as MockInstruction['kind'],
+        initialFieldIds,
+        showAbstractField: showAbstract,
+      };
+    }
+    setInstructions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      return { ...prev, [abstractId]: [...existing, newInstruction] };
+    });
+  }, []);
+
+  const handleRemoveInstruction = useCallback((abstractId: string, instructionId: string) => {
+    setInstructions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      return { ...prev, [abstractId]: existing.filter((i) => i.id !== instructionId) };
+    });
+  }, []);
+
+  const handleWrapInstruction = useCallback((abstractId: string, instructionId: string, kind: string) => {
+    setInstructions((prev) => {
+      const existing = prev[abstractId] ?? [];
+      const target = existing.find((i) => i.id === instructionId);
+      if (!target) return prev;
+
+      const uid = `${Date.now()}-${instructionCounterRef.current++}`;
+      let wrapper: MockInstruction;
+      if (kind === 'choose') {
+        wrapper = {
+          id: `choose-${uid}`,
+          kind: 'choose',
+          children: [
+            { id: `when-${uid}`, kind: 'when', children: [target] },
+            { id: `otherwise-${uid}`, kind: 'otherwise' },
+          ],
+        };
+      } else {
+        wrapper = {
+          id: `${kind}-${uid}`,
+          kind: kind as MockInstruction['kind'],
+          children: [target],
+        };
+      }
+      return { ...prev, [abstractId]: existing.map((i) => (i.id === instructionId ? wrapper : i)) };
+    });
+  }, []);
+
+  return (
+    <AbstractTreeMock
+      treeNode={args.mockData}
+      substitutions={substitutions}
+      onSelectSubstitute={handleSelectSubstitute}
+      onClearSubstitution={handleClearSubstitution}
+      onDuplicate={handleDuplicate}
+      onRemoveInstance={handleRemoveInstance}
+      instructions={instructions}
+      onAddInstruction={handleAddInstruction}
+      onRemoveInstruction={handleRemoveInstruction}
+      onWrapInstruction={handleWrapInstruction}
+      data-testid="abstract-tree-root"
+    />
+  );
+};
+
+export const SingleOccurrence: StoryFn = () => {
+  return (
+    <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+      <h2 style={{ marginBottom: '0.5rem' }}>maxOccurs=1</h2>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        Abstract fields render as regular field nodes with an <code>abstract</code> badge and candidate list. No
+        children are rendered until the user selects a substitute via the right-click context menu.
+      </p>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        When <code>maxOccurs=1</code>, selecting a substitute hides the abstract wrapper and renders the candidate
+        directly as a regular field. Right-click the substituted field to &quot;Clear substitution&quot;.
+      </p>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        <strong>Try it:</strong> Right-click AbstractLabel → &quot;Select substitute&quot; → pick Nickname. The wrapper
+        disappears and Nickname renders directly. Right-click Nickname → &quot;Clear substitution&quot; to revert.
+      </p>
+      <div style={{ backgroundColor: 'white', padding: '1rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+        <Template mockData={mockZooSingle} />
+      </div>
+    </div>
+  );
+};
+SingleOccurrence.storyName = 'maxOccurs=1';
+
+export const Collection: StoryFn = () => {
+  return (
+    <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+      <h2 style={{ marginBottom: '0.5rem' }}>maxOccurs &gt; 1</h2>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        When <code>maxOccurs &gt; 1</code> (collection), the abstract wrapper stays visible after substitution.
+        Right-click to &quot;Select substitute&quot; or &quot;Duplicate&quot; for more instances. Each instance is
+        independently substitutable.
+      </p>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        Mapping instructions (for-each, choose-when-otherwise) are available via the 3-dot menu (&#8942;). The
+        instruction wraps the abstract field — the abstract node renders inside it.
+      </p>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        <strong>Try it:</strong> Right-click AbstractAnimal → &quot;Select substitute&quot; → pick Cat. Then right-click
+        AbstractAnimal again → &quot;Duplicate&quot; to create an unsubstituted sibling. Or click &#8942; → &quot;Wrap
+        with for-each&quot; to wrap it with an instruction.
+      </p>
+      <div style={{ backgroundColor: 'white', padding: '1rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+        <Template mockData={mockZooCollection} />
+      </div>
+    </div>
+  );
+};
+Collection.storyName = 'maxOccurs>1';
+
+export const ManyCandidates: StoryFn = () => {
+  return (
+    <div style={{ padding: '2rem', backgroundColor: '#f5f5f5' }}>
+      <h2 style={{ marginBottom: '0.5rem' }}>Many Candidates</h2>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        An abstract element with over 200 substitution candidates. The &quot;Select substitute&quot; modal includes a
+        search/filter input to handle large candidate lists efficiently.
+      </p>
+      <p style={{ marginBottom: '1rem', color: '#666', maxWidth: '800px' }}>
+        <strong>Try it:</strong> Right-click AbstractMessage → &quot;Select substitute&quot; → use the search input to
+        filter through 200 candidates.
+      </p>
+      <div style={{ backgroundColor: 'white', padding: '1rem', borderRadius: '4px', border: '1px solid #ccc' }}>
+        <Template mockData={mockManyRoot} />
+      </div>
+    </div>
+  );
+};
+ManyCandidates.storyName = 'Many Candidates';

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.scss
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.scss
@@ -1,0 +1,114 @@
+.abstract-tree {
+  &__empty-state {
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+    padding: 0.5rem;
+  }
+
+  &__empty-text {
+    font-style: italic;
+    color: var(--pf-v6-global--palette--black-500);
+    font-size: 0.8125rem;
+  }
+
+  &__conditional-row {
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+    padding: 0.25rem 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__test-input {
+    max-width: 12rem;
+    font-family: var(--pf-t--global--font--family--mono);
+    font-size: 0.8125rem;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0;
+
+    .pf-v6-c-button {
+      --pf-v6-c-button--FontSize: 0.75rem;
+    }
+  }
+
+  &__conditional-placeholder {
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+    padding: 0.25rem 0.5rem;
+  }
+
+  &__field-node {
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+    padding: 0.25rem 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &--pending {
+      border: 1px dashed var(--pf-v6-global--palette--black-400);
+      border-radius: 4px;
+      background: rgba(0, 0, 0, 0.02);
+    }
+  }
+
+  &__abstract-candidates {
+    font-style: italic;
+    font-size: 0.8125rem;
+    color: var(--pf-v6-global--palette--black-500);
+  }
+
+  &__mapping-actions {
+    margin-left: auto;
+  }
+
+  &__field-expand {
+    cursor: pointer;
+  }
+
+  &__field-expand-placeholder {
+    display: inline-block;
+    width: 1rem;
+  }
+
+  &__field-name {
+    color: var(--pf-v6-global--palette--black-800);
+  }
+
+  &__field-type {
+    font-size: 0.75rem;
+    color: var(--pf-v6-global--palette--black-500);
+    font-family: var(--pf-t--global--font--family--mono);
+  }
+
+  &__instruction-node {
+    margin-left: calc(var(--node-rank, 0) * 0.85rem);
+    padding: 0.25rem 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px dashed var(--pf-v6-global--palette--purple-300);
+    background: rgba(150, 80, 200, 0.04);
+    border-radius: 4px;
+    margin-bottom: 0.25rem;
+  }
+
+  &__instruction-input {
+    max-width: 14rem;
+    font-family: var(--pf-t--global--font--family--mono);
+    font-size: 0.8125rem;
+  }
+
+  &__instruction-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  &__right-click-menu {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    background: var(--pf-v6-global--BackgroundColor--100, #fff);
+  }
+}

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.tsx
@@ -1,0 +1,413 @@
+import './AbstractTreeMock.scss';
+
+import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+
+import { AddFieldCandidateModal } from './AddFieldCandidateModal';
+import { DocMenuItem, FieldRow, MappingMenuItem } from './FieldRow';
+import { InstructionNodeMock } from './InstructionNodeMock';
+import {
+  getAbstractDisplayName,
+  isAbstractNode,
+  MockAbstractNode,
+  MockAbstractTreeNode,
+  MockFieldNode,
+  MockInstruction,
+} from './mockAbstractData';
+
+export interface AbstractInstance {
+  instanceId: string;
+  candidateId?: string;
+}
+
+interface AbstractTreeMockProps {
+  treeNode: MockAbstractTreeNode;
+  rank?: number;
+  substitutions: Record<string, AbstractInstance[]>;
+  onSelectSubstitute: (abstractId: string, instanceId: string, candidateId: string) => void;
+  onClearSubstitution: (abstractId: string, instanceId: string) => void;
+  onDuplicate: (abstractId: string, sourceInstanceId?: string) => void;
+  onRemoveInstance: (abstractId: string, instanceId: string) => void;
+  instructions?: Record<string, MockInstruction[]>;
+  onAddInstruction?: (abstractId: string, kind: string, initialFieldIds?: string[]) => void;
+  onRemoveInstruction?: (abstractId: string, instructionId: string) => void;
+  onWrapInstruction?: (abstractId: string, instructionId: string, kind: string) => void;
+  'data-testid'?: string;
+}
+
+export const AbstractTreeMock: FunctionComponent<AbstractTreeMockProps> = ({
+  treeNode,
+  rank = 0,
+  substitutions,
+  onSelectSubstitute,
+  onClearSubstitution,
+  onDuplicate,
+  onRemoveInstance,
+  instructions,
+  onAddInstruction,
+  onRemoveInstruction,
+  onWrapInstruction,
+  'data-testid': dataTestId,
+}) => {
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(() => new Set<string>());
+
+  const toggleExpansion = useCallback((nodeId: string) => {
+    setExpandedNodes((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(nodeId)) {
+        newSet.delete(nodeId);
+      } else {
+        newSet.add(nodeId);
+      }
+      return newSet;
+    });
+  }, []);
+
+  if (isAbstractNode(treeNode)) {
+    return (
+      <AbstractNodeRenderer
+        abstractNode={treeNode}
+        rank={rank}
+        substitutions={substitutions}
+        onSelectSubstitute={onSelectSubstitute}
+        onClearSubstitution={onClearSubstitution}
+        onDuplicate={onDuplicate}
+        onRemoveInstance={onRemoveInstance}
+        instructions={instructions}
+        onAddInstruction={onAddInstruction}
+        onRemoveInstruction={onRemoveInstruction}
+        onWrapInstruction={onWrapInstruction}
+        expandedNodes={expandedNodes}
+        toggleExpansion={toggleExpansion}
+        data-testid={dataTestId || `abstract-${treeNode.id}`}
+      />
+    );
+  }
+
+  const fieldNode = treeNode as MockFieldNode;
+  const hasChildren = fieldNode.children && fieldNode.children.length > 0;
+  const isExpanded = expandedNodes.has(fieldNode.id) || (hasChildren && rank === 0);
+
+  return (
+    <FieldRow
+      rank={rank}
+      name={fieldNode.displayName}
+      typeOrCandidates={fieldNode.type}
+      showChoicesIcon={false}
+      expandable={hasChildren}
+      isExpanded={isExpanded}
+      onToggle={() => toggleExpansion(fieldNode.id)}
+      data-testid={dataTestId || `node-${fieldNode.id}`}
+    >
+      {fieldNode.children?.map((child) => (
+        <AbstractTreeMock
+          key={child.id}
+          treeNode={child}
+          rank={rank + 1}
+          substitutions={substitutions}
+          onSelectSubstitute={onSelectSubstitute}
+          onClearSubstitution={onClearSubstitution}
+          onDuplicate={onDuplicate}
+          onRemoveInstance={onRemoveInstance}
+          instructions={instructions}
+          onAddInstruction={onAddInstruction}
+          onRemoveInstruction={onRemoveInstruction}
+          onWrapInstruction={onWrapInstruction}
+          data-testid={`child-${child.id}`}
+        />
+      ))}
+    </FieldRow>
+  );
+};
+
+interface AbstractNodeRendererProps {
+  abstractNode: MockAbstractNode;
+  rank: number;
+  substitutions: Record<string, AbstractInstance[]>;
+  onSelectSubstitute: (abstractId: string, instanceId: string, candidateId: string) => void;
+  onClearSubstitution: (abstractId: string, instanceId: string) => void;
+  onDuplicate: (abstractId: string, sourceInstanceId?: string) => void;
+  onRemoveInstance: (abstractId: string, instanceId: string) => void;
+  instructions?: Record<string, MockInstruction[]>;
+  onAddInstruction?: (abstractId: string, kind: string, initialFieldIds?: string[]) => void;
+  onRemoveInstruction?: (abstractId: string, instructionId: string) => void;
+  onWrapInstruction?: (abstractId: string, instructionId: string, kind: string) => void;
+  expandedNodes: Set<string>;
+  toggleExpansion: (nodeId: string) => void;
+  'data-testid'?: string;
+}
+
+const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
+  abstractNode,
+  rank,
+  substitutions,
+  onSelectSubstitute,
+  onClearSubstitution,
+  onDuplicate,
+  onRemoveInstance,
+  instructions,
+  onAddInstruction,
+  onRemoveInstruction,
+  onWrapInstruction,
+  expandedNodes,
+  toggleExpansion,
+  'data-testid': dataTestId,
+}) => {
+  const isCollection = abstractNode.maxOccurs === -1 || abstractNode.maxOccurs > 1;
+  const instances = substitutions[abstractNode.id] ?? [];
+  const instructionList = instructions?.[abstractNode.id] ?? [];
+  const hasInstructions = instructionList.length > 0;
+  const hasInstances = instances.length > 0;
+
+  const [isSubstituteModalOpen, setIsSubstituteModalOpen] = useState(false);
+
+  const handleSelectSubstitute = useCallback(
+    (candidateId: string) => {
+      const instanceId = `inst-${Date.now()}`;
+      onSelectSubstitute(abstractNode.id, instanceId, candidateId);
+      setIsSubstituteModalOpen(false);
+    },
+    [abstractNode.id, onSelectSubstitute],
+  );
+
+  const handleAddInstructionWithFields = useCallback(
+    (abstractId: string, kind: string) => {
+      const fieldIds = instances.filter((i) => i.candidateId).map((i) => i.candidateId!);
+      onAddInstruction?.(abstractId, kind, fieldIds);
+    },
+    [instances, onAddInstruction],
+  );
+
+  const buildWrapActions = useCallback((): MappingMenuItem[] => {
+    const items: MappingMenuItem[] = [];
+    if (isCollection) {
+      items.push({
+        key: 'wrap-for-each',
+        label: 'Wrap with "for-each"',
+        onClick: () => handleAddInstructionWithFields(abstractNode.id, 'for-each'),
+      });
+    }
+    items.push({
+      key: 'wrap-if',
+      label: 'Wrap with "if"',
+      onClick: () => handleAddInstructionWithFields(abstractNode.id, 'if'),
+    });
+    items.push({
+      key: 'wrap-choose',
+      label: 'Wrap with "choose-when-otherwise"',
+      onClick: () => handleAddInstructionWithFields(abstractNode.id, 'choose'),
+    });
+    return items;
+  }, [abstractNode.id, isCollection, handleAddInstructionWithFields]);
+
+  const abstractRowDocItems = useMemo(
+    (): DocMenuItem[] => [
+      { key: 'select-sub', label: 'Select Substitution', onClick: () => setIsSubstituteModalOpen(true) },
+    ],
+    [],
+  );
+
+  const abstractRowMappingItems = useMemo((): MappingMenuItem[] => {
+    const items = buildWrapActions();
+    if (isCollection) {
+      items.push({ key: 'dup-field', label: 'Duplicate Field', onClick: () => onDuplicate(abstractNode.id) });
+    }
+    return items;
+  }, [abstractNode.id, isCollection, buildWrapActions, onDuplicate]);
+
+  const renderAbstractRow = (rowRank: number) => (
+    <FieldRow
+      rank={rowRank}
+      name={abstractNode.elementName}
+      typeOrCandidates={getAbstractDisplayName(abstractNode)}
+      isAbstract
+      isCollection={isCollection}
+      docMenuItems={abstractRowDocItems}
+      mappingMenuItems={abstractRowMappingItems}
+      data-testid={dataTestId}
+    />
+  );
+
+  const renderInstanceNodes = (instanceRank: number) =>
+    instances.map((inst) => {
+      const candidate = inst.candidateId ? abstractNode.candidates.find((c) => c.id === inst.candidateId) : undefined;
+
+      if (candidate) {
+        const docItems: DocMenuItem[] = [
+          {
+            key: 'clear-sub',
+            label: 'Clear Substitution',
+            onClick: () => onClearSubstitution(abstractNode.id, inst.instanceId),
+          },
+        ];
+        const mappingItems: MappingMenuItem[] = [...buildWrapActions()];
+        if (isCollection) {
+          mappingItems.push({
+            key: 'dup-field',
+            label: 'Duplicate Field',
+            onClick: () => onDuplicate(abstractNode.id, inst.instanceId),
+          });
+        }
+
+        const nodeKey = `${abstractNode.id}-${inst.instanceId}`;
+        const hasChildren = candidate.children && candidate.children.length > 0;
+        const isExpanded = expandedNodes.has(nodeKey);
+
+        return (
+          <FieldRow
+            key={inst.instanceId}
+            rank={instanceRank}
+            name={candidate.displayName}
+            typeOrCandidates={candidate.type}
+            isCollection={isCollection}
+            expandable={hasChildren}
+            isExpanded={isExpanded}
+            onToggle={() => toggleExpansion(nodeKey)}
+            docMenuItems={docItems}
+            mappingMenuItems={mappingItems}
+            onRemove={isCollection ? () => onRemoveInstance(abstractNode.id, inst.instanceId) : undefined}
+            data-testid={`substituted-${inst.instanceId}`}
+          >
+            {candidate.children?.map((child) => (
+              <AbstractTreeMock
+                key={child.id}
+                treeNode={child}
+                rank={instanceRank + 1}
+                substitutions={substitutions}
+                onSelectSubstitute={onSelectSubstitute}
+                onClearSubstitution={onClearSubstitution}
+                onDuplicate={onDuplicate}
+                onRemoveInstance={onRemoveInstance}
+                instructions={instructions}
+                onAddInstruction={onAddInstruction}
+                onRemoveInstruction={onRemoveInstruction}
+                onWrapInstruction={onWrapInstruction}
+                data-testid={`child-${child.id}`}
+              />
+            ))}
+          </FieldRow>
+        );
+      }
+
+      return (
+        <UnsubstitutedInstanceRow
+          key={inst.instanceId}
+          abstractNode={abstractNode}
+          instanceId={inst.instanceId}
+          rank={instanceRank}
+          isCollection={isCollection}
+          buildWrapActions={buildWrapActions}
+          onSelectSubstitute={onSelectSubstitute}
+          onDuplicate={onDuplicate}
+          onRemoveInstance={onRemoveInstance}
+        />
+      );
+    });
+
+  const substituteModal = isSubstituteModalOpen && (
+    <AddFieldCandidateModal
+      isOpen={isSubstituteModalOpen}
+      onClose={() => setIsSubstituteModalOpen(false)}
+      onConfirm={handleSelectSubstitute}
+      abstractNode={abstractNode}
+    />
+  );
+
+  if (hasInstructions) {
+    return (
+      <>
+        {instructionList.map((inst) => (
+          <InstructionNodeMock
+            key={inst.id}
+            instruction={inst}
+            rank={rank}
+            onRemove={() => onRemoveInstruction?.(abstractNode.id, inst.id)}
+            onDuplicateIf={
+              inst.kind === 'if'
+                ? (fieldIds) => {
+                    onAddInstruction?.(abstractNode.id, 'if', fieldIds);
+                  }
+                : undefined
+            }
+            onWrapWith={(kind) => onWrapInstruction?.(abstractNode.id, inst.id, kind)}
+            abstractNode={abstractNode}
+          />
+        ))}
+        {substituteModal}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {hasInstances ? renderInstanceNodes(rank) : renderAbstractRow(rank)}
+      {substituteModal}
+    </>
+  );
+};
+
+interface UnsubstitutedInstanceRowProps {
+  abstractNode: MockAbstractNode;
+  instanceId: string;
+  rank: number;
+  isCollection: boolean;
+  buildWrapActions: () => MappingMenuItem[];
+  onSelectSubstitute: (abstractId: string, instanceId: string, candidateId: string) => void;
+  onDuplicate: (abstractId: string, sourceInstanceId?: string) => void;
+  onRemoveInstance: (abstractId: string, instanceId: string) => void;
+}
+
+const UnsubstitutedInstanceRow: FunctionComponent<UnsubstitutedInstanceRowProps> = ({
+  abstractNode,
+  instanceId,
+  rank,
+  isCollection,
+  buildWrapActions,
+  onSelectSubstitute,
+  onDuplicate,
+  onRemoveInstance,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSelectSubstitute = useCallback(
+    (candidateId: string) => {
+      onSelectSubstitute(abstractNode.id, instanceId, candidateId);
+      setIsModalOpen(false);
+    },
+    [abstractNode.id, instanceId, onSelectSubstitute],
+  );
+
+  const docItems = useMemo(
+    (): DocMenuItem[] => [{ key: 'select-sub', label: 'Select Substitution', onClick: () => setIsModalOpen(true) }],
+    [],
+  );
+
+  const mappingItems = useMemo((): MappingMenuItem[] => {
+    const items = buildWrapActions();
+    items.push({ key: 'dup-field', label: 'Duplicate Field', onClick: () => onDuplicate(abstractNode.id, instanceId) });
+    return items;
+  }, [abstractNode.id, instanceId, buildWrapActions, onDuplicate]);
+
+  return (
+    <>
+      <FieldRow
+        rank={rank}
+        name={abstractNode.elementName}
+        typeOrCandidates={getAbstractDisplayName(abstractNode)}
+        isAbstract
+        isCollection={isCollection}
+        docMenuItems={docItems}
+        mappingMenuItems={mappingItems}
+        onRemove={() => onRemoveInstance(abstractNode.id, instanceId)}
+        data-testid={`unsubstituted-${instanceId}`}
+      />
+      {isModalOpen && (
+        <AddFieldCandidateModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          onConfirm={handleSelectSubstitute}
+          abstractNode={abstractNode}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AddFieldCandidateModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AddFieldCandidateModal.tsx
@@ -1,0 +1,118 @@
+import './AbstractConfigModal.scss';
+
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Radio,
+  SearchInput,
+} from '@patternfly/react-core';
+import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+
+import { MockAbstractNode, MockFieldNode } from './mockAbstractData';
+
+interface AddFieldCandidateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (candidateId: string) => void;
+  abstractNode: MockAbstractNode;
+}
+
+export const AddFieldCandidateModal: FunctionComponent<AddFieldCandidateModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  abstractNode,
+}) => {
+  const [selected, setSelected] = useState<string | undefined>(undefined);
+  const [searchFilter, setSearchFilter] = useState('');
+
+  const showSearch = abstractNode.candidates.length > 10;
+
+  const filteredCandidates = useMemo(() => {
+    if (!searchFilter) return abstractNode.candidates;
+    const lower = searchFilter.toLowerCase();
+    return abstractNode.candidates.filter((c) => c.displayName.toLowerCase().includes(lower));
+  }, [abstractNode.candidates, searchFilter]);
+
+  const handleConfirm = useCallback(() => {
+    if (selected) {
+      onConfirm(selected);
+      setSelected(undefined);
+      setSearchFilter('');
+    }
+  }, [selected, onConfirm]);
+
+  const handleClose = useCallback(() => {
+    setSelected(undefined);
+    setSearchFilter('');
+    onClose();
+  }, [onClose]);
+
+  const renderCandidate = (candidate: MockFieldNode) => {
+    const childrenPreview = candidate.children
+      ? candidate.children.map((c) => ('displayName' in c ? c.displayName : '')).join(', ')
+      : undefined;
+
+    const label = (
+      <div className="abstract-config-modal__candidate-label">
+        <span className="abstract-config-modal__candidate-name">{candidate.displayName}</span>
+        <span className="abstract-config-modal__candidate-type">{candidate.type}</span>
+      </div>
+    );
+
+    return (
+      <div key={candidate.id} className="abstract-config-modal__candidate-item">
+        <Radio
+          isChecked={selected === candidate.id}
+          name="add-field-candidate"
+          onChange={() => setSelected(candidate.id)}
+          label={label}
+          id={`add-field-radio-${candidate.id}`}
+        />
+        {candidate.description && (
+          <div className="abstract-config-modal__candidate-description">{candidate.description}</div>
+        )}
+        {childrenPreview && <div className="abstract-config-modal__candidate-children">Fields: {childrenPreview}</div>}
+      </div>
+    );
+  };
+
+  return (
+    <Modal isOpen={isOpen} variant={ModalVariant.medium} onClose={handleClose} ouiaId="AddFieldCandidateModal">
+      <ModalHeader
+        title="Add Field"
+        description={`Choose a concrete element to add under ${abstractNode.elementName}`}
+      />
+      <ModalBody>
+        {showSearch && (
+          <div className="abstract-config-modal__search">
+            <SearchInput
+              placeholder="Filter candidates..."
+              value={searchFilter}
+              onChange={(_event, value) => setSearchFilter(value)}
+              onClear={() => setSearchFilter('')}
+            />
+          </div>
+        )}
+        <div className="abstract-config-modal__candidate-list">
+          {filteredCandidates.map(renderCandidate)}
+          {filteredCandidates.length === 0 && (
+            <p className="abstract-config-modal__no-results">No candidates match the filter.</p>
+          )}
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="confirm" variant="primary" onClick={handleConfirm} isDisabled={!selected}>
+          Confirm
+        </Button>
+        <Button key="cancel" variant="link" onClick={handleClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/FieldRow.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/FieldRow.tsx
@@ -1,0 +1,208 @@
+import './AbstractTreeMock.scss';
+
+import { ChevronDown, ChevronRight, Choices } from '@carbon/icons-react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Icon,
+  Label,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import { EllipsisVIcon, LayerGroupIcon, TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent, MouseEvent, ReactNode, Ref, useCallback, useEffect, useState } from 'react';
+
+export interface DocMenuItem {
+  key: string;
+  label: string;
+  onClick: () => void;
+}
+
+export interface MappingMenuItem {
+  key: string;
+  label: string;
+  onClick: () => void;
+}
+
+interface FieldRowProps {
+  rank: number;
+  name: string;
+  typeOrCandidates: string;
+  isAbstract?: boolean;
+  isCollection?: boolean;
+  showChoicesIcon?: boolean;
+  expandable?: boolean;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  onRemove?: () => void;
+  docMenuItems?: DocMenuItem[];
+  mappingMenuItems?: MappingMenuItem[];
+  children?: ReactNode;
+  'data-testid'?: string;
+}
+
+export const FieldRow: FunctionComponent<FieldRowProps> = ({
+  rank,
+  name,
+  typeOrCandidates,
+  isAbstract,
+  isCollection,
+  showChoicesIcon = true,
+  expandable,
+  isExpanded,
+  onToggle,
+  onRemove,
+  docMenuItems,
+  mappingMenuItems,
+  children,
+  'data-testid': dataTestId,
+}) => {
+  const [docMenuOpen, setDocMenuOpen] = useState(false);
+  const [docMenuPos, setDocMenuPos] = useState({ x: 0, y: 0 });
+  const [mappingMenuOpen, setMappingMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (!docMenuOpen) return;
+    const close = () => setDocMenuOpen(false);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [docMenuOpen]);
+
+  const handleContextMenu = useCallback(
+    (e: MouseEvent) => {
+      if (!docMenuItems || docMenuItems.length === 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setDocMenuPos({ x: e.clientX, y: e.clientY });
+      setDocMenuOpen(true);
+    },
+    [docMenuItems],
+  );
+
+  const handleToggle = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onToggle?.();
+    },
+    [onToggle],
+  );
+
+  const renderMappingToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={(e) => {
+          e.stopPropagation();
+          setMappingMenuOpen((prev) => !prev);
+        }}
+        variant="plain"
+        isExpanded={mappingMenuOpen}
+        aria-label="Mapping actions"
+      >
+        <EllipsisVIcon />
+      </MenuToggle>
+    ),
+    [mappingMenuOpen],
+  );
+
+  const sectionClassName = isAbstract
+    ? 'abstract-tree__field-node abstract-tree__field-node--pending'
+    : 'abstract-tree__field-node';
+
+  return (
+    <>
+      <div className="node__container" data-testid={dataTestId}>
+        <section
+          className={sectionClassName}
+          style={{ '--node-rank': rank } as React.CSSProperties}
+          onContextMenu={handleContextMenu}
+        >
+          {expandable ? (
+            <Icon className="abstract-tree__field-expand" onClick={handleToggle}>
+              {isExpanded ? <ChevronDown /> : <ChevronRight />}
+            </Icon>
+          ) : (
+            <span className="abstract-tree__field-expand-placeholder" />
+          )}
+          {isAbstract && (
+            <Label isCompact variant="outline">
+              abstract
+            </Label>
+          )}
+          <span className="abstract-tree__field-name">{name}</span>
+          <span className={isAbstract ? 'abstract-tree__abstract-candidates' : 'abstract-tree__field-type'}>
+            {typeOrCandidates}
+          </span>
+          {isCollection && (
+            <Icon>
+              <LayerGroupIcon />
+            </Icon>
+          )}
+          {showChoicesIcon && (
+            <Icon>
+              <Choices />
+            </Icon>
+          )}
+          {(onRemove || (mappingMenuItems && mappingMenuItems.length > 0)) && (
+            <div className="abstract-tree__mapping-actions">
+              {mappingMenuItems && mappingMenuItems.length > 0 && (
+                <Dropdown
+                  onSelect={(e) => {
+                    e?.stopPropagation();
+                    setMappingMenuOpen(false);
+                  }}
+                  toggle={renderMappingToggle}
+                  isOpen={mappingMenuOpen}
+                  onOpenChange={setMappingMenuOpen}
+                  popperProps={{ position: 'end' }}
+                >
+                  <DropdownList>
+                    {mappingMenuItems.map((item) => (
+                      <DropdownItem key={item.key} onClick={item.onClick}>
+                        {item.label}
+                      </DropdownItem>
+                    ))}
+                  </DropdownList>
+                </Dropdown>
+              )}
+              {onRemove && (
+                <Button variant="plain" icon={<TrashIcon />} size="sm" onClick={onRemove} aria-label="Delete" />
+              )}
+            </div>
+          )}
+        </section>
+        {expandable && isExpanded && children && <div className="node__children">{children}</div>}
+      </div>
+      {docMenuOpen && docMenuItems && docMenuItems.length > 0 && (
+        <div
+          className="abstract-tree__right-click-menu"
+          style={{ position: 'fixed', left: docMenuPos.x, top: docMenuPos.y, zIndex: 9999 }}
+        >
+          <Menu>
+            <MenuContent>
+              <MenuList>
+                {docMenuItems.map((item) => (
+                  <MenuItem
+                    key={item.key}
+                    onClick={() => {
+                      item.onClick();
+                      setDocMenuOpen(false);
+                    }}
+                  >
+                    {item.label}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </MenuContent>
+          </Menu>
+        </div>
+      )}
+    </>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/InstructionNodeMock.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/InstructionNodeMock.tsx
@@ -1,0 +1,453 @@
+import './AbstractTreeMock.scss';
+
+import { ChevronDown, ChevronRight } from '@carbon/icons-react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Icon,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  TextInput,
+} from '@patternfly/react-core';
+import { EllipsisVIcon, TrashIcon } from '@patternfly/react-icons';
+import { FunctionComponent, Ref, useCallback, useMemo, useRef, useState } from 'react';
+
+import { AddFieldCandidateModal } from './AddFieldCandidateModal';
+import { DocMenuItem, FieldRow, MappingMenuItem } from './FieldRow';
+import { getAbstractDisplayName, MockAbstractNode, MockFieldNode, MockInstruction } from './mockAbstractData';
+
+interface InstructionNodeMockProps {
+  instruction: MockInstruction;
+  rank: number;
+  onRemove: () => void;
+  onDuplicateIf?: (fieldIds: string[]) => void;
+  onWrapWith?: (kind: string) => void;
+  abstractNode?: MockAbstractNode;
+}
+
+export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = ({
+  instruction,
+  rank,
+  onRemove,
+  onDuplicateIf,
+  onWrapWith,
+  abstractNode,
+}) => {
+  const [expression, setExpression] = useState('');
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [childInstructions, setChildInstructions] = useState<MockInstruction[]>(instruction.children ?? []);
+  const [childFields, setChildFields] = useState<{ slotId: string; candidate?: MockFieldNode }[]>(() => {
+    if (instruction.initialFieldIds && abstractNode) {
+      return instruction.initialFieldIds
+        .map((id) => ({
+          slotId: `slot-${id}`,
+          candidate: abstractNode.candidates.find((c) => c.id === id),
+        }))
+        .filter((slot) => slot.candidate);
+    }
+    return [];
+  });
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [modalTarget, setModalTarget] = useState<string | null>(null);
+  const [placeholderDismissed, setPlaceholderDismissed] = useState(false);
+  const counterRef = useRef(0);
+
+  const isCollection = abstractNode ? abstractNode.maxOccurs === -1 || abstractNode.maxOccurs > 1 : false;
+  const hasExpression = instruction.kind === 'for-each' || instruction.kind === 'if' || instruction.kind === 'when';
+  const canAddInstruction = instruction.kind !== 'choose';
+  const canAddWhen = instruction.kind === 'choose';
+  const hasOtherwise = childInstructions.some((c) => c.kind === 'otherwise');
+  const showAbstractPlaceholder =
+    !!instruction.showAbstractField && !placeholderDismissed && childFields.length === 0 && !!abstractNode;
+  const hasChildren = showAbstractPlaceholder || childInstructions.length > 0 || childFields.length > 0;
+
+  const generateId = useCallback(() => {
+    return `${Date.now()}-${counterRef.current++}`;
+  }, []);
+
+  const handleAddChildInstruction = useCallback(
+    (kind: string) => {
+      const uid = generateId();
+      let newInstruction: MockInstruction;
+      if (kind === 'choose') {
+        newInstruction = {
+          id: `choose-${uid}`,
+          kind: 'choose',
+          children: [
+            { id: `when-${uid}`, kind: 'when' },
+            { id: `otherwise-${uid}`, kind: 'otherwise' },
+          ],
+        };
+      } else {
+        newInstruction = { id: `${kind}-${uid}`, kind: kind as MockInstruction['kind'] };
+      }
+      setChildInstructions((prev) => [...prev, newInstruction]);
+      setIsMenuOpen(false);
+    },
+    [generateId],
+  );
+
+  const handleAddWhen = useCallback(() => {
+    const uid = generateId();
+    const newWhen: MockInstruction = { id: `when-${uid}`, kind: 'when' };
+    setChildInstructions((prev) => {
+      const lastIndex = prev.length - 1;
+      if (lastIndex >= 0 && prev[lastIndex].kind === 'otherwise') {
+        return [...prev.slice(0, lastIndex), newWhen, prev[lastIndex]];
+      }
+      return [...prev, newWhen];
+    });
+  }, [generateId]);
+
+  const handleAddOtherwise = useCallback(() => {
+    const uid = generateId();
+    setChildInstructions((prev) => [...prev, { id: `otherwise-${uid}`, kind: 'otherwise' }]);
+  }, [generateId]);
+
+  const handleRemoveChild = useCallback((childId: string) => {
+    setChildInstructions((prev) => prev.filter((i) => i.id !== childId));
+  }, []);
+
+  const handleModalConfirm = useCallback(
+    (candidateId: string) => {
+      if (!abstractNode) return;
+      const candidate = abstractNode.candidates.find((c) => c.id === candidateId);
+      if (!candidate) return;
+
+      if (modalTarget === 'new') {
+        const slotId = `slot-${generateId()}`;
+        setChildFields((prev) => [...prev, { slotId, candidate }]);
+      } else if (modalTarget) {
+        setChildFields((prev) => prev.map((slot) => (slot.slotId === modalTarget ? { ...slot, candidate } : slot)));
+      }
+      setModalTarget(null);
+    },
+    [abstractNode, modalTarget, generateId],
+  );
+
+  const handleClearSubstitution = useCallback((slotId: string) => {
+    setChildFields((prev) => prev.map((slot) => (slot.slotId === slotId ? { slotId: slot.slotId } : slot)));
+  }, []);
+
+  const handleRemoveField = useCallback((slotId: string) => {
+    setChildFields((prev) => prev.filter((slot) => slot.slotId !== slotId));
+  }, []);
+
+  const handleDuplicateField = useCallback(
+    (sourceSlot: { slotId: string; candidate?: MockFieldNode }) => {
+      const newSlotId = `slot-${generateId()}`;
+      setChildFields((prev) => [...prev, { slotId: newSlotId, candidate: sourceSlot.candidate }]);
+    },
+    [generateId],
+  );
+
+  const handleWrapField = useCallback(
+    (kind: string, slot?: { slotId: string; candidate?: MockFieldNode }) => {
+      const uid = generateId();
+      const initialFieldIds = slot?.candidate ? [slot.candidate.id] : undefined;
+      const showAbstractField = !slot?.candidate;
+      let newInstruction: MockInstruction;
+      if (kind === 'choose') {
+        newInstruction = {
+          id: `choose-${uid}`,
+          kind: 'choose',
+          children: [
+            { id: `when-${uid}`, kind: 'when', showAbstractField, initialFieldIds },
+            { id: `otherwise-${uid}`, kind: 'otherwise' },
+          ],
+        };
+      } else {
+        newInstruction = {
+          id: `${kind}-${uid}`,
+          kind: kind as MockInstruction['kind'],
+          showAbstractField,
+          initialFieldIds,
+        };
+      }
+      setChildInstructions((prev) => [...prev, newInstruction]);
+      if (slot) {
+        setChildFields((prev) => prev.filter((s) => s.slotId !== slot.slotId));
+      } else {
+        setPlaceholderDismissed(true);
+      }
+    },
+    [generateId],
+  );
+
+  const buildFieldMappingItems = useCallback(
+    (slot: { slotId: string; candidate?: MockFieldNode }): MappingMenuItem[] => {
+      const items: MappingMenuItem[] = [];
+      if (isCollection) {
+        items.push({
+          key: 'wrap-for-each',
+          label: 'Wrap with "for-each"',
+          onClick: () => handleWrapField('for-each', slot),
+        });
+      }
+      items.push({
+        key: 'wrap-if',
+        label: 'Wrap with "if"',
+        onClick: () => handleWrapField('if', slot),
+      });
+      items.push({
+        key: 'wrap-choose',
+        label: 'Wrap with "choose-when-otherwise"',
+        onClick: () => handleWrapField('choose', slot),
+      });
+      if (isCollection) {
+        items.push({
+          key: 'dup-field',
+          label: 'Duplicate Field',
+          onClick: () => handleDuplicateField(slot),
+        });
+      }
+      return items;
+    },
+    [isCollection, handleWrapField, handleDuplicateField],
+  );
+
+  const renderContextMenuToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <MenuToggle
+        icon={<EllipsisVIcon />}
+        ref={toggleRef}
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsMenuOpen((prev) => !prev);
+        }}
+        variant="plain"
+        isExpanded={isMenuOpen}
+        size="sm"
+        aria-label="Actions"
+      />
+    ),
+    [isMenuOpen],
+  );
+
+  const placeholderDocItems = useMemo(
+    (): DocMenuItem[] => [{ key: 'select-sub', label: 'Select Substitution', onClick: () => setModalTarget('new') }],
+    [],
+  );
+
+  const buildPlaceholderMappingItems = useMemo((): MappingMenuItem[] => {
+    const items: MappingMenuItem[] = [];
+    if (isCollection) {
+      items.push({ key: 'wrap-for-each', label: 'Wrap with "for-each"', onClick: () => handleWrapField('for-each') });
+    }
+    items.push({ key: 'wrap-if', label: 'Wrap with "if"', onClick: () => handleWrapField('if') });
+    items.push({
+      key: 'wrap-choose',
+      label: 'Wrap with "choose-when-otherwise"',
+      onClick: () => handleWrapField('choose'),
+    });
+    if (isCollection) {
+      items.push({
+        key: 'dup-field',
+        label: 'Duplicate Field',
+        onClick: () => {
+          const slotId = `slot-${generateId()}`;
+          setChildFields((prev) => [...prev, { slotId }]);
+        },
+      });
+    }
+    return items;
+  }, [isCollection, handleWrapField, generateId]);
+
+  return (
+    <div className="node__container" data-testid={`instruction-${instruction.id}`}>
+      <section className="abstract-tree__instruction-node" style={{ '--node-rank': rank } as React.CSSProperties}>
+        {hasChildren ? (
+          <Icon className="abstract-tree__field-expand" onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? <ChevronDown /> : <ChevronRight />}
+          </Icon>
+        ) : (
+          <span className="abstract-tree__field-expand-placeholder" />
+        )}
+        <Label isCompact variant="outline" color="purple">
+          {instruction.kind}
+        </Label>
+        {hasExpression && (
+          <TextInput
+            type="text"
+            value={expression}
+            onChange={(_e, val) => setExpression(val)}
+            placeholder={instruction.kind === 'for-each' ? 'select expression' : 'test expression'}
+            className="abstract-tree__instruction-input"
+          />
+        )}
+        <div className="abstract-tree__instruction-actions">
+          <Dropdown
+            onSelect={(e) => {
+              e?.stopPropagation();
+              setIsMenuOpen(false);
+            }}
+            toggle={renderContextMenuToggle}
+            isOpen={isMenuOpen}
+            onOpenChange={setIsMenuOpen}
+            popperProps={{ position: 'end' }}
+            zIndex={100}
+          >
+            <DropdownList>
+              {canAddInstruction && abstractNode && (
+                <DropdownItem
+                  key="add-field"
+                  onClick={() => {
+                    setModalTarget('new');
+                    setIsMenuOpen(false);
+                  }}
+                >
+                  Add Field
+                </DropdownItem>
+              )}
+              {canAddInstruction && (
+                <DropdownItem key="add-for-each" onClick={() => handleAddChildInstruction('for-each')}>
+                  Add for-each
+                </DropdownItem>
+              )}
+              {canAddInstruction && (
+                <DropdownItem key="add-choose" onClick={() => handleAddChildInstruction('choose')}>
+                  Add choose-when-otherwise
+                </DropdownItem>
+              )}
+              {canAddWhen && (
+                <DropdownItem key="add-when" onClick={handleAddWhen}>
+                  Add when
+                </DropdownItem>
+              )}
+              {canAddWhen && !hasOtherwise && (
+                <DropdownItem key="add-otherwise" onClick={handleAddOtherwise}>
+                  Add otherwise
+                </DropdownItem>
+              )}
+              {instruction.kind === 'if' && onDuplicateIf && (
+                <DropdownItem
+                  key="duplicate-if"
+                  onClick={() =>
+                    onDuplicateIf(childFields.filter((slot) => slot.candidate).map((slot) => slot.candidate!.id))
+                  }
+                >
+                  Duplicate &quot;if&quot;
+                </DropdownItem>
+              )}
+              {onWrapWith && isCollection && (
+                <DropdownItem key="wrap-for-each" onClick={() => onWrapWith('for-each')}>
+                  Wrap with &quot;for-each&quot;
+                </DropdownItem>
+              )}
+              {onWrapWith && (
+                <DropdownItem key="wrap-if" onClick={() => onWrapWith('if')}>
+                  Wrap with &quot;if&quot;
+                </DropdownItem>
+              )}
+              {onWrapWith && (
+                <DropdownItem key="wrap-choose" onClick={() => onWrapWith('choose')}>
+                  Wrap with &quot;choose-when-otherwise&quot;
+                </DropdownItem>
+              )}
+            </DropdownList>
+          </Dropdown>
+          <Button variant="plain" icon={<TrashIcon />} size="sm" onClick={onRemove} aria-label="Delete" />
+        </div>
+      </section>
+      {hasChildren && isExpanded && (
+        <div className="node__children">
+          {showAbstractPlaceholder && abstractNode && (
+            <FieldRow
+              rank={rank + 1}
+              name={abstractNode.elementName}
+              typeOrCandidates={getAbstractDisplayName(abstractNode)}
+              isAbstract
+              docMenuItems={placeholderDocItems}
+              mappingMenuItems={buildPlaceholderMappingItems}
+              onRemove={() => setPlaceholderDismissed(true)}
+            />
+          )}
+          {childFields.map((slot) =>
+            slot.candidate ? (
+              <FieldRow
+                key={slot.slotId}
+                rank={rank + 1}
+                name={slot.candidate.displayName}
+                typeOrCandidates={slot.candidate.type}
+                docMenuItems={[
+                  {
+                    key: 'clear-sub',
+                    label: 'Clear Substitution',
+                    onClick: () => handleClearSubstitution(slot.slotId),
+                  },
+                ]}
+                mappingMenuItems={buildFieldMappingItems(slot)}
+                onRemove={() => handleRemoveField(slot.slotId)}
+              />
+            ) : (
+              <FieldRow
+                key={slot.slotId}
+                rank={rank + 1}
+                name={abstractNode!.elementName}
+                typeOrCandidates={getAbstractDisplayName(abstractNode!)}
+                isAbstract
+                docMenuItems={[
+                  { key: 'select-sub', label: 'Select Substitution', onClick: () => setModalTarget(slot.slotId) },
+                ]}
+                mappingMenuItems={buildFieldMappingItems(slot)}
+                onRemove={() => handleRemoveField(slot.slotId)}
+              />
+            ),
+          )}
+          {childInstructions.map((child) => (
+            <InstructionNodeMock
+              key={child.id}
+              instruction={child}
+              rank={rank + 1}
+              onRemove={() => handleRemoveChild(child.id)}
+              onDuplicateIf={
+                child.kind === 'if'
+                  ? (fieldIds) => {
+                      const uid = generateId();
+                      setChildInstructions((prev) => [
+                        ...prev,
+                        { id: `if-${uid}`, kind: 'if' as const, initialFieldIds: fieldIds },
+                      ]);
+                    }
+                  : undefined
+              }
+              onWrapWith={(kind) => {
+                const uid = generateId();
+                let wrapper: MockInstruction;
+                if (kind === 'choose') {
+                  wrapper = {
+                    id: `choose-${uid}`,
+                    kind: 'choose',
+                    children: [
+                      { id: `when-${uid}`, kind: 'when', children: [child] },
+                      { id: `otherwise-${uid}`, kind: 'otherwise' },
+                    ],
+                  };
+                } else {
+                  wrapper = {
+                    id: `${kind}-${uid}`,
+                    kind: kind as MockInstruction['kind'],
+                    children: [child],
+                  };
+                }
+                setChildInstructions((prev) => prev.map((c) => (c.id === child.id ? wrapper : c)));
+              }}
+              abstractNode={abstractNode}
+            />
+          ))}
+        </div>
+      )}
+      {modalTarget !== null && abstractNode && (
+        <AddFieldCandidateModal
+          isOpen={modalTarget !== null}
+          onClose={() => setModalTarget(null)}
+          onConfirm={handleModalConfirm}
+          abstractNode={abstractNode}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/mockAbstractData.ts
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/mockAbstractData.ts
@@ -1,0 +1,210 @@
+import { Types } from '@kaoto/kaoto/testing';
+
+export interface MockFieldNode {
+  id: string;
+  displayName: string;
+  type: Types;
+  path: string;
+  description?: string;
+  children?: MockAbstractTreeNode[];
+}
+
+export interface MockAbstractNode {
+  id: string;
+  elementName: string;
+  isAbstract: true;
+  maxOccurs: number;
+  candidates: MockFieldNode[];
+  isExpanded: boolean;
+  path: string;
+}
+
+export type MockAbstractTreeNode = MockFieldNode | MockAbstractNode;
+
+export function isAbstractNode(node: MockAbstractTreeNode): node is MockAbstractNode {
+  return 'isAbstract' in node && node.isAbstract === true;
+}
+
+export interface MockInstruction {
+  id: string;
+  kind: 'for-each' | 'if' | 'choose' | 'when' | 'otherwise';
+  children?: MockInstruction[];
+  initialFieldIds?: string[];
+  showAbstractField?: boolean;
+}
+
+const mockCatCandidate: MockFieldNode = {
+  id: 'cat',
+  displayName: 'Cat',
+  type: Types.Container,
+  path: 'Zoo/AbstractAnimal/Cat',
+  description: 'A domestic cat (Cat_t)',
+  children: [
+    { id: 'cat-name', displayName: 'name', type: Types.String, path: 'Zoo/AbstractAnimal/Cat/name' },
+    { id: 'cat-indoor', displayName: 'indoor', type: Types.Boolean, path: 'Zoo/AbstractAnimal/Cat/indoor' },
+  ],
+};
+
+const mockDogCandidate: MockFieldNode = {
+  id: 'dog',
+  displayName: 'Dog',
+  type: Types.Container,
+  path: 'Zoo/AbstractAnimal/Dog',
+  description: 'A domestic dog (Dog_t)',
+  children: [
+    { id: 'dog-name', displayName: 'name', type: Types.String, path: 'Zoo/AbstractAnimal/Dog/name' },
+    { id: 'dog-breed', displayName: 'breed', type: Types.String, path: 'Zoo/AbstractAnimal/Dog/breed' },
+  ],
+};
+
+const mockFishCandidate: MockFieldNode = {
+  id: 'fish',
+  displayName: 'Fish',
+  type: Types.Container,
+  path: 'Zoo/AbstractAnimal/Fish',
+  description: 'A fish with inline type definition',
+  children: [
+    { id: 'fish-name', displayName: 'name', type: Types.String, path: 'Zoo/AbstractAnimal/Fish/name' },
+    {
+      id: 'fish-freshwater',
+      displayName: 'freshwater',
+      type: Types.Boolean,
+      path: 'Zoo/AbstractAnimal/Fish/freshwater',
+    },
+  ],
+};
+
+const mockKittenCandidate: MockFieldNode = {
+  id: 'kitten',
+  displayName: 'Kitten',
+  type: Types.Container,
+  path: 'Zoo/AbstractAnimal/Kitten',
+  description: 'A kitten, extends Feline_t → Animal_t',
+  children: [
+    { id: 'kitten-name', displayName: 'name', type: Types.String, path: 'Zoo/AbstractAnimal/Kitten/name' },
+    { id: 'kitten-indoor', displayName: 'indoor', type: Types.Boolean, path: 'Zoo/AbstractAnimal/Kitten/indoor' },
+    { id: 'kitten-age', displayName: 'age', type: Types.Integer, path: 'Zoo/AbstractAnimal/Kitten/age' },
+  ],
+};
+
+export const mockAbstractAnimal: MockAbstractNode = {
+  id: 'abstract-animal',
+  elementName: 'AbstractAnimal',
+  isAbstract: true,
+  maxOccurs: -1,
+  candidates: [mockCatCandidate, mockDogCandidate, mockFishCandidate, mockKittenCandidate],
+  isExpanded: true,
+  path: 'Zoo/AbstractAnimal',
+};
+
+export const mockAbstractLabel: MockAbstractNode = {
+  id: 'abstract-label',
+  elementName: 'AbstractLabel',
+  isAbstract: true,
+  maxOccurs: 1,
+  candidates: [
+    {
+      id: 'nickname',
+      displayName: 'Nickname',
+      type: Types.String,
+      path: 'Zoo/AbstractLabel/Nickname',
+      description: 'A nickname (Nickname_t, max 50 chars)',
+    },
+    {
+      id: 'xs-string-tag',
+      displayName: 'XsStringTag',
+      type: Types.String,
+      path: 'Zoo/AbstractLabel/XsStringTag',
+      description: 'A plain xs:string tag',
+    },
+  ],
+  isExpanded: true,
+  path: 'Zoo/AbstractLabel',
+};
+
+export const mockZooSingle: MockFieldNode = {
+  id: 'zoo',
+  displayName: 'Zoo',
+  type: Types.Container,
+  path: 'Zoo',
+  children: [mockAbstractLabel],
+};
+
+export const mockZooCollection: MockFieldNode = {
+  id: 'zoo',
+  displayName: 'Zoo',
+  type: Types.Container,
+  path: 'Zoo',
+  children: [mockAbstractAnimal],
+};
+
+function generateManyCandidates(count: number): MockFieldNode[] {
+  const candidates: MockFieldNode[] = [];
+  for (let i = 1; i <= count; i++) {
+    const name = `MsgType${String(i).padStart(3, '0')}`;
+    candidates.push({
+      id: `msg-${name.toLowerCase()}`,
+      displayName: name,
+      type: Types.Container,
+      path: `Envelope/AbstractMessage/${name}`,
+      description: `Message type ${name}`,
+      children: [
+        {
+          id: `msg-${name.toLowerCase()}-id`,
+          displayName: 'msgId',
+          type: Types.String,
+          path: `Envelope/AbstractMessage/${name}/msgId`,
+        },
+        {
+          id: `msg-${name.toLowerCase()}-timestamp`,
+          displayName: 'timestamp',
+          type: Types.String,
+          path: `Envelope/AbstractMessage/${name}/timestamp`,
+        },
+        {
+          id: `msg-${name.toLowerCase()}-payload`,
+          displayName: 'payload',
+          type: Types.Container,
+          path: `Envelope/AbstractMessage/${name}/payload`,
+          children: [
+            {
+              id: `msg-${name.toLowerCase()}-payload-data`,
+              displayName: 'data',
+              type: Types.String,
+              path: `Envelope/AbstractMessage/${name}/payload/data`,
+            },
+          ],
+        },
+      ],
+    });
+  }
+  return candidates;
+}
+
+export const mockManyAbstract: MockAbstractNode = {
+  id: 'many-abstract-message',
+  elementName: 'AbstractMessage',
+  isAbstract: true,
+  maxOccurs: 1,
+  candidates: generateManyCandidates(200),
+  isExpanded: true,
+  path: 'Envelope/AbstractMessage',
+};
+
+export const mockManyRoot: MockFieldNode = {
+  id: 'envelope-root',
+  displayName: 'Envelope',
+  type: Types.Container,
+  path: 'Envelope',
+  children: [mockManyAbstract],
+};
+
+export function getAbstractDisplayName(node: MockAbstractNode, maxDisplay = 3): string {
+  const names = node.candidates.map((c) => c.displayName);
+  if (names.length <= maxDisplay) {
+    return `(${names.join(' | ')})`;
+  }
+  const displayed = names.slice(0, maxDisplay).join(' | ');
+  const remaining = names.length - maxDisplay;
+  return `(${displayed} | +${remaining} more)`;
+}


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3243

Storybook UI mockup for the abstract field configuration redesign.

**Problem**: When an abstract element in the target document is not yet substituted, all candidates appear as if they can receive mappings. Users can create mappings to any candidate, but at runtime when `maxOccurs = 1`, only one can exist — causing failures.

**Solution**: Stop rendering substitution candidates of abstract elements as children. User has to substitute it to a concrete element.

### maxOccurs = 1

When `maxOccurs=1`, exactly one concrete element can exist at runtime. 2 options available:
- **Choose one candidate** — substitute the abstract element with a single concrete type. Right-click field context menu offers `Select Substitution` option. The selected candidate's children appear directly in the tree.
- **Wrap with mapping instruction** — 3-dots mapping context menu offers options such as `Wrap with if` or `Wrap with choose-when-otherwise`. Inside the mapping instruction item, user can conditionally assign substitution.

Right-click on a substituted field offers `Reset Substitution` to reset the substitution.


https://github.com/user-attachments/assets/64ab9aed-767b-46ef-a60e-bbaf4a6c537a



### maxOccurs > 1

When `maxOccurs > 1` (collection), the abstract element can contain multiple instances of mixed concrete types. The collection field offers `Duplicate Field` in 3-dots mapping context menu. The substitution could be applied on each duplicated abstract field to create mappings for each static substitution.
Mapping instructions allow creating more complex mapping. For example, the 2nd half of the following screencast demonstrates that combination of `for-each` and `choose-when-otherwise` mapping instructions can assign concrete substitutions conditionally in a iteration.

https://github.com/user-attachments/assets/f2967edd-be0e-40d1-95e7-071b1345117f




### Many Candidates (more than 10)

An abstract element with more than 10 substitution candidates. The configuration modal includes a `SearchInput` to filter through the candidate list.

https://github.com/user-attachments/assets/83a99d67-a4bb-4eea-bd6c-db06cd435ce2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive DataMapper abstract-field mock UI with single/multi candidate selection, candidate search for large lists, “select all,” and confirm/cancel flows.
  * Introduced a recursive abstract tree mock with expand/collapse, wrap actions, duplication/removal, and context menus.
  * Added new Storybook scenarios (single, collection, many candidates) with supporting mock data and realistic candidate previews.
* **Style**
  * Added SCSS styling for the modal, tree layout, candidate lists, menus, and empty-state/placeholder presentations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->