### PR TITLE
fix: fix responsiveness navigation

### DIFF
--- a/packages/ui/src/layout/Shell.test.tsx
+++ b/packages/ui/src/layout/Shell.test.tsx
@@ -17,10 +17,28 @@ jest.mock('./TopBar', () => ({
   ),
 }));
 
-describe('Shell Component', () => {
-  it('renders the Shell component with children', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([true, jest.fn()]);
+describe('Shell', () => {
+  const originalInnerWidth = globalThis.window.innerWidth;
+  const mockSetNavOpen = jest.fn();
 
+  const setWindowWidth = (width: number) => {
+    Object.defineProperty(globalThis.window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: width,
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useLocalStorage as jest.Mock).mockReturnValue([true, mockSetNavOpen]);
+  });
+
+  afterEach(() => {
+    setWindowWidth(originalInnerWidth);
+  });
+
+  it('renders children', () => {
     render(
       <Shell>
         <div data-testid="child">Child Content</div>
@@ -28,29 +46,29 @@ describe('Shell Component', () => {
     );
 
     expect(screen.getByTestId('child')).toBeInTheDocument();
-    expect(screen.getByTestId('navigation')).toHaveAttribute('data-is-open', 'true');
-    expect(screen.getByTestId('topbar')).toBeInTheDocument();
   });
 
-  it('toggles navigation state when navToggle is called', () => {
-    const setIsNavOpenMock = jest.fn();
-    (useLocalStorage as jest.Mock).mockReturnValue([true, setIsNavOpenMock]);
-
+  it('toggles navigation when button is clicked', () => {
     render(<Shell />);
 
     act(() => {
-      const topBarButton = screen.getByTestId('topbar');
-      topBarButton.click();
+      screen.getByTestId('topbar').click();
     });
 
-    expect(setIsNavOpenMock).toHaveBeenCalledWith(false);
+    expect(mockSetNavOpen).toHaveBeenCalledWith(false);
   });
 
-  it('renders navigation as closed when isNavOpen is false', () => {
-    (useLocalStorage as jest.Mock).mockReturnValue([false, jest.fn()]);
+  it.each([
+    ['desktop', 1200, true],
+    ['wide desktop', 1920, true],
+    ['just below breakpoint', 1199, false],
+    ['tablet', 768, false],
+    ['mobile', 375, false],
+  ])('defaults to %s behavior at %dpx', (_, width, expectedDefault) => {
+    setWindowWidth(width);
 
     render(<Shell />);
 
-    expect(screen.getByTestId('navigation')).toHaveAttribute('data-is-open', 'false');
+    expect(useLocalStorage).toHaveBeenCalledWith(expect.any(String), expectedDefault);
   });
 });

--- a/packages/ui/src/layout/Shell.tsx
+++ b/packages/ui/src/layout/Shell.tsx
@@ -1,7 +1,7 @@
 import './Shell.scss';
 
 import { Page, PageSection } from '@patternfly/react-core';
-import { FunctionComponent, PropsWithChildren, useCallback } from 'react';
+import { FunctionComponent, PropsWithChildren, useCallback, useMemo } from 'react';
 
 import { useLocalStorage } from '../hooks/local-storage.hook';
 import { LocalStorageKeys } from '../models';
@@ -9,7 +9,15 @@ import { Navigation } from './Navigation';
 import { TopBar } from './TopBar';
 
 export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
-  const [isNavOpen, setIsNavOpen] = useLocalStorage(LocalStorageKeys.NavigationExpanded, true);
+  const defaultNavState = useMemo(() => {
+    if (globalThis.window !== undefined) {
+      return globalThis.window.innerWidth >= 1200;
+    }
+    // Server Side Rendering fallback can't be tested in JSDom
+    return true;
+  }, []);
+
+  const [isNavOpen, setIsNavOpen] = useLocalStorage(LocalStorageKeys.NavigationExpanded, defaultNavState);
 
   const navToggle = useCallback(() => {
     setIsNavOpen(!isNavOpen);


### PR DESCRIPTION
This PR fixes the navigation component to render closed following the Patternfly default values.

fix: https://github.com/KaotoIO/kaoto/issues/3246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation sidebar now defaults to expanded on wide desktop and collapsed on smaller screens, with a safe fallback for server-rendered pages to improve responsive behavior.

* **Tests**
  * Strengthened navigation open-state tests: reorganized setup, responsive-width helpers, parameterized checks for screen-size defaults, and verification of toggle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->