### PR TITLE
fix(DataMapper): sort substitution group members deterministically

### DIFF
--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
@@ -804,10 +804,7 @@ describe('XmlSchemaTypesService', () => {
 
       expect(members.length).toBe(4);
       const names = members.map((el) => el.getName());
-      expect(names).toContain('Cat');
-      expect(names).toContain('Dog');
-      expect(names).toContain('Fish');
-      expect(names).toContain('Kitten');
+      expect(names).toEqual(['Cat', 'Dog', 'Fish', 'Kitten']);
       expect(names).not.toContain('Feline');
     });
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
@@ -837,7 +837,7 @@ export class XmlSchemaTypesService {
         if (!el.isAbstract()) results.push(el);
       }
     }
-    results.sort((a, b) => (a.getQName()?.toString() ?? '').localeCompare(b.getQName()?.toString() ?? ''));
+    results.sort((a, b) => (a.getQName()?.toString() ?? '').localeCompare(b.getQName()?.toString() ?? '', 'en-US'));
     return results;
   }
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
@@ -837,6 +837,7 @@ export class XmlSchemaTypesService {
         if (!el.isAbstract()) results.push(el);
       }
     }
+    results.sort((a, b) => (a.getQName()?.toString() ?? '').localeCompare(b.getQName()?.toString() ?? ''));
     return results;
   }
 

--- a/packages/ui/src/stubs/datamapper/xml/FieldSubstitution.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/FieldSubstitution.xsd
@@ -15,10 +15,10 @@
   </xs:element>
 
   <xs:element name="AbstractAnimal" type="Animal_t" abstract="true"/>
-  <xs:element name="Cat" type="Cat_t" substitutionGroup="AbstractAnimal"/>
   <xs:element name="Dog" type="Dog_t" substitutionGroup="AbstractAnimal"/>
   <xs:element name="Feline" type="Feline_t" abstract="true" substitutionGroup="AbstractAnimal"/>
   <xs:element name="Kitten" type="Kitten_t" substitutionGroup="Feline"/>
+  <xs:element name="Cat" type="Cat_t" substitutionGroup="AbstractAnimal"/>
 
   <xs:element name="AbstractLabel" type="xs:string" abstract="true"/>
   <xs:element name="Nickname" type="Nickname_t" substitutionGroup="AbstractLabel"/>


### PR DESCRIPTION
## Problem

`XmlSchemaTypesService.getSubstitutionGroupMembers()` returned substitution-group members in whatever order the BFS traversal encountered them, which depends on schema loading order and element declaration order in the XSD. As a result, the substitution candidate list could appear in different orders across runs or across schemas, with no stable ordering guarantee.

## Fix

Sort the results by QName string before returning, so candidates always appear in a consistent, predictable order regardless of how the schema was loaded or how elements were declared:

```ts
results.sort((a, b) => (a.getQName()?.toString() ?? '').localeCompare(b.getQName()?.toString() ?? '', 'en-US'));
```
Fixes #3254

## Test

Added an ordered assertion test in the `getSubstitutionGroupMembers()` block using `toEqual` on the exact sequence. To make this a genuine verification of the sort (rather than a pass that depends on input order), I reordered the substitution members in `FieldSubstitution.xsd` so their declaration order no longer matches alphabetical order. The test fails without the sort line and passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Substitution-group member lists now return in a deterministic, stable order across runs.
  * Results and exports that depend on element ordering are now reproducible and consistent.
  * No functional or interface changes; behavior change only affects ordering of existing elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->