### PR TITLE
fix(e2e): stabilize flaky sourceCodeActions test

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
+++ b/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
@@ -24,7 +24,10 @@ Cypress.Commands.add('editorAddText', (line, text) => {
   cy.get('input[aria-describedby="quickInput_message"]').type(`${line}` + '{enter}', { delay: 1 });
   cy.get(editorTextarea).type('{enter}{upArrow}', { force: true, delay: 20 });
   for (const lineToWrite of text.split('\n')) {
-    cy.get(editorTextarea).type('{enter}{enter}{upArrow}{home}{shift}{end}' + lineToWrite, { force: true, delay: 20 });
+    cy.get(editorTextarea).type('{esc}{enter}{enter}{upArrow}{home}{shift}{end}' + lineToWrite, {
+      force: true,
+      delay: 20,
+    });
   }
 });
 


### PR DESCRIPTION
fix flaky sourceCodeActions test - add pushing `Esc` button prior to entering new line, for closing `monaco suggestion widget`, opened prior to inserting new line. Otherwise this opened widget is causing issues, when moving to new line using pressing `Enter`