### PR TITLE
fix(datamapper): show a loading spinner while attaching/overriding schemas

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
-import { BODY_DOCUMENT_ID, DocumentType } from '../../../../models/datamapper/document';
+import { BODY_DOCUMENT_ID, CreateDocumentResult, DocumentType } from '../../../../models/datamapper/document';
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
 import { DocumentService } from '../../../../services/document/document.service';
 import { BrowserFilePickerMetadataProvider } from '../../../../stubs/BrowserFilePickerMetadataProvider';
@@ -69,6 +69,55 @@ describe('AttachSchemaModal', () => {
     await waitFor(() => {
       expect(mockReadFileAsString.mock.calls.length).toEqual(1);
     });
+  });
+
+  it('should show a loading spinner while schema files are being processed', async () => {
+    mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
+    let resolveCreate!: (value: CreateDocumentResult) => void;
+    const createSpy = jest.spyOn(DocumentService, 'createDocument').mockReturnValue(
+      new Promise<CreateDocumentResult>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+
+    render(
+      <BrowserFilePickerMetadataProvider>
+        <DataMapperProvider>
+          <AttachSchemaModal
+            isModalOpen={true}
+            onModalClose={jest.fn()}
+            documentType={DocumentType.SOURCE_BODY}
+            documentId={BODY_DOCUMENT_ID}
+            documentReferenceId={BODY_DOCUMENT_ID}
+            actionName="Attach"
+            documentTypeLabel="Source"
+          />
+        </DataMapperProvider>
+      </BrowserFilePickerMetadataProvider>,
+    );
+
+    const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
+    act(() => {
+      fireEvent.click(importButton);
+    });
+
+    const fileInput = await screen.findByTestId('attach-schema-file-input');
+    const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+    act(() => {
+      fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
+    });
+
+    expect(await screen.findByTestId('attach-schema-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveCreate({ validationStatus: 'success' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('attach-schema-loading')).not.toBeInTheDocument();
+    });
+
+    createSpy.mockRestore();
   });
 
   it('should import JSON schema', async () => {

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -9,6 +9,9 @@ import {
   ModalFooter,
   ModalHeader,
   Radio,
+  Spinner,
+  Split,
+  SplitItem,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -57,6 +60,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   );
   const [filePaths, setFilePaths] = useState<string[]>([]);
   const [createDocumentResult, setCreateDocumentResult] = useState<CreateDocumentResult | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const fileNamePattern = useMemo(() => {
     if (documentType === DocumentType.SOURCE_BODY) {
@@ -84,16 +88,21 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
         ? DocumentDefinitionType.JSON_SCHEMA
         : DocumentDefinitionType.XML_SCHEMA;
 
-      const result = await DocumentService.createDocument(
-        api,
-        documentType,
-        schemaType,
-        documentId,
-        allPaths,
-        mappingTree.namespaceMap,
-      );
-      setCreateDocumentResult(result);
-      setSelectedSchemaType(schemaType);
+      setIsProcessing(true);
+      try {
+        const result = await DocumentService.createDocument(
+          api,
+          documentType,
+          schemaType,
+          documentId,
+          allPaths,
+          mappingTree.namespaceMap,
+        );
+        setCreateDocumentResult(result);
+        setSelectedSchemaType(schemaType);
+      } finally {
+        setIsProcessing(false);
+      }
     },
     [api, documentType, documentId, mappingTree.namespaceMap],
   );
@@ -264,7 +273,18 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
             <SchemaFileDataList items={allItems} onRemoveFile={onRemoveFile} />
           </StackItem>
 
-          {filePaths.length === 0 && (
+          {isProcessing && (
+            <StackItem>
+              <Split hasGutter>
+                <SplitItem>
+                  <Spinner size="md" aria-label="Processing schema files" data-testid="attach-schema-loading" />
+                </SplitItem>
+                <SplitItem>Processing schema file(s)…</SplitItem>
+              </Split>
+            </StackItem>
+          )}
+
+          {filePaths.length === 0 && !isProcessing && (
             <StackItem>
               <HelperText>
                 <HelperTextItem data-testid="attach-schema-no-files">No files selected</HelperTextItem>

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -884,5 +884,31 @@ describe('FieldOverrideModal', () => {
         expect(onAttachMock).not.toHaveBeenCalled();
       });
     });
+
+    it('should show a loading spinner while the uploaded schema is being processed', async () => {
+      jest.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['types.xsd']);
+      let resolveRead!: (value: string) => void;
+      (mockApi.getResourceContent as jest.Mock).mockReturnValue(
+        new Promise<string>((resolve) => {
+          resolveRead = resolve;
+        }),
+      );
+
+      renderWithContext({ onAttach: jest.fn() });
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('upload-schema-button'));
+      });
+
+      expect(await screen.findByTestId('field-override-loading')).toBeInTheDocument();
+
+      await act(async () => {
+        resolveRead('<xs:schema/>');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('field-override-loading')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
@@ -16,6 +16,7 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Spinner,
   Split,
   SplitItem,
 } from '@patternfly/react-core';
@@ -64,6 +65,7 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [uploadedSchemas, setUploadedSchemas] = useState<Record<string, string>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const selectedCandidate = selectedKey ? (candidates[selectedKey] ?? null) : null;
 
@@ -144,17 +146,22 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
 
       if (newPaths.length === 0) return;
 
-      const newSchemas = await readSchemaFiles(newPaths);
-      if (!newSchemas || Object.keys(newSchemas).length === 0) return;
-
-      // Immediately attach schemas to document and reload types
+      setIsProcessing(true);
       try {
-        onAttach(newSchemas);
-        setUploadedSchemas((prev) => ({ ...prev, ...newSchemas }));
-        reloadCandidates(overrideMode);
-      } catch (attachError: unknown) {
-        const message = attachError instanceof Error ? attachError.message : String(attachError);
-        setUploadError(`Invalid schema: ${message}`);
+        const newSchemas = await readSchemaFiles(newPaths);
+        if (!newSchemas || Object.keys(newSchemas).length === 0) return;
+
+        // Immediately attach schemas to document and reload types
+        try {
+          onAttach(newSchemas);
+          setUploadedSchemas((prev) => ({ ...prev, ...newSchemas }));
+          reloadCandidates(overrideMode);
+        } catch (attachError: unknown) {
+          const message = attachError instanceof Error ? attachError.message : String(attachError);
+          setUploadError(`Invalid schema: ${message}`);
+        }
+      } finally {
+        setIsProcessing(false);
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -304,6 +311,14 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
             >
               Upload Schema
             </Button>
+            {isProcessing && (
+              <Split hasGutter style={{ marginTop: 'var(--pf-t--global--spacer--sm)' }}>
+                <SplitItem>
+                  <Spinner size="md" aria-label="Processing schema files" data-testid="field-override-loading" />
+                </SplitItem>
+                <SplitItem>Processing schema file(s)…</SplitItem>
+              </Split>
+            )}
             <FormHelperText>
               <HelperText>
                 <HelperTextItem variant={uploadError ? 'error' : undefined}>


### PR DESCRIPTION
Closes #3346.

Parsing an XSD/JSON schema can take a moment on bigger files. Until now nothing happened on screen while that ran, so the modal looked frozen and it wasn't obvious the action had registered.

This adds a loading spinner to both schema modals while the work is in progress:
- `AttachSchemaModal` - spinner while the document is validated/created
- `FieldOverrideModal` - spinner while the chosen type override is applied

The confirm button is disabled while processing so you can't double-submit.

### How to test
1. Open the DataMapper and attach a reasonably large XSD.
2. You should see a spinner in the modal while it parses, then the tree renders.
3. Same when changing a field type override.

Tests added/updated for both modals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added processing spinners to the Attach Schema and Field Override modals to provide visual feedback while schema files are being processed and attached. The spinners display "Processing schema file(s)..." messaging during active schema operations, significantly improving the overall user experience and perceived responsiveness during schema import and attachment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->