### PR TITLE
fix(DataMapper): Export mapping dropdown item close on modal open

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ExportMappingFileDropdownItem } from './ExportMappingFileDropdownItem';
+
+describe('ExportMappingFileDropdownItem', () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    mockOnClick.mockClear();
+  });
+
+  it('should render the dropdown item', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    expect(dropdownItem).toBeInTheDocument();
+  });
+
+  it('should display correct text', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    expect(screen.getByText('Export current mappings (.xsl)')).toBeInTheDocument();
+  });
+
+  it('should render with ExportIcon', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    // Check that the icon is rendered (ExportIcon should be present in the DOM)
+    const icon = dropdownItem.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    const button = dropdownItem.querySelector('button');
+
+    expect(button).toBeInTheDocument();
+
+    if (button) {
+      fireEvent.click(button);
+    }
+
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClick multiple times when clicked multiple times', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    const button = dropdownItem.querySelector('button');
+
+    expect(button).toBeInTheDocument();
+
+    if (button) {
+      fireEvent.click(button);
+      fireEvent.click(button);
+      fireEvent.click(button);
+    }
+
+    expect(mockOnClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('should be accessible via test id', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    expect(dropdownItem).toBeInTheDocument();
+    expect(dropdownItem.tagName).toBe('LI');
+  });
+
+  it('should render as a DropdownItem component', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    // DropdownItem renders as a list item element
+    expect(dropdownItem.tagName).toBe('LI');
+  });
+
+  it('should have proper ARIA attributes for accessibility', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    // Button should be accessible
+    expect(dropdownItem).toBeEnabled();
+  });
+
+  it('should not call onClick when not interacted with', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    expect(mockOnClick).not.toHaveBeenCalled();
+  });
+
+  it('should handle keyboard interaction', () => {
+    render(<ExportMappingFileDropdownItem onClick={mockOnClick} />);
+
+    const dropdownItem = screen.getByTestId('dm-debug-export-mappings-button');
+    const button = dropdownItem.querySelector('button');
+
+    expect(button).toBeInTheDocument();
+
+    if (button) {
+      // Simulate Enter key press on the button
+      fireEvent.keyDown(button, { key: 'Enter', code: 'Enter' });
+    }
+
+    // The button should be present and interactive
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.tsx
@@ -1,82 +1,15 @@
-import { Monaco } from '@monaco-editor/react';
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
-import { Button, DropdownItem, Modal, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import { DropdownItem } from '@patternfly/react-core';
 import { ExportIcon } from '@patternfly/react-icons';
-import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
-import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+import { FunctionComponent } from 'react';
 
-import { useDataMapper } from '../../../hooks/useDataMapper';
-import { MappingSerializerService } from '../../../services/mapping/mapping-serializer.service';
-import IStandaloneEditorConstructionOptions = editor.IStandaloneEditorConstructionOptions;
+interface ExportMappingFileDropdownItemProps {
+  onClick: () => void;
+}
 
-export const ExportMappingFileDropdownItem: FunctionComponent<{
-  onComplete: () => void;
-}> = ({ onComplete }) => {
-  const { mappingTree, sourceParameterMap } = useDataMapper();
-  const [isModalOpen, setIsModalOpen] = useState<boolean>();
-  const [serializedMappings, setSerializedMappings] = useState<string>();
-
-  const handleMenuClick = useCallback(() => {
-    const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
-    setSerializedMappings(serialized);
-    setIsModalOpen(true);
-  }, [mappingTree, sourceParameterMap]);
-
-  const handleModalClose = useCallback(() => {
-    setSerializedMappings('');
-    setIsModalOpen(false);
-    onComplete();
-  }, [onComplete]);
-
-  const onEditorDidMount = useCallback((editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
-    editor.layout();
-    editor.focus();
-    monaco.editor.getModels()[0].updateOptions({ tabSize: 2 });
-  }, []);
-
-  const modalActions = useMemo(() => {
-    return [
-      <Button
-        key="Close"
-        variant="primary"
-        onClick={handleModalClose}
-        data-testid="dm-debug-export-mappings-modal-close-btn"
-      >
-        Close
-      </Button>,
-    ];
-  }, [handleModalClose]);
-
-  const editorOptions: IStandaloneEditorConstructionOptions = useMemo(() => {
-    return { wordWrap: 'on' };
-  }, []);
-
+export const ExportMappingFileDropdownItem: FunctionComponent<ExportMappingFileDropdownItemProps> = ({ onClick }) => {
   return (
-    <>
-      <DropdownItem icon={<ExportIcon />} onClick={handleMenuClick} data-testid="dm-debug-export-mappings-button">
-        Export current mappings (.xsl)
-      </DropdownItem>
-      <Modal
-        variant="large"
-        title="Exported Mappings"
-        isOpen={isModalOpen}
-        onClose={() => handleModalClose()}
-        data-testid="dm-debug-export-mappings-modal"
-      >
-        <ModalHeader title="Exported Mappings" />
-        <CodeEditor
-          isReadOnly={false}
-          isDownloadEnabled={true}
-          code={serializedMappings}
-          language={Language.xml}
-          onEditorDidMount={onEditorDidMount}
-          height="sizeToFit"
-          width="sizeToFit"
-          options={editorOptions}
-          data-testid="dm-debug-export-mappings-code-editor"
-        />
-        <ModalFooter>{modalActions}</ModalFooter>
-      </Modal>
-    </>
+    <DropdownItem icon={<ExportIcon />} onClick={onClick} data-testid="dm-debug-export-mappings-button">
+      Export current mappings (.xsl)
+    </DropdownItem>
   );
 };

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
@@ -1,0 +1,439 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
+
+import { useDataMapper } from '../../../hooks/useDataMapper';
+import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
+import { DataMapperProvider } from '../../../providers/datamapper.provider';
+import { DataMapperDndProvider } from '../../../providers/datamapper-dnd.provider';
+import { SourceTargetDnDHandler } from '../../../providers/dnd/SourceTargetDnDHandler';
+import { MappingSerializerService } from '../../../services/mapping/mapping-serializer.service';
+import { getShipOrderToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { ExportMappingFileModal } from './ExportMappingFileModal';
+
+// Mock CodeEditor to capture onEditorDidMount callback
+jest.mock('@patternfly/react-code-editor', () => {
+  const actual = jest.requireActual('@patternfly/react-code-editor');
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    CodeEditor: ({ onEditorDidMount, ...props }: any) => {
+      // Store the callback for testing
+      if (onEditorDidMount && typeof onEditorDidMount === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any).__onEditorDidMountCallback = onEditorDidMount;
+      }
+      // Render a mock that maintains the expected DOM structure
+      return (
+        <div className="pf-v6-c-code-editor" data-testid="mocked-code-editor">
+          <div className="pf-v6-c-code-editor__main">
+            <div className="pf-v6-c-code-editor__code">
+              <pre>{props.code}</pre>
+            </div>
+          </div>
+          <button aria-label="Download code">Download</button>
+        </div>
+      );
+    },
+  };
+});
+
+const dndHandler = new SourceTargetDnDHandler();
+
+const TestProviders: FunctionComponent<PropsWithChildren> = ({ children }) => (
+  <DataMapperProvider>
+    <DataMapperDndProvider handler={dndHandler}>
+      <MappingLinksProvider>{children}</MappingLinksProvider>
+    </DataMapperDndProvider>
+  </DataMapperProvider>
+);
+
+describe('ExportMappingFileModal', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={false} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    expect(screen.queryByTestId('dm-debug-export-mappings-modal')).not.toBeInTheDocument();
+  });
+
+  it('should render when isOpen is true', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    expect(screen.getByTestId('dm-debug-export-mappings-modal')).toBeInTheDocument();
+  });
+
+  it('should display modal title', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    expect(screen.getByText('Exported Mappings')).toBeInTheDocument();
+  });
+
+  it('should render code editor wrapper', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    // CodeEditor component renders within a code editor wrapper
+    const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+    expect(codeEditorWrapper).toBeInTheDocument();
+  });
+
+  it('should render close button', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const closeButton = screen.getByTestId('dm-debug-export-mappings-modal-close-btn');
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton).toHaveTextContent('Close');
+  });
+
+  it('should call onClose when close button is clicked', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const closeButton = screen.getByTestId('dm-debug-export-mappings-modal-close-btn');
+
+    act(() => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClose when modal is closed via backdrop or escape', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const modal = screen.getByTestId('dm-debug-export-mappings-modal');
+
+    // Simulate closing via the modal's onClose handler
+    act(() => {
+      fireEvent.keyDown(modal, { key: 'Escape', code: 'Escape' });
+    });
+
+    // The modal component should trigger onClose
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should serialize and display empty mappings when no mappings exist', async () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+      expect(codeEditorWrapper).toBeInTheDocument();
+    });
+  });
+
+  it('should serialize and display mappings when mappings exist', async () => {
+    const TestLoader: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const { mappingTree, setMappingTree, sourceParameterMap, setSourceBodyDocument, setTargetBodyDocument } =
+        useDataMapper();
+      useEffect(() => {
+        const sourceDoc = TestUtil.createSourceOrderDoc();
+        setSourceBodyDocument(sourceDoc);
+        const targetDoc = TestUtil.createTargetOrderDoc();
+        setTargetBodyDocument(targetDoc);
+        MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
+        setMappingTree(mappingTree);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return <>{children}</>;
+    };
+
+    render(
+      <TestProviders>
+        <TestLoader>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestLoader>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+      expect(codeEditorWrapper).toBeInTheDocument();
+    });
+  });
+
+  it('should have code editor with XML language', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+    expect(codeEditorWrapper).toBeInTheDocument();
+    // CodeEditor component should be configured with XML language
+  });
+
+  it('should have code editor with download enabled', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const downloadButton = screen.getByLabelText('Download code');
+    expect(downloadButton).toBeInTheDocument();
+    // CodeEditor should have download functionality enabled
+  });
+
+  it('should update serialized mappings when mappingTree changes', async () => {
+    const TestLoader: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const { mappingTree, setMappingTree, setSourceBodyDocument, setTargetBodyDocument } = useDataMapper();
+      useEffect(() => {
+        const sourceDoc = TestUtil.createSourceOrderDoc();
+        setSourceBodyDocument(sourceDoc);
+        const targetDoc = TestUtil.createTargetOrderDoc();
+        setTargetBodyDocument(targetDoc);
+        // Initially no mappings
+        setMappingTree(mappingTree);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return <>{children}</>;
+    };
+
+    const { rerender } = render(
+      <TestProviders>
+        <TestLoader>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestLoader>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('.pf-v6-c-code-editor')).toBeInTheDocument();
+    });
+
+    // Rerender to trigger useEffect
+    rerender(
+      <TestProviders>
+        <TestLoader>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestLoader>
+      </TestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('.pf-v6-c-code-editor')).toBeInTheDocument();
+    });
+  });
+
+  it('should have modal with large variant', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const modal = screen.getByTestId('dm-debug-export-mappings-modal');
+    expect(modal).toBeInTheDocument();
+    // Modal should be rendered with large variant
+  });
+
+  it('should render code editor with word wrap enabled', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+    expect(codeEditorWrapper).toBeInTheDocument();
+    // Editor options should include wordWrap: 'on'
+  });
+
+  it('should render code editor with sizeToFit dimensions', () => {
+    render(
+      <TestProviders>
+        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+      </TestProviders>,
+    );
+
+    const codeEditorWrapper = document.querySelector('.pf-v6-c-code-editor');
+    expect(codeEditorWrapper).toBeInTheDocument();
+    // Editor should have height and width set to 'sizeToFit'
+  });
+
+  describe('onEditorDidMount callback', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockEditor: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockMonaco: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockModel: any;
+
+    beforeEach(() => {
+      // Reset the global callback
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).__onEditorDidMountCallback = undefined;
+
+      // Create mock model with updateOptions
+      mockModel = {
+        updateOptions: jest.fn(),
+      };
+
+      // Create mock editor with layout and focus methods
+      mockEditor = {
+        layout: jest.fn(),
+        focus: jest.fn(),
+      };
+
+      // Create mock monaco with getModels method
+      mockMonaco = {
+        editor: {
+          getModels: jest.fn().mockReturnValue([mockModel]),
+        },
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call editor.layout() when editor mounts', () => {
+      render(
+        <TestProviders>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestProviders>,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callback = (globalThis as any).__onEditorDidMountCallback;
+      expect(callback).toBeDefined();
+
+      // Invoke the callback
+      act(() => {
+        callback(mockEditor, mockMonaco);
+      });
+
+      expect(mockEditor.layout).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call editor.focus() when editor mounts', () => {
+      render(
+        <TestProviders>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestProviders>,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callback = (globalThis as any).__onEditorDidMountCallback;
+      expect(callback).toBeDefined();
+
+      // Invoke the callback
+      act(() => {
+        callback(mockEditor, mockMonaco);
+      });
+
+      expect(mockEditor.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call monaco.editor.getModels()[0].updateOptions with tabSize: 2', () => {
+      render(
+        <TestProviders>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestProviders>,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callback = (globalThis as any).__onEditorDidMountCallback;
+      expect(callback).toBeDefined();
+
+      // Invoke the callback
+      act(() => {
+        callback(mockEditor, mockMonaco);
+      });
+
+      expect(mockMonaco.editor.getModels).toHaveBeenCalledTimes(1);
+      expect(mockModel.updateOptions).toHaveBeenCalledTimes(1);
+      expect(mockModel.updateOptions).toHaveBeenCalledWith({ tabSize: 2 });
+    });
+
+    it('should call all three operations in sequence when editor mounts', () => {
+      render(
+        <TestProviders>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestProviders>,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callback = (globalThis as any).__onEditorDidMountCallback;
+      expect(callback).toBeDefined();
+
+      // Invoke the callback
+      act(() => {
+        callback(mockEditor, mockMonaco);
+      });
+
+      // Verify all three operations were called
+      expect(mockEditor.layout).toHaveBeenCalledTimes(1);
+      expect(mockEditor.focus).toHaveBeenCalledTimes(1);
+      expect(mockMonaco.editor.getModels).toHaveBeenCalledTimes(1);
+      expect(mockModel.updateOptions).toHaveBeenCalledWith({ tabSize: 2 });
+
+      // Verify the order of calls
+      const layoutCallOrder = mockEditor.layout.mock.invocationCallOrder[0];
+      const focusCallOrder = mockEditor.focus.mock.invocationCallOrder[0];
+      const getModelsCallOrder = mockMonaco.editor.getModels.mock.invocationCallOrder[0];
+
+      expect(layoutCallOrder).toBeLessThan(focusCallOrder);
+      expect(focusCallOrder).toBeLessThan(getModelsCallOrder);
+    });
+
+    it('should handle onEditorDidMount callback being called multiple times', () => {
+      render(
+        <TestProviders>
+          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        </TestProviders>,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callback = (globalThis as any).__onEditorDidMountCallback;
+      expect(callback).toBeDefined();
+
+      // Invoke the callback multiple times
+      act(() => {
+        callback(mockEditor, mockMonaco);
+        callback(mockEditor, mockMonaco);
+      });
+
+      // Each call should trigger the operations
+      expect(mockEditor.layout).toHaveBeenCalledTimes(2);
+      expect(mockEditor.focus).toHaveBeenCalledTimes(2);
+      expect(mockMonaco.editor.getModels).toHaveBeenCalledTimes(2);
+      expect(mockModel.updateOptions).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.tsx
@@ -1,0 +1,66 @@
+import { Monaco } from '@monaco-editor/react';
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useDataMapper } from '../../../hooks/useDataMapper';
+import { MappingSerializerService } from '../../../services/mapping/mapping-serializer.service';
+import IStandaloneEditorConstructionOptions = editor.IStandaloneEditorConstructionOptions;
+
+interface ExportMappingFileModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ExportMappingFileModal: FunctionComponent<ExportMappingFileModalProps> = ({ isOpen, onClose }) => {
+  const { mappingTree, sourceParameterMap } = useDataMapper();
+  const [serializedMappings, setSerializedMappings] = useState<string>();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    setSerializedMappings(serialized);
+  }, [isOpen, mappingTree, sourceParameterMap]);
+
+  const onEditorDidMount = useCallback((editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
+    editor.layout();
+    editor.focus();
+    monaco.editor.getModels()[0]?.updateOptions({ tabSize: 2 });
+  }, []);
+
+  const modalActions = useMemo(() => {
+    return [
+      <Button key="Close" variant="primary" onClick={onClose} data-testid="dm-debug-export-mappings-modal-close-btn">
+        Close
+      </Button>,
+    ];
+  }, [onClose]);
+
+  const editorOptions: IStandaloneEditorConstructionOptions = useMemo(() => {
+    return { wordWrap: 'on' };
+  }, []);
+
+  return (
+    <Modal variant="large" isOpen={isOpen} onClose={onClose} data-testid="dm-debug-export-mappings-modal">
+      <ModalHeader title="Exported Mappings" />
+      <ModalBody>
+        <CodeEditor
+          isReadOnly={false}
+          isDownloadEnabled={true}
+          code={serializedMappings}
+          language={Language.xml}
+          onEditorDidMount={onEditorDidMount}
+          height="sizeToFit"
+          width="sizeToFit"
+          options={editorOptions}
+          data-testid="dm-debug-export-mappings-code-editor"
+        />
+      </ModalBody>
+      <ModalFooter>{modalActions}</ModalFooter>
+    </Modal>
+  );
+};

--- a/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.test.tsx
@@ -1,0 +1,210 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
+import { DataMapperProvider } from '../../../providers/datamapper.provider';
+import { DataMapperDndProvider } from '../../../providers/datamapper-dnd.provider';
+import { SourceTargetDnDHandler } from '../../../providers/dnd/SourceTargetDnDHandler';
+import { MainMenuToolbarItem } from './MainMenuToolbarItem';
+
+const dndHandler = new SourceTargetDnDHandler();
+
+const TestProviders: FunctionComponent<PropsWithChildren> = ({ children }) => (
+  <DataMapperProvider>
+    <DataMapperDndProvider handler={dndHandler}>
+      <MappingLinksProvider>{children}</MappingLinksProvider>
+    </DataMapperDndProvider>
+  </DataMapperProvider>
+);
+
+describe('MainMenuToolbarItem', () => {
+  it('should render the main menu button', () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('DataMapper Debugger');
+  });
+
+  it('should toggle dropdown menu when button is clicked', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    // Click to open
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    // Verify dropdown items are present
+    expect(screen.getByTestId('dm-debug-import-mappings-button')).toBeInTheDocument();
+  });
+
+  it('should render all dropdown items when menu is open', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    expect(screen.getByTestId('dm-debug-import-mappings-button')).toBeInTheDocument();
+    expect(screen.getByTestId('dm-debug-export-mappings-button')).toBeInTheDocument();
+    expect(screen.getByText('Reset Mappings')).toBeInTheDocument();
+  });
+
+  it('should open export modal when export button is clicked', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    const exportButton = screen.getByTestId('dm-debug-export-mappings-button');
+    const exportButtonElement = exportButton.querySelector('button');
+
+    expect(exportButtonElement).toBeInTheDocument();
+
+    await act(async () => {
+      if (exportButtonElement) {
+        fireEvent.click(exportButtonElement);
+      }
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-export-mappings-modal')).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should close export modal when close button is clicked', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    const exportButton = screen.getByTestId('dm-debug-export-mappings-button');
+    const exportButtonElement = exportButton.querySelector('button');
+
+    expect(exportButtonElement).toBeInTheDocument();
+
+    await act(async () => {
+      if (exportButtonElement) {
+        fireEvent.click(exportButtonElement);
+      }
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-export-mappings-modal')).toBeInTheDocument();
+      });
+    });
+
+    const closeButton = screen.getByTestId('dm-debug-export-mappings-modal-close-btn');
+
+    await act(async () => {
+      fireEvent.click(closeButton);
+      await waitFor(() => {
+        expect(screen.queryByTestId('dm-debug-export-mappings-modal')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should close dropdown after import action completes', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    const importButton = screen.getByTestId('dm-debug-import-mappings-button');
+    const importButtonElement = importButton.querySelector('button');
+
+    expect(importButtonElement).toBeInTheDocument();
+
+    await act(async () => {
+      if (importButtonElement) {
+        fireEvent.click(importButtonElement);
+      }
+    });
+
+    // Dropdown should remain present (closes only after file is selected)
+    expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+  });
+
+  it('should render export modal with isOpen prop controlled by state', async () => {
+    render(
+      <TestProviders>
+        <MainMenuToolbarItem />
+      </TestProviders>,
+    );
+
+    // Modal should not be visible initially
+    expect(screen.queryByTestId('dm-debug-export-mappings-modal')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('dm-debug-main-menu-button');
+
+    await act(async () => {
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-main-menu-dropdownlist')).toBeInTheDocument();
+      });
+    });
+
+    const exportButton = screen.getByTestId('dm-debug-export-mappings-button');
+    const exportButtonElement = exportButton.querySelector('button');
+
+    expect(exportButtonElement).toBeInTheDocument();
+
+    await act(async () => {
+      if (exportButtonElement) {
+        fireEvent.click(exportButtonElement);
+      }
+      await waitFor(() => {
+        expect(screen.getByTestId('dm-debug-export-mappings-modal')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
@@ -1,13 +1,21 @@
 import { Dropdown, DropdownList, MenuToggle, ToolbarItem } from '@patternfly/react-core';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 
 import { useToggle } from '../../../hooks/useToggle';
 import { ExportMappingFileDropdownItem } from './ExportMappingFileDropdownItem';
+import { ExportMappingFileModal } from './ExportMappingFileModal';
 import { ImportMappingFileDropdownItem } from './ImportMappingFileDropdownItem';
 import { ResetMappingsDropdownItem } from './ResetMappingsDropdownItem';
 
 export const MainMenuToolbarItem: FunctionComponent = () => {
   const { state: isOpen, toggle: onToggle, toggleOff } = useToggle(false);
+  const [isExportFileModalOpen, setIsExportFileModalOpen] = useState<boolean>(false);
+
+  const handleOpenExportModal = () => {
+    setIsExportFileModalOpen(true);
+    toggleOff();
+  };
+
   return (
     <ToolbarItem>
       <Dropdown
@@ -21,10 +29,11 @@ export const MainMenuToolbarItem: FunctionComponent = () => {
       >
         <DropdownList data-testid={'dm-debug-main-menu-dropdownlist'}>
           <ImportMappingFileDropdownItem onComplete={toggleOff} key={'import-mapping'} />
-          <ExportMappingFileDropdownItem onComplete={toggleOff} key={'export-mapping'} />
+          <ExportMappingFileDropdownItem onClick={handleOpenExportModal} key={'export-mapping'} />
           <ResetMappingsDropdownItem onComplete={toggleOff} key={'reset-mappings'} />
         </DropdownList>
       </Dropdown>
+      <ExportMappingFileModal isOpen={isExportFileModalOpen} onClose={() => setIsExportFileModalOpen(false)} />
     </ToolbarItem>
   );
 };


### PR DESCRIPTION
Resolves: [#2820](https://github.com/KaotoIO/kaoto/issues/2820)


https://github.com/user-attachments/assets/c5b6dd81-564b-4e40-9620-a007a6f05ddb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export modal with integrated code viewer and download option for serialized mappings; accessible from the main menu.
* **Refactor**
  * Export action simplified to a lightweight dropdown item that opens the export modal; modal/editor logic moved into its own component and main menu now controls modal visibility.
* **Tests**
  * Added comprehensive tests covering the modal, dropdown export action, keyboard/accessibility, and main menu export flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->