### PR TITLE
feat(DataMapper): Extract field info into Popover component

### DIFF
--- a/packages/ui/src/components/Document/AddMappingNode.tsx
+++ b/packages/ui/src/components/Document/AddMappingNode.tsx
@@ -28,6 +28,7 @@ export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData; r
         nodeData={nodeData}
         data-testid={nodeData.title}
         isExpandable={false}
+        namespaceMap={mappingTree.namespaceMap}
         title={
           <>
             <Icon className="node__spacer">
@@ -38,7 +39,6 @@ export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData; r
               nodeData={nodeData}
               isDocument={false}
               rank={rank}
-              namespaceMap={mappingTree.namespaceMap}
             />
             <Icon className="node__spacer">
               <LayerGroupIcon className="node__add__mapping__icon" />

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.scss
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.scss
@@ -1,0 +1,16 @@
+.field {
+  &__row {
+    display: table-row;
+  }
+
+  &__cell {
+    display: table-cell;
+    padding: 0.25rem;
+  }
+
+  &__cell--title {
+    font-weight: bold;
+    padding-right: 0.75rem;
+    white-space: nowrap;
+  }
+}

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.test.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import { FieldDetailRow } from './FieldDetailRow';
+
+describe('FieldDetailRow', () => {
+  it('should render label and value', () => {
+    render(<FieldDetailRow label="Category" value="Element" />);
+
+    expect(screen.getByText('Category:')).toBeInTheDocument();
+    expect(screen.getByText('Element')).toBeInTheDocument();
+  });
+
+  it('should apply correct CSS classes', () => {
+    const { container } = render(<FieldDetailRow label="Test" value="Value" />);
+
+    const row = container.querySelector('.field__row');
+    expect(row).toBeInTheDocument();
+
+    const titleCell = container.querySelector('.field__cell--title');
+    expect(titleCell).toBeInTheDocument();
+    expect(titleCell).toHaveTextContent('Test:');
+
+    const cells = container.querySelectorAll('.field__cell');
+    expect(cells).toHaveLength(2);
+  });
+
+  it('should render with empty value', () => {
+    const { container } = render(<FieldDetailRow label="Empty" value="" />);
+
+    expect(screen.getByText('Empty:')).toBeInTheDocument();
+    const valueCell = container.querySelectorAll('.field__cell')[1];
+    expect(valueCell).toHaveTextContent('');
+  });
+
+  it('should render with special characters in label', () => {
+    render(<FieldDetailRow label="Min/Max Occurs" value="1" />);
+
+    expect(screen.getByText('Min/Max Occurs:')).toBeInTheDocument();
+  });
+
+  it('should render with special characters in value', () => {
+    render(<FieldDetailRow label="Namespace" value="http://example.com/schema" />);
+
+    expect(screen.getByText('http://example.com/schema')).toBeInTheDocument();
+  });
+
+  it('should render with long value', () => {
+    const longValue = 'This is a very long value that might wrap to multiple lines in the UI';
+    render(<FieldDetailRow label="Description" value={longValue} />);
+
+    expect(screen.getByText(longValue)).toBeInTheDocument();
+  });
+
+  it('should render with numeric value', () => {
+    render(<FieldDetailRow label="Min Occurs" value="0" />);
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('should render label with colon', () => {
+    const { container } = render(<FieldDetailRow label="Type" value="string" />);
+
+    const titleCell = container.querySelector('.field__cell--title');
+    expect(titleCell?.textContent).toBe('Type:');
+  });
+
+  it('should render value in separate cell', () => {
+    const { container } = render(<FieldDetailRow label="Category" value="Element" />);
+
+    const cells = container.querySelectorAll('.field__cell');
+    expect(cells[0]).toHaveClass('field__cell--title');
+    expect(cells[0]).toHaveTextContent('Category:');
+    expect(cells[1]).toHaveClass('field__cell');
+    expect(cells[1]).not.toHaveClass('field__cell--title');
+    expect(cells[1]).toHaveTextContent('Element');
+  });
+});

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailRow.tsx
@@ -1,0 +1,15 @@
+import { FunctionComponent } from 'react';
+
+interface FieldDetailRowProps {
+  label: string;
+  value: string;
+}
+
+export const FieldDetailRow: FunctionComponent<FieldDetailRowProps> = ({ label, value }) => {
+  return (
+    <div className="field__row">
+      <span className="field__cell field__cell--title">{label}:</span>
+      <span className="field__cell">{value}</span>
+    </div>
+  );
+};

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.scss
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.scss
@@ -1,0 +1,20 @@
+.field {
+  &__content {
+    display: table;
+  }
+
+  &__row {
+    display: table-row;
+  }
+
+  &__cell {
+    display: table-cell;
+    padding: 0.25rem;
+  }
+
+  &__cell--title {
+    font-weight: bold;
+    padding-right: 0.75rem;
+    white-space: nowrap;
+  }
+}

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.test.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+
+import { FieldDetailsContent } from './FieldDetailsContent';
+
+describe('FieldDetailsContent', () => {
+  it('should render empty content when items array is empty', () => {
+    const { container } = render(<FieldDetailsContent items={[]} />);
+
+    expect(container.querySelector('.field__content')).toBeInTheDocument();
+    expect(container.querySelector('.field__row')).not.toBeInTheDocument();
+  });
+
+  it('should render single item', () => {
+    const items = [{ label: 'Category', value: 'Element' }];
+
+    render(<FieldDetailsContent items={items} />);
+
+    expect(screen.getByText('Category:')).toBeInTheDocument();
+    expect(screen.getByText('Element')).toBeInTheDocument();
+  });
+
+  it('should render multiple items', () => {
+    const items = [
+      { label: 'Category', value: 'Element' },
+      { label: 'Type', value: 'string' },
+      { label: 'Min Occurs', value: '1' },
+    ];
+
+    render(<FieldDetailsContent items={items} />);
+
+    expect(screen.getByText('Category:')).toBeInTheDocument();
+    expect(screen.getByText('Element')).toBeInTheDocument();
+    expect(screen.getByText('Type:')).toBeInTheDocument();
+    expect(screen.getByText('string')).toBeInTheDocument();
+    expect(screen.getByText('Min Occurs:')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('should render items in the order provided', () => {
+    const items = [
+      { label: 'First', value: 'A' },
+      { label: 'Second', value: 'B' },
+      { label: 'Third', value: 'C' },
+    ];
+
+    const { container } = render(<FieldDetailsContent items={items} />);
+
+    const rows = container.querySelectorAll('.field__row');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('First:');
+    expect(rows[1]).toHaveTextContent('Second:');
+    expect(rows[2]).toHaveTextContent('Third:');
+  });
+
+  it('should handle special characters in values', () => {
+    const items = [
+      { label: 'Namespace', value: 'http://example.com/schema' },
+      { label: 'Description', value: 'A field with <special> & "characters"' },
+    ];
+
+    render(<FieldDetailsContent items={items} />);
+
+    expect(screen.getByText('http://example.com/schema')).toBeInTheDocument();
+    expect(screen.getByText('A field with <special> & "characters"')).toBeInTheDocument();
+  });
+
+  it('should apply correct CSS class to container', () => {
+    const items = [{ label: 'Test', value: 'Value' }];
+
+    const { container } = render(<FieldDetailsContent items={items} />);
+
+    expect(container.firstChild).toHaveClass('field__content');
+  });
+});

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldDetailsContent.tsx
@@ -1,0 +1,20 @@
+import './FieldDetailsContent.scss';
+
+import { FunctionComponent } from 'react';
+
+import { LabelValuePair } from './field-details-utils';
+import { FieldDetailRow } from './FieldDetailRow';
+
+interface FieldDetailsContentProps {
+  items: LabelValuePair[];
+}
+
+export const FieldDetailsContent: FunctionComponent<FieldDetailsContentProps> = ({ items }) => {
+  return (
+    <div className="field__content">
+      {items.map(({ label, value }) => (
+        <FieldDetailRow key={label} label={label} value={value} />
+      ))}
+    </div>
+  );
+};

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.scss
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.scss
@@ -1,0 +1,7 @@
+// Fix Carbon icon centering in PatternFly button
+/* stylelint-disable-next-line selector-class-pattern */
+.pf-v6-c-button__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
@@ -1,0 +1,322 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { IField } from '../../../models/datamapper/document';
+import { DocumentNodeData, FieldNodeData } from '../../../models/datamapper/visualization';
+import { DataMapperProvider } from '../../../providers/datamapper.provider';
+import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
+import { TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { FieldNodePopover } from './FieldNodePopover';
+
+describe('FieldNodePopover', () => {
+  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+    <DataMapperProvider>{children}</DataMapperProvider>
+  );
+
+  const createFieldNodeData = () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const field = shipOrderDoc.fields[0]; // Get first field
+    return new FieldNodeData(documentNodeData, field);
+  };
+
+  it('should not render for non-field nodes (DocumentNodeData)', () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+
+    const { container } = render(<FieldNodePopover nodeData={documentNodeData} />, { wrapper });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render when getField returns undefined', () => {
+    const fieldNodeData = createFieldNodeData();
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(undefined);
+
+    const { container } = render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    expect(container.firstChild).toBeNull();
+    getFieldSpy.mockRestore();
+  });
+
+  it('should render popover button for FieldNodeData', () => {
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should display field type in popover content', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Category:')).toBeInTheDocument();
+    });
+    // The actual type will be from the test data (Container for the first field)
+    expect(screen.getByText('Container')).toBeInTheDocument();
+  });
+
+  it('should display minOccurs and maxOccurs', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Min Occurs:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Max Occurs:')).toBeInTheDocument();
+  });
+
+  it('should not display popover when enabled is false', () => {
+    const fieldNodeData = createFieldNodeData();
+
+    const { container } = render(<FieldNodePopover nodeData={fieldNodeData} enabled={false} />, { wrapper });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should use default empty namespaceMap when not provided', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    // Should render without errors
+    await waitFor(() => {
+      expect(screen.getByText('Category:')).toBeInTheDocument();
+    });
+  });
+
+  it('should use provided namespaceMap', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+    const namespaceMap = { 'https://example.com': 'ex' };
+
+    render(<FieldNodePopover nodeData={fieldNodeData} namespaceMap={namespaceMap} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    // Should render without errors with the provided namespaceMap
+    await waitFor(() => {
+      expect(screen.getByText('Category:')).toBeInTheDocument();
+    });
+  });
+
+  it('should stop event propagation when popover button is clicked', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+    const parentClickHandler = jest.fn();
+
+    render(
+      <div onClick={parentClickHandler}>
+        <FieldNodePopover nodeData={fieldNodeData} />
+      </div>,
+      { wrapper },
+    );
+
+    const button = screen.getByRole('button', { name: 'More info' });
+    await user.click(button);
+
+    // The parent onClick should not be called due to stopPropagation
+    expect(parentClickHandler).not.toHaveBeenCalled();
+  });
+
+  it('should render popover with field information', async () => {
+    const user = userEvent.setup();
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    // Verify the popover content is displayed
+    await waitFor(() => {
+      expect(screen.getByText('Category:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Min Occurs:')).toBeInTheDocument();
+    expect(screen.getByText('Max Occurs:')).toBeInTheDocument();
+  });
+
+  it('should have accessible label on button', () => {
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label');
+  });
+
+  it('should render information icon', () => {
+    const fieldNodeData = createFieldNodeData();
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    // The Information icon should be rendered
+    const button = screen.getByRole('button');
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
+  it('should display field description when present', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const fieldWithDescription = { ...baseField, description: 'Test description' } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(fieldWithDescription);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Description:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+
+  it('should display namespace URI when present', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const fieldWithNamespace = {
+      ...baseField,
+      namespaceURI: 'http://example.com/schema',
+      namespacePrefix: 'ex',
+    } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(fieldWithNamespace);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+    const namespaceMap = { ex: 'http://example.com/schema' };
+
+    render(<FieldNodePopover nodeData={fieldNodeData} namespaceMap={namespaceMap} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Namespace:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('http://example.com/schema')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+
+  it('should display namespace URI without prefix when prefix is not in namespaceMap', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const fieldWithNamespace = {
+      ...baseField,
+      namespaceURI: 'http://example.com/schema',
+      namespacePrefix: 'ex',
+    } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(fieldWithNamespace);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+    const namespaceMap = {}; // Empty namespace map
+
+    render(<FieldNodePopover nodeData={fieldNodeData} namespaceMap={namespaceMap} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Namespace:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('http://example.com/schema')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+
+  it('should display Attribute when field is an attribute', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const attributeField = { ...baseField, isAttribute: true } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(attributeField);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Attribute:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('yes')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+
+  it('should display wrapperKind when field has wrapperKind', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const fieldWithWrapper = { ...baseField, wrapperKind: 'COLLECTION' } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(fieldWithWrapper);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+
+    render(<FieldNodePopover nodeData={fieldNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Wrapper Kind:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('COLLECTION')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+
+  it('should display override information when present', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const fieldWithOverride = {
+      ...baseField,
+      typeOverride: 'string',
+      namespaceOverride: 'https://override.com',
+    } as unknown as IField;
+    const getFieldSpy = jest.spyOn(VisualizationUtilService, 'getField').mockReturnValue(fieldWithOverride);
+    const fieldNodeData = new FieldNodeData(documentNodeData, baseField);
+    const namespaceMap = { 'https://override.com': 'override' };
+
+    render(<FieldNodePopover nodeData={fieldNodeData} namespaceMap={namespaceMap} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Original type:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Overridden type:')).toBeInTheDocument();
+
+    getFieldSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
@@ -1,0 +1,56 @@
+import './FieldNodePopover.scss';
+
+import { Information } from '@carbon/icons-react';
+import { Button, Popover } from '@patternfly/react-core';
+import { FunctionComponent, MouseEvent } from 'react';
+
+import { NodeData } from '../../../models/datamapper/visualization';
+import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
+import { isFieldNode, prepareFieldDetails } from './field-details-utils';
+import { FieldDetailsContent } from './FieldDetailsContent';
+
+interface FieldNodePopoverProps {
+  nodeData: NodeData;
+  namespaceMap?: Record<string, string>;
+  enabled?: boolean;
+}
+
+/**
+ * Component that displays an (i) icon which shows field details in a Popover
+ * when clicked. The popover displays field details like minOccurs, maxOccurs,
+ * and override information.
+ *
+ * For non-field nodes (documents, variables, mappings), nothing is rendered.
+ */
+export const FieldNodePopover: FunctionComponent<FieldNodePopoverProps> = ({
+  nodeData,
+  namespaceMap = {},
+  enabled = true,
+}) => {
+  if (!enabled || !isFieldNode(nodeData)) {
+    return null;
+  }
+
+  const field = VisualizationUtilService.getField(nodeData);
+
+  if (!field) {
+    return null;
+  }
+
+  const detailItems = prepareFieldDetails(field, namespaceMap);
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <Popover
+      aria-label={`Field details for ${field.name}`}
+      bodyContent={<FieldDetailsContent items={detailItems} />}
+      position="right"
+      distance={10}
+    >
+      <Button onClick={handleClick} variant="plain" aria-label="More info" icon={<Information />} />
+    </Popover>
+  );
+};

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
@@ -1,0 +1,263 @@
+import { IField } from '../../../models/datamapper/document';
+import { FieldItem, MappingTree } from '../../../models/datamapper/mapping';
+import {
+  AddMappingNodeData,
+  DocumentNodeData,
+  FieldItemNodeData,
+  FieldNodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../../../models/datamapper/visualization';
+import { TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { QName } from '../../../xml-schema-ts/QName';
+import { formatTypeQName, isFieldNode, prepareFieldDetails } from './field-details-utils';
+
+describe('field-details-utils', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isFieldNode', () => {
+    it('should return true for FieldNodeData', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const field = shipOrderDoc.fields[0];
+      const fieldNodeData = new FieldNodeData(documentNodeData, field);
+
+      expect(isFieldNode(fieldNodeData)).toBe(true);
+    });
+
+    it('should return true for FieldItemNodeData', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, targetDoc.definitionType);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const field = targetDoc.fields[0];
+      const targetFieldNodeData = new TargetFieldNodeData(targetDocNodeData, field);
+      const fieldItem = new FieldItem(mappingTree, field);
+      const fieldItemNodeData = new FieldItemNodeData(targetFieldNodeData, fieldItem);
+
+      expect(isFieldNode(fieldItemNodeData)).toBe(true);
+    });
+
+    it('should return true for AddMappingNodeData', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, targetDoc.definitionType);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const field = targetDoc.fields[0];
+      const addMappingNodeData = new AddMappingNodeData(targetDocNodeData, field);
+
+      expect(isFieldNode(addMappingNodeData)).toBe(true);
+    });
+
+    it('should return false for DocumentNodeData', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+
+      expect(isFieldNode(documentNodeData)).toBe(false);
+    });
+  });
+
+  describe('formatTypeQName', () => {
+    it('should return "N/A" when typeQName is null', () => {
+      expect(formatTypeQName(null)).toBe('N/A');
+    });
+
+    it('should return local part when namespace URI is not present', () => {
+      const qname = new QName(null, 'string');
+      expect(formatTypeQName(qname)).toBe('string');
+    });
+
+    it('should return formatted string with namespace when local part is empty', () => {
+      const qname = new QName('http://example.com', '');
+      expect(formatTypeQName(qname)).toBe(' (http://example.com)');
+    });
+
+    it('should return "N/A" when getLocalPart returns null', () => {
+      const qname = new QName('http://example.com', 'test');
+      jest.spyOn(qname, 'getLocalPart').mockReturnValue(null);
+      expect(formatTypeQName(qname)).toBe('N/A (http://example.com)');
+    });
+
+    it('should return formatted string with namespace when both are present', () => {
+      const qname = new QName('http://www.w3.org/2001/XMLSchema', 'string');
+      expect(formatTypeQName(qname)).toBe('string (http://www.w3.org/2001/XMLSchema)');
+    });
+  });
+
+  describe('prepareFieldDetails', () => {
+    const createMockField = (overrides: Partial<IField> = {}): IField => {
+      return {
+        name: 'testField',
+        type: 'Element',
+        typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'string'),
+        minOccurs: 1,
+        maxOccurs: 1,
+        namespaceURI: '',
+        namespacePrefix: null,
+        isAttribute: false,
+        nillable: false,
+        wrapperKind: undefined,
+        description: undefined,
+        ...overrides,
+      } as IField;
+    };
+
+    it('should include all basic field properties', () => {
+      const field = createMockField();
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Category', value: 'Element' });
+      expect(result).toContainEqual({ label: 'Type', value: 'string (http://www.w3.org/2001/XMLSchema)' });
+      expect(result).toContainEqual({ label: 'Min Occurs', value: '1' });
+      expect(result).toContainEqual({ label: 'Max Occurs', value: '1' });
+    });
+
+    it('should convert empty string to "N/A" for namespace', () => {
+      const field = createMockField({
+        namespaceURI: '',
+        description: undefined,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Namespace', value: 'N/A' });
+      expect(result.find((item) => item.label === 'Description')).toBeUndefined();
+    });
+
+    it('should convert empty string to "N/A"', () => {
+      const field = createMockField({
+        description: '',
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Description', value: 'N/A' });
+    });
+
+    it('should include namespace when present', () => {
+      const field = createMockField({
+        namespaceURI: 'http://example.com/schema',
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Namespace', value: 'http://example.com/schema' });
+    });
+
+    it('should include "Attribute: yes" when field is an attribute', () => {
+      const field = createMockField({
+        isAttribute: true,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Attribute', value: 'yes' });
+    });
+
+    it('should not include Attribute when field is not an attribute', () => {
+      const field = createMockField({
+        isAttribute: false,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result.find((item) => item.label === 'Attribute')).toBeUndefined();
+    });
+
+    it('should include "Nillable: yes" when field is nillable', () => {
+      const field = createMockField({
+        nillable: true,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Nillable', value: 'yes' });
+    });
+
+    it('should not include Nillable when field is not nillable', () => {
+      const field = createMockField({
+        nillable: false,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result.find((item) => item.label === 'Nillable')).toBeUndefined();
+    });
+
+    it('should include wrapperKind when present', () => {
+      const field = createMockField({
+        wrapperKind: 'choice',
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Wrapper Kind', value: 'choice' });
+    });
+
+    it('should not include wrapperKind when undefined', () => {
+      const field = createMockField({
+        wrapperKind: undefined,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result.find((item) => item.label === 'Wrapper Kind')).toBeUndefined();
+    });
+
+    it('should include description when present', () => {
+      const field = createMockField({
+        description: 'Test description',
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Description', value: 'Test description' });
+    });
+
+    it('should handle minOccurs as 0', () => {
+      const field = createMockField({
+        minOccurs: 0,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Min Occurs', value: '0' });
+    });
+
+    it('should handle maxOccurs as "unbounded"', () => {
+      const field = createMockField({
+        maxOccurs: 'unbounded',
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Max Occurs', value: 'unbounded' });
+    });
+
+    it('should call getOverrideDisplayInfo with field and namespaceMap', () => {
+      const field = createMockField();
+      const namespaceMap = { 'http://example.com': 'ex' };
+
+      // Just verify the function is called - the override logic is tested in FieldNodePopover.test.tsx
+      prepareFieldDetails(field, namespaceMap);
+
+      // The function should be called internally, we're just testing the integration
+      expect(prepareFieldDetails(field, namespaceMap)).toBeDefined();
+    });
+
+    it('should handle undefined minOccurs', () => {
+      const field = createMockField({
+        minOccurs: undefined as unknown as number,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result.find((item) => item.label === 'Min Occurs')).toBeUndefined();
+    });
+
+    it('should handle undefined maxOccurs', () => {
+      const field = createMockField({
+        maxOccurs: undefined as unknown as number,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result.find((item) => item.label === 'Max Occurs')).toBeUndefined();
+    });
+
+    it('should handle null typeQName', () => {
+      const field = createMockField({
+        typeQName: null,
+      });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Type', value: 'N/A' });
+    });
+  });
+});

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
@@ -1,0 +1,66 @@
+import { IField } from '../../../models/datamapper/document';
+import {
+  AddMappingNodeData,
+  FieldItemNodeData,
+  FieldNodeData,
+  NodeData,
+} from '../../../models/datamapper/visualization';
+import { QName } from '../../../xml-schema-ts/QName';
+import { getOverrideDisplayInfo } from '../actions/FieldOverride/override-util';
+
+export const isFieldNode = (nodeData: NodeData): boolean => {
+  return (
+    nodeData instanceof FieldNodeData || nodeData instanceof FieldItemNodeData || nodeData instanceof AddMappingNodeData
+  );
+};
+
+export interface LabelValuePair {
+  label: string;
+  value: string;
+}
+
+export const formatTypeQName = (typeQName: QName | null): string => {
+  if (!typeQName) return 'N/A';
+
+  const localPart = typeQName.getLocalPart() ?? 'N/A';
+  const namespaceURI = typeQName.getNamespaceURI();
+
+  return namespaceURI ? `${localPart} (${namespaceURI})` : localPart;
+};
+
+export const prepareFieldDetails = (field: IField, namespaceMap: Record<string, string> = {}): LabelValuePair[] => {
+  const overrideDisplay = getOverrideDisplayInfo(field, namespaceMap);
+
+  const rows = [
+    { label: 'Category', value: field.type },
+    { label: 'Type', value: formatTypeQName(field.typeQName) },
+    {
+      label: 'Min Occurs',
+      value: field.minOccurs !== null && field.minOccurs !== undefined ? String(field.minOccurs) : null,
+    },
+    {
+      label: 'Max Occurs',
+      value: field.maxOccurs !== null && field.maxOccurs !== undefined ? String(field.maxOccurs) : null,
+    },
+    { label: 'Namespace', value: field.namespaceURI },
+    { label: 'Attribute', value: field.isAttribute ? 'yes' : null },
+    { label: 'Nillable', value: field.nillable ? 'yes' : null },
+    { label: 'Wrapper Kind', value: field.wrapperKind },
+
+    ...(overrideDisplay
+      ? [
+          { label: overrideDisplay.originalLabel, value: overrideDisplay.original },
+          { label: overrideDisplay.currentLabel, value: overrideDisplay.current },
+        ]
+      : []),
+
+    { label: 'Description', value: field.description },
+  ];
+
+  return rows
+    .map((row) => ({
+      label: row.label,
+      value: row.value === '' ? 'N/A' : row.value,
+    }))
+    .filter((row): row is LabelValuePair => row.value !== null && row.value !== undefined);
+};

--- a/packages/ui/src/components/Document/FieldNodePopover/index.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/index.ts
@@ -1,0 +1,1 @@
+export * from './FieldNodePopover';

--- a/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
@@ -1,5 +1,5 @@
 import { NullSign } from '@carbon/icons-react';
-import { Label, Popover } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 import { CheckIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent } from 'react';
@@ -9,23 +9,15 @@ import Repeat0Icon from '../../../assets/data-mapper/field-icons/Repeat0Icon';
 import Repeat1Icon from '../../../assets/data-mapper/field-icons/Repeat1Icon';
 import { AddMappingNodeData, FieldItemNodeData, FieldNodeData } from '../../../models/datamapper/visualization';
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
-import { getOverrideDisplayInfo } from '../actions/FieldOverride/override-util';
 
 type FieldNodeTitleProps = {
   className?: string;
   rank: number;
   title: string;
   nodeData: FieldNodeData | FieldItemNodeData | AddMappingNodeData;
-  namespaceMap?: Record<string, string>;
 };
 
-export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({
-  className,
-  rank,
-  title,
-  nodeData,
-  namespaceMap = {},
-}) => {
+export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({ className, rank, title, nodeData }) => {
   const isChoiceWrapper = VisualizationUtilService.isUnselectedChoiceField(nodeData);
   const isSelectedChoiceWrapper = VisualizationUtilService.isSelectedNestedChoice(nodeData);
   const isAbstractWrapper = VisualizationUtilService.isUnselectedAbstractField(nodeData);
@@ -33,70 +25,39 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({
   const optionalField = nodeData.field.minOccurs === 0;
   const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
   const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
-  const overrideDisplay = getOverrideDisplayInfo(nodeData.field, namespaceMap);
 
   return (
-    <Popover
-      triggerAction="hover"
-      position="right"
-      aria-label={`Field details for ${title}`}
-      bodyContent={
-        <div>
-          <div className="popover__row">
-            <span className="popover__cell">minOccurs :&nbsp;</span>
-            <span className="popover__cell">{nodeData.field.minOccurs}</span>
-          </div>
-          <div className="popover__row">
-            <span className="popover__cell">maxOccurs :&nbsp;</span>
-            <span className="popover__cell">{nodeData.field.maxOccurs}</span>
-          </div>
-          {overrideDisplay && (
-            <>
-              <div className="popover__row">
-                <span className="popover__cell">{overrideDisplay.originalLabel} :&nbsp;</span>
-                <span className="popover__cell">{overrideDisplay.original}</span>
-              </div>
-              <div className="popover__row">
-                <span className="popover__cell">{overrideDisplay.currentLabel} :&nbsp;</span>
-                <span className="popover__cell">{overrideDisplay.current}</span>
-              </div>
-            </>
-          )}
-        </div>
-      }
-    >
-      <div className={clsx('node-title-container', { 'node-title-container__abstract': isAbstractWrapper })}>
-        {isChoiceWrapper && <Label>choice</Label>}
-        {isSelectedChoiceWrapper && (
-          <Label color="green" icon={<CheckIcon />}>
-            choice
-          </Label>
+    <div className={clsx('node-title-container', { 'node-title-container__abstract': isAbstractWrapper })}>
+      {isChoiceWrapper && <Label>choice</Label>}
+      {isSelectedChoiceWrapper && (
+        <Label color="green" icon={<CheckIcon />}>
+          choice
+        </Label>
+      )}
+      {isAbstractWrapper && (
+        <Label color={hasNoCandidates ? 'red' : undefined}>
+          {hasNoCandidates ? 'abstract (no candidates)' : 'abstract'}
+        </Label>
+      )}
+      <span
+        className={clsx(
+          'node-title__text',
+          isChoiceWrapper && 'node-title__text__choice',
+          isAbstractWrapper && 'node-title__text__abstract',
+          className,
         )}
-        {isAbstractWrapper && (
-          <Label color={hasNoCandidates ? 'red' : undefined}>
-            {hasNoCandidates ? 'abstract (no candidates)' : 'abstract'}
-          </Label>
-        )}
-        <span
-          className={clsx(
-            'node-title__text',
-            isChoiceWrapper && 'node-title__text__choice',
-            isAbstractWrapper && 'node-title__text__abstract',
-            className,
-          )}
-          data-rank={rank}
-        >
-          {title}
-        </span>
-        {optionalField && !repeatingField0 && (
-          <OptIcon className="node__spacer datamapper-marker-field" aria-label="Optional" />
-        )}
-        {repeatingField0 && !repeatingField1 && (
-          <Repeat0Icon className="node__spacer datamapper-marker-field" aria-label="Repeat0" />
-        )}
-        {repeatingField1 && <Repeat1Icon className="node__spacer datamapper-marker-field" aria-label="Repeat1" />}
-        {nodeData.field.nillable && <NullSign className="node__spacer datamapper-marker-field" aria-label="Nullable" />}
-      </div>
-    </Popover>
+        data-rank={rank}
+      >
+        {title}
+      </span>
+      {optionalField && !repeatingField0 && (
+        <OptIcon className="node__spacer datamapper-marker-field" aria-label="Optional" />
+      )}
+      {repeatingField0 && !repeatingField1 && (
+        <Repeat0Icon className="node__spacer datamapper-marker-field" aria-label="Repeat0" />
+      )}
+      {repeatingField1 && <Repeat1Icon className="node__spacer datamapper-marker-field" aria-label="Repeat1" />}
+      {nodeData.field.nillable && <NullSign className="node__spacer datamapper-marker-field" aria-label="Nullable" />}
+    </div>
   );
 };

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.scss
@@ -17,16 +17,6 @@
   }
 }
 
-.popover {
-  &__row {
-    display: table-row;
-  }
-
-  &__cell {
-    display: table-cell;
-  }
-}
-
 div.node-title-container {
   display: flex;
   align-items: center;

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
@@ -129,24 +129,6 @@ describe('NodeTitle', () => {
     expect(element).toHaveClass('node-title__text');
   });
 
-  it('should display minOccurs and maxOccurs in popover for FieldNodeData on hover', async () => {
-    const user = userEvent.setup();
-    const shipOrderDoc = TestUtil.createSourceOrderDoc();
-    const documentNodeData = new DocumentNodeData(shipOrderDoc);
-    const mockField = createMockField();
-    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
-
-    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
-
-    const fieldElement = screen.getByText(mockField.displayName);
-    await user.hover(fieldElement);
-
-    await waitFor(() => {
-      expect(screen.getByText(/minOccurs/)).toBeInTheDocument();
-      expect(screen.getByText(/maxOccurs/)).toBeInTheDocument();
-    });
-  });
-
   it('should display an optional icon when the field information is optional', async () => {
     const shipOrderDoc = TestUtil.createSourceOrderDoc();
     const documentNodeData = new DocumentNodeData(shipOrderDoc);

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.tsx
@@ -22,16 +22,9 @@ interface INodeTitle {
   rank: number;
   nodeData: NodeData;
   isDocument: boolean;
-  namespaceMap?: Record<string, string>;
 }
 
-export const NodeTitle: FunctionComponent<INodeTitle> = ({
-  className,
-  rank,
-  nodeData,
-  isDocument,
-  namespaceMap = {},
-}) => {
+export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, rank, nodeData, isDocument }) => {
   const title = VisualizationService.createNodeTitle(nodeData);
   const content = (
     <span className={clsx('node-title__text', className)} data-rank={rank}>
@@ -65,9 +58,7 @@ export const NodeTitle: FunctionComponent<INodeTitle> = ({
     nodeData instanceof FieldItemNodeData ||
     nodeData instanceof AddMappingNodeData
   ) {
-    return (
-      <FieldNodeTitle className={className} rank={rank} title={title} nodeData={nodeData} namespaceMap={namespaceMap} />
-    );
+    return <FieldNodeTitle className={className} rank={rank} title={title} nodeData={nodeData} />;
   }
 
   return content;

--- a/packages/ui/src/components/Document/Nodes/BaseNode.scss
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.scss
@@ -86,6 +86,10 @@
     }
   }
 
+  &__icon--no-popover {
+    pointer-events: none;
+  }
+
   &__override-indicator {
     padding: var(--pf-t--global--spacer--sm);
     cursor: help;

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -12,6 +12,7 @@ import { MappingValidationService } from '../../../services/visualization/mappin
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
 import { CommentModal } from '../actions/MappingMenu/Comment/CommentModal';
 import { FieldIcon } from '../FieldIcon';
+import { FieldNodePopover } from '../FieldNodePopover';
 
 interface BaseNodeProps extends IDataTestID {
   /** Node data containing all node information */
@@ -44,6 +45,9 @@ interface BaseNodeProps extends IDataTestID {
 
   /** Document ID for connection port identification */
   documentId?: string;
+
+  /** Namespace map for field details */
+  namespaceMap?: Record<string, string>;
 }
 
 export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
@@ -58,6 +62,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
   isSelected,
   nodePath,
   documentId,
+  namespaceMap = {},
   'data-testid': dataTestId,
   children,
 }) => {
@@ -145,7 +150,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
           <Choices />
         </Icon>
       )}
-      <FieldIcon className="node__spacer" type={iconType} />
+      <FieldIcon className="node__spacer node__icon--no-popover" type={iconType} />
 
       {isAttributeField && (
         <Icon className="node__spacer" data-testid="attribute-field-icon">
@@ -164,6 +169,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
           </Icon>
         </Tooltip>
       )}
+      <FieldNodePopover nodeData={nodeData} namespaceMap={namespaceMap} />
       {children}
 
       {mapping && onUpdate && (

--- a/packages/ui/src/components/Document/SourceDocumentNode.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.tsx
@@ -85,19 +85,12 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = memo(
                 isExpandable={hasChildren}
                 isExpanded={isExpanded}
                 onExpandChange={handleClickToggle}
-                title={
-                  <NodeTitle
-                    className="node__spacer"
-                    nodeData={nodeData}
-                    isDocument={isDocument}
-                    rank={rank}
-                    namespaceMap={mappingTree.namespaceMap}
-                  />
-                }
+                title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
                 rank={rank}
                 isSelected={isSelected}
                 nodePath={nodePathString}
                 documentId={documentId}
+                namespaceMap={mappingTree.namespaceMap}
               >
                 <OverrideIndicator field={field} namespaceMap={mappingTree.namespaceMap} />
               </BaseNode>

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -171,19 +171,12 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
                 onExpandChange={handleClickToggle}
                 mapping={mappingItem}
                 onUpdate={handleUpdate}
-                title={
-                  <NodeTitle
-                    className="node__spacer"
-                    nodeData={nodeData}
-                    isDocument={isDocument}
-                    rank={rank}
-                    namespaceMap={mappingTree.namespaceMap}
-                  />
-                }
+                title={<NodeTitle className="node__spacer" nodeData={nodeData} isDocument={isDocument} rank={rank} />}
                 rank={rank}
                 isSelected={isSelected}
                 nodePath={nodePathString}
                 documentId={documentId}
+                namespaceMap={mappingTree.namespaceMap}
               >
                 <OverrideIndicator field={field} namespaceMap={mappingTree.namespaceMap} />
                 {showNodeActions ? (

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -129,6 +129,8 @@ export interface IField {
   selectedMemberIndex?: number;
   /** Whether the field's declared type is an abstract xs:complexType */
   isAbstractType?: boolean;
+  /** Optional description extracted from xs:annotation/xs:documentation for tooltip/help text */
+  description?: string;
 
   /**
    * Adopts itself to a passed-in parent {@link IField} as a child. This method is also responsible for inheritance.
@@ -324,6 +326,7 @@ export class BaseField implements IField {
   selectedMemberIndex?: number;
   isAbstractType?: boolean;
   originalField?: IOriginalFieldState;
+  description?: string;
 
   protected mergeInto(existing: IField): void {
     if (this.type && this.type !== Types.AnyType) existing.type = this.type;
@@ -335,6 +338,7 @@ export class BaseField implements IField {
     if (this.wrapperKind !== undefined) existing.wrapperKind = this.wrapperKind;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
     if (this.isAbstractType !== undefined) existing.isAbstractType = this.isAbstractType;
+    if (this.description !== undefined) existing.description = this.description;
     for (const child of this.fields) child.adopt(existing);
   }
 
@@ -361,6 +365,7 @@ export class BaseField implements IField {
     adopted.wrapperKind = this.wrapperKind;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
     adopted.isAbstractType = this.isAbstractType;
+    adopted.description = this.description;
     adopted.fields = this.fields.map((child) => child.adopt(adopted));
     parent.fields.push(adopted);
     parent.ownerDocument.totalFieldCount++;

--- a/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
@@ -507,6 +507,7 @@ export class JsonSchemaField extends BaseField {
     }
     if (this.wrapperKind !== undefined) existing.wrapperKind = this.wrapperKind;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
+    if (this.description !== undefined) existing.description = this.description;
     for (const child of this.fields) child.adopt(existing);
     return existing;
   }
@@ -523,6 +524,7 @@ export class JsonSchemaField extends BaseField {
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     to.wrapperKind = this.wrapperKind;
     to.selectedMemberIndex = this.selectedMemberIndex;
+    to.description = this.description;
     to.fields = this.fields.map((child) => child.adopt(to) as JsonSchemaField);
     return to;
   }

--- a/packages/ui/src/services/document/json-schema/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.service.test.ts
@@ -255,6 +255,99 @@ describe('JsonSchemaDocumentService', () => {
     expect(arrTwo.getExpression(namespaces)).toEqual("fn:string[@key='arrTwo']");
   });
 
+  it('should parse and preserve field description', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The name of the person' },
+        age: { type: 'number', description: 'The age in years' },
+      },
+    };
+    const doc = createTestJsonDocument(DocumentType.PARAM, 'test', JSON.stringify(schema));
+
+    expect(doc.fields).toHaveLength(1);
+    const root = doc.fields[0];
+    expect(root.fields).toHaveLength(2);
+
+    const nameField = root.fields.find((f) => f.key === 'name');
+    expect(nameField).toBeDefined();
+    expect(nameField!.description).toBe('The name of the person');
+
+    const ageField = root.fields.find((f) => f.key === 'age');
+    expect(ageField).toBeDefined();
+    expect(ageField!.description).toBe('The age in years');
+  });
+
+  it('should copy description when adopting a field', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        parent: {
+          type: 'object',
+          properties: {
+            child: { type: 'string', description: 'Child field description' },
+          },
+        },
+      },
+    };
+    const doc = createTestJsonDocument(DocumentType.PARAM, 'test', JSON.stringify(schema));
+
+    const root = doc.fields[0];
+    const parentField = root.fields.find((f) => f.key === 'parent');
+    expect(parentField).toBeDefined();
+
+    const childField = parentField!.fields.find((f) => f.key === 'child');
+    expect(childField).toBeDefined();
+    expect(childField!.description).toBe('Child field description');
+
+    // Test adopt method by adopting into a distinct parent field
+    const targetDoc = createTestJsonDocument(
+      DocumentType.PARAM,
+      'target',
+      JSON.stringify({
+        type: 'object',
+        properties: {
+          parent: { type: 'object', properties: {} },
+        },
+      }),
+    );
+    const targetRoot = targetDoc.fields[0];
+    const targetParent = targetRoot.fields.find((f) => f.key === 'parent')!;
+    const adoptedChild = childField!.adopt(targetParent);
+
+    expect(adoptedChild.description).toBe('Child field description');
+  });
+
+  it('should update description when adopting a field with description over existing field', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        field1: { type: 'string' },
+      },
+    };
+    const doc = createTestJsonDocument(DocumentType.PARAM, 'test', JSON.stringify(schema));
+
+    const root = doc.fields[0];
+    const field1 = root.fields.find((f) => f.key === 'field1');
+    expect(field1).toBeDefined();
+    expect(field1!.description).toBeUndefined();
+
+    // Create a new field with the same key but with description
+    const schemaWithDesc: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        field1: { type: 'string', description: 'Updated description' },
+      },
+    };
+    const doc2 = createTestJsonDocument(DocumentType.PARAM, 'test2', JSON.stringify(schemaWithDesc));
+    const root2 = doc2.fields[0];
+    const field1WithDesc = root2.fields.find((f) => f.key === 'field1');
+
+    // Adopt the field with description into the original parent
+    const adopted = field1WithDesc!.adopt(root);
+    expect(adopted.description).toBe('Updated description');
+  });
+
   it('should parse camelYamlDsl', () => {
     const camelDoc = createTestJsonDocument(DocumentType.PARAM, 'test', getCamelYamlDslJsonSchema());
 

--- a/packages/ui/src/services/document/json-schema/json-schema-document.service.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.service.ts
@@ -570,6 +570,10 @@ export class JsonSchemaDocumentService {
     if (schema.required) {
       field.required.push(...schema.required);
     }
+
+    if (schema.description) {
+      field.description = schema.description;
+    }
   }
 
   /**

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.model.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.model.ts
@@ -96,6 +96,7 @@ export class XmlSchemaField extends BaseField {
     adopted.wrapperKind = this.wrapperKind;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
     adopted.isAbstractType = this.isAbstractType;
+    adopted.description = this.description;
     adopted.fields = this.fields.map((child) => child.adopt(adopted) as XmlSchemaField);
     parent.fields.push(adopted);
     parent.ownerDocument.totalFieldCount++;

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
@@ -7,6 +7,7 @@ import {
 import { NS_XML_SCHEMA_INSTANCE } from '../../../models/datamapper/standard-namespaces';
 import { Types } from '../../../models/datamapper/types';
 import {
+  getAnnotatedFieldsXsd,
   getAnonymousGlobalElementRefLargeXsd,
   getCamelSpringXsd,
   getCommonTypesXsd,
@@ -1210,5 +1211,153 @@ describe('XmlSchemaDocumentService', () => {
     const typeA01Field = choiceWrapper!.fields.find((f) => f.name === 'TypeA01');
     expect(typeA01Field).toBeDefined();
     expect(typeA01Field!.type).toEqual(Types.Container);
+  });
+
+  describe('Field descriptions from xs:annotation/xs:documentation', () => {
+    it('should extract description from element annotation', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'AnnotatedFields.xsd': getAnnotatedFieldsXsd(),
+        },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const document = result.document as XmlSchemaDocument;
+
+      const customerElement = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+      const fields: XmlSchemaField[] = [];
+      XmlSchemaDocumentService.populateElement(document, fields, customerElement);
+
+      const customerField = fields[0];
+      expect(customerField.name).toBe('Customer');
+      expect(customerField.description).toBe(
+        'Represents a customer entity with contact information and purchase history',
+      );
+
+      const nameField = customerField.fields.find((f) => f.name === 'name');
+      expect(nameField).toBeDefined();
+      expect(nameField!.description).toBe("Customer's full legal name");
+
+      const emailField = customerField.fields.find((f) => f.name === 'email');
+      expect(emailField).toBeDefined();
+      expect(emailField!.description).toBe('Primary email address for customer communications');
+
+      const ageField = customerField.fields.find((f) => f.name === 'age');
+      expect(ageField).toBeDefined();
+      expect(ageField!.description).toBe("Customer's age in years");
+    });
+
+    it('should extract description from attribute annotation', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'AnnotatedFields.xsd': getAnnotatedFieldsXsd(),
+        },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const document = result.document as XmlSchemaDocument;
+
+      const customerElement = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+      const fields: XmlSchemaField[] = [];
+      XmlSchemaDocumentService.populateElement(document, fields, customerElement);
+
+      const customerField = fields[0];
+      const idAttr = customerField.fields.find((f) => f.isAttribute && f.name === 'id');
+      expect(idAttr).toBeDefined();
+      expect(idAttr!.description).toBe('Unique customer identifier in the system');
+
+      const statusAttr = customerField.fields.find((f) => f.isAttribute && f.name === 'status');
+      expect(statusAttr).toBeDefined();
+      expect(statusAttr!.description).toBe('Current customer status (active, inactive, suspended)');
+    });
+
+    it('should handle elements without annotation', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'AnnotatedFields.xsd': getAnnotatedFieldsXsd(),
+        },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const document = result.document as XmlSchemaDocument;
+
+      const customerElement = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+      const fields: XmlSchemaField[] = [];
+      XmlSchemaDocumentService.populateElement(document, fields, customerElement);
+
+      const customerField = fields[0];
+      const noAnnotationField = customerField.fields.find((f) => f.name === 'noAnnotation');
+      expect(noAnnotationField).toBeDefined();
+      expect(noAnnotationField!.description).toBeUndefined();
+    });
+
+    it('should handle attributes without annotation', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'AnnotatedFields.xsd': getAnnotatedFieldsXsd(),
+        },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const document = result.document as XmlSchemaDocument;
+
+      const customerElement = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+      const fields: XmlSchemaField[] = [];
+      XmlSchemaDocumentService.populateElement(document, fields, customerElement);
+
+      const customerField = fields[0];
+      const noAnnotationAttr = customerField.fields.find((f) => f.isAttribute && f.name === 'noAnnotationAttr');
+      expect(noAnnotationAttr).toBeDefined();
+      expect(noAnnotationAttr!.description).toBeUndefined();
+    });
+
+    it('should extract description from nested complex type elements', () => {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'AnnotatedFields.xsd': getAnnotatedFieldsXsd(),
+        },
+      );
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('success');
+      const document = result.document as XmlSchemaDocument;
+
+      // Check that the AddressType fragment has descriptions
+      // QName.toString() format is {namespace}localPart
+      const addressTypeFragmentKey = '{http://www.example.com/annotated}AddressType';
+      const addressTypeFragment = document.namedTypeFragments[addressTypeFragmentKey];
+      expect(addressTypeFragment).toBeDefined();
+
+      const streetField = addressTypeFragment.fields.find((f) => f.name === 'street');
+      expect(streetField).toBeDefined();
+      expect(streetField!.description).toBe('Street address including number and name');
+
+      const cityField = addressTypeFragment.fields.find((f) => f.name === 'city');
+      expect(cityField).toBeDefined();
+      expect(cityField!.description).toBe('City or town name');
+
+      const zipCodeField = addressTypeFragment.fields.find((f) => f.name === 'zipCode');
+      expect(zipCodeField).toBeDefined();
+      expect(zipCodeField!.description).toBe('Postal or ZIP code');
+    });
   });
 });

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -32,11 +32,13 @@ import {
   XmlSchemaType,
   XmlSchemaUse,
 } from '../../../xml-schema-ts';
+import { XmlSchemaDocumentation } from '../../../xml-schema-ts/annotation/XmlSchemaDocumentation';
 import { QName } from '../../../xml-schema-ts/QName';
 import { XmlSchemaSimpleTypeContent } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeContent';
 import { XmlSchemaSimpleTypeList } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeList';
 import { XmlSchemaSimpleTypeRestriction } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction';
 import { XmlSchemaSimpleTypeUnion } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeUnion';
+import { XmlSchemaAnnotated } from '../../../xml-schema-ts/XmlSchemaAnnotated';
 import { parseQNameString } from '../../namespace-util';
 import { DocumentUtilService } from '../document-util.service';
 import { XmlSchemaAnalysisService } from './xml-schema-analysis.service';
@@ -522,6 +524,7 @@ export class XmlSchemaDocumentService {
     field.maxOccurs = element.getMaxOccurs();
     field.minOccursExplicit = element.isMinOccursExplicit();
     field.maxOccursExplicit = element.isMaxOccursExplicit();
+    field.description = XmlSchemaDocumentService.extractDocumentationFromAnnotated(resolvedElement);
     fields.push(field);
 
     ownerDoc.totalFieldCount++;
@@ -645,6 +648,39 @@ export class XmlSchemaDocumentService {
   }
 
   /**
+   * Extract documentation text from an XML Schema annotated object (element or attribute).
+   * @param annotated - The annotated schema object (element, attribute, etc.)
+   * @returns Documentation text, or undefined if no documentation found
+   */
+  private static extractDocumentationFromAnnotated(annotated: XmlSchemaAnnotated): string | undefined {
+    const annotation = annotated.getAnnotation();
+    if (!annotation) {
+      return undefined;
+    }
+
+    const items = annotation.getItems();
+    for (const item of items) {
+      if (!(item instanceof XmlSchemaDocumentation)) continue;
+
+      const markup = item.getMarkup();
+      if (!markup || markup.length === 0) continue;
+
+      let text = '';
+      for (const node of markup) {
+        if (node.textContent) {
+          text += node.textContent;
+        }
+      }
+      text = text.trim().replace(/\s+/g, ' ');
+      if (text) {
+        return text;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Adds a synthetic xsi:nil attribute child to a nillable XML element field.
    * This allows the Document tree to represent the nil state distinctly from an empty element.
    */
@@ -693,6 +729,7 @@ export class XmlSchemaDocumentService {
     field.defaultValue = attr.getDefaultValue() || attr.getFixedValue();
     const attrTypeName = attr.getSchemaTypeName()?.getLocalPart();
     field.type = (attrTypeName ? Types[capitalize(attrTypeName) as keyof typeof Types] : null) || Types.AnyType;
+    field.description = XmlSchemaDocumentService.extractDocumentationFromAnnotated(attr);
     fields.push(field);
 
     ownerDoc.totalFieldCount++;

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -301,6 +301,9 @@ export function getFieldSubstitutionNoNsXsd(): string {
 export function getChoiceWithAbstractXsd(): string {
   return readStubFile('./xml/ChoiceWithAbstract.xsd');
 }
+export function getAnnotatedFieldsXsd(): string {
+  return readStubFile('./xml/AnnotatedFields.xsd');
+}
 export function getRawTextNodeXslt(): string {
   return readStubFile('./xml/RawTextNode.xsl');
 }

--- a/packages/ui/src/stubs/datamapper/xml/AnnotatedFields.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/AnnotatedFields.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.example.com/annotated"
+           xmlns:tns="http://www.example.com/annotated"
+           elementFormDefault="qualified">
+
+  <xs:element name="Customer">
+    <xs:annotation>
+      <xs:documentation>Represents a customer entity with contact information and purchase history</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Customer's full legal name</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="email" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Primary email address for customer communications</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="age" type="xs:int">
+          <xs:annotation>
+            <xs:documentation>Customer's age in years</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="address" type="tns:AddressType"/>
+        <xs:element name="noAnnotation" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique customer identifier in the system</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="status" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Current customer status (active, inactive, suspended)</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="noAnnotationAttr" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="AddressType">
+    <xs:annotation>
+      <xs:documentation>Physical mailing address</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="street" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Street address including number and name</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="city" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>City or town name</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="zipCode" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Postal or ZIP code</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
**Resolves:** [#1871](https://github.com/KaotoIO/kaoto/issues/1871)

<img width="721" height="589" alt="Screenshot 2026-06-16 at 18 03 13" src="https://github.com/user-attachments/assets/ad97d0ff-fb37-45c2-a87a-826858c3375b" />
<img width="571" height="448" alt="Screenshot 2026-06-16 at 18 03 37" src="https://github.com/user-attachments/assets/d202cbbb-8246-4fd5-9b37-c5888f9f06f2" />
<img width="589" height="304" alt="Screenshot 2026-06-16 at 18 05 47" src="https://github.com/user-attachments/assets/6fcd59c7-a81b-4d3e-9fe3-139881fa687b" />


**Note:** We are using the `Popover` component from PatternFly. There was a discussion to use Carbon component `Toggletip`, but in the implementation the `autoAlign` parameter was used and it caused test time issues since it is experimental. Furthermore the `Toggletip` without `autoAlign` was overlapped by other PatternFly components and the CSS workaround didn't work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Field descriptions extracted from JSON Schema `description` and XML Schema `xs:annotation/xs:documentation` are now shown in field details.
  * Added a click-activated info icon popover for viewing detailed field metadata (category, type, namespace, min/max occurs, wrapper kind, and more).

* **Refactor**
  * Moved field metadata display from hover-based behavior to a dedicated info popover.
  * Adjusted node title rendering to remove namespace/override dependencies and centralize popover handling.

* **Tests**
  * Updated popover and icon-based assertions to match the new interaction pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->