### PR TITLE
Refactor config integration type tests

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -1,49 +1,30 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
-import { KaotoSchemaDefinition } from '../../../../models';
-import { sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
 import { KaotoResource } from '../../../../models/kaoto-resource';
 import { RuntimeContext } from '../../../../providers';
-import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../stubs';
+import { configureSourceSchemaTypes, TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../stubs';
 import { CatalogSchemaLoader } from '../../../../utils';
 import { IntegrationTypeSelector } from './IntegrationTypeSelector';
 
 describe('IntegrationTypeSelector.tsx', () => {
-  const config = sourceSchemaConfig;
-  config.config[SourceSchemaType.Integration].schema = {
-    schema: { name: 'Integration', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Pipe].schema = {
-    schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Kamelet].schema = {
-    schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.KameletBinding].schema = {
-    name: 'kameletBinding',
-    schema: { description: 'desc' },
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Route].schema = {
-    schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Test].schema = {
-    schema: { name: 'Test', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
 
   const mockCamelCatalog: CatalogLibraryEntry = {
     name: 'Camel Main',
     runtime: 'Main',
     version: '4.0.0',
     fileName: 'camel-catalog-4.0.0.json',
-  } as CatalogLibraryEntry;
+  };
 
   const mockCitrusCatalog: CatalogLibraryEntry = {
     name: 'Citrus',
     runtime: 'Citrus',
     version: '4.0.0',
     fileName: 'citrus-catalog-4.0.0.json',
-  } as CatalogLibraryEntry;
+  };
 
   const mockCatalogLibrary: CatalogLibrary = {
     definitions: [mockCamelCatalog, mockCitrusCatalog],
@@ -93,8 +74,13 @@ describe('IntegrationTypeSelector.tsx', () => {
       fireEvent.click(trigger);
     });
 
-    for (const name of ['Pipe', 'Camel Route', 'Kamelet', 'Test']) {
-      const element = await wrapper.findByTestId(`integration-type-${name}`);
+    for (const testId of [
+      'integration-type-route',
+      'integration-type-Pipe',
+      'integration-type-Kamelet',
+      'integration-type-Test',
+    ]) {
+      const element = await wrapper.findByTestId(testId);
       expect(element).toBeInTheDocument();
     }
   });

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
@@ -1,25 +1,13 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
-import { KaotoSchemaDefinition } from '../../../../../models';
-import { sourceSchemaConfig, SourceSchemaType } from '../../../../../models/camel';
-import { TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../../stubs';
+import { configureSourceSchemaTypes, TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../../stubs';
 import { IntegrationTypeSelectorToggle } from './IntegrationTypeSelectorToggle';
 
-const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Pipe].schema = {
-  name: 'Pipe',
-  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Kamelet].schema = {
-  name: 'Kamelet',
-  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Route].schema = {
-  name: 'route',
-  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-
 describe('IntegrationTypeSelectorToggle.tsx', () => {
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
+
   it('component renders with the integration-type-list-dropdown toggle', () => {
     const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
     const { Provider } = TestProvidersWrapper();

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -2,28 +2,18 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
-import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../models';
-import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
-import { TestProvidersWrapper } from '../../../../stubs';
+import { CamelCatalogService, CatalogKind } from '../../../../models';
+import { CamelRouteResource } from '../../../../models/camel';
+import { configureSourceSchemaTypes, TestProvidersWrapper } from '../../../../stubs';
 import { camelRouteJson } from '../../../../stubs/camel-route';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { NewEntity } from './NewEntity';
 
-const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Pipe].schema = {
-  name: 'Pipe',
-  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Kamelet].schema = {
-  name: 'Kamelet',
-  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Route].schema = {
-  name: 'route',
-  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-
 describe('NewEntity', () => {
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
+
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
@@ -1,24 +1,10 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { KaotoSchemaDefinition } from '../../../../models';
-import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
+import { CamelRouteResource, SourceSchemaType } from '../../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { configureSourceSchemaTypes } from '../../../../stubs';
 import { FlowTypeSelector } from './FlowTypeSelector';
-
-const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Pipe].schema = {
-  name: 'Pipe',
-  schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Kamelet].schema = {
-  name: 'Kamelet',
-  schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Route].schema = {
-  name: 'route',
-  schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
-} as KaotoSchemaDefinition;
 
 const onSelect = jest.fn();
 const FlowTypeSelectorWithContext: React.FunctionComponent<{
@@ -40,6 +26,10 @@ const FlowTypeSelectorWithContext: React.FunctionComponent<{
 };
 
 describe('FlowTypeSelector.tsx', () => {
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
+
   it('component renders', async () => {
     await act(async () => {
       render(<FlowTypeSelectorWithContext />);

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
@@ -1,49 +1,32 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render } from '@testing-library/react';
 
-import { KaotoSchemaDefinition } from '../../../../models';
-import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
+import { CamelRouteResource, SourceSchemaType } from '../../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { VisibleFlowsProvider } from '../../../../providers';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { IRuntimeContext, RuntimeContext } from '../../../../providers/runtime.provider';
+import { configureSourceSchemaTypes } from '../../../../stubs';
 import { NewFlow } from './NewFlow';
 
 describe('NewFlow.tsx', () => {
-  const config = sourceSchemaConfig;
-  config.config[SourceSchemaType.Integration].schema = {
-    schema: { name: 'Integration', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Pipe].schema = {
-    schema: { name: 'Pipe', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Kamelet].schema = {
-    schema: { name: 'Kamelet', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.KameletBinding].schema = {
-    name: 'kameletBinding',
-    schema: { description: 'desc' },
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Route].schema = {
-    schema: { name: 'route', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
-  config.config[SourceSchemaType.Test].schema = {
-    schema: { name: 'Test', description: 'desc' } as KaotoSchemaDefinition['schema'],
-  } as KaotoSchemaDefinition;
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
 
   const mockCamelCatalog: CatalogLibraryEntry = {
     name: 'Camel Main',
     runtime: 'Main',
     version: '4.0.0',
     fileName: 'camel-catalog-4.0.0.json',
-  } as CatalogLibraryEntry;
+  };
 
   const mockCitrusCatalog: CatalogLibraryEntry = {
     name: 'Citrus',
     runtime: 'Citrus',
     version: '4.0.0',
     fileName: 'citrus-catalog-4.0.0.json',
-  } as CatalogLibraryEntry;
+  };
 
   const mockCatalogLibrary: CatalogLibrary = {
     definitions: [mockCamelCatalog, mockCitrusCatalog],

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -2,28 +2,10 @@ import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { Ref } from 'react';
 
-import { KaotoSchemaDefinition } from '../../../models';
 import { sourceSchemaConfig, SourceSchemaType } from '../../../models/camel';
 import { EntitiesContext, EntitiesContextResult } from '../../../providers/entities.provider';
+import { configureSourceSchemaTypes } from '../../../stubs';
 import { IntegrationTypeSelector } from './IntegrationTypeSelector';
-
-const config = sourceSchemaConfig;
-config.config[SourceSchemaType.Route].schema = {
-  name: 'route',
-  schema: { name: 'route', description: 'Camel Route desc' },
-} as unknown as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Kamelet].schema = {
-  name: 'Kamelet',
-  schema: { name: 'Kamelet', description: 'Kamelet desc' },
-} as unknown as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Pipe].schema = {
-  name: 'Pipe',
-  schema: { name: 'Pipe', description: 'Pipe desc' },
-} as unknown as KaotoSchemaDefinition;
-config.config[SourceSchemaType.Test].schema = {
-  name: 'Test',
-  schema: { name: 'Test', description: 'Test desc' },
-} as unknown as KaotoSchemaDefinition;
 
 const makeToggle = (testId: string) => (toggleRef: Ref<MenuToggleElement>, isOpen: boolean, onToggle: () => void) => (
   <MenuToggle data-testid={testId} ref={toggleRef} onClick={onToggle} isExpanded={isOpen}>
@@ -61,6 +43,10 @@ const renderSelector = (
   );
 
 describe('IntegrationTypeSelector', () => {
+  beforeAll(() => {
+    configureSourceSchemaTypes();
+  });
+
   it('renders the toggle', () => {
     const wrapper = renderSelector();
     expect(wrapper.getByTestId('test-toggle')).toBeInTheDocument();

--- a/packages/ui/src/stubs/index.ts
+++ b/packages/ui/src/stubs/index.ts
@@ -4,6 +4,7 @@ export * from './kamelet-route';
 export * from './mock-random-values';
 export * from './pipe';
 export * from './rest-visual-entity';
+export * from './sourceSchemaConfig';
 export * from './TestProvidersWrapper';
 export * from './TestRuntimeProviderWrapper';
 export * from './tiles';

--- a/packages/ui/src/stubs/sourceSchemaConfig.ts
+++ b/packages/ui/src/stubs/sourceSchemaConfig.ts
@@ -1,0 +1,26 @@
+import { sourceSchemaConfig, SourceSchemaType } from '../models/camel';
+
+/**
+ * Configures the `sourceSchemaConfig` singleton with minimal schema stubs so that
+ * tests that render DSL-selector components don't fail on missing schema data.
+ *
+ * Call this once at the top of any test file (or inside a `beforeAll`) that
+ * renders components relying on `sourceSchemaConfig.config[type].schema`.
+ */
+export const configureSourceSchemaTypes = (): void => {
+  const types: { type: SourceSchemaType; name: string; description: string }[] = [
+    { type: SourceSchemaType.Route, name: 'route', description: 'Camel Route desc' },
+    { type: SourceSchemaType.Kamelet, name: 'Kamelet', description: 'Kamelet desc' },
+    { type: SourceSchemaType.Pipe, name: 'Pipe', description: 'Pipe desc' },
+    { type: SourceSchemaType.Test, name: 'Test', description: 'Test desc' },
+    { type: SourceSchemaType.Integration, name: 'Integration', description: 'Integration desc' },
+    { type: SourceSchemaType.KameletBinding, name: 'kameletBinding', description: 'KameletBinding desc' },
+  ];
+
+  for (const { type, name, description } of types) {
+    sourceSchemaConfig.config[type].schema = {
+      name,
+      schema: { name, description },
+    } as unknown as (typeof sourceSchemaConfig.config)[typeof type]['schema'];
+  }
+};


### PR DESCRIPTION
Introduces a shared `configureSourceSchemaTypes()` helper in `src/stubs/sourceSchemaConfig.ts` that populates the `sourceSchemaConfig` singleton with minimal schema stubs for all `SourceSchemaType` values. This removes the repetitive inline schema setup that was duplicated across 6 test files (`IntegrationTypeSelector`, `IntegrationTypeSelectorToggle`, `NewEntity`, `FlowTypeSelector`, `NewFlow`), reducing test boilerplate by ~60 lines and making the setup consistent across all DSL-selector component tests.

fix: https://github.com/KaotoIO/kaoto/issues/3354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated multiple component tests to use a shared `configureSourceSchemaTypes()` helper for consistent schema-type setup.
  * Adjusted `IntegrationTypeSelector` dropdown assertions to use test-id-based option checks rather than label-based lookup.

* **Refactor**
  * Added a centralized stub helper for source schema-type configuration and re-exported it for reuse across the test suite.

* **Chores**
  * Improved test fixture maintainability by removing repetitive inline schema mutations.  

*Note: No user-facing changes; this is test-only maintenance.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->