### PR TITLE
fix(Resource): Load appropriate Kaoto Resource

### DIFF
--- a/packages/ui/src/components/RenderingAnchor/rendering.provider.tsx
+++ b/packages/ui/src/components/RenderingAnchor/rendering.provider.tsx
@@ -1,3 +1,4 @@
+import { Content, ContentVariants } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, Suspense, useCallback, useMemo, useRef } from 'react';
 
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
@@ -35,7 +36,9 @@ export const RenderingProvider: FunctionComponent<PropsWithChildren> = ({ childr
     <Suspense
       fallback={
         <Loading>
-          <span>Loading dynamic components...</span>
+          <Content data-testid="loading-dynamic-components" component={ContentVariants.h3}>
+            Loading dynamic components...
+          </Content>
         </Loading>
       }
     >

--- a/packages/ui/src/dynamic-catalog/catalog.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.tsx
@@ -36,7 +36,7 @@ export const CatalogLoaderProvider: FunctionComponent<
         return response;
       })
       .then((response) => response.json())
-      .then(async (catalogIndex: CatalogDefinition) => {
+      .then((catalogIndex: CatalogDefinition) => {
         if (catalogIndex.runtime === 'Citrus') {
           return fetchCitrusCatalog({ catalogIndex: catalogIndex as CitrusCatalogIndex, relativeBasePath });
         } else {

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -3,12 +3,15 @@ import { PropsWithChildren } from 'react';
 
 import { EntitiesProvider } from '../../providers/entities.provider';
 import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';
+import { SourceCodeSync } from '../../providers/source-code-sync';
 import { errorMessage, useEntityContext } from './useEntityContext';
 
 const wrapper = ({ children }: PropsWithChildren) => (
-  <KaotoResourceProvider>
-    <EntitiesProvider>{children}</EntitiesProvider>
-  </KaotoResourceProvider>
+  <SourceCodeSync>
+    <KaotoResourceProvider>
+      <EntitiesProvider>{children}</EntitiesProvider>
+    </KaotoResourceProvider>
+  </SourceCodeSync>
 );
 
 describe('useEntityContext', () => {

--- a/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
+++ b/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
@@ -2,9 +2,14 @@ import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
 import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';
+import { SourceCodeSync } from '../../providers/source-code-sync';
 import { errorMessage, useKaotoResourceContext } from './useKaotoResourceContext';
 
-const wrapper = ({ children }: PropsWithChildren) => <KaotoResourceProvider>{children}</KaotoResourceProvider>;
+const wrapper = ({ children }: PropsWithChildren) => (
+  <SourceCodeSync>
+    <KaotoResourceProvider>{children}</KaotoResourceProvider>
+  </SourceCodeSync>
+);
 
 describe('useKaotoResourceContext', () => {
   it('should be throw when use hook without provider', () => {

--- a/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.tsx
+++ b/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.tsx
@@ -1,13 +1,13 @@
 import { useContext } from 'react';
 
-import { KaotoResourceContext } from '../../providers/kaoto-resource.provider';
+import { KaotoResourceContext, KaotoResourceContextResult } from '../../providers/kaoto-resource.provider';
 
 export const errorMessage = 'useKaotoResourceContext should be called into KaotoResourceContext';
 
-export function useKaotoResourceContext() {
+export function useKaotoResourceContext(): Required<KaotoResourceContextResult> {
   const ctx = useContext(KaotoResourceContext);
 
-  if (!ctx) throw new Error(errorMessage);
+  if (!ctx?.kaotoResource) throw new Error(errorMessage);
 
-  return ctx;
+  return ctx as Required<KaotoResourceContextResult>;
 }

--- a/packages/ui/src/models/camel/source-schema-type.ts
+++ b/packages/ui/src/models/camel/source-schema-type.ts
@@ -21,15 +21,15 @@ export const getResourceTypeFromPath = (path?: string): SourceSchemaType | undef
   } else if (path?.includes('.pipe') || path?.includes('pipe.yaml') || path?.includes('pipe.yml')) {
     return SourceSchemaType.Pipe;
   } else if (
-    path?.endsWith('.citrus.xml') ||
-    path?.endsWith('.citrus.yaml') ||
-    path?.endsWith('.citrus.yml') ||
-    path?.endsWith('.citrus.test.xml') ||
-    path?.endsWith('.citrus.test.yaml') ||
-    path?.endsWith('.citrus.test.yml') ||
-    path?.endsWith('.citrus.it.xml') ||
-    path?.endsWith('.citrus.it.yaml') ||
-    path?.endsWith('.citrus.it.yml')
+    path?.endsWith('citrus.xml') ||
+    path?.endsWith('citrus.yaml') ||
+    path?.endsWith('citrus.yml') ||
+    path?.endsWith('citrus.test.xml') ||
+    path?.endsWith('citrus.test.yaml') ||
+    path?.endsWith('citrus.test.yml') ||
+    path?.endsWith('citrus.it.xml') ||
+    path?.endsWith('citrus.it.yaml') ||
+    path?.endsWith('citrus.it.yml')
   ) {
     return SourceSchemaType.Test;
   } else if (path?.endsWith('.xml') || path?.endsWith('.yaml') || path?.endsWith('.yml')) {

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -79,14 +79,15 @@ describe('EntitiesProvider', () => {
       expect(result.current?.camelResource.toJSON()).toEqual(['A non camel source code']);
     });
 
-    it('should fallback to an empty Camel Resource when there is a wrong Source Code', () => {
+    it('should keep resource undefined when there is a wrong Source Code at mount', () => {
       useSourceCodeStore.getState().setSourceCode('- from: {');
 
       const { result } = renderHook(() => useContext(EntitiesContext), {
         wrapper: buildWrapper('- from: {'),
       });
 
-      expect(result.current?.camelResource.toJSON()).toEqual([]);
+      // With invalid source code at mount, the resource stays undefined (loading screen)
+      expect(result.current).toBeNull();
     });
   });
 

--- a/packages/ui/src/providers/kaoto-resource.provider.test.tsx
+++ b/packages/ui/src/providers/kaoto-resource.provider.test.tsx
@@ -53,7 +53,7 @@ describe('KaotoResourceProvider', () => {
     });
 
     // The mount emits code:updated with no path → handler must reconcile path ?? fileExtension
-    expect(result.current?.kaotoResource.getSerializerType()).toEqual(SerializerType.XML);
+    expect(result.current?.kaotoResource?.getSerializerType()).toEqual(SerializerType.XML);
   });
 
   it('prefers an explicit path from the event over fileExtension', () => {
@@ -70,10 +70,10 @@ describe('KaotoResourceProvider', () => {
     });
 
     // An explicit YAML path must win over the .xml fileExtension
-    expect(result.current?.kaotoResource.getSerializerType()).toEqual(SerializerType.YAML);
+    expect(result.current?.kaotoResource?.getSerializerType()).toEqual(SerializerType.YAML);
   });
 
-  it('keeps a defined resource when the factory throws on malformed code', () => {
+  it('keeps resource undefined when the factory throws on malformed code at mount', () => {
     const real = CamelResourceFactory.createCamelResource.bind(CamelResourceFactory);
     const createSpy = jest.spyOn(CamelResourceFactory, 'createCamelResource').mockImplementation((code, opts) => {
       if (code === '- from: {') throw new Error('parse error');
@@ -88,9 +88,9 @@ describe('KaotoResourceProvider', () => {
       ),
     });
 
-    // The mount emission makes the factory throw; the handler must swallow it and keep the
-    // (initial, empty) resource rather than crashing.
-    expect(result.current?.kaotoResource).toBeDefined();
+    // The mount emission makes the factory throw; the handler must swallow it and keep
+    // the resource as undefined (showing loading screen) rather than crashing.
+    expect(result.current?.kaotoResource).toBeUndefined();
 
     createSpy.mockRestore();
   });

--- a/packages/ui/src/providers/kaoto-resource.provider.tsx
+++ b/packages/ui/src/providers/kaoto-resource.provider.tsx
@@ -1,11 +1,13 @@
+import { Content, ContentVariants } from '@patternfly/react-core';
 import { createContext, FunctionComponent, PropsWithChildren, useLayoutEffect, useMemo, useState } from 'react';
 
+import { Loading } from '../components/Loading';
 import { CamelResourceFactory } from '../models/camel/camel-resource-factory';
 import { KaotoResource } from '../models/kaoto-resource';
 import { EventNotifier } from '../utils';
 
 export interface KaotoResourceContextResult {
-  kaotoResource: KaotoResource;
+  kaotoResource?: KaotoResource;
 }
 
 export const KaotoResourceContext = createContext<KaotoResourceContextResult | null>(null);
@@ -18,13 +20,11 @@ export const KaotoResourceProvider: FunctionComponent<KaotoResourceProviderProps
   const eventNotifier = EventNotifier.getInstance();
 
   /**
-   * Start with an empty resource. The real source code arrives through the single
+   * Start with undefined. The real source code arrives through the single
    * `code:updated` ingress, emitted on mount by the SourceCodeSync. Using a lazy
    * initializer avoids re-parsing the YAML on every render.
    */
-  const [kaotoResource, setKaotoResource] = useState<KaotoResource>(() =>
-    CamelResourceFactory.createCamelResource('', { path: fileExtension }),
-  );
+  const [kaotoResource, setKaotoResource] = useState<KaotoResource | undefined>();
 
   /**
    * Subscribe to the `code:updated` event to (re)create the CamelResource.
@@ -60,6 +60,16 @@ export const KaotoResourceProvider: FunctionComponent<KaotoResourceProviderProps
     }),
     [kaotoResource],
   );
+
+  if (!kaotoResource) {
+    return (
+      <Loading>
+        <Content data-testid="loading-kaoto-resource" component={ContentVariants.h3}>
+          Loading Kaoto resource...
+        </Content>
+      </Loading>
+    );
+  }
 
   return <KaotoResourceContext.Provider value={value}>{children}</KaotoResourceContext.Provider>;
 };

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -7,7 +7,7 @@ import { VisualFlowsApi } from '../models/visualization/flows/support/flows-visi
 import {
   EntitiesContext,
   EntitiesContextResult,
-  KaotoResourceProvider,
+  KaotoResourceContext,
   VisibleFlowsContext,
   VisibleFlowsContextResult,
 } from '../providers';
@@ -55,14 +55,15 @@ export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): Test
       : props.entitiesContextValue;
 
   const entitiesContextKey = Date.now();
+  const kaotoResourceContextValue = { kaotoResource: camelResource };
   const Provider: FunctionComponent<PropsWithChildren> = (props) => (
-    <KaotoResourceProvider>
+    <KaotoResourceContext.Provider value={kaotoResourceContextValue}>
       <EntitiesContext.Provider key={entitiesContextKey} value={entitiesContextValue}>
         <VisibleFlowsContext.Provider value={visibleFlowsContext}>
           <SuggestionRegistryProvider>{props.children}</SuggestionRegistryProvider>
         </VisibleFlowsContext.Provider>
       </EntitiesContext.Provider>
-    </KaotoResourceProvider>
+    </KaotoResourceContext.Provider>
   );
 
   return { Provider, camelResource, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy };


### PR DESCRIPTION
### Context
Currently, when loading the `KaotoResourceProvider` for the first time, an empty `CamelRouteResource` is created regardless of the source code because 2 reasons:
1. There's a `CamelResourceFactory.createCamelResource` call in the `useState()`
2. The Citrus suffix in the `getResourceTypeFromPath` function have `.` in the beginning, but the actual `fileExtension` coming from the MA for the first time doesn't have it.

This causes a race condition between creating the appropriate resource vs loading the catalog for it, as sometimes the catalog finished loading BEFORE receiving the actual source code from the MA, causing that some testing components are not available.

### Changes
The fix is to remove the extra `.` for Citrus, and to start with `resource = undefined`, this way we'll wait until the actual source code comes and create it once. This also have the side benefit of creating one resource less.

fix: https://github.com/KaotoIO/kaoto/issues/3326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the dynamic component and resource loading experience with a clearer PatternFly-styled heading.

* **Refactor**
  * Improved Kaoto resource provider initialization to start unset and render a loading UI until ready.
  * Tightened hook/context typing and validation to require a non-null context result.

* **Bug Fixes**
  * Refined resource type inference for “citrus” test resources based on filename patterns.

* **Tests**
  * Adjusted test wrappers and expectations to match the updated provider composition and loading/error behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->