### PR TITLE
fix(datamapper): group an xs:sequence nested inside an xs:choice

### DIFF
--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -17,8 +17,10 @@ export type IParentType = IDocument | IField;
  * Discriminator for synthetic wrapper fields that group selectable candidates.
  * - `'choice'` — xs:choice compositor wrapping mutually exclusive element alternatives
  * - `'abstract'` — abstract element wrapper holding concrete substitution group members
+ * - `'sequence'` — xs:sequence compositor nested inside an xs:choice, grouping its members
+ *   into a single choice alternative so they stay together instead of rendering flat
  */
-export type WrapperKind = 'choice' | 'abstract';
+export type WrapperKind = 'choice' | 'abstract' | 'sequence';
 
 /**
  * Immutable snapshot of a field's identity and structure taken lazily on first expansion

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
@@ -180,6 +180,79 @@ describe('XmlSchemaDocumentService', () => {
     expect(choiceWrappers[1].fields.find((f) => f.name === 'B2')).toBeDefined();
   });
 
+  it('should group a multi-element xs:sequence nested in xs:choice into a sequence wrapper (#3345)', () => {
+    const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="dataValue" type="xs:string"/>
+        <xs:element name="numericValue" type="xs:int"/>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="key" type="xs:string"/>
+          <xs:element name="value" type="xs:string"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'root.xsd': xsdContent },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const root = document.fields[0];
+    const choiceWrapper = root.fields.find((f) => f.wrapperKind === 'choice')!;
+    expect(choiceWrapper).toBeDefined();
+
+    // The choice now has three alternatives: dataValue, numericValue, and the grouped sequence.
+    expect(choiceWrapper.fields.length).toEqual(3);
+    const sequenceWrapper = choiceWrapper.fields.find((f) => f.wrapperKind === 'sequence')!;
+    expect(sequenceWrapper).toBeDefined();
+    expect(sequenceWrapper.name).toEqual('__sequence__');
+    expect(sequenceWrapper.displayName).toEqual('sequence');
+    expect(sequenceWrapper.minOccurs).toEqual(0);
+    expect(sequenceWrapper.maxOccurs).toEqual('unbounded');
+
+    // key and value stay together under the sequence wrapper instead of flattening into the choice.
+    expect(sequenceWrapper.fields.map((f) => f.name)).toEqual(['key', 'value']);
+    expect(choiceWrapper.fields.find((f) => f.name === 'key')).toBeUndefined();
+    expect(choiceWrapper.fields.find((f) => f.name === 'value')).toBeUndefined();
+  });
+
+  it('should keep a single-element xs:sequence nested in xs:choice flat (no wrapper)', () => {
+    const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="only" type="xs:string"/>
+        <xs:sequence>
+          <xs:element name="solo" type="xs:string"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'root.xsd': xsdContent },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const root = document.fields[0];
+    const choiceWrapper = root.fields.find((f) => f.wrapperKind === 'choice')!;
+    expect(choiceWrapper.fields.find((f) => f.wrapperKind === 'sequence')).toBeUndefined();
+    expect(choiceWrapper.fields.map((f) => f.name)).toEqual(['only', 'solo']);
+  });
+
   it('should parse camel-spring.xsd XML schema', () => {
     const definition = new DocumentDefinition(
       DocumentType.TARGET_BODY,

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -840,9 +840,43 @@ export class XmlSchemaDocumentService {
     fields.push(choiceField);
     ownerDoc.totalFieldCount++;
     for (const member of choice.getItems()) {
-      XmlSchemaDocumentService.populateSequenceMember(choiceField, choiceField.fields, member, visitedGroupRefs);
+      if (member instanceof XmlSchemaSequence && member.getItems().length > 1) {
+        XmlSchemaDocumentService.populateSequenceWrapper(choiceField, choiceField.fields, member, visitedGroupRefs);
+      } else {
+        XmlSchemaDocumentService.populateSequenceMember(choiceField, choiceField.fields, member, visitedGroupRefs);
+      }
     }
     choiceField.displayName = 'choice';
+  }
+
+  /**
+   * Creates a sequence wrapper {@link XmlSchemaField} with {@link XmlSchemaField.wrapperKind} set to
+   * `'sequence'` for an `xs:sequence` nested directly inside an `xs:choice`. Without this wrapper the
+   * sequence members would be flattened into the choice and rendered as individual alternatives, losing
+   * the fact that they belong together as one choice branch. The wrapper is synthetic (no XML element of
+   * its own) and is skipped when building XPath/XSLT, just like the `'choice'` wrapper. The `{sequence:N}`
+   * path index is derived at runtime from the field's position among sibling `wrapperKind === 'sequence'`
+   * fields — no explicit index is stored on the field.
+   */
+  private static populateSequenceWrapper(
+    parent: XmlSchemaParentType,
+    fields: XmlSchemaField[],
+    sequence: XmlSchemaSequence,
+    visitedGroupRefs?: Set<string>,
+  ) {
+    const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;
+    const sequenceField = new XmlSchemaField(parent, '__sequence__', false);
+    sequenceField.wrapperKind = 'sequence';
+    sequenceField.minOccurs = sequence.getMinOccurs();
+    sequenceField.maxOccurs = sequence.getMaxOccurs();
+    sequenceField.minOccursExplicit = sequence.isMinOccursExplicit();
+    sequenceField.maxOccursExplicit = sequence.isMaxOccursExplicit();
+    fields.push(sequenceField);
+    ownerDoc.totalFieldCount++;
+    for (const member of sequence.getItems()) {
+      XmlSchemaDocumentService.populateSequenceMember(sequenceField, sequenceField.fields, member, visitedGroupRefs);
+    }
+    sequenceField.displayName = 'sequence';
   }
 
   /**

--- a/packages/ui/src/services/schema-path.service.test.ts
+++ b/packages/ui/src/services/schema-path.service.test.ts
@@ -357,6 +357,59 @@ describe('SchemaPathService', () => {
     });
   });
 
+  describe('sequence segments (#3345)', () => {
+    function makeSequenceField(parent: XmlSchemaField, memberNames: string[]) {
+      const sequenceField = new XmlSchemaField(parent, '__sequence__', false);
+      sequenceField.wrapperKind = 'sequence';
+      sequenceField.fields = memberNames.map((n) => {
+        const f = new XmlSchemaField(sequenceField, n, false);
+        f.namespaceURI = 'io.kaoto.datamapper.poc.test';
+        return f;
+      });
+      return sequenceField;
+    }
+
+    it('parse() should parse {sequence:N} segments', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:0}/{sequence:0}/ns0:key');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 0 },
+        { kind: 'sequence', index: 0 },
+        { kind: 'element', segment: 'ns0:key' },
+      ]);
+    });
+
+    it('build() should produce {choice:N}/{sequence:N} for a field grouped under a nested sequence', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const root = document.fields[0];
+      const choiceField = makeChoiceField(root, []);
+      const sequenceField = makeSequenceField(choiceField, ['key', 'value']);
+      choiceField.fields = [sequenceField];
+      root.fields.push(choiceField);
+
+      expect(SchemaPathService.build(sequenceField, namespaceMap)).toBe('/ns0:ShipOrder/{choice:0}/{sequence:0}');
+      expect(SchemaPathService.build(sequenceField.fields[1], namespaceMap)).toBe(
+        '/ns0:ShipOrder/{choice:0}/{sequence:0}/ns0:value',
+      );
+    });
+
+    it('navigateToField() should traverse {choice:N}/{sequence:N} segments back to the grouped member', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const root = document.fields[0];
+      const choiceField = makeChoiceField(root, []);
+      const sequenceField = makeSequenceField(choiceField, ['key', 'value']);
+      choiceField.fields = [sequenceField];
+      root.fields.push(choiceField);
+
+      const found = SchemaPathService.navigateToField(
+        document,
+        '/ns0:ShipOrder/{choice:0}/{sequence:0}/ns0:key',
+        namespaceMap,
+      );
+      expect(found).toBe(sequenceField.fields[0]);
+    });
+  });
+
   describe('formatDisplayPath()', () => {
     it('should collapse non-terminal abstract with its candidate child', () => {
       const document = TestUtil.createSourceOrderDoc();

--- a/packages/ui/src/services/schema-path.service.ts
+++ b/packages/ui/src/services/schema-path.service.ts
@@ -7,7 +7,8 @@ import { XPathService } from './xpath/xpath.service';
 export type SchemaPathSegment =
   | { kind: 'element'; segment: string }
   | { kind: 'choice'; index: number }
-  | { kind: 'abstract'; index: number };
+  | { kind: 'abstract'; index: number }
+  | { kind: 'sequence'; index: number };
 
 /**
  * Service for schema path string operations: parsing, building, and navigation.
@@ -37,6 +38,7 @@ export type SchemaPathSegment =
 export class SchemaPathService {
   private static readonly CHOICE_SEGMENT_REGEX = /^\{choice:(\d+)}$/;
   private static readonly ABSTRACT_SEGMENT_REGEX = /^\{abstract:(\d+)}$/;
+  private static readonly SEQUENCE_SEGMENT_REGEX = /^\{sequence:(\d+)}$/;
   /**
    * Parses a schema path string into an array of typed segments.
    *
@@ -55,6 +57,11 @@ export class SchemaPathService {
       const abstractMatch = SchemaPathService.ABSTRACT_SEGMENT_REGEX.exec(part);
       if (abstractMatch) {
         segments.push({ kind: 'abstract', index: Number.parseInt(abstractMatch[1], 10) });
+        continue;
+      }
+      const sequenceMatch = SchemaPathService.SEQUENCE_SEGMENT_REGEX.exec(part);
+      if (sequenceMatch) {
+        segments.push({ kind: 'sequence', index: Number.parseInt(sequenceMatch[1], 10) });
         continue;
       }
       segments.push({ kind: 'element', segment: part });
@@ -106,9 +113,9 @@ export class SchemaPathService {
     const lastIndex = fieldStack.length - 1;
     for (let i = 0; i <= lastIndex; i++) {
       const f = fieldStack[i];
-      if (f.wrapperKind === 'choice') {
+      if (f.wrapperKind === 'choice' || f.wrapperKind === 'sequence') {
         segments.push(
-          `{choice:${SchemaPathService.getSiblingIndex(f, (sibling) => sibling.wrapperKind === 'choice')}}`,
+          `{${f.wrapperKind}:${SchemaPathService.getSiblingIndex(f, (sibling) => sibling.wrapperKind === f.wrapperKind)}}`,
         );
       } else if (f.wrapperKind === 'abstract' && i < lastIndex) {
         i++;

--- a/packages/ui/src/services/visualization/visualization.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.choice.test.ts
@@ -569,6 +569,72 @@ describe('VisualizationService / choice fields', () => {
       const choiceField = createMockChoiceField(members);
       expect(VisualizationService.getChoiceMemberLabel(choiceField)).toEqual('(member0 | member1 | member2 | +7 more)');
     });
+
+    it('should label a single nested sequence member as "sequence"', () => {
+      const baseField = sourceDoc.fields[0];
+      const innerSequence = {
+        ...baseField,
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [],
+      };
+      const choiceField = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        fields: [{ ...baseField, name: 'dataValue', displayName: 'dataValue', fields: [] }, innerSequence],
+      } as unknown as typeof baseField;
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toEqual('(dataValue | sequence)');
+    });
+  });
+
+  describe('xs:sequence nested in xs:choice (#3345)', () => {
+    const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="dataValue" type="xs:string"/>
+        <xs:element name="numericValue" type="xs:int"/>
+        <xs:sequence>
+          <xs:element name="key" type="xs:string"/>
+          <xs:element name="value" type="xs:string"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+
+    function buildChoiceNode() {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        {
+          'root.xsd': xsdContent,
+        },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      const docNode = new DocumentNodeData(result.document!);
+      const rootNode = VisualizationService.generateStructuredDocumentChildren(docNode)[0];
+      const choiceNode = VisualizationService.generateNonDocumentNodeDataChildren(rootNode)[0] as ChoiceFieldNodeData;
+      return choiceNode;
+    }
+
+    it('groups the nested sequence members under one sequence node instead of flattening them', () => {
+      const choiceNode = buildChoiceNode();
+      expect(choiceNode).toBeInstanceOf(ChoiceFieldNodeData);
+      expect(VisualizationService.createNodeTitle(choiceNode)).toEqual('(dataValue | numericValue | sequence)');
+
+      const members = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
+      expect(members.map((m) => m.title)).toEqual(['dataValue', 'numericValue', 'sequence']);
+
+      const sequenceNode = members[2];
+      const sequenceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sequenceNode);
+      expect(sequenceChildren.map((c) => c.title)).toEqual(['key', 'value']);
+    });
   });
 
   describe('createNodeTitle', () => {

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -382,10 +382,13 @@ export class VisualizationService {
   static getChoiceMemberLabel(field: IField): string {
     const members = field.fields ?? [];
     const nestedChoiceCount = members.filter((m) => m.wrapperKind === 'choice').length;
+    const nestedSequenceCount = members.filter((m) => m.wrapperKind === 'sequence').length;
     let choiceIndex = 0;
+    let sequenceIndex = 0;
     const labels = members.map((m) => {
-      if (m.wrapperKind !== 'choice') return m.displayName ?? m.name;
-      return nestedChoiceCount > 1 ? `choice${++choiceIndex}` : 'choice';
+      if (m.wrapperKind === 'choice') return nestedChoiceCount > 1 ? `choice${++choiceIndex}` : 'choice';
+      if (m.wrapperKind === 'sequence') return nestedSequenceCount > 1 ? `sequence${++sequenceIndex}` : 'sequence';
+      return m.displayName ?? m.name;
     });
     if (labels.length === 0) return '(empty)';
     const maxVisible = 3;


### PR DESCRIPTION
Closes #3345.

### Problem
When an `xs:choice` contains an `xs:sequence` directly, the sequence members were flattened into the choice. So a choice like:

```xml
<xs:choice>
  <xs:element name="dataValue"/>
  <xs:element name="numericValue"/>
  <xs:sequence>
    <xs:element name="key"/>
    <xs:element name="value"/>
  </xs:sequence>
</xs:choice>
```

rendered as four sibling alternatives `(dataValue | numericValue | key | value)`. The `key`/`value` pair lost the fact that they belong together as one branch, and selecting one of them dropped the other.

### Fix
Wrap a multi-element nested sequence in a synthetic `sequence` wrapper field, reusing the same machinery as the existing `choice`/`abstract` wrappers:
- new `'sequence'` `WrapperKind`
- the schema builder creates the wrapper for an `xs:sequence` with 2+ members inside a choice
- it renders as `(dataValue | numericValue | sequence)`, with `key`/`value` grouped under the `sequence` node
- it stays transparent to XPath/XSLT and gets a `{sequence:N}` schema-path segment, so mappings still resolve to the real elements

Single-element sequences keep the old flattened behaviour, and sequences pulled in indirectly via `xs:group ref` are left as-is, to avoid changing existing cases.

### How to test
New tests in `xml-schema-document.service.test.ts`, `schema-path.service.test.ts` and `visualization.service.choice.test.ts` cover the wrapper creation, the path round-trip and the grouped rendering.
