### PR TITLE
Feat/2857 container auto mapping

### DIFF
--- a/packages/ui/src/components/View/MappingLink.scss
+++ b/packages/ui/src/components/View/MappingLink.scss
@@ -1,42 +1,85 @@
 .mapping-link {
-  stroke: gray;
-  stroke-width: 3;
+  fill: none;
+  stroke-linecap: round;
   pointer-events: auto;
 
-  &:hover {
-    stroke-width: 6;
+  &--copy-of {
+    stroke: #3c3f42;
+    stroke-width: 2;
+  }
+
+  &--complete {
+    stroke: gray;
+    stroke-width: 3;
+    stroke-dasharray: 20 5 5 5;
+  }
+
+  &--regular {
+    stroke: gray;
+    stroke-width: 2;
+  }
+
+  &--partial {
+    stroke: gray;
+    stroke-width: 2;
+    stroke-dasharray: 5 3;
+  }
+
+  // stylelint-disable-next-line selector-class-pattern
+  &--out-of-view {
+    stroke: #b8bbbe;
+    stroke-width: 1;
+    stroke-dasharray: 0.1 4;
   }
 
   &--selected {
     stroke: var(--pf-t--global--border--color--brand--default);
-    stroke-width: 6;
-  }
 
-  &--partial {
-    stroke-dasharray: 5, 5;
-    opacity: 0.5;
-  }
-
-  &--edge {
-    stroke-width: 2;
-
-    &:hover {
-      stroke-width: 4;
+    // stylelint-disable-next-line selector-class-pattern
+    &.mapping-link--out-of-view {
+      stroke: #73bcf7;
     }
   }
 
+  &:hover {
+    stroke-width: 4;
+  }
+
   &--source-edge {
-    // Edge -> Node: fade in from 25% to 100%
     mask-image: linear-gradient(to right, rgb(0 0 0 / 25%) 0%, rgb(0 0 0 / 100%) 100%);
   }
 
   &--target-edge {
-    // Node -> Edge: fade out from 100% to 25%
     mask-image: linear-gradient(to right, rgb(0 0 0 / 100%) 0%, rgb(0 0 0 / 25%) 100%);
   }
 
-  // Edge -> Edge: both ends at 25%, peak in middle
   &--source-edge#{&}--target-edge {
     mask-image: linear-gradient(to right, rgb(0 0 0 / 25%) 0%, rgb(0 0 0 / 100%) 50%, rgb(0 0 0 / 25%) 100%);
+  }
+}
+
+.mapping-link-dot {
+  &--copy-of {
+    fill: #3c3f42;
+  }
+
+  &--complete,
+  &--regular,
+  &--partial {
+    fill: gray;
+  }
+
+  // stylelint-disable-next-line selector-class-pattern
+  &--out-of-view {
+    fill: #b8bbbe;
+  }
+
+  &--selected {
+    fill: var(--pf-t--global--border--color--brand--default);
+  }
+
+  // stylelint-disable-next-line selector-class-pattern
+  &--selected.mapping-link-dot--out-of-view {
+    fill: #73bcf7;
   }
 }

--- a/packages/ui/src/components/View/MappingLink.test.tsx
+++ b/packages/ui/src/components/View/MappingLink.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 
+import { MappingLineStyle } from '../../models/datamapper';
 import { useDocumentTreeStore } from '../../store';
 import { MappingLink } from './MappingLink';
 
@@ -30,9 +31,9 @@ describe('MappingLink', () => {
     sourceNodePath: 'source.path',
     targetNodePath: 'target.path',
     isSelected: false,
-    isPartial: false,
     isSourceEdge: false,
     isTargetEdge: false,
+    lineStyle: MappingLineStyle.REGULAR,
   };
 
   it('renders circles at endpoints', () => {

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -5,11 +5,18 @@ import { Circle, LinePath } from '@visx/shape';
 import clsx from 'clsx';
 import { FunctionComponent, useCallback, useState } from 'react';
 
-import { LineProps } from '../../models/datamapper';
+import { LineProps, MappingLineStyle } from '../../models/datamapper';
 import { useDocumentTreeStore } from '../../store';
 
 const getY = (d: number[]) => d[1];
 const getX = (d: number[]) => d[0];
+
+const COPY_OF_OFFSET = 3;
+
+function bezierPath(sx: number, sy: number, tx: number, ty: number): string {
+  const cx = (sx + tx) / 2;
+  return `M ${sx} ${sy} C ${cx} ${sy} ${cx} ${ty} ${tx} ${ty}`;
+}
 
 export const MappingLink: FunctionComponent<LineProps> = ({
   x1,
@@ -19,32 +26,32 @@ export const MappingLink: FunctionComponent<LineProps> = ({
   sourceNodePath,
   targetNodePath,
   isSelected,
-  isPartial,
   isSourceEdge,
   isTargetEdge,
+  lineStyle,
 }) => {
   const toggleSelectedNode = useDocumentTreeStore((state) => state.toggleSelectedNode);
   const [isOver, setIsOver] = useState<boolean>(false);
   const dotRadius = isOver ? 6 : 3;
 
-  // Calculate control points as 10% from each end
   const controlPoint1X = x1 + (x2 - x1) * 0.1;
   const controlPoint2X = x1 + (x2 - x1) * 0.9;
 
-  const isEdge = isSourceEdge || isTargetEdge;
-
-  const onMouseEnter = useCallback(() => {
-    setIsOver(true);
-  }, []);
-
-  const onMouseLeave = useCallback(() => {
-    setIsOver(false);
-  }, []);
-
+  const onMouseEnter = useCallback(() => setIsOver(true), []);
+  const onMouseLeave = useCallback(() => setIsOver(false), []);
   const onLineClick = useCallback(() => {
-    // Select the target node - this will highlight all involved nodes in the mapping
     toggleSelectedNode(targetNodePath, false);
   }, [toggleSelectedNode, targetNodePath]);
+
+  const lineClassName = clsx('mapping-link', `mapping-link--${lineStyle}`, {
+    'mapping-link--selected': isSelected,
+    'mapping-link--source-edge': isSourceEdge,
+    'mapping-link--target-edge': isTargetEdge,
+  });
+
+  const dotClassName = clsx('mapping-link-dot', `mapping-link-dot--${lineStyle}`, {
+    'mapping-link-dot--selected': isSelected,
+  });
 
   const curveData: [number, number][] = [
     [x1, y1],
@@ -53,28 +60,46 @@ export const MappingLink: FunctionComponent<LineProps> = ({
     [x2, y2],
   ];
 
+  const interactionProps = {
+    onClick: onLineClick,
+    onMouseEnter,
+    onMouseLeave,
+  };
+
+  const testId = `mapping-link-${isSelected ? 'selected-' : ''}${x1}-${y1}-${x2}-${y2}`;
+  const isCopyOf = lineStyle === MappingLineStyle.COPY_OF;
+
   return (
     <>
-      <Circle role="presentation" r={dotRadius} cx={x1} cy={y1} />
-      <LinePath<[number, number]>
-        data={curveData}
-        x={getX}
-        y={getY}
-        curve={curveMonotoneX}
-        className={clsx('mapping-link', {
-          'mapping-link--selected': isSelected,
-          'mapping-link--partial': isPartial,
-          'mapping-link--edge': isEdge,
-          'mapping-link--source-edge': isSourceEdge,
-          'mapping-link--target-edge': isTargetEdge,
-        })}
-        onClick={onLineClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        data-testid={`mapping-link-${isSelected ? 'selected-' : ''}${x1}-${y1}-${x2}-${y2}`}
-        xlinkTitle={`Source: ${sourceNodePath}, Target: ${targetNodePath}`}
-      />
-      <Circle role="presentation" r={dotRadius} cx={x2} cy={y2} />
+      <Circle role="presentation" r={dotRadius} cx={x1} cy={y1} className={dotClassName} />
+      {isCopyOf ? (
+        <>
+          <path
+            d={bezierPath(x1, y1 - COPY_OF_OFFSET, x2, y2 - COPY_OF_OFFSET)}
+            className={lineClassName}
+            data-testid={testId}
+            xlinkTitle={`Source: ${sourceNodePath}, Target: ${targetNodePath}`}
+            {...interactionProps}
+          />
+          <path
+            d={bezierPath(x1, y1 + COPY_OF_OFFSET, x2, y2 + COPY_OF_OFFSET)}
+            className={lineClassName}
+            {...interactionProps}
+          />
+        </>
+      ) : (
+        <LinePath<[number, number]>
+          data={curveData}
+          x={getX}
+          y={getY}
+          curve={curveMonotoneX}
+          className={lineClassName}
+          data-testid={testId}
+          xlinkTitle={`Source: ${sourceNodePath}, Target: ${targetNodePath}`}
+          {...interactionProps}
+        />
+      )}
+      <Circle role="presentation" r={dotRadius} cx={x2} cy={y2} className={dotClassName} />
     </>
   );
 };

--- a/packages/ui/src/components/View/MappingLinkContainer.test.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-import { IMappingLink } from '../../models/datamapper';
+import { IMappingLink, MappingLineStyle } from '../../models/datamapper';
 import { MappingLinksContainer } from './MappingLinkContainer';
 
 const mockGetNearestVisiblePort = jest.fn();
@@ -25,12 +25,18 @@ jest.mock('../../store', () => ({
     }),
 }));
 
-const buildLink = (sourceNodePath: string, targetNodePath: string, isSelected: boolean): IMappingLink => ({
+const buildLink = (
+  sourceNodePath: string,
+  targetNodePath: string,
+  isSelected: boolean,
+  lineStyle: MappingLineStyle = MappingLineStyle.REGULAR,
+): IMappingLink => ({
   sourceNodePath,
   targetNodePath,
   sourceDocumentId: 'doc-SOURCE_BODY-body',
   targetDocumentId: 'doc-TARGET_BODY-body',
   isSelected,
+  lineStyle,
 });
 
 describe('MappingLinksContainer', () => {
@@ -90,5 +96,65 @@ describe('MappingLinksContainer', () => {
 
     const { container } = render(<MappingLinksContainer />);
     expect(container.querySelectorAll('[data-testid^="mapping-link-"]')).toHaveLength(1);
+  });
+
+  it('should override lineStyle to OUT_OF_VIEW when source port is at edge', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.COMPLETE)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'edge', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--out-of-view');
+    expect(link).not.toHaveClass('mapping-link--complete');
+  });
+
+  it('should override lineStyle to OUT_OF_VIEW when target port is at edge', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.PARTIAL)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'edge', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--out-of-view');
+    expect(link).not.toHaveClass('mapping-link--partial');
+  });
+
+  it('should override COMPLETE to REGULAR when both ports are visible nodes', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.COMPLETE)]);
+
+    mockGetNearestVisiblePort.mockReturnValue({ connectionTarget: 'node', position: [100, 200] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--regular');
+    expect(link).not.toHaveClass('mapping-link--complete');
+  });
+
+  it('should override PARTIAL to REGULAR when both ports are visible nodes', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.PARTIAL)]);
+
+    mockGetNearestVisiblePort.mockReturnValue({ connectionTarget: 'node', position: [100, 200] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--regular');
+    expect(link).not.toHaveClass('mapping-link--partial');
+  });
+
+  it('should preserve COPY_OF lineStyle when both ports are visible nodes', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.COPY_OF)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--copy-of');
   });
 });

--- a/packages/ui/src/components/View/MappingLinkContainer.test.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.test.tsx
@@ -157,4 +157,43 @@ describe('MappingLinksContainer', () => {
     const link = container.querySelector('[data-testid^="mapping-link-"]');
     expect(link).toHaveClass('mapping-link--copy-of');
   });
+
+  it('should override COPY_OF to PARTIAL when target port is on a collapsed parent', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.COPY_OF)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'parent', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--partial');
+    expect(link).not.toHaveClass('mapping-link--copy-of');
+  });
+
+  it('should override REGULAR to PARTIAL when source port is on a collapsed parent', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.REGULAR)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'parent', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--partial');
+    expect(link).not.toHaveClass('mapping-link--regular');
+  });
+
+  it('should override COMPLETE to PARTIAL when source port is on a collapsed parent', () => {
+    mockGetMappingLinks.mockReturnValue([buildLink('source/1', 'target/1', false, MappingLineStyle.COMPLETE)]);
+
+    mockGetNearestVisiblePort
+      .mockReturnValueOnce({ connectionTarget: 'parent', position: [10, 20] })
+      .mockReturnValueOnce({ connectionTarget: 'node', position: [300, 400] });
+
+    const { container } = render(<MappingLinksContainer />);
+    const link = container.querySelector('[data-testid^="mapping-link-"]');
+    expect(link).toHaveClass('mapping-link--partial');
+    expect(link).not.toHaveClass('mapping-link--complete');
+  });
 });

--- a/packages/ui/src/components/View/MappingLinkContainer.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.tsx
@@ -58,9 +58,14 @@ export const MappingLinksContainer: FunctionComponent = () => {
       const isSourceEdge = sourcePort.connectionTarget === 'edge';
       const isTargetEdge = targetPort.connectionTarget === 'edge';
 
+      const isSourceParent = sourcePort.connectionTarget === 'parent';
+      const isTargetParent = targetPort.connectionTarget === 'parent';
+
       let resolvedLineStyle = lineStyle;
       if (isSourceEdge || isTargetEdge) {
         resolvedLineStyle = MappingLineStyle.OUT_OF_VIEW;
+      } else if (isSourceParent || isTargetParent) {
+        resolvedLineStyle = MappingLineStyle.PARTIAL;
       } else if (
         sourcePort.connectionTarget === 'node' &&
         targetPort.connectionTarget === 'node' &&

--- a/packages/ui/src/components/View/MappingLinkContainer.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.tsx
@@ -3,7 +3,7 @@ import './MappingLinkContainer.scss';
 import { FunctionComponent, useRef as useReactRef } from 'react';
 
 import { useMappingLinks } from '../../hooks/useMappingLinks';
-import { LineProps } from '../../models/datamapper';
+import { LineProps, MappingLineStyle } from '../../models/datamapper';
 import { useDocumentTreeStore } from '../../store';
 import { getNearestVisiblePort } from '../../utils';
 import { MappingLink } from './MappingLink';
@@ -42,7 +42,7 @@ export const MappingLinksContainer: FunctionComponent = () => {
   const svgOffsetTop = svgRect?.top ?? 0;
 
   const lineCoordList: LineProps[] = mappingLinks
-    .map(({ sourceNodePath, targetNodePath, sourceDocumentId, targetDocumentId, isSelected }) => {
+    .map(({ sourceNodePath, targetNodePath, sourceDocumentId, targetDocumentId, isSelected, lineStyle }) => {
       const sourcePort = getNearestVisiblePort(sourceNodePath, {
         nodesConnectionPorts: nodesConnectionPorts[sourceDocumentId],
         nodesConnectionPortsArray: nodesConnectionPortsArray[sourceDocumentId],
@@ -55,9 +55,19 @@ export const MappingLinksContainer: FunctionComponent = () => {
         expansionState: expansionState[targetDocumentId],
         expansionStateArray: expansionStateArray[targetDocumentId],
       });
-      const isPartial = sourcePort.connectionTarget !== 'node' || targetPort.connectionTarget !== 'node';
       const isSourceEdge = sourcePort.connectionTarget === 'edge';
       const isTargetEdge = targetPort.connectionTarget === 'edge';
+
+      let resolvedLineStyle = lineStyle;
+      if (isSourceEdge || isTargetEdge) {
+        resolvedLineStyle = MappingLineStyle.OUT_OF_VIEW;
+      } else if (
+        sourcePort.connectionTarget === 'node' &&
+        targetPort.connectionTarget === 'node' &&
+        (lineStyle === MappingLineStyle.COMPLETE || lineStyle === MappingLineStyle.PARTIAL)
+      ) {
+        resolvedLineStyle = MappingLineStyle.REGULAR;
+      }
 
       /* Convert absolute screen coordinates to SVG-relative coordinates */
       return {
@@ -68,9 +78,9 @@ export const MappingLinksContainer: FunctionComponent = () => {
         sourceNodePath,
         targetNodePath,
         isSelected,
-        isPartial,
         isSourceEdge,
         isTargetEdge,
+        lineStyle: resolvedLineStyle,
       } as LineProps;
     })
     .filter(deduplicateByCoords())
@@ -94,9 +104,9 @@ export const MappingLinksContainer: FunctionComponent = () => {
             sourceNodePath={lineProps.sourceNodePath}
             targetNodePath={lineProps.targetNodePath}
             isSelected={lineProps.isSelected}
-            isPartial={lineProps.isPartial}
             isSourceEdge={lineProps.isSourceEdge}
             isTargetEdge={lineProps.isTargetEdge}
+            lineStyle={lineProps.lineStyle}
           />
         ))}
       </g>

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -317,7 +317,8 @@ export class ValueSelector extends MappingItem implements IExpressionHolder {
     public parent: MappingParentType,
     public valueType: ValueType = ValueType.VALUE,
   ) {
-    super(parent, 'value', getCamelRandomId('value', 4));
+    const label = valueType === ValueType.CONTAINER || valueType === ValueType.CONTAINER_NODE ? 'copy-of' : 'value';
+    super(parent, label, getCamelRandomId(label, 4));
   }
   expression = '';
   isLiteral = false;

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -299,8 +299,10 @@ export class SortItem {
 export enum ValueType {
   /** Emits a text value via `xsl:value-of`. */
   VALUE = 'value',
-  /** Emits a structured element container. */
+  /** Emits a structured element container via `xsl:copy-of`. */
   CONTAINER = 'container',
+  /** Emits container children only via `xsl:copy-of select="path/node()"` (for xs:anyType scenarios). */
+  CONTAINER_NODE = 'container_node',
   /** Emits an XML attribute. */
   ATTRIBUTE = 'attribute',
 }

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -338,6 +338,14 @@ export class FunctionNodeData implements NodeData {
   title: string;
 }
 
+export enum MappingLineStyle {
+  COPY_OF = 'copy-of',
+  COMPLETE = 'complete',
+  REGULAR = 'regular',
+  PARTIAL = 'partial',
+  OUT_OF_VIEW = 'out-of-view',
+}
+
 /** Describes a drawn mapping line between a source and a target node. */
 export interface IMappingLink {
   sourceNodePath: string;
@@ -345,6 +353,7 @@ export interface IMappingLink {
   sourceDocumentId: string;
   targetDocumentId: string;
   isSelected: boolean;
+  lineStyle: MappingLineStyle;
 }
 
 /** SVG line endpoint coordinates. */
@@ -360,9 +369,9 @@ export type LineProps = LineCoord & {
   sourceNodePath: string;
   targetNodePath: string;
   isSelected: boolean;
-  isPartial: boolean;
   isSourceEdge: boolean;
   isTargetEdge: boolean;
+  lineStyle: MappingLineStyle;
 };
 
 /** Props passed to the alert notification handler. */

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -419,7 +419,7 @@ describe('MappingSerializerService', () => {
       expect(orderPersonSelect?.nodeValue).toEqual('/ns0:ShipOrder/ns0:OrderPerson');
       const shipToSelect = xsltDocument
         .evaluate(
-          '/xsl:stylesheet/xsl:template/ShipOrder/ShipTo/xsl:copy-of/@select',
+          '/xsl:stylesheet/xsl:template/ShipOrder/xsl:copy-of/@select',
           xsltDocument,
           null,
           XPathResult.ORDERED_NODE_ITERATOR_TYPE,
@@ -600,8 +600,8 @@ describe('MappingSerializerService', () => {
       const xslIf = shipOrderSelect.iterateNext() as Element;
       expect(xslIf.nodeName).toEqual('xsl:if');
       expect(xslIf.getAttribute('test')).toEqual("/ns0:ShipOrder/ns0:OrderPerson != ''");
-      const shipTo = shipOrderSelect.iterateNext() as Element;
-      expect(shipTo.nodeName).toEqual('ShipTo');
+      const copyOf = shipOrderSelect.iterateNext() as Element;
+      expect(copyOf.nodeName).toEqual('xsl:copy-of');
       const xslForEach = shipOrderSelect.iterateNext() as Element;
       expect(xslForEach.nodeName).toEqual('xsl:for-each');
       expect(xslForEach.getAttribute('select')).toEqual('/ns0:ShipOrder/Item');

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -950,7 +950,7 @@ describe('MappingService', () => {
       const childFieldItems = shipToItem.children.filter((c) => c instanceof FieldItem);
       expect(childFieldItems.length).toBe(4);
       childFieldItems.forEach((fi) => {
-        const vs = (fi as FieldItem).children.find((c) => c instanceof ValueSelector);
+        const vs = fi.children.find((c) => c instanceof ValueSelector);
         expect(vs).toBeDefined();
       });
     });
@@ -970,7 +970,7 @@ describe('MappingService', () => {
 
       const childFieldItems = rootItem.children.filter((c) => c instanceof FieldItem);
       expect(childFieldItems.length).toBeGreaterThan(0);
-      const shipToChild = childFieldItems.find((c) => (c as FieldItem).field.name === 'ShipTo') as FieldItem;
+      const shipToChild = childFieldItems.find((c) => c.field.name === 'ShipTo')!;
       expect(shipToChild).toBeDefined();
       const shipToVs = shipToChild.children.find((c) => c instanceof ValueSelector) as ValueSelector;
       expect(shipToVs).toBeDefined();

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -1,4 +1,4 @@
-import { DocumentDefinitionType, DocumentType, IDocument } from '../../models/datamapper/document';
+import { DocumentDefinitionType, DocumentType, IDocument, IField } from '../../models/datamapper/document';
 import {
   ChooseItem,
   FieldItem,
@@ -24,9 +24,11 @@ import {
   TestUtil,
 } from '../../stubs/datamapper/data-mapper';
 import { DocumentService } from '../document/document.service';
+import { DocumentUtilService } from '../document/document-util.service';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { MappingLinksService } from '../visualization/mapping-links.service';
 import { XPathService } from '../xpath/xpath.service';
+import { FieldMatchingService } from './field-matching.service';
 import { MappingService } from './mapping.service';
 import { MappingSerializerService } from './mapping-serializer.service';
 
@@ -888,6 +890,123 @@ describe('MappingService', () => {
       MappingService.updateVariable(variable, 'newName', 'newExpr');
       expect(variable.name).toEqual('newName');
       expect(variable.expression).toEqual('newExpr');
+    });
+  });
+
+  describe('container auto-mapping', () => {
+    let sourceRoot: IField;
+    let targetRoot: IField;
+
+    beforeEach(() => {
+      sourceRoot = sourceDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(sourceRoot);
+      targetRoot = targetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(targetRoot);
+    });
+
+    it('applyContainerMapping should use copy-of for identical containers', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      MappingService.applyContainerMapping(sourceShipTo, targetShipTo, shipToItem);
+
+      const vs = shipToItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      expect(vs).toBeDefined();
+      expect(vs.valueType).toBe(ValueType.CONTAINER);
+    });
+
+    it('generateAutoChildMappings should create value-of for terminal matching children', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(sourceShipTo);
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      MappingService.generateAutoChildMappings(sourceShipTo, targetShipTo, shipToItem);
+
+      const childFieldItems = shipToItem.children.filter((c) => c instanceof FieldItem);
+      expect(childFieldItems.length).toBe(4);
+      childFieldItems.forEach((fi) => {
+        const vs = (fi as FieldItem).children.find((c) => c instanceof ValueSelector);
+        expect(vs).toBeDefined();
+      });
+    });
+
+    it('generateAutoChildMappings should recurse into nested containers', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+
+      MappingService.generateAutoChildMappings(sourceRoot, targetRoot, rootItem);
+
+      const childFieldItems = rootItem.children.filter((c) => c instanceof FieldItem);
+      expect(childFieldItems.length).toBeGreaterThan(0);
+      const shipToChild = childFieldItems.find((c) => (c as FieldItem).field.name === 'ShipTo') as FieldItem;
+      expect(shipToChild).toBeDefined();
+      const shipToVs = shipToChild.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      expect(shipToVs).toBeDefined();
+      expect(shipToVs.valueType).toBe(ValueType.CONTAINER);
+    });
+
+    it('applyContainerMapping should recurse when canUseCopyOf is false', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(sourceShipTo);
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      jest.spyOn(FieldMatchingService, 'canUseCopyOf').mockReturnValue(false);
+      MappingService.applyContainerMapping(sourceShipTo, targetShipTo, shipToItem);
+
+      const childFieldItems = shipToItem.children.filter((c) => c instanceof FieldItem);
+      expect(childFieldItems.length).toBe(4);
+      jest.restoreAllMocks();
+    });
+
+    it('getContainerValueType should return CONTAINER for normal fields', () => {
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      expect(MappingService.getContainerValueType(sourceShipTo, targetShipTo)).toBe(ValueType.CONTAINER);
     });
   });
 });

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -18,9 +18,12 @@ import {
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
+import { Types } from '../../models/datamapper/types';
 import { DocumentService } from '../document/document.service';
+import { XmlSchemaField } from '../document/xml-schema/xml-schema-document.model';
 import { ensureNamespaceRegistered } from '../namespace-util';
 import { XPathService } from '../xpath/xpath.service';
+import { FieldMatchingService } from './field-matching.service';
 
 /**
  * All-static utility service for manipulating the in-memory {@link MappingTree}/{@link MappingItem}
@@ -457,11 +460,41 @@ export class MappingService {
    * @param targetFieldItem - the target mapping item to map the source to
    */
   static mapToField(source: PrimitiveDocument | IField, targetFieldItem: MappingItem) {
+    const valueSelector = MappingService.ensureValueSelector(targetFieldItem);
+    MappingService.applySourceExpression(source, targetFieldItem, valueSelector);
+  }
+
+  /**
+   * Like {@link mapToField} but sets an explicit {@link ValueType} on the selector.
+   * Used for container copy-of scenarios where we need CONTAINER or CONTAINER_NODE.
+   */
+  static mapToFieldWithValueType(
+    source: PrimitiveDocument | IField,
+    targetFieldItem: MappingItem,
+    valueType: ValueType,
+  ) {
+    const valueSelector = MappingService.ensureValueSelector(targetFieldItem, valueType);
+    valueSelector.valueType = valueType;
+    MappingService.applySourceExpression(source, targetFieldItem, valueSelector);
+  }
+
+  private static ensureValueSelector(targetFieldItem: MappingItem, valueType?: ValueType): ValueSelector {
     let valueSelector = targetFieldItem?.children.find((child) => child instanceof ValueSelector) as ValueSelector;
     if (!valueSelector) {
-      valueSelector = MappingService.createValueSelector(targetFieldItem);
+      valueSelector =
+        valueType == null
+          ? MappingService.createValueSelector(targetFieldItem)
+          : new ValueSelector(targetFieldItem, valueType);
       targetFieldItem.children.push(valueSelector);
     }
+    return valueSelector;
+  }
+
+  private static applySourceExpression(
+    source: PrimitiveDocument | IField,
+    targetFieldItem: MappingItem,
+    valueSelector: ValueSelector,
+  ) {
     MappingService.registerNamespaceFromField(targetFieldItem.mappingTree, source);
     const relativePath = XPathService.toPathExpression(
       targetFieldItem.mappingTree.namespaceMap,
@@ -469,6 +502,74 @@ export class MappingService {
       valueSelector.contextPath,
     );
     valueSelector.expression = XPathService.addSource(valueSelector.expression, relativePath);
+  }
+
+  /**
+   * Recursively generates child mappings for container fields that cannot use copy-of.
+   * For each matching child pair from {@link FieldMatchingService.findMatchingChildren}:
+   * - Both terminal → {@link mapToField} (value-of)
+   * - Both container + copy-of eligible → {@link mapToFieldWithValueType} with CONTAINER/CONTAINER_NODE
+   * - Both container + NOT copy-of eligible → recurse
+   * - Kind mismatch (leaf↔container) → skipped (already filtered by findMatchingChildren)
+   *
+   * @param sourceField - Source container field
+   * @param targetField - Target container field
+   * @param parentItem - Parent mapping item to attach children to
+   */
+  static generateAutoChildMappings(sourceField: IField, targetField: IField, parentItem: MappingItem): void {
+    const matchingPairs = FieldMatchingService.findMatchingChildren(sourceField, targetField);
+
+    for (const pair of matchingPairs) {
+      MappingService.processPair(pair.source, pair.target, parentItem);
+    }
+  }
+
+  /**
+   * Processes a single source-target field pair during auto-mapping.
+   * Decides whether to create a terminal mapping, container copy-of, or recurse.
+   * @param sourceChild - Source field from the pair
+   * @param targetChild - Target field from the pair
+   * @param parentItem - Parent mapping item to attach the new mapping to
+   */
+  private static processPair(sourceChild: IField, targetChild: IField, parentItem: MappingItem): void {
+    const childFieldItem = MappingService.createFieldItem(parentItem, targetChild);
+
+    if (!DocumentService.hasChildren(sourceChild)) {
+      MappingService.mapToField(sourceChild, childFieldItem);
+      return;
+    }
+
+    MappingService.applyContainerMapping(sourceChild, targetChild, childFieldItem);
+  }
+
+  /**
+   * Applies container-to-container mapping: uses copy-of when eligible, otherwise recurses
+   * into child mappings. Shared by auto-mapping ({@link processPair}) and drag-and-drop
+   * ({@link MappingActionService.engageMapping}).
+   */
+  static applyContainerMapping(sourceField: IField, targetField: IField, parentItem: MappingItem): void {
+    if (FieldMatchingService.canUseCopyOf(sourceField, targetField)) {
+      const valueType = MappingService.getContainerValueType(sourceField, targetField);
+      MappingService.mapToFieldWithValueType(sourceField, parentItem, valueType);
+    } else {
+      MappingService.generateAutoChildMappings(sourceField, targetField, parentItem);
+    }
+  }
+
+  /**
+   * Determines whether to use CONTAINER or CONTAINER_NODE based on xs:anyType involvement.
+   * When xs:anyType is involved, CONTAINER_NODE is used to generate `xsl:copy-of select="path/node()"`,
+   * which copies only children to avoid name mismatch between source and target wrapper elements.
+   * @param sourceField - Source field
+   * @param targetField - Target field
+   * @returns CONTAINER_NODE if xs:anyType is involved, otherwise CONTAINER
+   */
+  static getContainerValueType(sourceField: IField, targetField: IField): ValueType {
+    const anyTypeInvolved =
+      (sourceField instanceof XmlSchemaField && sourceField.type === Types.AnyType) ||
+      (targetField instanceof XmlSchemaField && targetField.type === Types.AnyType);
+
+    return anyTypeInvolved ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
   }
 
   /**

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -29,9 +29,12 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
 
   serialize(parent: Element, mapping: ValueSelector): Element {
     const doc = parent.ownerDocument;
-    if (mapping.valueType === ValueType.CONTAINER) {
+    if (mapping.valueType === ValueType.CONTAINER || mapping.valueType === ValueType.CONTAINER_NODE) {
       const copyOf = doc.createElementNS(NS_XSL, 'copy-of');
-      copyOf.setAttribute('select', mapping.expression);
+      // For CONTAINER_NODE, append /node() to select only children (xs:anyType scenarios)
+      const selectExpression =
+        mapping.valueType === ValueType.CONTAINER_NODE ? `${mapping.expression}/node()` : mapping.expression;
+      copyOf.setAttribute('select', selectExpression);
       parent.appendChild(copyOf);
       return copyOf;
     }
@@ -48,8 +51,11 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
   ): DeserializeItemResult<ValueSelector> {
     switch (element.localName) {
       case 'copy-of': {
-        const selector = new ValueSelector(parentMapping, ValueType.CONTAINER);
-        selector.expression = element.getAttribute('select') || '';
+        const rawSelect = element.getAttribute('select') || '';
+        const isNodeCopy = rawSelect.endsWith('/node()');
+        const valueType = isNodeCopy ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
+        const selector = new ValueSelector(parentMapping, valueType);
+        selector.expression = isNodeCopy ? rawSelect.slice(0, -7) : rawSelect;
         return { mappingItem: selector, fieldItem: null };
       }
       case 'text': {
@@ -83,6 +89,12 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
       parent.appendChild(xslAttribute);
       return xslAttribute;
     }
+
+    const hasContainerCopyOf = mapping.children.some(
+      (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER,
+    );
+    const hasChildFieldItems = mapping.children.some((c) => c instanceof FieldItem);
+    if (hasContainerCopyOf && !hasChildFieldItems) return parent;
 
     const jsonElement = MappingSerializerJsonAddon.populateFieldItem(parent, mapping);
     if (jsonElement) return jsonElement;

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -16,6 +16,7 @@ import {
   OtherwiseItem,
   UnknownMappingItem,
   ValueSelector,
+  ValueType,
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
@@ -36,7 +37,9 @@ import { useDocumentTreeStore } from '../../store/document-tree.store';
 import {
   getConditionalMappingsToShipOrderXslt,
   getContactsXsd,
+  getEnvelopeXsd,
   getExtensionSimpleXsd,
+  getOrderInfoXsd,
   getOrgXsd,
   getShipOrderToShipOrderInvalidForEachXslt,
   getShipOrderToShipOrderXslt,
@@ -626,6 +629,165 @@ describe('MappingActionService', () => {
         expect(expressionItem?.expression).toEqual('/ns0:Product/ns0:price/@currency');
       });
     });
+
+    describe('container auto-mapping', () => {
+      it('should place ForEachItem with copy-of in parent when both collections share name and namespace', () => {
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceDocChildren[0]);
+        const sourceItem = sourceShipOrderChildren[3] as FieldNodeData;
+
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+
+        MappingActionService.engageMapping(tree, sourceItem, targetItem);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+
+        const forEachItem = shipOrderFieldItem.children.find((c) => c instanceof ForEachItem) as ForEachItem;
+        expect(forEachItem).toBeDefined();
+        expect(forEachItem.expression).toEqual('/ns0:ShipOrder/Item');
+
+        expect(forEachItem.children.some((c) => c instanceof FieldItem)).toBeFalsy();
+
+        const copyOf = forEachItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        expect(copyOf).toBeDefined();
+        expect(copyOf.expression).toEqual('.');
+      });
+
+      it('should place ForEachItem with inner FieldItem when collections have different names', () => {
+        const orderInfoDef = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          BODY_DOCUMENT_ID,
+          { 'OrderInfo.xsd': getOrderInfoXsd() },
+        );
+        const orderInfoResult = XmlSchemaDocumentService.createXmlSchemaDocument(orderInfoDef);
+        expect(orderInfoResult.validationStatus).toBe('success');
+        const orderInfoDoc = orderInfoResult.document!;
+        const orderInfoDocNode = new DocumentNodeData(orderInfoDoc);
+
+        const orderInfoDocChildren = VisualizationService.generateStructuredDocumentChildren(orderInfoDocNode);
+        const orderInfoChildren = VisualizationService.generateNonDocumentNodeDataChildren(orderInfoDocChildren[0]);
+        const sourceOrderEntry = orderInfoChildren[0] as FieldNodeData;
+
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+
+        MappingActionService.engageMapping(tree, sourceOrderEntry, targetItem);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+
+        const forEachItem = shipOrderFieldItem.children.find((c) => c instanceof ForEachItem) as ForEachItem;
+        expect(forEachItem).toBeDefined();
+        expect(forEachItem.expression).toContain('OrderEntry');
+
+        const innerFieldItem = forEachItem.children.find((c) => c instanceof FieldItem) as FieldItem;
+        expect(innerFieldItem).toBeDefined();
+        expect(innerFieldItem.field.name).toEqual('Item');
+
+        expect(innerFieldItem.children.length).toBeGreaterThan(0);
+        const titleMapping = innerFieldItem.children.find(
+          (c) => c instanceof FieldItem && c.field.name === 'Title',
+        ) as FieldItem;
+        expect(titleMapping).toBeDefined();
+      });
+
+      it('should not create duplicate ForEachItem on repeated DnD (copy-of case)', () => {
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceDocChildren[0]);
+        const sourceItem = sourceShipOrderChildren[3] as FieldNodeData;
+
+        let targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        let targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+
+        MappingActionService.engageMapping(tree, sourceItem, targetItem);
+
+        targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+
+        MappingActionService.engageMapping(tree, sourceItem, targetShipOrderChildren[3] as TargetNodeData);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        const forEachItems = shipOrderFieldItem.children.filter((c) => c instanceof ForEachItem);
+        expect(forEachItems.length).toEqual(1);
+      });
+
+      it('should not create duplicate ForEachItem on repeated DnD (auto-child case)', () => {
+        const orderInfoDef = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          BODY_DOCUMENT_ID,
+          { 'OrderInfo.xsd': getOrderInfoXsd() },
+        );
+        const orderInfoResult = XmlSchemaDocumentService.createXmlSchemaDocument(orderInfoDef);
+        const orderInfoDoc = orderInfoResult.document!;
+        const orderInfoDocNode = new DocumentNodeData(orderInfoDoc);
+
+        const orderInfoDocChildren = VisualizationService.generateStructuredDocumentChildren(orderInfoDocNode);
+        const orderInfoChildren = VisualizationService.generateNonDocumentNodeDataChildren(orderInfoDocChildren[0]);
+        const sourceOrderEntry = orderInfoChildren[0] as FieldNodeData;
+
+        let targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        let targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+
+        MappingActionService.engageMapping(tree, sourceOrderEntry, targetItem);
+
+        targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+
+        MappingActionService.engageMapping(tree, sourceOrderEntry, targetShipOrderChildren[3] as TargetNodeData);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        const forEachItems = shipOrderFieldItem.children.filter((c) => c instanceof ForEachItem);
+        expect(forEachItems.length).toEqual(1);
+      });
+    });
+
+    describe('xs:anyType container mapping', () => {
+      it('should create copy-of with CONTAINER_NODE when xs:anyType source is mapped to a container target', () => {
+        const anyTypeDef = new DocumentDefinition(
+          DocumentType.SOURCE_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          BODY_DOCUMENT_ID,
+          { 'Envelope.xsd': getEnvelopeXsd() },
+        );
+        const anyTypeResult = XmlSchemaDocumentService.createXmlSchemaDocument(anyTypeDef);
+        expect(anyTypeResult.validationStatus).toBe('success');
+        const anyTypeDoc = anyTypeResult.document!;
+        const anyTypeDocNode = new DocumentNodeData(anyTypeDoc);
+
+        const anyTypeDocChildren = VisualizationService.generateStructuredDocumentChildren(anyTypeDocNode);
+        const envelopeChildren = VisualizationService.generateNonDocumentNodeDataChildren(anyTypeDocChildren[0]);
+        const payloadField = envelopeChildren[0] as FieldNodeData;
+        expect(payloadField.title).toEqual('Payload');
+
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+        expect(targetItem.title).toEqual('Item');
+
+        MappingActionService.engageMapping(tree, payloadField, targetItem);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+
+        const itemFieldItem = shipOrderFieldItem.children.find(
+          (c) => c instanceof FieldItem && c.field.name === 'Item',
+        ) as FieldItem;
+        expect(itemFieldItem).toBeDefined();
+
+        const copyOf = itemFieldItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        expect(copyOf).toBeDefined();
+        expect(copyOf.valueType).toEqual(ValueType.CONTAINER_NODE);
+      });
+    });
+
     it('should fill ContextItemExpr (.) and AbbrevReverseStep (..) in xpath when it maps under for-each', () => {
       const orgDefinition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'Org', {
         'Org.xsd': getOrgXsd(),

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -202,6 +202,8 @@ export class MappingActionService {
       return;
     }
 
+    if (MappingActionService.tryEngageContainerMapping(sourceNode, targetNode)) return;
+
     if (targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
       MappingService.mapToField(sourceField, item);
@@ -234,6 +236,38 @@ export class MappingActionService {
     }
     if (nodeData instanceof MappingNodeData) return nodeData.mapping;
     return undefined;
+  }
+
+  private static tryEngageContainerMapping(sourceNode: SourceNodeDataType, targetNode: TargetNodeData): boolean {
+    if (
+      !('field' in sourceNode) ||
+      !sourceNode.field ||
+      !(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)
+    ) {
+      return false;
+    }
+    const sourceFieldFromNode = sourceNode.field;
+    const targetFieldFromNode = targetNode.field;
+
+    if (!DocumentService.hasChildren(sourceFieldFromNode) || !DocumentService.hasChildren(targetFieldFromNode)) {
+      return false;
+    }
+
+    const item = MappingActionService.getOrCreateFieldItem(targetNode);
+    const bothCollections =
+      VisualizationUtilService.isCollectionField(sourceNode) && VisualizationUtilService.isCollectionField(targetNode);
+
+    if (bothCollections) {
+      if (item.children.some((c) => c instanceof ForEachItem)) return true;
+      item.children = item.children.filter((c) => !(c instanceof ValueSelector));
+      const forEachItem = new ForEachItem(item);
+      MappingService.mapToCondition(forEachItem, sourceFieldFromNode);
+      MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, forEachItem);
+      item.children.push(forEachItem);
+    } else {
+      MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, item);
+    }
+    return true;
   }
 
   private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -11,9 +11,11 @@ import {
   OtherwiseItem,
   UnknownMappingItem,
   ValueSelector,
+  ValueType,
   WhenItem,
 } from '../../models/datamapper/mapping';
 import { IMappingAction, IMappingContextMenuAction, MappingActionKind } from '../../models/datamapper/mapping-action';
+import { Types } from '../../models/datamapper/types';
 import {
   AddMappingNodeData,
   ChoiceFieldNodeData,
@@ -28,7 +30,8 @@ import {
   VariableNodeData,
 } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
-// import { DocumentService } from '../document/document.service';
+import { DocumentService } from '../document/document.service';
+import { FieldMatchingService } from '../mapping/field-matching.service';
 import { MappingService } from '../mapping/mapping.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
@@ -248,8 +251,21 @@ export class MappingActionService {
     }
     const sourceFieldFromNode = sourceNode.field;
     const targetFieldFromNode = targetNode.field;
+    const sourceHasChildren = DocumentService.hasChildren(sourceFieldFromNode);
+    const targetHasChildren = DocumentService.hasChildren(targetFieldFromNode);
+    const anyTypeInvolved = sourceFieldFromNode.type === Types.AnyType || targetFieldFromNode.type === Types.AnyType;
 
-    if (!DocumentService.hasChildren(sourceFieldFromNode) || !DocumentService.hasChildren(targetFieldFromNode)) {
+    if (!sourceHasChildren && !targetHasChildren && !anyTypeInvolved) {
+      return false;
+    }
+
+    if (anyTypeInvolved && (!sourceHasChildren || !targetHasChildren)) {
+      const item = MappingActionService.getOrCreateFieldItem(targetNode);
+      MappingService.mapToFieldWithValueType(sourceFieldFromNode, item, ValueType.CONTAINER_NODE);
+      return true;
+    }
+
+    if (!sourceHasChildren || !targetHasChildren) {
       return false;
     }
 
@@ -258,16 +274,48 @@ export class MappingActionService {
       VisualizationUtilService.isCollectionField(sourceNode) && VisualizationUtilService.isCollectionField(targetNode);
 
     if (bothCollections) {
-      if (item.children.some((c) => c instanceof ForEachItem)) return true;
-      item.children = item.children.filter((c) => !(c instanceof ValueSelector));
-      const forEachItem = new ForEachItem(item);
-      MappingService.mapToCondition(forEachItem, sourceFieldFromNode);
-      MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, forEachItem);
-      item.children.push(forEachItem);
+      const guardResult = MappingActionService.guardExistingForEach(item);
+      if (guardResult !== undefined) return guardResult;
+
+      MappingActionService.createCollectionForEach(item, sourceFieldFromNode, targetFieldFromNode);
     } else {
       MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, item);
     }
     return true;
+  }
+
+  /**
+   * Checks whether a container auto-mapping ForEachItem already exists for this target field.
+   * Returns `true` (handled), `false` (defer to regular mapping), or `undefined` (proceed with auto-mapping).
+   */
+  private static guardExistingForEach(item: MappingItem): boolean | undefined {
+    if (item.children.some((c) => c instanceof ForEachItem)) return true;
+    if (item.parent instanceof ForEachItem) return false;
+    if (item.parent.children.some((c) => c !== item && c instanceof ForEachItem)) {
+      const idx = item.parent.children.indexOf(item);
+      if (idx !== -1) item.parent.children.splice(idx, 1);
+      return true;
+    }
+    return undefined;
+  }
+
+  private static createCollectionForEach(item: MappingItem, sourceField: IField, targetField: IField): void {
+    const parentOfItem = item.parent;
+    const index = parentOfItem.children.indexOf(item);
+    if (index !== -1) parentOfItem.children.splice(index, 1);
+
+    const forEachItem = new ForEachItem(parentOfItem);
+    MappingService.mapToCondition(forEachItem, sourceField);
+
+    if (FieldMatchingService.canUseCopyOf(sourceField, targetField)) {
+      const valueType = MappingService.getContainerValueType(sourceField, targetField);
+      MappingService.mapToFieldWithValueType(sourceField, forEachItem, valueType);
+    } else {
+      const innerFieldItem = MappingService.createFieldItem(forEachItem, targetField);
+      MappingService.generateAutoChildMappings(sourceField, targetField, innerFieldItem);
+    }
+
+    parentOfItem.children.push(forEachItem);
   }
 
   private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -720,6 +720,50 @@ describe('MappingLinksService', () => {
       }
     });
 
+    it('should downgrade COMPLETE to PARTIAL when duplicate source mappings hide unmapped siblings', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(sourceShipTo);
+      const extraField = new BaseField(sourceShipTo, sourceDoc, 'PostalCode');
+      sourceShipTo.fields.push(extraField);
+
+      try {
+        const rootItem = new FieldItem(manualTree, targetRoot);
+        manualTree.children.push(rootItem);
+        const shipToItem = new FieldItem(rootItem, targetShipTo);
+        rootItem.children.push(shipToItem);
+
+        const targetChildren = targetShipTo.fields;
+        targetChildren.forEach((childField: IField, i: number) => {
+          const childItem = new FieldItem(shipToItem, childField);
+          shipToItem.children.push(childItem);
+          const vs = new ValueSelector(childItem);
+          // Map first two target children to the same source child (Name),
+          // so mappedSourceCount would be 4 but unique mapped sources is only 3
+          const sourceName = i < 2 ? 'Name' : targetChildren[i].name;
+          vs.expression = `/ns0:ShipOrder/ShipTo/${sourceName}`;
+          childItem.children.push(vs);
+        });
+
+        const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+        expect(links.length).toBe(4);
+        links.forEach((link) => {
+          expect(link.lineStyle).toBe(MappingLineStyle.PARTIAL);
+        });
+      } finally {
+        sourceShipTo.fields.pop();
+      }
+    });
+
     it('should classify copy-of with CONTAINER_NODE as COPY_OF', () => {
       const manualTree = new MappingTree(
         targetDoc.documentType,

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -764,7 +764,7 @@ describe('MappingLinksService', () => {
       }
     });
 
-    it('should classify copy-of with CONTAINER_NODE as COPY_OF', () => {
+    it('should classify copy-of with CONTAINER_NODE as PARTIAL (inherits from parent)', () => {
       const manualTree = new MappingTree(
         targetDoc.documentType,
         targetDoc.documentId,
@@ -784,7 +784,7 @@ describe('MappingLinksService', () => {
 
       const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
       expect(links.length).toBe(1);
-      expect(links[0].lineStyle).toBe(MappingLineStyle.COPY_OF);
+      expect(links[0].lineStyle).toBe(MappingLineStyle.PARTIAL);
     });
   });
 });

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -1,4 +1,5 @@
 import {
+  BaseField,
   BODY_DOCUMENT_ID,
   DocumentDefinition,
   DocumentDefinitionType,
@@ -6,7 +7,8 @@ import {
   IDocument,
   IField,
 } from '../../models/datamapper/document';
-import { FieldItem, MappingTree, ValueSelector } from '../../models/datamapper/mapping';
+import { FieldItem, MappingTree, ValueSelector, ValueType } from '../../models/datamapper/mapping';
+import { MappingLineStyle } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store';
 import { mockRandomValues } from '../../stubs';
 import {
@@ -549,6 +551,196 @@ describe('MappingLinksService', () => {
       expect(links).toHaveLength(0);
 
       validateSpy.mockRestore();
+    });
+  });
+
+  describe('lineStyle classification', () => {
+    let sourceRoot: IField;
+    let targetRoot: IField;
+
+    beforeEach(() => {
+      sourceRoot = sourceDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(sourceRoot);
+      targetRoot = targetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(targetRoot);
+    });
+
+    it('should classify copy-of mapping as COPY_OF', () => {
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const shipToLink = links.find((l) => l.sourceNodePath.includes('ShipTo'));
+      expect(shipToLink).toBeDefined();
+      expect(shipToLink!.lineStyle).toBe(MappingLineStyle.COPY_OF);
+    });
+
+    it('should classify links inside InstructionItem as REGULAR', () => {
+      const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
+      const itemChildLinks = links.filter((l) => /for-each-.*fx-(Title|Quantity|Price)/.exec(l.targetNodePath));
+      expect(itemChildLinks.length).toBe(3);
+      itemChildLinks.forEach((link) => {
+        expect(link.lineStyle).toBe(MappingLineStyle.REGULAR);
+      });
+    });
+
+    it('should classify container with all children mapped as COMPLETE', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      for (const childField of targetShipTo.fields) {
+        const childItem = new FieldItem(shipToItem, childField);
+        shipToItem.children.push(childItem);
+        const vs = new ValueSelector(childItem);
+        vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
+        childItem.children.push(vs);
+      }
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      expect(links.length).toBe(4);
+      links.forEach((link) => {
+        expect(link.lineStyle).toBe(MappingLineStyle.COMPLETE);
+      });
+    });
+
+    it('should classify shuffled field mappings as COMPLETE when all children are mapped', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(sourceShipTo);
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      const sourceNames = sourceShipTo.fields.map((f: IField) => f.name);
+      const shuffledSourceNames = [...sourceNames].reverse();
+      targetShipTo.fields.forEach((targetChild: IField, i: number) => {
+        const childItem = new FieldItem(shipToItem, targetChild);
+        shipToItem.children.push(childItem);
+        const vs = new ValueSelector(childItem);
+        vs.expression = `/ns0:ShipOrder/ShipTo/${shuffledSourceNames[i]}`;
+        childItem.children.push(vs);
+      });
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      expect(links.length).toBe(4);
+      links.forEach((link) => {
+        expect(link.lineStyle).toBe(MappingLineStyle.COMPLETE);
+      });
+    });
+
+    it('should classify container with some children unmapped as PARTIAL', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      const mappedFields = targetShipTo.fields.slice(0, 3);
+      for (const childField of mappedFields) {
+        const childItem = new FieldItem(shipToItem, childField);
+        shipToItem.children.push(childItem);
+        const vs = new ValueSelector(childItem);
+        vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
+        childItem.children.push(vs);
+      }
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      expect(links.length).toBe(3);
+      links.forEach((link) => {
+        expect(link.lineStyle).toBe(MappingLineStyle.PARTIAL);
+      });
+    });
+
+    it('should downgrade COMPLETE to PARTIAL when source has extra children', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(targetShipTo);
+
+      const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      DocumentUtilService.resolveTypeFragment(sourceShipTo);
+      const extraField = new BaseField(sourceShipTo, sourceDoc, 'PostalCode');
+      sourceShipTo.fields.push(extraField);
+
+      try {
+        const rootItem = new FieldItem(manualTree, targetRoot);
+        manualTree.children.push(rootItem);
+        const shipToItem = new FieldItem(rootItem, targetShipTo);
+        rootItem.children.push(shipToItem);
+
+        for (const childField of targetShipTo.fields) {
+          const childItem = new FieldItem(shipToItem, childField);
+          shipToItem.children.push(childItem);
+          const vs = new ValueSelector(childItem);
+          vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
+          childItem.children.push(vs);
+        }
+
+        const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+        expect(links.length).toBe(4);
+        links.forEach((link) => {
+          expect(link.lineStyle).toBe(MappingLineStyle.PARTIAL);
+        });
+      } finally {
+        sourceShipTo.fields.pop();
+      }
+    });
+
+    it('should classify copy-of with CONTAINER_NODE as COPY_OF', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+      const vs = new ValueSelector(shipToItem, ValueType.CONTAINER_NODE);
+      vs.expression = '/ns0:ShipOrder/ShipTo';
+      shipToItem.children.push(vs);
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      expect(links.length).toBe(1);
+      expect(links[0].lineStyle).toBe(MappingLineStyle.COPY_OF);
     });
   });
 });

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -174,11 +174,7 @@ export class MappingLinksService {
     const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
 
     const vs = item.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
-    if (
-      childFieldItems.length === 0 &&
-      vs &&
-      (vs.valueType === ValueType.CONTAINER || vs.valueType === ValueType.CONTAINER_NODE)
-    ) {
+    if (childFieldItems.length === 0 && vs?.valueType === ValueType.CONTAINER) {
       return MappingLineStyle.COPY_OF;
     }
 
@@ -217,7 +213,7 @@ export class MappingLinksService {
       }
     }
 
-    if (sourceParents.size !== 1) return false;
+    if (sourceParents.size !== 1) return true;
     const sourceParent = [...sourceParents][0];
     if (!('fields' in sourceParent)) return false;
     const sourceChildren = (sourceParent as IField).fields.filter(

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -205,7 +205,7 @@ export class MappingLinksService {
   ): boolean {
     const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
     const sourceParents = new Set<IParentType>();
-    let mappedSourceCount = 0;
+    const mappedSourceChildren = new Set<string>();
 
     for (const child of childFieldItems) {
       const vs = child.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
@@ -213,7 +213,7 @@ export class MappingLinksService {
       const resolved = MappingLinksService.resolveSourceFields(vs, sourceParameterMap, sourceBody);
       for (const { field } of resolved) {
         sourceParents.add(field.parent);
-        mappedSourceCount++;
+        mappedSourceChildren.add(field.id);
       }
     }
 
@@ -223,7 +223,7 @@ export class MappingLinksService {
     const sourceChildren = (sourceParent as IField).fields.filter(
       (f) => !f.isAttribute && !MappingLinksService.isWrapperField(f),
     );
-    return sourceChildren.length > mappedSourceCount;
+    return sourceChildren.length > mappedSourceChildren.size;
   }
 
   /**

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -6,13 +6,16 @@ import {
   IExpressionHolder,
   IField,
   IMappingLink,
+  InstructionItem,
   IParentType,
   isExpressionHolder,
   MappingItem,
+  MappingLineStyle,
   MappingTree,
   NodePath,
   PrimitiveDocument,
   ValueSelector,
+  ValueType,
 } from '../../models/datamapper';
 import { DocumentService } from '../document/document.service';
 import { XPathService } from '../xpath/xpath.service';
@@ -27,9 +30,19 @@ export class MappingLinksService {
     sourceBody: IDocument,
     selectedNodePath: string | null = null,
     selectedNodeIsSource: boolean = false,
+    parentLineStyle?: MappingLineStyle,
   ): IMappingLink[] {
     const answer = [] as IMappingLink[];
     const targetNodePath = MappingLinksService.computeVisualTargetNodePath(item).toString();
+    let ownLineStyle =
+      item instanceof FieldItem ? MappingLinksService.classifyContainerLineStyle(item) : MappingLineStyle.REGULAR;
+    if (ownLineStyle === MappingLineStyle.COMPLETE) {
+      if (MappingLinksService.hasExtraSourceChildren(item as FieldItem, sourceParameterMap, sourceBody)) {
+        ownLineStyle = MappingLineStyle.PARTIAL;
+      }
+    }
+    const lineStyle = ownLineStyle === MappingLineStyle.REGULAR ? (parentLineStyle ?? ownLineStyle) : ownLineStyle;
+
     if (item instanceof MappingItem && isExpressionHolder(item)) {
       const links = MappingLinksService.doExtractMappingLinks(
         item,
@@ -38,10 +51,12 @@ export class MappingLinksService {
         sourceBody,
         selectedNodePath,
         selectedNodeIsSource,
+        lineStyle,
       );
       answer.push(...links);
     }
     if ('children' in item) {
+      const childLineStyle = ownLineStyle === MappingLineStyle.REGULAR ? undefined : ownLineStyle;
       item.children.forEach((child) => {
         if (
           item instanceof FieldItem &&
@@ -55,6 +70,7 @@ export class MappingLinksService {
             sourceBody,
             selectedNodePath,
             selectedNodeIsSource,
+            lineStyle,
           );
           answer.push(...links);
         } else {
@@ -64,12 +80,36 @@ export class MappingLinksService {
             sourceBody,
             selectedNodePath,
             selectedNodeIsSource,
+            childLineStyle,
           );
           answer.push(...links);
         }
       });
     }
     return answer;
+  }
+
+  private static resolveSourceFields(
+    expressionHolder: IExpressionHolder & MappingItem,
+    sourceParameterMap: Map<string, IDocument>,
+    sourceBody: IDocument,
+  ): { field: IField; document: IDocument }[] {
+    const namespaces = expressionHolder.mappingTree.namespaceMap;
+    const sourceXPath = expressionHolder.expression;
+    const validationResult = XPathService.validate(sourceXPath);
+    if (!validationResult.getExprNode() || validationResult.dataMapperErrors.length > 0) return [];
+    const fieldPaths = XPathService.extractFieldPaths(sourceXPath, expressionHolder.parent.contextPath);
+    const results: { field: IField; document: IDocument }[] = [];
+    for (const xpath of fieldPaths) {
+      const absolutePath = XPathService.toAbsolutePath(xpath);
+      const document = DocumentService.resolveSourceDocument(absolutePath, namespaces, sourceBody, sourceParameterMap);
+      if (!document) continue;
+      const result = DocumentService.getFieldFromPathSegments(namespaces, document, absolutePath.pathSegments);
+      if (result && 'parent' in result) {
+        results.push({ field: result, document });
+      }
+    }
+    return results;
   }
 
   private static doExtractMappingLinks(
@@ -79,41 +119,32 @@ export class MappingLinksService {
     sourceBody: IDocument,
     selectedNodePath: string | null,
     selectedNodeIsSource: boolean,
+    lineStyle: MappingLineStyle = MappingLineStyle.REGULAR,
   ) {
-    const namespaces = sourceExpressionItem.mappingTree.namespaceMap;
-    const sourceXPath = sourceExpressionItem.expression;
-    const validationResult = XPathService.validate(sourceXPath);
-    if (!validationResult.getExprNode() || validationResult.dataMapperErrors.length > 0) return [];
-    const fieldPaths = XPathService.extractFieldPaths(sourceXPath, sourceExpressionItem.parent.contextPath);
-    return fieldPaths.reduce((acc, xpath) => {
-      const absolutePath = XPathService.toAbsolutePath(xpath);
-      const document = DocumentService.resolveSourceDocument(absolutePath, namespaces, sourceBody, sourceParameterMap);
-      const sourceResult = document
-        ? DocumentService.getFieldFromPathSegments(namespaces, document, absolutePath.pathSegments)
-        : undefined;
-      const sourceField = sourceResult && 'parent' in sourceResult ? sourceResult : undefined;
-      const sourceNodePath = sourceField && MappingLinksService.computeVisualSourceNodePath(sourceField);
-
-      if (sourceNodePath) {
-        const sourceNodePathString = sourceNodePath.toString();
-        const sourceDocumentId = document
-          ? `doc-${document.documentType}-${document.documentId}`
-          : `doc-${DocumentType.SOURCE_BODY}-${BODY_DOCUMENT_ID}`;
-        const targetDocumentId = `doc-${DocumentType.TARGET_BODY}-${BODY_DOCUMENT_ID}`;
-        const isSelected = MappingLinksService.isLinkSelected(
-          sourceNodePathString,
-          targetNodePath,
-          selectedNodePath,
-          selectedNodeIsSource,
-        );
-        acc.push({
-          sourceNodePath: sourceNodePathString,
-          targetNodePath: targetNodePath,
-          sourceDocumentId,
-          targetDocumentId,
-          isSelected,
-        });
-      }
+    const resolvedFields = MappingLinksService.resolveSourceFields(
+      sourceExpressionItem,
+      sourceParameterMap,
+      sourceBody,
+    );
+    return resolvedFields.reduce((acc, { field, document }) => {
+      const sourceNodePath = MappingLinksService.computeVisualSourceNodePath(field);
+      const sourceNodePathString = sourceNodePath.toString();
+      const sourceDocumentId = `doc-${document.documentType}-${document.documentId}`;
+      const targetDocumentId = `doc-${DocumentType.TARGET_BODY}-${BODY_DOCUMENT_ID}`;
+      const isSelected = MappingLinksService.isLinkSelected(
+        sourceNodePathString,
+        targetNodePath,
+        selectedNodePath,
+        selectedNodeIsSource,
+      );
+      acc.push({
+        sourceNodePath: sourceNodePathString,
+        targetNodePath: targetNodePath,
+        sourceDocumentId,
+        targetDocumentId,
+        isSelected,
+        lineStyle,
+      });
       return acc;
     }, [] as IMappingLink[]);
   }
@@ -137,6 +168,62 @@ export class MappingLinksService {
     return mappingLinks
       .filter((link) => link.isSelected)
       .some((link) => link.sourceNodePath === nodePath || link.targetNodePath === nodePath);
+  }
+
+  private static classifyContainerLineStyle(item: FieldItem): MappingLineStyle {
+    const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
+
+    const vs = item.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
+    if (
+      childFieldItems.length === 0 &&
+      vs &&
+      (vs.valueType === ValueType.CONTAINER || vs.valueType === ValueType.CONTAINER_NODE)
+    ) {
+      return MappingLineStyle.COPY_OF;
+    }
+
+    if (childFieldItems.length === 0) return MappingLineStyle.REGULAR;
+    if (item.parent instanceof InstructionItem) return MappingLineStyle.REGULAR;
+
+    const targetChildren = item.field.fields.filter((f) => !MappingLinksService.isWrapperField(f));
+    if (childFieldItems.length < targetChildren.length) return MappingLineStyle.PARTIAL;
+
+    const allContainerChildrenCopyOf = childFieldItems
+      .filter((child) => DocumentService.hasChildren(child.field))
+      .every((child) => {
+        const childVs = child.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
+        return childVs && (childVs.valueType === ValueType.CONTAINER || childVs.valueType === ValueType.CONTAINER_NODE);
+      });
+
+    return allContainerChildrenCopyOf ? MappingLineStyle.COMPLETE : MappingLineStyle.PARTIAL;
+  }
+
+  private static hasExtraSourceChildren(
+    item: FieldItem,
+    sourceParameterMap: Map<string, IDocument>,
+    sourceBody: IDocument,
+  ): boolean {
+    const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
+    const sourceParents = new Set<IParentType>();
+    let mappedSourceCount = 0;
+
+    for (const child of childFieldItems) {
+      const vs = child.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
+      if (!vs || !isExpressionHolder(vs)) continue;
+      const resolved = MappingLinksService.resolveSourceFields(vs, sourceParameterMap, sourceBody);
+      for (const { field } of resolved) {
+        sourceParents.add(field.parent);
+        mappedSourceCount++;
+      }
+    }
+
+    if (sourceParents.size !== 1) return false;
+    const sourceParent = [...sourceParents][0];
+    if (!('fields' in sourceParent)) return false;
+    const sourceChildren = (sourceParent as IField).fields.filter(
+      (f) => !f.isAttribute && !MappingLinksService.isWrapperField(f),
+    );
+    return sourceChildren.length > mappedSourceCount;
   }
 
   /**

--- a/packages/ui/src/services/visualization/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.test.ts
@@ -70,6 +70,20 @@ describe('MappingValidationService', () => {
         const result = MappingValidationService.validateFieldPair(source, target);
         expect(result.isValid).toBe(true);
       });
+
+      it('should allow xs:anyType source to container target', () => {
+        const source = createMockField({ type: Types.AnyType });
+        const target = createMockField({ type: Types.Container });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+
+      it('should allow container source to xs:anyType target', () => {
+        const source = createMockField({ type: Types.Container });
+        const target = createMockField({ type: Types.AnyType });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
     });
 
     describe('choice validation', () => {

--- a/packages/ui/src/services/visualization/mapping-validation.service.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.ts
@@ -180,8 +180,9 @@ export class MappingValidationService {
 
     const sourceIsContainer = MappingValidationService.isContainer(source);
     const targetIsContainer = MappingValidationService.isContainer(target);
+    const anyTypeInvolved = source.type === Types.AnyType || target.type === Types.AnyType;
 
-    if (sourceIsContainer !== targetIsContainer) {
+    if (sourceIsContainer !== targetIsContainer && !anyTypeInvolved) {
       return {
         isValid: false,
         errorMessage: 'Cannot map between a container field and a terminal field.',

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -331,6 +331,12 @@ export function getVariableEmptyNameXslt(): string {
 export function getVariableNestedInForEachXslt(): string {
   return readStubFile('./xml/VariableNestedInForEach.xsl');
 }
+export function getOrderInfoXsd(): string {
+  return readStubFile('./xml/OrderInfo.xsd');
+}
+export function getEnvelopeXsd(): string {
+  return readStubFile('./xml/Envelope.xsd');
+}
 
 export class TestUtil {
   static createSourceOrderDoc() {

--- a/packages/ui/src/stubs/datamapper/xml/Envelope.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/Envelope.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="io.kaoto.datamapper.poc.test">
+  <xs:element name="Envelope">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Payload" type="xs:anyType" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/OrderInfo.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/OrderInfo.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="io.kaoto.datamapper.poc.test">
+  <xs:element name="OrderInfo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="OrderEntry" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Title" type="xs:string" />
+              <xs:element name="Note" type="xs:string" minOccurs="0" />
+              <xs:element name="Quantity" type="xs:positiveInteger" />
+              <xs:element name="Price" type="xs:decimal" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Summary

- **Container auto-mapping (#2857):** Dragging a source container onto a target container auto-maps matching children by name. If namespace and structure match exactly, uses `xsl:copy-of`; otherwise generates individual `xsl:value-of` mappings. Supports collection containers via `xsl:for-each` wrapping and `xs:anyType` via `xsl:copy-of select="path/node()"`.

- **Line style classification (#2858):** Mapping lines are visually classified as `copy-of` (dual line), `complete` (heavy dash-dot), `partial` (thin dashed), or `regular` (solid) based on container mapping structure per PR #3038 mockup. Style responds to collapsed/expanded state — `complete`/`partial` show only when both endpoints are collapsed; when expanded, individual child lines render as `regular`.



## Changes

### Auto-mapping
- `ValueType.CONTAINER_NODE` for `xs:anyType` copy-of with `/node()` suffix
- `MappingService.mapToFieldWithValueType()`, `generateAutoChildMappings()`, `getContainerValueType()`
- `MappingActionService` container-to-container DnD branch with collection support
- `FieldItemHandler` skip wrapper for pure copy-of, preserve wrapper when mixed with child mappings

### Line styles
- `MappingLineStyle` enum (`copy-of`, `complete`, `regular`, `partial`, `out-of-view`)
- `classifyContainerLineStyle()` — pure classification (conditions 1+2)
- `hasExtraSourceChildren()` — source side check (condition 3), downgrades COMPLETE → PARTIAL
- `resolveSourceFields()` — extracted shared method eliminating duplication
- `MappingLinkContainer` viewport override: expanded → regular, edge → out-of-view
- `MappingLink` dual bezier path rendering for copy-of, CSS per PR #3038 mockup
- Replaced `isPartial` (virtual scroll) with `lineStyle` enum


fixes #2857, #2858

https://github.com/user-attachments/assets/4de5e8b5-0bd0-41e1-acee-9d31ab02c0af



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic container field mapping (including xs:anyType node-child mapping) and explicit mapping line styles (COPY_OF, COMPLETE, PARTIAL, REGULAR, OUT_OF_VIEW, SELECTED).

* **Improvements**
  * Refined mapping link visuals and hover/selection behavior for lines and dots.
  * More accurate XSLT serialization for container copy-of vs node-child copies.
  * Smarter link classification and edge/out-of-view handling to reflect container completeness.

* **Tests**
  * Expanded coverage for container auto-mapping, line-style classification, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->