### PR TITLE
fix(DataMapper): Show inner choice members in nested choice context menu (#3184)

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -373,6 +373,180 @@ describe('useChoiceContextMenu', () => {
     expect(setSpy).toHaveBeenCalledWith(expect.any(Object), choiceField, 1, expect.any(Object));
     setSpy.mockRestore();
   });
-});
 
-// Made with Bob
+  describe('nested choice wrapper', () => {
+    const createNestedChoiceFieldNode = (selectInner = false) => {
+      const document = TestUtil.createSourceOrderDoc();
+      const parentField = document.fields[0];
+      const outerChoiceField = {
+        name: 'outerChoice',
+        displayName: 'Outer Choice',
+        type: Types.Container,
+        wrapperKind: 'choice' as const,
+        namedTypeFragmentRefs: [],
+        parent: parentField,
+        ownerDocument: document,
+        fields: [] as Record<string, unknown>[],
+        selectedMemberIndex: undefined as number | undefined,
+      };
+      const innerChoiceField = {
+        name: 'innerChoice',
+        displayName: 'Inner Choice',
+        type: Types.Container,
+        wrapperKind: 'choice' as const,
+        namedTypeFragmentRefs: [],
+        parent: outerChoiceField,
+        ownerDocument: document,
+        fields: [] as Record<string, unknown>[],
+        selectedMemberIndex: selectInner ? 0 : undefined,
+      };
+      const innerMembers = [
+        {
+          name: 'innerA',
+          displayName: 'InnerA',
+          type: Types.String,
+          fields: [],
+          namedTypeFragmentRefs: [],
+          parent: innerChoiceField,
+          ownerDocument: document,
+        },
+        {
+          name: 'innerB',
+          displayName: 'InnerB',
+          type: Types.String,
+          fields: [],
+          namedTypeFragmentRefs: [],
+          parent: innerChoiceField,
+          ownerDocument: document,
+        },
+        {
+          name: 'innerC',
+          displayName: 'InnerC',
+          type: Types.String,
+          fields: [],
+          namedTypeFragmentRefs: [],
+          parent: innerChoiceField,
+          ownerDocument: document,
+        },
+      ];
+      innerChoiceField.fields = innerMembers;
+      const plainMember = {
+        name: 'plain',
+        displayName: 'Plain',
+        type: Types.String,
+        fields: [],
+        namedTypeFragmentRefs: [],
+        parent: outerChoiceField,
+        ownerDocument: document,
+      };
+      outerChoiceField.fields = [innerChoiceField, plainMember];
+      outerChoiceField.selectedMemberIndex = 0;
+      parentField.fields.push(outerChoiceField as never);
+
+      const documentNodeData = new DocumentNodeData(document);
+      const tree = new DocumentTree(documentNodeData);
+      TreeParsingService.parseTree(tree);
+      const orderNode = tree.root.children[0];
+      const lastChild = orderNode.children.length - 1;
+      const choiceNode = orderNode.children[lastChild];
+      return { document, documentNodeData, choiceNode, outerChoiceField, innerChoiceField };
+    };
+
+    it('should show inner choice members and Show All Choice Options for nested choice', () => {
+      const { documentNodeData, choiceNode } = createNestedChoiceFieldNode();
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+      });
+
+      expect(screen.getByText('InnerA')).toBeInTheDocument();
+      expect(screen.getByText('InnerB')).toBeInTheDocument();
+      expect(screen.getByText('InnerC')).toBeInTheDocument();
+      expect(screen.getByText('Show All Choice Options')).toBeInTheDocument();
+    });
+
+    it('should call setChoiceSelection on inner wrapper when clicking an inner member', () => {
+      const { documentNodeData, choiceNode, innerChoiceField } = createNestedChoiceFieldNode();
+
+      const setSpy = jest.spyOn(ChoiceSelectionService, 'setChoiceSelection').mockImplementation(jest.fn());
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('InnerB'));
+      });
+
+      expect(setSpy).toHaveBeenCalledWith(expect.any(Object), innerChoiceField, 1, expect.any(Object));
+      setSpy.mockRestore();
+    });
+
+    it('should call clearChoiceSelection on outer wrapper when clicking Show All Choice Options', () => {
+      const { documentNodeData, choiceNode, outerChoiceField } = createNestedChoiceFieldNode();
+
+      const clearSpy = jest.spyOn(ChoiceSelectionService, 'clearChoiceSelection').mockImplementation(jest.fn());
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Show All Choice Options'));
+      });
+
+      expect(clearSpy).toHaveBeenCalledWith(expect.any(Object), outerChoiceField, expect.any(Object));
+      clearSpy.mockRestore();
+    });
+
+    it('should not show Select self action when choice member is already selected', () => {
+      const { documentNodeData, choiceNode } = createNestedChoiceFieldNode();
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+      });
+
+      expect(screen.queryByText(/Select '.*' in '.*'/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
@@ -38,6 +38,7 @@ interface ChoiceNodeInfo {
   isChoiceWrapper: boolean;
   isSelectedChoice: boolean;
   isChoiceMember: boolean;
+  activeChoiceWrapperForMembers: IField | undefined;
   choiceWrapperField: IField | undefined;
   choiceMemberField: IField | undefined;
   parentChoiceWrapperField: IField | undefined;
@@ -66,11 +67,13 @@ function resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
   } else if (isChoiceWrapper) {
     choiceWrapperField = field;
   }
+  const activeChoiceWrapperForMembers = isSelectedChoice && isChoiceWrapper ? field : choiceWrapperField;
 
   return {
     isChoiceWrapper,
     isSelectedChoice,
     isChoiceMember,
+    activeChoiceWrapperForMembers,
     choiceWrapperField,
     choiceMemberField,
     parentChoiceWrapperField,
@@ -112,11 +115,14 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     isChoiceWrapper,
     isSelectedChoice,
     isChoiceMember,
+    activeChoiceWrapperForMembers,
     choiceWrapperField,
     choiceMemberField,
     parentChoiceWrapperField,
     choiceMemberIndex,
   } = resolveChoiceNodeInfo(nodeData);
+
+  const isNestedSelectedChoice = isSelectedChoice && isChoiceWrapper;
 
   const [isChoiceModalOpen, setIsChoiceModalOpen] = useState(false);
 
@@ -143,10 +149,10 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   // Case A: select a member from this node's own wrapper member list
   const handleSelectChoiceMember = useCallback(
     (selectedIndex: number) => {
-      if (!choiceWrapperField) return;
-      applyChoiceSelection(choiceWrapperField, selectedIndex);
+      if (!activeChoiceWrapperForMembers) return;
+      applyChoiceSelection(activeChoiceWrapperForMembers, selectedIndex);
     },
-    [choiceWrapperField, applyChoiceSelection],
+    [activeChoiceWrapperForMembers, applyChoiceSelection],
   );
 
   // Case A/B: clear selection on this node's wrapper (or the selected wrapper)
@@ -171,25 +177,29 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     testId: 'clear-choice',
   };
 
-  const selectSelfAction = isChoiceMember
-    ? buildSelectSelfAction(
-        choiceMemberField,
-        parentChoiceWrapperField,
-        handleSelectSelfAsChoiceMember,
-        'select-choice-member',
-        getFieldDisplayName,
-      )
-    : undefined;
+  const selectSelfAction =
+    isChoiceMember && !isSelectedChoice
+      ? buildSelectSelfAction(
+          choiceMemberField,
+          parentChoiceWrapperField,
+          handleSelectSelfAsChoiceMember,
+          'select-choice-member',
+          getFieldDisplayName,
+        )
+      : undefined;
 
   let menuGroups: MenuGroup[];
   if (isChoiceWrapper) {
     menuGroups = buildChoiceWrapperMenuGroups(
-      choiceWrapperField,
+      activeChoiceWrapperForMembers,
       selectSelfAction,
       clearChoiceAction,
       handleSelectChoiceMember,
       handleOpenChoiceModal,
     );
+    if (isNestedSelectedChoice) {
+      menuGroups.push({ actions: [clearChoiceAction] });
+    }
   } else {
     const choiceActions: MenuAction[] = [];
     if (isSelectedChoice) choiceActions.push(clearChoiceAction);
@@ -204,10 +214,10 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   return {
     groups: menuGroups,
     modals:
-      isChoiceModalOpen && choiceWrapperField ? (
+      isChoiceModalOpen && activeChoiceWrapperForMembers ? (
         <ChoiceSelectionModal
           isOpen={isChoiceModalOpen}
-          choiceField={choiceWrapperField}
+          choiceField={activeChoiceWrapperForMembers}
           onSelect={handleSelectChoiceMember}
           onClose={closeChoiceModal}
         />


### PR DESCRIPTION
When a choice wrapper's selected member is itself a choice wrapper, the context menu now shows the inner choice's members instead of only the parent's "Show All Choice Options" action.

fix: #3184

https://github.com/user-attachments/assets/91e2808e-50af-47ac-a6a4-5333f8db5bd7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering nested choice-wrapper scenarios: menu rendering, "Show All Choice Options" behavior, selection actions, and selection-edge cases.

* **Bug Fixes**
  * Context menus and selection actions for nested choices now correctly display relevant options, hide inappropriate actions when a nested choice is selected, and properly clear or apply selections across nested choice levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->