### PR TITLE
e2e: catalog change and upload fixtures directly in local storage

### DIFF
--- a/packages/ui-tests/cypress/e2e/beansConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/beansConfig.cy.ts
@@ -29,7 +29,6 @@ describe('Test for Bean support', () => {
   });
 
   it('Beans - create a new bean using editor and edit in bean editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/camelRoute/beans.yaml');
 
     cy.openBeans();

--- a/packages/ui-tests/cypress/e2e/codeEditor/malformedFlows.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/malformedFlows.cy.ts
@@ -5,7 +5,6 @@ describe('Test for Multi route actions from the code editor', () => {
 
   // blocked ATM by https://github.com/KaotoIO/kaoto/issues/575
   it.skip('User creates a flow with missing route ID', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/malformed/camelRoute/missingId.yaml');
     cy.openDesignPage();
 
@@ -25,7 +24,6 @@ describe('Test for Multi route actions from the code editor', () => {
 
   // blocked ATM by https://github.com/KaotoIO/kaoto/issues/683
   it.skip('User creates kameletBinding with missing kind definition', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/malformed/kamelet/missingKind.yaml');
     cy.openDesignPage();
 
@@ -38,7 +36,6 @@ describe('Test for Multi route actions from the code editor', () => {
   });
 
   it('User creates a flow with unknown node', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/malformed/camelRoute/unknownNode.yaml');
     cy.openDesignPage();
     cy.checkNodeExist('id', 1);
@@ -52,7 +49,6 @@ describe('Test for Multi route actions from the code editor', () => {
   });
 
   it('User creates a flow with wrongly indented node properties', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/malformed/kamelet/wrongIndentProperties.yaml');
     cy.openDesignPage();
     cy.checkNodeExist('source', 1);
@@ -63,7 +59,6 @@ describe('Test for Multi route actions from the code editor', () => {
   });
 
   it('User creates a flow with wrongly indented source definition', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/malformed/kamelet/wrongIndentSource.yaml');
     cy.openDesignPage();
     cy.checkNodeExist('source', 1);

--- a/packages/ui-tests/cypress/e2e/codeEditor/multiFlowEditor.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/multiFlowEditor.cy.ts
@@ -4,7 +4,6 @@ describe('Test for Multi route actions from the code editor', () => {
   });
 
   it('User deletes first route from multi-route using code editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
     cy.openDesignPage();
     cy.get('[data-testid="flows-list-route-count"]').should('have.text', '2/2');
@@ -17,8 +16,8 @@ describe('Test for Multi route actions from the code editor', () => {
   });
 
   it('User adds new route to Camel multi-route using code editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openSourceCode();
 
     const stepToInsert = `- route:
       id: route-new
@@ -42,6 +41,7 @@ describe('Test for Multi route actions from the code editor', () => {
 
   it('User deletes second route from multi-route using code editor', () => {
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openSourceCode();
 
     cy.editorDeleteLine(11, 11);
     cy.openDesignPage();
@@ -52,6 +52,7 @@ describe('Test for Multi route actions from the code editor', () => {
 
   it('User deletes step from first route using code editor', () => {
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openSourceCode();
 
     cy.editorDeleteLine(7, 4);
     cy.openDesignPage();
@@ -63,6 +64,8 @@ describe('Test for Multi route actions from the code editor', () => {
 
   it('User adds step to the first route using code editor', () => {
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openSourceCode();
+
     const stepToInsert = `        - setHeader:
             constant: test`;
     cy.editorAddText(9, stepToInsert);
@@ -74,6 +77,8 @@ describe('Test for Multi route actions from the code editor', () => {
 
   it('User adds step to the second route using code editor', () => {
     cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openSourceCode();
+
     const stepToInsert = `        - setBody:
           constant: test`;
     cy.editorAddText(20, stepToInsert);

--- a/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/sourceCodeActions.cy.ts
@@ -4,7 +4,7 @@ describe('Test source code editor', () => {
   });
 
   it('loads the YAML editor and deletes steps, check with visualization', () => {
-    cy.uploadFixture('flows/kameletBinding/kafkaSourceSink.yaml');
+    cy.uploadFixtureUsingEditor('flows/kameletBinding/kafkaSourceSink.yaml');
     cy.openDesignPage();
     cy.get('[data-id^="Updated integration|steps.0"]').should('exist');
     cy.openSourceCode();
@@ -16,7 +16,7 @@ describe('Test source code editor', () => {
   });
 
   it('User adds step to the YAML', () => {
-    cy.uploadFixture('flows/kameletBinding/timerKafka.yaml');
+    cy.uploadFixtureUsingEditor('flows/kameletBinding/timerKafka.yaml');
 
     const stepToInsert = `  steps:
   - ref:
@@ -31,7 +31,7 @@ describe('Test source code editor', () => {
   });
 
   it('User removes step from the YAML', () => {
-    cy.uploadFixture('flows/kameletBinding/timerKafka.yaml');
+    cy.uploadFixtureUsingEditor('flows/kameletBinding/timerKafka.yaml');
 
     cy.editorDeleteLine(12, 6);
     cy.openDesignPage();
@@ -40,7 +40,7 @@ describe('Test source code editor', () => {
   });
 
   it('User edits step in the YAML', () => {
-    cy.uploadFixture('flows/kameletBinding/timerKafka.yaml');
+    cy.uploadFixtureUsingEditor('flows/kameletBinding/timerKafka.yaml');
 
     cy.editorDeleteLine(13, 1);
     const name = `      name: aws-s3-sink`;
@@ -53,7 +53,7 @@ describe('Test source code editor', () => {
   });
 
   it('User Deletes branch in the YAML', () => {
-    cy.uploadFixture('flows/kamelet/complex.yaml');
+    cy.uploadFixtureUsingEditor('flows/kamelet/complex.yaml');
 
     cy.editorDeleteLine(41, 7);
     cy.openDesignPage();
@@ -64,7 +64,7 @@ describe('Test source code editor', () => {
   });
 
   it('User Add a new branch in the YAML', () => {
-    cy.uploadFixture('flows/kamelet/complex.yaml');
+    cy.uploadFixtureUsingEditor('flows/kamelet/complex.yaml');
     const stepToInsert = `              - simple: {{}{{}?test}}
                 steps:
                   - to:
@@ -77,7 +77,7 @@ describe('Test source code editor', () => {
   });
 
   it('User undoes a change and redoes a change', () => {
-    cy.uploadFixture('flows/camelRoute/basic.yaml');
+    cy.uploadFixtureUsingEditor('flows/camelRoute/basic.yaml');
 
     cy.editorDeleteLine(5, 7);
     // click undo button => reverted automatic adjustments
@@ -98,7 +98,7 @@ describe('Test source code editor', () => {
   });
 
   it('User uploads YAML file, syncs with canvas', () => {
-    cy.uploadFixture('flows/kameletBinding/timerKafka.yaml');
+    cy.uploadFixtureUsingEditor('flows/kameletBinding/timerKafka.yaml');
     cy.openDesignPage();
 
     // CHECK the kafka-sink and timer-source were imported

--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/routeBeanConf.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/routeBeanConf.cy.ts
@@ -41,7 +41,6 @@ describe('Test for node bean reference and configuration support', () => {
   ];
   newTestData.forEach((data) => {
     it('Beans - select existing bean in node form config ' + data.file, () => {
-      cy.openSourceCode();
       cy.uploadFixture('flows/' + data.file);
 
       cy.openDesignPage();
@@ -55,7 +54,6 @@ describe('Test for node bean reference and configuration support', () => {
     });
 
     it('Beans - unselect selected bean', () => {
-      cy.openSourceCode();
       cy.uploadFixture('flows/' + data.file);
 
       cy.openDesignPage();

--- a/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/sidepanelConfig/uriRouteConfig.cy.ts
@@ -36,6 +36,7 @@ describe('Test URI node config', () => {
 
   it('User adds URI step to a Kamelet YAML', () => {
     cy.uploadFixture('flows/kamelet/uriConf.yaml');
+    cy.openSourceCode();
     const stepToInsert = `      - to: aws2-s3:testBucket?autoCreateBucket=true`;
     cy.editorAddText(43, stepToInsert);
     cy.openDesignPage();
@@ -57,6 +58,7 @@ describe('Test URI node config', () => {
 
   it('User adds URI step to a Camel Route YAML', () => {
     cy.uploadFixture('flows/camelRoute/uriConf.yaml');
+    cy.openSourceCode();
     const stepToInsert = `        - to: aws2-s3:testBucket?autoCreateBucket=true`;
     cy.editorAddText(11, stepToInsert);
     cy.openDesignPage();

--- a/packages/ui-tests/cypress/e2e/designer/undoRedoKeyboard.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/undoRedoKeyboard.cy.ts
@@ -1,6 +1,5 @@
 describe('Undo/Redo - Global keyboard shortcuts on Design page', () => {
   beforeEach(() => {
-    cy.openHomePage();
     cy.uploadFixture('flows/kameletBinding/timerKafka.yaml');
     cy.openDesignPage();
   });

--- a/packages/ui-tests/cypress/e2e/metadata.cy.ts
+++ b/packages/ui-tests/cypress/e2e/metadata.cy.ts
@@ -76,7 +76,6 @@ describe('Test for Metadata Editor support', () => {
   });
 
   it('Metadata Editor - create a new bean using editor and edit in bean editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/pipe/metadata.yaml');
     cy.openMetadata();
 
@@ -107,7 +106,6 @@ describe('Test for Metadata Editor support', () => {
   });
 
   it('Metadata Editor - delete bean properties using the bean editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/pipe/metadata.yaml');
     cy.openMetadata();
 

--- a/packages/ui-tests/cypress/e2e/pipeErrorHandler.cy.ts
+++ b/packages/ui-tests/cypress/e2e/pipeErrorHandler.cy.ts
@@ -43,7 +43,6 @@ describe('Test for Pipe Error handler support', () => {
   });
 
   it('ErrorHandler - edit in errorHandler editor', () => {
-    cy.openSourceCode();
     cy.uploadFixture('flows/pipe/errorHandler.yaml');
     cy.openPipeErrorHandler();
     cy.get(`input[name="#.log.parameters.maximumRedeliveries"]`).clear().type('5');

--- a/packages/ui-tests/cypress/e2e/xmlSupport/editingSourceXml.cy.ts
+++ b/packages/ui-tests/cypress/e2e/xmlSupport/editingSourceXml.cy.ts
@@ -5,6 +5,7 @@ describe('Tests for edit of XML document in code editor', () => {
 
   it('User edits the imported XML camel route in source code editor, transforms to Yaml', () => {
     cy.uploadFixture('flows/camelRoute/basic.xml');
+    cy.openSourceCode();
     const stepToInsert = `    <to description="insert-field-XML" uri="log:InfoLogger?level=DEBUG"/>`;
     cy.editorAddText(5, stepToInsert);
     cy.openDesignPage();

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -153,6 +153,7 @@ declare global {
       waitForEditorToLoad(): Chainable<JQuery<Element>>;
       editorAddText(line: number, text: string): Chainable<JQuery<Element>>;
       uploadFixture(fixture: string): Chainable<JQuery<Element>>;
+      uploadFixtureUsingEditor(fixture: string): Chainable<JQuery<Element>>;
       editorDeleteLine(line: number, repeatCount: number): Chainable<JQuery<Element>>;
       getMonacoValue(): Chainable<{ sourceCode: string; eol: string }>;
       checkCodeSpanLine(spanText: string, linesCount?: number): Chainable<JQuery<Element>>;

--- a/packages/ui-tests/cypress/support/next-commands/default.ts
+++ b/packages/ui-tests/cypress/support/next-commands/default.ts
@@ -1,9 +1,29 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+
 Cypress.Commands.add('openHomePage', () => {
   const url = Cypress.config().baseUrl;
-  cy.visit(url!);
-  cy.waitSchemasLoading();
 
-  cy.selectRuntimeVersion('Main');
+  if (!catalogLibrary.definitions || catalogLibrary.definitions.length === 0) {
+    throw new Error('Catalog library definitions array is empty or missing');
+  }
+
+  const settings = {
+    catalogUrl: '',
+    runtimeCatalogName: catalogLibrary.definitions[0].name,
+    testingCatalogName: '',
+    nodeLabel: 'description',
+    nodeToolbarTrigger: 'onHover',
+    colorScheme: 'auto',
+    rest: { apicurioRegistryUrl: '', customMediaTypes: [] },
+    canvasLayoutDirection: 'SelectInCanvas',
+  };
+
+  cy.visit(url!, {
+    onBeforeLoad(win) {
+      win.localStorage.setItem('settings', JSON.stringify(settings));
+    },
+  });
+  cy.waitSchemasLoading();
 });
 
 Cypress.Commands.add('openHomePageWithPreExistingRoutes', () => {

--- a/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
+++ b/packages/ui-tests/cypress/support/next-commands/sourceCode.ts
@@ -32,6 +32,18 @@ Cypress.Commands.add('editorAddText', (line, text) => {
 });
 
 Cypress.Commands.add('uploadFixture', (fixture) => {
+  const url = Cypress.config().baseUrl;
+  cy.fixture(fixture).then((fixtureContent) => {
+    cy.visit(url!, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('sourceCode', fixtureContent);
+      },
+    });
+  });
+  cy.waitSchemasLoading();
+});
+
+Cypress.Commands.add('uploadFixtureUsingEditor', (fixture) => {
   cy.openSourceCode();
   cy.waitForEditorToLoad();
   cy.get('.pf-v6-c-code-editor__main input[type="file"]').attachFile(fixture);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Optimized UI test initialization by removing redundant source-code openings between scenarios.
  * Improved editor-focused fixture loading by adding a dedicated fixture-upload command that seeds content during initialization.
  * Updated existing fixture loading to inject source content into local storage before the app loads.
  * Refined home-page navigation setup by seeding catalog-related runtime settings up-front.
  * Adjusted a few test flows to open the source editor at the correct time for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->