### PR TITLE
fix(DataMapper): remove vertical scrollbar in XPath editor when content fits

### DIFF
--- a/packages/ui/src/components/XPath/monaco-options.ts
+++ b/packages/ui/src/components/XPath/monaco-options.ts
@@ -24,6 +24,7 @@ export const xpathEditorConstrufctionOption: monaco.editor.IStandaloneEditorCons
   automaticLayout: true,
   wordWrap: 'on',
   scrollBeyondLastColumn: 0,
+  scrollBeyondLastLine: false,
   scrollbar: {
     horizontal: 'hidden',
     horizontalHasArrows: false,


### PR DESCRIPTION
## Problem
The XPath editor was showing a vertical scrollbar even for a single short expression, with plenty of empty space below it.
Monaco adds phantom space beneath the last line by default, which was enough to trigger the auto scrollbar.

## Fix
Added `scrollBeyondLastLine: false` to the editor options in `monaco-options.ts`.
The scrollbar itself stays on `auto` so it still shows up when an expression is actually long enough to need it.
Fixes #1809

## Mapping
<img width="800" alt="mapping" src="https://github.com/user-attachments/assets/69a38a53-7deb-4fdc-b646-ac0c08b7636d" />

## Before
<img width="300" alt="before" src="https://github.com/user-attachments/assets/badc2310-f38b-412a-aa42-9ad164f36a12" />

## After
<img width="300" alt="after" src="https://github.com/user-attachments/assets/81bc82f2-82f1-46b0-ba43-fe707cbe2f16" />

## Scrollbar function when needed
<img width="300" alt="full" src="https://github.com/user-attachments/assets/7a134ba6-0e6e-473b-87ab-6c5f2d536d6c" />

## Tests
<img width="1500" alt="{42C7A62B-FD6B-41FF-9125-FB3E987D8D96}" src="https://github.com/user-attachments/assets/bef73529-9352-4cb5-883b-af6cb164c62b" />
