### PR TITLE
chore(resource): Remove getCompatibleRuntime() method

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -163,7 +163,6 @@ describe('DataMapperLauncher', () => {
     getSerializerType: jest.fn(),
     setSerializer: jest.fn(),
     getCompatibleComponents: jest.fn().mockReturnValue([]),
-    getCompatibleRuntimes: jest.fn().mockReturnValue([]),
   };
 
   const mockEntitiesContext = {

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -108,10 +108,6 @@ export abstract class CamelKResource implements KaotoResource {
     return undefined;
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Main', 'Quarkus', 'Spring Boot'];
-  }
-
   getSerializerType() {
     return this.serializer.getType();
   }

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -937,33 +937,6 @@ describe('CamelRouteResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new CamelRouteResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new CamelRouteResource();
-      emptyResource.initialize();
-      const resourceWithRoutes = new CamelRouteResource([camelRouteJson, camelFromJson]);
-      resourceWithRoutes.initialize();
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithRoutes.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new CamelRouteResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   describe('edge cases and error handling', () => {
     it('should handle empty entities array in constructor', () => {
       const resource = new CamelRouteResource([]);

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -287,10 +287,6 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     return CamelComponentFilterService.getCamelCompatibleComponents(mode, visualEntityData, definition);
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Main', 'Quarkus', 'Spring Boot'];
-  }
-
   private getEntity(rawItem: unknown): BaseEntity | undefined {
     if (!isDefined(rawItem) || Array.isArray(rawItem)) {
       return undefined;

--- a/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
@@ -15,33 +15,6 @@ describe('KameletBindingResource', () => {
     expect(resource.getEntities().length).toEqual(2);
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new KameletBindingResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new KameletBindingResource();
-      emptyResource.initialize();
-      const resourceWithBinding = new KameletBindingResource(kameletBindingJson);
-      resourceWithBinding.initialize();
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithBinding.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new KameletBindingResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should initialize KameletBinding if no args is specified', () => {
     const resource = new KameletBindingResource(undefined);
     resource.initialize();

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -119,33 +119,6 @@ describe('KameletResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const kameletResource = new KameletResource();
-      kameletResource.initialize();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new KameletResource();
-      emptyResource.initialize();
-      const resourceWithKamelet = new KameletResource(kameletJson);
-      resourceWithKamelet.initialize();
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const kameletResource = new KameletResource();
-      kameletResource.initialize();
-      const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should support RouteTemplateBeansAwareResource methods', () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -31,33 +31,6 @@ describe('PipeResource', () => {
     expect(vis.pipe.spec?.sink).toBeUndefined();
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new PipeResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new PipeResource();
-      emptyResource.initialize();
-      const resourceWithPipe = new PipeResource(pipeJson);
-      resourceWithPipe.initialize();
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithPipe.getCompatibleRuntimes());
-    });
-
-    it('should return an array with three runtime names', () => {
-      const resource = new PipeResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
-    });
-  });
-
   it('should create/delete entities', () => {
     const resource = new PipeResource();
     resource.initialize();

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -242,33 +242,6 @@ describe('CitrusTestResource', () => {
     });
   });
 
-  describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
-      const resource = new CitrusTestResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Citrus']);
-    });
-
-    it('should return the same list regardless of resource content', () => {
-      const emptyResource = new CitrusTestResource();
-      emptyResource.initialize();
-      const resourceWithTest = new CitrusTestResource(citrusTestJson);
-      resourceWithTest.initialize();
-
-      expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithTest.getCompatibleRuntimes());
-    });
-
-    it('should return an array with one runtime name', () => {
-      const resource = new CitrusTestResource();
-      resource.initialize();
-      const compatibleRuntimes = resource.getCompatibleRuntimes();
-
-      expect(compatibleRuntimes).toEqual(['Citrus']);
-    });
-  });
-
   describe('getCompatibleComponents', () => {
     it('should get compatible types', () => {
       const resource = new CitrusTestResource(citrusTestJson);

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -224,10 +224,6 @@ export class CitrusTestResource implements KaotoResource {
     };
   }
 
-  getCompatibleRuntimes(): string[] {
-    return ['Citrus'];
-  }
-
   /**
    * Converts a raw item to a BaseCamelEntity.
    *

--- a/packages/ui/src/models/kaoto-resource.ts
+++ b/packages/ui/src/models/kaoto-resource.ts
@@ -36,13 +36,6 @@ export interface KaotoResource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter | undefined;
-
-  /**
-   * Returns the list of compatible runtime catalog names for this resource type.
-   * For example, CamelRouteResource returns ["Main", "Quarkus", "Spring Boot"],
-   * while CitrusTestResource returns ["Citrus"].
-   */
-  getCompatibleRuntimes(): string[];
 }
 
 export enum SerializerType {


### PR DESCRIPTION
### Context
After aligning the catalog settings with VS Code Kaoto, the Testing catalog is split the Runtime catalog, so we no longer need each resource notifying what type of catalog they require, as this process is now handled by:

```ts
// runtime.provider.tsx

const catalogName = currentSchemaType === SourceSchemaType.Test ? testingCatalogName : runtimeCatalogName;
```