### PR TITLE
fix(DataMapper): Root element dropdown cannot scroll

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
@@ -150,6 +150,8 @@ export const TypeaheadSelect: FunctionComponent<TypeaheadSelectProps> = ({
       onSelect={handleSelect}
       onOpenChange={setIsOpen}
       toggle={toggle}
+      maxMenuHeight="240px"
+      popperProps={{ preventOverflow: true }}
     >
       <SelectList>
         {filteredOptions.map((opt, idx) => (


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3319

<img width="1098" height="1133" alt="Screenshot From 2026-06-15 19-25-35" src="https://github.com/user-attachments/assets/45b9f3cb-8797-4733-8e0e-f03359bd7e8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the typeahead select dropdown behavior by constraining its maximum height and preventing overflow issues, ensuring options remain visible and accessible within the page boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->