### PR TITLE
fix(Citrus): Load Test root schema

### DIFF
--- a/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
@@ -2,8 +2,10 @@ import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { CamelCatalogService, CatalogKind } from '../../models';
+import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../models/citrus/citrus-catalog-index';
 import { citrusCatalogSelector, getFirstCitrusCatalogMap } from '../../stubs/test-load-catalog';
 import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+import { DynamicCatalogRegistry } from '../dynamic-catalog-registry';
 import { fetchCitrusCatalog } from './fetch-citrus-catalog';
 
 const catalogLibrary = catalogLibraryJson as CatalogLibrary;
@@ -35,6 +37,27 @@ describe('fetchCitrusCatalog', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should register the root test schema (citrus-yaml) as a catalog entity', async () => {
+    const setCatalogSpy = jest.spyOn(DynamicCatalogRegistry.get(), 'setCatalog');
+
+    await fetchCitrusCatalog({ catalogIndex: catalogDefinition, relativeBasePath });
+
+    // The citrus-yaml schema file referenced in the index `schemas` section is fetched
+    expect(fetchFileMock).toHaveBeenCalledWith(expect.stringContaining(`${relativeBasePath}/citrus-testcase`));
+
+    // Registered into CamelCatalogService under CatalogKind.Entity, shaped like a propertiesSchema entity
+    const entityCall = setCatalogKeySpy.mock.calls.find((call) => call[0] === CatalogKind.Entity);
+    expect(entityCall).toBeDefined();
+    expect(entityCall![1]).toHaveProperty(CITRUS_TEST_ROOT_ENTITY_NAME);
+    expect(entityCall![1][CITRUS_TEST_ROOT_ENTITY_NAME]).toHaveProperty('propertiesSchema');
+
+    // And registered into the DynamicCatalogRegistry, consistent with the other Citrus catalogs
+    expect(setCatalogSpy).toHaveBeenCalledWith(CatalogKind.Entity, expect.anything());
+    await expect(
+      DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, CITRUS_TEST_ROOT_ENTITY_NAME),
+    ).resolves.toHaveProperty('propertiesSchema');
   });
 
   it('should fetch all expected catalog files', async () => {
@@ -85,6 +108,10 @@ describe('fetchCitrusCatalog', () => {
       ) {
         expect(call[0]).toEqual(CatalogKind.TestValidationMatcher);
         expect(Object.values(call[1])[0]).toEqual('dummy-data');
+        count++;
+      } else if (Object.keys(call[1])[0] === CITRUS_TEST_ROOT_ENTITY_NAME) {
+        expect(call[0]).toEqual(CatalogKind.Entity);
+        expect(Object.values(call[1])[0]).toHaveProperty('propertiesSchema');
         count++;
       } else {
         throw new Error(`Unexpected setCatalogKey call: ${JSON.stringify(call)}`);

--- a/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.ts
@@ -1,10 +1,16 @@
 import { CamelCatalogService } from '../../models';
 import { ComponentsCatalog } from '../../models/camel/camel-catalog-index';
+import { ICamelProcessorDefinition } from '../../models/camel/camel-processors-catalog';
 import { CatalogKind } from '../../models/catalog-kind';
-import { CitrusCatalogIndex } from '../../models/citrus/citrus-catalog-index';
+import {
+  CITRUS_TEST_ROOT_ENTITY_NAME,
+  CITRUS_YAML_SCHEMA_KEY,
+  CitrusCatalogIndex,
+} from '../../models/citrus/citrus-catalog-index';
 import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
 import { DynamicCatalog } from '../dynamic-catalog';
 import { DynamicCatalogRegistry } from '../dynamic-catalog-registry';
+import { CamelProcessorsProvider } from '../providers/camel-components.provider';
 import {
   CitrusTestActionsProvider,
   CitrusTestContainersProvider,
@@ -39,21 +45,42 @@ export async function fetchCitrusCatalog(options: {
   const validationMatcherFiles = CatalogSchemaLoader.fetchFile<ComponentsCatalog[CatalogKind.TestValidationMatcher]>(
     `${relativeBasePath}/${catalogIndex.catalogs.validationMatcher.file}`,
   );
+  /** Citrus root test schema (citrus-yaml), served through the catalog like other entities */
+  const testRootSchemaFile = CatalogSchemaLoader.fetchFile<ICamelProcessorDefinition['propertiesSchema']>(
+    `${relativeBasePath}/${catalogIndex.schemas[CITRUS_YAML_SCHEMA_KEY].file}`,
+  );
 
-  const [testActions, testContainers, testEndpoints, testFunctions, testValidationMatcher] = await Promise.all([
-    actionsFiles,
-    containerFiles,
-    endpointFiles,
-    functionFiles,
-    validationMatcherFiles,
-  ]);
+  const [testActions, testContainers, testEndpoints, testFunctions, testValidationMatcher, testRootSchema] =
+    await Promise.all([
+      actionsFiles,
+      containerFiles,
+      endpointFiles,
+      functionFiles,
+      validationMatcherFiles,
+      testRootSchemaFile,
+    ]);
+
+  /**
+   * Expose the root test schema as a catalog entity (mirroring Kamelet's `KameletConfiguration`)
+   * so the Citrus Test visual entity sources its root schema from the catalog, the same path used
+   * by Camel Routes and Kamelets. This avoids relying on the `SchemasLoaderProvider`/`sourceSchemaConfig`
+   * singleton, which is not mounted in the VS Code editor entry point.
+   */
+  const testRootEntity: ComponentsCatalog[CatalogKind.Entity] = {
+    [CITRUS_TEST_ROOT_ENTITY_NAME]: { propertiesSchema: testRootSchema.body } as ICamelProcessorDefinition,
+  };
 
   CamelCatalogService.setCatalogKey(CatalogKind.TestAction, testActions.body);
   CamelCatalogService.setCatalogKey(CatalogKind.TestContainer, testContainers.body);
   CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, testEndpoints.body);
   CamelCatalogService.setCatalogKey(CatalogKind.TestFunction, testFunctions.body);
   CamelCatalogService.setCatalogKey(CatalogKind.TestValidationMatcher, testValidationMatcher.body);
+  CamelCatalogService.setCatalogKey(CatalogKind.Entity, testRootEntity);
 
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Entity,
+    new DynamicCatalog(new CamelProcessorsProvider(testRootEntity)),
+  );
   DynamicCatalogRegistry.get().setCatalog(
     CatalogKind.TestAction,
     new DynamicCatalog(new CitrusTestActionsProvider(testActions.body)),

--- a/packages/ui/src/models/citrus/citrus-catalog-index.ts
+++ b/packages/ui/src/models/citrus/citrus-catalog-index.ts
@@ -1,6 +1,20 @@
 import { CatalogDefinition, CatalogDefinitionEntry } from '@kaoto/camel-catalog/types';
 
 /**
+ * Key under which the Citrus root test schema (`citrus-yaml`) is declared in the
+ * Citrus catalog index `schemas` section.
+ */
+export const CITRUS_YAML_SCHEMA_KEY = 'citrus-yaml';
+
+/**
+ * Name under which the Citrus root test schema is registered in the catalog
+ * (`CatalogKind.Entity`), mirroring how Kamelets expose `KameletConfiguration`.
+ * This lets the Citrus Test entity source its root schema from the catalog,
+ * the same path used by Camel Routes and Kamelets.
+ */
+export const CITRUS_TEST_ROOT_ENTITY_NAME = 'TestConfiguration';
+
+/**
  * Citrus catalog index interface that extends the base CatalogDefinition.
  * Defines the structure of the Citrus catalog with specific catalog types for test automation.
  *

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -6,11 +6,12 @@ import { camelRouteJson } from '../../../stubs/camel-route';
 import { citrusTestJson } from '../../../stubs/citrus-test';
 import { getFirstCitrusCatalogMap } from '../../../stubs/test-load-catalog';
 import { setValue } from '../../../utils';
-import { sourceSchemaConfig, SourceSchemaType } from '../../camel';
+import { SourceSchemaType } from '../../camel';
+import { ICamelProcessorDefinition } from '../../camel/camel-processors-catalog';
 import { CatalogKind } from '../../catalog-kind';
+import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../citrus/citrus-catalog-index';
 import { Test } from '../../citrus/entities/Test';
 import { EntityType } from '../../entities/base-entity';
-import { KaotoSchemaDefinition } from '../../kaoto-schema';
 import { NodeLabelType } from '../../settings/settings.model';
 import { AddStepMode } from '../base-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
@@ -129,15 +130,16 @@ describe('CitrusTestVisualEntity', () => {
       expect(result).toEqual({});
     });
 
-    it('should return root test schema', () => {
-      const config = sourceSchemaConfig;
-      config.config[SourceSchemaType.Test].schema = {
-        schema: {
-          name: 'Test',
-          description: 'desc',
-          properties: { name: {}, variables: {}, actions: { type: 'array' }, finally: { type: 'array' } },
-        } as KaotoSchemaDefinition['schema'],
-      } as KaotoSchemaDefinition;
+    it('should return root test schema from the catalog', () => {
+      CamelCatalogService.setCatalogKey(CatalogKind.Entity, {
+        [CITRUS_TEST_ROOT_ENTITY_NAME]: {
+          propertiesSchema: {
+            name: 'Test',
+            description: 'desc',
+            properties: { name: {}, variables: {}, actions: { type: 'array' }, finally: { type: 'array' } },
+          },
+        } as unknown as ICamelProcessorDefinition,
+      });
       const result = citrusTestEntity.getNodeSchema(CitrusTestVisualEntity.ROOT_PATH);
 
       expect(result).toHaveProperty('name');

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -4,9 +4,9 @@ import { cloneDeep } from 'lodash';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { getArrayProperty, getValue, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
-import { sourceSchemaConfig } from '../../camel/source-schema-config';
 import { SourceSchemaType } from '../../camel/source-schema-type';
 import { CatalogKind } from '../../catalog-kind';
+import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../citrus/citrus-catalog-index';
 import { Test, TestAction, TestActions } from '../../citrus/entities/Test';
 import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
@@ -19,6 +19,7 @@ import {
 } from '../base-visual-entity';
 import { IClipboardCopyObject } from '../clipboard';
 import { createVisualizationNode } from '../visualization-node';
+import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { CitrusTestDefaultService } from './support/citrus-test-default.service';
 import { CitrusTestContainerSettings, CitrusTestSchemaService } from './support/citrus-test-schema.service';
@@ -489,13 +490,13 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
   }
 
   private getRootTestSchema(): KaotoSchemaDefinition['schema'] {
-    const testSchemaDef = sourceSchemaConfig.config[SourceSchemaType.Test]?.schema;
-    const schema = cloneDeep(testSchemaDef?.schema || ({} as unknown as KaotoSchemaDefinition['schema']));
+    const testRootDefinition = CamelCatalogService.getComponent(CatalogKind.Entity, CITRUS_TEST_ROOT_ENTITY_NAME);
+    const schema = cloneDeep(testRootDefinition?.propertiesSchema ?? {});
 
     if (schema.properties) {
       // remove actions and finally from test schema because the properties panel should not display those items.
-      schema.properties['actions'] = {} as unknown as KaotoSchemaDefinition['schema'];
-      schema.properties['finally'] = {} as unknown as KaotoSchemaDefinition['schema'];
+      schema.properties['actions'] = {};
+      schema.properties['finally'] = {};
     }
 
     return schema;


### PR DESCRIPTION
### Context
Currently, the `CitrusTestVisualEntity` class is loading its root schema using the schema provided through the `SchemasLoaderProvider`.

This is problematic in VS Code Kaoto because those schemas are not loaded because those are not necessary since VS Code Kaoto loads them dynamically for the source code view.

### Changes
The fix is to consume the root schema through the same `CatalogKind.Entity` as the other entities.

fix: https://github.com/KaotoIO/kaoto/issues/3313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citrus YAML root schema is now fetched and registered as a catalog entity, making it available via catalog-based schema retrieval.
* **Refactor**
  * Citrus test visualization now derives the root test schema from the centralized catalog service instead of schema configuration.
* **Tests**
  * Added coverage to verify Citrus root schema fetching, entity registration, and correct retrieval from the catalog service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->