### PR TITLE
chore(core): Implement two-phase initialization for CamelRouteResource

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -146,6 +146,7 @@ describe('DataMapperLauncher', () => {
   };
 
   const mockCamelResource = {
+    initialize: jest.fn(),
     getVisualEntities: jest.fn().mockReturnValue([]),
     getEntities: jest.fn().mockReturnValue([]),
     addNewEntity: jest.fn(),

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
@@ -19,6 +19,7 @@ describe('routeIdValidator', () => {
 
   it('should return sucess if the name is unique', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     const visualEntities = resource.getVisualEntities();
     jest.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -29,6 +30,7 @@ describe('routeIdValidator', () => {
 
   it('should return an error if the name is not unique', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     const visualEntities = resource.getVisualEntities();
     jest.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -40,6 +42,7 @@ describe('routeIdValidator', () => {
 
   it('should return an error if the name is not a valid URI', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     const visualEntities = resource.getVisualEntities();
     jest.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -51,6 +54,7 @@ describe('routeIdValidator', () => {
 
   it('should return an error if the name is not unique neither a valid URI', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     const visualEntities = resource.getVisualEntities();
     jest.spyOn(visualEntities[0], 'getId').mockReturnValue('The amazing Route');
 

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -142,6 +142,7 @@ describe('Canvas', () => {
 
   it('should be able to delete the routes', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
+    camelResource.initialize();
     const routeEntities = camelResource.getVisualEntities();
     const vizNode = await routeEntities[0].toVizNode();
     const removeSpy = jest.spyOn(camelResource, 'removeEntity');
@@ -201,6 +202,7 @@ describe('Canvas', () => {
 
   it('should be able to delete the kamelets', async () => {
     const kameletResource = new KameletResource(kameletJson);
+    kameletResource.initialize();
     const kameletEntities = kameletResource.getVisualEntities();
     const vizNode = await kameletEntities[0].toVizNode();
     const removeSpy = jest.spyOn(kameletResource, 'removeEntity');

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -17,6 +17,7 @@ describe('CanvasSideBar', () => {
   beforeAll(async () => {
     mockRandomValues();
     const camelResource = new CamelRouteResource();
+    camelResource.initialize();
     camelResource.addNewEntity(EntityType.Route);
     const visualEntity = camelResource.getVisualEntities()[0];
     selectedNode = FlowService.getFlowDiagram('test', await visualEntity.toVizNode()).nodes[0];

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
@@ -23,6 +23,7 @@ describe('DirectEndpointNameField', () => {
     visibleFlowsContext?: VisibleFlowsContextResult,
   ) => {
     const camelResource = new CamelRouteResource(routes as unknown as CamelYamlDsl);
+    camelResource.initialize();
     const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({
       camelResource,
       visibleFlowsContext,

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -69,6 +69,7 @@ describe('EndpointField', () => {
     options: { disabled?: boolean; required?: boolean } = {},
   ) => {
     const camelResource = createTestResource(testModel);
+    camelResource.initialize();
     const { Provider } = TestProvidersWrapper({ camelResource });
 
     await act(async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -74,6 +74,7 @@ describe('EndpointListField', () => {
     options: { disabled?: boolean; required?: boolean } = {},
   ) => {
     const camelResource = createTestResource(testModel);
+    camelResource.initialize();
     const { Provider } = TestProvidersWrapper({ camelResource });
 
     await act(async () => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
@@ -57,6 +57,7 @@ describe('ContextToolbar', () => {
   describe('when using multipleRoute configuration', () => {
     it('should include NewEntity component for Route schema type', () => {
       const camelResource = new CamelRouteResource([]);
+      camelResource.initialize();
       const { Provider } = TestProvidersWrapper({ camelResource });
 
       render(
@@ -85,6 +86,7 @@ describe('ContextToolbar', () => {
   describe('when using single route configuration', () => {
     it('should not include NewEntity component for Kamelet schema type', () => {
       const camelResource = new KameletResource();
+      camelResource.initialize();
       const { Provider } = TestProvidersWrapper({ camelResource });
 
       render(
@@ -98,6 +100,7 @@ describe('ContextToolbar', () => {
 
     it('should not include NewEntity component for Pipe schema type', () => {
       const camelResource = new PipeResource();
+      camelResource.initialize();
       const { Provider } = TestProvidersWrapper({ camelResource });
 
       render(
@@ -111,6 +114,7 @@ describe('ContextToolbar', () => {
 
     it('should not include NewEntity component for KameletBinding schema type', () => {
       const camelResource = new KameletBindingResource();
+      camelResource.initialize();
       const { Provider } = TestProvidersWrapper({ camelResource });
 
       render(
@@ -244,6 +248,7 @@ describe('ContextToolbar', () => {
   describe('SerializerSelector visibility', () => {
     it('should render SerializerSelector for CamelRouteResource (Route schema)', () => {
       const camelResource = new CamelRouteResource([]);
+      camelResource.initialize();
       const { Provider } = TestProvidersWrapper({ camelResource });
 
       render(

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
@@ -26,6 +26,7 @@ jest.mock('../../Canvas/flow.service');
 
 describe('ExportDocumentPreviewModal', () => {
   const camelResource = new CamelRouteResource([camelRouteJson]);
+  camelResource.initialize();
   let onCloseSpy: jest.Mock;
   let wrapper: FunctionComponent<PropsWithChildren>;
   let originalCreateObjectURL: typeof URL.createObjectURL;

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
@@ -90,6 +90,7 @@ describe('FlowsMenu.tsx', () => {
 
   it('should render the route id when a single route is visible', async () => {
     const singleFlowCamelResource = new CamelRouteResource();
+    singleFlowCamelResource.initialize();
     singleFlowCamelResource.addNewEntity(EntityType.Route);
 
     const { Provider } = TestProvidersWrapper({

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -271,6 +271,7 @@ describe('NewEntity', () => {
 
     it('should handle empty groups gracefully', async () => {
       const mockResource = new CamelRouteResource([camelRouteJson]);
+      mockResource.initialize();
 
       // Mock empty groups scenario
       const originalGetCanvasEntityList = mockResource.getCanvasEntityList;

--- a/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/SerializerSelector/SerializerSelector.test.tsx
@@ -49,6 +49,7 @@ describe('SerializerSelector', () => {
 
   it('calls setSerializer and updateSourceCodeFromEntities when a different serializer is selected', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
+    camelResource.initialize();
     const setSerializerSpy = jest.spyOn(camelResource, 'setSerializer');
     const { Provider, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({ camelResource });
 
@@ -79,6 +80,7 @@ describe('SerializerSelector', () => {
 
   it('does not call setSerializer when the already-selected serializer is clicked', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
+    camelResource.initialize();
     const setSerializerSpy = jest.spyOn(camelResource, 'setSerializer');
     const { Provider, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({ camelResource });
 

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -70,6 +70,7 @@ describe('ItemDeleteGroup', () => {
 
   it('should call removeEntity if deletion is confirmed', async () => {
     const camelResource = new CamelRouteResource();
+    camelResource.initialize();
     const removeEntitySpy = jest.spyOn(camelResource, 'removeEntity');
     const entityId = camelResource.addNewEntity(EntityType.Route);
     vizNode = await camelResource.getVisualEntities()[0].toVizNode();

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
@@ -22,6 +22,7 @@ describe('ItemEnableAllSteps', () => {
 
   it('should NOT render an ItemEnableAllSteps if there are not at least 2 or more disabled steps', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
+    camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 
@@ -52,6 +53,7 @@ describe('ItemEnableAllSteps', () => {
 
   it('should call updateModel and updateEntitiesFromCamelResource on click', async () => {
     const camelResource = new CamelRouteResource([camelRouteWithDisabledSteps]);
+    camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -28,6 +28,7 @@ describe('ItemReplaceStep', () => {
   });
 
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const mockEntitiesContext = {
     camelResource,
     entities: camelResource.getEntities(),

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -201,6 +201,7 @@ describe('NodeContextMenu', () => {
 
   it('should render an ItemEnableAllSteps', async () => {
     const camelResource = new CamelRouteResource([camelRouteWithDisabledSteps]);
+    camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -14,6 +14,7 @@ import { useAddStep } from './add-step.hook';
 
 describe('useAddStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const getCompatibleComponentsSpy = jest.spyOn(camelResource, 'getCompatibleComponents');
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
@@ -25,6 +25,7 @@ jest.mock('../ContextMenu/item-interaction-helper', () => ({
 
 describe('useDeleteGroup', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
@@ -25,6 +25,7 @@ jest.mock('../ContextMenu/item-interaction-helper', () => ({
 
 describe('useDeleteStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
@@ -14,6 +14,7 @@ jest.mock('@kaoto/forms', () => ({
 
 describe('useDisableStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -81,6 +81,7 @@ describe('useDuplicateStep', () => {
   vizNode.setParentNode(routeVizNode);
 
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const mockEntitiesContext = {
     camelResource,
     entities: camelResource.getEntities(),

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -28,6 +28,7 @@ const mockSetValue = setValue as jest.MockedFunction<typeof setValue>;
 
 describe('useEnableAllSteps', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockGraph: Node<ElementModel, unknown>;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -22,6 +22,7 @@ jest.mock('@patternfly/react-topology', () => ({
 
 describe('useInsertStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
@@ -44,6 +44,7 @@ describe('useMoveStep', () => {
   });
 
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const mockEntitiesContext = {
     camelResource,
     entities: camelResource.getEntities(),

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -30,6 +30,7 @@ Object.assign(navigator, {
 
 describe('usePasteStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const getCompatibleComponentsSpy = jest.spyOn(camelResource, 'getCompatibleComponents');
   const getTypeSpy = jest.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
   const mockEntitiesContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../ContextMenu/item-interaction-helper', () => ({
 
 describe('useReplaceStep', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
 
   const mockEntitiesContext = {

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -23,6 +23,7 @@ Object.assign(navigator, {
 
 describe('usePasteEntity', () => {
   const camelResource = new CamelRouteResource();
+  camelResource.initialize();
   const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
   const removeEntitySpy = jest.spyOn(camelResource, 'removeEntity');
   jest.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -43,6 +43,12 @@ export abstract class CamelKResource implements KaotoResource {
     this.metadata = this.resource.metadata && new MetadataEntity(this.resource);
   }
 
+  initialize(): void {
+    if (this.resource.metadata && !this.metadata) {
+      this.metadata = new MetadataEntity(this.resource);
+    }
+  }
+
   getCanvasEntityList(): BaseVisualEntityDefinition {
     return {
       common: [],

--- a/packages/ui/src/models/camel/camel-resource-factory.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.ts
@@ -26,15 +26,24 @@ export class CamelResourceFactory {
 
     const testResource = CitrusTestResourceFactory.getCitrusTestResource(parsedCode as Test, pathResourceType);
 
-    if (testResource) return testResource;
+    if (testResource) {
+      testResource.initialize();
+      return testResource;
+    }
 
     const resource = CamelKResourceFactory.getCamelKResource(
       parsedCode as Integration | KameletBinding | Pipe | IKameletDefinition,
       pathResourceType,
     );
 
-    if (resource) return resource;
-    return new CamelRouteResource(parsedCode as CamelYamlDsl, serializer);
+    if (resource) {
+      resource.initialize();
+      return resource;
+    }
+
+    const camelRouteResource = new CamelRouteResource(parsedCode as CamelYamlDsl, serializer);
+    camelRouteResource.initialize();
+    return camelRouteResource;
   }
 
   private static initSerializer(source?: string, path?: string): KaotoResourceSerializer {

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -19,6 +19,7 @@ import { SourceSchemaType } from './source-schema-type';
 describe('CamelRouteResource', () => {
   it('should create CamelRouteResource', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getVisualEntities().length).toEqual(1);
     expect(resource.getEntities().length).toEqual(0);
@@ -26,9 +27,11 @@ describe('CamelRouteResource', () => {
 
   it('should initialize Camel Route if no args is specified', () => {
     const resource = new CamelRouteResource(undefined);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
+    resource.initialize();
   });
 
   describe('entity ordering in constructor', () => {
@@ -42,6 +45,7 @@ describe('CamelRouteResource', () => {
       ];
 
       const resource = new CamelRouteResource(mixedEntities);
+      resource.initialize();
       const entities = resource.getVisualEntities();
 
       // Should be sorted: RestConfiguration, Rest, RouteConfiguration, Route, Route
@@ -61,6 +65,7 @@ describe('CamelRouteResource', () => {
       ];
 
       const resource = new CamelRouteResource(multipleRoutes);
+      resource.initialize();
       const entities = resource.getVisualEntities();
 
       expect(entities).toHaveLength(3);
@@ -81,6 +86,7 @@ describe('CamelRouteResource', () => {
       ];
 
       const resource = new CamelRouteResource(mixedWithMultiples);
+      resource.initialize();
 
       // Verify internal ordering via toJSON: RestConfiguration, RouteConfiguration(config2), RouteConfiguration(config1), Route(route1), Route(route2)
       const json = resource.toJSON() as Record<string, unknown>[];
@@ -125,6 +131,7 @@ describe('CamelRouteResource', () => {
     ];
     it.each(testCases)('should return the appropriate entity for: %s', (json, expected) => {
       const resource = new CamelRouteResource(json);
+      resource.initialize();
       const firstEntity = resource.getVisualEntities()[0] ?? resource.getEntities()[0];
 
       if (typeof expected === 'function') {
@@ -138,6 +145,7 @@ describe('CamelRouteResource', () => {
   describe('addNewEntity', () => {
     it('should add new entity and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const id = resource.addNewEntity();
 
       expect(resource.getVisualEntities()).toHaveLength(1);
@@ -146,6 +154,7 @@ describe('CamelRouteResource', () => {
 
     it('should add new entities at the end of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.Route);
 
@@ -155,6 +164,7 @@ describe('CamelRouteResource', () => {
 
     it('should add the given entities at the end of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(
         EntityType.Route,
@@ -167,6 +177,7 @@ describe('CamelRouteResource', () => {
 
     it('should add OnException entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.OnException);
 
@@ -176,6 +187,7 @@ describe('CamelRouteResource', () => {
 
     it('should add the given OnException entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.OnException, { onException: { id: 'onException-test' } });
 
@@ -185,6 +197,7 @@ describe('CamelRouteResource', () => {
 
     it('should add ErrorHandler entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.ErrorHandler);
 
@@ -194,6 +207,7 @@ describe('CamelRouteResource', () => {
 
     it('should add the given ErrorHandler entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.ErrorHandler, { errorHandler: { id: 'errorHandler-test' } });
 
@@ -203,6 +217,7 @@ describe('CamelRouteResource', () => {
 
     it('should add OnCompletion entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.OnCompletion);
 
@@ -212,6 +227,7 @@ describe('CamelRouteResource', () => {
 
     it('should add the given OnCompletion entity at the beginning of the list and return its ID', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.OnCompletion, { onCompletion: { id: 'onCompletion-test' } });
 
@@ -226,6 +242,7 @@ describe('CamelRouteResource', () => {
           { from: { uri: 'direct:route2', steps: [] } },
           { from: { uri: 'direct:route3', steps: [] } },
         ]);
+        resource.initialize();
 
         const entities = resource.getVisualEntities();
         expect(entities).toHaveLength(3);
@@ -246,6 +263,7 @@ describe('CamelRouteResource', () => {
           { from: { uri: 'direct:route1', steps: [] } },
           { from: { uri: 'direct:route2', steps: [] } },
         ]);
+        resource.initialize();
 
         const entities = resource.getVisualEntities();
         const route2Id = entities[1].id;
@@ -264,6 +282,7 @@ describe('CamelRouteResource', () => {
           { from: { uri: 'direct:route1', steps: [] } },
           { from: { uri: 'direct:route2', steps: [] } },
         ]);
+        resource.initialize();
 
         const entities = resource.getVisualEntities();
         const route1Id = entities.find((e) => e.type === EntityType.Route)!.id;
@@ -282,6 +301,7 @@ describe('CamelRouteResource', () => {
 
       it('should fall back to default ordering when insertAfterEntityId is not found', () => {
         const resource = new CamelRouteResource([{ from: { uri: 'direct:route1', steps: [] } }]);
+        resource.initialize();
 
         const newId = resource.addNewEntity(EntityType.Route, undefined, 'non-existing-id');
 
@@ -292,6 +312,7 @@ describe('CamelRouteResource', () => {
 
       it('should fall back to default ordering when insertAfterEntityId is not provided', () => {
         const resource = new CamelRouteResource([{ from: { uri: 'direct:route1', steps: [] } }]);
+        resource.initialize();
 
         const newId = resource.addNewEntity(EntityType.Route);
 
@@ -304,16 +325,19 @@ describe('CamelRouteResource', () => {
 
   it('should return the right type', () => {
     const resource = new CamelRouteResource();
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
   });
 
   it('should allow consumers to have multiple visual entities', () => {
     const resource = new CamelRouteResource();
+    resource.initialize();
     expect(resource.supportsMultipleVisualEntities()).toEqual(true);
   });
 
   it('should return visual entities', () => {
     const resource = new CamelRouteResource([camelRouteJson]);
+    resource.initialize();
     expect(resource.getVisualEntities()).toHaveLength(1);
     expect(resource.getVisualEntities()[0]).toBeInstanceOf(CamelRouteVisualEntity);
     expect(resource.getEntities()).toHaveLength(0);
@@ -329,6 +353,7 @@ describe('CamelRouteResource', () => {
       ];
 
       const resource = new CamelRouteResource(mixedEntities);
+      resource.initialize();
       const visualEntities = resource.getVisualEntities();
 
       // Rest and RestConfiguration are non-visual entities
@@ -347,6 +372,7 @@ describe('CamelRouteResource', () => {
 
     it('should maintain consistent ordering after adding entities', () => {
       const resource = new CamelRouteResource([{ from: { uri: 'direct:route1', steps: [] } }]);
+      resource.initialize();
 
       // Add entities that should be ordered before routes
       resource.addNewEntity(EntityType.RestConfiguration);
@@ -377,6 +403,7 @@ describe('CamelRouteResource', () => {
       ];
 
       const resource = new CamelRouteResource(multipleEntitiesPerType);
+      resource.initialize();
       const visualEntities = resource.getVisualEntities();
 
       // Visual entities: RouteConfiguration(config2), RouteConfiguration(config1), Route(route3), Route(route1)
@@ -404,6 +431,7 @@ describe('CamelRouteResource', () => {
 
   it('should return entities', () => {
     const resource = new CamelRouteResource([beansJson]);
+    resource.initialize();
     expect(resource.getEntities()).toHaveLength(1);
     expect(resource.getEntities()[0]).toBeInstanceOf(BeansEntity);
     expect(resource.getVisualEntities()).toHaveLength(0);
@@ -412,6 +440,7 @@ describe('CamelRouteResource', () => {
   describe('toJSON', () => {
     it('should return JSON', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
       expect(resource.toJSON()).toMatchSnapshot();
     });
 
@@ -421,6 +450,7 @@ describe('CamelRouteResource', () => {
 
   it('should create beans entity', () => {
     const resource = new CamelRouteResource();
+    resource.initialize();
     const beansEntity = resource.createBeansEntity();
 
     expect(resource.getEntities()).toHaveLength(1);
@@ -430,6 +460,7 @@ describe('CamelRouteResource', () => {
 
   it('should delete beans entity', () => {
     const resource = new CamelRouteResource();
+    resource.initialize();
     const beansEntity = resource.createBeansEntity();
 
     resource.deleteBeansEntity(beansEntity);
@@ -440,6 +471,7 @@ describe('CamelRouteResource', () => {
   describe('beans entity management', () => {
     it('should create beans entity with empty beans array', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const beansEntity = resource.createBeansEntity();
 
       expect(beansEntity).toBeInstanceOf(BeansEntity);
@@ -449,6 +481,7 @@ describe('CamelRouteResource', () => {
 
     it('should delete the correct beans entity when multiple exist', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const firstBeansEntity = resource.createBeansEntity();
       const secondBeansEntity = resource.createBeansEntity();
 
@@ -462,6 +495,7 @@ describe('CamelRouteResource', () => {
 
     it('should not fail when trying to delete non-existing beans entity', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const beansEntity = new BeansEntity({ beans: [] });
 
       expect(() => resource.deleteBeansEntity(beansEntity)).not.toThrow();
@@ -470,6 +504,7 @@ describe('CamelRouteResource', () => {
 
     it('should handle beans entities in mixed entity lists', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.addNewEntity(); // Add a route
       const beansEntity = resource.createBeansEntity();
 
@@ -487,6 +522,7 @@ describe('CamelRouteResource', () => {
   describe('removeEntity', () => {
     it('should not do anything if the ID is not provided', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
 
       resource.removeEntity();
 
@@ -495,6 +531,7 @@ describe('CamelRouteResource', () => {
 
     it('should not do anything when providing a non existing ID', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
 
       resource.removeEntity(['non-existing-id']);
 
@@ -503,6 +540,7 @@ describe('CamelRouteResource', () => {
 
     it('should allow to remove an entity', () => {
       const resource = new CamelRouteResource([camelRouteJson, camelFromJson]);
+      resource.initialize();
       const camelRouteEntity = resource.getVisualEntities()[0];
 
       resource.removeEntity([camelRouteEntity.id]);
@@ -512,6 +550,7 @@ describe('CamelRouteResource', () => {
 
     it('should remove multiple entities when multiple IDs are provided', () => {
       const resource = new CamelRouteResource([camelRouteJson, camelFromJson]);
+      resource.initialize();
       const entitiesToRemove = resource.getVisualEntities().map((e) => e.id);
 
       resource.removeEntity(entitiesToRemove);
@@ -521,6 +560,7 @@ describe('CamelRouteResource', () => {
 
     it('should NOT create a new entity after deleting them all', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
       const camelRouteEntity = resource.getVisualEntities()[0];
 
       resource.removeEntity([camelRouteEntity.id]);
@@ -530,6 +570,7 @@ describe('CamelRouteResource', () => {
 
     it('should preserve comments and metadata when changing serializer', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
       resource.setSerializer(SerializerType.XML);
       resource['serializer'].setComments(['Initial Comment']);
       resource['serializer'].setMetadata({
@@ -558,6 +599,7 @@ describe('CamelRouteResource', () => {
   describe('getCanvasEntityList', () => {
     it('should return all entities for YAML serializer', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const entityList = resource.getCanvasEntityList();
@@ -584,6 +626,7 @@ describe('CamelRouteResource', () => {
 
     it('should filter out YAML-only entities for XML serializer', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.XML);
 
       const entityList = resource.getCanvasEntityList();
@@ -612,6 +655,7 @@ describe('CamelRouteResource', () => {
 
     it('should return consistent entity list structure on multiple calls', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
 
       const firstCall = resource.getCanvasEntityList();
       const secondCall = resource.getCanvasEntityList();
@@ -621,6 +665,7 @@ describe('CamelRouteResource', () => {
 
     it('should recreate entity list when called after serializer change', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const yamlEntityList = resource.getCanvasEntityList();
@@ -636,6 +681,7 @@ describe('CamelRouteResource', () => {
 
     it('should include entity titles and descriptions from catalog', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
@@ -649,6 +695,7 @@ describe('CamelRouteResource', () => {
 
     it('should properly group entities', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const entityList = resource.getCanvasEntityList();
@@ -669,6 +716,7 @@ describe('CamelRouteResource', () => {
         { rest: { path: '/api' } },
         { from: { uri: 'direct:route1', steps: [] } },
       ]);
+      resource.initialize();
 
       const visualEntities = resource.getVisualEntities();
       expect(visualEntities).toHaveLength(1);
@@ -681,6 +729,7 @@ describe('CamelRouteResource', () => {
         { rest: { path: '/api' } },
         { from: { uri: 'direct:route1', steps: [] } },
       ]);
+      resource.initialize();
 
       const entities = resource.getEntities();
       const entityTypes = entities.map((e) => e.type);
@@ -690,6 +739,7 @@ describe('CamelRouteResource', () => {
 
     it('should not include Rest and RestConfiguration in getCanvasEntityList', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const entityList = resource.getCanvasEntityList();
@@ -707,6 +757,7 @@ describe('CamelRouteResource', () => {
 
     it('should still allow adding Rest and RestConfiguration via addNewEntity', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
 
       const restConfigId = resource.addNewEntity(EntityType.RestConfiguration);
       const restId = resource.addNewEntity(EntityType.Rest);
@@ -726,17 +777,20 @@ describe('CamelRouteResource', () => {
   describe('getSerializerType', () => {
     it('should return YAML serializer type by default', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       expect(resource.getSerializerType()).toBe(SerializerType.YAML);
     });
 
     it('should return XML serializer type after setting XML serializer', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.XML);
       expect(resource.getSerializerType()).toBe(SerializerType.XML);
     });
 
     it('should return current serializer type after multiple changes', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
 
       resource.setSerializer(SerializerType.XML);
       expect(resource.getSerializerType()).toBe(SerializerType.XML);
@@ -749,6 +803,7 @@ describe('CamelRouteResource', () => {
   describe('toString', () => {
     it('should delegate to serializer serialize method', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
       const serialized = resource.toString();
 
       expect(typeof serialized).toBe('string');
@@ -757,6 +812,7 @@ describe('CamelRouteResource', () => {
 
     it('should support switching between serializer types', () => {
       const resource = new CamelRouteResource([camelRouteJson]);
+      resource.initialize();
 
       // Test YAML serializer
       expect(resource.getSerializerType()).toBe(SerializerType.YAML);
@@ -827,6 +883,7 @@ describe('CamelRouteResource', () => {
     ];
     it.each(testCases)('should not throw error when calling: %s', (json) => {
       const resource = new CamelRouteResource(json);
+      resource.initialize();
       const firstEntity = resource.getVisualEntities()[0] ?? resource.getEntities()[0];
       expect(firstEntity.toJSON()).not.toBeUndefined();
     });
@@ -835,6 +892,7 @@ describe('CamelRouteResource', () => {
   describe('getCompatibleRuntimes', () => {
     it('should return the correct list of compatible runtimes', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -842,13 +900,16 @@ describe('CamelRouteResource', () => {
 
     it('should return the same list regardless of resource content', () => {
       const emptyResource = new CamelRouteResource();
+      emptyResource.initialize();
       const resourceWithRoutes = new CamelRouteResource([camelRouteJson, camelFromJson]);
+      resourceWithRoutes.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithRoutes.getCompatibleRuntimes());
     });
 
     it('should return an array with three runtime names', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -858,6 +919,7 @@ describe('CamelRouteResource', () => {
   describe('edge cases and error handling', () => {
     it('should handle empty entities array in constructor', () => {
       const resource = new CamelRouteResource([]);
+      resource.initialize();
 
       expect(resource.getVisualEntities()).toHaveLength(0);
       expect(resource.getEntities()).toHaveLength(0);
@@ -867,6 +929,7 @@ describe('CamelRouteResource', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const entities = [camelRouteJson, null, undefined, { from: { uri: 'direct:test' } }] as any;
       const resource = new CamelRouteResource(entities);
+      resource.initialize();
 
       expect(resource.getVisualEntities()).toHaveLength(2); // Only valid entities
     });
@@ -882,6 +945,7 @@ describe('CamelRouteResource', () => {
       ] as any;
 
       const resource = new CamelRouteResource(malformedEntities);
+      resource.initialize();
 
       // Should create NonVisualEntity for unrecognized entities
       expect(resource.getEntities()).toHaveLength(5); // All become NonVisualEntity
@@ -892,6 +956,7 @@ describe('CamelRouteResource', () => {
         { routeConfiguration: { id: 'config1' } },
         { from: { uri: 'direct:route1', steps: [] } },
       ]);
+      resource.initialize();
 
       const initialVisualCount = resource.getVisualEntities().length;
 
@@ -923,12 +988,14 @@ describe('CamelRouteResource', () => {
       const arrayInput = [{ from: { uri: 'direct:test' } }];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const resourceWithArray = new CamelRouteResource(arrayInput as any);
+      resourceWithArray.initialize();
 
       expect(resourceWithArray.getVisualEntities()).toHaveLength(1);
     });
 
     it('should support template parameter in addNewEntity for all entity types', () => {
       const resource = new CamelRouteResource();
+      resource.initialize();
 
       // Test with RouteConfiguration template
       const configTemplate = { routeConfiguration: { id: 'custom-config', description: 'Custom configuration' } };

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -116,12 +116,17 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   private resolvedEntities: BaseVisualEntityDefinition | undefined;
 
   constructor(
-    rawEntities?: CamelYamlDsl,
+    private readonly rawEntities?: CamelYamlDsl,
     private serializer: KaotoResourceSerializer = new YamlCamelResourceSerializer(),
-  ) {
-    if (!rawEntities) return;
+  ) {}
 
-    const entities = Array.isArray(rawEntities) ? rawEntities : [rawEntities];
+  initialize(): void {
+    if (!this.rawEntities) {
+      this.entities = [];
+      return;
+    }
+
+    const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
     const parsedEntities = entities.reduce((acc, rawItem) => {
       const entity = this.getEntity(rawItem);
       if (isDefined(entity) && typeof entity === 'object') {

--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -19,6 +19,11 @@ export class IntegrationResource extends CamelKResource {
     }
   }
 
+  initialize(): void {
+    super.initialize();
+    // TODO: Initialize visual entities when implemented
+  }
+
   getEntities(): BaseEntity[] {
     return super.getEntities(); // TODO
   }

--- a/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
@@ -5,6 +5,7 @@ import { SourceSchemaType } from './source-schema-type';
 describe('KameletBindingResource', () => {
   it('should create KameletBindingResource', () => {
     const resource = new KameletBindingResource(kameletBindingJson);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0];
@@ -17,6 +18,7 @@ describe('KameletBindingResource', () => {
   describe('getCompatibleRuntimes', () => {
     it('should return the correct list of compatible runtimes', () => {
       const resource = new KameletBindingResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -24,13 +26,16 @@ describe('KameletBindingResource', () => {
 
     it('should return the same list regardless of resource content', () => {
       const emptyResource = new KameletBindingResource();
+      emptyResource.initialize();
       const resourceWithBinding = new KameletBindingResource(kameletBindingJson);
+      resourceWithBinding.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithBinding.getCompatibleRuntimes());
     });
 
     it('should return an array with three runtime names', () => {
       const resource = new KameletBindingResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -39,6 +44,7 @@ describe('KameletBindingResource', () => {
 
   it('should initialize KameletBinding if no args is specified', () => {
     const resource = new KameletBindingResource(undefined);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -15,6 +15,7 @@ describe('KameletResource', () => {
 
   it('should create a new KameletResource', () => {
     const kameletResource = new KameletResource();
+    kameletResource.initialize();
     expect(kameletResource).toMatchSnapshot();
   });
 
@@ -51,12 +52,14 @@ describe('KameletResource', () => {
         },
       },
     });
+    kameletResource.initialize();
 
     expect(kameletResource).toMatchSnapshot();
   });
 
   it('should remove the entity', () => {
     const kameletResource = new KameletResource();
+    kameletResource.initialize();
 
     kameletResource.removeEntity();
 
@@ -67,16 +70,19 @@ describe('KameletResource', () => {
 
   it('should get the type', () => {
     const kameletResource = new KameletResource();
+    kameletResource.initialize();
     expect(kameletResource.getType()).toEqual(SourceSchemaType.Kamelet);
   });
 
   it('should get the visual entities (Camel Route Visual Entity)', () => {
     const kameletResource = new KameletResource();
+    kameletResource.initialize();
     expect(kameletResource.getVisualEntities()).toMatchSnapshot();
   });
 
   it('should convert to JSON', () => {
     const kameletResource = new KameletResource();
+    kameletResource.initialize();
     expect(kameletResource.toJSON()).toMatchSnapshot();
   });
 
@@ -116,6 +122,7 @@ describe('KameletResource', () => {
   describe('getCompatibleRuntimes', () => {
     it('should return the correct list of compatible runtimes', () => {
       const kameletResource = new KameletResource();
+      kameletResource.initialize();
       const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -123,13 +130,16 @@ describe('KameletResource', () => {
 
     it('should return the same list regardless of resource content', () => {
       const emptyResource = new KameletResource();
+      emptyResource.initialize();
       const resourceWithKamelet = new KameletResource(kameletJson);
+      resourceWithKamelet.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
     });
 
     it('should return an array with three runtime names', () => {
       const kameletResource = new KameletResource();
+      kameletResource.initialize();
       const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -140,6 +150,7 @@ describe('KameletResource', () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();
     const kameletResource = new KameletResource(model);
+    kameletResource.initialize();
     expect(kameletResource.getRouteTemplateBeansEntity()).toBeUndefined();
     kameletResource.createRouteTemplateBeansEntity();
     const beansEntity = kameletResource.getRouteTemplateBeansEntity();

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -24,8 +24,12 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
     if (!kamelet) {
       this.resource = FlowTemplateService.getFlowTemplate(this.getType());
     }
-
     this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
+  }
+
+  initialize(): void {
+    super.initialize();
+
     if (this.flow.kamelet.spec.template.beans) {
       this.beans = new RouteTemplateBeansEntity(this.flow.kamelet.spec.template as RouteTemplateBeansParentType);
     }

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -5,6 +5,7 @@ import { SourceSchemaType } from './source-schema-type';
 describe('PipeResource', () => {
   it('should create KameletBindingResource', () => {
     const resource = new PipeResource(pipeJson);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0];
@@ -20,6 +21,7 @@ describe('PipeResource', () => {
 
   it('should initialize Pipe if no args is specified', () => {
     const resource = new PipeResource();
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -32,6 +34,7 @@ describe('PipeResource', () => {
   describe('getCompatibleRuntimes', () => {
     it('should return the correct list of compatible runtimes', () => {
       const resource = new PipeResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -39,13 +42,16 @@ describe('PipeResource', () => {
 
     it('should return the same list regardless of resource content', () => {
       const emptyResource = new PipeResource();
+      emptyResource.initialize();
       const resourceWithPipe = new PipeResource(pipeJson);
+      resourceWithPipe.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithPipe.getCompatibleRuntimes());
     });
 
     it('should return an array with three runtime names', () => {
       const resource = new PipeResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
@@ -54,6 +60,7 @@ describe('PipeResource', () => {
 
   it('should create/delete entities', () => {
     const resource = new PipeResource();
+    resource.initialize();
     expect(resource.getEntities().length).toEqual(0);
     expect(resource.getMetadataEntity()).toBeUndefined();
     expect(resource.getErrorHandlerEntity()).toBeUndefined();

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -26,9 +26,14 @@ export class PipeResource extends CamelKResource {
     if (!this.pipe.spec) {
       this.pipe.spec = {};
     }
+  }
+
+  initialize(): void {
+    super.initialize();
+
     this.flow = new PipeVisualEntity(this.pipe);
     this.errorHandler =
-      this.pipe.spec.errorHandler && new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler);
+      this.pipe.spec?.errorHandler && new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler);
   }
 
   removeEntity(): void {

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -11,6 +11,7 @@ import { CitrusTestResource } from './citrus-test-resource';
 describe('CitrusTestResource', () => {
   it('should initialize Citrus test if no args is specified', () => {
     const resource = new CitrusTestResource();
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(0);
@@ -18,6 +19,7 @@ describe('CitrusTestResource', () => {
 
   it('should initialize Citrus test', () => {
     const resource = new CitrusTestResource(citrusTestJson);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -30,6 +32,7 @@ describe('CitrusTestResource', () => {
   describe('addNewEntity', () => {
     it('should add new entity and return its ID', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       const id = resource.addNewEntity();
 
       expect(resource.getVisualEntities()).toHaveLength(1);
@@ -38,6 +41,7 @@ describe('CitrusTestResource', () => {
 
     it('should add new entities at the end of the list and return its ID', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.Test);
 
@@ -47,6 +51,7 @@ describe('CitrusTestResource', () => {
 
     it('should add the given entities at the end of the list and return its ID', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.Test, FlowTemplateService.getFlowTemplate(SourceSchemaType.Test)[0]);
 
@@ -57,16 +62,19 @@ describe('CitrusTestResource', () => {
 
   it('should return the right type', () => {
     const resource = new CitrusTestResource();
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
   });
 
   it('should not allow consumers to have multiple visual entities', () => {
     const resource = new CitrusTestResource();
+    resource.initialize();
     expect(resource.supportsMultipleVisualEntities()).toEqual(false);
   });
 
   it('should return visual entities', () => {
     const resource = new CitrusTestResource(citrusTestJson);
+    resource.initialize();
     expect(resource.getVisualEntities()).toHaveLength(1);
     expect(resource.getVisualEntities()[0]).toBeInstanceOf(CitrusTestVisualEntity);
     expect(resource.getEntities()).toHaveLength(0);
@@ -74,6 +82,7 @@ describe('CitrusTestResource', () => {
 
   it('should return entities', () => {
     const resource = new CitrusTestResource(citrusTestJson);
+    resource.initialize();
     expect(resource.getEntities()).toHaveLength(0);
     expect(resource.getVisualEntities()).toHaveLength(1);
   });
@@ -81,6 +90,7 @@ describe('CitrusTestResource', () => {
   describe('toJSON', () => {
     it('should return JSON', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       expect(resource.toJSON()).toMatchSnapshot();
     });
   });
@@ -88,6 +98,7 @@ describe('CitrusTestResource', () => {
   describe('removeEntity', () => {
     it('should not do anything if the ID is not provided', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
 
       resource.removeEntity();
 
@@ -96,6 +107,7 @@ describe('CitrusTestResource', () => {
 
     it('should not do anything when providing a non existing ID', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
 
       resource.removeEntity(['non-existing-id']);
 
@@ -104,6 +116,7 @@ describe('CitrusTestResource', () => {
 
     it('should allow to remove an entity', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       resource.addNewEntity();
       expect(resource.getVisualEntities()).toHaveLength(2);
 
@@ -116,6 +129,7 @@ describe('CitrusTestResource', () => {
 
     it('should remove multiple entities when multiple IDs are provided', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       resource.addNewEntity();
       const entitiesToRemove = resource.getVisualEntities().map((e) => e.id);
 
@@ -126,6 +140,7 @@ describe('CitrusTestResource', () => {
 
     it('should NOT create a new entity after deleting them all', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       const citrusTestEntity = resource.getVisualEntities()[0];
 
       resource.removeEntity([citrusTestEntity.id]);
@@ -137,6 +152,7 @@ describe('CitrusTestResource', () => {
   describe('getCanvasEntityList', () => {
     it('should return all entities for YAML serializer', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const entityList = resource.getCanvasEntityList();
@@ -148,6 +164,7 @@ describe('CitrusTestResource', () => {
 
     it('should return consistent entity list structure on multiple calls', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
 
       const firstCall = resource.getCanvasEntityList();
       const secondCall = resource.getCanvasEntityList();
@@ -157,6 +174,7 @@ describe('CitrusTestResource', () => {
 
     it('should recreate entity list when called after serializer change', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const yamlEntityList = resource.getCanvasEntityList();
@@ -172,6 +190,7 @@ describe('CitrusTestResource', () => {
 
     it('should include entity titles and descriptions from catalog', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
@@ -185,6 +204,7 @@ describe('CitrusTestResource', () => {
 
     it('should properly group entities', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       resource.setSerializer(SerializerType.YAML);
 
       const entityList = resource.getCanvasEntityList();
@@ -200,6 +220,7 @@ describe('CitrusTestResource', () => {
   describe('toString', () => {
     it('should delegate to serializer serialize method', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       const serialized = resource.toString();
 
       expect(typeof serialized).toBe('string');
@@ -208,6 +229,7 @@ describe('CitrusTestResource', () => {
 
     it('should support switching between serializer types', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
 
       // Test YAML serializer
       expect(resource.getSerializerType()).toBe(SerializerType.YAML);
@@ -223,6 +245,7 @@ describe('CitrusTestResource', () => {
   describe('getCompatibleRuntimes', () => {
     it('should return the correct list of compatible runtimes', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Citrus']);
@@ -230,13 +253,16 @@ describe('CitrusTestResource', () => {
 
     it('should return the same list regardless of resource content', () => {
       const emptyResource = new CitrusTestResource();
+      emptyResource.initialize();
       const resourceWithTest = new CitrusTestResource(citrusTestJson);
+      resourceWithTest.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithTest.getCompatibleRuntimes());
     });
 
     it('should return an array with one runtime name', () => {
       const resource = new CitrusTestResource();
+      resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Citrus']);
@@ -246,6 +272,7 @@ describe('CitrusTestResource', () => {
   describe('getCompatibleComponents', () => {
     it('should get compatible types', () => {
       const resource = new CitrusTestResource(citrusTestJson);
+      resource.initialize();
       const tileFilter = resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
         name: 'print',
         path: 'actions.0',

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -49,12 +49,17 @@ export class CitrusTestResource implements KaotoResource {
    * @param serializer - Serializer for converting between object and string representations (defaults to YAML)
    */
   constructor(
-    rawEntities?: Test | Test[],
+    private readonly rawEntities?: Test | Test[],
     private serializer: KaotoResourceSerializer = new YamlCamelResourceSerializer(),
-  ) {
-    if (!rawEntities) return;
+  ) {}
 
-    const entities = Array.isArray(rawEntities) ? rawEntities : [rawEntities];
+  initialize(): void {
+    if (!this.rawEntities) {
+      this.entities = [];
+      return;
+    }
+
+    const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
     const parsedEntities = entities.reduce((acc, rawItem) => {
       const entity = this.getEntity(rawItem);
       if (isDefined(entity) && typeof entity === 'object') {

--- a/packages/ui/src/models/kaoto-resource.test.ts
+++ b/packages/ui/src/models/kaoto-resource.test.ts
@@ -3,12 +3,17 @@ import { citrusTestYaml } from '../stubs/citrus-test';
 import { integrationJson } from '../stubs/integration';
 import { kameletBindingJson } from '../stubs/kamelet-binding-route';
 import { kameletJson } from '../stubs/kamelet-route';
+import { mockRandomValues } from '../stubs/mock-random-values';
 import { pipeJson } from '../stubs/pipe';
 import { CamelResourceFactory } from './camel/camel-resource-factory';
 import { SourceSchemaType } from './camel/source-schema-type';
 import { CamelRouteVisualEntity, CitrusTestVisualEntity, PipeVisualEntity } from './visualization/flows';
 
 describe('CamelResourceFactory.createCamelResource', () => {
+  beforeAll(() => {
+    mockRandomValues();
+  });
+
   it('should create an empty CamelRouteResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
@@ -40,7 +45,9 @@ describe('CamelResourceFactory.createCamelResource', () => {
   it('should create an empty KameletResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chuck-norris-source.kamelet.yaml' });
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
-    expect(resource.getEntities()).toEqual([]);
+    const entities = resource.getEntities();
+    expect(entities).toHaveLength(1);
+    expect(entities[0].toJSON()).toEqual({ metadata: { name: expect.stringMatching(/^kamelet-\d{4}$/) } });
     expect(resource.getVisualEntities()).toMatchSnapshot();
   });
 

--- a/packages/ui/src/models/kaoto-resource.ts
+++ b/packages/ui/src/models/kaoto-resource.ts
@@ -8,7 +8,15 @@ import { AddStepMode, BaseVisualEntity, IVisualizationNodeData } from './visuali
 import { BeansEntity } from './visualization/metadata';
 import { RouteTemplateBeansEntity } from './visualization/metadata/routeTemplateBeansEntity';
 
+/**
+ * The KaotoResource should be created lazily, as some require a fully loaded catalog to properly
+ * parse them (f.i. XML Camel Routes)
+ */
 export interface KaotoResource {
+  /**
+   * After creation, the `initialize` method parses the underlying DSL to populate the resource entities
+   */
+  initialize(): void;
   getVisualEntities(): BaseVisualEntity[];
   getEntities(): BaseEntity[];
   addNewEntity(entityType?: EntityType, entityTemplate?: unknown, insertAfterEntityId?: string): string;

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -24,6 +24,7 @@ describe('BeansEntityHandler', () => {
     beforeEach(() => {
       model = cloneDeep(routeStub.camelRouteJson);
       const camelRouteResource = new CamelRouteResource(model);
+      camelRouteResource.initialize();
       beansHandler = new BeansEntityHandler(camelRouteResource);
     });
 
@@ -77,6 +78,7 @@ describe('BeansEntityHandler', () => {
     beforeEach(() => {
       model = cloneDeep(kameletStub.kameletJson);
       const kameletResource = new KameletResource(model);
+      kameletResource.initialize();
       beansHandler = new BeansEntityHandler(kameletResource);
     });
 
@@ -140,6 +142,7 @@ describe('BeansEntityHandler', () => {
 
     it('if CamelResource is not the supported one', () => {
       const camelResource = new PipeResource({});
+      camelResource.initialize();
       const beansHandler = new BeansEntityHandler(camelResource);
       expect(beansHandler.isSupported()).toBeFalsy();
       expect(beansHandler.stripReferenceQuote('#myBean')).toBeUndefined();

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
@@ -25,6 +25,7 @@ describe('EndpointsEntityHandler', () => {
         actions: [],
       };
       testResource = new CitrusTestResource(testModel);
+      testResource.initialize();
       endpointsHandler = new EndpointsEntityHandler(testResource);
     });
 

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -41,6 +41,7 @@ describe('RestRouteEndpointField', () => {
       { route: { from: { uri: 'direct:billing', steps: [] } } },
     ]);
     const { Provider } = TestProvidersWrapper({ camelResource });
+    camelResource.initialize();
 
     await act(async () => {
       render(

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -185,6 +185,7 @@ describe('useRestDslImportWizard', () => {
       },
     ]);
 
+    camelResource.initialize();
     const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
 
@@ -244,6 +245,7 @@ describe('useRestDslImportWizard', () => {
         },
       },
     ]);
+    camelResource.initialize();
 
     const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');

--- a/packages/ui/src/providers/visible-flows.provider.test.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.test.tsx
@@ -11,6 +11,7 @@ describe('VisibleFlowsProvider', () => {
     mockRandomValues();
 
     const camelResource = new CamelRouteResource();
+    camelResource.initialize();
     camelResource.addNewEntity(EntityType.Route);
 
     const { Provider } = TestProvidersWrapper({ camelResource });
@@ -28,6 +29,7 @@ describe('VisibleFlowsProvider', () => {
 
   it('should initialize visible flows with an empty context', () => {
     const camelResource = new CamelRouteResource();
+    camelResource.initialize();
     const { Provider } = TestProvidersWrapper({ camelResource });
 
     const wrapper = render(

--- a/packages/ui/src/serializers/xml-camel-resource-serializer.test.ts
+++ b/packages/ui/src/serializers/xml-camel-resource-serializer.test.ts
@@ -26,6 +26,7 @@ describe('XmlCamelResourceSerializer', () => {
 
   it('should insert comments into XML', () => {
     const resource = new CamelRouteResource([]);
+    resource.initialize();
     serializer.setComments(['Comment 1', 'Comment 2']);
 
     const xml = serializer.serialize(resource);
@@ -35,6 +36,7 @@ describe('XmlCamelResourceSerializer', () => {
 
   it('should include XML declaration in serialized XML', () => {
     const resource = new CamelRouteResource([]);
+    resource.initialize();
     serializer.setMetadata({ xmlDeclaration: '<?xml version="1.0" encoding="UTF-8"?>' });
     const xml = serializer.serialize(resource);
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
@@ -42,12 +44,14 @@ describe('XmlCamelResourceSerializer', () => {
 
   it('should include default camel namespace in root', () => {
     const resource = new CamelRouteResource([]);
+    resource.initialize();
     const xml = serializer.serialize(resource);
     expect(xml).toContain('xmlns="http://camel.apache.org/schema/spring"');
   });
 
   it('should include all root element definitions', () => {
     const resource = new CamelRouteResource([]);
+    resource.initialize();
     serializer.setMetadata({
       rootElementDefinitions: [
         { name: 'xmlns:xsi', value: 'http://www.w3.org/2001/XMLSchema-instance' },

--- a/packages/ui/src/services/documentation.service.test.ts
+++ b/packages/ui/src/services/documentation.service.test.ts
@@ -97,6 +97,7 @@ describe('DocumentationService', () => {
       mockRandomValues();
 
       const camelResource = new CamelRouteResource([restStub, restConfigurationStub]);
+      camelResource.initialize();
       const documentationEntities = createDocumentationEntitiesFromCamelResource(camelResource);
 
       expect(documentationEntities.length).toEqual(2);
@@ -209,6 +210,7 @@ describe('DocumentationService', () => {
 
     it('should generate rest markdown', () => {
       const camelResource = new CamelRouteResource([restStub, restConfigurationStub]);
+      camelResource.initialize();
       const documentationEntities = createDocumentationEntitiesFromCamelResource(camelResource);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -21,6 +21,9 @@ interface TestProvidersWrapperResult {
 
 export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): TestProvidersWrapperResult => {
   const camelResource = props.camelResource ?? new CamelRouteResource([camelRouteJson]);
+  if (!props.camelResource) {
+    camelResource.initialize();
+  }
   const currentSchemaType = camelResource.getType();
   const updateEntitiesFromCamelResourceSpy = jest.fn();
   const updateSourceCodeFromEntitiesSpy = jest.fn();

--- a/packages/ui/src/tests/nodes-edges.test.ts
+++ b/packages/ui/src/tests/nodes-edges.test.ts
@@ -10,6 +10,7 @@ describe('Nodes and Edges', () => {
 
   it('should generate edges for steps with branches', async () => {
     const camelResource = new CamelRouteResource(camelRouteBranch);
+    camelResource.initialize();
     const [camelRoute] = camelResource.getVisualEntities();
 
     const rootVizNode = await camelRoute.toVizNode();


### PR DESCRIPTION
### Context
Currently, creating and initializing a `KaotoResource` is made in a single step, at the constructor level. While this approach is working at the moment, it creates a circular dependency between the Catalog and the DSL parsing:

1. In order to properly parse some DSL (like XML Camel routes), a fully loaded catalog is required.
2. On the other hand, determining what catalog should be loaded, for instance, to decide between a Camel catalog vs a Citrus catalog, a resource should be already created.

This pull request splits the `KaotoResource` initialization from the creation process, effectively turning it into a 2-phase process, first it creates the resource container, enough information to properly asses what type of catalog should be loaded, then parsing its entities once the catalog is fully loaded.

### Changes
- Add rawEntities field to store unparsed data
- Move entity parsing from constructor to generate() method
- Update tests to call generate() after construction
- Add tests for two-phase initialization pattern

relates: https://github.com/KaotoIO/kaoto/issues/3230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Many test suites were updated to explicitly initialize resource instances before running assertions, improving test setup consistency.

* **Refactor**
  * Resource classes now support deferred initialization via a new initialize() method; constructors no longer eagerly parse entities.
  * Factory now initializes created resources before returning them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->