### PR TITLE
fix(datamapper): keep authored wrapper element around xsl:copy-of of a differently-named node

### DIFF
--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -1,5 +1,6 @@
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IParentType } from '../../models/datamapper/document';
 import {
+  FieldItem,
   ForEachGroupItem,
   ForEachItem,
   GroupingStrategy,
@@ -7,6 +8,8 @@ import {
   MappingTree,
   SortItem,
   UnknownMappingItem,
+  ValueSelector,
+  ValueType,
 } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
 import {
@@ -80,6 +83,37 @@ describe('FieldItemHandler', () => {
     expect('name' in field && field.name).toBe('newAttr');
     expect('isAttribute' in field && field.isAttribute).toBe(true);
     expect('namespaceURI' in field && field.namespaceURI).toBe('urn:test');
+  });
+
+  it('should preserve the wrapper element when copy-of reproduces a differently-named element (#3343)', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const targetField = targetDoc.fields[0];
+    const fieldItem = new FieldItem(mappingTree, targetField);
+    const selector = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    selector.expression = '$stockInfoDoc//si:StockInfo/si:Warehouse[1]/addr:StandardAddress';
+    fieldItem.children.push(selector);
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const el = handler.serialize(parent, fieldItem);
+
+    expect(el).not.toBe(parent);
+    expect(el.localName).toBe(targetField.name);
+  });
+
+  it('should drop the wrapper element when copy-of reproduces a same-named element', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const targetField = targetDoc.fields[0];
+    const fieldItem = new FieldItem(mappingTree, targetField);
+    const selector = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    selector.expression = `/ns0:Source/ns0:${targetField.name}`;
+    fieldItem.children.push(selector);
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const el = handler.serialize(parent, fieldItem);
+
+    expect(el).toBe(parent);
   });
 });
 

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -90,11 +90,19 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
       return xslAttribute;
     }
 
-    const hasContainerCopyOf = mapping.children.some(
-      (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER,
+    const containerCopyOf = mapping.children.find(
+      (c): c is ValueSelector => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER,
     );
     const hasChildFieldItems = mapping.children.some((c) => c instanceof FieldItem);
-    if (hasContainerCopyOf && !hasChildFieldItems) return parent;
+    // A whole-node `xsl:copy-of` already reproduces the target element when its selected
+    // node has the same name (e.g. auto-mapped ShipTo -> copy-of of source ShipTo), so the
+    // wrapper element is dropped to avoid double nesting. When the copied node has a different
+    // name, the element is an authored wrapper (e.g. <ReturnAddress><xsl:copy-of .../></...>)
+    // and must be preserved.
+    if (containerCopyOf && !hasChildFieldItems) {
+      const copiedName = FieldItemHandler.getCopyOfElementName(containerCopyOf.expression);
+      if (copiedName === mapping.field.name) return parent;
+    }
 
     const jsonElement = MappingSerializerJsonAddon.populateFieldItem(parent, mapping);
     if (jsonElement) return jsonElement;
@@ -115,6 +123,18 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
     const field = FieldItemHandler.getOrCreateAttributeField(element, parentField);
     if (!field) return null;
     return { mappingItem: new FieldItem(parentMapping, field), fieldItem: field };
+  }
+
+  /**
+   * Extract the local name of the element an `xsl:copy-of` would reproduce from its `select`
+   * expression — i.e. the element name of the last location step. Returns `null` when the last
+   * step is not a plain element name (wildcard, attribute, function call, node test, etc.).
+   */
+  private static getCopyOfElementName(expression: string): string | null {
+    const lastStep = (expression.trim().split('/').pop() ?? '').replace(/\[[^\]]*\]/g, '').trim();
+    if (!lastStep || lastStep.startsWith('@') || lastStep.includes('(') || lastStep.includes('*')) return null;
+    const localName = lastStep.includes(':') ? lastStep.slice(lastStep.lastIndexOf(':') + 1) : lastStep;
+    return localName || null;
   }
 
   private static getOrCreateAttributeField(item: Element, parentField: IParentType): IField | null {


### PR DESCRIPTION
Closes #3343.

### Problem
When a target element's only mapping is a whole-node `xsl:copy-of`, the serializer drops the wrapper element to avoid double-nesting. That's right for auto-mapped compatible containers (e.g. a target `ShipTo` mapped to a `copy-of` of the source `ShipTo`), where the copied node already reproduces the element.

But the same skip also stripped *authored* wrappers like:

```xml
<ReturnAddress>
  <xsl:copy-of select=".../StandardAddress"/>
</ReturnAddress>
```

Here the copied node (`StandardAddress`) has a different name than the wrapper (`ReturnAddress`), so dropping the wrapper is wrong - `ReturnAddress` just disappears from the output.

### Fix
Only skip the wrapper when the `copy-of` reproduces an element with the *same name* as the target field. When the names differ it's a real authored wrapper, so keep it.

Added a small helper to pull the element name out of the `copy-of` `select` expression - it handles namespace prefixes and predicates, and bails out for wildcards/attributes/function calls.

### How to test
See the two new cases in `xslt-item-handlers.test.ts`: a differently-named `copy-of` keeps the wrapper, a same-named one still drops it.
