### PR TITLE
chore(DataMapper): Hide `Add Variable` and `Wrap with for-each-group`…

### DIFF
--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -791,7 +791,8 @@ describe('MappingActionService', () => {
         expect(addMappingNode.title).toEqual('Item');
         expect(addMappingNode.id).toContain('add-mapping-fx-Item');
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEach);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEachGroup);
+        // TODO enable when https://github.com/KaotoIO/kaoto/issues/2866 is implemented
+        // expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEachGroup);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.If);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.Choose);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ContextMenu);
@@ -888,7 +889,8 @@ describe('MappingActionService', () => {
     });
 
     describe('Variable action availability', () => {
-      it('should include Variable for container FieldItemNodeData and TargetFieldNodeData', () => {
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      it.skip('should include Variable for container FieldItemNodeData and TargetFieldNodeData', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
@@ -920,7 +922,8 @@ describe('MappingActionService', () => {
         expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Variable);
       });
 
-      it('should include Variable for ForEachItem and IfItem MappingNodeData', () => {
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      it.skip('should include Variable for ForEachItem and IfItem MappingNodeData', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
@@ -961,7 +964,8 @@ describe('MappingActionService', () => {
     });
 
     describe('RenameVariable action availability', () => {
-      it('should include RenameVariable only for VariableNodeData', () => {
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      it.skip('should include RenameVariable only for VariableNodeData', () => {
         const variable = new VariableItem(tree, 'testVar');
         tree.children.push(variable);
         const variableNode = new VariableNodeData(targetDocNode, variable);
@@ -1112,7 +1116,8 @@ describe('MappingActionService', () => {
     });
 
     describe('Variable and RenameVariable action apply callbacks', () => {
-      it('Variable apply should call setAddingVariableTo with node path', () => {
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      it.skip('Variable apply should call setAddingVariableTo with node path', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderNode = targetDocChildren[0] as FieldItemNodeData;
         const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderNode);
@@ -1126,7 +1131,8 @@ describe('MappingActionService', () => {
         useDocumentTreeStore.getState().setAddingVariableTo(null);
       });
 
-      it('RenameVariable apply should call setRenamingVariable with variable id', () => {
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      it.skip('RenameVariable apply should call setRenamingVariable with variable id', () => {
         const variable = new VariableItem(tree, 'testVar');
         tree.children.push(variable);
         const variableNode = new VariableNodeData(targetDocNode, variable);

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -28,7 +28,7 @@ import {
   VariableNodeData,
 } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
-import { DocumentService } from '../document/document.service';
+// import { DocumentService } from '../document/document.service';
 import { MappingService } from '../mapping/mapping.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
@@ -413,9 +413,11 @@ export class MappingActionService {
         MappingActionService.applyForEachGroup(n as TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData);
         onUpdate();
       },
-      isAllowed: (n) =>
-        n instanceof AddMappingNodeData ||
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2866 is implemented
+      // isAllowed: (n) =>
+      //   n instanceof AddMappingNodeData ||
+      //   (MappingActionService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
+      isAllowed: () => false,
     },
     {
       key: MappingActionKind.If,
@@ -448,15 +450,17 @@ export class MappingActionService {
       apply: (n) => {
         useDocumentTreeStore.getState().setAddingVariableTo(n.path.toString());
       },
-      isAllowed: (n) => {
-        if (n instanceof VariableNodeData) return false;
-        if (n instanceof TargetDocumentNodeData) return false;
-        if (MappingActionService.isFieldNode(n)) return DocumentService.hasChildren(n.field);
-        return (
-          MappingActionService.isMappingNode(n) &&
-          !MappingActionService.mappingIsOneOf(ValueSelector, ChooseItem, UnknownMappingItem)(n)
-        );
-      },
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      // isAllowed: (n) => {
+      //   if (n instanceof VariableNodeData) return false;
+      //   if (n instanceof TargetDocumentNodeData) return false;
+      //   if (MappingActionService.isFieldNode(n)) return DocumentService.hasChildren(n.field);
+      //   return (
+      //     MappingActionService.isMappingNode(n) &&
+      //     !MappingActionService.mappingIsOneOf(ValueSelector, ChooseItem, UnknownMappingItem)(n)
+      //   );
+      // },
+      isAllowed: () => false,
     },
     {
       key: MappingActionKind.RenameVariable,
@@ -467,7 +471,9 @@ export class MappingActionService {
           useDocumentTreeStore.getState().setRenamingVariable(n.mapping.id);
         }
       },
-      isAllowed: (n) => n instanceof VariableNodeData,
+      // TODO enable when https://github.com/KaotoIO/kaoto/issues/2846 is implemented
+      // isAllowed: (n) => n instanceof VariableNodeData,
+      isAllowed: () => false,
     },
   ];
 


### PR DESCRIPTION
… until implementation completes

These features are still work in progress. Hide them until the work completes up to:
* https://github.com/KaotoIO/kaoto/issues/2846
* https://github.com/KaotoIO/kaoto/issues/2866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled for-each-group, variable, and rename-variable mapping actions pending further review.
  * Updated corresponding test cases with skip flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->