### PR TITLE
fix(DataMapper): when xslt not exists show error message, removed unnecessary comment

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
@@ -188,7 +188,7 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
           />
         </FormGroup>
       )}
-      {!isXsltDocumentDefined && (
+      {(!xsltFileExists || !isXsltDocumentDefined) && (
         <HelperText>
           <HelperTextItem variant="error">
             This Kaoto DataMapper step is missing some configuration. Please click the configure button to configure it.

--- a/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.test.tsx
+++ b/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.test.tsx
@@ -602,5 +602,3 @@ describe('XsltDocumentRenameInput', () => {
     });
   });
 });
-
-// Made with Bob


### PR DESCRIPTION
Resolves: [#3351](https://github.com/KaotoIO/kaoto/issues/3351)

<img width="1162" height="826" alt="configure-step" src="https://github.com/user-attachments/assets/f8cea5de-d9c4-4316-adeb-1664c74e470e" />
<img width="1163" height="832" alt="configured-step" src="https://github.com/user-attachments/assets/012b25ce-d12e-464a-9a7c-69e0179d2a17" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation to display the missing configuration warning when the referenced XSLT resource does not exist, in addition to when the document name is undefined.

* **Tests**
  * Removed unnecessary comments from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->