### PR TITLE
fix(DataMapper): Sync param lines on add with no attached schema in SourcePanel

### DIFF
--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -142,6 +142,30 @@ const renderPanels = (configs: PanelConfig[]) => {
   return render(<ExpansionPanels>{configs.map(createPanelElement)}</ExpansionPanels>);
 };
 
+// Helper component for testing layout callbacks
+const createTestPanelWithCallback = (callbackRef: { current: boolean }) => {
+  const TestPanel = ({ id }: { id: string }) => {
+    const context = useContext(ExpansionContext);
+
+    useEffect(() => {
+      if (context) {
+        const callback = () => {
+          callbackRef.current = true;
+        };
+        context.registerLayoutCallback(id, callback);
+        return () => context.unregisterLayoutCallback(id);
+      }
+    }, [context, id]);
+
+    return (
+      <ExpansionPanel id={id} summary={<div>Test Panel</div>} defaultExpanded={true}>
+        Content
+      </ExpansionPanel>
+    );
+  };
+  return TestPanel;
+};
+
 describe('ExpansionPanels', () => {
   let mockResizeObserver: MockResizeObserver;
   let originalResizeObserver: typeof ResizeObserver;
@@ -805,26 +829,8 @@ describe('ExpansionPanels', () => {
 
     it('should execute all queued layout callbacks via executeAllLayoutCallbacks', async () => {
       // Create a component that registers a layout callback
-      let callbackExecuted = false;
-      const TestPanel = ({ id }: { id: string }) => {
-        const context = useContext(ExpansionContext);
-
-        useEffect(() => {
-          if (context) {
-            const callback = () => {
-              callbackExecuted = true;
-            };
-            context.registerLayoutCallback(id, callback);
-            return () => context.unregisterLayoutCallback(id);
-          }
-        }, [context, id]);
-
-        return (
-          <ExpansionPanel id={id} summary={<div>Test Panel</div>} defaultExpanded={true}>
-            Content
-          </ExpansionPanel>
-        );
-      };
+      const callbackRef = { current: false };
+      const TestPanel = createTestPanelWithCallback(callbackRef);
 
       const { container } = render(
         <ExpansionPanels>
@@ -847,7 +853,44 @@ describe('ExpansionPanels', () => {
       });
 
       // Verify the callback was actually executed (line 71 was hit)
-      expect(callbackExecuted).toBe(true);
+      expect(callbackRef.current).toBe(true);
+    });
+
+    it('should flush layout callbacks after panel registration (fix for primitive parameters)', async () => {
+      // This test covers the bug fix for primitive parameters without schemas
+      // When a panel registers, callbacks should be flushed via double RAF
+      const callbackRef = { current: false };
+      const TestPanel = createTestPanelWithCallback(callbackRef);
+
+      const { container, rerender } = render(
+        <ExpansionPanels>
+          <TestPanel id="test-panel-1" />
+        </ExpansionPanels>,
+      );
+
+      await setupPanelMocks(container);
+
+      // Reset the flag
+      callbackRef.current = false;
+
+      // Add a new panel - this triggers the register function
+      rerender(
+        <ExpansionPanels>
+          <TestPanel id="test-panel-1" />
+          <TestPanel id="test-panel-2" />
+        </ExpansionPanels>,
+      );
+
+      await setupPanelMocks(container);
+
+      // Wait for double RAF to complete (lines 229-235 in ExpansionPanels.tsx)
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      });
+
+      // Verify the callback was executed after panel registration
+      // This ensures connection ports are synced for primitive parameters
+      expect(callbackRef.current).toBe(true);
     });
   });
 });

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
@@ -225,9 +225,24 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
             fitPanelsToContainer();
           }
         }
+
+        // Flush queued layout callbacks after grid settles
+        // This is critical for panels without children (primitive parameters) which don't
+        // trigger CSS transitions and thus never fire transitionend events
+        // Use double RAF to ensure layout is fully settled
+        requestAnimationFrame(() => {
+          requestAnimationFrame(flushLayoutCallbacks);
+        });
       });
     },
-    [updateGridTemplate, updateOrdersFromChildren, firstPanelId, lastPanelId, fitPanelsToContainer],
+    [
+      updateGridTemplate,
+      updateOrdersFromChildren,
+      firstPanelId,
+      lastPanelId,
+      fitPanelsToContainer,
+      flushLayoutCallbacks,
+    ],
   );
 
   const unregister = useCallback(


### PR DESCRIPTION
Resolves: [#3248](https://github.com/KaotoIO/kaoto/issues/3248)


https://github.com/user-attachments/assets/592b5caa-8b78-41cc-948d-2934867d5c87



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure layout callbacks are flushed after panel registration and updates so visual mappings recalc correctly even when CSS transitions do not run.

* **Tests**
  * Added and refactored tests with a reusable callback helper to verify layout callback flushing during panel registration, re-rendering, and resize scenarios, improving coverage around callback execution timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->