### PR TITLE
feat(RestDslEditor): add property search filter

### DIFF
--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.scss
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.scss
@@ -22,4 +22,8 @@
 
 .rest-right-panel {
   height: 100%;
+
+  .filter-fields {
+    margin-bottom: $spacing-05;
+  }
 }

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -2,7 +2,7 @@ import './RestDslEditorPage.scss';
 
 import { CodeSnippet } from '@carbon/react';
 import { Rest } from '@kaoto/camel-catalog/types';
-import { CanvasFormTabsProvider, getCamelRandomId, KaotoForm } from '@kaoto/forms';
+import { CanvasFormTabsProvider, FilteredFieldProvider, getCamelRandomId, KaotoForm } from '@kaoto/forms';
 import { FunctionComponent, Suspense, useCallback, useMemo, useState } from 'react';
 
 import { Loading } from '../../components/Loading';
@@ -12,6 +12,7 @@ import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext'
 import { EntityType } from '../../models/entities';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
 import { getRestEntities } from './components/get-rest-entities';
+import { RestDslFormHeader } from './components/RestDslFormHeader';
 import { restFormFieldFactory } from './components/restFormFieldFactory';
 import { IRestTreeSelection, RestTree } from './components/RestTree';
 import { RestTreeToolbar, RestTreeToolbarProps } from './components/RestTreeToolbar';
@@ -155,15 +156,18 @@ export const RestDslEditorPage: FunctionComponent = () => {
               ) : (
                 <Suspense fallback={<Loading>Loading form...</Loading>}>
                   <CanvasFormTabsProvider tab="All">
-                    <SuggestionRegistrar>
-                      <KaotoForm
-                        key={`${selectedElement.entityId}__${selectedElement.modelPath}`}
-                        schema={schema}
-                        onChangeProp={handleOnChangeIndividualProp}
-                        model={model}
-                        customFieldsFactory={restFormFieldFactory}
-                      />
-                    </SuggestionRegistrar>
+                    <FilteredFieldProvider key={`${selectedElement.entityId}__${selectedElement.modelPath}`}>
+                      <RestDslFormHeader />
+                      <SuggestionRegistrar>
+                        <KaotoForm
+                          key={`${selectedElement.entityId}__${selectedElement.modelPath}`}
+                          schema={schema}
+                          onChangeProp={handleOnChangeIndividualProp}
+                          model={model}
+                          customFieldsFactory={restFormFieldFactory}
+                        />
+                      </SuggestionRegistrar>
+                    </FilteredFieldProvider>
                   </CanvasFormTabsProvider>
                 </Suspense>
               )}

--- a/packages/ui/src/pages/RestDslEditor/components/RestDslFormHeader.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestDslFormHeader.test.tsx
@@ -1,0 +1,84 @@
+import { FilteredFieldContext } from '@kaoto/forms';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { RestDslFormHeader } from './RestDslFormHeader';
+
+describe('RestDslFormHeader', () => {
+  it('should render the search input', () => {
+    const mockFilteredFieldContext = {
+      filteredFieldText: '',
+      onFilterChange: jest.fn(),
+      isGroupExpanded: false,
+    };
+
+    render(
+      <FilteredFieldContext.Provider value={mockFilteredFieldContext}>
+        <RestDslFormHeader />
+      </FilteredFieldContext.Provider>,
+    );
+
+    const searchInput = screen.getByTestId('filter-fields');
+    expect(searchInput).toBeInTheDocument();
+  });
+
+  it('should display the filtered text from context', () => {
+    const mockFilteredFieldContext = {
+      filteredFieldText: 'test search',
+      onFilterChange: jest.fn(),
+      isGroupExpanded: false,
+    };
+
+    render(
+      <FilteredFieldContext.Provider value={mockFilteredFieldContext}>
+        <RestDslFormHeader />
+      </FilteredFieldContext.Provider>,
+    );
+
+    const searchInput = screen.getByLabelText('Search input') as HTMLInputElement;
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput.value).toBe('test search');
+  });
+
+  it('should call onFilterChange when input changes', async () => {
+    const user = userEvent.setup();
+    const mockOnFilterChange = jest.fn();
+    const mockFilteredFieldContext = {
+      filteredFieldText: '',
+      onFilterChange: mockOnFilterChange,
+      isGroupExpanded: false,
+    };
+
+    render(
+      <FilteredFieldContext.Provider value={mockFilteredFieldContext}>
+        <RestDslFormHeader />
+      </FilteredFieldContext.Provider>,
+    );
+
+    const searchInput = screen.getByLabelText('Search input');
+    await user.type(searchInput, 'test');
+
+    expect(mockOnFilterChange).toHaveBeenCalled();
+  });
+
+  it('should call onFilterChange when reset button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnFilterChange = jest.fn();
+    const mockFilteredFieldContext = {
+      filteredFieldText: 'test search',
+      onFilterChange: mockOnFilterChange,
+      isGroupExpanded: false,
+    };
+
+    render(
+      <FilteredFieldContext.Provider value={mockFilteredFieldContext}>
+        <RestDslFormHeader />
+      </FilteredFieldContext.Provider>,
+    );
+
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    await user.click(resetButton);
+
+    expect(mockOnFilterChange).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/pages/RestDslEditor/components/RestDslFormHeader.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestDslFormHeader.tsx
@@ -1,0 +1,18 @@
+import { FilteredFieldContext } from '@kaoto/forms';
+import { SearchInput } from '@patternfly/react-core';
+import { FunctionComponent, useContext } from 'react';
+
+export const RestDslFormHeader: FunctionComponent = () => {
+  const { filteredFieldText, onFilterChange } = useContext(FilteredFieldContext);
+
+  return (
+    <SearchInput
+      className="filter-fields"
+      placeholder="Find properties by name"
+      data-testid="filter-fields"
+      value={filteredFieldText}
+      onChange={onFilterChange}
+      onClear={onFilterChange}
+    />
+  );
+};


### PR DESCRIPTION
## Description
Adds a search filter to the REST DSL Editor to allow users to quickly find properties by name.

## Changes
- Add RestDslFormHeader component with search input for filtering REST DSL properties
- Integrate FilteredFieldContext from @kaoto/forms package without modifications
- Add comprehensive tests with proper user interaction testing using userEvent
- Update RestDslEditorPage to include search header in the form panel
- Add styling with Carbon design tokens

## Testing
- All tests pass (4/4)
- 100% coverage of the new component
- Follows existing test patterns in the repository

Fixes #3114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filter/search header to the REST DSL Editor so users can find properties by name; includes clear/reset.

* **Tests**
  * Added tests covering the new filtering header and its interactions.

* **Style**
  * Minor spacing adjustment to the editor layout for the filter area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->