### PR TITLE
tests(resources): Standardize test providers

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -1,6 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
-import { CanvasFormTabsContext, SuggestionRegistryProvider } from '@kaoto/forms';
+import { CanvasFormTabsContext } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
@@ -13,7 +13,6 @@ import {
   IKameletDefinition,
 } from '../../../../models';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { VisibleFlowsProvider } from '../../../../providers';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { TestProvidersWrapper } from '../../../../stubs';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
@@ -66,20 +65,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const setHeaderNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={setHeaderNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={setHeaderNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -89,14 +88,16 @@ describe('CanvasFormBody', () => {
       await formPageObject.selectTypeaheadItem('simple');
       await formPageObject.inputText('Expression', '${header.foo}');
 
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
-      expect((camelRoute.from.steps[0].setHeader! as any).simple.expression).toEqual('${header.foo}');
+      expect((camelRoute.from.steps[0].setHeader!.simple as { expression: string }).expression).toEqual(
+        '${header.foo}',
+      );
       expect(camelRoute.from.steps[0].setHeader!.name).toEqual('foo');
 
       await formPageObject.inputText('Name', 'bar');
 
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
-      expect((camelRoute.from.steps[0].setHeader! as any).simple.expression).toEqual('${header.foo}');
+      expect((camelRoute.from.steps[0].setHeader!.simple as { expression: string }).expression).toEqual(
+        '${header.foo}',
+      );
       expect(camelRoute.from.steps[0].setHeader!.name).toEqual('bar');
     });
 
@@ -120,20 +121,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const setHeaderNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={setHeaderNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={setHeaderNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -148,8 +149,9 @@ describe('CanvasFormBody', () => {
       await formPageObject.selectTypeaheadItem('simple');
       await formPageObject.inputText('Expression', '${header.foo}');
 
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
-      expect((camelRoute.from.steps[0].setHeader! as any).simple.expression).toEqual('${header.foo}');
+      expect((camelRoute.from.steps[0].setHeader!.simple as { expression: string }).expression).toEqual(
+        '${header.foo}',
+      );
       expect(camelRoute.from.steps[0].setHeader!.name).toEqual('bar');
     });
   });
@@ -179,20 +181,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const marshalNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={marshalNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={marshalNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -203,7 +205,7 @@ describe('CanvasFormBody', () => {
 
       await formPageObject.inputText('Id', 'avro-id', { index: 1 });
 
-      expect((camelRoute.from.steps[0].marshal!.avro as any).id).toEqual('avro-id');
+      expect((camelRoute.from.steps[0].marshal!.avro as { id: string }).id).toEqual('avro-id');
       expect(camelRoute.from.steps[0].marshal!.id).toEqual('ms');
 
       await formPageObject.inputText('Id', 'modified', { index: 0 });
@@ -230,20 +232,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const marshalNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={marshalNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={marshalNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -256,7 +258,7 @@ describe('CanvasFormBody', () => {
       await formPageObject.selectTypeaheadItem('avro');
       await formPageObject.inputText('Id', 'avro-id', { index: 1 });
 
-      expect((camelRoute.from.steps[0].marshal!.avro as any).id).toEqual('avro-id');
+      expect((camelRoute.from.steps[0].marshal!.avro as { id: string }).id).toEqual('avro-id');
       expect(camelRoute.from.steps[0].marshal!.id).toEqual('modified');
     });
   });
@@ -286,20 +288,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const loadBalanceNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={loadBalanceNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={loadBalanceNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -309,11 +311,15 @@ describe('CanvasFormBody', () => {
       await formPageObject.selectTypeaheadItem('weighted load balancer');
 
       await formPageObject.inputText('Distribution Ratio', '3.5');
-      expect((camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as any).distributionRatio).toEqual('3.5');
+      expect(
+        (camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as { distributionRatio: string }).distributionRatio,
+      ).toEqual('3.5');
       expect(camelRoute.from.steps[0].loadBalance!.id).toEqual('lb');
 
       await formPageObject.inputText('Id', 'modified', { index: 0 });
-      expect((camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as any).distributionRatio).toEqual('3.5');
+      expect(
+        (camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as { distributionRatio: string }).distributionRatio,
+      ).toEqual('3.5');
       expect(camelRoute.from.steps[0].loadBalance!.id).toEqual('modified');
     });
 
@@ -337,20 +343,20 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const loadBalanceNode = rootNode.getChildren()![1];
 
+      const { Provider } = TestProvidersWrapper();
+
       render(
         <EntitiesContext.Provider value={null}>
-          <VisibleFlowsProvider>
-            <SuggestionRegistryProvider>
-              <CanvasFormTabsContext.Provider
-                value={{
-                  selectedTab: 'All',
-                  setSelectedTab: jest.fn(),
-                }}
-              >
-                <CanvasFormBody vizNode={loadBalanceNode} />
-              </CanvasFormTabsContext.Provider>
-            </SuggestionRegistryProvider>
-          </VisibleFlowsProvider>
+          <Provider>
+            <CanvasFormTabsContext.Provider
+              value={{
+                selectedTab: 'All',
+                setSelectedTab: jest.fn(),
+              }}
+            >
+              <CanvasFormBody vizNode={loadBalanceNode} />
+            </CanvasFormTabsContext.Provider>
+          </Provider>
         </EntitiesContext.Provider>,
       );
 
@@ -363,7 +369,9 @@ describe('CanvasFormBody', () => {
       await formPageObject.selectTypeaheadItem('weighted load balancer');
 
       await formPageObject.inputText('Distribution Ratio', '3.5');
-      expect((camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as any).distributionRatio).toEqual('3.5');
+      expect(
+        (camelRoute.from.steps[0].loadBalance!.weightedLoadBalancer as { distributionRatio: string }).distributionRatio,
+      ).toEqual('3.5');
       expect(camelRoute.from.steps[0].loadBalance!.id).toEqual('modified');
     });
   });

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
@@ -1,12 +1,8 @@
 import { useVisualizationController } from '@patternfly/react-topology';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { toBlob } from 'html-to-image';
-import { PropsWithChildren } from 'react';
 
-import { EntitiesProvider } from '../../../../providers/entities.provider';
-import { KaotoResourceProvider } from '../../../../providers/kaoto-resource.provider';
-import { SourceCodeSync } from '../../../../providers/source-code-sync';
-import { VisibleFlowsProvider } from '../../../../providers/visible-flows.provider';
+import { TestProvidersWrapper } from '../../../../stubs';
 import { FlowExportImage } from './FlowExportImage';
 
 jest.mock('html-to-image', () => ({
@@ -44,16 +40,6 @@ interface MockGraph {
   getLayout: jest.Mock<string, []>;
   getGraph: () => MockGraph;
 }
-
-const wrapper = ({ children }: PropsWithChildren) => (
-  <SourceCodeSync>
-    <KaotoResourceProvider>
-      <EntitiesProvider>
-        <VisibleFlowsProvider>{children}</VisibleFlowsProvider>
-      </EntitiesProvider>
-    </KaotoResourceProvider>
-  </SourceCodeSync>
-);
 
 describe('FlowExportImage', () => {
   let mockSurface: HTMLElement;
@@ -98,12 +84,22 @@ describe('FlowExportImage', () => {
   });
 
   it('renders the export button', () => {
-    render(<FlowExportImage />, { wrapper });
+    const { Provider } = TestProvidersWrapper();
+    render(
+      <Provider>
+        <FlowExportImage />
+      </Provider>,
+    );
     expect(screen.getByTestId('exportImageButton')).toBeInTheDocument();
   });
 
   it('runs full export flow', async () => {
-    render(<FlowExportImage />, { wrapper });
+    const { Provider } = TestProvidersWrapper();
+    render(
+      <Provider>
+        <FlowExportImage />
+      </Provider>,
+    );
 
     const button = screen.getByTestId('exportImageButton');
     fireEvent.click(button);
@@ -130,7 +126,12 @@ describe('FlowExportImage', () => {
       return realQuerySelector(selector ?? '');
     }) as unknown as typeof document.querySelector;
 
-    render(<FlowExportImage />, { wrapper });
+    const { Provider } = TestProvidersWrapper();
+    render(
+      <Provider>
+        <FlowExportImage />
+      </Provider>,
+    );
 
     fireEvent.click(screen.getByTestId('exportImageButton'));
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -8,23 +8,14 @@ import { CamelRouteResource } from '../../../../models/camel/camel-route-resourc
 import { EntityType } from '../../../../models/entities';
 import { AddStepMode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
 import { IMetadataApi, MetadataContext } from '../../../../providers/metadata.provider';
+import { TestProvidersWrapper } from '../../../../stubs';
 import { useAddStep } from './add-step.hook';
 
 describe('useAddStep', () => {
-  const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const getCompatibleComponentsSpy = jest.spyOn(camelResource, 'getCompatibleComponents');
-
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: jest.fn(),
-    updateEntitiesFromCamelResource: jest.fn(),
-  };
+  let camelResource: CamelRouteResource;
+  let getCompatibleComponentsSpy: jest.SpyInstance;
+  let updateEntitiesFromCamelResourceSpy: jest.Mock;
 
   const mockCatalogModalContext = {
     setIsModalOpen: jest.fn(),
@@ -53,17 +44,28 @@ describe('useAddStep', () => {
 
   const mockCompatibleComponents = (item: ITile) => ['log', 'to'].includes(item.type);
 
+  let wrapper: FunctionComponent<PropsWithChildren>;
+
+  beforeEach(() => {
+    camelResource = new CamelRouteResource();
+    camelResource.initialize();
+    getCompatibleComponentsSpy = jest.spyOn(camelResource, 'getCompatibleComponents');
+
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({ camelResource });
+    updateEntitiesFromCamelResourceSpy = updateSpy;
+
+    wrapper = ({ children }) => (
+      <Provider>
+        <CatalogModalContext.Provider value={mockCatalogModalContext}>
+          <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
+        </CatalogModalContext.Provider>
+      </Provider>
+    );
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-    <EntitiesContext.Provider value={mockEntitiesContext}>
-      <CatalogModalContext.Provider value={mockCatalogModalContext}>
-        <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
-      </CatalogModalContext.Provider>
-    </EntitiesContext.Provider>
-  );
 
   it('should return onAddStep function', () => {
     const vizNode = createVisualizationNode('test', {
@@ -120,13 +122,18 @@ describe('useAddStep', () => {
       title: '',
       description: '',
     });
-    const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <EntitiesContext.Provider value={null}>
-        <CatalogModalContext.Provider value={mockCatalogModalContext}>
-          <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
-        </CatalogModalContext.Provider>
-      </EntitiesContext.Provider>
-    );
+
+    // Create a wrapper that provides null entities context
+    const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
+      return (
+        <Provider>
+          <CatalogModalContext.Provider value={mockCatalogModalContext}>
+            <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
+          </CatalogModalContext.Provider>
+        </Provider>
+      );
+    };
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), {
       wrapper: nullEntitiesWrapper,
@@ -159,7 +166,7 @@ describe('useAddStep', () => {
     expect(getCompatibleComponentsSpy).toHaveBeenCalledWith(AddStepMode.AppendStep, vizNode.data);
     expect(mockCatalogModalContext.getNewComponent).toHaveBeenCalledWith(mockCompatibleComponents);
     expect(addBaseEntityStepSpy).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.AppendStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).toHaveBeenCalledWith(
       StepUpdateAction.Add,
       mockDefinedComponent.type,
@@ -210,7 +217,7 @@ describe('useAddStep', () => {
     expect(getCompatibleComponentsSpy).toHaveBeenCalledWith(AddStepMode.AppendStep, vizNode.data);
     expect(mockCatalogModalContext.getNewComponent).toHaveBeenCalledWith(mockCompatibleComponents);
     expect(addBaseEntityStepSpy).not.toHaveBeenCalled();
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).not.toHaveBeenCalled();
   });
 
@@ -233,7 +240,7 @@ describe('useAddStep', () => {
     await result.current.onAddStep();
 
     expect(addBaseEntityStepSpy).not.toHaveBeenCalled();
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).not.toHaveBeenCalled();
   });
 
@@ -251,12 +258,13 @@ describe('useAddStep', () => {
     getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
+    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = TestProvidersWrapper({ camelResource });
     const noMetadataWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <EntitiesContext.Provider value={mockEntitiesContext}>
+      <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>
           <MetadataContext.Provider value={undefined}>{children}</MetadataContext.Provider>
         </CatalogModalContext.Provider>
-      </EntitiesContext.Provider>
+      </Provider>
     );
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), {
@@ -266,6 +274,6 @@ describe('useAddStep', () => {
     await result.current.onAddStep();
 
     expect(addBaseEntityStepSpy).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.AppendStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(localUpdateSpy).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
@@ -14,8 +14,8 @@ import {
   ActionConfirmationModalContext,
   MetadataContext,
 } from '../../../../providers';
-import { EntitiesContext } from '../../../../providers/entities.provider';
 import { IMetadataApi } from '../../../../providers/metadata.provider';
+import { TestProvidersWrapper } from '../../../../stubs';
 import {
   IInteractionType,
   INodeInteractionAddonContext,
@@ -33,18 +33,9 @@ jest.mock('../ContextMenu/item-interaction-helper', () => ({
 }));
 
 describe('useReplaceStep', () => {
-  const camelResource = new CamelRouteResource();
-  camelResource.initialize();
+  let camelResource: CamelRouteResource;
   let mockVizNode: IVisualizationNode;
-
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: jest.fn(),
-    updateEntitiesFromCamelResource: jest.fn(),
-  };
+  let updateEntitiesFromCamelResourceSpy: jest.Mock;
 
   const mockCatalogModalContext = {
     setIsModalOpen: jest.fn(),
@@ -82,7 +73,11 @@ describe('useReplaceStep', () => {
 
   const mockCompatibleComponents = (item: ITile) => ['log', 'to'].includes(item.type);
 
+  let wrapper: FunctionComponent<PropsWithChildren>;
+
   beforeEach(() => {
+    camelResource = new CamelRouteResource();
+    camelResource.initialize();
     mockVizNode = createVisualizationNode('test-step', {
       name: EntityType.Route,
       isPlaceholder: false,
@@ -96,25 +91,28 @@ describe('useReplaceStep', () => {
     jest.spyOn(camelResource, 'getCompatibleComponents').mockReturnValue(mockCompatibleComponents);
     (findOnDeleteModalCustomizationRecursively as jest.Mock).mockReturnValue([]);
     (processOnDeleteAddonRecursively as jest.Mock).mockImplementation(() => {});
+
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({ camelResource });
+    updateEntitiesFromCamelResourceSpy = updateSpy;
+
+    wrapper = ({ children }) => (
+      <Provider>
+        <CatalogModalContext.Provider value={mockCatalogModalContext}>
+          <MetadataContext.Provider value={mockMetadataContext}>
+            <ActionConfirmationModalContext.Provider value={mockActionConfirmationModalContext}>
+              <NodeInteractionAddonContext.Provider value={mockNodeInteractionAddonContext}>
+                {children}
+              </NodeInteractionAddonContext.Provider>
+            </ActionConfirmationModalContext.Provider>
+          </MetadataContext.Provider>
+        </CatalogModalContext.Provider>
+      </Provider>
+    );
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-    <EntitiesContext.Provider value={mockEntitiesContext}>
-      <CatalogModalContext.Provider value={mockCatalogModalContext}>
-        <MetadataContext.Provider value={mockMetadataContext}>
-          <ActionConfirmationModalContext.Provider value={mockActionConfirmationModalContext}>
-            <NodeInteractionAddonContext.Provider value={mockNodeInteractionAddonContext}>
-              {children}
-            </NodeInteractionAddonContext.Provider>
-          </ActionConfirmationModalContext.Provider>
-        </MetadataContext.Provider>
-      </CatalogModalContext.Provider>
-    </EntitiesContext.Provider>
-  );
 
   it('should return onReplaceNode function', () => {
     const { result } = renderHook(() => useReplaceStep(mockVizNode), { wrapper });
@@ -133,8 +131,9 @@ describe('useReplaceStep', () => {
   });
 
   it('should return early when entitiesContext is null', async () => {
+    const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
     const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <EntitiesContext.Provider value={null}>
+      <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>
           <MetadataContext.Provider value={mockMetadataContext}>
             <ActionConfirmationModalContext.Provider value={mockActionConfirmationModalContext}>
@@ -144,7 +143,7 @@ describe('useReplaceStep', () => {
             </ActionConfirmationModalContext.Provider>
           </MetadataContext.Provider>
         </CatalogModalContext.Provider>
-      </EntitiesContext.Provider>
+      </Provider>
     );
 
     const { result } = renderHook(() => useReplaceStep(mockVizNode), { wrapper: nullEntitiesWrapper });
@@ -167,7 +166,7 @@ describe('useReplaceStep', () => {
     expect(camelResource.getCompatibleComponents).toHaveBeenCalledWith(AddStepMode.ReplaceStep, mockVizNode.data);
     expect(mockCatalogModalContext.getNewComponent).toHaveBeenCalledWith(mockCompatibleComponents);
     expect(mockVizNode.addBaseEntityStep).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.ReplaceStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).toHaveBeenCalledWith(
       StepUpdateAction.Replace,
       mockDefinedComponent.type,
@@ -193,7 +192,7 @@ describe('useReplaceStep', () => {
 
     expect(mockActionConfirmationModalContext.actionConfirmation).not.toHaveBeenCalled();
     expect(mockVizNode.addBaseEntityStep).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.ReplaceStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
   });
 
   it('should show confirmation modal when step has non-placeholder children', async () => {
@@ -220,7 +219,7 @@ describe('useReplaceStep', () => {
       buttonOptions: undefined,
     });
     expect(mockVizNode.addBaseEntityStep).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.ReplaceStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
   });
 
   it('should not replace step when modal is cancelled', async () => {
@@ -276,7 +275,7 @@ describe('useReplaceStep', () => {
     expect(camelResource.getCompatibleComponents).toHaveBeenCalledWith(AddStepMode.ReplaceStep, mockVizNode.data);
     expect(mockCatalogModalContext.getNewComponent).toHaveBeenCalledWith(mockCompatibleComponents);
     expect(mockVizNode.addBaseEntityStep).not.toHaveBeenCalled();
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).not.toHaveBeenCalled();
   });
 
@@ -288,7 +287,7 @@ describe('useReplaceStep', () => {
     await result.current.onReplaceNode();
 
     expect(mockVizNode.addBaseEntityStep).not.toHaveBeenCalled();
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
     expect(mockMetadataContext.onStepUpdated).not.toHaveBeenCalled();
   });
 
@@ -352,8 +351,9 @@ describe('useReplaceStep', () => {
   it('should handle missing metadata context gracefully', async () => {
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
+    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = TestProvidersWrapper({ camelResource });
     const noMetadataWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <EntitiesContext.Provider value={mockEntitiesContext}>
+      <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>
           <MetadataContext.Provider value={undefined}>
             <ActionConfirmationModalContext.Provider value={mockActionConfirmationModalContext}>
@@ -363,7 +363,7 @@ describe('useReplaceStep', () => {
             </ActionConfirmationModalContext.Provider>
           </MetadataContext.Provider>
         </CatalogModalContext.Provider>
-      </EntitiesContext.Provider>
+      </Provider>
     );
 
     const { result } = renderHook(() => useReplaceStep(mockVizNode), { wrapper: noMetadataWrapper });
@@ -371,6 +371,6 @@ describe('useReplaceStep', () => {
     await result.current.onReplaceNode();
 
     expect(mockVizNode.addBaseEntityStep).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.ReplaceStep);
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(localUpdateSpy).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -4,13 +4,13 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { SourceSchemaType } from '../models/camel/source-schema-type';
 import { IClipboardCopyObject } from '../models/visualization/clipboard';
+import { VisualFlowsApi } from '../models/visualization/flows/support/flows-visibility';
 import {
   ACTION_ID_CANCEL,
   ACTION_ID_CONFIRM,
   ActionConfirmationModalContext,
 } from '../providers/action-confirmation-modal.provider';
-import { EntitiesContext } from '../providers/entities.provider';
-import { VisibleFlowsContext, VisibleFlowsContextResult } from '../providers/visible-flows.provider';
+import { TestProvidersWrapper } from '../stubs';
 import { ClipboardManager } from '../utils/ClipboardManager';
 import { usePasteEntity } from './usePasteEntity';
 
@@ -22,36 +22,12 @@ Object.assign(navigator, {
 });
 
 describe('usePasteEntity', () => {
-  const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
-  const removeEntitySpy = jest.spyOn(camelResource, 'removeEntity');
-  jest.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
-  const supportsMultipleVisualEntitiesSpy = jest
-    .spyOn(camelResource, 'supportsMultipleVisualEntities')
-    .mockReturnValue(true);
-
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: jest.fn(),
-    updateEntitiesFromCamelResource: jest.fn(),
-  };
-
-  const mockVisibleFlowsContext = {
-    visibleFlows: {},
-    allFlowsVisible: true,
-    visualFlowsApi: {
-      toggleFlowVisible: jest.fn(),
-      showFlows: jest.fn(),
-      hideFlows: jest.fn(),
-      clearFlows: jest.fn(),
-      initVisibleFlows: jest.fn(),
-      renameFlow: jest.fn(),
-    } as unknown as VisibleFlowsContextResult['visualFlowsApi'],
-  };
+  let camelResource: CamelRouteResource;
+  let addNewEntitySpy: jest.SpyInstance;
+  let removeEntitySpy: jest.SpyInstance;
+  let supportsMultipleVisualEntitiesSpy: jest.SpyInstance;
+  let updateEntitiesFromCamelResourceSpy: jest.Mock;
+  let toggleFlowVisibleSpy: jest.SpyInstance;
 
   const mockActionConfirmationContext = {
     actionConfirmation: jest.fn(),
@@ -63,19 +39,41 @@ describe('usePasteEntity', () => {
     definition: { id: 'test-route', from: { uri: 'timer:tick' } },
   };
 
+  beforeEach(() => {
+    camelResource = new CamelRouteResource();
+    camelResource.initialize();
+    addNewEntitySpy = jest.spyOn(camelResource, 'addNewEntity');
+    removeEntitySpy = jest.spyOn(camelResource, 'removeEntity');
+    jest.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
+    supportsMultipleVisualEntitiesSpy = jest
+      .spyOn(camelResource, 'supportsMultipleVisualEntities')
+      .mockReturnValue(true);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-    <EntitiesContext.Provider value={mockEntitiesContext}>
-      <VisibleFlowsContext.Provider value={mockVisibleFlowsContext}>
+  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
+    const visualFlowsApi = new VisualFlowsApi(jest.fn());
+    toggleFlowVisibleSpy = jest.spyOn(visualFlowsApi, 'toggleFlowVisible');
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({
+      camelResource,
+      visibleFlowsContext: {
+        allFlowsVisible: true,
+        visibleFlows: {},
+        visualFlowsApi,
+      },
+    });
+    updateEntitiesFromCamelResourceSpy = updateSpy;
+    return (
+      <Provider>
         <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
           {children}
         </ActionConfirmationModalContext.Provider>
-      </VisibleFlowsContext.Provider>
-    </EntitiesContext.Provider>
-  );
+      </Provider>
+    );
+  };
 
   it('should return isCompatible false when clipboard is empty', async () => {
     jest.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
@@ -189,8 +187,8 @@ describe('usePasteEntity', () => {
     });
 
     expect(addNewEntitySpy).toHaveBeenCalled();
-    expect(mockVisibleFlowsContext.visualFlowsApi.toggleFlowVisible).toHaveBeenCalledWith('new-route-id');
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(toggleFlowVisibleSpy).toHaveBeenCalledWith('new-route-id');
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
   });
 
   describe('single-entity resources', () => {
@@ -268,18 +266,21 @@ describe('usePasteEntity', () => {
       expect(mockActionConfirmationContext.actionConfirmation).not.toHaveBeenCalled();
       expect(removeEntitySpy).not.toHaveBeenCalled();
       expect(addNewEntitySpy).toHaveBeenCalled();
-      expect(mockVisibleFlowsContext.visualFlowsApi.toggleFlowVisible).toHaveBeenCalledWith('new-route-id');
+      expect(toggleFlowVisibleSpy).toHaveBeenCalledWith('new-route-id');
     });
   });
 
   it('should handle null entitiesContext gracefully', async () => {
-    const wrapperWithoutEntities: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <VisibleFlowsContext.Provider value={mockVisibleFlowsContext}>
-        <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
-          {children}
-        </ActionConfirmationModalContext.Provider>
-      </VisibleFlowsContext.Provider>
-    );
+    const wrapperWithoutEntities: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
+      return (
+        <Provider>
+          <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
+            {children}
+          </ActionConfirmationModalContext.Provider>
+        </Provider>
+      );
+    };
 
     jest.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
     jest.spyOn(ClipboardManager, 'paste').mockResolvedValue(copiedRouteContent);
@@ -298,11 +299,10 @@ describe('usePasteEntity', () => {
   });
 
   describe('should handle null actionConfirmationContext', () => {
-    const wrapperWithoutActionConfirmation: FunctionComponent<PropsWithChildren> = ({ children }) => (
-      <EntitiesContext.Provider value={mockEntitiesContext}>
-        <VisibleFlowsContext.Provider value={mockVisibleFlowsContext}>{children}</VisibleFlowsContext.Provider>
-      </EntitiesContext.Provider>
-    );
+    const wrapperWithoutActionConfirmation: FunctionComponent<PropsWithChildren> = ({ children }) => {
+      const { Provider } = TestProvidersWrapper({ camelResource });
+      return <Provider>{children}</Provider>;
+    };
 
     it('when clipboard is empty', async () => {
       jest.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
@@ -380,7 +380,7 @@ describe('usePasteEntity', () => {
     });
 
     expect(addNewEntitySpy).toHaveBeenCalled();
-    expect(mockVisibleFlowsContext.visualFlowsApi.toggleFlowVisible).not.toHaveBeenCalled();
-    expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
+    expect(toggleFlowVisibleSpy).not.toHaveBeenCalled();
+    expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -40,8 +40,8 @@ describe('RestRouteEndpointField', () => {
       { route: { from: { uri: 'direct:orders', steps: [] } } },
       { route: { from: { uri: 'direct:billing', steps: [] } } },
     ]);
-    const { Provider } = TestProvidersWrapper({ camelResource });
     camelResource.initialize();
+    const { Provider } = TestProvidersWrapper({ camelResource });
 
     await act(async () => {
       render(

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -16,13 +16,14 @@ import { camelRouteJson } from './camel-route';
 interface TestProviderWrapperProps extends PropsWithChildren {
   camelResource?: KaotoResource;
   visibleFlowsContext?: VisibleFlowsContextResult;
+  entitiesContextValue?: EntitiesContextResult | null;
 }
 
 interface TestProvidersWrapperResult {
   Provider: FunctionComponent<PropsWithChildren>;
   camelResource: KaotoResource;
-  updateEntitiesFromCamelResourceSpy: EntitiesContextResult['updateEntitiesFromCamelResource'];
-  updateSourceCodeFromEntitiesSpy: EntitiesContextResult['updateSourceCodeFromEntities'];
+  updateEntitiesFromCamelResourceSpy: jest.Mock;
+  updateSourceCodeFromEntitiesSpy: jest.Mock;
 }
 
 export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): TestProvidersWrapperResult => {
@@ -41,21 +42,22 @@ export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): Test
     visualFlowsApi: props.visibleFlowsContext?.visualFlowsApi ?? new VisualFlowsApi(dispatchSpy),
   };
 
+  const entitiesContextValue: EntitiesContextResult | null =
+    props.entitiesContextValue === undefined
+      ? {
+          camelResource,
+          entities: camelResource.getEntities(),
+          visualEntities: camelResource.getVisualEntities(),
+          currentSchemaType,
+          updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
+          updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
+        }
+      : props.entitiesContextValue;
+
+  const entitiesContextKey = Date.now();
   const Provider: FunctionComponent<PropsWithChildren> = (props) => (
     <KaotoResourceProvider>
-      <EntitiesContext.Provider
-        key={Date.now()}
-        value={
-          {
-            camelResource,
-            entities: camelResource.getEntities(),
-            visualEntities: camelResource.getVisualEntities(),
-            currentSchemaType,
-            updateEntitiesFromCamelResource: updateEntitiesFromCamelResourceSpy,
-            updateSourceCodeFromEntities: updateSourceCodeFromEntitiesSpy,
-          } as unknown as EntitiesContextResult
-        }
-      >
+      <EntitiesContext.Provider key={entitiesContextKey} value={entitiesContextValue}>
         <VisibleFlowsContext.Provider value={visibleFlowsContext}>
           <SuggestionRegistryProvider>{props.children}</SuggestionRegistryProvider>
         </VisibleFlowsContext.Provider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated test provider setup to use a shared test wrapper with optional injection of an entities context and exposed spies.
  * Updated many tests to consume the shared wrapper instead of composing providers manually.
  * Adjusted assertions to rely on the new spies and more specific value checks.
  * No production/public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->