### PR TITLE
chore(DataMapper): Hide `Configure Sort` option

### DIFF
--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -490,7 +490,8 @@ describe('MappingContextMenuAction', () => {
     });
   });
 
-  describe('Sort Functionality', () => {
+  describe.skip('Sort Functionality', () => {
+    // TODO enable when https://github.com/KaotoIO/kaoto/issues/3302 is fixed
     it('should open SortModal when Sort action is clicked on a ForEachItem', async () => {
       const forEachItem = new ForEachItem(mappingTree);
       const nodeData = new MappingNodeData(documentNodeData, forEachItem);

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -946,7 +946,8 @@ describe('MappingActionService', () => {
         const forEachNode = shipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toEqual('for-each');
         expect(MappingActionService.getAllowedActions(forEachNode)).toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(forEachNode)).toContain(MappingActionKind.Sort);
+        // TODO flip when https://github.com/KaotoIO/kaoto/issues/3302 is fixed
+        expect(MappingActionService.getAllowedActions(forEachNode)).not.toContain(MappingActionKind.Sort);
 
         expect(shipOrderChildren[4] instanceof AddMappingNodeData).toBeTruthy();
         const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
@@ -1025,7 +1026,8 @@ describe('MappingActionService', () => {
         expect(forEachGroupNode.title).toEqual('for-each-group');
         expect(forEachGroupNode.mapping instanceof ForEachGroupItem).toBeTruthy();
         expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(MappingActionKind.Sort);
+        // TODO flip when https://github.com/KaotoIO/kaoto/issues/3302 is fixed
+        expect(MappingActionService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.Sort);
         expect(MappingActionService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.ValueSelector);
 
         const forEachGroupChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachGroupNode);

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -424,7 +424,9 @@ export class MappingActionService {
         return 'Configure Sort';
       },
       apply: (_n, { openModal }) => openModal(MappingActionKind.Sort),
-      isAllowed: MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem),
+      // TODO workaround for - https://github.com/KaotoIO/kaoto/issues/3302
+      // isAllowed: MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem),
+      isAllowed: () => false,
     },
     {
       key: MappingActionKind.Comment,


### PR DESCRIPTION
Workaround until https://github.com/KaotoIO/kaoto/issues/3302 is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled the complete sort functionality test suite in the mapping context menu action component with associated issue documentation
  * Updated test expectations throughout the mapping action service test suite to reflect and verify sort action availability changes

* **Bug Fixes**
  * Sort action functionality has been disabled in the mapping action service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->