### PR TITLE
fix(DataMapper): Fix xs:include resolution for same file name in diff…

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -1,13 +1,4 @@
-import {
-  act,
-  findByLabelText,
-  fireEvent,
-  getAllByLabelText,
-  getByLabelText,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentType } from '../../../../models/datamapper/document';
@@ -461,6 +452,11 @@ describe('AttachSchemaModal', () => {
   });
 
   describe('Root Element Selection', () => {
+    async function findRootElementInput() {
+      const container = await screen.findByTestId('attach-schema-root-element');
+      return container.querySelector('input') as HTMLInputElement;
+    }
+
     it('should show root element selector when multiple elements are available', async () => {
       mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
       render(
@@ -497,25 +493,19 @@ describe('AttachSchemaModal', () => {
         expect(fileItem).toBeInTheDocument();
       });
 
-      const rootElementSelector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-      const typeaheadInput = getByLabelText(rootElementSelector, 'Attach schema / Choose Root Element');
-      expect(typeaheadInput.getAttribute('value')).toEqual('Order');
+      const input = await findRootElementInput();
+      expect(input.value).toEqual('Order');
 
-      const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
       act(() => {
-        fireEvent.click(dropdownToggle);
+        fireEvent.focus(input);
       });
 
       await waitFor(() => {
-        const rootElementSelect = screen.getByTestId('attach-schema-root-element-typeahead-select');
-        const order = getByLabelText(rootElementSelect, 'option order');
-        expect(order.getAttribute('aria-selected')).toEqual('true');
-
-        const invoice = getByLabelText(rootElementSelect, 'option invoice');
-        expect(invoice.getAttribute('aria-selected')).toEqual('false');
-
-        const shipment = getByLabelText(rootElementSelect, 'option shipment');
-        expect(shipment.getAttribute('aria-selected')).toEqual('false');
+        const rootElementSelect = screen.getByTestId('attach-schema-root-element-select');
+        expect(rootElementSelect.querySelector('[role="option"]')).toBeInTheDocument();
+        expect(screen.getByText('Order')).toBeInTheDocument();
+        expect(screen.getByText('Invoice')).toBeInTheDocument();
+        expect(screen.getByText('Shipment')).toBeInTheDocument();
       });
     });
 
@@ -553,21 +543,18 @@ describe('AttachSchemaModal', () => {
         expect(fileItem).toBeInTheDocument();
       });
 
-      const rootElementSelector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-      const typeaheadInput = getByLabelText(rootElementSelector, 'Attach schema / Choose Root Element');
-      expect(typeaheadInput.getAttribute('value')).toEqual('ShipOrder');
+      const input = await findRootElementInput();
+      expect(input.value).toEqual('ShipOrder');
 
-      const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
       act(() => {
-        fireEvent.click(dropdownToggle);
+        fireEvent.focus(input);
       });
 
       await waitFor(() => {
-        const rootElementSelect = screen.getByTestId('attach-schema-root-element-typeahead-select');
-        const options = getAllByLabelText(rootElementSelect, /option.*/);
+        const rootElementSelect = screen.getByTestId('attach-schema-root-element-select');
+        const options = rootElementSelect.querySelectorAll('[role="option"]');
         expect(options.length).toEqual(1);
-        expect(options[0].getAttribute('aria-label')).toEqual('option shiporder');
-        expect(options[0].getAttribute('aria-selected')).toEqual('true');
+        expect(screen.getByText('ShipOrder')).toBeInTheDocument();
       });
     });
 
@@ -607,26 +594,23 @@ describe('AttachSchemaModal', () => {
         expect(fileItem).toBeInTheDocument();
       });
 
-      const rootElementSelector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-      const typeaheadInput = getByLabelText(rootElementSelector, 'Attach schema / Choose Root Element');
-      expect(typeaheadInput.getAttribute('value')).toEqual('Order');
+      const input = await findRootElementInput();
+      expect(input.value).toEqual('Order');
 
-      const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
       act(() => {
-        fireEvent.click(dropdownToggle);
+        fireEvent.focus(input);
       });
 
       act(() => {
-        fireEvent.change(typeaheadInput, { target: { value: 'Invoice' } });
+        fireEvent.change(input, { target: { value: 'Invoice' } });
       });
-      expect(typeaheadInput.getAttribute('value')).toEqual('Invoice');
+      expect(input.value).toEqual('Invoice');
 
       await waitFor(() => {
-        const rootElementSelect = screen.getByTestId('attach-schema-root-element-typeahead-select');
-        const options = getAllByLabelText(rootElementSelect, /option.*/);
+        const rootElementSelect = screen.getByTestId('attach-schema-root-element-select');
+        const options = rootElementSelect.querySelectorAll('[role="option"]');
         expect(options.length).toEqual(1);
-        expect(options[0].getAttribute('aria-label')).toEqual('option invoice');
-        expect(options[0].getAttribute('aria-selected')).toEqual('false');
+        expect(screen.getByText('Invoice')).toBeInTheDocument();
       });
     });
 
@@ -675,13 +659,12 @@ describe('AttachSchemaModal', () => {
         expect(fileItem).toBeInTheDocument();
       });
 
-      const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
+      const input = await findRootElementInput();
       act(() => {
-        fireEvent.click(dropdownToggle);
+        fireEvent.focus(input);
       });
 
-      const rootElementSelect = screen.getByTestId('attach-schema-root-element-typeahead-select');
-      const invoice = await findByLabelText(rootElementSelect, 'option invoice');
+      const invoice = await screen.findByText('Invoice');
 
       act(() => {
         fireEvent.click(invoice);
@@ -736,7 +719,7 @@ describe('AttachSchemaModal', () => {
         expect(fileItem).toBeInTheDocument();
       });
 
-      const rootElementSelector = screen.queryByTestId('attach-schema-root-element-typeahead-select-input');
+      const rootElementSelector = screen.queryByTestId('attach-schema-root-element');
       expect(rootElementSelector).not.toBeInTheDocument();
     });
 
@@ -778,21 +761,19 @@ describe('AttachSchemaModal', () => {
         expect(screen.getByTestId('attach-schema-file-item-ShipOrder.xsd')).toBeInTheDocument();
       });
 
-      const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
+      const input = await findRootElementInput();
       act(() => {
-        fireEvent.click(dropdownToggle);
+        fireEvent.focus(input);
       });
 
-      const rootElementSelect = screen.getByTestId('attach-schema-root-element-typeahead-select');
-      const invoice = await findByLabelText(rootElementSelect, 'option invoice');
+      const invoice = await screen.findByText('Invoice');
       act(() => {
         fireEvent.click(invoice);
       });
 
-      await waitFor(() => {
-        const selector = screen.getByTestId('attach-schema-root-element-typeahead-select-input');
-        const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-        expect(input.getAttribute('value')).toEqual('Invoice');
+      await waitFor(async () => {
+        const inputEl = await findRootElementInput();
+        expect(inputEl.value).toEqual('Invoice');
       });
 
       const removeButton = await screen.findByTestId('attach-schema-file-remove-ShipOrder.xsd');
@@ -805,10 +786,9 @@ describe('AttachSchemaModal', () => {
         expect(screen.getByTestId('attach-schema-file-item-MultipleElements.xsd')).toBeInTheDocument();
       });
 
-      await waitFor(() => {
-        const selector = screen.getByTestId('attach-schema-root-element-typeahead-select-input');
-        const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-        expect(input.getAttribute('value')).toEqual('Invoice');
+      await waitFor(async () => {
+        const inputEl = await findRootElementInput();
+        expect(inputEl.value).toEqual('Invoice');
       });
     });
   });

--- a/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.test.tsx
@@ -1,4 +1,4 @@
-import { act, findByLabelText, fireEvent, getByLabelText, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { RootElementOption } from '../../../../models/datamapper/document';
 import { RootElementSelect } from './RootElementSelect';
@@ -7,136 +7,202 @@ describe('RootElementSelect', () => {
   const createOptions = (names: string[], namespaceUri = 'urn:test'): RootElementOption[] =>
     names.map((name) => ({ name, namespaceUri }));
 
+  const getInput = () => screen.getByTestId('attach-schema-root-element').querySelector('input') as HTMLInputElement;
+
+  const openDropdown = () => {
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+  };
+
   it('should render with selected option', async () => {
     const options = createOptions(['Order', 'Invoice', 'Shipment']);
-    const onChange = jest.fn();
-
-    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={onChange} />);
-
-    const selector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-    const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-    expect(input.getAttribute('value')).toEqual('Order');
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />);
+    expect(getInput().value).toEqual('Order');
   });
 
   it('should reflect new selectedOption on re-render', async () => {
     const options = createOptions(['Order', 'Invoice', 'Shipment']);
-    const onChange = jest.fn();
-
     const { rerender } = render(
-      <RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={onChange} />,
+      <RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />,
     );
-
-    const selector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-    const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-    expect(input.getAttribute('value')).toEqual('Order');
+    expect(getInput().value).toEqual('Order');
 
     const updatedOptions = createOptions(['Shipment']);
     rerender(
-      <RootElementSelect rootElementOptions={updatedOptions} selectedOption={updatedOptions[0]} onChange={onChange} />,
+      <RootElementSelect rootElementOptions={updatedOptions} selectedOption={updatedOptions[0]} onChange={jest.fn()} />,
     );
-
     await waitFor(() => {
-      expect(input.getAttribute('value')).toEqual('Shipment');
+      expect(getInput().value).toEqual('Shipment');
     });
   });
 
   it('should default to first option when selectedOption is undefined', async () => {
     const options = createOptions(['Order', 'Invoice']);
-    const onChange = jest.fn();
-
-    render(<RootElementSelect rootElementOptions={options} selectedOption={undefined} onChange={onChange} />);
-
-    const selector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-    const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-    expect(input.getAttribute('value')).toEqual('Order');
+    render(<RootElementSelect rootElementOptions={options} selectedOption={undefined} onChange={jest.fn()} />);
+    expect(getInput().value).toEqual('Order');
   });
 
   it('should call onChange with the matching RootElementOption when user selects', async () => {
     const options = createOptions(['Order', 'Invoice', 'Shipment']);
     const onChange = jest.fn();
-
     render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={onChange} />);
 
-    const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
-    act(() => {
-      fireEvent.click(dropdownToggle);
-    });
+    openDropdown();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
 
-    const selectList = screen.getByTestId('attach-schema-root-element-typeahead-select');
-    const invoiceOption = await findByLabelText(selectList, 'option invoice');
     act(() => {
-      fireEvent.click(invoiceOption);
+      fireEvent.click(screen.getByText('Invoice'));
     });
-
     expect(onChange).toHaveBeenCalledWith({ name: 'Invoice', namespaceUri: 'urn:test' });
   });
 
   it('should preserve selection when unrelated file is removed', async () => {
     const options = createOptions(['Order', 'Invoice', 'Shipment']);
-    const onChange = jest.fn();
-
     const { rerender } = render(
-      <RootElementSelect rootElementOptions={options} selectedOption={options[1]} onChange={onChange} />,
+      <RootElementSelect rootElementOptions={options} selectedOption={options[1]} onChange={jest.fn()} />,
     );
-
-    const selector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-    const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-    expect(input.getAttribute('value')).toEqual('Invoice');
+    expect(getInput().value).toEqual('Invoice');
 
     const remainingOptions = createOptions(['Order', 'Invoice']);
     rerender(
       <RootElementSelect
         rootElementOptions={remainingOptions}
         selectedOption={remainingOptions[1]}
-        onChange={onChange}
+        onChange={jest.fn()}
       />,
     );
-
     await waitFor(() => {
-      expect(input.getAttribute('value')).toEqual('Invoice');
+      expect(getInput().value).toEqual('Invoice');
     });
   });
 
   it('should default to first remaining option when selected root element is removed', async () => {
     const options = createOptions(['Order', 'Invoice', 'Shipment']);
-    const onChange = jest.fn();
-
     const { rerender } = render(
-      <RootElementSelect rootElementOptions={options} selectedOption={options[1]} onChange={onChange} />,
+      <RootElementSelect rootElementOptions={options} selectedOption={options[1]} onChange={jest.fn()} />,
     );
-
-    const selector = await screen.findByTestId('attach-schema-root-element-typeahead-select-input');
-    const input = getByLabelText(selector, 'Attach schema / Choose Root Element');
-    expect(input.getAttribute('value')).toEqual('Invoice');
+    expect(getInput().value).toEqual('Invoice');
 
     const remainingOptions = createOptions(['Order', 'Shipment']);
     rerender(
       <RootElementSelect
         rootElementOptions={remainingOptions}
         selectedOption={remainingOptions[0]}
-        onChange={onChange}
+        onChange={jest.fn()}
       />,
     );
-
     await waitFor(() => {
-      expect(input.getAttribute('value')).toEqual('Order');
+      expect(getInput().value).toEqual('Order');
     });
+  });
+
+  it('should distinguish same-name elements in different namespaces', async () => {
+    const options: RootElementOption[] = [
+      { name: 'Root', namespaceUri: 'urn:ns-a' },
+      { name: 'Root', namespaceUri: 'urn:ns-b' },
+    ];
+    const onChange = jest.fn();
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[1]} onChange={onChange} />);
+    expect(getInput().value).toEqual('Root');
+
+    openDropdown();
+    const listbox = screen.getByRole('listbox');
+    const rootOptions = listbox.querySelectorAll('[role="option"]');
+    expect(rootOptions).toHaveLength(2);
+
+    act(() => {
+      fireEvent.click(rootOptions[0]);
+    });
+    expect(onChange).toHaveBeenCalledWith({ name: 'Root', namespaceUri: 'urn:ns-a' });
+  });
+
+  it('should select correct option when same-name elements exist in different namespaces', async () => {
+    const options: RootElementOption[] = [
+      { name: 'Root', namespaceUri: 'urn:ns-a' },
+      { name: 'Root', namespaceUri: 'urn:ns-b' },
+    ];
+    const onChange = jest.fn();
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={onChange} />);
+
+    openDropdown();
+    const listbox = screen.getByRole('listbox');
+    const rootOptions = listbox.querySelectorAll('[role="option"]');
+
+    act(() => {
+      fireEvent.click(rootOptions[1]);
+    });
+    expect(onChange).toHaveBeenCalledWith({ name: 'Root', namespaceUri: 'urn:ns-b' });
   });
 
   it('should omit description when namespaceUri is empty', async () => {
     const options = createOptions(['Order', 'Invoice'], '');
-    const onChange = jest.fn();
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />);
 
+    openDropdown();
+    const orderOption = screen.getByText('Order');
+    expect(orderOption).toBeInTheDocument();
+    expect(orderOption.closest('[role="option"]')?.textContent).not.toContain('Namespace URI');
+  });
+
+  it('should filter options by typing', async () => {
+    const options = createOptions(['Order', 'Invoice', 'Shipment']);
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />);
+
+    openDropdown();
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    const listbox = screen.getByRole('listbox');
+    const visibleOptions = listbox.querySelectorAll('[role="option"]');
+    expect(visibleOptions).toHaveLength(1);
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+  });
+
+  it('should filter by namespace description', async () => {
+    const options: RootElementOption[] = [
+      { name: 'Root', namespaceUri: 'urn:ns-a' },
+      { name: 'Root', namespaceUri: 'urn:ns-b' },
+      { name: 'Other', namespaceUri: 'urn:ns-c' },
+    ];
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />);
+
+    openDropdown();
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'ns-a' } });
+    });
+    const listbox = screen.getByRole('listbox');
+    const visibleOptions = listbox.querySelectorAll('[role="option"]');
+    expect(visibleOptions).toHaveLength(1);
+  });
+
+  it('should not call onChange when typing', async () => {
+    const options = createOptions(['Order', 'Invoice']);
+    const onChange = jest.fn();
     render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={onChange} />);
 
-    const dropdownToggle = screen.getByLabelText('Attach schema / Choose Root Element toggle');
+    openDropdown();
     act(() => {
-      fireEvent.click(dropdownToggle);
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
     });
+    expect(onChange).not.toHaveBeenCalled();
+  });
 
-    const selectList = screen.getByTestId('attach-schema-root-element-typeahead-select');
-    const orderOption = await findByLabelText(selectList, 'option order');
-    expect(orderOption).toBeInTheDocument();
-    expect(orderOption.textContent).not.toContain('Namespace URI');
+  it('should revert to selected option label on blur', async () => {
+    const options = createOptions(['Order', 'Invoice']);
+    render(<RootElementSelect rootElementOptions={options} selectedOption={options[0]} onChange={jest.fn()} />);
+
+    openDropdown();
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    expect(getInput().value).toEqual('Inv');
+
+    act(() => {
+      fireEvent.blur(getInput(), { relatedTarget: document.body });
+    });
+    await waitFor(() => {
+      expect(getInput().value).toEqual('Order');
+    });
   });
 });

--- a/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.tsx
@@ -1,8 +1,8 @@
-import { Typeahead, TypeaheadItem } from '@kaoto/forms';
 import { InputGroup, InputGroupItem, InputGroupText } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useMemo } from 'react';
 
 import { RootElementOption } from '../../../../models/datamapper/document';
+import { TypeaheadSelect, TypeaheadSelectOption } from './TypeaheadSelect';
 
 type RootElementSelectProps = {
   rootElementOptions: RootElementOption[];
@@ -10,32 +10,29 @@ type RootElementSelectProps = {
   onChange: (option: RootElementOption) => void;
 };
 
+const toOptionKey = (option: RootElementOption): string =>
+  option.namespaceUri ? `{${option.namespaceUri}}${option.name}` : option.name;
+
 export const RootElementSelect: FunctionComponent<RootElementSelectProps> = ({
   rootElementOptions,
   selectedOption,
   onChange,
 }) => {
-  const items: TypeaheadItem[] = useMemo(
+  const options: TypeaheadSelectOption[] = useMemo(
     () =>
-      rootElementOptions.map((option) => ({
-        name: option.name,
-        value: option.name,
-        description: option.namespaceUri ? `Namespace URI: ${option.namespaceUri}` : undefined,
+      rootElementOptions.map((opt) => ({
+        value: toOptionKey(opt),
+        label: opt.name,
+        description: opt.namespaceUri ? `Namespace URI: ${opt.namespaceUri}` : '',
       })),
     [rootElementOptions],
   );
 
-  const selectedItem: TypeaheadItem | undefined = useMemo(() => {
-    if (selectedOption) {
-      return items.find((item) => item.name === selectedOption.name);
-    }
-    return items[0];
-  }, [selectedOption, items]);
+  const selectedKey = selectedOption ? toOptionKey(selectedOption) : (options[0]?.value ?? '');
 
-  const handleSelectionChange = useCallback(
-    (item?: TypeaheadItem) => {
-      if (!item?.value) return;
-      const option = rootElementOptions.find((opt) => opt.name === item.value);
+  const handleChange = useCallback(
+    (value: string) => {
+      const option = rootElementOptions.find((opt) => toOptionKey(opt) === value);
       if (option) onChange(option);
     },
     [rootElementOptions, onChange],
@@ -45,14 +42,13 @@ export const RootElementSelect: FunctionComponent<RootElementSelectProps> = ({
     <InputGroup>
       <InputGroupText>Root element</InputGroupText>
       <InputGroupItem>
-        <Typeahead
+        <TypeaheadSelect
+          value={selectedKey}
+          onChange={handleChange}
+          options={options}
           id="attach-schema-root-element"
           data-testid="attach-schema-root-element"
-          aria-label="Attach schema / Choose Root Element"
-          placeholder={selectedItem?.name}
-          selectedItem={selectedItem}
-          onChange={handleSelectionChange}
-          items={items}
+          ariaLabel="Attach schema / Choose Root Element"
         />
       </InputGroupItem>
     </InputGroup>

--- a/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.test.tsx
@@ -1,0 +1,166 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { TypeaheadSelect, TypeaheadSelectOption } from './TypeaheadSelect';
+
+const OPTIONS: TypeaheadSelectOption[] = [
+  { value: 'order-key', label: 'Order', description: 'type: order' },
+  { value: 'invoice-key', label: 'Invoice', description: 'type: invoice' },
+  { value: 'shipment-key', label: 'Shipment', description: 'type: shipment' },
+];
+
+const getInput = () => screen.getByTestId('select-input').querySelector('input') as HTMLInputElement;
+const getToggleButton = () =>
+  screen
+    .getByTestId('select-input')
+    .closest('.pf-v6-c-menu-toggle')!
+    .querySelector('.pf-v6-c-menu-toggle__button') as HTMLButtonElement;
+
+describe('TypeaheadSelect', () => {
+  it('should display selected option label when dropdown is closed', () => {
+    render(<TypeaheadSelect value="invoice-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    expect(getInput().value).toEqual('Invoice');
+  });
+
+  it('should open dropdown on focus regardless of current value', () => {
+    render(<TypeaheadSelect value="invoice-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('should show all options when dropdown opens', () => {
+    render(<TypeaheadSelect value="invoice-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+    expect(screen.getByText('Shipment')).toBeInTheDocument();
+  });
+
+  it('should not call onChange when typing', () => {
+    const onChange = jest.fn();
+    render(<TypeaheadSelect value="order-key" onChange={onChange} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should filter options when typing', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+    expect(screen.queryByText('Order')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shipment')).not.toBeInTheDocument();
+  });
+
+  it('should call onChange when option is clicked', () => {
+    const onChange = jest.fn();
+    render(<TypeaheadSelect value="order-key" onChange={onChange} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.click(screen.getByText('Invoice'));
+    });
+    expect(onChange).toHaveBeenCalledWith('invoice-key');
+  });
+
+  it('should revert to selected label on blur', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    expect(getInput().value).toEqual('Inv');
+
+    act(() => {
+      fireEvent.blur(getInput(), { relatedTarget: document.body });
+    });
+    expect(getInput().value).toEqual('Order');
+  });
+
+  it('should display label instead of value in dropdown', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.queryByText('order-key')).not.toBeInTheDocument();
+  });
+
+  it('should filter by description', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'invoice' } });
+    });
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+    expect(screen.queryByText('Order')).not.toBeInTheDocument();
+  });
+
+  it('should open dropdown via toggle click', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    const toggle = getToggleButton();
+    act(() => {
+      fireEvent.click(toggle);
+    });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+  });
+
+  it('should close dropdown via toggle click when open', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    const toggle = getToggleButton();
+    act(() => {
+      fireEvent.click(toggle);
+    });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('should clear filter text when clear button is clicked', () => {
+    render(<TypeaheadSelect value="order-key" onChange={jest.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'Inv' } });
+    });
+    expect(getInput().value).toEqual('Inv');
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText('Clear expression'));
+    });
+    expect(getInput().value).toEqual('');
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.getByText('Invoice')).toBeInTheDocument();
+  });
+
+  it('should not open dropdown on focus when no options exist', () => {
+    render(<TypeaheadSelect value="" onChange={jest.fn()} options={[]} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
@@ -1,0 +1,163 @@
+import {
+  Button,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { FunctionComponent, Ref, useCallback, useMemo, useRef, useState } from 'react';
+
+export interface TypeaheadSelectOption {
+  value: string;
+  label?: string;
+  description: string;
+}
+
+interface TypeaheadSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: TypeaheadSelectOption[];
+  id?: string;
+  'data-testid'?: string;
+  placeholder?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Typeahead select that requires picking from the list.
+ * Typing filters the candidates but does not change the value.
+ * Only clicking an option fires onChange.
+ */
+export const TypeaheadSelect: FunctionComponent<TypeaheadSelectProps> = ({
+  value: selectedValue,
+  onChange,
+  options,
+  id,
+  'data-testid': dataTestId,
+  placeholder,
+  ariaLabel,
+  className,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [filterText, setFilterText] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedLabel = useMemo(() => {
+    const found = options.find((opt) => opt.value === selectedValue);
+    return found ? (found.label ?? found.value) : '';
+  }, [selectedValue, options]);
+
+  const displayedValue = isOpen ? filterText : selectedLabel;
+
+  const filteredOptions = useMemo(() => {
+    if (!filterText) return options;
+    const lower = filterText.toLowerCase();
+    return options.filter(
+      (opt) => (opt.label ?? opt.value).toLowerCase().includes(lower) || opt.description.toLowerCase().includes(lower),
+    );
+  }, [options, filterText]);
+
+  const handleInputChange = useCallback(
+    (_event: React.SyntheticEvent, value: string) => {
+      setFilterText(value);
+      if (!isOpen) setIsOpen(true);
+    },
+    [isOpen],
+  );
+
+  const handleSelect = useCallback(
+    (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+      if (typeof value !== 'string') return;
+      setFilterText('');
+      onChange(value);
+      setIsOpen(false);
+    },
+    [onChange],
+  );
+
+  const handleFocus = useCallback(() => {
+    if (options.length > 0) {
+      setFilterText('');
+      setIsOpen(true);
+    }
+  }, [options.length]);
+
+  const handleBlur = useCallback((e: React.FocusEvent) => {
+    if (e.relatedTarget?.closest?.('[role="listbox"]')) return;
+    setIsOpen(false);
+    setFilterText('');
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setFilterText('');
+    inputRef.current?.focus();
+  }, []);
+
+  const handleToggleClick = () => {
+    if (isOpen) {
+      setIsOpen(false);
+      setFilterText('');
+    } else {
+      setFilterText('');
+      setIsOpen(true);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  };
+
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      isExpanded={isOpen}
+      isFullWidth
+      className={className}
+      onClick={handleToggleClick}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          autoComplete="off"
+          id={id}
+          data-testid={dataTestId}
+          ref={inputRef}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          value={displayedValue}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleInputChange}
+        />
+        {displayedValue && (
+          <TextInputGroupUtilities>
+            <Button variant="plain" onClick={handleClear} aria-label="Clear expression" icon={<TimesIcon />} />
+          </TextInputGroupUtilities>
+        )}
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id={id ? `${id}-select` : undefined}
+      data-testid={dataTestId ? `${dataTestId}-select` : undefined}
+      isOpen={isOpen}
+      selected={selectedValue}
+      onSelect={handleSelect}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+    >
+      <SelectList>
+        {filteredOptions.map((opt, idx) => (
+          <SelectOption key={`${opt.value}-${idx}`} value={opt.value} description={opt.description}>
+            {opt.label ?? opt.value}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/lib.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/lib.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:a="urn:example:ns-a"
+            targetNamespace="urn:example:ns-a">
+  <xsd:include schemaLocation="shared.xsd"/>
+  <xsd:complexType name="LibType">
+    <xsd:sequence>
+      <xsd:element name="value" type="a:SharedType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Document" type="a:LibType"/>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/main.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/main.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:example:ns-a">
+  <xsd:include schemaLocation="lib.xsd"/>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/shared.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-a/shared.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:example:ns-a">
+  <xsd:simpleType name="SharedType">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="100"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/lib.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/lib.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:b="urn:example:ns-b"
+            targetNamespace="urn:example:ns-b">
+  <xsd:include schemaLocation="shared.xsd"/>
+  <xsd:complexType name="LibType">
+    <xsd:sequence>
+      <xsd:element name="value" type="b:SharedType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Document" type="b:LibType"/>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/main.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/main.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:example:ns-b">
+  <xsd:include schemaLocation="lib.xsd"/>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/shared.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/ns-b/shared.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:example:ns-b">
+  <xsd:simpleType name="SharedType">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/root.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/2nd-include-crash/root.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:a="urn:example:ns-a"
+            xmlns:b="urn:example:ns-b"
+            targetNamespace="urn:example:root">
+  <xsd:import namespace="urn:example:ns-a" schemaLocation="ns-a/main.xsd"/>
+  <xsd:import namespace="urn:example:ns-b" schemaLocation="ns-b/main.xsd"/>
+  <xsd:element name="Root">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="partA" type="a:LibType"/>
+        <xsd:element name="partB" type="b:LibType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Order">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="item" type="a:LibType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Invoice">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="detail" type="b:LibType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/packages/ui/src/xml-schema-ts/SchemaBuilder.ts
+++ b/packages/ui/src/xml-schema-ts/SchemaBuilder.ts
@@ -517,20 +517,16 @@ export class SchemaBuilder {
     // use the entity resolver provided if the schema location is present
     // null
     if (schemaLocation != null && '' !== schemaLocation) {
-      const source = this.collection.getSchemaResolver().resolveEntity(targetNamespace, schemaLocation, baseUri);
+      const result = this.collection.getSchemaResolver().resolveEntity(targetNamespace, schemaLocation, baseUri);
 
       // the entity resolver was unable to resolve this!!
-      if (source == null) {
+      if (result == null) {
         // try resolving it with the target namespace only with the
         // known namespace map
         return this.collection.getKnownSchema(targetNamespace);
       }
 
-      const systemId = schemaLocation;
-      // Push repaired system id back into source where read sees it.
-      // It is perhaps a bad thing to patch the source, but this fixes
-      // a problem.
-      //source.setSystemId(systemId);
+      const systemId = result.resolvedPath;
       const key = new SchemaKey(targetNamespace, systemId);
       const schema = this.collection.getSchema(key);
       if (schema != null) {
@@ -539,7 +535,7 @@ export class SchemaBuilder {
       if (this.collection.check(key)) {
         this.collection.push(key);
         try {
-          const readSchema = this.collection.read(source, validator, systemId);
+          const readSchema = this.collection.read(result.content, validator, systemId);
           this.putCachedSchema(targetNamespace, schemaLocation, baseUri || '', readSchema);
           return readSchema;
         } finally {

--- a/packages/ui/src/xml-schema-ts/index.ts
+++ b/packages/ui/src/xml-schema-ts/index.ts
@@ -18,6 +18,7 @@ export { XmlSchemaParticle } from './particle/XmlSchemaParticle';
 export { XmlSchemaSequence } from './particle/XmlSchemaSequence';
 export type { XmlSchemaSequenceMember } from './particle/XmlSchemaSequenceMember';
 export { DefaultURIResolver } from './resolver/DefaultURIResolver';
+export type { EntityResolveResult } from './resolver/URIResolver';
 export { XmlSchemaSimpleContentExtension } from './simple/XmlSchemaSimpleContentExtension';
 export { XmlSchemaSimpleContentRestriction } from './simple/XmlSchemaSimpleContentRestriction';
 export { XmlSchemaSimpleType } from './simple/XmlSchemaSimpleType';

--- a/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
@@ -15,7 +15,10 @@ describe('DefaultURIResolver', () => {
 
       resolver.addFiles({ 'schema.xsd': '<schema>schema</schema>' });
 
-      expect(resolver.resolveEntity(null, 'schema.xsd', null)).toBe('<schema>schema</schema>');
+      expect(resolver.resolveEntity(null, 'schema.xsd', null)).toEqual({
+        content: '<schema>schema</schema>',
+        resolvedPath: 'schema.xsd',
+      });
     });
   });
 
@@ -30,7 +33,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, 'common.xsd', null);
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
       });
 
       it('should resolve relative path with ./ prefix', () => {
@@ -42,7 +45,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, './common.xsd', 'schemas/main.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' });
       });
 
       it('should resolve relative path with baseUri', () => {
@@ -54,7 +57,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, 'common.xsd', 'schemas/main.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' });
       });
 
       it('should normalize ./ in schemaLocation', () => {
@@ -65,7 +68,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, './types/./base.xsd', 'schemas/main.xsd');
 
-        expect(result).toBe('<schema>base</schema>');
+        expect(result).toEqual({ content: '<schema>base</schema>', resolvedPath: 'schemas/types/base.xsd' });
       });
 
       it('should resolve ../ in schemaLocation', () => {
@@ -77,7 +80,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, '../common.xsd', 'schemas/main.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
       });
 
       it('should resolve nested relative paths (../../common.xsd)', () => {
@@ -89,7 +92,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, '../../common.xsd', 'schemas/types/nested/specific.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' });
       });
 
       it('should fallback to filename-only match when unique', () => {
@@ -101,7 +104,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, 'common.xsd', null);
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/types/common.xsd' });
       });
 
       it('should throw error when filename match is ambiguous', () => {
@@ -114,6 +117,22 @@ describe('DefaultURIResolver', () => {
         expect(() => {
           resolver.resolveEntity(null, 'common.xsd', null);
         }).toThrow('Ambiguous filename match for "common.xsd"');
+      });
+
+      it('should resolve ambiguous filenames when baseUri provides directory context', () => {
+        const definitionFiles = {
+          'ns-a/lib.xsd': '<schema>lib-a</schema>',
+          'ns-a/shared.xsd': '<schema>shared-a</schema>',
+          'ns-b/lib.xsd': '<schema>lib-b</schema>',
+          'ns-b/shared.xsd': '<schema>shared-b</schema>',
+        };
+        const resolver = new DefaultURIResolver(definitionFiles);
+
+        const resultA = resolver.resolveEntity(null, 'shared.xsd', 'ns-a/lib.xsd');
+        expect(resultA).toEqual({ content: '<schema>shared-a</schema>', resolvedPath: 'ns-a/shared.xsd' });
+
+        const resultB = resolver.resolveEntity(null, 'shared.xsd', 'ns-b/lib.xsd');
+        expect(resultB).toEqual({ content: '<schema>shared-b</schema>', resolvedPath: 'ns-b/shared.xsd' });
       });
 
       it('should throw error when schema not found', () => {
@@ -149,7 +168,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, '/schemas/common.xsd', null);
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: '/schemas/common.xsd' });
       });
 
       it('should resolve with absolute schemaLocation ignoring baseUri', () => {
@@ -161,7 +180,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, '/absolute/common.xsd', 'schemas/main.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: '/absolute/common.xsd' });
       });
 
       it('should resolve with normalized path when it differs from original', () => {
@@ -172,7 +191,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, 'schemas/./types/./common.xsd', null);
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/types/common.xsd' });
       });
 
       it('should handle baseUri without directory separator when no exact match', () => {
@@ -184,7 +203,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, './common.xsd', 'main.xsd');
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
       });
 
       it('should handle ../ at the beginning of path', () => {
@@ -195,7 +214,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, '../common.xsd', null);
 
-        expect(result).toBe('<schema>common</schema>');
+        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
       });
     });
 
@@ -237,9 +256,9 @@ describe('DefaultURIResolver', () => {
         };
         resolver.addFiles(additionalFiles);
 
-        expect(resolver.resolveEntity(null, 'types.xsd', null)).toBe('<schema>types</schema>');
-        expect(resolver.resolveEntity(null, 'enums.xsd', null)).toBe('<schema>enums</schema>');
-        expect(resolver.resolveEntity(null, 'common.xsd', null)).toBe('<schema>common</schema>');
+        expect(resolver.resolveEntity(null, 'types.xsd', null).content).toBe('<schema>types</schema>');
+        expect(resolver.resolveEntity(null, 'enums.xsd', null).content).toBe('<schema>enums</schema>');
+        expect(resolver.resolveEntity(null, 'common.xsd', null).content).toBe('<schema>common</schema>');
       });
 
       it('should overwrite existing files with same path', () => {
@@ -254,8 +273,8 @@ describe('DefaultURIResolver', () => {
         };
         resolver.addFiles(updatedFiles);
 
-        expect(resolver.resolveEntity(null, 'main.xsd', null)).toBe('<schema>main updated</schema>');
-        expect(resolver.resolveEntity(null, 'common.xsd', null)).toBe('<schema>common</schema>');
+        expect(resolver.resolveEntity(null, 'main.xsd', null).content).toBe('<schema>main updated</schema>');
+        expect(resolver.resolveEntity(null, 'common.xsd', null).content).toBe('<schema>common</schema>');
       });
 
       it('should handle adding files to initially empty resolver', () => {
@@ -266,7 +285,7 @@ describe('DefaultURIResolver', () => {
         };
         resolver.addFiles(newFiles);
 
-        expect(resolver.resolveEntity(null, 'schema.xsd', null)).toBe('<schema>schema</schema>');
+        expect(resolver.resolveEntity(null, 'schema.xsd', null).content).toBe('<schema>schema</schema>');
       });
 
       it('should allow resolution of newly added file imports', () => {
@@ -282,7 +301,7 @@ describe('DefaultURIResolver', () => {
 
         const result = resolver.resolveEntity(null, 'imported.xsd', 'main.xsd');
 
-        expect(result).toBe('<schema>imported</schema>');
+        expect(result).toEqual({ content: '<schema>imported</schema>', resolvedPath: 'imported.xsd' });
       });
     });
   });

--- a/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.ts
@@ -1,4 +1,5 @@
 import { CollectionURIResolver } from './CollectionURIResolver';
+import { EntityResolveResult } from './URIResolver';
 
 export class DefaultURIResolver implements CollectionURIResolver {
   private collectionBaseUri?: string;
@@ -21,7 +22,7 @@ export class DefaultURIResolver implements CollectionURIResolver {
     Object.assign(this.definitionFiles, newFiles);
   }
 
-  resolveEntity(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): string {
+  resolveEntity(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): EntityResolveResult {
     if (this.definitionFiles) {
       return this.resolveFromFileMap(targetNamespace, schemaLocation, baseUri);
     }
@@ -31,25 +32,28 @@ export class DefaultURIResolver implements CollectionURIResolver {
     );
   }
 
-  private resolveFromFileMap(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): string {
+  private resolveFromFileMap(
+    targetNamespace: string | null,
+    schemaLocation: string,
+    baseUri: string | null,
+  ): EntityResolveResult {
     if (this.definitionFiles![schemaLocation]) {
-      return this.definitionFiles![schemaLocation];
+      return { content: this.definitionFiles![schemaLocation], resolvedPath: schemaLocation };
     }
 
     if (baseUri) {
       const resolvedPath = this.resolvePath(schemaLocation, baseUri);
       if (this.definitionFiles![resolvedPath]) {
-        return this.definitionFiles![resolvedPath];
+        return { content: this.definitionFiles![resolvedPath], resolvedPath };
       }
     }
 
     const normalizedPath = this.normalizePath(schemaLocation);
     if (normalizedPath !== schemaLocation && this.definitionFiles![normalizedPath]) {
-      return this.definitionFiles![normalizedPath];
+      return { content: this.definitionFiles![normalizedPath], resolvedPath: normalizedPath };
     }
 
-    const filename = this.extractFilename(schemaLocation);
-    const matchByFilename = this.findByFilename(filename);
+    const matchByFilename = this.findByFilename(this.extractFilename(schemaLocation));
     if (matchByFilename) {
       return matchByFilename;
     }
@@ -108,12 +112,12 @@ export class DefaultURIResolver implements CollectionURIResolver {
     return lastSlash === -1 ? path : path.substring(lastSlash + 1);
   }
 
-  private findByFilename(filename: string): string | null {
-    const matches: string[] = [];
+  private findByFilename(filename: string): EntityResolveResult | null {
+    const matches: EntityResolveResult[] = [];
 
     for (const [path, content] of Object.entries(this.definitionFiles!)) {
       if (this.extractFilename(path) === filename) {
-        matches.push(content);
+        matches.push({ content, resolvedPath: path });
       }
     }
 

--- a/packages/ui/src/xml-schema-ts/resolver/URIResolver.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/URIResolver.ts
@@ -1,3 +1,8 @@
+export interface EntityResolveResult {
+  content: string;
+  resolvedPath: string;
+}
+
 export interface URIResolver {
-  resolveEntity(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): string;
+  resolveEntity(targetNamespace: string | null, schemaLocation: string, baseUri: string | null): EntityResolveResult;
 }


### PR DESCRIPTION
…erent path

Fixes: https://github.com/KaotoIO/kaoto/issues/3277

Also fix same localName elements in different namespace

Fixes: https://github.com/KaotoIO/kaoto/issues/3278


https://github.com/user-attachments/assets/7a5f3a3f-74ef-446d-bffe-d4ac64e62f8c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved typeahead root-element selector with clearer selection, filtering, and namespace disambiguation
  * Enhanced XML schema handling across multiple namespaces for more reliable element discovery
  * Preserves root-element selection when unrelated files are removed

* **Tests**
  * Expanded test coverage for typeahead interactions, selection behaviors, namespace edge-cases, and schema resolution scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->