### PR TITLE
fix(datamapper): make the Field Override type dropdown searchable and namespace-aware

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -47,6 +47,25 @@ describe('FieldOverrideModal', () => {
     jest.restoreAllMocks();
   });
 
+  const getTypeaheadInput = () =>
+    document.querySelector('input.pf-v6-c-text-input-group__text-input') as HTMLInputElement;
+
+  const openTypeahead = async () => {
+    act(() => {
+      fireEvent.focus(getTypeaheadInput());
+    });
+    await screen.findAllByRole('option');
+  };
+
+  const selectOption = async (text: string) => {
+    const options = await screen.findAllByText(text);
+    const option = options.find((el) => el.closest('[role="option"]'));
+    if (!option) throw new Error(`Option not found: ${text}`);
+    act(() => {
+      fireEvent.click(option);
+    });
+  };
+
   it('should render modal when isOpen is true', () => {
     render(
       <FieldOverrideModal
@@ -76,7 +95,17 @@ describe('FieldOverrideModal', () => {
     expect(screen.getByText(new RegExp(`Field Override:.*${fieldName}`))).toBeInTheDocument();
   });
 
-  it('should open type selector when toggle is clicked', () => {
+  it('should open type selector when input is focused', async () => {
+    const mockCandidates: Record<string, IFieldTypeInfo> = {
+      'xs:string': {
+        typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'string'),
+        displayName: 'string',
+        type: Types.String,
+        isBuiltIn: true,
+      },
+    };
+    jest.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockCandidates);
+
     render(
       <FieldOverrideModal
         onClose={jest.fn()}
@@ -87,12 +116,10 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
-    act(() => {
-      fireEvent.click(toggle);
-    });
+    await openTypeahead();
 
-    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Menu toggle' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getAllByText('string').some((el) => el.closest('[role="option"]'))).toBe(true);
   });
 
   it('should update selected type when a type is selected from dropdown', async () => {
@@ -125,28 +152,13 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
-    act(() => {
-      fireEvent.click(toggle);
-    });
-
-    const stringOptions = screen.getAllByText('string');
-    const stringOption = stringOptions.find((el) => el.closest('[role="option"]'));
-    if (!stringOption) {
-      throw new Error('String option not found');
-    }
-    act(() => {
-      fireEvent.click(stringOption);
-    });
+    await openTypeahead();
+    await selectOption('string');
 
     await waitFor(() => {
-      // After selection, the toggle should show the selected type name
-      const toggle = screen.getByRole('button', { name: /string/i });
-      expect(toggle).toBeInTheDocument();
+      // After selection, the typeahead input should show the selected type name
+      expect(getTypeaheadInput().value).toMatch(/string/i);
     });
-
-    // Verify the placeholder text is no longer visible
-    expect(screen.queryByText('Select a new type...')).not.toBeInTheDocument();
   });
 
   it('should enable Save button when a type is selected', async () => {
@@ -172,19 +184,8 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
-    act(() => {
-      fireEvent.click(toggle);
-    });
-
-    const stringOptions = screen.getAllByText('string');
-    const stringOption = stringOptions.find((el) => el.closest('[role="option"]'));
-    if (!stringOption) {
-      throw new Error('String option not found');
-    }
-    act(() => {
-      fireEvent.click(stringOption);
-    });
+    await openTypeahead();
+    await selectOption('string');
 
     await waitFor(() => {
       const saveButton = screen.getByRole('button', { name: 'Save' });
@@ -254,19 +255,8 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
-    act(() => {
-      fireEvent.click(toggle);
-    });
-
-    const stringOptions = screen.getAllByText('string');
-    const stringOption = stringOptions.find((el) => el.closest('[role="option"]'));
-    if (!stringOption) {
-      throw new Error('String option not found');
-    }
-    act(() => {
-      fireEvent.click(stringOption);
-    });
+    await openTypeahead();
+    await selectOption('string');
 
     await waitFor(() => {
       const saveButton = screen.getByRole('button', { name: 'Save' });
@@ -384,23 +374,14 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
-    act(() => {
-      fireEvent.click(toggle);
-    });
-
-    const stringOptions = screen.getAllByText('string');
-    const stringOption = stringOptions.find((el) => el.closest('[role="option"]'));
-    if (!stringOption) {
-      throw new Error('String option not found');
-    }
-    act(() => {
-      fireEvent.click(stringOption);
-    });
+    await openTypeahead();
+    await selectOption('string');
 
     await waitFor(() => {
-      expect(screen.getByText('A text string type')).toBeInTheDocument();
+      expect(getTypeaheadInput().value).toMatch(/string/i);
     });
+
+    expect(screen.getByText('A text string type')).toBeInTheDocument();
   });
 
   it('should pre-select current type when field has existing override', () => {
@@ -437,7 +418,7 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'xs:int' })).toBeInTheDocument();
+    expect(getTypeaheadInput().value).toBe('xs:int');
   });
 
   describe('Substitution mode', () => {
@@ -496,7 +477,7 @@ describe('FieldOverrideModal', () => {
         fireEvent.click(screen.getByLabelText('Substitute Element'));
       });
 
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(getTypeaheadInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should call onSave with substitution payload when saving in substitution mode', async () => {
@@ -522,16 +503,8 @@ describe('FieldOverrideModal', () => {
       });
 
       // Open dropdown and select Cat
-      const toggle = screen.getByRole('button', { name: 'Select a substitute element...' });
-      act(() => {
-        fireEvent.click(toggle);
-      });
-
-      const catOption = screen.getAllByText('Cat').find((el) => el.closest('[role="option"]'));
-      if (!catOption) throw new Error('Cat option not found');
-      act(() => {
-        fireEvent.click(catOption);
-      });
+      await openTypeahead();
+      await selectOption('Cat');
 
       // Save
       await waitFor(() => {
@@ -572,15 +545,8 @@ describe('FieldOverrideModal', () => {
       );
 
       // Select a type in type mode
-      const typeToggle = screen.getByRole('button', { name: 'Select a new type...' });
-      act(() => {
-        fireEvent.click(typeToggle);
-      });
-      const stringOption = screen.getAllByText('string').find((el) => el.closest('[role="option"]'));
-      if (!stringOption) throw new Error('string option not found');
-      act(() => {
-        fireEvent.click(stringOption);
-      });
+      await openTypeahead();
+      await selectOption('string');
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
@@ -592,7 +558,7 @@ describe('FieldOverrideModal', () => {
       });
 
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(getTypeaheadInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should start in substitution mode when field has existing substitution', () => {
@@ -615,7 +581,7 @@ describe('FieldOverrideModal', () => {
 
       // Should auto-select substitution radio and show substitution placeholder
       expect(screen.getByLabelText('Substitute Element')).toBeChecked();
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(getTypeaheadInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should pre-select the active substitute element when field has existing substitution', () => {
@@ -640,8 +606,8 @@ describe('FieldOverrideModal', () => {
         />,
       );
 
-      // The active substitute 'sub:Cat' should be pre-selected in the dropdown toggle
-      expect(screen.getByRole('button', { name: 'Cat' })).toBeInTheDocument();
+      // The active substitute 'sub:Cat' should be pre-selected in the dropdown
+      expect(getTypeaheadInput().value).toBe('Cat');
     });
 
     it('should disable Override Type radio when field has existing substitution', () => {

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
@@ -6,21 +6,16 @@ import {
   HelperText,
   HelperTextItem,
   Icon,
-  MenuToggle,
-  MenuToggleElement,
   ModalBody,
   ModalFooter,
   ModalHeader,
   ModalVariant,
   Radio,
-  Select,
-  SelectList,
-  SelectOption,
   Split,
   SplitItem,
 } from '@patternfly/react-core';
 import { FileImportIcon, WrenchIcon } from '@patternfly/react-icons';
-import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useEffect, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField, SCHEMA_FILE_NAME_PATTERN_XML } from '../../../../models/datamapper/document';
@@ -29,8 +24,9 @@ import { MetadataContext } from '../../../../providers';
 import { formatQNameWithPrefix } from '../../../../services/namespace-util';
 import { SchemaPathService } from '../../../../services/schema-path.service';
 import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
+import { TypeaheadSelect } from '../AttachSchema/TypeaheadSelect';
 import { getFileName, pickAndValidateSchemaFiles } from '../utils';
-import { CandidateDisplay, getOverrideCandidates, OverrideMode } from './override-util';
+import { CandidateDisplay, CandidateOption, getOverrideCandidates, OverrideMode } from './override-util';
 import { SchemaFileList } from './SchemaFileList';
 
 export type OverrideSavePayload =
@@ -61,7 +57,7 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
   const [overrideMode, setOverrideMode] = useState<OverrideMode>(initialMode);
   const [selectedKey, setSelectedKey] = useState<string | null>(initialCandidates.selectedKey);
   const [candidates, setCandidates] = useState<Record<string, CandidateDisplay>>(initialCandidates.candidates);
-  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [candidateOptions, setCandidateOptions] = useState<CandidateOption[]>(initialCandidates.options);
   const [uploadedSchemas, setUploadedSchemas] = useState<Record<string, string>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
 
@@ -74,6 +70,7 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
       if (!field) return;
       const result = getOverrideCandidates(field, mode, mappingTree.namespaceMap);
       setCandidates(result.candidates);
+      setCandidateOptions(result.options);
       setSelectedKey(result.selectedKey);
     },
     [field, mappingTree.namespaceMap],
@@ -92,18 +89,13 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
     return () => {
       setUploadError(null);
       setSelectedKey(null);
-      setIsSelectOpen(false);
       setUploadedSchemas({});
     };
   }, []);
 
   const handleTypeSelect = useCallback(
-    (_event: MouseEvent | undefined, value: string | number | undefined) => {
-      const key = value as string;
-      if (key in candidates) {
-        setSelectedKey(key);
-      }
-      setIsSelectOpen(false);
+    (key: string) => {
+      setSelectedKey(key in candidates ? key : null);
     },
     [candidates],
   );
@@ -174,27 +166,9 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
     }
   }, [selectedKey, overrideMode, candidates, onSave]);
 
-  const handleToggleSelect = useCallback(() => {
-    setIsSelectOpen((prev) => !prev);
-  }, []);
-
   const isSubstitutionMode = overrideMode === 'substitution';
   const selectLabel = isSubstitutionMode ? 'Substitute Element' : 'New Type';
   const selectPlaceholder = isSubstitutionMode ? 'Select a substitute element...' : 'Select a new type...';
-
-  const renderToggle = useCallback(
-    (toggleRef: Ref<MenuToggleElement>) => (
-      <MenuToggle ref={toggleRef} onClick={handleToggleSelect} isExpanded={isSelectOpen} isFullWidth>
-        {selectedCandidate?.displayName || selectPlaceholder}
-      </MenuToggle>
-    ),
-    [handleToggleSelect, isSelectOpen, selectedCandidate?.displayName, selectPlaceholder],
-  );
-
-  const sortedCandidates = useMemo(
-    () => Object.entries(candidates).sort(([, a], [, b]) => a.displayName.localeCompare(b.displayName)),
-    [candidates],
-  );
 
   const hasExistingOverride = field?.typeOverride !== FieldOverrideVariant.NONE || isAbstractWrapper;
 
@@ -263,26 +237,15 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
           </FormGroup>
 
           <FormGroup label={selectLabel} fieldId="type-select" isRequired>
-            <Select
+            <TypeaheadSelect
               id="type-select"
-              isOpen={isSelectOpen}
-              selected={selectedKey}
-              onSelect={handleTypeSelect}
-              onOpenChange={(isOpen) => setIsSelectOpen(isOpen)}
-              toggle={renderToggle}
-              maxMenuHeight="240px"
-              popperProps={{
-                preventOverflow: true,
-              }}
-            >
-              <SelectList>
-                {sortedCandidates.map(([key, candidate]) => (
-                  <SelectOption key={key} value={key}>
-                    {candidate.displayName}
-                  </SelectOption>
-                ))}
-              </SelectList>
-            </Select>
+              data-testid="field-override-type-select"
+              value={selectedKey ?? ''}
+              onChange={handleTypeSelect}
+              options={candidateOptions}
+              placeholder={selectPlaceholder}
+              ariaLabel={selectPlaceholder}
+            />
             {selectedCandidate?.description && (
               <FormHelperText>
                 <HelperText>

--- a/packages/ui/src/components/Document/actions/FieldOverride/override-util.ts
+++ b/packages/ui/src/components/Document/actions/FieldOverride/override-util.ts
@@ -46,6 +46,18 @@ export type OverrideMode = 'type' | 'substitution';
 /** Minimal display shape shared by type and substitution candidates */
 export type CandidateDisplay = { displayName: string; description?: string };
 
+/** A candidate rendered as an option in the typeahead dropdown. */
+export type CandidateOption = { value: string; label: string; description: string };
+
+/**
+ * Build the option description shown under each candidate in the dropdown.
+ * Always surfaces the namespace URI; the optional annotation (from xs:documentation) is appended when present.
+ */
+export function buildCandidateDescription(namespaceUri: string | undefined, annotation?: string): string {
+  const namespacePart = namespaceUri ? `Namespace URI: ${namespaceUri}` : 'No namespace';
+  return annotation ? `${namespacePart} — ${annotation}` : namespacePart;
+}
+
 /** Derive the pre-selected key when opening the modal for a field with an existing override. */
 export function derivePreselectedKey(
   field: IField,
@@ -76,11 +88,29 @@ export function getOverrideCandidates(
   field: IField,
   mode: OverrideMode,
   namespaceMap: Record<string, string>,
-): { candidates: Record<string, CandidateDisplay>; selectedKey: string | null } {
-  const candidates =
-    mode === 'substitution'
-      ? FieldOverrideService.getFieldSubstitutionCandidates(field, namespaceMap)
-      : FieldOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+): { candidates: Record<string, CandidateDisplay>; options: CandidateOption[]; selectedKey: string | null } {
+  let candidates: Record<string, CandidateDisplay>;
+  let options: CandidateOption[];
+
+  if (mode === 'substitution') {
+    const substitutionCandidates = FieldOverrideService.getFieldSubstitutionCandidates(field, namespaceMap);
+    candidates = substitutionCandidates;
+    options = Object.entries(substitutionCandidates).map(([value, info]) => ({
+      value,
+      label: info.displayName,
+      description: buildCandidateDescription(info.qname.getNamespaceURI()),
+    }));
+  } else {
+    const typeCandidates = FieldOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+    candidates = typeCandidates;
+    options = Object.entries(typeCandidates).map(([value, info]) => ({
+      value,
+      label: info.displayName,
+      description: buildCandidateDescription(info.typeQName.getNamespaceURI(), info.description),
+    }));
+  }
+
+  options.sort((a, b) => a.label.localeCompare(b.label));
   const selectedKey = derivePreselectedKey(field, mode, namespaceMap, candidates);
-  return { candidates, selectedKey };
+  return { candidates, options, selectedKey };
 }


### PR DESCRIPTION
Closes #3344.

The type selector in the Field Override modal was a plain dropdown. On schemas with a lot of candidates - or several elements that share a local name across different namespaces - it was hard to find the right one and impossible to tell the duplicates apart.

Changes:
- Replaced the plain `Select` with the existing `TypeaheadSelect`, so you can type to filter the candidates.
- Each option now shows its namespace URI under the name (plus the element's annotation/doc text when it has one), so same-named elements from different namespaces are distinguishable.

### How to test
1. Override a field type on a schema with many candidate elements.
2. Start typing - the list filters.
3. Candidates from different namespaces show their namespace URI under the name.

Tests updated to drive the new typeahead interaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced field override modal's type selection interface with improved searchable input functionality and clearer option descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->