### PR TITLE
fix(DataMapper): show delete button for target node added by "Add Mapping"

### DIFF
--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -76,6 +76,8 @@ export abstract class MappingItem {
  * in the generated XSLT template.
  */
 export class FieldItem extends MappingItem {
+  isUserCreated = false;
+
   constructor(
     public parent: MappingParentType,
     public field: IField,
@@ -84,7 +86,9 @@ export class FieldItem extends MappingItem {
     super(parent, name, getCamelRandomId(name, 4));
   }
   doClone() {
-    return new FieldItem(this.parent, this.field);
+    const cloned = new FieldItem(this.parent, this.field);
+    cloned.isUserCreated = this.isUserCreated;
+    return cloned;
   }
 }
 

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -816,6 +816,14 @@ describe('MappingActionService', () => {
         expect(MappingActionService.getAllowedActions(addedNode)).toContain(MappingActionKind.Delete);
       });
 
+      it('should keep Delete for an existing value-mapped field node', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
+        expect(orderIdNode.title).toEqual('OrderId');
+        expect(MappingActionService.getAllowedActions(orderIdNode)).toContain(MappingActionKind.Delete);
+      });
+
       it('should include ContextMenu for primitive TargetDocumentNodeData', () => {
         const primitiveTargetDoc = new PrimitiveDocument(
           new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
@@ -1140,7 +1148,7 @@ describe('MappingActionService', () => {
       const docData = new TargetDocumentNodeData(targetDoc, tree);
 
       const fieldNodeData = new FieldItemNodeData(docData, tree.children[0] as FieldItem);
-      expect(MappingActionService.getAllowedActions(fieldNodeData)).toContain(MappingActionKind.Delete);
+      expect(MappingActionService.getAllowedActions(fieldNodeData)).not.toContain(MappingActionKind.Delete);
 
       const forEachNodeData = new MappingNodeData(docData, tree.children[0].children[0] as ForEachItem);
       expect(MappingActionService.getAllowedActions(forEachNodeData)).toContain(MappingActionKind.Delete);

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -798,6 +798,24 @@ describe('MappingActionService', () => {
         expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.ValueSelector);
       });
 
+      it('should allow Delete for a field node added via Add Mapping', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        expect(addMappingNode instanceof AddMappingNodeData).toBeTruthy();
+        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.Delete);
+        MappingActionService.addMapping(addMappingNode);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(updatedDocChildren[0]);
+
+        const addedNode = updatedShipOrderChildren.find(
+          (n) => n instanceof FieldItemNodeData && n.title === 'Item',
+        ) as FieldItemNodeData;
+        expect(addedNode).toBeDefined();
+        expect(MappingActionService.getAllowedActions(addedNode)).toContain(MappingActionKind.Delete);
+      });
+
       it('should include ContextMenu for primitive TargetDocumentNodeData', () => {
         const primitiveTargetDoc = new PrimitiveDocument(
           new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
@@ -1122,7 +1140,7 @@ describe('MappingActionService', () => {
       const docData = new TargetDocumentNodeData(targetDoc, tree);
 
       const fieldNodeData = new FieldItemNodeData(docData, tree.children[0] as FieldItem);
-      expect(MappingActionService.getAllowedActions(fieldNodeData)).not.toContain(MappingActionKind.Delete);
+      expect(MappingActionService.getAllowedActions(fieldNodeData)).toContain(MappingActionKind.Delete);
 
       const forEachNodeData = new MappingNodeData(docData, tree.children[0].children[0] as ForEachItem);
       expect(MappingActionService.getAllowedActions(forEachNodeData)).toContain(MappingActionKind.Delete);

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -807,7 +807,9 @@ describe('MappingActionService', () => {
         MappingActionService.addMapping(addMappingNode);
         targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
         const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
-        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(updatedDocChildren[0]);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
 
         const addedNode = updatedShipOrderChildren.find(
           (n) => n instanceof FieldItemNodeData && n.title === 'Item',

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -319,6 +319,7 @@ export class MappingActionService {
       key: MappingActionKind.Delete,
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
+        if (n instanceof FieldItemNodeData) return true;
         if (MappingActionService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
           return MappingActionService.hasValueSelector(n);
         return MappingActionService.isMappingNode(n);

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -321,7 +321,8 @@ export class MappingActionService {
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
         if (n instanceof FieldItemNodeData)
-          return (n.mapping instanceof FieldItem && n.mapping.isUserCreated) || MappingActionService.hasValueSelector(n);
+          // A workaround until https://github.com/KaotoIO/kaoto/issues/3242 is solved
+          return (n.mapping instanceof FieldItem && n.mapping.isUserCreated && n.mapping.parent instanceof FieldItem)  || MappingActionService.hasValueSelector(n);
         if (MappingActionService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
           return MappingActionService.hasValueSelector(n);
         return MappingActionService.isMappingNode(n);

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -322,7 +322,10 @@ export class MappingActionService {
         if (n instanceof AddMappingNodeData) return false;
         if (n instanceof FieldItemNodeData)
           // A workaround until https://github.com/KaotoIO/kaoto/issues/3242 is solved
-          return (n.mapping instanceof FieldItem && n.mapping.isUserCreated && n.mapping.parent instanceof FieldItem)  || MappingActionService.hasValueSelector(n);
+          return (
+            (n.mapping instanceof FieldItem && n.mapping.isUserCreated && n.mapping.parent instanceof FieldItem) ||
+            MappingActionService.hasValueSelector(n)
+          );
         if (MappingActionService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
           return MappingActionService.hasValueSelector(n);
         return MappingActionService.isMappingNode(n);

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -219,7 +219,8 @@ export class MappingActionService {
    */
   static addMapping(nodeData: AddMappingNodeData) {
     const parentItem = MappingActionService.getOrCreateFieldItem(nodeData.parent);
-    MappingService.createFieldItem(parentItem, nodeData.field);
+    const fieldItem = MappingService.createFieldItem(parentItem, nodeData.field);
+    fieldItem.isUserCreated = true;
   }
 
   static getOrCreateParentMapping(nodeData: TargetNodeData): MappingParentType | undefined {
@@ -319,7 +320,8 @@ export class MappingActionService {
       key: MappingActionKind.Delete,
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
-        if (n instanceof FieldItemNodeData) return true;
+        if (n instanceof FieldItemNodeData)
+          return (n.mapping instanceof FieldItem && n.mapping.isUserCreated) || MappingActionService.hasValueSelector(n);
         if (MappingActionService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
           return MappingActionService.hasValueSelector(n);
         return MappingActionService.isMappingNode(n);


### PR DESCRIPTION
## Problem
On a collection target field, you can add extra mappings with the "Add Mapping" button. The `for-each` and `if` nodes get a delete (trash can) button, but the node created by "Add Mapping" didn't, so there was no way to remove it.

The delete button's visibility is decided by the `Delete` action in `mapping-action.service.ts`. The node added by "Add Mapping" was being treated like a plain document field, whose delete button only shows once it has a value selector. A freshly added mapping doesn't have one yet, so the button never appeared.

## Fix
Made nodes created via "Add Mapping" deletable by tracking them with an isUserCreated flag and allowing delete based on that flag or an existing value selector. Plain document fields are unchanged, and the "Add Mapping" placeholder remains non-deletable

Fixes #3258

## Before
<img width="1500" alt="before_tcan" src="https://github.com/user-attachments/assets/f82d7318-04d7-46c4-b3a8-bdd07f51228f" />

## After
<img width="1500" alt="after_tcan" src="https://github.com/user-attachments/assets/f0fd880a-9e98-4054-8d76-887a78688c29" />

## Tests
Added a test confirming that the node created with "Add Mapping" is deletable. The "Add Mapping" placeholder remains non-deletable, and only the resulting user-created field items are deletable.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/1fcd89a2-d4f9-4fa0-8b93-167601ecb4df" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-created field items can now be removed; deletion is also permitted when a field already has a value selector.
* **Tests**
  * Added tests to verify delete availability for newly created field items and to confirm delete permission behavior for existing value-mapped fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto/pull/3262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->