### PR TITLE
fix(DataMapper): Refresh mapping lines on window resize

### DIFF
--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -230,6 +230,7 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
           components={virtuosoComponents}
           itemContent={renderParameterItem}
           overscan={VIRTUOSO_OVERSCAN}
+          totalListHeightChanged={syncConnectionPorts}
         />
       )}
     </ExpansionPanel>

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -827,8 +827,7 @@ describe('ExpansionPanels', () => {
       expect(gridTemplate).toBeTruthy();
     });
 
-    it('should execute all queued layout callbacks via executeAllLayoutCallbacks', async () => {
-      // Create a component that registers a layout callback
+    it('should execute registered layout callbacks on resize even when queue is empty', async () => {
       const callbackRef = { current: false };
       const TestPanel = createTestPanelWithCallback(callbackRef);
 
@@ -841,18 +840,26 @@ describe('ExpansionPanels', () => {
 
       await setupPanelMocks(container);
 
-      // Trigger a container resize that doesn't change heights
-      // This will call fitPanelsToContainer which executes callbacks via double RAF
+      // Flush any stale queued callbacks from registration so the queue is empty,
+      // simulating the real app where transitionend drains the queue before a resize
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      });
+
+      // Reset after registration callbacks
+      callbackRef.current = false;
+
+      // Trigger a container resize that doesn't change heights (horizontal resize)
+      // With an empty queue, executeAllLayoutCallbacks must iterate the persistent
+      // panelCallbacksRef registry — not the transient layoutChangeQueueRef
       const expansionPanelsContainer = container.querySelector('.expansion-panels') as HTMLElement;
       Object.defineProperty(expansionPanelsContainer, 'offsetHeight', { value: 600, configurable: true });
 
       await act(async () => {
         mockResizeObserver.trigger();
-        // Wait for double RAF to complete (this executes line 71: callback())
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       });
 
-      // Verify the callback was actually executed (line 71 was hit)
       expect(callbackRef.current).toBe(true);
     });
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
@@ -63,13 +63,12 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
   }, [firstPanelId, lastPanelId]); // Only depends on panel ID props (stable)
 
   /**
-   * Execute all registered panel callbacks immediately
-   * Used after resize settles to update connection ports
+   * Execute all registered panel callbacks immediately.
+   * Iterates the persistent callback registry (panelCallbacksRef),
+   * not the transient queue (layoutChangeQueueRef).
    */
   const executeAllLayoutCallbacks = useCallback(() => {
-    for (const callback of layoutChangeQueueRef.current.values()) {
-      callback();
-    }
+    panelCallbacksRef.current.forEach((callback) => callback());
   }, []);
 
   /**
@@ -138,11 +137,11 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
         }
       });
       updateGridTemplate();
-      return;
     }
 
-    // Always execute layout callbacks after resize settles, even if heights didn't change
-    // This handles horizontal resizes that don't affect panel heights but still need connection port updates
+    // Always sync connection ports after any resize settles (width-only or height change).
+    // During continuous resize (e.g. VSCode window drag), CSS transitions are repeatedly
+    // interrupted so transitionend never fires — this ensures ports stay in sync regardless.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         executeAllLayoutCallbacks();

--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -125,6 +125,7 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
               components={virtuosoComponents}
               itemContent={renderSourceItem}
               overscan={VIRTUOSO_OVERSCAN}
+              totalListHeightChanged={syncConnectionPorts}
             />
           )}
         </ExpansionPanel>

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -176,6 +176,7 @@ export const TargetPanel: FunctionComponent = () => {
               components={virtuosoComponents}
               itemContent={renderTargetItem}
               overscan={VIRTUOSO_OVERSCAN}
+              totalListHeightChanged={syncConnectionPorts}
             />
           )}
         </ExpansionPanel>


### PR DESCRIPTION
## Summary
- Fix `executeAllLayoutCallbacks` to iterate the persistent callback registry (`panelCallbacksRef`) instead of the transient queue (`layoutChangeQueueRef`), which was always empty after being drained
- Always fire `executeAllLayoutCallbacks` after resize settles, not only when panel heights change — this fixes width-only resizes (e.g. VSCode sidebar drag) that never triggered `transitionend`
- Add `totalListHeightChanged` callback to all Virtuoso instances so `syncConnectionPorts` fires after virtual scroll actually renders items in DOM, fixing target lines appearing at the bottom on initial load

Fixes #3106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection port synchronization so ports realign correctly when virtualized panel heights change (including resize-related list height updates).

* **Enhancements**
  * Refined expansion panel resize behavior so registered layout callbacks run reliably, even when the transient callback queue is empty.

* **Tests**
  * Updated layout callback coverage to validate callback execution on resize under the new scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->