### PR TITLE
chore: update multiples workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -10,15 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v7
         with:
-          node-version: '22.x'
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
           cache: 'yarn'
-
 
       # Install dependencies
       - run: yarn
@@ -40,7 +41,7 @@ jobs:
         run: yarn workspaces foreach --verbose --all --topological-dev run test
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,14 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # 👇 Fetches all Git history so that Chromatic can compare against the previous version
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
           cache: 'yarn'
@@ -51,7 +52,7 @@ jobs:
 
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        uses: chromaui/action@v13.3.5
+        uses: chromaui/action@v13
         # Chromatic GitHub Action options
         with:
           # This token needs to be specified directly here so forks of the repository can push their changes to the chromatic UI

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -17,16 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: '🛰️ Setup Node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
           cache: 'yarn'
-
 
       - name: '🔧 Install dependencies'
         run: yarn
@@ -43,7 +44,7 @@ jobs:
           ls -lh ${{ runner.temp }}/kaoto-ui.tgz
 
       - name: '🔧 Persist UI Dist'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'kaoto-ui-${{ github.run_id }}'
           path: '${{ runner.temp }}/kaoto-ui.tgz'
@@ -59,13 +60,15 @@ jobs:
       - build-distribution
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: '🛰️ Setup Pages'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: '🛰️ Download UI Dist'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kaoto-ui-${{ github.run_id }}
           path: '${{ runner.temp }}'
@@ -77,13 +80,13 @@ jobs:
           tar -xzf "${{ runner.temp }}/kaoto-ui.tgz" -C packages/ui/dist
 
       - name: '📤 Upload artifact @kaoto/kaoto web application'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'packages/ui/dist'
 
       - name: '🚀 Deploy to GitHub Pages'
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   deploy-images:
     if: github.repository == 'KaotoIO/kaoto'
@@ -94,10 +97,12 @@ jobs:
       - build-distribution
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: '🛰️ Download UI Dist'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kaoto-ui-${{ github.run_id }}
           path: '${{ runner.temp }}'
@@ -109,7 +114,7 @@ jobs:
           tar -xzf "${{ runner.temp }}/kaoto-ui.tgz" -C packages/ui/dist
 
       - name: '🛰️ Login to Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,20 +6,21 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-
 jobs:
   install:
     runs-on: ubuntu-latest
 
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             **/node_modules
@@ -30,7 +31,6 @@ jobs:
       # Install dependencies
       - run: yarn install --immutable
 
-
       - name: Build packages
         run: yarn workspace @kaoto/kaoto run build:dev
 
@@ -39,18 +39,17 @@ jobs:
         run: yarn workspace @kaoto/kaoto run build:lib
 
       - name: 💾 Save build folder
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: ui-dist
           if-no-files-found: error
           path: packages/ui/dist
 
-
   test-on-firefox:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
     strategy:
       fail-fast: false
@@ -58,16 +57,18 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: firefox
           # we have already installed all dependencies above
@@ -87,14 +88,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: videos-firefox-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-firefox-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots
@@ -103,7 +104,7 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
     strategy:
       fail-fast: false
@@ -112,16 +113,18 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: chrome
           # we have already installed all dependencies above
@@ -141,14 +144,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: videos-chrome-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-chrome-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots
@@ -157,7 +160,7 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
     strategy:
       fail-fast: false
@@ -165,16 +168,18 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: edge
           # we have already installed all dependencies above
@@ -193,14 +198,14 @@ jobs:
           SPLIT_INDEX: ${{ strategy.job-index }}
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: videos-edge-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-edge-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots

--- a/.github/workflows/e2e-weekly.yml
+++ b/.github/workflows/e2e-weekly.yml
@@ -9,14 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             **/node_modules
@@ -36,32 +38,33 @@ jobs:
         run: yarn workspace @kaoto/kaoto run build:lib
 
       - name: 💾 Save build folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-dist
           if-no-files-found: error
           path: packages/ui/dist
 
-
   test-on-firefox:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: firefox
           # we have already installed all dependencies above
@@ -79,14 +82,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: videos-firefox
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-firefox
           path: packages/ui-tests/cypress/screenshots
@@ -95,21 +98,23 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: chrome
           # we have already installed all dependencies above
@@ -127,14 +132,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: videos-chrome
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-chrome
           path: packages/ui-tests/cypress/screenshots
@@ -143,21 +148,23 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.15.0-chrome-136.0.7103.92-1-ff-138.0.1-edge-136.0.3240.50-1
+      image: cypress/browsers:node-24.17.0-chrome-149.0.7827.155-1-ff-152.0-edge-149.0.4022.69-1
       options: --user 1001
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v6.10.8
+        uses: cypress-io/github-action@v7
         with:
           browser: edge
           # we have already installed all dependencies above
@@ -175,14 +182,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: videos-edge
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-edge
           path: packages/ui-tests/cypress/screenshots

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -20,7 +20,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Bump version and push tag
         id: tag_version
@@ -47,11 +49,13 @@ jobs:
 
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v7
         with:
-          node-version: '22.x'
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
           cache: 'yarn'
@@ -80,14 +84,15 @@ jobs:
     needs:
       - tag-and-release
       - npm-release
-
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v7
         with:
-          node-version: '22.x'
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
           cache: 'yarn'
@@ -100,7 +105,7 @@ jobs:
           yarn workspaces foreach --verbose --all --topological-dev run build
 
       - name: '🛰️ Login to Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
Closes: #3329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD, release, visual testing, VS Code tests, and issue monitoring workflows to run JavaScript-based actions on Node.js 24.x consistently.
  * Refreshed and pinned multiple GitHub Actions by commit SHA across these workflows (checkout, Node setup, artifact handling, Pages deployment, container registry authentication, and release steps).

* **Tests**
  * Updated Cypress E2E (Firefox/Chrome/Edge) and weekly runs to use Node 24-based browser containers, with pinned Cypress GitHub actions for consistent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->