### PR TITLE
fix(Catalog): Reset Catalogs upon resource switch

### DIFF
--- a/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
@@ -1,25 +1,25 @@
 import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
-import { CatalogDefinition, CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { CatalogDefinition, CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
 
-import { CamelCatalogService, CatalogKind } from '../models';
 import { ReloadContext } from '../providers/reload.provider';
 import { TestRuntimeProviderWrapper } from '../stubs';
 import { citrusCatalogSelector, getFirstCatalogMap, getFirstCitrusCatalogMap } from '../stubs/test-load-catalog';
 import { CatalogSchemaLoader } from '../utils/catalog-schema-loader';
 import { CatalogLoaderProvider } from './catalog.provider';
+import { fetchCamelCatalog } from './support/fetch-camel-catalog';
+import { fetchCitrusCatalog } from './support/fetch-citrus-catalog';
+
+jest.mock('./support/fetch-camel-catalog');
+jest.mock('./support/fetch-citrus-catalog');
 
 const catalogLibrary = catalogLibraryJson as CatalogLibrary;
 
 describe('CatalogLoaderProvider', () => {
   let fetchMock: jest.SpyInstance;
-  let fetchFileMock: jest.SpyInstance;
-  let setCatalogKeySpy: jest.SpyInstance;
   let fetchResolve: () => void;
   let fetchReject: () => void;
   let catalogDefinition: CatalogDefinition;
-  const [catalogLibraryEntry] = catalogLibrary.definitions;
-  const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary);
@@ -27,6 +27,8 @@ describe('CatalogLoaderProvider', () => {
   });
 
   beforeEach(() => {
+    (fetchCamelCatalog as jest.Mock).mockResolvedValue(undefined);
+
     fetchMock = jest.spyOn(globalThis, 'fetch');
     fetchMock.mockImplementationOnce((file) => {
       return new Promise((resolve, reject) => {
@@ -41,12 +43,6 @@ describe('CatalogLoaderProvider', () => {
         };
       });
     });
-
-    fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
-    fetchFileMock.mockImplementation((uri: string) => {
-      return Promise.resolve({ body: { [uri]: 'dummy-data' } });
-    });
-    setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
   });
 
   afterEach(() => {
@@ -111,7 +107,7 @@ describe('CatalogLoaderProvider', () => {
     );
   });
 
-  it('should fetch the subsequent catalog files', async () => {
+  it('should call fetchCamelCatalog for a Camel catalog', async () => {
     const { Provider } = TestRuntimeProviderWrapper();
     await act(async () => {
       render(
@@ -127,42 +123,7 @@ describe('CatalogLoaderProvider', () => {
       fetchResolve();
     });
 
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-components`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-models`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-patterns`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-languages`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-dataformats`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(`${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/kamelets-aggregate`),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(`${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/kamelet-boundaries`),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-functions`,
-      ),
-    );
+    expect(fetchCamelCatalog).toHaveBeenCalledTimes(1);
   });
 
   it('should set loading to false after fetching the catalogs', async () => {
@@ -183,118 +144,13 @@ describe('CatalogLoaderProvider', () => {
 
     expect(screen.getByTestId('catalogs-loaded')).toBeInTheDocument();
   });
-
-  it('should load the CamelCatalogService', async () => {
-    const { Provider } = TestRuntimeProviderWrapper();
-    await act(async () => {
-      render(
-        <Provider>
-          <CatalogLoaderProvider>
-            <span data-testid="catalogs-loaded">Loaded</span>
-          </CatalogLoaderProvider>
-        </Provider>,
-      );
-    });
-
-    await act(async () => {
-      fetchResolve();
-    });
-
-    let count = 0;
-    setCatalogKeySpy.mock.calls.forEach((call) => {
-      if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-components`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Component);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-models`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Processor);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-patterns`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Pattern);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-entities`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Entity);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-languages`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Language);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-dataformats`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Dataformat);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-loadbalancers`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Loadbalancer);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/kamelet-boundaries`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Kamelet);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        expect(Object.keys(call[1])[1]).toContain(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/kamelets-aggregate`,
-        );
-        expect(Object.values(call[1])[1]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].includes(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/camel-catalog-aggregate-functions`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.Function);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else {
-        throw new Error(call);
-      }
-    });
-    expect(count).toEqual(setCatalogKeySpy.mock.calls.length);
-  });
 });
 
 describe('CitrusCatalogLoaderProvider', () => {
   let fetchMock: jest.SpyInstance;
-  let fetchFileMock: jest.SpyInstance;
-  let setCatalogKeySpy: jest.SpyInstance;
   let fetchResolve: () => void;
   let fetchReject: () => void;
   let catalogDefinition: CatalogDefinition;
-  const catalogLibraryEntry = citrusCatalogSelector(catalogLibrary) as CatalogLibraryEntry;
-  const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary);
@@ -302,6 +158,8 @@ describe('CitrusCatalogLoaderProvider', () => {
   });
 
   beforeEach(() => {
+    (fetchCitrusCatalog as jest.Mock).mockResolvedValue(undefined);
+
     fetchMock = jest.spyOn(globalThis, 'fetch');
     fetchMock.mockImplementationOnce((file) => {
       return new Promise((resolve, reject) => {
@@ -316,12 +174,6 @@ describe('CitrusCatalogLoaderProvider', () => {
         };
       });
     });
-
-    fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
-    fetchFileMock.mockImplementation((uri: string) => {
-      return Promise.resolve({ body: { [uri]: 'dummy-data' } });
-    });
-    setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
   });
 
   afterEach(() => {
@@ -386,7 +238,7 @@ describe('CitrusCatalogLoaderProvider', () => {
     );
   });
 
-  it('should fetch the subsequent catalog files', async () => {
+  it('should call fetchCitrusCatalog for a Citrus catalog', async () => {
     const { Provider } = TestRuntimeProviderWrapper(citrusCatalogSelector);
     await act(async () => {
       render(
@@ -402,31 +254,7 @@ describe('CitrusCatalogLoaderProvider', () => {
       fetchResolve();
     });
 
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-test-actions`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-test-containers`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-endpoints`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-functions`,
-      ),
-    );
-    expect(fetchFileMock).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-validation-matcher`,
-      ),
-    );
+    expect(fetchCitrusCatalog).toHaveBeenCalledTimes(1);
   });
 
   it('should set loading to false after fetching the catalogs', async () => {
@@ -446,70 +274,5 @@ describe('CitrusCatalogLoaderProvider', () => {
     });
 
     expect(screen.getByTestId('catalogs-loaded')).toBeInTheDocument();
-  });
-
-  it('should load the CitrusCatalogService', async () => {
-    const { Provider } = TestRuntimeProviderWrapper(citrusCatalogSelector);
-    await act(async () => {
-      render(
-        <Provider>
-          <CatalogLoaderProvider>
-            <span data-testid="catalogs-loaded">Loaded</span>
-          </CatalogLoaderProvider>
-        </Provider>,
-      );
-    });
-
-    await act(async () => {
-      fetchResolve();
-    });
-
-    let count = 0;
-    setCatalogKeySpy.mock.calls.forEach((call) => {
-      if (
-        Object.keys(call[1])[0].endsWith(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-test-actions.json`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.TestAction);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].endsWith(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-test-containers.json`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.TestContainer);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].endsWith(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-endpoints.json`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.TestEndpoint);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].endsWith(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-functions.json`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.TestFunction);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else if (
-        Object.keys(call[1])[0].endsWith(
-          `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}/citrus-catalog-aggregate-validation-matcher.json`,
-        )
-      ) {
-        expect(call[0]).toEqual(CatalogKind.TestValidationMatcher);
-        expect(Object.values(call[1])[0]).toEqual('dummy-data');
-        count++;
-      } else {
-        throw new Error(call);
-      }
-    });
-    expect(count).toEqual(setCatalogKeySpy.mock.calls.length);
   });
 });

--- a/packages/ui/src/dynamic-catalog/catalog.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.tsx
@@ -5,36 +5,13 @@ import { createContext, FunctionComponent, PropsWithChildren, useEffect, useStat
 import { LoadDefaultCatalog } from '../components/LoadDefaultCatalog';
 import { Loading } from '../components/Loading';
 import { useRuntimeContext } from '../hooks/useRuntimeContext/useRuntimeContext';
-import {
-  CamelCatalogIndex,
-  CamelCatalogService,
-  CatalogKind,
-  ComponentsCatalog,
-  FileTypes,
-  FileTypesResponse,
-  LoadingStatus,
-} from '../models';
+import { CamelCatalogIndex, CamelCatalogService, FileTypes, FileTypesResponse, LoadingStatus } from '../models';
 import { CitrusCatalogIndex } from '../models/citrus/citrus-catalog-index';
 import { CatalogSchemaLoader } from '../utils';
-import { DynamicCatalog } from './dynamic-catalog';
 import { DynamicCatalogRegistry } from './dynamic-catalog-registry';
 import { IDynamicCatalogRegistry } from './models';
-import {
-  CamelComponentsProvider,
-  CamelDataformatProvider,
-  CamelFunctionProvider,
-  CamelLanguageProvider,
-  CamelLoadbalancerProvider,
-  CamelProcessorsProvider,
-} from './providers/camel-components.provider';
-import { CamelKameletsProvider } from './providers/camel-kamelets.provider';
-import {
-  CitrusTestActionsProvider,
-  CitrusTestContainersProvider,
-  CitrusTestEndpointsProvider,
-  CitrusTestFunctionsProvider,
-  CitrusTestValidationMatcherProvider,
-} from './providers/citrus-components.provider';
+import { fetchCamelCatalog } from './support/fetch-camel-catalog';
+import { fetchCitrusCatalog } from './support/fetch-citrus-catalog';
 
 export const CatalogContext = createContext<IDynamicCatalogRegistry>(DynamicCatalogRegistry.get());
 
@@ -61,9 +38,13 @@ export const CatalogLoaderProvider: FunctionComponent<
       .then((response) => response.json())
       .then(async (catalogIndex: CatalogDefinition) => {
         if (catalogIndex.runtime === 'Citrus') {
-          return fetchCitrusCatalog(catalogIndex as CitrusCatalogIndex, relativeBasePath);
+          return fetchCitrusCatalog({ catalogIndex: catalogIndex as CitrusCatalogIndex, relativeBasePath });
         } else {
-          return fetchCamelCatalog(catalogIndex as CamelCatalogIndex, relativeBasePath);
+          return fetchCamelCatalog({
+            catalogIndex: catalogIndex as CamelCatalogIndex,
+            relativeBasePath,
+            getResourcesContentByType,
+          });
         }
       })
       .then(() => {
@@ -73,186 +54,13 @@ export const CatalogLoaderProvider: FunctionComponent<
         setErrorMessage(error.message);
         setLoadingStatus(LoadingStatus.Error);
       });
+
+    return () => {
+      CamelCatalogService.clearCatalogs();
+      DynamicCatalogRegistry.get().clearRegistry();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCatalogIndexFile, getResourcesContentByType]);
-
-  async function fetchCamelCatalog(catalogIndex: CamelCatalogIndex, relativeBasePath: string) {
-    /** Camel Component list */
-    const camelComponentsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Component]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.components.file}`,
-    );
-    /** Full list of Camel Models, used as lookup for processors definitions */
-    const camelModelsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Processor]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.models.file}`,
-    );
-    /** Short list of patterns (EIPs) to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
-    const camelPatternsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Pattern]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.patterns.file}`,
-    );
-    /** Short list of entities to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
-    const camelEntitiesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Entity]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.entities.file}`,
-    );
-    /** Camel Languages list */
-    const camelLanguagesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Language]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.languages.file}`,
-    );
-    /** Camel Dataformats list */
-    const camelDataformatsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Dataformat]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.dataformats.file}`,
-    );
-    /** Camel Loadbalancers list */
-    const camelLoadbalancersFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Loadbalancer]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.loadbalancers.file}`,
-    );
-    /** Camel Kamelets definitions list (CRDs) */
-    const kameletsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.kamelets.file}`,
-    );
-    /** Camel Kamelets boundaries definitions list (CRDs) */
-    const kameletBoundariesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.kameletBoundaries.file}`,
-    );
-    /** Functions catalog */
-    const functionsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Function]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.functions.file}`,
-    );
-
-    const [
-      camelComponents,
-      camelModels,
-      camelPatterns,
-      camelEntities,
-      camelLanguages,
-      camelDataformats,
-      camelLoadbalancers,
-      kamelets,
-      kameletBoundaries,
-      functions,
-    ] = await Promise.all([
-      camelComponentsFiles,
-      camelModelsFiles,
-      camelPatternsFiles,
-      camelEntitiesFiles,
-      camelLanguagesFiles,
-      camelDataformatsFiles,
-      camelLoadbalancersFiles,
-      kameletsFiles,
-      kameletBoundariesFiles,
-      functionsFiles,
-    ]);
-
-    /**
-     * Temporary while we switch all sync API to ASYNC from the DynamicCatalogRegistry.
-     * This will be removed once all consumers are refactored to use DynamicCatalogRegistry
-     */
-    CamelCatalogService.setCatalogKey(CatalogKind.Component, camelComponents.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelModels.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatterns.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, camelEntities.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Loadbalancer, camelLoadbalancers.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, { ...kameletBoundaries.body, ...kamelets.body });
-    CamelCatalogService.setCatalogKey(CatalogKind.Function, functions.body);
-
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Component,
-      new DynamicCatalog(new CamelComponentsProvider(camelComponents.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Processor,
-      new DynamicCatalog(new CamelProcessorsProvider(camelModels.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Pattern,
-      new DynamicCatalog(new CamelProcessorsProvider(camelPatterns.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Entity,
-      new DynamicCatalog(new CamelProcessorsProvider(camelEntities.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Language,
-      new DynamicCatalog(new CamelLanguageProvider(camelLanguages.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Dataformat,
-      new DynamicCatalog(new CamelDataformatProvider(camelDataformats.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Loadbalancer,
-      new DynamicCatalog(new CamelLoadbalancerProvider(camelLoadbalancers.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Kamelet,
-      new DynamicCatalog(
-        new CamelKameletsProvider({ ...kameletBoundaries.body, ...kamelets.body }, getResourcesContentByType),
-      ),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.Function,
-      new DynamicCatalog(new CamelFunctionProvider(functions.body)),
-    );
-  }
-
-  async function fetchCitrusCatalog(catalogIndex: CitrusCatalogIndex, relativeBasePath: string) {
-    /** Citrus test actions */
-    const actionsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestAction]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.actions.file}`,
-    );
-    /** Citrus test containers */
-    const containerFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestContainer]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.containers.file}`,
-    );
-    /** Citrus test endpoints */
-    const endpointFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestEndpoint]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.endpoints.file}`,
-    );
-    /** Citrus test functions */
-    const functionFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestFunction]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.functions.file}`,
-    );
-    /** Citrus test validation matcher */
-    const validationMatcherFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestValidationMatcher]>(
-      `${relativeBasePath}/${catalogIndex.catalogs.validationMatcher.file}`,
-    );
-
-    const [testActions, testContainers, testEndpoints, testFunctions, testValidationMatcher] = await Promise.all([
-      actionsFiles,
-      containerFiles,
-      endpointFiles,
-      functionFiles,
-      validationMatcherFiles,
-    ]);
-
-    CamelCatalogService.setCatalogKey(CatalogKind.TestAction, testActions.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestContainer, testContainers.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, testEndpoints.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestFunction, testFunctions.body);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestValidationMatcher, testValidationMatcher.body);
-
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestAction,
-      new DynamicCatalog(new CitrusTestActionsProvider(testActions.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestContainer,
-      new DynamicCatalog(new CitrusTestContainersProvider(testContainers.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestEndpoint,
-      new DynamicCatalog(new CitrusTestEndpointsProvider(testEndpoints.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestFunction,
-      new DynamicCatalog(new CitrusTestFunctionsProvider(testFunctions.body)),
-    );
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestValidationMatcher,
-      new DynamicCatalog(new CitrusTestValidationMatcherProvider(testValidationMatcher.body)),
-    );
-  }
 
   return (
     <>

--- a/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.test.ts
@@ -1,0 +1,120 @@
+import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+
+import { CamelCatalogService, CatalogKind } from '../../models';
+import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { fetchCamelCatalog } from './fetch-camel-catalog';
+
+const catalogLibrary = catalogLibraryJson as CatalogLibrary;
+
+describe('fetchCamelCatalog', () => {
+  let fetchFileMock: jest.SpyInstance;
+  let setCatalogKeySpy: jest.SpyInstance;
+  let catalogDefinition: Awaited<ReturnType<typeof getFirstCatalogMap>>['catalogDefinition'];
+  let relativeBasePath: string;
+
+  const [catalogLibraryEntry] = catalogLibrary.definitions;
+  const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
+
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary);
+    catalogDefinition = catalogsMap.catalogDefinition;
+  });
+
+  beforeEach(() => {
+    relativeBasePath = `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}`;
+
+    fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
+    fetchFileMock.mockImplementation((uri: string) => {
+      return Promise.resolve({ body: { [uri]: 'dummy-data' } });
+    });
+
+    setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch all expected catalog files', async () => {
+    await fetchCamelCatalog({ catalogIndex: catalogDefinition, relativeBasePath });
+
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-components`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-models`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-patterns`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-entities`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-languages`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-dataformats`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-loadbalancers`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(expect.stringContaining(`${relativeBasePath}/kamelets-aggregate`));
+    expect(fetchFileMock).toHaveBeenCalledWith(expect.stringContaining(`${relativeBasePath}/kamelet-boundaries`));
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/camel-catalog-aggregate-functions`),
+    );
+  });
+
+  it('should set CamelCatalogService keys with the correct CatalogKind for each file', async () => {
+    await fetchCamelCatalog({ catalogIndex: catalogDefinition, relativeBasePath });
+
+    let count = 0;
+    setCatalogKeySpy.mock.calls.forEach((call) => {
+      if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-components`)) {
+        expect(call[0]).toEqual(CatalogKind.Component);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-models`)) {
+        expect(call[0]).toEqual(CatalogKind.Processor);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-patterns`)) {
+        expect(call[0]).toEqual(CatalogKind.Pattern);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-entities`)) {
+        expect(call[0]).toEqual(CatalogKind.Entity);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-languages`)) {
+        expect(call[0]).toEqual(CatalogKind.Language);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-dataformats`)) {
+        expect(call[0]).toEqual(CatalogKind.Dataformat);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-loadbalancers`)) {
+        expect(call[0]).toEqual(CatalogKind.Loadbalancer);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/kamelet-boundaries`)) {
+        expect(call[0]).toEqual(CatalogKind.Kamelet);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        expect(Object.keys(call[1])[1]).toContain(`${relativeBasePath}/kamelets-aggregate`);
+        expect(Object.values(call[1])[1]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].includes(`${relativeBasePath}/camel-catalog-aggregate-functions`)) {
+        expect(call[0]).toEqual(CatalogKind.Function);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else {
+        throw new Error(`Unexpected setCatalogKey call: ${JSON.stringify(call)}`);
+      }
+    });
+    expect(count).toEqual(setCatalogKeySpy.mock.calls.length);
+  });
+});

--- a/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.ts
@@ -1,0 +1,141 @@
+import { CamelCatalogService, FileTypes, FileTypesResponse } from '../../models';
+import { CamelCatalogIndex, ComponentsCatalog } from '../../models/camel/camel-catalog-index';
+import { CatalogKind } from '../../models/catalog-kind';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { DynamicCatalog } from '../dynamic-catalog';
+import { DynamicCatalogRegistry } from '../dynamic-catalog-registry';
+import {
+  CamelComponentsProvider,
+  CamelDataformatProvider,
+  CamelFunctionProvider,
+  CamelLanguageProvider,
+  CamelLoadbalancerProvider,
+  CamelProcessorsProvider,
+} from '../providers/camel-components.provider';
+import { CamelKameletsProvider } from '../providers/camel-kamelets.provider';
+
+export async function fetchCamelCatalog(options: {
+  catalogIndex: CamelCatalogIndex;
+  relativeBasePath: string;
+  getResourcesContentByType?: (filetype: FileTypes) => Promise<FileTypesResponse[]>;
+}): Promise<void> {
+  const { catalogIndex, relativeBasePath, getResourcesContentByType } = options;
+
+  /** Camel Component list */
+  const camelComponentsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Component]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.components.file}`,
+  );
+  /** Full list of Camel Models, used as lookup for processors definitions */
+  const camelModelsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Processor]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.models.file}`,
+  );
+  /** Short list of patterns (EIPs) to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
+  const camelPatternsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Pattern]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.patterns.file}`,
+  );
+  /** Short list of entities to fill the Catalog, as opposed of the CatalogKind.Processor which have all definitions */
+  const camelEntitiesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Entity]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.entities.file}`,
+  );
+  /** Camel Languages list */
+  const camelLanguagesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Language]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.languages.file}`,
+  );
+  /** Camel Dataformats list */
+  const camelDataformatsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Dataformat]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.dataformats.file}`,
+  );
+  /** Camel Loadbalancers list */
+  const camelLoadbalancersFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Loadbalancer]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.loadbalancers.file}`,
+  );
+  /** Camel Kamelets definitions list (CRDs) */
+  const kameletsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.kamelets.file}`,
+  );
+  /** Camel Kamelets boundaries definitions list (CRDs) */
+  const kameletBoundariesFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Kamelet]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.kameletBoundaries.file}`,
+  );
+  /** Functions catalog */
+  const functionsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.Function]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.functions.file}`,
+  );
+
+  const [
+    camelComponents,
+    camelModels,
+    camelPatterns,
+    camelEntities,
+    camelLanguages,
+    camelDataformats,
+    camelLoadbalancers,
+    kamelets,
+    kameletBoundaries,
+    functions,
+  ] = await Promise.all([
+    camelComponentsFiles,
+    camelModelsFiles,
+    camelPatternsFiles,
+    camelEntitiesFiles,
+    camelLanguagesFiles,
+    camelDataformatsFiles,
+    camelLoadbalancersFiles,
+    kameletsFiles,
+    kameletBoundariesFiles,
+    functionsFiles,
+  ]);
+
+  /**
+   * Temporary while we switch all sync API to ASYNC from the DynamicCatalogRegistry.
+   * This will be removed once all consumers are refactored to use DynamicCatalogRegistry
+   */
+  CamelCatalogService.setCatalogKey(CatalogKind.Component, camelComponents.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Processor, camelModels.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Pattern, camelPatterns.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Entity, camelEntities.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Language, camelLanguages.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Dataformat, camelDataformats.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Loadbalancer, camelLoadbalancers.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, { ...kameletBoundaries.body, ...kamelets.body });
+  CamelCatalogService.setCatalogKey(CatalogKind.Function, functions.body);
+
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Component,
+    new DynamicCatalog(new CamelComponentsProvider(camelComponents.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Processor,
+    new DynamicCatalog(new CamelProcessorsProvider(camelModels.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Pattern,
+    new DynamicCatalog(new CamelProcessorsProvider(camelPatterns.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Entity,
+    new DynamicCatalog(new CamelProcessorsProvider(camelEntities.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Language,
+    new DynamicCatalog(new CamelLanguageProvider(camelLanguages.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Dataformat,
+    new DynamicCatalog(new CamelDataformatProvider(camelDataformats.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Loadbalancer,
+    new DynamicCatalog(new CamelLoadbalancerProvider(camelLoadbalancers.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Kamelet,
+    new DynamicCatalog(
+      new CamelKameletsProvider({ ...kameletBoundaries.body, ...kamelets.body }, getResourcesContentByType),
+    ),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Function,
+    new DynamicCatalog(new CamelFunctionProvider(functions.body)),
+  );
+}

--- a/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
@@ -1,0 +1,95 @@
+import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+
+import { CamelCatalogService, CatalogKind } from '../../models';
+import { citrusCatalogSelector, getFirstCitrusCatalogMap } from '../../stubs/test-load-catalog';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { fetchCitrusCatalog } from './fetch-citrus-catalog';
+
+const catalogLibrary = catalogLibraryJson as CatalogLibrary;
+
+describe('fetchCitrusCatalog', () => {
+  let fetchFileMock: jest.SpyInstance;
+  let setCatalogKeySpy: jest.SpyInstance;
+  let catalogDefinition: Awaited<ReturnType<typeof getFirstCitrusCatalogMap>>['catalogDefinition'];
+  let relativeBasePath: string;
+
+  const catalogLibraryEntry = citrusCatalogSelector(catalogLibrary)!;
+  const catalogPath = catalogLibraryEntry.fileName.substring(0, catalogLibraryEntry.fileName.lastIndexOf('/'));
+
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary);
+    catalogDefinition = catalogsMap.catalogDefinition;
+  });
+
+  beforeEach(() => {
+    relativeBasePath = `${CatalogSchemaLoader.DEFAULT_CATALOG_BASE_PATH}/${catalogPath}`;
+
+    fetchFileMock = jest.spyOn(CatalogSchemaLoader, 'fetchFile');
+    fetchFileMock.mockImplementation((uri: string) => {
+      return Promise.resolve({ body: { [uri]: 'dummy-data' } });
+    });
+
+    setCatalogKeySpy = jest.spyOn(CamelCatalogService, 'setCatalogKey');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch all expected catalog files', async () => {
+    await fetchCitrusCatalog({ catalogIndex: catalogDefinition, relativeBasePath });
+
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/citrus-catalog-aggregate-test-actions`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/citrus-catalog-aggregate-test-containers`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/citrus-catalog-aggregate-endpoints`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/citrus-catalog-aggregate-functions`),
+    );
+    expect(fetchFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(`${relativeBasePath}/citrus-catalog-aggregate-validation-matcher`),
+    );
+  });
+
+  it('should set CamelCatalogService keys with the correct CatalogKind for each file', async () => {
+    await fetchCitrusCatalog({ catalogIndex: catalogDefinition, relativeBasePath });
+
+    let count = 0;
+    setCatalogKeySpy.mock.calls.forEach((call) => {
+      if (Object.keys(call[1])[0].endsWith(`${relativeBasePath}/citrus-catalog-aggregate-test-actions.json`)) {
+        expect(call[0]).toEqual(CatalogKind.TestAction);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (
+        Object.keys(call[1])[0].endsWith(`${relativeBasePath}/citrus-catalog-aggregate-test-containers.json`)
+      ) {
+        expect(call[0]).toEqual(CatalogKind.TestContainer);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].endsWith(`${relativeBasePath}/citrus-catalog-aggregate-endpoints.json`)) {
+        expect(call[0]).toEqual(CatalogKind.TestEndpoint);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0].endsWith(`${relativeBasePath}/citrus-catalog-aggregate-functions.json`)) {
+        expect(call[0]).toEqual(CatalogKind.TestFunction);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (
+        Object.keys(call[1])[0].endsWith(`${relativeBasePath}/citrus-catalog-aggregate-validation-matcher.json`)
+      ) {
+        expect(call[0]).toEqual(CatalogKind.TestValidationMatcher);
+        expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else {
+        throw new Error(`Unexpected setCatalogKey call: ${JSON.stringify(call)}`);
+      }
+    });
+    expect(count).toEqual(setCatalogKeySpy.mock.calls.length);
+  });
+});

--- a/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.ts
@@ -1,0 +1,77 @@
+import { CamelCatalogService } from '../../models';
+import { ComponentsCatalog } from '../../models/camel/camel-catalog-index';
+import { CatalogKind } from '../../models/catalog-kind';
+import { CitrusCatalogIndex } from '../../models/citrus/citrus-catalog-index';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { DynamicCatalog } from '../dynamic-catalog';
+import { DynamicCatalogRegistry } from '../dynamic-catalog-registry';
+import {
+  CitrusTestActionsProvider,
+  CitrusTestContainersProvider,
+  CitrusTestEndpointsProvider,
+  CitrusTestFunctionsProvider,
+  CitrusTestValidationMatcherProvider,
+} from '../providers/citrus-components.provider';
+
+export async function fetchCitrusCatalog(options: {
+  catalogIndex: CitrusCatalogIndex;
+  relativeBasePath: string;
+}): Promise<void> {
+  const { catalogIndex, relativeBasePath } = options;
+
+  /** Citrus test actions */
+  const actionsFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestAction]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.actions.file}`,
+  );
+  /** Citrus test containers */
+  const containerFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestContainer]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.containers.file}`,
+  );
+  /** Citrus test endpoints */
+  const endpointFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestEndpoint]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.endpoints.file}`,
+  );
+  /** Citrus test functions */
+  const functionFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestFunction]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.functions.file}`,
+  );
+  /** Citrus test validation matcher */
+  const validationMatcherFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestValidationMatcher]>(
+    `${relativeBasePath}/${catalogIndex.catalogs.validationMatcher.file}`,
+  );
+
+  const [testActions, testContainers, testEndpoints, testFunctions, testValidationMatcher] = await Promise.all([
+    actionsFiles,
+    containerFiles,
+    endpointFiles,
+    functionFiles,
+    validationMatcherFiles,
+  ]);
+
+  CamelCatalogService.setCatalogKey(CatalogKind.TestAction, testActions.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.TestContainer, testContainers.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, testEndpoints.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.TestFunction, testFunctions.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.TestValidationMatcher, testValidationMatcher.body);
+
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestAction,
+    new DynamicCatalog(new CitrusTestActionsProvider(testActions.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestContainer,
+    new DynamicCatalog(new CitrusTestContainersProvider(testContainers.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestEndpoint,
+    new DynamicCatalog(new CitrusTestEndpointsProvider(testEndpoints.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestFunction,
+    new DynamicCatalog(new CitrusTestFunctionsProvider(testFunctions.body)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestValidationMatcher,
+    new DynamicCatalog(new CitrusTestValidationMatcherProvider(testValidationMatcher.body)),
+  );
+}


### PR DESCRIPTION
### Context
After switching resources, we need to clear the catalogs in order to load the resource-related ones.

This is the clear function of the catalog provider `useEffect`:

```tsx
    return () => {
      CamelCatalogService.clearCatalogs();
      DynamicCatalogRegistry.get().clearRegistry();
    };
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog provider cleanup to properly clear resources during unmounting or dependency changes.

* **Refactor**
  * Refactored catalog loading logic into modular helper modules for better code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for catalog loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->