### PR TITLE
feat(Catalog): Read catalog versions from settings 2-3

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
@@ -34,7 +34,7 @@ describe('Test URI node config', () => {
     });
   });
 
-  it('User adds URI step to the YAML', () => {
+  it('User adds URI step to a Kamelet YAML', () => {
     cy.uploadFixture('flows/kamelet/uriConf.yaml');
     const stepToInsert = `      - to: aws2-s3:testBucket?autoCreateBucket=true`;
     cy.editorAddText(43, stepToInsert);
@@ -55,7 +55,7 @@ describe('Test URI node config', () => {
     cy.checkConfigInputObject('parameters.bucketNameOrArn', 'testBucket');
   });
 
-  it('User adds URI step to the YAML', () => {
+  it('User adds URI step to a Camel Route YAML', () => {
     cy.uploadFixture('flows/camelRoute/uriConf.yaml');
     const stepToInsert = `        - to: aws2-s3:testBucket?autoCreateBucket=true`;
     cy.editorAddText(11, stepToInsert);

--- a/packages/ui-tests/stories/canvas/Canvas.stories.tsx
+++ b/packages/ui-tests/stories/canvas/Canvas.stories.tsx
@@ -9,6 +9,7 @@ import {
   EntitiesProvider,
   kameletJson,
   KameletVisualEntity,
+  KaotoResourceProvider,
   pipeJson,
   PipeVisualEntity,
   RuntimeProvider,
@@ -73,21 +74,27 @@ const ContextDecorator = (Story: StoryFn) => {
 
   return (
     <SourceCodeSync>
-      <EntitiesProvider>
-        <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+      <KaotoResourceProvider>
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
           <SchemasLoaderProvider>
             <CatalogLoaderProvider>
-              <CatalogTilesProvider>
-                <VisibleFlowsProvider>
-                  <VisualizationProvider controller={controller}>
-                    <Story />
-                  </VisualizationProvider>
-                </VisibleFlowsProvider>
-              </CatalogTilesProvider>
+              <EntitiesProvider>
+                <CatalogTilesProvider>
+                  <VisibleFlowsProvider>
+                    <VisualizationProvider controller={controller}>
+                      <Story />
+                    </VisualizationProvider>
+                  </VisibleFlowsProvider>
+                </CatalogTilesProvider>
+              </EntitiesProvider>
             </CatalogLoaderProvider>
           </SchemasLoaderProvider>
         </RuntimeProvider>
-      </EntitiesProvider>
+      </KaotoResourceProvider>
     </SourceCodeSync>
   );
 };

--- a/packages/ui-tests/stories/canvas/CanvasFormBody.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasFormBody.stories.tsx
@@ -5,6 +5,7 @@ import {
   CatalogLoaderProvider,
   CatalogSchemaLoader,
   createVisualizationNode,
+  KaotoResourceProvider,
   RuntimeProvider,
   SchemasLoaderProvider,
   VisibleFlowsProvider,
@@ -18,24 +19,30 @@ export default {
   component: CanvasFormBody,
   decorators: [
     (Story: StoryFn) => (
-      <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-        <SchemasLoaderProvider>
-          <CatalogLoaderProvider>
-            <CanvasFormTabsContext.Provider
-              value={{
-                selectedTab: 'All',
-                setSelectedTab: () => {},
-              }}
-            >
-              <VisibleFlowsProvider>
-                <SuggestionRegistryProvider>
-                  <Story />
-                </SuggestionRegistryProvider>
-              </VisibleFlowsProvider>
-            </CanvasFormTabsContext.Provider>
-          </CatalogLoaderProvider>
-        </SchemasLoaderProvider>
-      </RuntimeProvider>
+      <KaotoResourceProvider>
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
+          <SchemasLoaderProvider>
+            <CatalogLoaderProvider>
+              <CanvasFormTabsContext.Provider
+                value={{
+                  selectedTab: 'All',
+                  setSelectedTab: () => {},
+                }}
+              >
+                <VisibleFlowsProvider>
+                  <SuggestionRegistryProvider>
+                    <Story />
+                  </SuggestionRegistryProvider>
+                </VisibleFlowsProvider>
+              </CanvasFormTabsContext.Provider>
+            </CatalogLoaderProvider>
+          </SchemasLoaderProvider>
+        </RuntimeProvider>
+      </KaotoResourceProvider>
     ),
   ],
 } as Meta<typeof CanvasFormBody>;

--- a/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
+++ b/packages/ui-tests/stories/canvas/ContextToolbar.stories.tsx
@@ -7,6 +7,7 @@ import {
   ControllerService,
   EntitiesProvider,
   kameletYaml,
+  KaotoResourceProvider,
   pipeYaml,
   RuntimeProvider,
   SchemasLoaderProvider,
@@ -39,26 +40,32 @@ export default {
 const Template: StoryFn<{ sourceCode: string }> = (props: { sourceCode: string }) => {
   return (
     <SourceCodeSync initialSourceCode={props.sourceCode}>
-      <EntitiesProvider>
-        <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+      <KaotoResourceProvider>
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
           <SchemasLoaderProvider>
             <CatalogLoaderProvider>
-              <CatalogTilesProvider>
-                <VisibleFlowsProvider>
-                  <Toolbar>
-                    <ToolbarContent>
-                      <ToolbarGroup className="pf-topology-view__project-toolbar">
-                        <ContextToolbar />
-                      </ToolbarGroup>
-                    </ToolbarContent>
-                    <Divider />
-                  </Toolbar>
-                </VisibleFlowsProvider>
-              </CatalogTilesProvider>
+              <EntitiesProvider>
+                <CatalogTilesProvider>
+                  <VisibleFlowsProvider>
+                    <Toolbar>
+                      <ToolbarContent>
+                        <ToolbarGroup className="pf-topology-view__project-toolbar">
+                          <ContextToolbar />
+                        </ToolbarGroup>
+                      </ToolbarContent>
+                      <Divider />
+                    </Toolbar>
+                  </VisibleFlowsProvider>
+                </CatalogTilesProvider>
+              </EntitiesProvider>
             </CatalogLoaderProvider>
           </SchemasLoaderProvider>
         </RuntimeProvider>
-      </EntitiesProvider>
+      </KaotoResourceProvider>
     </SourceCodeSync>
   );
 };

--- a/packages/ui-tests/stories/catalog/Catalog.stories.tsx
+++ b/packages/ui-tests/stories/catalog/Catalog.stories.tsx
@@ -5,6 +5,7 @@ import {
   CatalogSchemaLoader,
   CatalogTilesProvider,
   getIconRequest,
+  KaotoResourceProvider,
   RuntimeProvider,
   SchemasLoaderProvider,
 } from '@kaoto/kaoto/testing';
@@ -47,15 +48,17 @@ async function tilesWithIcons(rawTiles: FixtureTile[]): Promise<ITile[]> {
 }
 
 const ContextDecorator = (Story: StoryFn) => (
-  <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-    <SchemasLoaderProvider>
-      <CatalogLoaderProvider>
-        <CatalogTilesProvider>
-          <Story />
-        </CatalogTilesProvider>
-      </CatalogLoaderProvider>
-    </SchemasLoaderProvider>
-  </RuntimeProvider>
+  <KaotoResourceProvider>
+    <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH} runtimeCatalogName="" testingCatalogName="">
+      <SchemasLoaderProvider>
+        <CatalogLoaderProvider>
+          <CatalogTilesProvider>
+            <Story />
+          </CatalogTilesProvider>
+        </CatalogLoaderProvider>
+      </SchemasLoaderProvider>
+    </RuntimeProvider>
+  </KaotoResourceProvider>
 );
 
 export default {

--- a/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
+++ b/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
@@ -5,6 +5,7 @@ import {
   CatalogSchemaLoader,
   CatalogTilesProvider,
   getIconRequest,
+  KaotoResourceProvider,
   RuntimeProvider,
   SchemasLoaderProvider,
 } from '@kaoto/kaoto/testing';
@@ -12,16 +13,18 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 const ContextDecorator = (Story: StoryFn) => (
-  <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-    <SchemasLoaderProvider>
-      <CatalogLoaderProvider>
-        <CatalogTilesProvider>
-          {/* @ts-expect-error Storybook Decorator AnnotatedStoryFn */}
-          <Story />
-        </CatalogTilesProvider>
-      </CatalogLoaderProvider>
-    </SchemasLoaderProvider>
-  </RuntimeProvider>
+  <KaotoResourceProvider>
+    <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH} runtimeCatalogName="" testingCatalogName="">
+      <SchemasLoaderProvider>
+        <CatalogLoaderProvider>
+          <CatalogTilesProvider>
+            {/* @ts-expect-error Storybook Decorator AnnotatedStoryFn */}
+            <Story />
+          </CatalogTilesProvider>
+        </CatalogLoaderProvider>
+      </SchemasLoaderProvider>
+    </RuntimeProvider>
+  </KaotoResourceProvider>
 );
 
 const aggregateTileBase = {

--- a/packages/ui-tests/stories/navigation/Navigation.stories.tsx
+++ b/packages/ui-tests/stories/navigation/Navigation.stories.tsx
@@ -2,6 +2,7 @@ import {
   EntitiesContext,
   EntitiesContextResult,
   EntitiesProvider,
+  KaotoResourceProvider,
   Navigation,
   Shell,
   SourceCodeSync,
@@ -16,9 +17,11 @@ export default {
     withRouter,
     (Story: StoryFn) => (
       <SourceCodeSync>
-        <EntitiesProvider>
-          <Story />
-        </EntitiesProvider>
+        <KaotoResourceProvider>
+          <EntitiesProvider>
+            <Story />
+          </EntitiesProvider>
+        </KaotoResourceProvider>
       </SourceCodeSync>
     ),
   ],

--- a/packages/ui-tests/stories/settings/SettingsForm.stories.tsx
+++ b/packages/ui-tests/stories/settings/SettingsForm.stories.tsx
@@ -2,6 +2,7 @@ import { SettingsForm } from '@kaoto/kaoto';
 import {
   CatalogSchemaLoader,
   DefaultSettingsAdapter,
+  KaotoResourceProvider,
   ReloadContext,
   RuntimeProvider,
   SettingsProvider,
@@ -27,11 +28,17 @@ const Template: StoryFn<typeof SettingsForm> = (args) => {
   const settingsAdapter = new DefaultSettingsAdapter();
   return (
     <ReloadContext.Provider value={{ reloadPage, lastRender: 0 }}>
-      <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
-        <SettingsProvider adapter={settingsAdapter}>
-          <SettingsForm {...args} />
-        </SettingsProvider>
-      </RuntimeProvider>
+      <KaotoResourceProvider>
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
+          <SettingsProvider adapter={settingsAdapter}>
+            <SettingsForm {...args} />
+          </SettingsProvider>
+        </RuntimeProvider>
+      </KaotoResourceProvider>
     </ReloadContext.Provider>
   );
 };

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,6 +16,7 @@ import { Shell } from './layout/Shell';
 import { LocalStorageSettingsAdapter } from './models/settings/localstorage-settings-adapter';
 import {
   EntitiesProvider,
+  KaotoResourceProvider,
   KeyboardShortcutsProvider,
   RuntimeProvider,
   SchemasLoaderProvider,
@@ -30,49 +31,59 @@ function App() {
   const controller = useMemo(() => ControllerService.createController(), []);
   const settingsAdapter = new LocalStorageSettingsAdapter();
   let catalogUrl = CatalogSchemaLoader.DEFAULT_CATALOG_PATH;
-  const settingsCatalogUrl = settingsAdapter.getSettings().catalogUrl;
-  const colorSchema = settingsAdapter.getSettings().colorScheme;
+  const {
+    catalogUrl: settingsCatalogUrl,
+    runtimeCatalogName,
+    testingCatalogName,
+    colorScheme,
+  } = settingsAdapter.getSettings();
 
   if (isDefined(settingsCatalogUrl) && settingsCatalogUrl !== '') {
     catalogUrl = settingsCatalogUrl;
   }
 
   useLayoutEffect(() => {
-    setColorScheme(colorSchema);
-  }, [colorSchema]);
+    setColorScheme(colorScheme);
+  }, [colorScheme]);
 
   return (
     <SettingsProvider adapter={settingsAdapter}>
       <SourceCodeLocalStorageProvider>
-        <RuntimeProvider catalogUrl={catalogUrl}>
-          <SchemasLoaderProvider>
-            <CatalogLoaderProvider>
-              <EntitiesProvider>
-                <Shell>
-                  <CatalogTilesProvider>
-                    <VisualizationProvider controller={controller}>
-                      <VisibleFlowsProvider>
-                        <RenderingProvider>
-                          <RegisterComponents>
-                            <NodeInteractionAddonProvider>
-                              <RegisterNodeInteractionAddons>
-                                <SuggestionRegistryProvider>
-                                  <KeyboardShortcutsProvider>
-                                    <Outlet />
-                                  </KeyboardShortcutsProvider>
-                                </SuggestionRegistryProvider>
-                              </RegisterNodeInteractionAddons>
-                            </NodeInteractionAddonProvider>
-                          </RegisterComponents>
-                        </RenderingProvider>
-                      </VisibleFlowsProvider>
-                    </VisualizationProvider>
-                  </CatalogTilesProvider>
-                </Shell>
-              </EntitiesProvider>
-            </CatalogLoaderProvider>
-          </SchemasLoaderProvider>
-        </RuntimeProvider>
+        <KaotoResourceProvider>
+          <RuntimeProvider
+            catalogUrl={catalogUrl}
+            runtimeCatalogName={runtimeCatalogName}
+            testingCatalogName={testingCatalogName}
+          >
+            <SchemasLoaderProvider>
+              <CatalogLoaderProvider>
+                <EntitiesProvider>
+                  <Shell>
+                    <CatalogTilesProvider>
+                      <VisualizationProvider controller={controller}>
+                        <VisibleFlowsProvider>
+                          <RenderingProvider>
+                            <RegisterComponents>
+                              <NodeInteractionAddonProvider>
+                                <RegisterNodeInteractionAddons>
+                                  <SuggestionRegistryProvider>
+                                    <KeyboardShortcutsProvider>
+                                      <Outlet />
+                                    </KeyboardShortcutsProvider>
+                                  </SuggestionRegistryProvider>
+                                </RegisterNodeInteractionAddons>
+                              </NodeInteractionAddonProvider>
+                            </RegisterComponents>
+                          </RenderingProvider>
+                        </VisibleFlowsProvider>
+                      </VisualizationProvider>
+                    </CatalogTilesProvider>
+                  </Shell>
+                </EntitiesProvider>
+              </CatalogLoaderProvider>
+            </SchemasLoaderProvider>
+          </RuntimeProvider>
+        </KaotoResourceProvider>
       </SourceCodeLocalStorageProvider>
     </SettingsProvider>
   );

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -1,6 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
-import { CanvasFormTabsContext, CanvasFormTabsProvider, SuggestionRegistryProvider } from '@kaoto/forms';
+import { CanvasFormTabsContext, CanvasFormTabsProvider } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
@@ -18,9 +18,7 @@ import {
 import { EntityType } from '../../../../models/entities';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { VisualFlowsApi } from '../../../../models/visualization/flows/support/flows-visibility';
-import { VisibleFlowsContext, VisibleFlowsProvider } from '../../../../providers';
-import { EntitiesContext, EntitiesProvider } from '../../../../providers/entities.provider';
-import { camelRouteJson, kameletJson } from '../../../../stubs';
+import { camelRouteJson, kameletJson, TestProvidersWrapper } from '../../../../stubs';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { ROOT_PATH } from '../../../../utils';
 import { CanvasNode } from '../canvas.models';
@@ -61,17 +59,14 @@ describe('CanvasForm', () => {
   });
 
   it('should render', async () => {
+    const { Provider } = TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsProvider>
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsProvider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
-        </EntitiesProvider>,
+        <Provider>
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
+        </Provider>,
       ),
     );
 
@@ -87,17 +82,14 @@ describe('CanvasForm', () => {
       },
     } as CanvasNode;
 
+    const { Provider } = TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsProvider>
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsProvider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
-        </EntitiesProvider>,
+        <Provider>
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
+        </Provider>,
       ),
     );
 
@@ -128,17 +120,14 @@ describe('CanvasForm', () => {
     jest.spyOn(vizNode, 'getNodeSchema').mockReturnValue(undefined);
     jest.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
 
+    const { Provider } = TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
-        <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsProvider>
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsProvider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
-        </EntitiesContext.Provider>,
+        <Provider>
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
+        </Provider>,
       ),
     );
 
@@ -169,17 +158,14 @@ describe('CanvasForm', () => {
     jest.spyOn(vizNode, 'getNodeSchema').mockReturnValue(null as unknown as KaotoSchemaDefinition['schema']);
     jest.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(null);
 
+    const { Provider } = TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
-        <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsProvider>
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsProvider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
-        </EntitiesContext.Provider>,
+        <Provider>
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
+        </Provider>,
       ),
     );
 
@@ -193,24 +179,22 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
+    });
+
     await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsContext.Provider
-            value={{ visibleFlows: { [flowId]: true }, allFlowsVisible: true, visualFlowsApi }}
+        <Provider>
+          <CanvasFormTabsContext.Provider
+            value={{
+              selectedTab: 'All',
+              setSelectedTab: jest.fn(),
+            }}
           >
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsContext.Provider>
-        </EntitiesProvider>,
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsContext.Provider>
+        </Provider>,
       ),
     );
 
@@ -234,24 +218,22 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
+    });
+
     await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsContext.Provider
-            value={{ visibleFlows: { [flowId]: true }, allFlowsVisible: true, visualFlowsApi }}
+        <Provider>
+          <CanvasFormTabsContext.Provider
+            value={{
+              selectedTab: 'All',
+              setSelectedTab: jest.fn(),
+            }}
           >
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsContext.Provider>
-        </EntitiesProvider>,
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsContext.Provider>
+        </Provider>,
       ),
     );
 
@@ -276,24 +258,22 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
+    });
+
     await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsContext.Provider
-            value={{ visibleFlows: { [flowId]: true }, allFlowsVisible: true, visualFlowsApi }}
+        <Provider>
+          <CanvasFormTabsContext.Provider
+            value={{
+              selectedTab: 'All',
+              setSelectedTab: jest.fn(),
+            }}
           >
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsContext.Provider>
-        </EntitiesProvider>,
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsContext.Provider>
+        </Provider>,
       ),
     );
 
@@ -320,19 +300,17 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await kameletVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
+    const { Provider } = TestProvidersWrapper({
+      visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
+    });
+
     await act(async () =>
       render(
-        <EntitiesProvider>
-          <VisibleFlowsContext.Provider
-            value={{ visibleFlows: { [flowId]: true }, allFlowsVisible: true, visualFlowsApi }}
-          >
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsProvider>
-                <CanvasForm selectedNode={selectedNode} />
-              </CanvasFormTabsProvider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsContext.Provider>
-        </EntitiesProvider>,
+        <Provider>
+          <CanvasFormTabsProvider>
+            <CanvasForm selectedNode={selectedNode} />
+          </CanvasFormTabsProvider>
+        </Provider>,
       ),
     );
 
@@ -358,17 +336,15 @@ describe('CanvasForm', () => {
     });
 
     it('normal text field', async () => {
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesProvider>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesProvider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -417,17 +393,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -484,17 +458,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -555,17 +527,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -605,17 +575,15 @@ describe('CanvasForm', () => {
     });
 
     it('normal text field', async () => {
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesProvider>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesProvider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -660,17 +628,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -723,17 +689,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 
@@ -787,17 +751,15 @@ describe('CanvasForm', () => {
         },
       };
 
+      const { Provider } = TestProvidersWrapper();
+
       await act(async () =>
         render(
-          <EntitiesContext.Provider value={null}>
-            <VisibleFlowsProvider>
-              <SuggestionRegistryProvider>
-                <CanvasFormTabsProvider>
-                  <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
-                </CanvasFormTabsProvider>
-              </SuggestionRegistryProvider>
-            </VisibleFlowsProvider>
-          </EntitiesContext.Provider>,
+          <Provider>
+            <CanvasFormTabsProvider>
+              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+            </CanvasFormTabsProvider>
+          </Provider>,
         ),
       );
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
@@ -4,6 +4,7 @@ import { toBlob } from 'html-to-image';
 import { PropsWithChildren } from 'react';
 
 import { EntitiesProvider } from '../../../../providers/entities.provider';
+import { KaotoResourceProvider } from '../../../../providers/kaoto-resource.provider';
 import { SourceCodeSync } from '../../../../providers/source-code-sync';
 import { VisibleFlowsProvider } from '../../../../providers/visible-flows.provider';
 import { FlowExportImage } from './FlowExportImage';
@@ -45,10 +46,12 @@ interface MockGraph {
 }
 
 const wrapper = ({ children }: PropsWithChildren) => (
-  <SourceCodeSync initialSourceCode="">
-    <EntitiesProvider>
-      <VisibleFlowsProvider>{children}</VisibleFlowsProvider>
-    </EntitiesProvider>
+  <SourceCodeSync>
+    <KaotoResourceProvider>
+      <EntitiesProvider>
+        <VisibleFlowsProvider>{children}</VisibleFlowsProvider>
+      </EntitiesProvider>
+    </KaotoResourceProvider>
   </SourceCodeSync>
 );
 

--- a/packages/ui/src/external/RouteVisualization/RouteVisualization.test.tsx
+++ b/packages/ui/src/external/RouteVisualization/RouteVisualization.test.tsx
@@ -1,0 +1,77 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogDefinition, CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { act, render } from '@testing-library/react';
+
+import { camelRouteYaml } from '../../stubs/camel-route';
+import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { RouteVisualization } from './RouteVisualization';
+
+describe('RouteVisualization', () => {
+  let fetchResolve: () => void;
+  let catalogDefinition: CatalogDefinition;
+
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    catalogDefinition = catalogsMap.catalogDefinition;
+  });
+
+  beforeEach(() => {
+    const fetchMock = jest.spyOn(window, 'fetch');
+
+    // The first fetch (RuntimeProvider) loads the catalog library index, while
+    // the subsequent fetches (Schemas/Catalog loaders) load the catalog
+    // definition.
+    fetchMock.mockImplementationOnce((file) => {
+      return new Promise((resolve) => {
+        fetchResolve = () => {
+          resolve({
+            json: () => catalogLibrary,
+            url: `http://localhost/${file}`,
+          } as unknown as Response);
+        };
+      });
+    });
+    fetchMock.mockImplementation((file) => {
+      return new Promise((resolve) => {
+        fetchResolve = () => {
+          resolve({
+            json: () => catalogDefinition,
+            url: `http://localhost/${file}`,
+          } as unknown as Response);
+        };
+      });
+    });
+
+    jest.spyOn(CatalogSchemaLoader, 'fetchFile').mockImplementation((uri: string) => {
+      return Promise.resolve({ uri, body: { [uri]: 'dummy-data' } });
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the canvas from the code prop without throwing', async () => {
+    render(
+      <RouteVisualization
+        catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+        runtimeCatalogName=""
+        testingCatalogName=""
+        code={camelRouteYaml}
+        codeChange={jest.fn()}
+      />,
+    );
+
+    // The SchemasLoaderProvider and CatalogLoaderProvider each perform a
+    // sequential fetch of the index file, so resolve the pending fetch until
+    // the canvas surface is mounted.
+    for (let i = 0; i < 5 && !document.querySelector('.canvas-surface'); i++) {
+      await act(async () => {
+        fetchResolve();
+      });
+    }
+
+    expect(document.querySelector('.canvas-surface')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
+++ b/packages/ui/src/external/RouteVisualization/RouteVisualization.tsx
@@ -7,6 +7,7 @@ import { CatalogLoaderProvider } from '../../dynamic-catalog/catalog.provider';
 import {
   EntitiesContext,
   EntitiesProvider,
+  KaotoResourceProvider,
   ReloadProvider,
   RuntimeProvider,
   SchemasLoaderProvider,
@@ -16,43 +17,61 @@ import {
 import { EventNotifier } from '../../utils';
 
 const VisibleFlowsVisualization: FunctionComponent<{ className?: string }> = ({ className = '' }) => {
-  const { visibleFlows, visualFlowsApi } = useContext(VisibleFlowsContext)!;
+  const { visualFlowsApi } = useContext(VisibleFlowsContext)!;
   const entitiesContext = useContext(EntitiesContext);
   const visualEntities = entitiesContext?.visualEntities ?? [];
 
+  // `showFlows()` dispatches an action that returns a new `visibleFlows`
+  // reference, so depending on `visibleFlows` here would re-run this effect
+  // indefinitely. We only need to reveal the flows once per api instance.
   useEffect(() => {
     visualFlowsApi.showFlows();
-  }, [visibleFlows, visualFlowsApi]);
+  }, [visualFlowsApi]);
 
   return <Visualization className={`canvas-page ${className}`} entities={visualEntities} />;
 };
 
-const Viz: FunctionComponent<{ catalogUrl: string; className?: string }> = ({ catalogUrl, className = '' }) => {
+const Viz: FunctionComponent<{
+  catalogUrl: string;
+  runtimeCatalogName: string;
+  testingCatalogName: string;
+  className?: string;
+}> = ({ catalogUrl, runtimeCatalogName, testingCatalogName, className = '' }) => {
   const controller = useMemo(() => ControllerService.createController(), []);
 
   return (
     <ReloadProvider>
-      <RuntimeProvider catalogUrl={catalogUrl}>
-        <SchemasLoaderProvider>
-          <CatalogLoaderProvider>
-            <VisualizationProvider controller={controller}>
-              <VisibleFlowsProvider>
-                <VisibleFlowsVisualization className={`canvas-page ${className}`} />
-              </VisibleFlowsProvider>
-            </VisualizationProvider>
-          </CatalogLoaderProvider>
-        </SchemasLoaderProvider>
-      </RuntimeProvider>
+      <KaotoResourceProvider>
+        <RuntimeProvider
+          catalogUrl={catalogUrl}
+          runtimeCatalogName={runtimeCatalogName}
+          testingCatalogName={testingCatalogName}
+        >
+          <SchemasLoaderProvider>
+            <CatalogLoaderProvider>
+              <EntitiesProvider>
+                <VisualizationProvider controller={controller}>
+                  <VisibleFlowsProvider>
+                    <VisibleFlowsVisualization className={className} />
+                  </VisibleFlowsProvider>
+                </VisualizationProvider>
+              </EntitiesProvider>
+            </CatalogLoaderProvider>
+          </SchemasLoaderProvider>
+        </RuntimeProvider>
+      </KaotoResourceProvider>
     </ReloadProvider>
   );
 };
 
-export const RouteVisualization: React.FC<{
+export const RouteVisualization: FunctionComponent<{
   catalogUrl: string;
+  runtimeCatalogName: string;
+  testingCatalogName: string;
   code: string;
   codeChange: (code: string) => void;
   className?: string;
-}> = ({ catalogUrl, code, codeChange, className }) => {
+}> = ({ catalogUrl, runtimeCatalogName, testingCatalogName, code, codeChange, className }) => {
   const eventNotifier = EventNotifier.getInstance();
 
   useLayoutEffect(() => {
@@ -66,8 +85,11 @@ export const RouteVisualization: React.FC<{
   }, [code, eventNotifier]);
 
   return (
-    <EntitiesProvider>
-      <Viz catalogUrl={catalogUrl} className={className} />
-    </EntitiesProvider>
+    <Viz
+      catalogUrl={catalogUrl}
+      runtimeCatalogName={runtimeCatalogName}
+      testingCatalogName={testingCatalogName}
+      className={className}
+    />
   );
 };

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -2,9 +2,14 @@ import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
 import { EntitiesProvider } from '../../providers/entities.provider';
+import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';
 import { errorMessage, useEntityContext } from './useEntityContext';
 
-const wrapper = ({ children }: PropsWithChildren) => <EntitiesProvider>{children}</EntitiesProvider>;
+const wrapper = ({ children }: PropsWithChildren) => (
+  <KaotoResourceProvider>
+    <EntitiesProvider>{children}</EntitiesProvider>
+  </KaotoResourceProvider>
+);
 
 describe('useEntityContext', () => {
   it('should be throw when use hook without provider', () => {

--- a/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
+++ b/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+
+import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';
+import { errorMessage, useKaotoResourceContext } from './useKaotoResourceContext';
+
+const wrapper = ({ children }: PropsWithChildren) => <KaotoResourceProvider>{children}</KaotoResourceProvider>;
+
+describe('useKaotoResourceContext', () => {
+  it('should be throw when use hook without provider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+    expect(() => renderHook(() => useKaotoResourceContext())).toThrow(errorMessage);
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it('should return EntityContext', () => {
+    const { result } = renderHook(() => useKaotoResourceContext(), { wrapper });
+
+    expect(result.current).not.toBe(null);
+  });
+});

--- a/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.tsx
+++ b/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.tsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import { KaotoResourceContext } from '../../providers/kaoto-resource.provider';
+
+export const errorMessage = 'useKaotoResourceContext should be called into KaotoResourceContext';
+
+export function useKaotoResourceContext() {
+  const ctx = useContext(KaotoResourceContext);
+
+  if (!ctx) throw new Error(errorMessage);
+
+  return ctx;
+}

--- a/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
+++ b/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
@@ -2,12 +2,21 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { act, renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
+import { SourceSchemaType } from '../../models/camel';
+import { KaotoResource } from '../../models/kaoto-resource';
+import { KaotoResourceContext } from '../../providers/kaoto-resource.provider';
 import { RuntimeProvider } from '../../providers/runtime.provider';
 import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
 import { errorMessage, useRuntimeContext } from './useRuntimeContext';
 
+const kaotoResource = { getType: () => SourceSchemaType.Integration } as unknown as KaotoResource;
+
 const wrapper = ({ children }: PropsWithChildren) => (
-  <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>{children}</RuntimeProvider>
+  <KaotoResourceContext.Provider value={{ kaotoResource }}>
+    <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH} runtimeCatalogName="" testingCatalogName="">
+      {children}
+    </RuntimeProvider>
+  </KaotoResourceContext.Provider>
 );
 
 describe('useRuntimeContext', () => {

--- a/packages/ui/src/models/camel/camel-resource-factory.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.ts
@@ -27,7 +27,6 @@ export class CamelResourceFactory {
     const testResource = CitrusTestResourceFactory.getCitrusTestResource(parsedCode as Test, pathResourceType);
 
     if (testResource) {
-      testResource.initialize();
       return testResource;
     }
 
@@ -37,12 +36,10 @@ export class CamelResourceFactory {
     );
 
     if (resource) {
-      resource.initialize();
       return resource;
     }
 
     const camelRouteResource = new CamelRouteResource(parsedCode as CamelYamlDsl, serializer);
-    camelRouteResource.initialize();
     return camelRouteResource;
   }
 

--- a/packages/ui/src/models/kaoto-resource.test.ts
+++ b/packages/ui/src/models/kaoto-resource.test.ts
@@ -16,6 +16,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty CamelRouteResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource();
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
@@ -23,6 +24,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty CamelRouteResource if a camel.yaml path is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.yaml' });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
@@ -30,6 +32,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty CamelRouteResource if a camel.xml path is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.xml' });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
@@ -37,6 +40,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty IntegrationResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chat.integration.yaml' });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Integration);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
@@ -44,6 +48,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty KameletResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chuck-norris-source.kamelet.yaml' });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     const entities = resource.getEntities();
     expect(entities).toHaveLength(1);
@@ -55,6 +60,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, {
       path: 'webhook-binding.kamelet-binding.yaml',
     });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -62,6 +68,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create an empty PipeResource if no args is specified', () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'webhook.pipe.yaml' });
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -73,6 +80,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create a camel route', () => {
     const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
@@ -82,18 +90,21 @@ describe('CamelResourceFactory.createCamelResource', () => {
   // TODO
   it.skip('should create an Integration', () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(integrationJson));
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Integration);
     expect(resource.getVisualEntities().length).toEqual(2);
   });
 
   it('should create a Kamelet', () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(kameletJson));
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     expect(resource.getVisualEntities().length).toEqual(1);
   });
 
   it('should create a KameletBindingPipe', () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(kameletBindingJson));
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as PipeVisualEntity;
@@ -102,6 +113,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create a Pipe', () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(pipeJson));
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as PipeVisualEntity;
@@ -110,6 +122,7 @@ describe('CamelResourceFactory.createCamelResource', () => {
 
   it('should create a Citrus test resource', () => {
     const resource = CamelResourceFactory.createCamelResource(citrusTestYaml);
+    resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as CitrusTestVisualEntity;

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -17,6 +17,8 @@ describe('LocalStorageSettingsAdapter', () => {
     const adapter = new LocalStorageSettingsAdapter();
     const newSettings: SettingsModel = {
       catalogUrl: 'http://example.com',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
       colorScheme: ColorScheme.Auto,
@@ -48,6 +50,8 @@ describe('LocalStorageSettingsAdapter', () => {
     const adapter = new LocalStorageSettingsAdapter();
     const newSettings: SettingsModel = {
       catalogUrl: 'http://example.com',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       nodeLabel: NodeLabelType.Description,
       nodeToolbarTrigger: NodeToolbarTrigger.onSelection,
       colorScheme: ColorScheme.Auto,

--- a/packages/ui/src/models/settings/settings.model.ts
+++ b/packages/ui/src/models/settings/settings.model.ts
@@ -22,6 +22,8 @@ export const enum CanvasLayoutDirection {
 
 export interface ISettingsModel {
   catalogUrl: string;
+  runtimeCatalogName: string;
+  testingCatalogName: string;
   nodeLabel: NodeLabelType;
   nodeToolbarTrigger: NodeToolbarTrigger;
   colorScheme: ColorScheme;
@@ -39,6 +41,8 @@ export interface AbstractSettingsAdapter {
 
 export class SettingsModel implements ISettingsModel {
   catalogUrl: string = '';
+  runtimeCatalogName: string = '';
+  testingCatalogName: string = '';
   nodeLabel: NodeLabelType = NodeLabelType.Description;
   nodeToolbarTrigger: NodeToolbarTrigger = NodeToolbarTrigger.onHover;
   colorScheme: ColorScheme = ColorScheme.Auto;

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -15,13 +15,14 @@ export const isCamelRoute = (rawEntity: unknown): rawEntity is { route: RouteDef
     return false;
   }
 
-  const objectKeys = Object.keys(rawEntity!);
+  const objectKeys = Object.keys(rawEntity);
 
   return (
     objectKeys.length === 1 &&
-    'route' in rawEntity! &&
+    'route' in rawEntity &&
     typeof rawEntity.route === 'object' &&
-    'from' in rawEntity.route!
+    isDefined(rawEntity.route) &&
+    'from' in rawEntity.route
   );
 };
 
@@ -31,7 +32,7 @@ export const isCamelFrom = (rawEntity: unknown): rawEntity is { from: FromDefini
     return false;
   }
 
-  const objectKeys = Object.keys(rawEntity!);
+  const objectKeys = Object.keys(rawEntity);
   const isFromHolder = objectKeys.length === 1 && objectKeys[0] === 'from';
   const isValidUriField = typeof (rawEntity as { from: FromDefinition })?.from?.uri === 'string';
 

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react';
 import { FunctionComponent, useRef } from 'react';
 
+import { SourceCodeSync } from '../../providers/source-code-sync';
 import { useSourceCodeStore } from '../../store';
 import { EventNotifier } from '../../utils/event-notifier';
 import { SourceCodeBridgeProviderRef } from './editor-api';
@@ -119,6 +120,22 @@ describe('SourceCodeBridgeProvider', () => {
     });
 
     expect(setCodeAndNotifySpy).toHaveBeenCalledTimes(1);
+
+    setCodeAndNotifySpy.mockRestore();
+  });
+
+  it('does not call onNewEdit for the empty initial code emitted on mount', () => {
+    const mockOnNewEdit = jest.fn();
+
+    render(
+      <SourceCodeSync>
+        <SourceCodeBridgeProvider onNewEdit={mockOnNewEdit}>
+          <p>Mounting letter</p>
+        </SourceCodeBridgeProvider>
+      </SourceCodeSync>,
+    );
+
+    expect(mockOnNewEdit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/multiplying-architecture/Bridge/editor-api.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/editor-api.test.tsx
@@ -14,11 +14,21 @@ jest.mock('@patternfly/react-topology', () => ({
 }));
 
 describe('useEditorApi', () => {
+  const mockSetCodeAndNotify = jest.fn();
+  let originalSetCodeAndNotify: typeof mockSetCodeAndNotify;
+
   beforeEach(() => {
+    originalSetCodeAndNotify = useSourceCodeStore.getState().setCodeAndNotify as typeof mockSetCodeAndNotify;
     jest.clearAllMocks();
-    // Reset store state before each test
-    useSourceCodeStore.getState().setSourceCode('');
-    useSourceCodeStore.temporal.getState().clear();
+    act(() => {
+      useSourceCodeStore.setState({ setCodeAndNotify: mockSetCodeAndNotify });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useSourceCodeStore.setState({ setCodeAndNotify: originalSetCodeAndNotify });
+    });
   });
 
   it('should initialize editorApi and sourceCodeRef', () => {
@@ -29,7 +39,6 @@ describe('useEditorApi', () => {
   });
 
   it('should set content when setContent is called', async () => {
-    const setCodeAndNotifySpy = jest.spyOn(useSourceCodeStore.getState(), 'setCodeAndNotify');
     const { result } = renderHook(() => useEditorApi());
 
     const path = 'test-path';
@@ -39,12 +48,11 @@ describe('useEditorApi', () => {
       await result.current.editorApi.setContent(path, content);
     });
 
-    expect(setCodeAndNotifySpy).toHaveBeenCalledWith(content, path);
+    expect(mockSetCodeAndNotify).toHaveBeenCalledWith(content, path);
     expect(result.current.sourceCodeRef.current).toBe(content);
   });
 
   it('should not update content if the new content is the same as the current one', async () => {
-    const setCodeAndNotifySpy = jest.spyOn(useSourceCodeStore.getState(), 'setCodeAndNotify');
     const { result } = renderHook(() => useEditorApi());
 
     const path = 'test-path';
@@ -54,13 +62,13 @@ describe('useEditorApi', () => {
       await result.current.editorApi.setContent(path, content);
     });
 
-    expect(setCodeAndNotifySpy).toHaveBeenCalledTimes(1);
+    expect(mockSetCodeAndNotify).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await result.current.editorApi.setContent(path, content);
     });
 
-    expect(setCodeAndNotifySpy).toHaveBeenCalledTimes(1);
+    expect(mockSetCodeAndNotify).toHaveBeenCalledTimes(1);
   });
 
   it('should get content when getContent is called', async () => {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -15,7 +15,8 @@ import { RouterProvider } from 'react-router-dom';
 
 import { CatalogLoaderProvider } from '../dynamic-catalog/catalog.provider';
 import { CatalogKind, StepUpdateAction } from '../models';
-import { AbstractSettingsAdapter } from '../models/settings';
+import { AbstractSettingsAdapter, SettingsModel } from '../models/settings';
+import { KaotoResourceProvider } from '../providers';
 import { EntitiesProvider } from '../providers/entities.provider';
 import { ReloadProvider } from '../providers/reload.provider';
 import { RuntimeProvider } from '../providers/runtime.provider';
@@ -32,6 +33,7 @@ import { kaotoEditorRouter } from './KaotoEditorRouter';
 
 export class KaotoEditorApp implements Editor {
   protected editorRef: RefObject<SourceCodeBridgeProviderRef | null>;
+  protected settings: SettingsModel;
   af_isReact = true;
   af_componentId = 'kaoto-editor';
   af_componentTitle = 'Kaoto Editor';
@@ -42,6 +44,7 @@ export class KaotoEditorApp implements Editor {
     protected readonly settingsAdapter: AbstractSettingsAdapter,
   ) {
     this.editorRef = createRef<SourceCodeBridgeProviderRef>();
+    this.settings = this.settingsAdapter.getSettings();
     this.sendReady = this.sendReady.bind(this);
     this.sendNewEdit = this.sendNewEdit.bind(this);
     this.sendNotifications = this.sendNotifications.bind(this);
@@ -170,32 +173,38 @@ export class KaotoEditorApp implements Editor {
     return (
       <ReloadProvider>
         <SettingsProvider adapter={this.settingsAdapter}>
-          <SourceCodeSync initialSourceCode="">
+          <SourceCodeSync>
             <SourceCodeBridgeProvider ref={this.editorRef} onNewEdit={this.sendNewEdit}>
-              <RuntimeProvider catalogUrl={this.settingsAdapter.getSettings().catalogUrl}>
-                <CatalogLoaderProvider>
-                  <EntitiesProvider fileExtension={this.initArgs.fileExtension}>
-                    <KaotoBridge
-                      channelType={this.initArgs.channel}
-                      onReady={this.sendReady}
-                      setNotifications={this.sendNotifications}
-                      onStateControlCommandUpdate={this.sendStateControlCommand}
-                      getMetadata={this.getMetadata}
-                      setMetadata={this.setMetadata}
-                      getResourceContent={this.getResourceContent}
-                      saveResourceContent={this.saveResourceContent}
-                      isResourceExist={this.isResourceExist}
-                      deleteResource={this.deleteResource}
-                      askUserForFileSelection={this.askUserForFileSelection}
-                      getSuggestions={this.getSuggestions}
-                      shouldSaveSchema={false}
-                      onStepUpdated={this.onStepUpdated}
-                    >
-                      <RouterProvider router={kaotoEditorRouter} />
-                    </KaotoBridge>
-                  </EntitiesProvider>
-                </CatalogLoaderProvider>
-              </RuntimeProvider>
+              <KaotoResourceProvider fileExtension={this.initArgs.fileExtension}>
+                <RuntimeProvider
+                  catalogUrl={this.settings.catalogUrl}
+                  runtimeCatalogName={this.settings.runtimeCatalogName}
+                  testingCatalogName={this.settings.testingCatalogName}
+                >
+                  <CatalogLoaderProvider>
+                    <EntitiesProvider>
+                      <KaotoBridge
+                        channelType={this.initArgs.channel}
+                        onReady={this.sendReady}
+                        setNotifications={this.sendNotifications}
+                        onStateControlCommandUpdate={this.sendStateControlCommand}
+                        getMetadata={this.getMetadata}
+                        setMetadata={this.setMetadata}
+                        getResourceContent={this.getResourceContent}
+                        saveResourceContent={this.saveResourceContent}
+                        isResourceExist={this.isResourceExist}
+                        deleteResource={this.deleteResource}
+                        askUserForFileSelection={this.askUserForFileSelection}
+                        getSuggestions={this.getSuggestions}
+                        shouldSaveSchema={false}
+                        onStepUpdated={this.onStepUpdated}
+                      >
+                        <RouterProvider router={kaotoEditorRouter} />
+                      </KaotoBridge>
+                    </EntitiesProvider>
+                  </CatalogLoaderProvider>
+                </RuntimeProvider>
+              </KaotoResourceProvider>
             </SourceCodeBridgeProvider>
           </SourceCodeSync>
         </SettingsProvider>

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -15,6 +15,8 @@ describe('KaotoEditorFactory', () => {
   it('should create editor', async () => {
     const settingsModel: ISettingsModel = {
       catalogUrl: 'catalog-url',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       rest: {
         apicurioRegistryUrl: '',
         customMediaTypes: [],
@@ -46,6 +48,8 @@ describe('KaotoEditorFactory', () => {
   it('should get settings', async () => {
     const settingsModel: ISettingsModel = {
       catalogUrl: 'catalog-url',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       rest: {
         apicurioRegistryUrl: '',
         customMediaTypes: [],
@@ -102,6 +106,8 @@ describe('KaotoEditorFactory', () => {
   it('should update catalog URL', async () => {
     const settingsModel: ISettingsModel = {
       catalogUrl: '',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       rest: {
         apicurioRegistryUrl: '',
         customMediaTypes: [],
@@ -113,6 +119,8 @@ describe('KaotoEditorFactory', () => {
     };
     const expectedSettings: ISettingsModel = {
       catalogUrl: 'path-prefix/camel-catalog/index.json',
+      runtimeCatalogName: '',
+      testingCatalogName: '',
       rest: {
         apicurioRegistryUrl: '',
         customMediaTypes: [],

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
@@ -49,6 +49,7 @@ describe('RestDslEditorPage', () => {
    */
   const renderPage = (yamlContent: string) => {
     const camelResource = CamelResourceFactory.createCamelResource(yamlContent);
+    camelResource.initialize();
     const { Provider, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({
       camelResource,
     });

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -37,6 +37,7 @@ describe('RestTree', () => {
         to:
           uri: direct:deleteItem
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -66,6 +67,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -104,6 +106,7 @@ describe('RestTree', () => {
 - rest:
     id: rest-1234
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
 
@@ -126,6 +129,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest' };
@@ -157,6 +161,7 @@ describe('RestTree', () => {
         to:
           uri: direct:orders
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest.post.0' };
@@ -174,6 +179,7 @@ describe('RestTree', () => {
 - rest:
     id: rest-1234
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
 
@@ -193,6 +199,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const initialSelected = { entityId: 'rest-1234', modelPath: 'rest' };
@@ -222,6 +229,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -239,6 +247,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
+    camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
@@ -32,6 +32,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -57,6 +58,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -123,6 +125,7 @@ describe('RestTreeToolbar', () => {
 - restConfiguration:
     host: localhost
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -188,6 +191,7 @@ describe('RestTreeToolbar', () => {
     host: localhost
     port: "8080"
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
       const restConfigEntity = entities[0] as CamelRestConfigurationVisualEntity;
@@ -220,6 +224,7 @@ describe('RestTreeToolbar', () => {
         to:
           uri: direct:test
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -251,6 +256,7 @@ describe('RestTreeToolbar', () => {
         to:
           uri: direct:test
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -286,6 +292,7 @@ describe('RestTreeToolbar', () => {
     from:
       uri: direct:test
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -334,6 +341,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -360,6 +368,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -385,6 +394,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -412,6 +422,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -443,6 +454,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
+      camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 

--- a/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.test.ts
@@ -27,6 +27,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:createOrder
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -44,6 +45,7 @@ describe('getRestEntities', () => {
     host: localhost
     port: "8080"
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -72,6 +74,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:deleteItem
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -106,6 +109,7 @@ describe('getRestEntities', () => {
         - log:
             message: "tick"
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -158,6 +162,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:deleteUser
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -195,6 +200,7 @@ describe('getRestEntities', () => {
         - log:
             message: "tick"
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -229,6 +235,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:third
     `);
+    camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
@@ -48,6 +48,7 @@ describe('restToTree', () => {
     host: localhost
     port: "8080"
     `);
+    camelResource.initialize();
   });
 
   it('should convert rest to tree', () => {
@@ -119,6 +120,7 @@ describe('restToTree', () => {
         to:
           uri: direct:create
     `);
+    camelResource.initialize();
 
     const treeNodes = restToTree(getRestEntities(camelResource));
 

--- a/packages/ui/src/pages/SourceCode/SourceCodePage.tsx
+++ b/packages/ui/src/pages/SourceCode/SourceCodePage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useCallback } from 'react';
+import { FunctionComponent } from 'react';
 
 import { SourceCode } from '../../components/SourceCode';
 import { useSourceCodeStore } from '../../store';
@@ -7,13 +7,5 @@ export const SourceCodePage: FunctionComponent = () => {
   const sourceCode = useSourceCodeStore((state) => state.sourceCode);
   const setCodeAndNotify = useSourceCodeStore((state) => state.setCodeAndNotify);
 
-  const handleCodeChange = useCallback(
-    (code: string) => {
-      /** Update Entities and Visual Entities */
-      setCodeAndNotify(code);
-    },
-    [setCodeAndNotify],
-  );
-
-  return <SourceCode code={sourceCode} onCodeChange={handleCodeChange} />;
+  return <SourceCode code={sourceCode} onCodeChange={setCodeAndNotify} />;
 };

--- a/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
+++ b/packages/ui/src/providers/__snapshots__/settings.provider.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`SettingsProvider should render 1`] = `
 <p
   data-testid="settings"
 >
-  {"catalogUrl":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"canvasLayoutDirection":"SelectInCanvas"}
+  {"catalogUrl":"","runtimeCatalogName":"","testingCatalogName":"","nodeLabel":"description","nodeToolbarTrigger":"onHover","colorScheme":"auto","rest":{"apicurioRegistryUrl":"","customMediaTypes":[]},"canvasLayoutDirection":"SelectInCanvas"}
 </p>
 `;

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -10,7 +10,23 @@ import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
 import { camelRouteYaml_1_1_original, camelRouteYaml_1_1_updated } from '../stubs/camel-route-yaml-1.1';
 import { EventNotifier } from '../utils';
 import { EntitiesContext, EntitiesProvider } from './entities.provider';
+import { KaotoResourceProvider } from './kaoto-resource.provider';
 import { SourceCodeSync } from './source-code-sync';
+
+/**
+ * Compose the real provider chain. Source code enters through the single ingress
+ * (SourceCodeSync emits `code:updated` on mount), KaotoResourceProvider builds the
+ * resource, and EntitiesProvider derives the entities from it.
+ */
+const buildWrapper =
+  (initialSourceCode?: string, fileExtension?: string) =>
+  ({ children }: PropsWithChildren) => (
+    <SourceCodeSync initialSourceCode={initialSourceCode}>
+      <KaotoResourceProvider fileExtension={fileExtension}>
+        <EntitiesProvider>{children}</EntitiesProvider>
+      </KaotoResourceProvider>
+    </SourceCodeSync>
+  );
 
 describe('EntitiesProvider', () => {
   let eventNotifier: EventNotifier;
@@ -29,9 +45,7 @@ describe('EntitiesProvider', () => {
     'should initialize the camelResource using the `%s` serializer provided a `%s` file extension',
     (serializerType, fileExtension) => {
       const { result } = renderHook(() => useContext(EntitiesContext), {
-        wrapper: ({ children }: PropsWithChildren) => (
-          <EntitiesProvider fileExtension={fileExtension}>{children}</EntitiesProvider>
-        ),
+        wrapper: buildWrapper(undefined, fileExtension),
       });
 
       expect(result.current?.camelResource.getSerializerType()).toEqual(serializerType);
@@ -39,15 +53,9 @@ describe('EntitiesProvider', () => {
   );
 
   describe('Initialization', () => {
-    it('should use the sourceCode store to initialize the Camel Resource', () => {
-      useSourceCodeStore.getState().setSourceCode(camelRouteYaml);
-
+    it('should use the source code to initialize the Camel Resource', () => {
       const { result } = renderHook(() => useContext(EntitiesContext), {
-        wrapper: ({ children }: PropsWithChildren) => (
-          <SourceCodeSync initialSourceCode={camelRouteYaml}>
-            <EntitiesProvider>{children}</EntitiesProvider>
-          </SourceCodeSync>
-        ),
+        wrapper: buildWrapper(camelRouteYaml),
       });
 
       expect(result.current?.camelResource.toJSON()).toEqual(parse(camelRouteYaml));
@@ -55,7 +63,7 @@ describe('EntitiesProvider', () => {
 
     it('should create an empty Camel Resource if there is no Source Code available', () => {
       const { result } = renderHook(() => useContext(EntitiesContext), {
-        wrapper: EntitiesProvider,
+        wrapper: buildWrapper(),
       });
 
       expect(result.current?.camelResource.toJSON()).toEqual([]);
@@ -65,11 +73,7 @@ describe('EntitiesProvider', () => {
       useSourceCodeStore.getState().setSourceCode('A non camel source code');
 
       const { result } = renderHook(() => useContext(EntitiesContext), {
-        wrapper: ({ children }: PropsWithChildren) => (
-          <SourceCodeSync initialSourceCode="A non camel source code">
-            <EntitiesProvider>{children}</EntitiesProvider>
-          </SourceCodeSync>
-        ),
+        wrapper: buildWrapper('A non camel source code'),
       });
 
       expect(result.current?.camelResource.toJSON()).toEqual(['A non camel source code']);
@@ -79,27 +83,15 @@ describe('EntitiesProvider', () => {
       useSourceCodeStore.getState().setSourceCode('- from: {');
 
       const { result } = renderHook(() => useContext(EntitiesContext), {
-        wrapper: ({ children }: PropsWithChildren) => (
-          <SourceCodeSync initialSourceCode={'- from: {'}>
-            <EntitiesProvider>{children}</EntitiesProvider>
-          </SourceCodeSync>
-        ),
+        wrapper: buildWrapper('- from: {'),
       });
 
       expect(result.current?.camelResource.toJSON()).toEqual([]);
     });
   });
 
-  it('it should subscribe to the `code:updated` notification', () => {
-    const notifierSpy = jest.spyOn(eventNotifier, 'subscribe');
-
-    renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
-
-    expect(notifierSpy).toHaveBeenCalledWith('code:updated', expect.anything());
-  });
-
   it('updating the source code should NOT recreate the Camel Resource', () => {
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       const firstCamelResource = result.current?.camelResource;
@@ -111,7 +103,7 @@ describe('EntitiesProvider', () => {
   });
 
   it('should recreate the entities when the source code is updated', () => {
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       eventNotifier.next('code:updated', { code: camelRouteYaml });
@@ -123,7 +115,7 @@ describe('EntitiesProvider', () => {
 
   it('should serialize using YAML 1.1', () => {
     const notifierSpy = jest.spyOn(eventNotifier, 'next');
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       eventNotifier.next('code:updated', { code: camelRouteYaml_1_1_original });
@@ -141,7 +133,7 @@ describe('EntitiesProvider', () => {
     mockRandomValues();
 
     const notifierSpy = jest.spyOn(eventNotifier, 'next');
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       result.current?.camelResource.addNewEntity();
@@ -170,7 +162,7 @@ describe('EntitiesProvider', () => {
     let firstCamelResource: KaotoResource | undefined;
     let secondCamelResource: KaotoResource | undefined;
 
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       firstCamelResource = result.current?.camelResource;
@@ -187,7 +179,7 @@ describe('EntitiesProvider', () => {
   });
 
   it('should refresh entities', () => {
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       result.current?.camelResource.addNewEntity();
@@ -201,7 +193,7 @@ describe('EntitiesProvider', () => {
 
   it('should refresh entities and notify subscribers', () => {
     const notifierSpy = jest.spyOn(eventNotifier, 'next');
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       result.current?.updateEntitiesFromCamelResource();
@@ -233,7 +225,7 @@ describe('EntitiesProvider', () => {
             message: \${body}
 `;
 
-    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       eventNotifier.next('code:updated', { code });

--- a/packages/ui/src/providers/entities.provider.tsx
+++ b/packages/ui/src/providers/entities.provider.tsx
@@ -1,19 +1,10 @@
-import {
-  createContext,
-  FunctionComponent,
-  PropsWithChildren,
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, FunctionComponent, PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useKaotoResourceContext } from '../hooks/useKaotoResourceContext/useKaotoResourceContext';
 import { BaseVisualEntity } from '../models';
 import { SourceSchemaType } from '../models/camel';
-import { CamelResourceFactory } from '../models/camel/camel-resource-factory';
 import { BaseEntity } from '../models/entities';
 import { KaotoResource } from '../models/kaoto-resource';
-import { useSourceCodeStore } from '../store';
 import { EventNotifier } from '../utils';
 
 export interface EntitiesContextResult {
@@ -43,48 +34,30 @@ export interface EntitiesContextResult {
 
 export const EntitiesContext = createContext<EntitiesContextResult | null>(null);
 
-interface EntitiesProviderProps extends PropsWithChildren {
-  fileExtension?: string;
-}
-
-export const EntitiesProvider: FunctionComponent<EntitiesProviderProps> = ({ fileExtension, children }) => {
+export const EntitiesProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const eventNotifier = EventNotifier.getInstance();
-  const initialSourceCode = useSourceCodeStore.getState().sourceCode;
 
-  let initialCamelResource: KaotoResource;
-  try {
-    initialCamelResource = CamelResourceFactory.createCamelResource(initialSourceCode, { path: fileExtension });
-  } catch (error) {
-    initialCamelResource = CamelResourceFactory.createCamelResource('', { path: fileExtension });
-  }
+  const { kaotoResource } = useKaotoResourceContext();
+  const [entities, setEntities] = useState<BaseEntity[]>([]);
+  const [visualEntities, setVisualEntities] = useState<BaseVisualEntity[]>([]);
 
-  const [camelResource, setCamelResource] = useState<KaotoResource>(initialCamelResource);
-  const [entities, setEntities] = useState<BaseEntity[]>(camelResource.getEntities());
-  const [visualEntities, setVisualEntities] = useState<BaseVisualEntity[]>(camelResource.getVisualEntities());
+  useEffect(() => {
+    kaotoResource.initialize();
+    const entities = kaotoResource.getEntities();
+    const visualEntities = kaotoResource.getVisualEntities();
 
-  /**
-   * Subscribe to the `code:updated` event to recreate the CamelResource
-   */
-  useLayoutEffect(() => {
-    return eventNotifier.subscribe('code:updated', ({ code, path }) => {
-      const camelResource = CamelResourceFactory.createCamelResource(code, { path });
-      const entities = camelResource.getEntities();
-      const visualEntities = camelResource.getVisualEntities();
-
-      setCamelResource(camelResource);
-      setEntities(entities);
-      setVisualEntities(visualEntities);
-    });
-  }, [eventNotifier]);
+    setEntities(entities);
+    setVisualEntities(visualEntities);
+  }, [kaotoResource]);
 
   const updateSourceCodeFromEntities = useCallback(() => {
-    const code = camelResource.toString();
+    const code = kaotoResource.toString();
     eventNotifier.next('entities:updated', code);
-  }, [camelResource, eventNotifier]);
+  }, [kaotoResource, eventNotifier]);
 
   const updateEntitiesFromCamelResource = useCallback(() => {
-    const entities = camelResource.getEntities();
-    const visualEntities = camelResource.getVisualEntities();
+    const entities = kaotoResource.getEntities();
+    const visualEntities = kaotoResource.getVisualEntities();
     setEntities(entities);
     setVisualEntities(visualEntities);
 
@@ -92,18 +65,18 @@ export const EntitiesProvider: FunctionComponent<EntitiesProviderProps> = ({ fil
      * Notify consumers that entities has been refreshed, hence the code needs to be updated
      */
     updateSourceCodeFromEntities();
-  }, [camelResource, updateSourceCodeFromEntities]);
+  }, [kaotoResource, updateSourceCodeFromEntities]);
 
   const value = useMemo(
     () => ({
       entities,
       visualEntities,
-      currentSchemaType: camelResource?.getType(),
-      camelResource,
+      currentSchemaType: kaotoResource?.getType(),
+      camelResource: kaotoResource,
       updateEntitiesFromCamelResource,
       updateSourceCodeFromEntities,
     }),
-    [entities, visualEntities, camelResource, updateEntitiesFromCamelResource, updateSourceCodeFromEntities],
+    [entities, visualEntities, kaotoResource, updateEntitiesFromCamelResource, updateSourceCodeFromEntities],
   );
 
   return <EntitiesContext.Provider value={value}>{children}</EntitiesContext.Provider>;

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,5 +1,6 @@
 export * from './action-confirmation-modal.provider';
 export * from './entities.provider';
+export * from './kaoto-resource.provider';
 export * from './keyboard-shortcuts.provider';
 export * from './metadata.provider';
 export * from './reload.provider';

--- a/packages/ui/src/providers/kaoto-resource.provider.test.tsx
+++ b/packages/ui/src/providers/kaoto-resource.provider.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react';
+import { PropsWithChildren, useContext } from 'react';
+
+import { SourceSchemaType } from '../models/camel';
+import { CamelResourceFactory } from '../models/camel/camel-resource-factory';
+import { SerializerType } from '../models/kaoto-resource';
+import { CamelRouteVisualEntity } from '../models/visualization/flows';
+import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
+import { pipeYaml } from '../stubs/pipe';
+import { EventNotifier } from '../utils';
+import { EntitiesContext, EntitiesProvider } from './entities.provider';
+import { KaotoResourceContext, KaotoResourceProvider } from './kaoto-resource.provider';
+import { SourceCodeSync } from './source-code-sync';
+
+describe('KaotoResourceProvider', () => {
+  it('builds the resource and entities from the source code present at mount', () => {
+    const { result } = renderHook(() => useContext(EntitiesContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync initialSourceCode={camelRouteYaml}>
+          <KaotoResourceProvider>
+            <EntitiesProvider>{children}</EntitiesProvider>
+          </KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    expect(result.current?.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson)]);
+  });
+
+  it('subscribes to the code:updated notification', () => {
+    const subscribeSpy = jest.spyOn(EventNotifier.getInstance(), 'subscribe');
+
+    renderHook(() => useContext(KaotoResourceContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync>
+          <KaotoResourceProvider>{children}</KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    expect(subscribeSpy).toHaveBeenCalledWith('code:updated', expect.anything());
+
+    subscribeSpy.mockRestore();
+  });
+
+  it('falls back to fileExtension when the mount event carries no path', () => {
+    const { result } = renderHook(() => useContext(KaotoResourceContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync initialSourceCode={camelRouteYaml}>
+          <KaotoResourceProvider fileExtension=".xml">{children}</KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    // The mount emits code:updated with no path → handler must reconcile path ?? fileExtension
+    expect(result.current?.kaotoResource.getSerializerType()).toEqual(SerializerType.XML);
+  });
+
+  it('prefers an explicit path from the event over fileExtension', () => {
+    const { result } = renderHook(() => useContext(KaotoResourceContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync>
+          <KaotoResourceProvider fileExtension=".xml">{children}</KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    act(() => {
+      EventNotifier.getInstance().next('code:updated', { code: camelRouteYaml, path: 'route.yaml' });
+    });
+
+    // An explicit YAML path must win over the .xml fileExtension
+    expect(result.current?.kaotoResource.getSerializerType()).toEqual(SerializerType.YAML);
+  });
+
+  it('keeps a defined resource when the factory throws on malformed code', () => {
+    const real = CamelResourceFactory.createCamelResource.bind(CamelResourceFactory);
+    const createSpy = jest.spyOn(CamelResourceFactory, 'createCamelResource').mockImplementation((code, opts) => {
+      if (code === '- from: {') throw new Error('parse error');
+      return real(code, opts);
+    });
+
+    const { result } = renderHook(() => useContext(KaotoResourceContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync initialSourceCode="- from: {">
+          <KaotoResourceProvider>{children}</KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    // The mount emission makes the factory throw; the handler must swallow it and keep the
+    // (initial, empty) resource rather than crashing.
+    expect(result.current?.kaotoResource).toBeDefined();
+
+    createSpy.mockRestore();
+  });
+
+  it('keeps the last valid resource when a keystroke makes the source transiently invalid', () => {
+    const { result } = renderHook(() => useContext(EntitiesContext), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <SourceCodeSync initialSourceCode={pipeYaml}>
+          <KaotoResourceProvider>
+            <EntitiesProvider>{children}</EntitiesProvider>
+          </KaotoResourceProvider>
+        </SourceCodeSync>
+      ),
+    });
+
+    // Sanity: the valid Pipe is in place.
+    expect(result.current?.currentSchemaType).toBe(SourceSchemaType.Pipe);
+    const visualEntitiesBefore = result.current?.visualEntities;
+    expect(visualEntitiesBefore).toHaveLength(1);
+
+    // Simulate a keystroke that leaves the YAML momentarily unparseable.
+    act(() => {
+      EventNotifier.getInstance().next('code:updated', {
+        code: pipeYaml.replace('name: webhook-binding', 'name: {webhook-binding'),
+      });
+    });
+
+    // Regression: the schema type must NOT flip to Route, and the entities must be untouched,
+    // so the UI does not re-render/refresh on the invalid keystroke.
+    expect(result.current?.currentSchemaType).toBe(SourceSchemaType.Pipe);
+    expect(result.current?.visualEntities).toBe(visualEntitiesBefore);
+  });
+});

--- a/packages/ui/src/providers/kaoto-resource.provider.tsx
+++ b/packages/ui/src/providers/kaoto-resource.provider.tsx
@@ -1,0 +1,65 @@
+import { createContext, FunctionComponent, PropsWithChildren, useLayoutEffect, useMemo, useState } from 'react';
+
+import { CamelResourceFactory } from '../models/camel/camel-resource-factory';
+import { KaotoResource } from '../models/kaoto-resource';
+import { EventNotifier } from '../utils';
+
+export interface KaotoResourceContextResult {
+  kaotoResource: KaotoResource;
+}
+
+export const KaotoResourceContext = createContext<KaotoResourceContextResult | null>(null);
+
+interface KaotoResourceProviderProps extends PropsWithChildren {
+  fileExtension?: string;
+}
+
+export const KaotoResourceProvider: FunctionComponent<KaotoResourceProviderProps> = ({ fileExtension, children }) => {
+  const eventNotifier = EventNotifier.getInstance();
+
+  /**
+   * Start with an empty resource. The real source code arrives through the single
+   * `code:updated` ingress, emitted on mount by the SourceCodeSync. Using a lazy
+   * initializer avoids re-parsing the YAML on every render.
+   */
+  const [kaotoResource, setKaotoResource] = useState<KaotoResource>(() =>
+    CamelResourceFactory.createCamelResource('', { path: fileExtension }),
+  );
+
+  /**
+   * Subscribe to the `code:updated` event to (re)create the CamelResource.
+   * Reconcile the event's `path` with `fileExtension` so the correct serializer is
+   * chosen even when the initial emission carries no path.
+   *
+   * While editing, the source is transiently unparseable on many keystrokes. In that
+   * case we keep the last valid resource instead of substituting one: building an empty
+   * resource here would default to a Camel Route (no path is known mid-edit), flipping
+   * the schema type of Kamelets/Pipes to Route and forcing the UI to re-render on every
+   * invalid keystroke. Swallowing the error and not updating state mirrors the previous
+   * "thrown error aborts the update" behavior, so the resource stays put until the
+   * source parses again.
+   *
+   * Re-subscribes if `fileExtension` changes; in practice the editor remounts per file,
+   * so a `fileExtension` change without a following `code:updated` event does not occur.
+   */
+  useLayoutEffect(() => {
+    return eventNotifier.subscribe('code:updated', ({ code, path }) => {
+      const resolvedPath = path ?? fileExtension;
+
+      try {
+        setKaotoResource(CamelResourceFactory.createCamelResource(code, { path: resolvedPath }));
+      } catch {
+        // Transiently invalid source: keep the last valid resource untouched.
+      }
+    });
+  }, [eventNotifier, fileExtension]);
+
+  const value = useMemo(
+    () => ({
+      kaotoResource,
+    }),
+    [kaotoResource],
+  );
+
+  return <KaotoResourceContext.Provider value={value}>{children}</KaotoResourceContext.Provider>;
+};

--- a/packages/ui/src/providers/runtime.provider.test.tsx
+++ b/packages/ui/src/providers/runtime.provider.test.tsx
@@ -1,9 +1,44 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
 
+import { useRuntimeContext } from '../hooks/useRuntimeContext/useRuntimeContext';
+import { SourceSchemaType } from '../models/camel';
+import { KaotoResource } from '../models/kaoto-resource';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
+import { KaotoResourceContext } from './kaoto-resource.provider';
 import { ReloadContext } from './reload.provider';
 import { RuntimeProvider } from './runtime.provider';
+
+/**
+ * A small, deterministic catalog library so the catalog-selection assertions don't
+ * depend on whichever versions happen to ship in the real index.json. The newest
+ * entry per runtime is the implicit default (see `findCatalog`), so naming an older
+ * entry proves the settings-driven selection actually overrides the default.
+ */
+const CONTROLLED_LIBRARY: CatalogLibrary = {
+  name: 'test-library',
+  version: 1,
+  definitions: [
+    { name: 'Main Old', runtime: 'Main', version: '1.0.0', fileName: 'main-old.json' },
+    { name: 'Main New', runtime: 'Main', version: '2.0.0', fileName: 'main-new.json' },
+    { name: 'Citrus Old', runtime: 'Citrus', version: '1.0.0', fileName: 'citrus-old.json' },
+    { name: 'Citrus New', runtime: 'Citrus', version: '2.0.0', fileName: 'citrus-new.json' },
+  ],
+};
+
+/** Renders `ui` under a KaotoResourceContext whose resource reports the given schema type. */
+const renderInRuntime = (ui: ReactNode, schemaType: SourceSchemaType = SourceSchemaType.Integration) => {
+  const kaotoResource = { getType: () => schemaType } as unknown as KaotoResource;
+  return render(<KaotoResourceContext.Provider value={{ kaotoResource }}>{ui}</KaotoResourceContext.Provider>);
+};
+
+/** Surfaces the catalog the provider settled on so tests can assert against it. */
+const SelectedCatalogProbe = () => {
+  const { selectedCatalog } = useRuntimeContext();
+  return <span data-testid="selected-catalog">{selectedCatalog?.name ?? 'none'}</span>;
+};
 
 describe('RuntimeProvider', () => {
   let fetchMock: jest.SpyInstance;
@@ -33,8 +68,8 @@ describe('RuntimeProvider', () => {
 
   it('should start in loading mode', async () => {
     await act(async () => {
-      render(
-        <RuntimeProvider catalogUrl="">
+      renderInRuntime(
+        <RuntimeProvider catalogUrl="" runtimeCatalogName="" testingCatalogName="">
           <span data-testid="library-loaded">Loaded</span>
         </RuntimeProvider>,
       );
@@ -46,9 +81,9 @@ describe('RuntimeProvider', () => {
   it('should stay in Error mode when there is an error', async () => {
     jest.spyOn(console, 'error').mockImplementationOnce(() => {});
     await act(async () => {
-      render(
+      renderInRuntime(
         <ReloadContext.Provider value={{ reloadPage: jest.fn(), lastRender: 0 }}>
-          <RuntimeProvider catalogUrl="">
+          <RuntimeProvider catalogUrl="" runtimeCatalogName="" testingCatalogName="">
             <span data-testid="library-loaded">Loaded</span>
           </RuntimeProvider>
         </ReloadContext.Provider>,
@@ -64,8 +99,12 @@ describe('RuntimeProvider', () => {
 
   it('should fetch the index.json catalog file', async () => {
     await act(async () => {
-      render(
-        <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+      renderInRuntime(
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
           <span data-testid="library-loaded">Loaded</span>
         </RuntimeProvider>,
       );
@@ -80,8 +119,12 @@ describe('RuntimeProvider', () => {
 
   it('should render children when the index.json file is loaded', async () => {
     await act(async () => {
-      render(
-        <RuntimeProvider catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}>
+      renderInRuntime(
+        <RuntimeProvider
+          catalogUrl={CatalogSchemaLoader.DEFAULT_CATALOG_PATH}
+          runtimeCatalogName=""
+          testingCatalogName=""
+        >
           <span data-testid="library-loaded">Loaded</span>
         </RuntimeProvider>,
       );
@@ -92,5 +135,48 @@ describe('RuntimeProvider', () => {
     });
 
     expect(screen.getByTestId('library-loaded')).toBeInTheDocument();
+  });
+
+  describe('catalog selection from settings', () => {
+    beforeEach(() => {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue({ json: () => CONTROLLED_LIBRARY } as unknown as Response);
+    });
+
+    it('selects the catalog named by runtimeCatalogName for non-test sources', async () => {
+      renderInRuntime(
+        <RuntimeProvider catalogUrl="/index.json" runtimeCatalogName="Main Old" testingCatalogName="Citrus New">
+          <SelectedCatalogProbe />
+        </RuntimeProvider>,
+        SourceSchemaType.Integration,
+      );
+
+      // 'Main New' is the newest Main and would be the default; the setting overrides it.
+      expect(await screen.findByTestId('selected-catalog')).toHaveTextContent('Main Old');
+    });
+
+    it('selects the catalog named by testingCatalogName for test sources', async () => {
+      renderInRuntime(
+        <RuntimeProvider catalogUrl="/index.json" runtimeCatalogName="Main New" testingCatalogName="Citrus Old">
+          <SelectedCatalogProbe />
+        </RuntimeProvider>,
+        SourceSchemaType.Test,
+      );
+
+      // Test sources read testingCatalogName, not runtimeCatalogName.
+      expect(await screen.findByTestId('selected-catalog')).toHaveTextContent('Citrus Old');
+    });
+
+    it('falls back to the default catalog when the configured name is not found', async () => {
+      renderInRuntime(
+        <RuntimeProvider catalogUrl="/index.json" runtimeCatalogName="Does Not Exist" testingCatalogName="">
+          <SelectedCatalogProbe />
+        </RuntimeProvider>,
+        SourceSchemaType.Integration,
+      );
+
+      // No match -> findCatalog default -> newest Main.
+      expect(await screen.findByTestId('selected-catalog')).toHaveTextContent('Main New');
+    });
   });
 });

--- a/packages/ui/src/providers/runtime.provider.tsx
+++ b/packages/ui/src/providers/runtime.provider.tsx
@@ -1,14 +1,14 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { Content, ContentVariants } from '@patternfly/react-core';
-import { createContext, FunctionComponent, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, FunctionComponent, PropsWithChildren, useEffect, useMemo, useState } from 'react';
 
 import { LoadDefaultCatalog } from '../components/LoadDefaultCatalog';
 import { Loading } from '../components/Loading';
-import { LoadingStatus, LocalStorageKeys } from '../models';
+import { useKaotoResourceContext } from '../hooks/useKaotoResourceContext/useKaotoResourceContext';
+import { LoadingStatus } from '../models';
 import { SourceSchemaType } from '../models/camel';
 import { findCatalog } from '../utils/catalog-helper';
-import { EntitiesContext } from './entities.provider';
 
 export interface IRuntimeContext {
   basePath: string;
@@ -19,38 +19,42 @@ export interface IRuntimeContext {
 
 export const RuntimeContext = createContext<IRuntimeContext | undefined>(undefined);
 
+interface IRuntimeProvider {
+  catalogUrl: string;
+  runtimeCatalogName: string;
+  testingCatalogName: string;
+}
+
 /**
  * Loader for the available Catalog library.
  */
-export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: string }>> = (props) => {
+export const RuntimeProvider: FunctionComponent<PropsWithChildren<IRuntimeProvider>> = ({
+  catalogUrl,
+  runtimeCatalogName,
+  testingCatalogName,
+  children,
+}) => {
   const [loadingStatus, setLoadingStatus] = useState(LoadingStatus.Loading);
   const [errorMessage, setErrorMessage] = useState('');
   const [catalogLibrary, setCatalogLibrary] = useState<CatalogLibrary | undefined>(undefined);
-  const entitiesContext = useContext(EntitiesContext);
-  const currentSchemaType = entitiesContext?.currentSchemaType || SourceSchemaType.Route;
-  let localSelectedCatalog: CatalogLibraryEntry | undefined = undefined;
+  const [selectedCatalog, setSelectedCatalog] = useState<CatalogLibraryEntry | undefined>();
 
-  try {
-    localSelectedCatalog = JSON.parse(localStorage.getItem(LocalStorageKeys.SelectedCatalog) ?? 'undefined');
-  } catch (error) {
-    localSelectedCatalog = undefined;
-  }
+  const { kaotoResource } = useKaotoResourceContext();
+  const currentSchemaType = kaotoResource.getType();
+  const catalogName = currentSchemaType === SourceSchemaType.Test ? testingCatalogName : runtimeCatalogName;
 
-  const [selectedCatalog, setSelectedCatalog] = useState<CatalogLibraryEntry | undefined>(localSelectedCatalog);
-  const basePath = props.catalogUrl.substring(0, props.catalogUrl.lastIndexOf('/'));
+  const basePath = catalogUrl.substring(0, catalogUrl.lastIndexOf('/'));
 
   useEffect(() => {
-    fetch(props.catalogUrl)
+    fetch(catalogUrl)
       .then((response) => {
         setLoadingStatus(LoadingStatus.Loading);
         return response.json();
       })
       .then((catalogLibrary: CatalogLibrary) => {
         let catalogLibraryEntry: CatalogLibraryEntry | undefined = undefined;
-        if (isDefined(selectedCatalog)) {
-          catalogLibraryEntry = catalogLibrary.definitions.find(
-            (c: CatalogLibraryEntry) => c.name === selectedCatalog.name,
-          );
+        if (isDefined(catalogName)) {
+          catalogLibraryEntry = catalogLibrary.definitions.find((c: CatalogLibraryEntry) => c.name === catalogName);
         }
         if (!isDefined(catalogLibraryEntry)) {
           catalogLibraryEntry = findCatalog(currentSchemaType, catalogLibrary);
@@ -99,7 +103,7 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<{ catalogUrl: 
         </LoadDefaultCatalog>
       )}
 
-      {loadingStatus === LoadingStatus.Loaded && props.children}
+      {loadingStatus === LoadingStatus.Loaded && children}
     </RuntimeContext.Provider>
   );
 };

--- a/packages/ui/src/services/documentation.service.test.tsx
+++ b/packages/ui/src/services/documentation.service.test.tsx
@@ -1,11 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
 import JSZip from 'jszip';
-import { useContext } from 'react';
+import { PropsWithChildren, useContext } from 'react';
 
 import { PipeVisualEntity } from '../models';
 import { CamelRouteResource } from '../models/camel';
 import { KaotoResource } from '../models/kaoto-resource';
 import { EntitiesContext, EntitiesProvider } from '../providers/entities.provider';
+import { KaotoResourceProvider } from '../providers/kaoto-resource.provider';
 import { camelRouteYaml, kameletYaml, mockRandomValues, pipeYaml } from '../stubs';
 import { beansYaml } from '../stubs/beans';
 import { kameletAwsCloudtailSourceYaml } from '../stubs/kamelet-aws-cloudtail-source';
@@ -23,8 +24,16 @@ describe('DocumentationService', () => {
     eventNotifier = EventNotifier.getInstance();
   });
 
+  // EntitiesProvider now derives its resource from KaotoResourceContext, which also owns the
+  // `code:updated` subscription that recreates the resource — so both providers are needed here.
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <KaotoResourceProvider>
+      <EntitiesProvider>{children}</EntitiesProvider>
+    </KaotoResourceProvider>
+  );
+
   const createDocumentationEntitiesFromYaml = (yaml: string) => {
-    const { result: entitiesContext } = renderHook(() => useContext(EntitiesContext), { wrapper: EntitiesProvider });
+    const { result: entitiesContext } = renderHook(() => useContext(EntitiesContext), { wrapper });
 
     act(() => {
       eventNotifier.next('code:updated', { code: yaml });

--- a/packages/ui/src/services/parsers/beans-parser.test.ts
+++ b/packages/ui/src/services/parsers/beans-parser.test.ts
@@ -6,7 +6,9 @@ import { BeansParser } from './beans-parser';
 describe('BeansParser', () => {
   describe('parseBeansEntity()', () => {
     it('should parse BeansEntity', () => {
-      const beansEntity = CamelResourceFactory.createCamelResource(beansYaml).getEntities()[0] as BeansEntity;
+      const resource = CamelResourceFactory.createCamelResource(beansYaml);
+      resource.initialize();
+      const beansEntity = resource.getEntities()[0] as BeansEntity;
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
       expect(parsedTable.title).toEqual('Beans');
       expect(parsedTable.data.length).toEqual(3);
@@ -24,7 +26,9 @@ describe('BeansParser', () => {
     });
 
     it('should parse BeansEntity without properties', () => {
-      const beansEntity = CamelResourceFactory.createCamelResource(beansYaml).getEntities()[0] as BeansEntity;
+      const resource = CamelResourceFactory.createCamelResource(beansYaml);
+      resource.initialize();
+      const beansEntity = resource.getEntities()[0] as BeansEntity;
       beansEntity.parent.beans.forEach((bean) => (bean.properties = {}));
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
       expect(parsedTable.title).toEqual('Beans');
@@ -42,7 +46,9 @@ describe('BeansParser', () => {
     });
 
     it('should parse BeanEntity with parameters', () => {
-      const beansEntity = CamelResourceFactory.createCamelResource(beansWithParamsYaml).getEntities()[0] as BeansEntity;
+      const resource = CamelResourceFactory.createCamelResource(beansWithParamsYaml);
+      resource.initialize();
+      const beansEntity = resource.getEntities()[0] as BeansEntity;
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
       expect(parsedTable.data.length).toEqual(7);
       expect(parsedTable.data[0][0]).toEqual('test');

--- a/packages/ui/src/services/parsers/common-parser.test.ts
+++ b/packages/ui/src/services/parsers/common-parser.test.ts
@@ -5,9 +5,9 @@ import { datamapperRouteDefinitionStub } from '../../stubs/datamapper/data-mappe
 import { CommonParser } from './common-parser';
 
 describe('CommonParser', () => {
-  const camelRouteEntity = CamelResourceFactory.createCamelResource(
-    camelRouteYaml,
-  ).getVisualEntities()[0] as CamelRouteVisualEntity;
+  const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
+  resource.initialize();
+  const camelRouteEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
 
   describe('parseFrom()', () => {
     it('should parse from', () => {

--- a/packages/ui/src/services/parsers/pipe-parser.test.ts
+++ b/packages/ui/src/services/parsers/pipe-parser.test.ts
@@ -9,7 +9,9 @@ import { PipeParser } from './pipe-parser';
 describe('PipeParser', () => {
   describe('parsePipeEntity()', () => {
     it('should parse pipe', () => {
-      const pipeEntity = CamelResourceFactory.createCamelResource(pipeYaml).getVisualEntities()[0] as PipeVisualEntity;
+      const resource = CamelResourceFactory.createCamelResource(pipeYaml);
+      resource.initialize();
+      const pipeEntity = resource.getVisualEntities()[0] as PipeVisualEntity;
       const parsed = PipeParser.parsePipeEntity(pipeEntity);
 
       expect(parsed.title).toEqual('Steps');
@@ -28,9 +30,9 @@ describe('PipeParser', () => {
     });
 
     it('should parse pipe with properties', () => {
-      const pipeEntity = CamelResourceFactory.createCamelResource(
-        pipeTimerSourceYaml,
-      ).getVisualEntities()[0] as PipeVisualEntity;
+      const resource = CamelResourceFactory.createCamelResource(pipeTimerSourceYaml);
+      resource.initialize();
+      const pipeEntity = resource.getVisualEntities()[0] as PipeVisualEntity;
       const parsed = PipeParser.parsePipeEntity(pipeEntity);
 
       expect(parsed.data[3][0]).toEqual('');
@@ -42,9 +44,9 @@ describe('PipeParser', () => {
 
   describe('parseKameletBindingEntity()', () => {
     it('should parse kamelet binding', () => {
-      const kbEntity = CamelResourceFactory.createCamelResource(
-        kameletBindingYaml,
-      ).getVisualEntities()[0] as KameletBindingVisualEntity;
+      const resource = CamelResourceFactory.createCamelResource(kameletBindingYaml);
+      resource.initialize();
+      const kbEntity = resource.getVisualEntities()[0] as KameletBindingVisualEntity;
       const parsed = PipeParser.parseKameletBindingEntity(kbEntity);
 
       expect(parsed.title).toEqual('Steps');
@@ -65,7 +67,9 @@ describe('PipeParser', () => {
 
   describe('parsePipeErrorHandlerEntity()', () => {
     it('should parse pipe error handler', () => {
-      const pehEntity = CamelResourceFactory.createCamelResource(pipeYaml)
+      const resource = CamelResourceFactory.createCamelResource(pipeYaml);
+      resource.initialize();
+      const pehEntity = resource
         .getEntities()
         .find((e) => e instanceof PipeErrorHandlerEntity) as PipeErrorHandlerEntity;
       const parsed = PipeParser.parsePipeErrorHandlerEntity(pehEntity, 'Pipe Error Handler') as ParsedTable;

--- a/packages/ui/src/services/parsers/rest-parser.test.ts
+++ b/packages/ui/src/services/parsers/rest-parser.test.ts
@@ -15,6 +15,7 @@ describe('RestParser', () => {
   describe('parseRestEntity()', () => {
     it('should parse rest', () => {
       const camelResource = CamelResourceFactory.createCamelResource(restOperationsYaml);
+      camelResource.initialize();
       const restEntity = camelResource
         .getEntities()
         .find((e) => e instanceof CamelRestVisualEntity) as CamelRestVisualEntity;

--- a/packages/ui/src/services/parsers/route-parser.test.ts
+++ b/packages/ui/src/services/parsers/route-parser.test.ts
@@ -28,9 +28,9 @@ describe('RouteParser', () => {
 
   describe('parseRouteEntity()', () => {
     it('should parse route', () => {
-      const routeEntity = CamelResourceFactory.createCamelResource(
-        camelRouteYaml,
-      ).getVisualEntities()[0] as CamelRouteVisualEntity;
+      const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
+      resource.initialize();
+      const routeEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
       const parsed = RouteParser.parseRouteEntity(routeEntity);
 
       expect(parsed.title).toEqual('route-8888');
@@ -51,9 +51,9 @@ describe('RouteParser', () => {
     });
   });
 
-  const rcEntity = CamelResourceFactory.createCamelResource(
-    routeConfigurationFullYaml,
-  ).getVisualEntities()[0] as CamelRouteConfigurationVisualEntity;
+  const rcResource = CamelResourceFactory.createCamelResource(routeConfigurationFullYaml);
+  rcResource.initialize();
+  const rcEntity = rcResource.getVisualEntities()[0] as CamelRouteConfigurationVisualEntity;
 
   describe('parseRouteConfigurationEntity()', () => {
     it('should parse route configuration', () => {

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -4,7 +4,13 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { KaotoResource } from '../models/kaoto-resource';
 import { VisualFlowsApi } from '../models/visualization/flows/support/flows-visibility';
-import { EntitiesContext, EntitiesContextResult, VisibleFlowsContext, VisibleFlowsContextResult } from '../providers';
+import {
+  EntitiesContext,
+  EntitiesContextResult,
+  KaotoResourceProvider,
+  VisibleFlowsContext,
+  VisibleFlowsContextResult,
+} from '../providers';
 import { camelRouteJson } from './camel-route';
 
 interface TestProviderWrapperProps extends PropsWithChildren {
@@ -36,23 +42,25 @@ export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): Test
   };
 
   const Provider: FunctionComponent<PropsWithChildren> = (props) => (
-    <EntitiesContext.Provider
-      key={Date.now()}
-      value={
-        {
-          camelResource,
-          entities: camelResource.getEntities(),
-          visualEntities: camelResource.getVisualEntities(),
-          currentSchemaType,
-          updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
-          updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
-        } as unknown as EntitiesContextResult
-      }
-    >
-      <VisibleFlowsContext.Provider value={visibleFlowsContext}>
-        <SuggestionRegistryProvider>{props.children}</SuggestionRegistryProvider>
-      </VisibleFlowsContext.Provider>
-    </EntitiesContext.Provider>
+    <KaotoResourceProvider>
+      <EntitiesContext.Provider
+        key={Date.now()}
+        value={
+          {
+            camelResource,
+            entities: camelResource.getEntities(),
+            visualEntities: camelResource.getVisualEntities(),
+            currentSchemaType,
+            updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
+            updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
+          } as unknown as EntitiesContextResult
+        }
+      >
+        <VisibleFlowsContext.Provider value={visibleFlowsContext}>
+          <SuggestionRegistryProvider>{props.children}</SuggestionRegistryProvider>
+        </VisibleFlowsContext.Provider>
+      </EntitiesContext.Provider>
+    </KaotoResourceProvider>
   );
 
   return { Provider, camelResource, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy };


### PR DESCRIPTION

### Note
This is part 2 of a 3 part PR series
1. https://github.com/KaotoIO/kaoto/pull/3290
2. https://github.com/KaotoIO/kaoto/pull/3282 (This PR)
3. https://github.com/KaotoIO/kaoto/pull/3289

fix: https://github.com/KaotoIO/kaoto/issues/3230
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now include configurable runtime and testing catalog names.

* **Refactor**
  * Provider architecture reorganized to introduce a shared resource context and improved provider composition.
  * Catalog selection now respects runtime vs. testing catalog configuration based on source type.

* **Tests**
  * Test suites updated and expanded to validate the new resource provider, catalog selection, and consistent resource initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->