### PR TITLE
chore(Resource): Migrate `KaotoResource.initialize()` method to `async`

### DIFF
--- a/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
+++ b/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
@@ -7,8 +7,8 @@ import { TestProvidersWrapper } from '../../stubs';
 import { GroupAutoStartupSwitch } from './GroupAutoStartupSwitch';
 
 describe('GroupAutoStartupSwitch', () => {
-  it('should return null when vizNode is undefined', () => {
-    const { Provider } = TestProvidersWrapper();
+  it('should return null when vizNode is undefined', async () => {
+    const { Provider } = await TestProvidersWrapper();
     const { container } = render(
       <Provider>
         <GroupAutoStartupSwitch />
@@ -17,7 +17,7 @@ describe('GroupAutoStartupSwitch', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should return null when entity is undefined', () => {
+  it('should return null when entity is undefined', async () => {
     const vizNode = createVisualizationNode('test-node', {
       name: 'route',
       path: 'route',
@@ -28,7 +28,7 @@ describe('GroupAutoStartupSwitch', () => {
       description: '',
     });
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const { container } = render(
       <Provider>
         <GroupAutoStartupSwitch vizNode={vizNode} />
@@ -37,7 +37,7 @@ describe('GroupAutoStartupSwitch', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should render switch as checked when autoStartup is enabled (undefined)', () => {
+  it('should render switch as checked when autoStartup is enabled (undefined)', async () => {
     const entity = new CamelRouteVisualEntity({
       route: { from: { uri: 'direct:test', steps: [] } },
     });
@@ -53,7 +53,7 @@ describe('GroupAutoStartupSwitch', () => {
       description: '',
     }) as IVisualizationNode;
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -69,7 +69,7 @@ describe('GroupAutoStartupSwitch', () => {
     expect(containerDiv).toBeInTheDocument();
   });
 
-  it('should render switch as unchecked when autoStartup is false', () => {
+  it('should render switch as unchecked when autoStartup is false', async () => {
     const entity = new CamelRouteVisualEntity({
       route: { from: { uri: 'direct:test', steps: [] }, autoStartup: false },
     });
@@ -85,7 +85,7 @@ describe('GroupAutoStartupSwitch', () => {
       description: '',
     }) as IVisualizationNode;
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -119,7 +119,7 @@ describe('GroupAutoStartupSwitch', () => {
     }) as IVisualizationNode;
 
     const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -160,7 +160,7 @@ describe('GroupAutoStartupSwitch', () => {
     }) as IVisualizationNode;
 
     const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -198,7 +198,7 @@ describe('GroupAutoStartupSwitch', () => {
     }) as IVisualizationNode;
 
     const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -235,7 +235,7 @@ describe('GroupAutoStartupSwitch', () => {
     }) as IVisualizationNode;
 
     const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -277,7 +277,7 @@ describe('GroupAutoStartupSwitch', () => {
     }) as IVisualizationNode;
 
     const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -28,7 +28,7 @@ import { applyCollapseState } from './apply-collapse-state';
 describe('Canvas', () => {
   const entity = new CamelRouteVisualEntity(camelRouteJson);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
@@ -38,7 +38,7 @@ describe('Canvas', () => {
 
   it('should render correctly', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     let result: RenderResult | undefined;
@@ -63,7 +63,7 @@ describe('Canvas', () => {
 
   it('should schedule a graph.fit(80) upon loading', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
     const controller = ControllerService.createController();
     const fromModelSpy = vi.spyOn(controller, 'fromModel');
@@ -100,7 +100,7 @@ describe('Canvas', () => {
 
   it('when initialized is true, runs fromModel(model, true), and applyCollapseState', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const controller = ControllerService.createController();
     const fromModelSpy = vi.spyOn(controller, 'fromModel');
     const vizNode = await entity.toVizNode();
@@ -147,7 +147,7 @@ describe('Canvas', () => {
     const vizNode = await routeEntities[0].toVizNode();
     const removeSpy = vi.spyOn(camelResource, 'removeEntity');
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource,
     });
 
@@ -207,7 +207,7 @@ describe('Canvas', () => {
     const vizNode = await kameletEntities[0].toVizNode();
     const removeSpy = vi.spyOn(kameletResource, 'removeEntity');
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource: kameletResource,
     });
 
@@ -261,7 +261,7 @@ describe('Canvas', () => {
 
   describe('Catalog button', () => {
     it('should be present if `CatalogModalContext` is provided', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const vizNode = await entity.toVizNode();
 
       let result: RenderResult | undefined;
@@ -287,7 +287,7 @@ describe('Canvas', () => {
     });
 
     it('should NOT be present if `CatalogModalContext` is NOT provided', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const vizNode = await entity.toVizNode();
 
       let result: RenderResult | undefined;
@@ -314,7 +314,7 @@ describe('Canvas', () => {
   describe('Empty state', () => {
     it('should render empty state when there is no visual viznode', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper({
+      const { Provider } = await TestProvidersWrapper({
         visibleFlowsContext: { visibleFlows: {} } as unknown as VisibleFlowsContextResult,
       });
 
@@ -342,7 +342,7 @@ describe('Canvas', () => {
 
     it('should render empty state when there is no visible flows', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       let result: RenderResult | undefined;
 
       await act(async () => {
@@ -367,7 +367,7 @@ describe('Canvas', () => {
 
     it('should not render all-flows-hidden empty state while viz nodes are still resolving', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () => {
         render(
@@ -390,7 +390,7 @@ describe('Canvas', () => {
   });
 
   describe('Active Layout Priority', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       localStorage.clear();
     });
 
@@ -426,7 +426,7 @@ describe('Canvas', () => {
         const settingsAdapter = new DefaultSettingsAdapter({ canvasLayoutDirection });
         const vizNode = await entity.toVizNode();
 
-        const { Provider } = TestProvidersWrapper();
+        const { Provider } = await TestProvidersWrapper();
 
         const controller = ControllerService.createController();
         const fromModelSpy = vi.spyOn(controller, 'fromModel');
@@ -456,7 +456,7 @@ describe('Canvas', () => {
   });
 
   describe('Layout Toggle Buttons', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       localStorage.clear();
     });
 
@@ -469,7 +469,7 @@ describe('Canvas', () => {
         canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       });
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const vizNode = await entity.toVizNode();
 
       const localStorageSetItemSpy = vi.spyOn(Storage.prototype, 'setItem');
@@ -509,7 +509,7 @@ describe('Canvas', () => {
         canvasLayoutDirection: CanvasLayoutDirection.SelectInCanvas,
       });
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const vizNode = await entity.toVizNode();
 
       const localStorageSetItemSpy = vi.spyOn(Storage.prototype, 'setItem');
@@ -549,7 +549,7 @@ describe('Canvas', () => {
       async (canvasLayoutDirection) => {
         const settingsAdapter = new DefaultSettingsAdapter({ canvasLayoutDirection });
 
-        const { Provider } = TestProvidersWrapper();
+        const { Provider } = await TestProvidersWrapper();
         const vizNode = await entity.toVizNode();
 
         await act(async () => {

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -1,6 +1,8 @@
+import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { CanvasFormTabsProvider } from '@kaoto/forms';
 import { act, fireEvent, render } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
+import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../models/camel';
 import { EntityType } from '../../../models/entities';
@@ -16,12 +18,15 @@ describe('CanvasSideBar', () => {
 
   beforeAll(async () => {
     mockRandomValues();
-    const camelResource = new CamelRouteResource();
-    camelResource.initialize();
-    camelResource.addNewEntity(EntityType.Route);
+    const baseResource = new CamelRouteResource();
+    baseResource.addNewEntity(EntityType.Route);
+    // Materialize the route into source so the wrapper's re-initialize() reproduces
+    // it — mirrors how runtime recreates the resource from serialized code.
+    const camelResource = new CamelRouteResource(parse(baseResource.toString()) as CamelYamlDsl);
+    await camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     selectedNode = FlowService.getFlowDiagram('test', await visualEntity.toVizNode()).nodes[0];
-    Provider = TestProvidersWrapper({ camelResource }).Provider;
+    Provider = (await TestProvidersWrapper({ camelResource })).Provider;
   });
 
   it('does not render anything if there is no selectedNode', async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -59,7 +59,7 @@ describe('CanvasForm', () => {
   });
 
   it('should render', async () => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
@@ -82,7 +82,7 @@ describe('CanvasForm', () => {
       },
     } as CanvasNode;
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
@@ -120,7 +120,7 @@ describe('CanvasForm', () => {
     vi.spyOn(vizNode, 'getNodeSchema').mockReturnValue(undefined);
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
@@ -158,7 +158,7 @@ describe('CanvasForm', () => {
     vi.spyOn(vizNode, 'getNodeSchema').mockReturnValue(null as unknown as KaotoSchemaDefinition['schema']);
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(null);
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
@@ -179,7 +179,7 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
     });
 
@@ -218,7 +218,7 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
     });
 
@@ -258,7 +258,7 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
     });
 
@@ -300,7 +300,7 @@ describe('CanvasForm', () => {
     const { nodes } = FlowService.getFlowDiagram('test', await kameletVisualEntity.toVizNode());
     selectedNode = nodes[nodes.length - 1];
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
     });
 
@@ -336,7 +336,7 @@ describe('CanvasForm', () => {
     });
 
     it('normal text field', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -393,7 +393,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -458,7 +458,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -527,7 +527,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -575,7 +575,7 @@ describe('CanvasForm', () => {
     });
 
     it('normal text field', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -628,7 +628,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -689,7 +689,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(
@@ -751,7 +751,7 @@ describe('CanvasForm', () => {
         },
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       await act(async () =>
         render(

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -41,7 +41,7 @@ describe('CanvasFormBody', () => {
   });
 
   describe('should persists changes from both expression editor and main form', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
@@ -65,7 +65,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const setHeaderNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -121,7 +121,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const setHeaderNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -157,7 +157,7 @@ describe('CanvasFormBody', () => {
   });
 
   describe('should persists changes from both dataformat editor and main form', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
@@ -181,7 +181,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const marshalNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -232,7 +232,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const marshalNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -264,7 +264,7 @@ describe('CanvasFormBody', () => {
   });
 
   describe('should persists changes from both loadbalancer editor and main form', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
@@ -288,7 +288,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const loadBalanceNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -343,7 +343,7 @@ describe('CanvasFormBody', () => {
       const rootNode: IVisualizationNode = await entity.toVizNode();
       const loadBalanceNode = rootNode.getChildren()![1];
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <EntitiesContext.Provider value={null}>
@@ -377,7 +377,7 @@ describe('CanvasFormBody', () => {
   });
 
   it('should show suggestions', async () => {
-    const { Provider, camelResource } = TestProvidersWrapper();
+    const { Provider, camelResource } = await TestProvidersWrapper();
     const vizNode = await camelResource.getVisualEntities()[0].toVizNode();
     vi.spyOn(vizNode, 'getNodeSchema').mockReturnValue({
       type: 'object',

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
@@ -38,7 +38,7 @@ describe('BeanField', () => {
     schemaTitle: string,
     schema: KaotoSchemaDefinition['schema'],
   ) => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -78,8 +78,8 @@ describe('BeanField', () => {
   };
 
   describe('PrefixedBeanField', () => {
-    it('should render', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       const { container } = render(
         <Provider>
@@ -92,8 +92,8 @@ describe('BeanField', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should set the appropriate placeholder', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should set the appropriate placeholder', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       const wrapper = render(
         <Provider>
@@ -111,7 +111,7 @@ describe('BeanField', () => {
 
     it('should clear the input when using the clear button', async () => {
       const onPropertyChangeSpy = vi.fn();
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -130,7 +130,7 @@ describe('BeanField', () => {
 
     it('should show the new bean modal when creating a new bean', async () => {
       const onPropertyChangeSpy = vi.fn();
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -157,7 +157,7 @@ describe('BeanField', () => {
     beforeEach(async () => {
       onPropertyChangeSpy = vi.fn();
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -244,7 +244,7 @@ describe('BeanField', () => {
         return <PrefixedBeanField propName={ROOT_PATH} />;
       };
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       cleanup();
       render(
         <Provider>
@@ -275,8 +275,8 @@ describe('BeanField', () => {
   });
 
   describe('UnprefixedBeanField', () => {
-    it('should render', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       const { container } = render(
         <Provider>
@@ -289,8 +289,8 @@ describe('BeanField', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should set the appropriate placeholder', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should set the appropriate placeholder', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       const wrapper = render(
         <Provider>
@@ -308,7 +308,7 @@ describe('BeanField', () => {
 
     it('should clear the input when using the clear button', async () => {
       const onPropertyChangeSpy = vi.fn();
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -327,7 +327,7 @@ describe('BeanField', () => {
 
     it('should show the new bean modal when creating a new bean', async () => {
       const onPropertyChangeSpy = vi.fn();
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -354,7 +354,7 @@ describe('BeanField', () => {
     beforeEach(async () => {
       onPropertyChangeSpy = vi.fn();
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -443,7 +443,7 @@ describe('BeanField', () => {
     });
 
     it('should display existing beans correctly in prefixed mode', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       // First create a bean using UnprefixedBeanField to add it to the system
       render(
@@ -489,7 +489,7 @@ describe('BeanField', () => {
     });
 
     it('should display existing beans correctly in unprefixed mode', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       // First create a bean using PrefixedBeanField to add it to the system
       render(
@@ -551,7 +551,7 @@ describe('BeanField', () => {
     });
 
     it('should include default items in dropdown options', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -576,7 +576,7 @@ describe('BeanField', () => {
     });
 
     it('should allow selection of default items', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -596,7 +596,7 @@ describe('BeanField', () => {
     });
 
     it('should find beans to only show DataSource types', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       // First create regular bean and DataSource bean
       render(
@@ -671,7 +671,7 @@ describe('BeanField', () => {
     });
 
     it('should show new bean modal when creating DataSource bean', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
@@ -1,6 +1,6 @@
 import { CamelYamlDsl, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
 
 import { CamelRouteResource } from '../../../../../models/camel/camel-route-resource';
@@ -17,14 +17,13 @@ describe('DirectEndpointNameField', () => {
     description: 'Sets the endpoint name',
   };
 
-  const renderField = (
+  const renderField = async (
     model: string | undefined,
     routes: RouteDefinition[],
     visibleFlowsContext?: VisibleFlowsContextResult,
   ) => {
     const camelResource = new CamelRouteResource(routes as unknown as CamelYamlDsl);
-    camelResource.initialize();
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext,
     });
@@ -42,17 +41,22 @@ describe('DirectEndpointNameField', () => {
     return { camelResource, updateEntitiesFromCamelResourceSpy };
   };
 
-  it('renders known direct endpoint names as suggestions', () => {
-    renderField(undefined, [
+  it('renders known direct endpoint names as suggestions', async () => {
+    await renderField(undefined, [
       { from: { uri: 'direct:start', steps: [] } },
       { from: { uri: 'timer:test', steps: [{ to: { uri: 'direct:orders' } }] } },
       { from: { uri: 'direct', parameters: { name: 'billing' }, steps: [] } },
     ]);
 
     const toggle = screen.getByLabelText('Name toggle');
-    fireEvent.click(toggle);
+    act(() => {
+      fireEvent.click(toggle);
+    });
 
-    const options = screen.getAllByRole('option').map((option) => option.textContent);
+    // findAllByRole polls until the typeahead options render, which also flushes
+    // PatternFly's debounced Popper reposition inside act() — a plain getAllByRole
+    // would assert synchronously and let that update leak past the test.
+    const options = (await screen.findAllByRole('option')).map((option) => option.textContent);
 
     expect(options.some((option) => option?.includes('billing'))).toBeTruthy();
     expect(options.some((option) => option?.includes('orders'))).toBeTruthy();
@@ -60,7 +64,7 @@ describe('DirectEndpointNameField', () => {
   });
 
   it('enables create button only for new names', async () => {
-    renderField(undefined, [{ from: { uri: 'direct:start', steps: [] } }]);
+    await renderField(undefined, [{ from: { uri: 'direct:start', steps: [] } }]);
 
     const input = screen.getByRole('textbox', { name: 'Name' });
     const button = screen.getByRole('button', { name: 'Create Route' });
@@ -82,7 +86,7 @@ describe('DirectEndpointNameField', () => {
       visualFlowsApi: { toggleFlowVisible: toggleFlowVisibleSpy },
     } as unknown as VisibleFlowsContextResult;
 
-    const { camelResource, updateEntitiesFromCamelResourceSpy } = renderField(
+    const { camelResource, updateEntitiesFromCamelResourceSpy } = await renderField(
       undefined,
       [{ from: { uri: 'direct:start', steps: [] } }],
       visibleFlowsContext,

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -45,7 +45,7 @@ describe('EndpointField', () => {
     return wrapper;
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
   });
 
@@ -70,8 +70,7 @@ describe('EndpointField', () => {
     options: { disabled?: boolean; required?: boolean } = {},
   ) => {
     const camelResource = createTestResource(testModel);
-    camelResource.initialize();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     await act(async () => {
       const wrapper = createWrapper();

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -46,7 +46,7 @@ describe('EndpointListField', () => {
     return wrapper;
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
   });
 
@@ -75,8 +75,7 @@ describe('EndpointListField', () => {
     options: { disabled?: boolean; required?: boolean } = {},
   ) => {
     const camelResource = createTestResource(testModel);
-    camelResource.initialize();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     await act(async () => {
       const wrapper = createWrapper();

--- a/packages/ui/src/components/Visualization/ConfirmIntegrationTypeChangeModal/ConfirmIntegrationTypeChangeModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ConfirmIntegrationTypeChangeModal/ConfirmIntegrationTypeChangeModal.test.tsx
@@ -29,11 +29,11 @@ describe('ConfirmIntegrationTypeChangeModal', () => {
     definitions: [mockCamelCatalog, mockCitrusCatalog],
   } as CatalogLibrary;
 
-  const renderModal = (
+  const renderModal = async (
     proposedFlowType: SourceSchemaType | undefined,
     selectedCatalog: CatalogLibraryEntry = mockCamelCatalog,
   ) => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     const result = render(
       <RuntimeContext.Provider
@@ -58,44 +58,44 @@ describe('ConfirmIntegrationTypeChangeModal', () => {
     onClose = vi.fn();
   });
 
-  it('should be hidden when proposedFlowType is undefined', () => {
-    const { queryByTestId } = renderModal(undefined);
+  it('should be hidden when proposedFlowType is undefined', async () => {
+    const { queryByTestId } = await renderModal(undefined);
 
     expect(queryByTestId('confirmation-modal')).not.toBeInTheDocument();
   });
 
-  it('should be visible when proposedFlowType is set', () => {
-    const { queryByTestId } = renderModal(SourceSchemaType.Route);
+  it('should be visible when proposedFlowType is set', async () => {
+    const { queryByTestId } = await renderModal(SourceSchemaType.Route);
 
     expect(queryByTestId('confirmation-modal')).toBeInTheDocument();
   });
 
-  it('should call onClose when cancel button is clicked', () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Route);
+  it('should call onClose when cancel button is clicked', async () => {
+    const { getByTestId } = await renderModal(SourceSchemaType.Route);
 
     fireEvent.click(getByTestId('confirmation-modal-cancel'));
 
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('should call onClose when close button is clicked', () => {
-    const { getByLabelText } = renderModal(SourceSchemaType.Route);
+  it('should call onClose when close button is clicked', async () => {
+    const { getByLabelText } = await renderModal(SourceSchemaType.Route);
 
     fireEvent.click(getByLabelText('Close'));
 
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('should not show the catalog warning for a same-catalog flow type', () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Pipe, mockCamelCatalog);
+  it('should not show the catalog warning for a same-catalog flow type', async () => {
+    const { getByTestId } = await renderModal(SourceSchemaType.Pipe, mockCamelCatalog);
 
     expect(getByTestId('confirmation-modal-text')).not.toHaveTextContent(
       'This will also change the current selected catalog.',
     );
   });
 
-  it('should show the catalog warning when switching to a different catalog', () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Test, mockCamelCatalog);
+  it('should show the catalog warning when switching to a different catalog', async () => {
+    const { getByTestId } = await renderModal(SourceSchemaType.Test, mockCamelCatalog);
 
     expect(getByTestId('confirmation-modal-text')).toHaveTextContent(
       'This will also change the current selected catalog.',
@@ -103,7 +103,7 @@ describe('ConfirmIntegrationTypeChangeModal', () => {
   });
 
   it('should call onClose after confirming', async () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Route);
+    const { getByTestId } = await renderModal(SourceSchemaType.Route);
 
     await act(async () => {
       fireEvent.click(getByTestId('confirmation-modal-confirm'));
@@ -113,7 +113,7 @@ describe('ConfirmIntegrationTypeChangeModal', () => {
   });
 
   it('should update catalog when switching to a different catalog type', async () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Test, mockCamelCatalog);
+    const { getByTestId } = await renderModal(SourceSchemaType.Test, mockCamelCatalog);
 
     await act(async () => {
       fireEvent.click(getByTestId('confirmation-modal-confirm'));
@@ -123,7 +123,7 @@ describe('ConfirmIntegrationTypeChangeModal', () => {
   });
 
   it('should not update catalog when switching between same-catalog flow types', async () => {
-    const { getByTestId } = renderModal(SourceSchemaType.Pipe, mockCamelCatalog);
+    const { getByTestId } = await renderModal(SourceSchemaType.Pipe, mockCamelCatalog);
 
     await act(async () => {
       fireEvent.click(getByTestId('confirmation-modal-confirm'));

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
@@ -51,10 +51,9 @@ vi.mock('./IntegrationTypeSelector/IntegrationTypeSelector', () => ({
 
 describe('ContextToolbar', () => {
   describe('when using multipleRoute configuration', () => {
-    it('should include NewEntity component for Route schema type', () => {
+    it('should include NewEntity component for Route schema type', async () => {
       const camelResource = new CamelRouteResource([]);
-      camelResource.initialize();
-      const { Provider } = TestProvidersWrapper({ camelResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource });
 
       render(
         <Provider>
@@ -65,9 +64,9 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('new-entity')).toBeInTheDocument();
     });
 
-    it('should include NewEntity component for Integration schema type', () => {
+    it('should include NewEntity component for Integration schema type', async () => {
       const camelResource = new IntegrationResource();
-      const { Provider } = TestProvidersWrapper({ camelResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource });
 
       render(
         <Provider>
@@ -80,10 +79,9 @@ describe('ContextToolbar', () => {
   });
 
   describe('when using single route configuration', () => {
-    it('should not include NewEntity component for Kamelet schema type', () => {
+    it('should not include NewEntity component for Kamelet schema type', async () => {
       const camelResource = new KameletResource();
-      camelResource.initialize();
-      const { Provider } = TestProvidersWrapper({ camelResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource });
 
       render(
         <Provider>
@@ -94,10 +92,9 @@ describe('ContextToolbar', () => {
       expect(screen.queryByTestId('new-entity')).not.toBeInTheDocument();
     });
 
-    it('should not include NewEntity component for Pipe schema type', () => {
+    it('should not include NewEntity component for Pipe schema type', async () => {
       const camelResource = new PipeResource();
-      camelResource.initialize();
-      const { Provider } = TestProvidersWrapper({ camelResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource });
 
       render(
         <Provider>
@@ -108,10 +105,9 @@ describe('ContextToolbar', () => {
       expect(screen.queryByTestId('new-entity')).not.toBeInTheDocument();
     });
 
-    it('should not include NewEntity component for KameletBinding schema type', () => {
+    it('should not include NewEntity component for KameletBinding schema type', async () => {
       const camelResource = new KameletBindingResource();
-      camelResource.initialize();
-      const { Provider } = TestProvidersWrapper({ camelResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource });
 
       render(
         <Provider>
@@ -124,8 +120,8 @@ describe('ContextToolbar', () => {
   });
 
   describe('undo/redo buttons', () => {
-    it('should render undo button', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render undo button', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -139,8 +135,8 @@ describe('ContextToolbar', () => {
       expect(undoButton).not.toBeDisabled();
     });
 
-    it('should render redo button', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render redo button', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -156,8 +152,8 @@ describe('ContextToolbar', () => {
   });
 
   describe('other toolbar buttons', () => {
-    it('should render FlowsMenu component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render FlowsMenu component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -168,8 +164,8 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('flows-menu')).toBeInTheDocument();
     });
 
-    it('should render FlowClipboard component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render FlowClipboard component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -180,8 +176,8 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('flow-clipboard')).toBeInTheDocument();
     });
 
-    it('should render FlowExportImage component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render FlowExportImage component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -192,8 +188,8 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('flow-export-image')).toBeInTheDocument();
     });
 
-    it('should render ExportDocument component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render ExportDocument component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -204,8 +200,8 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('export-document')).toBeInTheDocument();
     });
 
-    it('should render SelectedRuntime component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render SelectedRuntime component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -216,8 +212,8 @@ describe('ContextToolbar', () => {
       expect(screen.getByTestId('selected-runtime')).toBeInTheDocument();
     });
 
-    it('should render IntegrationTypeSelector component', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should render IntegrationTypeSelector component', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -230,8 +226,8 @@ describe('ContextToolbar', () => {
   });
 
   describe('when isSimplified is true', () => {
-    it('should not render IntegrationTypeSelector', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should not render IntegrationTypeSelector', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -242,8 +238,8 @@ describe('ContextToolbar', () => {
       expect(screen.queryByTestId('integration-type-selector')).not.toBeInTheDocument();
     });
 
-    it('should not render SelectedRuntime', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should not render SelectedRuntime', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>
@@ -254,8 +250,8 @@ describe('ContextToolbar', () => {
       expect(screen.queryByTestId('selected-runtime')).not.toBeInTheDocument();
     });
 
-    it('should still render the core toolbar items', () => {
-      const { Provider } = TestProvidersWrapper();
+    it('should still render the core toolbar items', async () => {
+      const { Provider } = await TestProvidersWrapper();
 
       render(
         <Provider>

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
@@ -1,5 +1,7 @@
+import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/entities';
@@ -14,13 +16,17 @@ describe('FlowExportDocument.tsx', () => {
     camelResource = new CamelRouteResource();
     camelResource.addNewEntity(EntityType.Route);
     camelResource.addNewEntity(EntityType.RouteConfiguration);
+    // Materialize the new entities into source so the wrapper's re-initialize()
+    // (which rebuilds entities from source) preserves them — mirrors how runtime
+    // recreates the resource from serialized code on `code:updated`.
+    camelResource = new CamelRouteResource(parse(camelResource.toString()) as CamelYamlDsl);
   });
 
   afterEach(() => vi.clearAllMocks());
 
   it('should be render', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <VisualizationProvider controller={ControllerService.createController()}>
         <Provider>

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
@@ -34,7 +34,7 @@ describe('ExportDocumentPreviewModal', () => {
   let clickSpy: MockInstance;
   let eventListenerCallback: ((event?: Event) => void) | null = null;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     onCloseSpy = vi.fn();
 
     originalCreateObjectURL = URL.createObjectURL;
@@ -57,7 +57,7 @@ describe('ExportDocumentPreviewModal', () => {
       }
     });
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     wrapper = ({ children }) => (
       <VisualizationProvider controller={ControllerService.createController()}>
         <Provider>{children}</Provider>

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
@@ -45,7 +45,7 @@ describe('FlowExportImage', () => {
   let mockSurface: HTMLElement;
   let mockGraph: MockGraph;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockSurface = document.createElement('div');
     mockSurface.className = 'pf-topology-visualization-surface';
 
@@ -83,8 +83,8 @@ describe('FlowExportImage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the export button', () => {
-    const { Provider } = TestProvidersWrapper();
+  it('renders the export button', async () => {
+    const { Provider } = await TestProvidersWrapper();
     render(
       <Provider>
         <FlowExportImage />
@@ -94,7 +94,7 @@ describe('FlowExportImage', () => {
   });
 
   it('runs full export flow', async () => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     render(
       <Provider>
         <FlowExportImage />
@@ -126,7 +126,7 @@ describe('FlowExportImage', () => {
       return realQuerySelector(selector ?? '');
     }) as unknown as typeof document.querySelector;
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     render(
       <Provider>
         <FlowExportImage />

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
@@ -31,7 +31,7 @@ describe('HiddenCanvas', () => {
   let originalCT: typeof globalThis.clearTimeout;
   let clickSpy: MockInstance;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
 
     // Save original implementations
@@ -84,7 +84,7 @@ describe('HiddenCanvas', () => {
 
   it('renders the hidden canvas container', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     const { container } = render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, {
@@ -96,7 +96,7 @@ describe('HiddenCanvas', () => {
 
   it('creates a controller on mount', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -107,7 +107,7 @@ describe('HiddenCanvas', () => {
 
   it('builds the graph model from viz nodes', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -125,7 +125,7 @@ describe('HiddenCanvas', () => {
 
   it('resets and layouts the graph after model is loaded', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -135,7 +135,7 @@ describe('HiddenCanvas', () => {
 
   it('triggers export when GRAPH_LAYOUT_END_EVENT fires', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -152,7 +152,7 @@ describe('HiddenCanvas', () => {
 
   it('calls toBlob with correct options', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -175,7 +175,7 @@ describe('HiddenCanvas', () => {
 
   it('calls onComplete after successful export', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -197,7 +197,7 @@ describe('HiddenCanvas', () => {
     const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL');
     const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL');
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} autoDownload />, { wrapper: Provider });
@@ -222,7 +222,7 @@ describe('HiddenCanvas', () => {
 
   it('triggers fallback timer if layout does not complete', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -241,7 +241,7 @@ describe('HiddenCanvas', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(<HiddenCanvas vizNodes={[]} onComplete={mockOnComplete} />, { wrapper: Provider });
 
@@ -262,7 +262,7 @@ describe('HiddenCanvas', () => {
     (toBlob as Mock).mockResolvedValue(null);
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -288,7 +288,7 @@ describe('HiddenCanvas', () => {
     (toBlob as Mock).mockRejectedValue(error);
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, { wrapper: Provider });
@@ -308,7 +308,7 @@ describe('HiddenCanvas', () => {
 
   it('uses custom layout type when provided', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} layout={LayoutType.DagreVertical} onComplete={mockOnComplete} />, {
@@ -329,7 +329,7 @@ describe('HiddenCanvas', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     const { unmount } = render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} />, {
@@ -347,7 +347,7 @@ describe('HiddenCanvas', () => {
     (toBlob as Mock).mockResolvedValue(mockBlob);
     const mockOnBlobGenerated = vi.fn();
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} onBlobGenerated={mockOnBlobGenerated} />, {
@@ -366,7 +366,7 @@ describe('HiddenCanvas', () => {
 
   it('does not auto-download when autoDownload is false', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} autoDownload={false} />, {
@@ -388,7 +388,7 @@ describe('HiddenCanvas', () => {
 
   it('auto-downloads when autoDownload is true', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const vizNode = await entity.toVizNode();
 
     render(<HiddenCanvas vizNodes={[vizNode]} onComplete={mockOnComplete} autoDownload />, { wrapper: Provider });

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
@@ -1,4 +1,6 @@
+import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render } from '@testing-library/react';
+import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/entities';
@@ -26,15 +28,19 @@ describe('FlowsList.tsx', () => {
     mockRandomValues();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     camelResource = new CamelRouteResource();
     camelResource.addNewEntity(EntityType.Route);
     camelResource.addNewEntity(EntityType.RouteConfiguration);
+    // Materialize the new entities into source so the wrapper's re-initialize()
+    // (which rebuilds entities from source) preserves them — mirrors how runtime
+    // recreates the resource from serialized code on `code:updated`.
+    camelResource = new CamelRouteResource(parse(camelResource.toString()) as CamelYamlDsl);
   });
 
   it('should render the existing flows', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -47,9 +53,10 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should display an empty state when there is no routes available', async () => {
-    camelResource.removeEntity(['route-1234']);
-    camelResource.removeEntity(['routeConfiguration-1234']);
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    // "No routes" is expressed as an empty resource; building then removing in
+    // memory would be undone by the wrapper's re-initialize() from source.
+    const emptyResource = new CamelRouteResource();
+    const { Provider } = await TestProvidersWrapper({ camelResource: emptyResource });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -62,7 +69,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should render the flows ids', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -88,7 +95,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi,
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -105,7 +112,7 @@ describe('FlowsList.tsx', () => {
 
   it('should call onClose when clicking on a flow ID', async () => {
     const onCloseSpy = vi.fn();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsList onClose={onCloseSpy} />
@@ -126,7 +133,7 @@ describe('FlowsList.tsx', () => {
       actionConfirmation: vi.fn(),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <ActionConfirmationModalContext.Provider value={mockDeleteModalContext}>
@@ -146,7 +153,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should delete a flow when clicking the delete icon and then clicking delete', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <ActionConfirmationModalContextProvider>
@@ -169,7 +176,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should not delete a flow when clicking the delete icon and then clicking cancel', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <ActionConfirmationModalContextProvider>
@@ -204,7 +211,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi,
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -227,7 +234,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi: new VisualFlowsApi(vi.fn()),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -249,7 +256,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi: new VisualFlowsApi(vi.fn()),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -280,7 +287,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi,
     };
 
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext,
     });
@@ -321,7 +328,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi,
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -347,7 +354,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi,
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -370,7 +377,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi: new VisualFlowsApi(vi.fn()),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -389,7 +396,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi: new VisualFlowsApi(vi.fn()),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -411,7 +418,7 @@ describe('FlowsList.tsx', () => {
       visualFlowsApi: new VisualFlowsApi(vi.fn()),
     };
 
-    const { Provider } = TestProvidersWrapper({ camelResource, visibleFlowsContext });
+    const { Provider } = await TestProvidersWrapper({ camelResource, visibleFlowsContext });
     const wrapper = render(
       <Provider>
         <FlowsList />
@@ -445,7 +452,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should have the delete button disabled when there are no routes', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     const wrapper = render(
       <Provider>
@@ -463,7 +470,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should delete filtered flows when clicking the delete filtered button', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <ActionConfirmationModalContextProvider>
@@ -496,7 +503,7 @@ describe('FlowsList.tsx', () => {
   });
 
   it('should not delete any flows when canceling the delete filtered action', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <ActionConfirmationModalContextProvider>

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsMenu.test.tsx
@@ -1,4 +1,6 @@
+import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/entities';
@@ -13,10 +15,14 @@ describe('FlowsMenu.tsx', () => {
     camelResource = new CamelRouteResource();
     camelResource.addNewEntity(EntityType.Route);
     camelResource.addNewEntity(EntityType.RouteConfiguration);
+    // Materialize the new entities into source so the wrapper's re-initialize()
+    // (which rebuilds entities from source) preserves them — mirrors how runtime
+    // recreates the resource from serialized code on `code:updated`.
+    camelResource = new CamelRouteResource(parse(camelResource.toString()) as CamelYamlDsl);
   });
 
   it('should open the flows list when clicking the dropdown', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsMenu />
@@ -38,7 +44,7 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should open the flows list when clicking the action button', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsMenu />
@@ -60,7 +66,7 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should close the flows list when pressing ESC', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <FlowsMenu />
@@ -89,11 +95,11 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should render the route id when a single route is visible', async () => {
-    const singleFlowCamelResource = new CamelRouteResource();
-    singleFlowCamelResource.initialize();
+    let singleFlowCamelResource = new CamelRouteResource();
     singleFlowCamelResource.addNewEntity(EntityType.Route);
+    singleFlowCamelResource = new CamelRouteResource(parse(singleFlowCamelResource.toString()) as CamelYamlDsl);
 
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource: singleFlowCamelResource,
       visibleFlowsContext: { visibleFlows: { ['route-1234']: true } } as unknown as VisibleFlowsContextResult,
     });
@@ -109,7 +115,7 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should NOT render the route id but "Routes" when there is no flow visible', async () => {
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext: {
         visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },
@@ -126,7 +132,7 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should NOT render the route id but "Routes" when there is more than 1 flow visible', async () => {
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext: {
         visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },
@@ -143,7 +149,7 @@ describe('FlowsMenu.tsx', () => {
   });
 
   it('should render the visible routes count', async () => {
-    const { Provider } = TestProvidersWrapper({
+    const { Provider } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext: {
         visibleFlows: { ['route-1234']: true, ['routeConfiguration-1234']: true },

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -30,12 +30,12 @@ describe('IntegrationTypeSelector.tsx', () => {
     definitions: [mockCamelCatalog, mockCitrusCatalog],
   } as CatalogLibrary;
 
-  const renderWithCustomRuntime = (
+  const renderWithCustomRuntime = async (
     selectedCatalog: CatalogLibraryEntry = mockCamelCatalog,
     camelResource?: KaotoResource,
   ) => {
     const mockSetSelectedCatalog = vi.fn();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     return {
       ...render(
@@ -58,7 +58,7 @@ describe('IntegrationTypeSelector.tsx', () => {
 
   it('should render all of the types', async () => {
     const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const wrapper = render(
       <RuntimeProvider>
         <Provider>
@@ -87,7 +87,7 @@ describe('IntegrationTypeSelector.tsx', () => {
 
   it('should warn the user when adding a different type of flow', async () => {
     const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const wrapper = render(
       <RuntimeProvider>
         <Provider>
@@ -118,7 +118,7 @@ describe('IntegrationTypeSelector.tsx', () => {
   });
 
   it('should warn the user when selected flow changes the catalog', async () => {
-    const { findByTestId, getByTestId, mockSetSelectedCatalog } = renderWithCustomRuntime(mockCamelCatalog);
+    const { findByTestId, getByTestId, mockSetSelectedCatalog } = await renderWithCustomRuntime(mockCamelCatalog);
 
     const trigger = await findByTestId('integration-type-list-dropdown');
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
@@ -1,38 +1,49 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { ComponentProps } from 'react';
 
+import { sourceSchemaConfig, SourceSchemaType } from '../../../../../models/camel';
 import { configureSourceSchemaTypes, TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../../stubs';
 import { IntegrationTypeSelectorToggle } from './IntegrationTypeSelectorToggle';
 
 describe('IntegrationTypeSelectorToggle.tsx', () => {
+  const config = sourceSchemaConfig;
+  const previousSchemas = {
+    [SourceSchemaType.Pipe]: config.config[SourceSchemaType.Pipe].schema,
+    [SourceSchemaType.Kamelet]: config.config[SourceSchemaType.Kamelet].schema,
+    [SourceSchemaType.Route]: config.config[SourceSchemaType.Route].schema,
+  };
+
   beforeAll(() => {
     configureSourceSchemaTypes();
   });
 
-  it('component renders with the integration-type-list-dropdown toggle', () => {
+  afterAll(() => {
+    config.config[SourceSchemaType.Pipe].schema = previousSchemas[SourceSchemaType.Pipe];
+    config.config[SourceSchemaType.Kamelet].schema = previousSchemas[SourceSchemaType.Kamelet];
+    config.config[SourceSchemaType.Route].schema = previousSchemas[SourceSchemaType.Route];
+  });
+
+  const renderToggle = async (props?: ComponentProps<typeof IntegrationTypeSelectorToggle>) => {
     const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-    const { Provider } = TestProvidersWrapper();
-    const wrapper = render(
+    const { Provider } = await TestProvidersWrapper();
+    return render(
       <RuntimeProvider>
         <Provider>
-          <IntegrationTypeSelectorToggle />
+          <IntegrationTypeSelectorToggle {...props} />
         </Provider>
       </RuntimeProvider>,
     );
+  };
+
+  it('component renders', async () => {
+    const wrapper = await renderToggle();
     const toggle = wrapper.queryByTestId('integration-type-list-dropdown');
     expect(toggle).toBeInTheDocument();
   });
 
-  it('should call onSelect when clicking on an option', async () => {
-    const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
+  it('should call onSelect when clicking on the MenuToggleAction', async () => {
     const onSelectSpy = vi.fn();
-    const { Provider } = TestProvidersWrapper();
-    const wrapper = render(
-      <RuntimeProvider>
-        <Provider>
-          <IntegrationTypeSelectorToggle onSelect={onSelectSpy} />
-        </Provider>
-      </RuntimeProvider>,
-    );
+    const wrapper = await renderToggle({ onSelect: onSelectSpy });
 
     /** Click on toggle */
     const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
@@ -51,45 +62,115 @@ describe('IntegrationTypeSelectorToggle.tsx', () => {
     });
   });
 
-  it('should mark the currently selected integration type as disabled', async () => {
-    const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-    const { Provider } = TestProvidersWrapper();
-    const wrapper = render(
-      <RuntimeProvider>
-        <Provider>
-          <IntegrationTypeSelectorToggle />
-        </Provider>
-      </RuntimeProvider>,
-    );
-
+  it('should disable the MenuToggleAction if the integration type is already selected', async () => {
+    const wrapper = await renderToggle();
+    /** Click on toggle */
     const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
     act(() => {
       fireEvent.click(toggle);
     });
 
-    // The default schema type from TestProvidersWrapper is Route — its option should be disabled
-    // data-testid is set on the li wrapper which carries the pf-m-disabled class
-    const routeOption = await wrapper.findByTestId('integration-type-route');
-    expect(routeOption).toHaveClass('pf-m-disabled');
+    /** Click on first element */
+    const element = await wrapper.findAllByRole('option');
+    act(() => {
+      fireEvent.click(element[0]);
+    });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    await waitFor(async () => {
+      expect(element[0]).toBeDisabled();
+    });
   });
 
-  it('should display "(current integration type)" suffix for the active type', async () => {
-    const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-    const { Provider } = TestProvidersWrapper();
-    const wrapper = render(
-      <RuntimeProvider>
-        <Provider>
-          <IntegrationTypeSelectorToggle />
-        </Provider>
-      </RuntimeProvider>,
-    );
-
+  it('should toggle list of integration types', async () => {
+    const wrapper = await renderToggle();
     const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
+
+    /** Click on toggle */
     act(() => {
       fireEvent.click(toggle);
     });
 
-    const currentLabel = await wrapper.findByText('Camel Route (current integration type)');
-    expect(currentLabel).toBeInTheDocument();
+    const element = await wrapper.findByText('Pipe');
+    await waitFor(() => {
+      expect(element).toBeInTheDocument();
+    });
+    /** Close Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    await waitFor(() => {
+      expect(element).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show selected value', async () => {
+    const wrapper = await renderToggle();
+    const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Camel Route');
+      fireEvent.click(element);
+    });
+
+    /** Open Select again */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByRole('option', { selected: true });
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveTextContent('Camel Route');
+  });
+
+  it('should have selected integration type if provided', async () => {
+    const wrapper = await renderToggle();
+    const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    await waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Camel Route');
+    });
+  });
+
+  it('should close Select when pressing ESC', async () => {
+    const wrapper = await renderToggle();
+    const toggle = await wrapper.findByTestId('integration-type-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = await wrapper.findByRole('listbox');
+
+    expect(menu).toBeInTheDocument();
+
+    /** Press Escape key to close the menu */
+    act(() => {
+      fireEvent.focus(menu);
+      fireEvent.keyDown(menu, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    await waitFor(async () => {
+      /** The close panel is an async process */
+      expect(menu).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -19,8 +19,8 @@ describe('NewEntity', () => {
     CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
   });
 
-  it('component renders', () => {
-    const { Provider } = TestProvidersWrapper();
+  it('component renders', async () => {
+    const { Provider } = await TestProvidersWrapper();
     const wrapper = render(
       <Provider>
         <NewEntity />
@@ -32,7 +32,7 @@ describe('NewEntity', () => {
   });
 
   it('should call `updateEntitiesFromCamelResource` when selecting an item', async () => {
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
     const wrapper = render(
       <Provider>
         <NewEntity />
@@ -57,7 +57,7 @@ describe('NewEntity', () => {
   });
 
   it('should toggle list of DSLs', async () => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const wrapper = render(
       <Provider>
         <NewEntity />
@@ -85,7 +85,7 @@ describe('NewEntity', () => {
   });
 
   it('should close Select when pressing ESC', async () => {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const wrapper = render(
       <Provider>
         <NewEntity />
@@ -117,7 +117,7 @@ describe('NewEntity', () => {
 
   describe('YAML entity filtering', () => {
     it('should show all entities including YAML-only ones', async () => {
-      const { Provider, camelResource } = TestProvidersWrapper();
+      const { Provider, camelResource } = await TestProvidersWrapper();
 
       const wrapper = render(
         <Provider>
@@ -156,7 +156,7 @@ describe('NewEntity', () => {
 
   describe('entity grouping', () => {
     it('should display entities in proper groups', async () => {
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       const wrapper = render(
         <Provider>
@@ -180,7 +180,7 @@ describe('NewEntity', () => {
     });
 
     it('should allow selecting entities from submenus', async () => {
-      const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper();
+      const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper();
 
       const wrapper = render(
         <Provider>
@@ -227,7 +227,7 @@ describe('NewEntity', () => {
         groups: {},
       });
 
-      const { Provider } = TestProvidersWrapper({ camelResource: mockResource });
+      const { Provider } = await TestProvidersWrapper({ camelResource: mockResource });
 
       const wrapper = render(
         <Provider>

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -22,7 +22,7 @@ describe('ItemDeleteGroup', () => {
     actionConfirmation: vi.fn(),
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vizNode = createVisualizationNode('test', {
       name: EntityType.Route,
       isPlaceholder: false,
@@ -76,7 +76,7 @@ describe('ItemDeleteGroup', () => {
     vizNode = await camelResource.getVisualEntities()[0].toVizNode();
     mockDeleteModalContext.actionConfirmation.mockResolvedValueOnce(ACTION_ID_CONFIRM);
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     const wrapper = render(
       <Provider>

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
@@ -37,7 +37,7 @@ describe('ItemEnableAllSteps', () => {
     const visualizationController = ControllerService.createController();
     visualizationController.fromModel(model);
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <VisualizationProvider controller={visualizationController}>
@@ -71,7 +71,7 @@ describe('ItemEnableAllSteps', () => {
       return node.getNodeDefinition()?.disabled;
     });
 
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <VisualizationProvider controller={visualizationController}>

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -52,7 +52,7 @@ describe('NodeContextMenu', () => {
     });
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     nodeInteractions = {
       canHavePreviousStep: false,
       canHaveNextStep: false,
@@ -217,7 +217,7 @@ describe('NodeContextMenu', () => {
     const visualizationController = ControllerService.createController();
     visualizationController.fromModel(model);
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
     const wrapper = render(
       <Provider>
         <VisualizationProvider controller={visualizationController}>

--- a/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.test.tsx
@@ -43,7 +43,7 @@ describe('CustomEdge', () => {
     }).toThrow('EdgeEndWithButton must be used only on Edge elements');
   });
 
-  it('should render edge with custom-edge class when edge is valid', () => {
+  it('should render edge with custom-edge class when edge is valid', async () => {
     const vizNode = createVisualizationNode('route.from.steps.0.log', {
       name: 'log',
       path: 'route.from.steps.0.log',
@@ -83,7 +83,7 @@ describe('CustomEdge', () => {
     element.setStartPoint(0, 0);
     element.setEndPoint(100, 100);
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.test.tsx
@@ -33,7 +33,7 @@ describe('CustomGroup', () => {
     }).toThrow('CustomGroup must be used only on Node elements');
   });
 
-  it('should render CustomNodeWithSelection when group is collapsed', () => {
+  it('should render CustomNodeWithSelection when group is collapsed', async () => {
     const parentElement = new BaseGraph();
     const element = new BaseNode();
     const controller = ControllerService.createController();
@@ -42,7 +42,7 @@ describe('CustomGroup', () => {
     element.setParent(parentElement);
     element.setCollapsed(true);
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -57,7 +57,7 @@ describe('CustomGroup', () => {
     expect(screen.getByTestId('custom-node-collapsed')).toBeInTheDocument();
   });
 
-  it('should render CustomGroupExpanded when group is expanded', () => {
+  it('should render CustomGroupExpanded when group is expanded', async () => {
     const parentElement = new BaseGraph();
     const element = new BaseNode();
     const controller = ControllerService.createController();
@@ -65,7 +65,7 @@ describe('CustomGroup', () => {
     element.setParent(parentElement);
     element.setCollapsed(false);
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -59,7 +59,7 @@ describe('CustomGroupExpanded', () => {
   let element: BaseNode;
   let parentElement: BaseGraph;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     parentElement = new BaseGraph();
     element = new BaseNode();
     controller = ControllerService.createController();
@@ -73,7 +73,7 @@ describe('CustomGroupExpanded', () => {
   });
 
   async function renderInContext(children: React.ReactNode) {
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     const result = render(
       <Provider>
         <VisualizationProvider controller={controller}>

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
@@ -50,7 +50,7 @@ describe('CustomNode', () => {
     }).toThrow('CustomNode must be used only on Node elements');
   });
 
-  it('should return null when element has no vizNode in data', () => {
+  it('should return null when element has no vizNode in data', async () => {
     const parentElement = new BaseGraph();
     const element = new BaseNode();
     const controller = ControllerService.createController();
@@ -59,7 +59,7 @@ describe('CustomNode', () => {
     element.setParent(parentElement);
     vi.spyOn(element, 'getData').mockReturnValue({});
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     const { container } = render(
       <Provider>
@@ -74,7 +74,7 @@ describe('CustomNode', () => {
     expect(container.querySelector('[data-testid^="custom-node__"]')).not.toBeInTheDocument();
   });
 
-  it('should render node container with label from vizNode', () => {
+  it('should render node container with label from vizNode', async () => {
     const vizNode = createVisualizationNode('route.from.steps.0.log', {
       name: 'log',
       path: 'route.from.steps.0.log',
@@ -100,7 +100,7 @@ describe('CustomNode', () => {
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
     vi.spyOn(element, 'getId').mockReturnValue('node-log');
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -117,7 +117,7 @@ describe('CustomNode', () => {
     expect(node).toHaveAttribute('data-nodelabel', 'log');
   });
 
-  it('should return null when vizNode is undefined', () => {
+  it('should return null when vizNode is undefined', async () => {
     const parentElement = new BaseGraph();
     const element = new BaseNode();
     const controller = ControllerService.createController();
@@ -126,7 +126,7 @@ describe('CustomNode', () => {
     element.setParent(parentElement);
     // Do NOT set vizNode in element data - it will be undefined
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     const { container } = render(
       <Provider>

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
@@ -1,4 +1,4 @@
-import { BaseGraph, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
+import { BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { createVisualizationNode, IVisualizationNode, IVisualizationNodeData } from '../../../../models';
@@ -172,7 +172,7 @@ vi.mock('../hooks/insert-step.hook', () => ({
 }));
 
 describe('PlaceholderNode', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockOnReplaceNode.mockClear();
     mockOnInsertStep.mockClear();
   });
@@ -192,11 +192,16 @@ describe('PlaceholderNode', () => {
     }).toThrow('PlaceholderNode must be used only on Node elements');
   });
 
-  it('should render without error', () => {
-    const element = new MockBaseNode();
-    element.setType('node');
+  it('should return null when element has no vizNode in data', async () => {
+    const parentElement = new BaseGraph();
+    const element = new BaseNode();
+    const controller = ControllerService.createController();
+    parentElement.setController(controller);
+    element.setController(controller);
+    element.setParent(parentElement);
+    vi.spyOn(element, 'getData').mockReturnValue({});
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     const wrapper = render(
       <Provider>
@@ -209,7 +214,7 @@ describe('PlaceholderNode', () => {
     expect(wrapper.asFragment()).toMatchSnapshot();
   });
 
-  it('should render placeholder container with data-testid when vizNode is provided', () => {
+  it('should render placeholder container with data-testid when vizNode is provided', async () => {
     const vizNode = createVisualizationNode('route.from.steps.1.placeholder', {
       name: PlaceholderType.Placeholder,
       path: 'route.from.steps.1.placeholder',
@@ -231,7 +236,7 @@ describe('PlaceholderNode', () => {
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getId').mockReturnValue('node-placeholder');
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
 
     render(
       <Provider>
@@ -248,9 +253,13 @@ describe('PlaceholderNode', () => {
   });
 
   describe('isSpecialChildPlaceholder', () => {
-    const setupWithVizNode = (vizNodeData: Partial<IVisualizationNodeData>) => {
-      const element = new MockBaseNode();
-      element.setType('node');
+    const setupWithVizNode = async (vizNodeData: Partial<IVisualizationNodeData>) => {
+      const parentElement = new BaseGraph();
+      const element = new BaseNode();
+      const controller = ControllerService.createController();
+      parentElement.setController(controller);
+      element.setController(controller);
+      element.setParent(parentElement);
 
       const vizNode = createVisualizationNode('test-placeholder', {
         path: 'test.placeholder',
@@ -260,7 +269,7 @@ describe('PlaceholderNode', () => {
 
       element.setData({ vizNode });
 
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
 
       return render(
         <Provider>
@@ -271,32 +280,20 @@ describe('PlaceholderNode', () => {
       );
     };
 
-    it('should render PlusCircleIcon for special child placeholder', () => {
-      const wrapper = setupWithVizNode({ name: PlaceholderType.PlaceholderSpecialChild });
+    it.each([
+      ['PlusCircleIcon for special child placeholder', PlaceholderType.PlaceholderSpecialChild],
+      ['PlusCircleIcon for regular placeholder', PlaceholderType.Placeholder],
+      ['CodeBranchIcon for other placeholders', 'when'],
+    ])('should render %s', async (_label, name) => {
+      const wrapper = await setupWithVizNode({ name });
 
       const svgIcon = wrapper.container.querySelector('svg');
       expect(svgIcon).toBeInTheDocument();
       expect(wrapper.asFragment()).toMatchSnapshot();
     });
 
-    it('should render PlusCircleIcon for regular placeholder', () => {
-      const wrapper = setupWithVizNode({ name: PlaceholderType.Placeholder });
-
-      const svgIcon = wrapper.container.querySelector('svg');
-      expect(svgIcon).toBeInTheDocument();
-      expect(wrapper.asFragment()).toMatchSnapshot();
-    });
-
-    it('should render CodeBranchIcon for other placeholders', () => {
-      const wrapper = setupWithVizNode({ name: 'when' });
-
-      const svgIcon = wrapper.container.querySelector('svg');
-      expect(svgIcon).toBeInTheDocument();
-      expect(wrapper.asFragment()).toMatchSnapshot();
-    });
-
-    it('should call onInsertStep when clicking on special child placeholder', () => {
-      setupWithVizNode({ name: PlaceholderType.PlaceholderSpecialChild });
+    it('should call onInsertStep when clicking on special child placeholder', async () => {
+      await setupWithVizNode({ name: PlaceholderType.PlaceholderSpecialChild });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -305,8 +302,8 @@ describe('PlaceholderNode', () => {
       expect(mockOnReplaceNode).not.toHaveBeenCalled();
     });
 
-    it('should call onReplaceNode when clicking on regular placeholder', () => {
-      setupWithVizNode({ name: PlaceholderType.Placeholder });
+    it('should call onReplaceNode when clicking on regular placeholder', async () => {
+      await setupWithVizNode({ name: PlaceholderType.Placeholder });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -315,8 +312,8 @@ describe('PlaceholderNode', () => {
       expect(mockOnInsertStep).not.toHaveBeenCalled();
     });
 
-    it('should call onInsertStep when clicking on otherwise placeholder', () => {
-      setupWithVizNode({ name: 'otherwise', isPlaceholder: true });
+    it('should call onInsertStep when clicking on otherwise placeholder', async () => {
+      await setupWithVizNode({ name: 'otherwise', isPlaceholder: true });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -325,8 +322,8 @@ describe('PlaceholderNode', () => {
       expect(mockOnReplaceNode).not.toHaveBeenCalled();
     });
 
-    it('should call onInsertStep when clicking on when placeholder', () => {
-      setupWithVizNode({ name: 'when', isPlaceholder: true });
+    it('should call onInsertStep when clicking on when placeholder', async () => {
+      await setupWithVizNode({ name: 'when', isPlaceholder: true });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);

--- a/packages/ui/src/components/Visualization/Custom/Node/__snapshots__/PlaceholderNode.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Custom/Node/__snapshots__/PlaceholderNode.test.tsx.snap
@@ -174,4 +174,4 @@ exports[`PlaceholderNode > isSpecialChildPlaceholder > should render PlusCircleI
 </DocumentFragment>
 `;
 
-exports[`PlaceholderNode > should render without error 1`] = `<DocumentFragment />`;
+exports[`PlaceholderNode > should return null when element has no vizNode in data 1`] = `<DocumentFragment />`;

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -47,12 +47,12 @@ describe('useAddStep', () => {
 
   let wrapper: FunctionComponent<PropsWithChildren>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     camelResource = new CamelRouteResource();
     camelResource.initialize();
     getCompatibleComponentsSpy = vi.spyOn(camelResource, 'getCompatibleComponents');
 
-    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = await TestProvidersWrapper({ camelResource });
     updateEntitiesFromCamelResourceSpy = updateSpy;
 
     wrapper = ({ children }) => (
@@ -125,16 +125,17 @@ describe('useAddStep', () => {
     });
 
     // Create a wrapper that provides null entities context
-    const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
-      return (
-        <Provider>
-          <CatalogModalContext.Provider value={mockCatalogModalContext}>
-            <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
-          </CatalogModalContext.Provider>
-        </Provider>
-      );
-    };
+    const { Provider: NullEntitiesProvider } = await TestProvidersWrapper({
+      camelResource,
+      entitiesContextValue: null,
+    });
+    const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <NullEntitiesProvider>
+        <CatalogModalContext.Provider value={mockCatalogModalContext}>
+          <MetadataContext.Provider value={mockMetadataContext}>{children}</MetadataContext.Provider>
+        </CatalogModalContext.Provider>
+      </NullEntitiesProvider>
+    );
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), {
       wrapper: nullEntitiesWrapper,
@@ -259,7 +260,9 @@ describe('useAddStep', () => {
     getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
-    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = await TestProvidersWrapper({
+      camelResource,
+    });
     const noMetadataWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
       <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
@@ -76,7 +76,7 @@ describe('useReplaceStep', () => {
 
   let wrapper: FunctionComponent<PropsWithChildren>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     camelResource = new CamelRouteResource();
     camelResource.initialize();
     mockVizNode = createVisualizationNode('test-step', {
@@ -93,7 +93,7 @@ describe('useReplaceStep', () => {
     (findOnDeleteModalCustomizationRecursively as Mock).mockReturnValue([]);
     (processOnDeleteAddonRecursively as Mock).mockImplementation(() => {});
 
-    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = await TestProvidersWrapper({ camelResource });
     updateEntitiesFromCamelResourceSpy = updateSpy;
 
     wrapper = ({ children }) => (
@@ -132,7 +132,7 @@ describe('useReplaceStep', () => {
   });
 
   it('should return early when entitiesContext is null', async () => {
-    const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
+    const { Provider } = await TestProvidersWrapper({ camelResource, entitiesContextValue: null });
     const nullEntitiesWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
       <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>
@@ -352,7 +352,9 @@ describe('useReplaceStep', () => {
   it('should handle missing metadata context gracefully', async () => {
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
-    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = await TestProvidersWrapper({
+      camelResource,
+    });
     const noMetadataWrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
       <Provider>
         <CatalogModalContext.Provider value={mockCatalogModalContext}>

--- a/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.test.tsx
@@ -5,9 +5,9 @@ import { VisualizationEmptyState } from './VisualizationEmptyState';
 
 describe('VisualizationEmptyState.tsx', () => {
   describe('when there are no routes', () => {
-    it('should render the CubesIcon whenever there are no routes', () => {
+    it('should render the CubesIcon whenever there are no routes', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const wrapper = render(
         <RuntimeProvider>
           <Provider>
@@ -21,9 +21,9 @@ describe('VisualizationEmptyState.tsx', () => {
       expect(icon).toBeInTheDocument();
     });
 
-    it('should state that there are no routes', () => {
+    it('should state that there are no routes', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const wrapper = render(
         <RuntimeProvider>
           <Provider>
@@ -41,9 +41,9 @@ describe('VisualizationEmptyState.tsx', () => {
   });
 
   describe('when there are routes but they are not visible', () => {
-    it('should render the EyeSlashIcon whenever there are no routes', () => {
+    it('should render the EyeSlashIcon whenever there are no routes', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const wrapper = render(
         <RuntimeProvider>
           <Provider>
@@ -56,9 +56,9 @@ describe('VisualizationEmptyState.tsx', () => {
       expect(icon).toBeInTheDocument();
     });
 
-    it('should state that there are no visible routes', () => {
+    it('should state that there are no visible routes', async () => {
       const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
-      const { Provider } = TestProvidersWrapper();
+      const { Provider } = await TestProvidersWrapper();
       const wrapper = render(
         <RuntimeProvider>
           <Provider>

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -187,10 +187,13 @@ describe('IntegrationTypeSelector', () => {
       fireEvent.click(wrapper.getByTestId('test-toggle'));
     });
 
-    // Simulate a selection event with no value by directly triggering the
-    // underlying PatternFly Select with an undefined itemId — achieved by
-    // clicking a disabled option that has no itemId set. Instead, we verify
-    // that onSelect is NOT called when the dropdown is merely opened.
+    // Wait for the dropdown to actually open. Besides making the assertion
+    // meaningful, awaiting here flushes PatternFly's debounced Popper
+    // reposition inside act() — without it the late state update leaks past
+    // the test and triggers an "update not wrapped in act(...)" warning.
+    await wrapper.findByTestId('test-select-list');
+
+    // Merely opening the dropdown must not select anything.
     expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -24,11 +24,12 @@ Object.assign(navigator, {
 
 describe('usePasteEntity', () => {
   let camelResource: CamelRouteResource;
-  let addNewEntitySpy: SpyInstance;
-  let removeEntitySpy: SpyInstance;
-  let supportsMultipleVisualEntitiesSpy: SpyInstance;
+  let addNewEntitySpy: Mock;
+  let removeEntitySpy: Mock;
+  let supportsMultipleVisualEntitiesSpy: Mock;
   let updateEntitiesFromCamelResourceSpy: Mock;
-  let toggleFlowVisibleSpy: SpyInstance;
+  let toggleFlowVisibleSpy: Mock;
+  let WrapperProvider: FunctionComponent<PropsWithChildren>;
 
   const mockActionConfirmationContext = {
     actionConfirmation: vi.fn(),
@@ -40,23 +41,17 @@ describe('usePasteEntity', () => {
     definition: { id: 'test-route', from: { uri: 'timer:tick' } },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     camelResource = new CamelRouteResource();
     camelResource.initialize();
     addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');
     removeEntitySpy = vi.spyOn(camelResource, 'removeEntity');
     vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
     supportsMultipleVisualEntitiesSpy = vi.spyOn(camelResource, 'supportsMultipleVisualEntities').mockReturnValue(true);
-  });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
     const visualFlowsApi = new VisualFlowsApi(vi.fn());
     toggleFlowVisibleSpy = vi.spyOn(visualFlowsApi, 'toggleFlowVisible');
-    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = TestProvidersWrapper({
+    const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = await TestProvidersWrapper({
       camelResource,
       visibleFlowsContext: {
         allFlowsVisible: true,
@@ -65,14 +60,20 @@ describe('usePasteEntity', () => {
       },
     });
     updateEntitiesFromCamelResourceSpy = updateSpy;
-    return (
-      <Provider>
-        <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
-          {children}
-        </ActionConfirmationModalContext.Provider>
-      </Provider>
-    );
-  };
+    WrapperProvider = Provider;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+    <WrapperProvider>
+      <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
+        {children}
+      </ActionConfirmationModalContext.Provider>
+    </WrapperProvider>
+  );
 
   it('should return isCompatible false when clipboard is empty', async () => {
     vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
@@ -191,7 +192,7 @@ describe('usePasteEntity', () => {
   });
 
   describe('single-entity resources', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       supportsMultipleVisualEntitiesSpy.mockReturnValue(false);
     });
 
@@ -270,16 +271,17 @@ describe('usePasteEntity', () => {
   });
 
   it('should handle null entitiesContext gracefully', async () => {
-    const wrapperWithoutEntities: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { Provider } = TestProvidersWrapper({ camelResource, entitiesContextValue: null });
-      return (
-        <Provider>
-          <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
-            {children}
-          </ActionConfirmationModalContext.Provider>
-        </Provider>
-      );
-    };
+    const { Provider: NullEntitiesProvider } = await TestProvidersWrapper({
+      camelResource,
+      entitiesContextValue: null,
+    });
+    const wrapperWithoutEntities: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <NullEntitiesProvider>
+        <ActionConfirmationModalContext.Provider value={mockActionConfirmationContext}>
+          {children}
+        </ActionConfirmationModalContext.Provider>
+      </NullEntitiesProvider>
+    );
 
     vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
     vi.spyOn(ClipboardManager, 'paste').mockResolvedValue(copiedRouteContent);
@@ -298,10 +300,15 @@ describe('usePasteEntity', () => {
   });
 
   describe('should handle null actionConfirmationContext', () => {
-    const wrapperWithoutActionConfirmation: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { Provider } = TestProvidersWrapper({ camelResource });
-      return <Provider>{children}</Provider>;
-    };
+    let NullActionProvider: FunctionComponent<PropsWithChildren>;
+    const wrapperWithoutActionConfirmation: FunctionComponent<PropsWithChildren> = ({ children }) => (
+      <NullActionProvider>{children}</NullActionProvider>
+    );
+
+    beforeEach(async () => {
+      const { Provider } = await TestProvidersWrapper({ camelResource });
+      NullActionProvider = Provider;
+    });
 
     it('when clipboard is empty', async () => {
       vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -44,7 +44,7 @@ export abstract class CamelKResource implements KaotoResource {
     return [];
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     if (this.resource.metadata && !this.metadata) {
       this.metadata = new MetadataEntity(this.resource);
     }

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -124,7 +124,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     protected comments: string[] = [],
   ) {}
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     if (!this.rawEntities) {
       this.entities = [];
       return;

--- a/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
@@ -17,7 +17,7 @@ describe('CamelXMLRouteResource', () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
 
-    resource.initialize();
+    await resource.initialize();
 
     const visualEntities = resource.getVisualEntities();
     expect(visualEntities).toHaveLength(1);
@@ -30,13 +30,13 @@ describe('CamelXMLRouteResource', () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
     const resource = new CamelXMLRouteResource(xml);
-    resource.initialize();
+    await resource.initialize();
 
     expect(resource.toString()).toContain('<route');
     expect(resource.toString()).toContain('uri="direct:start"');
   });
 
-  it('excludes YAML-only entities from the canvas list', () => {
+  it('excludes YAML-only entities from the canvas list', async () => {
     const resource = new CamelXMLRouteResource(xml);
     const names = resource.supportedEntities.map((e) => e.type);
     expect(names).toContain(EntityType.Route);
@@ -44,7 +44,7 @@ describe('CamelXMLRouteResource', () => {
     expect(names).not.toContain(EntityType.Intercept);
   });
 
-  it('extracts leading comments, the XML declaration, and root element definitions on construction', () => {
+  it('extracts leading comments, the XML declaration, and root element definitions on construction', async () => {
     const source = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- Comment 1 -->\n<camel xmlns="http://camel.apache.org/schema/spring"></camel>`;
     const resource = new CamelXMLRouteResource(source);
     expect(resource.toString()).toContain('<?xml version="1.0" encoding="UTF-8"?>');
@@ -52,20 +52,20 @@ describe('CamelXMLRouteResource', () => {
     expect(resource.toString()).toContain('xmlns="http://camel.apache.org/schema/spring"');
   });
 
-  it('produces no XML declaration prefix when the source has none', () => {
+  it('produces no XML declaration prefix when the source has none', async () => {
     const resource = new CamelXMLRouteResource(xml);
     const output = resource.toString();
     expect(output.startsWith('<?xml')).toBe(false);
   });
 
-  it('XML declaration is followed by a newline when present', () => {
+  it('XML declaration is followed by a newline when present', async () => {
     const source = `<?xml version="1.0" encoding="UTF-8"?>\n<camel></camel>`;
     const resource = new CamelXMLRouteResource(source);
     const output = resource.toString();
     expect(output).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>\n/);
   });
 
-  it('extracts multiple leading comments and includes all in toString()', () => {
+  it('extracts multiple leading comments and includes all in toString()', async () => {
     const source = `<!-- First comment -->\n<!-- Second comment -->\n<camel></camel>`;
     const resource = new CamelXMLRouteResource(source);
     const output = resource.toString();
@@ -73,7 +73,7 @@ describe('CamelXMLRouteResource', () => {
     expect(output).toContain('<!-- Second comment -->');
   });
 
-  it('does not extract a comment that appears after non-whitespace content', () => {
+  it('does not extract a comment that appears after non-whitespace content', async () => {
     // The comment is inside the XML body, not a leading comment
     const source = `<camel><!-- inline comment --></camel>`;
     const resource = new CamelXMLRouteResource(source);
@@ -82,7 +82,7 @@ describe('CamelXMLRouteResource', () => {
     expect(output).not.toMatch(/^<!--/);
   });
 
-  it('preserves a multiline leading comment across a round-trip', () => {
+  it('preserves a multiline leading comment across a round-trip', async () => {
     const source = `<!-- line1\nline2\nline3 -->\n<camel></camel>`;
     const resource = new CamelXMLRouteResource(source);
     const output = resource.toString();
@@ -91,11 +91,11 @@ describe('CamelXMLRouteResource', () => {
     expect(output).toContain('line3 -->');
   });
 
-  it('does not throw when constructed with an empty string', () => {
+  it('does not throw when constructed with an empty string', async () => {
     expect(() => new CamelXMLRouteResource('')).not.toThrow();
   });
 
-  it('toString() returns a string when constructed from empty input', () => {
+  it('toString() returns a string when constructed from empty input', async () => {
     const resource = new CamelXMLRouteResource('');
     expect(typeof resource.toString()).toBe('string');
   });
@@ -105,7 +105,7 @@ describe('CamelXMLRouteResource', () => {
     CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
     const beansXml = `<camel><bean type="com.example.MyBean"/></camel>`;
     const resource = new CamelXMLRouteResource(beansXml);
-    resource.initialize();
+    await resource.initialize();
     const output = resource.toString();
     expect(typeof output).toBe('string');
   });

--- a/packages/ui/src/models/camel/camel-xml-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.ts
@@ -68,7 +68,7 @@ export class CamelXMLRouteResource extends CamelRouteResource {
   override async initialize(): Promise<void> {
     const parser = new KaotoXmlParser();
     this.setRawEntities(parser.parseXML(this.code) as CamelYamlDsl);
-    super.initialize();
+    await super.initialize();
   }
 
   override toString(): string {

--- a/packages/ui/src/models/camel/camel-xml-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.ts
@@ -65,7 +65,7 @@ export class CamelXMLRouteResource extends CamelRouteResource {
     return CamelXMLRouteResource.SUPPORTED_ENTITIES;
   }
 
-  override initialize(): void {
+  override async initialize(): Promise<void> {
     const parser = new KaotoXmlParser();
     this.setRawEntities(parser.parseXML(this.code) as CamelYamlDsl);
     super.initialize();

--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -19,7 +19,7 @@ export class IntegrationResource extends CamelKResource {
     }
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     super.initialize();
     // TODO: Initialize visual entities when implemented
   }

--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -20,7 +20,7 @@ export class IntegrationResource extends CamelKResource {
   }
 
   async initialize(): Promise<void> {
-    super.initialize();
+    await super.initialize();
     // TODO: Initialize visual entities when implemented
   }
 

--- a/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.test.ts
@@ -3,9 +3,9 @@ import { KameletBindingResource } from './kamelet-binding-resource';
 import { SourceSchemaType } from './source-schema-type';
 
 describe('KameletBindingResource', () => {
-  it('should create KameletBindingResource', () => {
+  it('should create KameletBindingResource', async () => {
     const resource = new KameletBindingResource(kameletBindingJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0];
@@ -16,35 +16,35 @@ describe('KameletBindingResource', () => {
   });
 
   describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
+    it('should return the correct list of compatible runtimes', async () => {
       const resource = new KameletBindingResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
 
-    it('should return the same list regardless of resource content', () => {
+    it('should return the same list regardless of resource content', async () => {
       const emptyResource = new KameletBindingResource();
-      emptyResource.initialize();
+      await emptyResource.initialize();
       const resourceWithBinding = new KameletBindingResource(kameletBindingJson);
-      resourceWithBinding.initialize();
+      await resourceWithBinding.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithBinding.getCompatibleRuntimes());
     });
 
-    it('should return an array with three runtime names', () => {
+    it('should return an array with three runtime names', async () => {
       const resource = new KameletBindingResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
   });
 
-  it('should initialize KameletBinding if no args is specified', () => {
+  it('should initialize KameletBinding if no args is specified', async () => {
     const resource = new KameletBindingResource(undefined);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -13,13 +13,13 @@ describe('KameletResource', () => {
     mockRandomValues();
   });
 
-  it('should create a new KameletResource', () => {
+  it('should create a new KameletResource', async () => {
     const kameletResource = new KameletResource();
-    kameletResource.initialize();
+    await kameletResource.initialize();
     expect(kameletResource).toMatchSnapshot();
   });
 
-  it('should create a new KameletResource with a kamelet', () => {
+  it('should create a new KameletResource with a kamelet', async () => {
     const kameletResource = new KameletResource({
       kind: SourceSchemaType.Kamelet,
       metadata: {
@@ -52,19 +52,19 @@ describe('KameletResource', () => {
         },
       },
     });
-    kameletResource.initialize();
+    await kameletResource.initialize();
 
     expect(kameletResource).toMatchSnapshot();
   });
 
-  it('should return an empty array for supportedEntities', () => {
+  it('should return an empty array for supportedEntities', async () => {
     const kameletResource = new KameletResource();
     expect(kameletResource.supportedEntities).toEqual([]);
   });
 
-  it('should remove the entity', () => {
+  it('should remove the entity', async () => {
     const kameletResource = new KameletResource();
-    kameletResource.initialize();
+    await kameletResource.initialize();
 
     kameletResource.removeEntity();
 
@@ -73,21 +73,21 @@ describe('KameletResource', () => {
     expect(kameletVisualEntities).toHaveLength(1);
   });
 
-  it('should get the type', () => {
+  it('should get the type', async () => {
     const kameletResource = new KameletResource();
-    kameletResource.initialize();
+    await kameletResource.initialize();
     expect(kameletResource.getType()).toEqual(SourceSchemaType.Kamelet);
   });
 
-  it('should get the visual entities (Camel Route Visual Entity)', () => {
+  it('should get the visual entities (Camel Route Visual Entity)', async () => {
     const kameletResource = new KameletResource();
-    kameletResource.initialize();
+    await kameletResource.initialize();
     expect(kameletResource.getVisualEntities()).toMatchSnapshot();
   });
 
-  it('should convert to JSON', () => {
+  it('should convert to JSON', async () => {
     const kameletResource = new KameletResource();
-    kameletResource.initialize();
+    await kameletResource.initialize();
     expect(kameletResource.toJSON()).toMatchSnapshot();
   });
 
@@ -125,37 +125,37 @@ describe('KameletResource', () => {
   });
 
   describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
+    it('should return the correct list of compatible runtimes', async () => {
       const kameletResource = new KameletResource();
-      kameletResource.initialize();
+      await kameletResource.initialize();
       const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
 
-    it('should return the same list regardless of resource content', () => {
+    it('should return the same list regardless of resource content', async () => {
       const emptyResource = new KameletResource();
-      emptyResource.initialize();
+      await emptyResource.initialize();
       const resourceWithKamelet = new KameletResource(kameletJson);
-      resourceWithKamelet.initialize();
+      await resourceWithKamelet.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithKamelet.getCompatibleRuntimes());
     });
 
-    it('should return an array with three runtime names', () => {
+    it('should return an array with three runtime names', async () => {
       const kameletResource = new KameletResource();
-      kameletResource.initialize();
+      await kameletResource.initialize();
       const compatibleRuntimes = kameletResource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
   });
 
-  it('should support RouteTemplateBeansAwareResource methods', () => {
+  it('should support RouteTemplateBeansAwareResource methods', async () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();
     const kameletResource = new KameletResource(model);
-    kameletResource.initialize();
+    await kameletResource.initialize();
     expect(kameletResource.getRouteTemplateBeansEntity()).toBeUndefined();
     kameletResource.createRouteTemplateBeansEntity();
     const beansEntity = kameletResource.getRouteTemplateBeansEntity();

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -27,7 +27,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
     this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     super.initialize();
 
     if (this.flow.kamelet.spec.template.beans) {

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -28,7 +28,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
   }
 
   async initialize(): Promise<void> {
-    super.initialize();
+    await super.initialize();
 
     if (this.flow.kamelet.spec.template.beans) {
       this.beans = new RouteTemplateBeansEntity(this.flow.kamelet.spec.template as RouteTemplateBeansParentType);

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -3,9 +3,9 @@ import { PipeResource } from './pipe-resource';
 import { SourceSchemaType } from './source-schema-type';
 
 describe('PipeResource', () => {
-  it('should create KameletBindingResource', () => {
+  it('should create KameletBindingResource', async () => {
     const resource = new PipeResource(pipeJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0];
@@ -19,9 +19,9 @@ describe('PipeResource', () => {
     expect(errorHandlerEntity?.parent.errorHandler!.log).toBeDefined();
   });
 
-  it('should initialize Pipe if no args is specified', () => {
+  it('should initialize Pipe if no args is specified', async () => {
     const resource = new PipeResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -32,35 +32,35 @@ describe('PipeResource', () => {
   });
 
   describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
+    it('should return the correct list of compatible runtimes', async () => {
       const resource = new PipeResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
 
-    it('should return the same list regardless of resource content', () => {
+    it('should return the same list regardless of resource content', async () => {
       const emptyResource = new PipeResource();
-      emptyResource.initialize();
+      await emptyResource.initialize();
       const resourceWithPipe = new PipeResource(pipeJson);
-      resourceWithPipe.initialize();
+      await resourceWithPipe.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithPipe.getCompatibleRuntimes());
     });
 
-    it('should return an array with three runtime names', () => {
+    it('should return an array with three runtime names', async () => {
       const resource = new PipeResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
     });
   });
 
-  it('should create/delete entities', () => {
+  it('should create/delete entities', async () => {
     const resource = new PipeResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getEntities().length).toEqual(0);
     expect(resource.getMetadataEntity()).toBeUndefined();
     expect(resource.getErrorHandlerEntity()).toBeUndefined();
@@ -84,9 +84,9 @@ describe('PipeResource', () => {
     expect(resource.toJSON().metadata).toBeUndefined();
   });
 
-  it('serializes to YAML without a serializer', () => {
+  it('serializes to YAML without a serializer', async () => {
     const resource = new PipeResource(pipeJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.toString()).toContain('apiVersion: camel.apache.org/v1');
   });
 });

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -28,7 +28,7 @@ export class PipeResource extends CamelKResource {
     }
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     super.initialize();
 
     this.flow = new PipeVisualEntity(this.pipe);

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -29,7 +29,7 @@ export class PipeResource extends CamelKResource {
   }
 
   async initialize(): Promise<void> {
-    super.initialize();
+    await super.initialize();
 
     this.flow = new PipeVisualEntity(this.pipe);
     this.errorHandler =

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -53,7 +53,7 @@ export class CitrusTestResource implements KaotoResource {
    */
   constructor(private readonly rawEntities?: Test | Test[]) {}
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     if (!this.rawEntities) {
       this.entities = [];
       return;

--- a/packages/ui/src/models/kaoto-resource.test.ts
+++ b/packages/ui/src/models/kaoto-resource.test.ts
@@ -14,41 +14,41 @@ describe('CamelResourceFactory.createCamelResource', () => {
     mockRandomValues();
   });
 
-  it('should create an empty CamelRouteResource if no args is specified', () => {
+  it('should create an empty CamelRouteResource if no args is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty CamelRouteResource if a camel.yaml path is specified', () => {
+  it('should create an empty CamelRouteResource if a camel.yaml path is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.yaml' });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty CamelRouteResource if a camel.xml path is specified', () => {
+  it('should create an empty CamelRouteResource if a camel.xml path is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'my-route.camel.xml' });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty IntegrationResource if no args is specified', () => {
+  it('should create an empty IntegrationResource if no args is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chat.integration.yaml' });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Integration);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toEqual([]);
   });
 
-  it('should create an empty KameletResource if no args is specified', () => {
+  it('should create an empty KameletResource if no args is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'chuck-norris-source.kamelet.yaml' });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     const entities = resource.getEntities();
     expect(entities).toHaveLength(1);
@@ -56,19 +56,19 @@ describe('CamelResourceFactory.createCamelResource', () => {
     expect(resource.getVisualEntities()).toMatchSnapshot();
   });
 
-  it('should create an empty CameletBindingResource if no args is specified', () => {
+  it('should create an empty CameletBindingResource if no args is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, {
       path: 'webhook-binding.kamelet-binding.yaml',
     });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
   });
 
-  it('should create an empty PipeResource if no args is specified', () => {
+  it('should create an empty PipeResource if no args is specified', async () => {
     const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'webhook.pipe.yaml' });
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities().length).toEqual(1);
@@ -78,9 +78,9 @@ describe('CamelResourceFactory.createCamelResource', () => {
     expect(vis.pipe.spec?.sink).toBeUndefined();
   });
 
-  it('should create a camel route', () => {
+  it('should create a camel route', async () => {
     const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Route);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
@@ -88,41 +88,41 @@ describe('CamelResourceFactory.createCamelResource', () => {
   });
 
   // TODO
-  it.skip('should create an Integration', () => {
+  it.skip('should create an Integration', async () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(integrationJson));
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Integration);
     expect(resource.getVisualEntities().length).toEqual(2);
   });
 
-  it('should create a Kamelet', () => {
+  it('should create a Kamelet', async () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(kameletJson));
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Kamelet);
     expect(resource.getVisualEntities().length).toEqual(1);
   });
 
-  it('should create a KameletBindingPipe', () => {
+  it('should create a KameletBindingPipe', async () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(kameletBindingJson));
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.KameletBinding);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as PipeVisualEntity;
     expect(vis.pipe.spec?.source?.ref?.name).toEqual('webhook-source');
   });
 
-  it('should create a Pipe', () => {
+  it('should create a Pipe', async () => {
     const resource = CamelResourceFactory.createCamelResource(JSON.stringify(pipeJson));
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Pipe);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as PipeVisualEntity;
     expect(vis.pipe.spec?.source?.ref?.name).toEqual('webhook-source');
   });
 
-  it('should create a Citrus test resource', () => {
+  it('should create a Citrus test resource', async () => {
     const resource = CamelResourceFactory.createCamelResource(citrusTestYaml);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getVisualEntities().length).toEqual(1);
     const vis = resource.getVisualEntities()[0] as CitrusTestVisualEntity;

--- a/packages/ui/src/models/kaoto-resource.ts
+++ b/packages/ui/src/models/kaoto-resource.ts
@@ -13,7 +13,7 @@ export interface KaotoResource {
   /**
    * After creation, the `initialize` method parses the underlying DSL to populate the resource entities
    */
-  initialize(): void;
+  initialize(): Promise<void>;
   /** Entities this resource supports. Polymorphic — subclasses may return a restricted subset. */
   readonly supportedEntities: ReadonlyArray<{ type: EntityType }>;
   getVisualEntities(): BaseVisualEntity[];

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
@@ -47,12 +47,12 @@ describe('RestDslEditorPage', () => {
   /**
    * Helper function to render RestDslEditorPage with a camel resource
    */
-  const renderPage = (yamlContent: string) => {
+  const renderPage = async (yamlContent: string) => {
     const camelResource = CamelResourceFactory.createCamelResource(yamlContent);
-    camelResource.initialize();
-    const { Provider, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy } = TestProvidersWrapper({
-      camelResource,
-    });
+    const { Provider, updateEntitiesFromCamelResourceSpy, updateSourceCodeFromEntitiesSpy } =
+      await TestProvidersWrapper({
+        camelResource,
+      });
 
     const result = render(
       <Provider>
@@ -88,7 +88,7 @@ describe('RestDslEditorPage', () => {
 
   describe('Entity Updates', () => {
     it('should update entity on property change', async () => {
-      const { camelResource, updateSourceCodeFromEntitiesSpy } = renderPage(`
+      const { camelResource, updateSourceCodeFromEntitiesSpy } = await renderPage(`
 - rest:
     id: rest-1
     path: /api
@@ -120,7 +120,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should add REST configuration', async () => {
-      const { camelResource, updateEntitiesFromCamelResourceSpy } = renderPage(`
+      const { camelResource, updateEntitiesFromCamelResourceSpy } = await renderPage(`
 - rest:
     id: rest-1
       `);
@@ -139,7 +139,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should add REST service', async () => {
-      const { camelResource, updateEntitiesFromCamelResourceSpy } = renderPage(`
+      const { camelResource, updateEntitiesFromCamelResourceSpy } = await renderPage(`
 - rest:
     id: rest-1
       `);
@@ -158,7 +158,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should add REST method', async () => {
-      const { camelResource, updateEntitiesFromCamelResourceSpy } = renderPage(`
+      const { camelResource, updateEntitiesFromCamelResourceSpy } = await renderPage(`
 - rest:
     id: rest-1
     path: /api
@@ -180,7 +180,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should delete entity', async () => {
-      const { camelResource, updateEntitiesFromCamelResourceSpy } = renderPage(`
+      const { camelResource, updateEntitiesFromCamelResourceSpy } = await renderPage(`
 - rest:
     id: rest-1
     get:
@@ -209,7 +209,7 @@ describe('RestDslEditorPage', () => {
 
   describe('UI Updates', () => {
     it('should update tree and form on add REST configuration', async () => {
-      const { camelResource } = renderPage(`
+      const { camelResource } = await renderPage(`
 - rest:
     id: rest-1
       `);
@@ -235,7 +235,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should update tree and form on add REST service', async () => {
-      const { camelResource } = renderPage(`
+      const { camelResource } = await renderPage(`
 - rest:
     id: rest-1
       `);
@@ -259,7 +259,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should update tree and form on add REST method', async () => {
-      renderPage(`
+      await renderPage(`
 - rest:
     id: rest-1
     path: /api
@@ -284,7 +284,7 @@ describe('RestDslEditorPage', () => {
     });
 
     it('should update tree and form on delete', async () => {
-      renderPage(`
+      await renderPage(`
 - rest:
     id: rest-1
     get:

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -42,7 +42,7 @@ describe('RestRouteEndpointField', () => {
       { route: { from: { uri: 'direct:billing', steps: [] } } },
     ]);
     camelResource.initialize();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     await act(async () => {
       render(

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -12,11 +12,11 @@ describe('useRestDslImportWizard', () => {
   const fetchSpy = vi.spyOn(globalThis, 'fetch');
   let wrapper: FunctionComponent<PropsWithChildren>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     fetchSpy.mockClear();
 
-    const { Provider } = TestProvidersWrapper();
+    const { Provider } = await TestProvidersWrapper();
     wrapper = ({ children }) => (
       <SettingsContext.Provider value={mockSettingsContext}>
         <Provider>{children}</Provider>
@@ -126,7 +126,7 @@ describe('useRestDslImportWizard', () => {
       expect(result.current.importOperations).toHaveLength(1);
     });
 
-    it('handles invalid OpenAPI spec gracefully', () => {
+    it('handles invalid OpenAPI spec gracefully', async () => {
       const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
 
       let returnValue: { error?: string } | undefined;
@@ -173,7 +173,7 @@ describe('useRestDslImportWizard', () => {
     });
   });
 
-  it('does not create duplicate route when operation direct route already exists (direct:operationId format)', () => {
+  it('does not create duplicate route when operation direct route already exists (direct:operationId format)', async () => {
     const camelResource = new CamelRouteResource([
       {
         route: {
@@ -186,7 +186,7 @@ describe('useRestDslImportWizard', () => {
     ]);
 
     camelResource.initialize();
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');
 
     const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
@@ -233,7 +233,7 @@ describe('useRestDslImportWizard', () => {
     expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
   });
 
-  it('does not create duplicate route when operation direct route already exists (parameters.name format)', () => {
+  it('does not create duplicate route when operation direct route already exists (parameters.name format)', async () => {
     const camelResource = new CamelRouteResource([
       {
         route: {
@@ -247,7 +247,7 @@ describe('useRestDslImportWizard', () => {
     ]);
     camelResource.initialize();
 
-    const { Provider, updateEntitiesFromCamelResourceSpy } = TestProvidersWrapper({ camelResource });
+    const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');
 
     const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
@@ -414,7 +414,7 @@ describe('useRestDslImportWizard', () => {
       expect(result.current.importOperations).toHaveLength(1);
     });
 
-    it('sets error when spec text is invalid', () => {
+    it('sets error when spec text is invalid', async () => {
       const { result } = renderHook(() => useRestDslImportWizard(), { wrapper });
 
       act(() => {
@@ -527,8 +527,8 @@ describe('useRestDslImportWizard', () => {
     let camelResource: KaotoResource;
     let updateEntitiesFromCamelResourceSpy: EntitiesContextResult['updateEntitiesFromCamelResource'];
 
-    beforeEach(() => {
-      const testProvider = TestProvidersWrapper();
+    beforeEach(async () => {
+      const testProvider = await TestProvidersWrapper();
       const Provider = testProvider.Provider;
       camelResource = testProvider.camelResource;
       updateEntitiesFromCamelResourceSpy = testProvider.updateEntitiesFromCamelResourceSpy;

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { PropsWithChildren, useContext } from 'react';
 import { parse } from 'yaml';
 
+import { SourceSchemaType } from '../models/camel';
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { CamelXMLRouteResource } from '../models/camel/camel-xml-route-resource';
 import { KaotoResource } from '../models/kaoto-resource';
@@ -12,8 +13,47 @@ import { camelRouteJson, camelRouteYaml } from '../stubs/camel-route';
 import { camelRouteYaml_1_1_original, camelRouteYaml_1_1_updated } from '../stubs/camel-route-yaml-1.1';
 import { EventNotifier } from '../utils';
 import { EntitiesContext, EntitiesProvider } from './entities.provider';
-import { KaotoResourceProvider } from './kaoto-resource.provider';
+import { KaotoResourceContext, KaotoResourceProvider } from './kaoto-resource.provider';
 import { SourceCodeSync } from './source-code-sync';
+
+/**
+ * A controllable deferred promise: lets a test decide *when* (and whether) an
+ * async call settles, so we can interleave it with React lifecycle events such
+ * as unmount. Returned alongside its `resolve`/`reject` handles.
+ */
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+/**
+ * Build a minimal mock KaotoResource covering only the surface EntitiesProvider
+ * touches. Pass `overrides` to control `initialize` (resolve/reject/defer) and the
+ * entities returned. Injected directly via KaotoResourceContext to bypass the
+ * factory, giving the test full control over the async init lifecycle.
+ */
+const createMockResource = (overrides: Partial<KaotoResource> = {}): KaotoResource =>
+  ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getEntities: vi.fn().mockReturnValue([]),
+    getVisualEntities: vi.fn().mockReturnValue([]),
+    getType: vi.fn().mockReturnValue(SourceSchemaType.Route),
+    toString: vi.fn().mockReturnValue(''),
+    ...overrides,
+  }) as unknown as KaotoResource;
+
+const buildMockResourceWrapper =
+  (resource: KaotoResource) =>
+  ({ children }: PropsWithChildren) => (
+    <KaotoResourceContext.Provider value={{ kaotoResource: resource }}>
+      <EntitiesProvider>{children}</EntitiesProvider>
+    </KaotoResourceContext.Provider>
+  );
 
 /**
  * Compose the real provider chain. Source code enters through the single ingress
@@ -102,24 +142,28 @@ describe('EntitiesProvider', () => {
     });
   });
 
-  it('should recreate the entities when the source code is updated', () => {
+  it('should recreate the entities when the source code is updated', async () => {
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       eventNotifier.next('code:updated', { code: camelRouteYaml });
     });
 
+    await act(async () => {});
+
     expect(result.current?.entities).toEqual([]);
     expect(result.current?.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson)]);
   });
 
-  it('should serialize using YAML 1.1', () => {
+  it('should serialize using YAML 1.1', async () => {
     const notifierSpy = vi.spyOn(eventNotifier, 'next');
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
     act(() => {
       eventNotifier.next('code:updated', { code: camelRouteYaml_1_1_original });
     });
+
+    await act(async () => {});
 
     act(() => {
       result.current?.visualEntities[0].updateModel('route.from.parameters.bindingMode', 'off');
@@ -235,5 +279,87 @@ describe('EntitiesProvider', () => {
       `# This is a comment
 #     An indented comment`,
     );
+  });
+
+  describe('async initialization lifecycle', () => {
+    // WORKED EXAMPLE — the failure path (entities.provider.tsx catch block).
+    it('should reset entities and log when initialization rejects', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('boom');
+      const resource = createMockResource({
+        initialize: vi.fn().mockRejectedValue(error),
+        // Returned only if the success path runs — it must NOT, since init rejects.
+        getEntities: vi.fn().mockReturnValue([{ id: 'should-not-appear' }]),
+        getVisualEntities: vi.fn().mockReturnValue([{ id: 'should-not-appear' }]),
+      });
+
+      const { result } = renderHook(() => useContext(EntitiesContext), {
+        wrapper: buildMockResourceWrapper(resource),
+      });
+
+      // Flush the rejected init microtask so the catch block runs.
+      await act(async () => {});
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to initialize KaotoResource', error);
+      expect(result.current?.entities).toEqual([]);
+      expect(result.current?.visualEntities).toEqual([]);
+      // Proof we took the catch path, not the success path.
+      expect(resource.getEntities).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    // Success-path cancellation guard — entities.provider.tsx line 49
+    // (`if (cancelled) return;` after `await kaotoResource.initialize()`).
+    it('should not read entities when unmounted before initialize resolves', async () => {
+      const deferred = createDeferred<void>();
+      const resource = createMockResource({
+        initialize: vi.fn().mockReturnValue(deferred.promise),
+      });
+
+      const { unmount } = renderHook(() => useContext(EntitiesContext), {
+        wrapper: buildMockResourceWrapper(resource),
+      });
+
+      // Unmount first so the effect cleanup sets `cancelled = true`...
+      unmount();
+
+      // ...then let initialize() resolve. The continuation should bail at the guard.
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(resource.getEntities).not.toHaveBeenCalled();
+      expect(resource.getVisualEntities).not.toHaveBeenCalled();
+    });
+
+    // Failure-path cancellation guard — entities.provider.tsx line 53
+    // (`if (cancelled) return;` at the top of the catch block).
+    it('should not log when unmounted before initialize rejects', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const deferred = createDeferred<void>();
+      const resource = createMockResource({
+        initialize: vi.fn().mockReturnValue(deferred.promise),
+      });
+
+      const { unmount } = renderHook(() => useContext(EntitiesContext), {
+        wrapper: buildMockResourceWrapper(resource),
+      });
+
+      // Unmount first so the effect cleanup sets `cancelled = true`...
+      unmount();
+
+      // ...then let initialize() reject. The catch should bail before logging.
+      await act(async () => {
+        deferred.reject(new Error('boom'));
+        // Swallow the rejection here so it doesn't surface as an unhandled rejection.
+        await deferred.promise.catch(() => {});
+      });
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/ui/src/providers/entities.provider.tsx
+++ b/packages/ui/src/providers/entities.provider.tsx
@@ -42,12 +42,25 @@ export const EntitiesProvider: FunctionComponent<PropsWithChildren> = ({ childre
   const [visualEntities, setVisualEntities] = useState<BaseVisualEntity[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
     const init = async () => {
-      await kaotoResource.initialize();
-      setEntities(kaotoResource.getEntities());
-      setVisualEntities(kaotoResource.getVisualEntities());
+      try {
+        await kaotoResource.initialize();
+        if (cancelled) return;
+        setEntities(kaotoResource.getEntities());
+        setVisualEntities(kaotoResource.getVisualEntities());
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Failed to initialize KaotoResource', error);
+        setEntities([]);
+        setVisualEntities([]);
+      }
     };
     void init();
+
+    return () => {
+      cancelled = true;
+    };
   }, [kaotoResource]);
 
   const updateSourceCodeFromEntities = useCallback(() => {
@@ -71,7 +84,7 @@ export const EntitiesProvider: FunctionComponent<PropsWithChildren> = ({ childre
     () => ({
       entities,
       visualEntities,
-      currentSchemaType: kaotoResource?.getType(),
+      currentSchemaType: kaotoResource.getType(),
       camelResource: kaotoResource,
       updateEntitiesFromCamelResource,
       updateSourceCodeFromEntities,

--- a/packages/ui/src/providers/entities.provider.tsx
+++ b/packages/ui/src/providers/entities.provider.tsx
@@ -42,12 +42,12 @@ export const EntitiesProvider: FunctionComponent<PropsWithChildren> = ({ childre
   const [visualEntities, setVisualEntities] = useState<BaseVisualEntity[]>([]);
 
   useEffect(() => {
-    kaotoResource.initialize();
-    const entities = kaotoResource.getEntities();
-    const visualEntities = kaotoResource.getVisualEntities();
-
-    setEntities(entities);
-    setVisualEntities(visualEntities);
+    const init = async () => {
+      await kaotoResource.initialize();
+      setEntities(kaotoResource.getEntities());
+      setVisualEntities(kaotoResource.getVisualEntities());
+    };
+    void init();
   }, [kaotoResource]);
 
   const updateSourceCodeFromEntities = useCallback(() => {

--- a/packages/ui/src/providers/kaoto-resource.provider.test.tsx
+++ b/packages/ui/src/providers/kaoto-resource.provider.test.tsx
@@ -14,7 +14,7 @@ import { KaotoResourceContext, KaotoResourceProvider } from './kaoto-resource.pr
 import { SourceCodeSync } from './source-code-sync';
 
 describe('KaotoResourceProvider', () => {
-  it('builds the resource and entities from the source code present at mount', () => {
+  it('builds the resource and entities from the source code present at mount', async () => {
     const { result } = renderHook(() => useContext(EntitiesContext), {
       wrapper: ({ children }: PropsWithChildren) => (
         <SourceCodeSync initialSourceCode={camelRouteYaml}>
@@ -24,6 +24,8 @@ describe('KaotoResourceProvider', () => {
         </SourceCodeSync>
       ),
     });
+
+    await act(async () => {});
 
     expect(result.current?.visualEntities).toEqual([new CamelRouteVisualEntity(camelRouteJson)]);
   });
@@ -97,7 +99,7 @@ describe('KaotoResourceProvider', () => {
     createSpy.mockRestore();
   });
 
-  it('keeps the last valid resource when a keystroke makes the source transiently invalid', () => {
+  it('keeps the last valid resource when a keystroke makes the source transiently invalid', async () => {
     const { result } = renderHook(() => useContext(EntitiesContext), {
       wrapper: ({ children }: PropsWithChildren) => (
         <SourceCodeSync initialSourceCode={pipeYaml}>
@@ -107,6 +109,8 @@ describe('KaotoResourceProvider', () => {
         </SourceCodeSync>
       ),
     });
+
+    await act(async () => {});
 
     // Sanity: the valid Pipe is in place.
     expect(result.current?.currentSchemaType).toBe(SourceSchemaType.Pipe);

--- a/packages/ui/src/providers/visible-flows.provider.test.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.test.tsx
@@ -1,5 +1,7 @@
+import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { render } from '@testing-library/react';
 import { FunctionComponent, useContext } from 'react';
+import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { EntityType } from '../models/entities';
@@ -7,14 +9,17 @@ import { mockRandomValues, TestProvidersWrapper } from '../stubs';
 import { VisibleFlowsContext, VisibleFlowsProvider } from './visible-flows.provider';
 
 describe('VisibleFlowsProvider', () => {
-  it('should initialize visible flows correctly', () => {
+  it('should initialize visible flows correctly', async () => {
     mockRandomValues();
 
-    const camelResource = new CamelRouteResource();
-    camelResource.initialize();
-    camelResource.addNewEntity(EntityType.Route);
+    const baseResource = new CamelRouteResource();
+    baseResource.addNewEntity(EntityType.Route);
+    // Materialize the new entity into source so the wrapper's re-initialize()
+    // (which rebuilds entities from source) preserves it — mirrors how runtime
+    // recreates the resource from serialized code on `code:updated`.
+    const camelResource = new CamelRouteResource(parse(baseResource.toString()) as CamelYamlDsl);
 
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     const wrapper = render(
       <Provider>
@@ -27,10 +32,9 @@ describe('VisibleFlowsProvider', () => {
     expect(wrapper.asFragment()).toMatchSnapshot();
   });
 
-  it('should initialize visible flows with an empty context', () => {
+  it('should initialize visible flows with an empty context', async () => {
     const camelResource = new CamelRouteResource();
-    camelResource.initialize();
-    const { Provider } = TestProvidersWrapper({ camelResource });
+    const { Provider } = await TestProvidersWrapper({ camelResource });
 
     const wrapper = render(
       <Provider>

--- a/packages/ui/src/services/documentation.service.test.tsx
+++ b/packages/ui/src/services/documentation.service.test.tsx
@@ -32,7 +32,7 @@ describe('DocumentationService', () => {
     </KaotoResourceProvider>
   );
 
-  const createDocumentationEntitiesFromYaml = (yaml: string) => {
+  const createDocumentationEntitiesFromYaml = async (yaml: string) => {
     const { result: entitiesContext } = renderHook(() => useContext(EntitiesContext), { wrapper });
 
     act(() => {
@@ -42,6 +42,11 @@ describe('DocumentationService', () => {
     if (entitiesContext.current === null) {
       throw new Error('EntitiesContext is null');
     }
+
+    // initialize() is async and re-runnable; await it on the context's resource so the
+    // entities/visual entities are fully built before we read them (the EntitiesProvider
+    // also initializes it, but asynchronously — this guarantees completion here).
+    await entitiesContext.current.camelResource.initialize();
 
     const visibleFlows = entitiesContext.current.camelResource.getVisualEntities().reduce((acc, entity) => {
       acc[entity.id] = true;
@@ -61,8 +66,8 @@ describe('DocumentationService', () => {
   };
 
   describe('getDocumentationEntities()', () => {
-    it('should generate route and beans documentation entities', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
+    it('should generate route and beans documentation entities', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
 
       expect(documentationEntities.length).toEqual(2);
       expect(documentationEntities[0].isVisualEntity).toBeTruthy();
@@ -75,8 +80,8 @@ describe('DocumentationService', () => {
       expect(documentationEntities[1].entity!.type).toEqual('beans');
     });
 
-    it('should generate kamelet documentation entities', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(kameletYaml);
+    it('should generate kamelet documentation entities', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(kameletYaml);
 
       expect(documentationEntities.length).toEqual(2);
       expect(documentationEntities[0].isVisualEntity).toBeTruthy();
@@ -87,8 +92,8 @@ describe('DocumentationService', () => {
       expect(documentationEntities[1].entity!.type).toEqual('metadata');
     });
 
-    it('should generate pipe documentation entities', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(pipeYaml);
+    it('should generate pipe documentation entities', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(pipeYaml);
 
       expect(documentationEntities.length).toEqual(3);
       expect(documentationEntities[0].isVisualEntity).toBeTruthy();
@@ -102,11 +107,11 @@ describe('DocumentationService', () => {
       expect(documentationEntities[2].entity!.type).toEqual('pipeErrorHandler');
     });
 
-    it('should generate rest documentation entities', () => {
+    it('should generate rest documentation entities', async () => {
       mockRandomValues();
 
       const camelResource = new CamelRouteResource([restStub, restConfigurationStub]);
-      camelResource.initialize();
+      await camelResource.initialize();
       const documentationEntities = createDocumentationEntitiesFromCamelResource(camelResource);
 
       expect(documentationEntities.length).toEqual(2);
@@ -118,8 +123,8 @@ describe('DocumentationService', () => {
       expect(documentationEntities[1].entity!.type).toEqual('rest');
     });
 
-    it('should generate route configuration documentation entities', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(routeConfigurationFullYaml);
+    it('should generate route configuration documentation entities', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(routeConfigurationFullYaml);
 
       expect(documentationEntities.length).toEqual(1);
       expect(documentationEntities[0].isVisualEntity).toBeTruthy();
@@ -129,8 +134,8 @@ describe('DocumentationService', () => {
   });
 
   describe('generateMarkdown()', () => {
-    it('should generate route and beans markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
+    it('should generate route and beans markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('![Diagram](route.png)');
@@ -142,8 +147,8 @@ describe('DocumentationService', () => {
       expect(markdown).toContain('| myBean  | io.kaoto.MyBean | p1            |                | p1v   |');
     });
 
-    it('should generate kamelet markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(kameletYaml);
+    it('should generate kamelet markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(kameletYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('![Diagram](route.png)');
@@ -159,16 +164,16 @@ describe('DocumentationService', () => {
       expect(markdown).toContain('## Metadata : Annotations');
     });
 
-    it('should generate markdown for kamelet with multiline property and XML', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(kameletWithMultilineXmlPropYaml);
+    it('should generate markdown for kamelet with multiline property and XML', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(kameletWithMultilineXmlPropYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('<strong>sample</strong>');
       expect(markdown).toContain('foo&#10;<Some>aaa</Some>&#10;bbb');
     });
 
-    it('should generate aws-cloudtail-source kamelet markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(kameletAwsCloudtailSourceYaml);
+    it('should generate aws-cloudtail-source kamelet markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(kameletAwsCloudtailSourceYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
       expect(markdown).toContain('![Diagram](route.png)');
       expect(markdown).toContain('# Steps');
@@ -184,8 +189,8 @@ describe('DocumentationService', () => {
       expect(markdown).toContain('## Metadata : Annotations');
     });
 
-    it('should generate pipe markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(pipeYaml);
+    it('should generate pipe markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(pipeYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('![Diagram](route.png)');
@@ -217,9 +222,9 @@ describe('DocumentationService', () => {
       expect(markdownSink).toContain('| sink | REF Kind        |                     | kamelet             |');
     });
 
-    it('should generate rest markdown', () => {
+    it('should generate rest markdown', async () => {
       const camelResource = new CamelRouteResource([restStub, restConfigurationStub]);
-      camelResource.initialize();
+      await camelResource.initialize();
       const documentationEntities = createDocumentationEntitiesFromCamelResource(camelResource);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
@@ -228,8 +233,8 @@ describe('DocumentationService', () => {
       expect(markdown).toContain('# restConfiguration-1234');
     });
 
-    it('should generate rest operations markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(restOperationsYaml);
+    it('should generate rest operations markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(restOperationsYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('![Diagram](route.png)');
@@ -239,8 +244,8 @@ describe('DocumentationService', () => {
       );
     });
 
-    it('should generate route configuration markdown', () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(routeConfigurationFullYaml);
+    it('should generate route configuration markdown', async () => {
+      const documentationEntities = await createDocumentationEntitiesFromYaml(routeConfigurationFullYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
 
       expect(markdown).toContain('![Diagram](route.png)');
@@ -257,7 +262,7 @@ describe('DocumentationService', () => {
 
   describe('generateDocumentationZip()', () => {
     it('should generate a zip file', async () => {
-      const documentationEntities = createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
+      const documentationEntities = await createDocumentationEntitiesFromYaml(camelRouteYaml + beansYaml);
       const markdown = DocumentationService.generateMarkdown(documentationEntities, 'route.png');
       let zipfile: Blob;
       await act(async () => {

--- a/packages/ui/src/services/parsers/pipe-parser.test.ts
+++ b/packages/ui/src/services/parsers/pipe-parser.test.ts
@@ -8,9 +8,9 @@ import { PipeParser } from './pipe-parser';
 
 describe('PipeParser', () => {
   describe('parsePipeEntity()', () => {
-    it('should parse pipe', () => {
+    it('should parse pipe', async () => {
       const resource = CamelResourceFactory.createCamelResource(pipeYaml);
-      resource.initialize();
+      await resource.initialize();
       const pipeEntity = resource.getVisualEntities()[0] as PipeVisualEntity;
       const parsed = PipeParser.parsePipeEntity(pipeEntity);
 
@@ -29,9 +29,9 @@ describe('PipeParser', () => {
       expect(parsed.data[0][3]).toEqual('Kamelet');
     });
 
-    it('should parse pipe with properties', () => {
+    it('should parse pipe with properties', async () => {
       const resource = CamelResourceFactory.createCamelResource(pipeTimerSourceYaml);
-      resource.initialize();
+      await resource.initialize();
       const pipeEntity = resource.getVisualEntities()[0] as PipeVisualEntity;
       const parsed = PipeParser.parsePipeEntity(pipeEntity);
 
@@ -43,9 +43,9 @@ describe('PipeParser', () => {
   });
 
   describe('parseKameletBindingEntity()', () => {
-    it('should parse kamelet binding', () => {
+    it('should parse kamelet binding', async () => {
       const resource = CamelResourceFactory.createCamelResource(kameletBindingYaml);
-      resource.initialize();
+      await resource.initialize();
       const kbEntity = resource.getVisualEntities()[0] as KameletBindingVisualEntity;
       const parsed = PipeParser.parseKameletBindingEntity(kbEntity);
 
@@ -66,9 +66,9 @@ describe('PipeParser', () => {
   });
 
   describe('parsePipeErrorHandlerEntity()', () => {
-    it('should parse pipe error handler', () => {
+    it('should parse pipe error handler', async () => {
       const resource = CamelResourceFactory.createCamelResource(pipeYaml);
-      resource.initialize();
+      await resource.initialize();
       const pehEntity = resource
         .getEntities()
         .find((e) => e instanceof PipeErrorHandlerEntity) as PipeErrorHandlerEntity;

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -27,11 +27,16 @@ interface TestProvidersWrapperResult {
   updateSourceCodeFromEntitiesSpy: Mock;
 }
 
-export const TestProvidersWrapper = (props: TestProviderWrapperProps = {}): TestProvidersWrapperResult => {
+export const TestProvidersWrapper = async (
+  props: TestProviderWrapperProps = {},
+): Promise<TestProvidersWrapperResult> => {
   const camelResource = props.camelResource ?? new CamelRouteResource([camelRouteJson]);
-  if (!props.camelResource) {
-    camelResource.initialize();
-  }
+  // The wrapper is the single initialization point for the resource it renders,
+  // whether created here or injected. initialize() is re-runnable, so this is
+  // safe even if the caller already initialized — but callers should NOT mutate
+  // a resource in memory (e.g. addNewEntity) before handing it over, because
+  // this re-init rebuilds entities from source. Express fixtures as source data.
+  await camelResource.initialize();
   const currentSchemaType = camelResource.getType();
   const updateEntitiesFromCamelResourceSpy = vi.fn();
   const updateSourceCodeFromEntitiesSpy = vi.fn();


### PR DESCRIPTION
### Context
As a prerequisite of moving the XML parsing to use the new `DynamicCatalog`, we need to migrate the `KaotoResource.initialize()` method to be `async`

fix https://github.com/KaotoIO/kaoto/issues/3376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI reliability by awaiting asynchronous resource/provider initialization before components read entities/state.
  * Added safer initialization behavior with unmount cancellation and a graceful fallback to empty entities when initialization fails.
* **Refactor**
  * Converted resource lifecycle `initialize()` methods (and provider initialization flow) to async/Promise-based execution.
  * Updated the shared test provider wrapper and related initialization paths to be asynchronous.
* **Tests**
  * Updated UI/provider/model tests to await async setup, rebuild serialized DSL fixtures when needed, and adjust timing-sensitive assertions (e.g., typeahead/dropdowns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->