### PR TITLE
fix(DataMapper): add exclude-result-prefixes to generated XSLT to prevent namespace leakage

### DIFF
--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -473,6 +473,31 @@ describe('MappingSerializerService', () => {
       expect(chooseOtherwiseSelect?.nodeValue).toEqual('Title');
     });
 
+    it('should set exclude-result-prefixes to prevent namespace leakage into the output', () => {
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(
+        getShipOrderToShipOrderXslt(),
+        targetDoc,
+        mappingTree,
+        sourceParameterMap,
+      ));
+      const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const stylesheet = domParser.parseFromString(xslt, 'text/xml').documentElement;
+      // `ns0` is declared only for matching the source document via XPath, so it
+      // must be excluded from the result to avoid leaking a redundant declaration.
+      expect(stylesheet.getAttribute('xmlns:ns0')).toEqual('io.kaoto.datamapper.poc.test');
+      expect(stylesheet.getAttribute('exclude-result-prefixes')?.split(' ')).toContain('ns0');
+    });
+
+    it('should not set exclude-result-prefixes when there are no namespaces', () => {
+      const empty = MappingSerializerService.serialize(
+        new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA),
+        sourceParameterMap,
+      );
+      const stylesheet = domParser.parseFromString(empty, 'application/xml').documentElement;
+      expect(stylesheet.hasAttribute('exclude-result-prefixes')).toBe(false);
+    });
+
     it('should round-trip UnknownMappingItem verbatim including nested children', () => {
       const xslt = getUnknownApplyTemplateXslt();
       let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -83,9 +83,21 @@ export class MappingSerializerService {
 
   private static populateNamespaces(xslt: Document, namespaceMap: { [prefix: string]: string }) {
     const rootElement = xslt.documentElement;
-    Object.entries(namespaceMap).forEach(
-      ([prefix, uri]) => prefix && uri && rootElement.setAttribute(`xmlns:${prefix}`, uri),
-    );
+    const prefixes: string[] = [];
+    Object.entries(namespaceMap).forEach(([prefix, uri]) => {
+      if (prefix && uri) {
+        rootElement.setAttribute(`xmlns:${prefix}`, uri);
+        prefixes.push(prefix);
+      }
+    });
+    // These prefixes are only declared for matching the source document via XPath.
+    // Without `exclude-result-prefixes` they leak into the output as redundant
+    // namespace declarations, which some consumers (e.g. HAPI HL7 v2 XMLParser)
+    // fail to parse. `exclude-result-prefixes` only suppresses declarations that
+    // are not actually used by an output element, so this is safe.
+    if (prefixes.length > 0) {
+      rootElement.setAttribute('exclude-result-prefixes', prefixes.join(' '));
+    }
   }
 
   private static getRootStyleSheet(xsltDocument: Document) {


### PR DESCRIPTION
### Description

The DataMapper-generated XSLT declares namespace prefixes on `<xsl:stylesheet>` for XPath matching of the source document (e.g. `xmlns:ns0="urn:hl7-org:v2xml"`). Without `exclude-result-prefixes`, those prefixes leak into the output as redundant namespace declarations, which some consumers — notably HAPI HL7 v2 `XMLParser` — fail to parse.

`MappingSerializerService.populateNamespaces()` now collects the declared prefixes and sets `exclude-result-prefixes` on the stylesheet element. This only suppresses declarations that are not actually used by an output element, so output that genuinely uses a prefix is unaffected. `restoreNamespaces()` needs no change — `exclude-result-prefixes` is not an `xmlns:` attribute, so the existing filter already ignores it.

Closes #3272

#### Type of Change
- [x] Bug fix

#### How Has This Been Tested?
Added two unit tests to `mapping-serializer.service.test.ts`:
- a mapping with a namespace prefix now also emits `exclude-result-prefixes` containing that prefix;
- a mapping with no namespaces does not emit the attribute.

Verified locally in `packages/ui`: `jest` (mapping-serializer suite — 39 passed), `eslint`, `tsc --noEmit`, and `prettier --check` all pass on the changed files.

#### Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/KaotoIO/kaoto/blob/main/CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] I have updated any relevant documentation. (No docs change needed — internal serializer behavior; the proposed fix is described in #3272.)
- [x] I have added tests that prove my fix or feature works.

---
_Built with AI assistance (Claude Code); reviewed, tested, and signed off by me. Sharing per the project's AI-Assisted Contributions guidance._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace handling in XSLT serialization to prevent unwanted namespace declarations in output.

* **Tests**
  * Added unit tests for namespace declaration behavior in XSLT generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->