### PR TITLE
chore: update catalogs to Camel 4.20

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/rootContainerConfig/rootContainersConf.cy.ts
@@ -59,7 +59,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.interactWithConfigInputObject('outputType.validate');
     cy.interactWithConfigInputObject('precondition', 'test.precondition');
     cy.interactWithConfigInputObject('routeConfigurationId', 'test.routeConfigurationId');
-    cy.interactWithConfigInputObject('routePolicy', 'test.routePolicy');
+    cy.interactWithConfigInputObject('routePolicyRef', 'test.routePolicy');
     cy.interactWithConfigInputObject('startupOrder', '5');
     cy.interactWithConfigInputObject('trace');
     cy.interactWithConfigInputObject('streamCache');
@@ -84,7 +84,7 @@ describe('Test for camel route root containers configuration', () => {
     cy.checkCodeSpanLine('validate: true');
     cy.checkCodeSpanLine('precondition: test.precondition');
     cy.checkCodeSpanLine('routeConfigurationId: test.routeConfigurationId');
-    cy.checkCodeSpanLine('routePolicy: test.routePolicy');
+    cy.checkCodeSpanLine('routePolicyRef: test.routePolicy');
     cy.checkCodeSpanLine('startupOrder: 5');
     cy.checkCodeSpanLine('streamCache: true');
     cy.checkCodeSpanLine('trace: true');

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -56,7 +56,7 @@
     "vite": "^5.4.0"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.4.4",
+    "@kaoto/camel-catalog": "^0.5.2",
     "@kaoto/forms": "^1.7.1",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.4.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -84,7 +84,7 @@
     "zustand": "^5.0.11"
   },
   "peerDependencies": {
-    "@kaoto/camel-catalog": "^0.4.4",
+    "@kaoto/camel-catalog": "^0.5.2",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.0",
@@ -103,7 +103,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
     "@eslint/js": "^9.10.0",
-    "@kaoto/camel-catalog": "^0.4.4",
+    "@kaoto/camel-catalog": "^0.5.2",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.0",

--- a/packages/ui/src/components/Catalog/DataListItem.tsx
+++ b/packages/ui/src/components/Catalog/DataListItem.tsx
@@ -53,11 +53,13 @@ export const CatalogDataListItem: FunctionComponent<ICatalogDataListItemProps> =
               <Grid>
                 <GridItem sm={12} md={6} order={titleElementOrder}>
                   <div className="catalog-data-list-item__title-div-left">
-                    <img
-                      src={props.tile.iconUrl}
-                      className="catalog-data-list-item__title-div-left__icon"
-                      alt={`${props.tile.type} icon`}
-                    />
+                    {props.tile.iconUrl && (
+                      <img
+                        src={props.tile.iconUrl}
+                        className="catalog-data-list-item__title-div-left__icon"
+                        alt={`${props.tile.type} icon`}
+                      />
+                    )}
                     <span id="clickable-action-item1" className="catalog-data-list-item__title-div-left__title">
                       {props.tile.title}
                     </span>

--- a/packages/ui/src/components/Catalog/Tile.tsx
+++ b/packages/ui/src/components/Catalog/Tile.tsx
@@ -33,7 +33,9 @@ export const Tile: FunctionComponent<PropsWithChildren<TileProps>> = (props) => 
         onClick={onTileClick}
       >
         <div className="tile__header">
-          <img src={props.tile.iconUrl} className="tile__icon" alt={`${props.tile.type} icon`} />
+          {props.tile.iconUrl && (
+            <img src={props.tile.iconUrl} className="tile__icon" alt={`${props.tile.type} icon`} />
+          )}
           <LabelGroup isCompact aria-label="tile-headers-tags">
             {props.tile.headerTags?.map((tag, index) => (
               <CatalogTag key={`${props.tile.name}-${tag}-${index}`} tag={tag} />

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -870,8 +870,10 @@ describe('TargetDocumentNode', () => {
 
   describe('Variable Node', () => {
     afterEach(() => {
-      useDocumentTreeStore.getState().setAddingVariableTo(null);
-      useDocumentTreeStore.getState().setRenamingVariable(null);
+      act(() => {
+        useDocumentTreeStore.getState().setAddingVariableTo(null);
+        useDocumentTreeStore.getState().setRenamingVariable(null);
+      });
     });
 
     it('should render variable node with $name label', () => {
@@ -910,10 +912,8 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setAddingVariableTo(nodePath);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       expect(screen.getByTestId('new-variable-name-input')).toBeInTheDocument();
@@ -938,10 +938,8 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setRenamingVariable(variableItem.id);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       const input = screen.getByTestId('new-variable-name-input');
@@ -950,7 +948,7 @@ describe('TargetDocumentNode', () => {
       expect(screen.getByTestId(`node-target-${variableNodeData.id}-renaming`)).toBeInTheDocument();
     });
 
-    it('should clear store state when cancel is clicked on add placeholder', () => {
+    it('should clear store state when cancel is clicked on add placeholder', async () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -969,17 +967,17 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setAddingVariableTo(nodePath);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       act(() => {
         fireEvent.click(screen.getByTestId('new-variable-cancel-btn'));
       });
 
-      expect(useDocumentTreeStore.getState().addingVariableToNodePath).toBeNull();
+      await waitFor(() => {
+        expect(useDocumentTreeStore.getState().addingVariableToNodePath).toBeNull();
+      });
     });
 
     it('should add variable when submit is clicked on add placeholder', async () => {
@@ -1002,10 +1000,8 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setAddingVariableTo(nodePath);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={fieldTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       const input = screen.getByTestId('new-variable-name-input');
@@ -1041,10 +1037,8 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setRenamingVariable(variableItem.id);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       const input = screen.getByTestId('new-variable-name-input');
@@ -1062,7 +1056,7 @@ describe('TargetDocumentNode', () => {
       updateVariableSpy.mockRestore();
     });
 
-    it('should clear store state when cancel is clicked on rename placeholder', () => {
+    it('should clear store state when cancel is clicked on rename placeholder', async () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -1079,17 +1073,17 @@ describe('TargetDocumentNode', () => {
         useDocumentTreeStore.getState().setRenamingVariable(variableItem.id);
       });
 
-      act(() => {
-        render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
-          wrapper,
-        });
+      render(<TargetDocumentNode treeNode={variableTreeNode} documentId={targetDocNode.id} rank={1} />, {
+        wrapper,
       });
 
       act(() => {
         fireEvent.click(screen.getByTestId('new-variable-cancel-btn'));
       });
 
-      expect(useDocumentTreeStore.getState().renamingVariableId).toBeNull();
+      await waitFor(() => {
+        expect(useDocumentTreeStore.getState().renamingVariableId).toBeNull();
+      });
     });
   });
 

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
@@ -96,7 +96,9 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
 
   const title: ReactElement = (
     <div className="properties-modal__title-div">
-      <img src={props.tile.iconUrl} alt={`${props.tile.type} icon`} className={'properties-modal__title-image'} />
+      {props.tile.iconUrl && (
+        <img src={props.tile.iconUrl} alt={`${props.tile.type} icon`} className={'properties-modal__title-image'} />
+      )}
       <h1 className="properties-modal__title">{props.tile.title}</h1>
     </div>
   );

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             class="runtime-selector pf-v6-u-m-sm"
           >
-            Camel Main 4.14.2.redhat-00019
+            Camel Main 4.18.1.redhat-00019
           </span>
         </span>
         <span
@@ -346,7 +346,7 @@ exports[`SettingsForm should render 1`] = `
           <span
             class="runtime-selector pf-v6-u-m-sm"
           >
-            Citrus 4.10.0
+            Citrus 4.10.1
           </span>
         </span>
         <span

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -582,18 +582,18 @@ describe('CanvasForm', () => {
       await formPageObject.toggleOneOfFieldForProperty(ROOT_PATH);
       await formPageObject.selectTypeaheadItem('failover load balancer');
 
-      let inputRoundRobin = formPageObject.getFieldByDisplayName('Round Robin');
+      let inputRoundRobin = await screen.findByLabelText('Round Robin');
       expect(inputRoundRobin).toBeInTheDocument();
 
-      await formPageObject.inputText('Round Robin', 'playoff');
+      fireEvent.click(inputRoundRobin);
 
       await formPageObject.showModifiedFields();
       loadbalancerField = formPageObject.getOneOfInputForProperty(ROOT_PATH);
       expect(loadbalancerField).toBeInTheDocument();
 
-      inputRoundRobin = formPageObject.getFieldByDisplayName('Round Robin');
+      inputRoundRobin = await screen.findByLabelText('Round Robin');
       expect(inputRoundRobin).toBeInTheDocument();
-      expect(inputRoundRobin).toHaveAttribute('value', 'playoff');
+      expect(inputRoundRobin).toBeChecked();
     });
   });
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormHeader.tsx
@@ -20,7 +20,7 @@ export const CanvasFormHeader: FunctionComponent<CanvasFormHeaderProps> = ({ nod
     <>
       <Grid hasGutter>
         <GridItem className="form-header" span={11}>
-          <img src={iconUrl} className={`form-header__icon-${nodeId}`} alt={title} />
+          {iconUrl && <img src={iconUrl} className={`form-header__icon-${nodeId}`} alt={title} />}
 
           <Title className="form-header__title" headingLevel="h2">
             {title}

--- a/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
@@ -265,10 +265,6 @@ exports[`CanvasForm should render nothing if no schema and no definition is avai
           <div
             class="pf-v6-l-grid__item pf-m-11-col form-header"
           >
-            <img
-              alt="route"
-              class="form-header__icon-1"
-            />
             <h2
               class="pf-v6-c-title pf-m-h2 form-header__title"
               data-ouia-component-id="OUIA-Generated-Title-3"
@@ -524,10 +520,6 @@ exports[`CanvasForm should render nothing if no schema is available 1`] = `
           <div
             class="pf-v6-l-grid__item pf-m-11-col form-header"
           >
-            <img
-              alt="route"
-              class="form-header__icon-1"
-            />
             <h2
               class="pf-v6-c-title pf-m-h2 form-header__title"
               data-ouia-component-id="OUIA-Generated-Title-2"

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
@@ -1,4 +1,5 @@
-import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { EnumField, TextAreaField } from '@kaoto/forms';
 
 import { ICamelComponentDefinition } from '../../../../../models/camel/camel-components-catalog';
@@ -18,6 +19,8 @@ import { ExpressionField } from './ExpressionField/ExpressionField';
 import { MediaTypeField } from './MediaTypeField/MediaTypeField';
 import { UriField } from './UriField/UriField';
 
+const catalogLibrary = catalogLibraryJson as CatalogLibrary;
+
 describe('customFieldsFactoryfactory', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
 
@@ -36,6 +39,18 @@ describe('customFieldsFactoryfactory', () => {
     const schema: KaotoSchemaDefinition['schema'] = { type: 'object', enum: ['option 1', 'option 2', 'option 3'] };
     const result = customFieldsFactoryfactory(schema);
     expect(result).toBe(EnumField);
+  });
+
+  it('returns PrefixedBeanField for Schema Resolver fields', () => {
+    const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'Schema Resolver' };
+    const result = customFieldsFactoryfactory(schema);
+    expect(result).toBe(PrefixedBeanField);
+  });
+
+  it('does not return PrefixedBeanField for non-string Schema Resolver schemas', () => {
+    const schema: KaotoSchemaDefinition['schema'] = { type: 'object', title: 'Schema Resolver' };
+    const result = customFieldsFactoryfactory(schema);
+    expect(result).not.toBe(PrefixedBeanField);
   });
 
   it('returns PrefixedBeanField for string type with format starting with "bean:"', () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.ts
@@ -24,7 +24,9 @@ const isMediaTypeField = (schema: Parameters<CustomFieldsFactory>[0]): boolean =
 };
 
 const isBeanField = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {
-  return schema.type === 'string' && schema.format?.startsWith('bean:') === true;
+  return (
+    schema.type === 'string' && (schema.format?.startsWith('bean:') === true || schema.title === 'Schema Resolver')
+  );
 };
 
 const isRefField = (schema: Parameters<CustomFieldsFactory>[0]): boolean => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
@@ -309,6 +309,16 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${list(val...)}",
   },
   {
+    "description": "Adds the result of the expression to the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listAdd(source,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listRemove(source,exp)}",
+  },
+  {
     "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
     "group": "Simple Language",
     "value": "\${load(file)}",
@@ -327,6 +337,16 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Adds the result of the expression to the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapAdd(source,key,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapRemove(source,key)}",
   },
   {
     "description": "Returns the maximum number from all the values (integral numbers only).",
@@ -469,6 +489,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${shuffle(val...)}",
   },
   {
+    "description": "When working with JSon data, then this allows using the Simple JSonPath language, for example, to extract data from the message body (in JSon format). For input (optional), you can choose \`header:key\`, \`exchangeProperty:key\` or \`variable:key\` to use as input for the JSon payload instead of the message body.",
+    "group": "Simple Language",
+    "value": "\${simpleJsonpath(input,exp)}",
+  },
+  {
     "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
     "group": "Simple Language",
     "value": "\${size(exp)}",
@@ -477,6 +502,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Sorts the message body or expression in natural order",
+    "group": "Simple Language",
+    "value": "\${sort(exp,reverse)}",
   },
   {
     "description": "Splits the message body/expression as a String value using the separator into a String array",
@@ -534,6 +564,26 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "value": "\${throwException(type,msg)}",
   },
   {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJsonBody}",
+  },
+  {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJsonBody}",
+  },
+  {
     "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
     "group": "Simple Language",
     "value": "\${trim(exp)}",
@@ -557,6 +607,11 @@ exports[`Properties Suggestions should return suggestions from the catalog 1`] =
     "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
+  },
+  {
+    "description": "Returns the expression as a constant value",
+    "group": "Simple Language",
+    "value": "\${val(exp)}",
   },
   {
     "description": "Converts the variable to the given type (classname).",
@@ -885,6 +940,16 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${list(val...)}",
   },
   {
+    "description": "Adds the result of the expression to the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listAdd(source,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listRemove(source,exp)}",
+  },
+  {
     "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
     "group": "Simple Language",
     "value": "\${load(file)}",
@@ -903,6 +968,16 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Adds the result of the expression to the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapAdd(source,key,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapRemove(source,key)}",
   },
   {
     "description": "Returns the maximum number from all the values (integral numbers only).",
@@ -1045,6 +1120,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${shuffle(val...)}",
   },
   {
+    "description": "When working with JSon data, then this allows using the Simple JSonPath language, for example, to extract data from the message body (in JSon format). For input (optional), you can choose \`header:key\`, \`exchangeProperty:key\` or \`variable:key\` to use as input for the JSon payload instead of the message body.",
+    "group": "Simple Language",
+    "value": "\${simpleJsonpath(input,exp)}",
+  },
+  {
     "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
     "group": "Simple Language",
     "value": "\${size(exp)}",
@@ -1053,6 +1133,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Sorts the message body or expression in natural order",
+    "group": "Simple Language",
+    "value": "\${sort(exp,reverse)}",
   },
   {
     "description": "Splits the message body/expression as a String value using the separator into a String array",
@@ -1110,6 +1195,26 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "value": "\${throwException(type,msg)}",
   },
   {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJsonBody}",
+  },
+  {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJsonBody}",
+  },
+  {
     "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
     "group": "Simple Language",
     "value": "\${trim(exp)}",
@@ -1133,6 +1238,11 @@ exports[`Properties Suggestions should return suggestions when \`word\` it is no
     "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
+  },
+  {
+    "description": "Returns the expression as a constant value",
+    "group": "Simple Language",
+    "value": "\${val(exp)}",
   },
   {
     "description": "Converts the variable to the given type (classname).",
@@ -1483,6 +1593,16 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${list(val...)}",
   },
   {
+    "description": "Adds the result of the expression to the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listAdd(source,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a list",
+    "group": "Simple Language",
+    "value": "\${listRemove(source,exp)}",
+  },
+  {
     "description": "Loads the content of the resource from classpath (cannot load from file-system to avoid dangerous situations).",
     "group": "Simple Language",
     "value": "\${load(file)}",
@@ -1501,6 +1621,16 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "The map function creates a LinkedHashMap with the given set of pairs.",
     "group": "Simple Language",
     "value": "\${map(key1,value1,...)}",
+  },
+  {
+    "description": "Adds the result of the expression to the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapAdd(source,key,exp)}",
+  },
+  {
+    "description": "Removes the result of the expression from the message body (or expression) which is a map",
+    "group": "Simple Language",
+    "value": "\${mapRemove(source,key)}",
   },
   {
     "description": "Returns the maximum number from all the values (integral numbers only).",
@@ -1643,6 +1773,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${shuffle(val...)}",
   },
   {
+    "description": "When working with JSon data, then this allows using the Simple JSonPath language, for example, to extract data from the message body (in JSon format). For input (optional), you can choose \`header:key\`, \`exchangeProperty:key\` or \`variable:key\` to use as input for the JSon payload instead of the message body.",
+    "group": "Simple Language",
+    "value": "\${simpleJsonpath(input,exp)}",
+  },
+  {
     "description": "Returns the number of elements in collection or array based payloads. If the value is null then 0 is returned, otherwise 1.",
     "group": "Simple Language",
     "value": "\${size(exp)}",
@@ -1651,6 +1786,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "The skip function iterates the message body and skips the first number of items. This can be used with the Splitter EIP to split a message body and skip the first N number of items.",
     "group": "Simple Language",
     "value": "\${skip(num)}",
+  },
+  {
+    "description": "Sorts the message body or expression in natural order",
+    "group": "Simple Language",
+    "value": "\${sort(exp,reverse)}",
   },
   {
     "description": "Splits the message body/expression as a String value using the separator into a String array",
@@ -1708,6 +1848,26 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "value": "\${throwException(type,msg)}",
   },
   {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toJsonBody}",
+  },
+  {
+    "description": "Converts the expression to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJson(exp)}",
+  },
+  {
+    "description": "Converts the body to JSon String representation.",
+    "group": "Simple Language",
+    "value": "\${toPrettyJsonBody}",
+  },
+  {
     "description": "The trim function trims the message body (or expression) by removing all leading and trailing white spaces.",
     "group": "Simple Language",
     "value": "\${trim(exp)}",
@@ -1731,6 +1891,11 @@ exports[`Properties Suggestions should use \`foo\` if word is empty 1`] = `
     "description": "Returns a UUID using the Camel \`UuidGenerator\`. You can choose between \`default\`, \`classic\`, \`short\` and \`simple\` as the type. If no type is given, the default is used. It is also possible to use a custom \`UuidGenerator\` and bind the bean to the Registry with an id. For example \`\${uuid(myGenerator)}\` where the ID is _myGenerator_.",
     "group": "Simple Language",
     "value": "\${uuid(type)}",
+  },
+  {
+    "description": "Returns the expression as a constant value",
+    "group": "Simple Language",
+    "value": "\${val(exp)}",
   },
   {
     "description": "Converts the variable to the given type (classname).",

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -131,6 +131,33 @@ describe('CustomGroupExpanded', () => {
     expect(group).toHaveAttribute('data-grouplabel', 'Choice');
   });
 
+  it('should fall back to iconAlt for the image alt text when description is empty', async () => {
+    // The <img> only renders when iconUrl is truthy, and its `alt` uses
+    // `description || iconAlt`. So to reach the iconAlt fallback (CustomGroupExpanded.tsx:236)
+    // we need: iconUrl set, description empty, and iconAlt as a string.
+    const vizNode = createVisualizationNode('choice-1', {
+      name: 'choice',
+      path: 'route.from.steps.0.choice',
+      isPlaceholder: false,
+      isGroup: false,
+      iconUrl: 'data:image/svg+xml;base64,icon',
+      title: '',
+      description: '',
+      iconAlt: 'Choice icon',
+    }) as IVisualizationNode;
+    jest.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
+    jest.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
+    jest.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+
+    jest.spyOn(element, 'getData').mockReturnValue({ vizNode });
+    jest.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
+    jest.spyOn(element, 'getId').mockReturnValue('node-choice-1');
+
+    await renderInContext(<CustomGroupExpanded element={element} />);
+
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'Choice icon');
+  });
+
   it('should render icon placeholder when group has validation warnings', async () => {
     const vizNode = createVisualizationNode('choice-1', {
       name: 'choice',

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -228,13 +228,15 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
                 {doesHaveWarnings ? (
                   <div className="custom-group__container__icon-placeholder" />
                 ) : (
-                  <img
-                    src={groupVizNode.data.iconUrl}
-                    alt={
-                      groupVizNode.data.description ||
-                      (typeof groupVizNode.data.iconAlt === 'string' ? groupVizNode.data.iconAlt : '')
-                    }
-                  />
+                  groupVizNode.data.iconUrl && (
+                    <img
+                      src={groupVizNode.data.iconUrl}
+                      alt={
+                        groupVizNode.data.description ||
+                        (typeof groupVizNode.data.iconAlt === 'string' ? groupVizNode.data.iconAlt : '')
+                      }
+                    />
+                  )
                 )}
                 <span title={label}>{label}</span>
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.tsx
@@ -49,7 +49,9 @@ export const CustomNodeContainer: FunctionComponent<CustomNodeContainerProps> = 
   >
     <div data-testid={dataTestId} className={clsx('custom-node__container', containerClassNames)}>
       <div title={vizNode.data.description} className="custom-node__container__image">
-        <img src={vizNode.data.iconUrl} alt={vizNode.data.description?.trim() || (vizNode.data.iconAlt as string)} />
+        {vizNode.data.iconUrl && (
+          <img src={vizNode.data.iconUrl} alt={vizNode.data.description?.trim() || (vizNode.data.iconAlt as string)} />
+        )}
 
         {isCollapsed && childCount > 0 && (
           <FloatingCircle

--- a/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
@@ -1,4 +1,4 @@
-import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
 import { CatalogDefinition, CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
 
@@ -8,6 +8,8 @@ import { TestRuntimeProviderWrapper } from '../stubs';
 import { citrusCatalogSelector, getFirstCatalogMap, getFirstCitrusCatalogMap } from '../stubs/test-load-catalog';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
 import { CatalogLoaderProvider } from './catalog.provider';
+
+const catalogLibrary = catalogLibraryJson as CatalogLibrary;
 
 describe('CatalogLoaderProvider', () => {
   let fetchMock: jest.SpyInstance;
@@ -20,7 +22,7 @@ describe('CatalogLoaderProvider', () => {
   const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
 
   beforeAll(async () => {
-    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary);
     catalogDefinition = catalogsMap.catalogDefinition;
   });
 
@@ -32,7 +34,7 @@ describe('CatalogLoaderProvider', () => {
           resolve({
             json: () => catalogDefinition,
             url: `http://localhost/${file}`,
-          } as unknown as Response);
+          } as unknown);
         };
         fetchReject = () => {
           reject(new Error('Error'));
@@ -295,7 +297,7 @@ describe('CitrusCatalogLoaderProvider', () => {
   const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
 
   beforeAll(async () => {
-    const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
+    const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary);
     catalogDefinition = catalogsMap.catalogDefinition;
   });
 
@@ -307,7 +309,7 @@ describe('CitrusCatalogLoaderProvider', () => {
           resolve({
             json: () => catalogDefinition,
             url: `http://localhost/${file}`,
-          } as unknown as Response);
+          } as unknown);
         };
         fetchReject = () => {
           reject(new Error('Error'));

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -230,12 +230,77 @@ describe('parser basics', () => {
       expect(result.onWhen).toBeDefined();
     });
 
+    it('should handle intercept elements without when element', () => {
+      const interceptElement = mockDocument.createElement('interceptFrom');
+      const processor = {};
+
+      StepParser['decorateIntercept'](interceptElement, processor);
+
+      expect(processor).toEqual({});
+    });
+
     it('should handle missing catalog entries', () => {
       const unknownElement = mockDocument.createElement('unknownProcessor');
       unknownElement.setAttribute('someAttr', 'value');
 
       const result = StepParser.parseElement(unknownElement) as { someAttr?: string };
       expect(result.someAttr).toBe('value');
+    });
+
+    it('should handle saga with compensation element without uri attribute', () => {
+      const sagaElement = mockDocument.createElement('saga');
+      const compensationElement = mockDocument.createElement('compensation');
+      sagaElement.appendChild(compensationElement);
+
+      const processor = {};
+      StepParser['decorateSaga'](sagaElement, processor);
+
+      expect(processor).toEqual({});
+    });
+
+    it('should handle saga with completion element without uri attribute', () => {
+      const sagaElement = mockDocument.createElement('saga');
+      const completionElement = mockDocument.createElement('completion');
+      sagaElement.appendChild(completionElement);
+
+      const processor = {};
+      StepParser['decorateSaga'](sagaElement, processor);
+
+      expect(processor).toEqual({});
+    });
+
+    it('should read compensation/completion uri from nested elements (legacy Camel < 4.20 format)', () => {
+      const sagaXml = `
+        <saga>
+          <compensation uri="direct:compensate"/>
+          <completion uri="direct:complete"/>
+        </saga>`;
+      const element = getElementFromXml(sagaXml);
+
+      const result = StepParser.parseElement(element) as { compensation?: string; completion?: string };
+
+      expect(result.compensation).toBe('direct:compensate');
+      expect(result.completion).toBe('direct:complete');
+    });
+
+    it('should return empty object when uri attribute is empty', () => {
+      const element = mockDocument.createElement('to');
+      element.setAttribute('uri', '');
+
+      const result = StepParser['parseAttributeType']('uri', element);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return undefined when findSingleElement has no oneOf and element not found', () => {
+      const element = mockDocument.createElement('parent');
+      const properties = {
+        type: 'object' as const,
+      } as unknown as ICamelProcessorProperty;
+
+      const result = StepParser['findSingleElement'](element, properties, 'nonexistent');
+
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -227,6 +227,26 @@ export class StepParser {
     if (processorName.includes('intercept') && !processorProperties['onWhen']) {
       this.decorateIntercept(element, processor);
     }
+    // saga compensation/completion changed from nested elements to attributes in Camel 4.20.0
+    if (processorName === 'saga') {
+      this.decorateSaga(element, processor);
+    }
+  }
+
+  private static decorateSaga(element: Element, processor: { [p: string]: unknown }) {
+    // Handle old format (nested elements) if attributes are not present
+    if (!processor['compensation']) {
+      const compensationElement = element.getElementsByTagName('compensation')[0];
+      if (compensationElement?.hasAttribute('uri')) {
+        processor['compensation'] = compensationElement.getAttribute('uri');
+      }
+    }
+    if (!processor['completion']) {
+      const completionElement = element.getElementsByTagName('completion')[0];
+      if (completionElement?.hasAttribute('uri')) {
+        processor['completion'] = completionElement.getAttribute('uri');
+      }
+    }
   }
 
   private static decorateIntercept(element: Element, processor: { [p: string]: unknown }) {

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -183,7 +183,7 @@ describe('step-xml-serializer tests', () => {
 
     it('should not call decorateDoTry when doCatch and doFinally are in the catalog', () => {
       const decorateDoTrySpy = jest.spyOn(StepXmlSerializer, 'decorateDoTry');
-      StepXmlSerializer.serialize('doTry', doTryEntity, getDocument());
+      StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
 
       expect(decorateDoTrySpy).not.toHaveBeenCalled();
       decorateDoTrySpy.mockRestore();
@@ -214,7 +214,7 @@ describe('step-xml-serializer tests', () => {
 
     it.each(testCases)('Parse $name', ({ name, xml, entity }) => {
       const document = domParser.parseFromString('', 'application/xml');
-      const result = StepXmlSerializer.serialize(name, entity, document);
+      const result = StepXmlSerializer.serialize(name, entity as unknown as ElementType, document);
       const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
       const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
       const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
@@ -235,7 +235,7 @@ describe('step-xml-serializer tests', () => {
     it('should call decorateDoTry when doCatch and doFinally are not in the catalog', () => {
       const decorateDoTrySpy = jest.spyOn(StepXmlSerializer, 'decorateDoTry');
       const document = getDocument();
-      StepXmlSerializer.serialize('doTry', doTryEntity, document);
+      StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, document);
 
       expect(decorateDoTrySpy).toHaveBeenCalledTimes(1);
       expect(decorateDoTrySpy).toHaveBeenCalledWith(
@@ -248,11 +248,123 @@ describe('step-xml-serializer tests', () => {
     });
 
     it('should decorate doTry element correctly', () => {
-      const result = StepXmlSerializer.serialize('doTry', doTryEntity, getDocument());
+      const result = StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
       const doCatchElement = result.getElementsByTagName('doCatch')[0];
 
       expect(doCatchElement).toBeDefined();
       expect(doCatchElement.getElementsByTagName('to')[0].getAttribute('uri')).toBe('mock:catch');
     });
+  });
+
+  it('should serialize unknown type with non-object value', () => {
+    const unknownStep = {
+      someAttribute: 'value',
+      anotherAttribute: 123,
+    };
+
+    const result = StepXmlSerializer.serialize('unknownProcessor', unknownStep, getDocument());
+
+    expect(result.tagName).toBe('unknownProcessor');
+    expect(result.getAttribute('someAttribute')).toBe('value');
+    expect(result.getAttribute('anotherAttribute')).toBe('123');
+  });
+
+  it('should serialize object type with javaType string', () => {
+    const step = {
+      name: 'myHeader',
+      expression: {
+        constant: {
+          expression: 'test value',
+        },
+      },
+    };
+
+    const result = StepXmlSerializer.serialize('setHeader', step, getDocument());
+
+    expect(result.tagName).toBe('setHeader');
+    expect(result.getAttribute('name')).toBe('myHeader');
+    const constantElement = result.getElementsByTagName('constant')[0];
+    expect(constantElement).toBeDefined();
+    expect(constantElement.textContent).toBe('test value');
+  });
+
+  it('should return uri when componentName is undefined', () => {
+    const step = {
+      uri: 'unknown:component',
+    };
+
+    const result = StepXmlSerializer.createUriFromParameters(step);
+
+    expect(result).toBe('unknown:component');
+  });
+
+  it('should handle saga with compensation as attribute in catalog', () => {
+    const sagaStep = {
+      compensation: 'direct:compensation',
+      completion: 'direct:completion',
+    };
+
+    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+
+    expect(result.tagName).toBe('saga');
+    expect(result.getAttribute('compensation')).toBe('direct:compensation');
+    expect(result.getAttribute('completion')).toBe('direct:completion');
+    // Should not have nested elements when attributes are in catalog
+    expect(result.getElementsByTagName('compensation').length).toBe(0);
+    expect(result.getElementsByTagName('completion').length).toBe(0);
+  });
+
+  it('should serialize saga with nested elements when not attributes in old catalog', async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    // Simulate old catalog where compensation/completion are not attributes
+    const originalSagaProps = { ...catalogsMap.modelCatalogMap['saga'].properties };
+    delete catalogsMap.modelCatalogMap['saga'].properties.compensation;
+    delete catalogsMap.modelCatalogMap['saga'].properties.completion;
+    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+
+    const sagaStep = {
+      compensation: 'direct:compensation',
+      completion: 'direct:completion',
+    };
+
+    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+
+    expect(result.tagName).toBe('saga');
+    const compensationElement = result.getElementsByTagName('compensation')[0];
+    const completionElement = result.getElementsByTagName('completion')[0];
+    expect(compensationElement).toBeDefined();
+    expect(compensationElement.getAttribute('uri')).toBe('direct:compensation');
+    expect(completionElement).toBeDefined();
+    expect(completionElement.getAttribute('uri')).toBe('direct:completion');
+
+    // Restore original properties
+    catalogsMap.modelCatalogMap['saga'].properties = originalSagaProps;
+    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+  });
+
+  it('should serialize saga nested elements when compensation/completion are legacy object-shaped values', async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    // Simulate old catalog where compensation/completion are not attributes
+    const originalSagaProps = { ...catalogsMap.modelCatalogMap['saga'].properties };
+    delete catalogsMap.modelCatalogMap['saga'].properties.compensation;
+    delete catalogsMap.modelCatalogMap['saga'].properties.completion;
+    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+
+    // Legacy model represented these as { uri } objects rather than plain strings
+    const sagaStep = {
+      compensation: { uri: 'direct:compensation' },
+      completion: { uri: 'direct:completion' },
+    } as unknown as Parameters<typeof StepXmlSerializer.serialize>[1];
+
+    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+
+    const compensationElement = result.getElementsByTagName('compensation')[0];
+    const completionElement = result.getElementsByTagName('completion')[0];
+    expect(compensationElement.getAttribute('uri')).toBe('direct:compensation');
+    expect(completionElement.getAttribute('uri')).toBe('direct:completion');
+
+    // Restore original properties
+    catalogsMap.modelCatalogMap['saga'].properties = originalSagaProps;
+    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
   });
 });

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -81,6 +81,11 @@ export class StepXmlSerializer {
       this.decorateDoTry(camelElement as DoTry, element, doc);
     }
 
+    // saga compensation/completion: support both old (nested elements) and new (attributes) formats
+    if (elementName === 'saga') {
+      this.decorateSaga(camelElement, element, doc, properties);
+    }
+
     return element;
   }
 
@@ -260,6 +265,33 @@ export class StepXmlSerializer {
 
     doTryElement.append(this.serialize('doFinally', doTry.doFinally as ElementType, doc));
     return doTryElement;
+  }
+
+  private static decorateSaga(
+    saga: ElementType,
+    sagaElement: Element,
+    doc: Document,
+    properties: Record<string, ICamelProcessorProperty>,
+  ): void {
+    // Check if catalog defines compensation/completion as attributes (Camel 4.20.0+)
+    const compensationIsAttribute = properties['compensation']?.kind === 'attribute';
+    const completionIsAttribute = properties['completion']?.kind === 'attribute';
+
+    // If not attributes in catalog, serialize as nested elements for backward compatibility.
+    // compensation/completion may be a string uri or a legacy object-shaped { uri } value.
+    const compensationUri = CamelUriHelper.getUriString(saga['compensation']);
+    if (!compensationIsAttribute && compensationUri) {
+      const compensationElement = doc.createElement('compensation');
+      compensationElement.setAttribute('uri', compensationUri);
+      sagaElement.appendChild(compensationElement);
+    }
+
+    const completionUri = CamelUriHelper.getUriString(saga['completion']);
+    if (!completionIsAttribute && completionUri) {
+      const completionElement = doc.createElement('completion');
+      completionElement.setAttribute('uri', completionUri);
+      sagaElement.appendChild(completionElement);
+    }
   }
 
   private static serializeTextType(element: Element, key: string, processor: ElementType, doc: Document) {

--- a/packages/ui/src/stubs/eip-entity-snippets.ts
+++ b/packages/ui/src/stubs/eip-entity-snippets.ts
@@ -1,5 +1,25 @@
 // packages/ui/src/stubs/eip-entity-snippets.ts
 
+import {
+  Choice,
+  CircuitBreaker,
+  DoTry,
+  DynamicRouter,
+  Enrich,
+  ErrorHandler,
+  Filter1,
+  LoadBalance,
+  Loop,
+  Pipeline,
+  RecipientList,
+  Resequence,
+  RoutingSlip,
+  Saga,
+  Sample,
+  Split,
+  Throttle,
+} from '@kaoto/camel-catalog/types';
+
 export const aggregateEntity = {
   steps: [{ to: { uri: 'mock:result' } }],
   aggregationStrategy: 'myAppender',
@@ -10,30 +30,30 @@ export const aggregateEntity = {
   },
   completionSize: '3',
   completionSizeExpression: {
-    header: { expression: 'head' },
+    header: { expression: 'head', namespace: undefined },
   },
-  completionTimeoutExpression: { datasonnet: { expression: 'datasonnet' } },
+  completionTimeoutExpression: { datasonnet: { expression: 'datasonnet' }, namespace: undefined },
   correlationExpression: {
-    constant: { expression: 'true', resultType: 'java.lang.Integer' },
+    constant: { expression: 'true', resultType: 'java.lang.Integer', namespace: undefined },
   },
 };
 
-export const circuitBreakerEntity = {
+export const circuitBreakerEntity: CircuitBreaker = {
   steps: [{ to: { uri: 'http://fooservice.com/slow' } }],
   onFallback: { steps: [{ transform: { constant: { expression: 'Fallback message' } } }] },
 };
 
-export const filterEntity = {
+export const filterEntity: Filter1 = {
   xpath: { expression: "/person[@name='James']" },
   steps: [{ to: { uri: 'mock:result' } }],
 };
 
-export const loadBalanceEntity = {
+export const loadBalanceEntity: LoadBalance = {
   steps: [{ to: { uri: 'seda:x' } }, { to: { uri: 'seda:y' } }, { to: { uri: 'seda:z' } }],
   roundRobinLoadBalancer: {},
 };
 
-export const loopEntity = {
+export const loopEntity: Loop = {
   steps: [{ to: { uri: 'mock:result' } }],
   header: { expression: 'loop' },
 };
@@ -45,11 +65,11 @@ export const multicastEntity = {
   aggregationStrategy: '#class:com.foo.MyAggregationStrategy',
 };
 
-export const pipelineEntity = {
+export const pipelineEntity: Pipeline = {
   steps: [{ to: { uri: 'bean:foo' } }, { to: { uri: 'bean:bar' } }, { to: { uri: 'activemq:wine' } }],
 };
 
-export const resequenceEntity = {
+export const resequenceEntity: Resequence = {
   steps: [{ to: { uri: 'mock:result' } }],
   simple: { expression: 'body' },
   batchConfig: {
@@ -58,28 +78,28 @@ export const resequenceEntity = {
   },
 };
 
-export const sagaEntity = {
-  compensation: { uri: 'direct:compensation' },
-  completion: { uri: 'direct:completion' },
+export const sagaEntity: Saga = {
+  compensation: 'direct:compensation',
+  completion: 'direct:completion',
   option: [
-    { key: 'myOptionKey', constant: { expression: 'myOptionValue' } },
-    { key: 'myOptionKey2', constant: { expression: 'myOptionValue2' } },
+    { key: 'myOptionKey', constant: { expression: 'myOptionValue', namespace: undefined } },
+    { key: 'myOptionKey2', constant: { expression: 'myOptionValue2', namespace: undefined } },
   ],
   steps: [],
 };
 
-export const splitEntity = {
+export const splitEntity: Split = {
   parallelProcessing: 'true',
   simple: { expression: 'body' },
   steps: [{ to: { uri: 'direct:b' } }, { to: { uri: 'direct:c' } }, { to: { uri: 'direct:d' } }],
 };
 
-export const choiceEntity = {
+export const choiceEntity: Choice = {
   when: [{ xpath: { expression: '/ns1:foo/' }, steps: [{ to: { uri: 'mock:bar' } }] }],
   otherwise: { steps: [{ to: { uri: 'mock:other' } }] },
 };
 
-export const doTryEntity = {
+export const doTryEntity: DoTry = {
   steps: [{ to: { uri: 'mock:try' } }],
   doCatch: [
     {
@@ -92,37 +112,37 @@ export const doTryEntity = {
   },
 };
 
-export const deadLetterChannelEntity = {
+export const deadLetterChannelEntity: ErrorHandler = {
   deadLetterChannel: {
     deadLetterUri: 'mock:dead',
     redeliveryPolicy: { maximumRedeliveries: '3', redeliveryDelay: '250' },
   },
 };
 
-export const enrichEntity = {
+export const enrichEntity: Enrich = {
   simple: { expression: 'http:myserver/${header.orderId}/order' },
 };
 
-export const dynamicRouterEntity = {
+export const dynamicRouterEntity: DynamicRouter = {
   method: { beanType: 'com.foo.MySlipBean', method: 'slip' },
 };
 
-export const recipientListEntity = {
+export const recipientListEntity: RecipientList = {
   parallelProcessing: 'true',
   header: { expression: 'myHeader' },
 };
 
-export const routingSlipEntity = {
+export const routingSlipEntity: Exclude<RoutingSlip, string> = {
   ignoreInvalidEndpoints: 'true',
   header: { expression: 'myHeader' },
 };
 
-export const throttleEntity = {
+export const throttleEntity: Throttle = {
   timePeriodMillis: '10000',
   constant: { expression: '3' },
 };
 
-export const sampleEntity = {
+export const sampleEntity: Exclude<Sample, string> = {
   samplePeriod: '5000',
   // to is missing in the catalog currently
   // { to: { uri: 'direct:sampled' } }],

--- a/packages/ui/src/stubs/eip-xml-snippets.ts
+++ b/packages/ui/src/stubs/eip-xml-snippets.ts
@@ -79,9 +79,7 @@ export const resequenceXml = `
 `;
 
 export const sagaXml = `
-<saga>
-  <compensation uri="direct:compensation" />
-  <completion uri="direct:completion" />
+<saga compensation="direct:compensation" completion="direct:completion">
   <option key="myOptionKey">
     <constant>myOptionValue</constant>
   </option>

--- a/packages/ui/src/stubs/test-load-catalog.test.ts
+++ b/packages/ui/src/stubs/test-load-catalog.test.ts
@@ -1,6 +1,9 @@
-import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { citrusCatalogSelector, testLoadCatalog, testLoadCitrusCatalog } from './test-load-catalog';
+
+const catalogLibrary = catalogLibraryJson as CatalogLibrary;
 
 describe('testLoadCatalog()', () => {
   it('should load Camel catalog', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,10 +3490,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "@kaoto/camel-catalog@npm:0.4.4"
-  checksum: 10/3c1eada821ab9460a4ad83f020bb02b2ebd008ccd95270611aab64a522d1d3d6a4b01931b1a77dc347371e4be934b67bdb005165cf70eb68cec5e4ca23e20a46
+"@kaoto/camel-catalog@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@kaoto/camel-catalog@npm:0.5.2"
+  checksum: 10/c2ffe0b9152403a39662be5dd6086b4d2058931509261af9e9907a41abd97d0c6278c0ab58fc9ac923e1905566b2d3a24eb6bb94468f49fcea0b884cb3cdef6d
   languageName: node
   linkType: hard
 
@@ -3521,7 +3521,7 @@ __metadata:
   dependencies:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.4.4"
+    "@kaoto/camel-catalog": "npm:^0.5.2"
     "@kaoto/forms": "npm:^1.7.1"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.4.0"
@@ -3576,7 +3576,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@dnd-kit/modifiers": "npm:^9.0.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.4.4"
+    "@kaoto/camel-catalog": "npm:^0.5.2"
     "@kaoto/forms": "npm:^1.7.1"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
@@ -3660,7 +3660,7 @@ __metadata:
     zundo: "npm:^2.3.0"
     zustand: "npm:^5.0.11"
   peerDependencies:
-    "@kaoto/camel-catalog": ^0.4.4
+    "@kaoto/camel-catalog": ^0.5.2
     "@patternfly/patternfly": ^6.4.0
     "@patternfly/react-code-editor": ^6.4.0
     "@patternfly/react-core": ^6.4.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Camel catalog dependency to 0.5.2.

* **Bug Fixes**
  * Only render tile/header/modal/node icons when an icon URL exists.
  * Improved saga compensation/completion handling for modern and legacy formats.

* **New Features**
  * Treats "Schema Resolver" as a bean/schema field.

* **Tests**
  * Updated tests for route-policy reference, form interactions, serialization/parsing, and catalog loading.

* **Refactor**
  * Converted various example entity exports to typed constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->