### PR TITLE
feat(datamapper): expose variables list from provider via getAllVariables()

### DIFF
--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -27,7 +27,7 @@ import {
   IDocument,
   PrimitiveDocument,
 } from '../models/datamapper/document';
-import { MappingTree } from '../models/datamapper/mapping';
+import { MappingTree, VariableItem } from '../models/datamapper/mapping';
 import { NS_XML_SCHEMA, NS_XPATH_FUNCTIONS, NS_XSL } from '../models/datamapper/standard-namespaces';
 import { CanvasView } from '../models/datamapper/view';
 import { DocumentService } from '../services/document/document.service';
@@ -59,6 +59,7 @@ export interface IDataMapperContext {
   refreshMappingTree(): void;
   resetMappingTree(): void;
   setMappingTree(mappings: MappingTree): void;
+  variables: VariableItem[];
 
   alerts: SendAlertProps[];
   sendAlert: (alert: SendAlertProps) => void;
@@ -312,6 +313,8 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     setAlerts((prev) => prev.filter((a) => a !== option));
   }, []);
 
+  const variables = useMemo(() => MappingService.getAllVariables(mappingTree), [mappingTree]);
+
   const value = useMemo(() => {
     return {
       isLoading,
@@ -334,6 +337,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       refreshMappingTree,
       resetMappingTree,
       setMappingTree,
+      variables,
       alerts,
       sendAlert,
       debug,
@@ -354,6 +358,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     mappingTree,
     refreshMappingTree,
     resetMappingTree,
+    variables,
     alerts,
     sendAlert,
     debug,

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -893,6 +893,72 @@ describe('MappingService', () => {
     });
   });
 
+  describe('getAllVariables()', () => {
+    it('should return empty array for tree without variables', () => {
+      const emptyTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      expect(MappingService.getAllVariables(emptyTree)).toEqual([]);
+    });
+
+    it('should return empty array when tree has children but no variables', () => {
+      expect(MappingService.getAllVariables(tree)).toEqual([]);
+    });
+
+    it('should collect variables from root level', () => {
+      const parent = tree.children[0];
+      const var1 = MappingService.addVariable(parent, 'var1');
+      const var2 = MappingService.addVariable(parent, 'var2');
+      const result = MappingService.getAllVariables(tree);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(var1);
+      expect(result).toContain(var2);
+    });
+
+    it('should collect variables nested in ForEachItem', () => {
+      const forEachItem = tree.children[0].children[3] as ForEachItem;
+      const variable = MappingService.addVariable(forEachItem, 'loopVar');
+      const result = MappingService.getAllVariables(tree);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(variable);
+    });
+
+    it('should collect variables nested in IfItem', () => {
+      const ifItem = tree.children[0].children[1] as IfItem;
+      const variable = MappingService.addVariable(ifItem, 'condVar');
+      const result = MappingService.getAllVariables(tree);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(variable);
+    });
+
+    it('should collect variables nested in WhenItem and OtherwiseItem', () => {
+      const parent = tree.children[0];
+      const chooseItem = new ChooseItem(parent);
+      parent.children.push(chooseItem);
+      const whenItem = MappingService.addWhen(chooseItem);
+      const otherwiseItem = MappingService.addOtherwise(chooseItem);
+      const whenVar = MappingService.addVariable(whenItem, 'whenVar');
+      const elseVar = MappingService.addVariable(otherwiseItem, 'elseVar');
+      const result = MappingService.getAllVariables(tree);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(whenVar);
+      expect(result).toContain(elseVar);
+    });
+
+    it('should collect variables from multiple nesting levels', () => {
+      const parent = tree.children[0];
+      const rootVar = MappingService.addVariable(parent, 'rootVar');
+      const forEachItem = tree.children[0].children.find((c) => c instanceof ForEachItem) as ForEachItem;
+      const nestedVar = MappingService.addVariable(forEachItem, 'nestedVar');
+      const result = MappingService.getAllVariables(tree);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(rootVar);
+      expect(result).toContain(nestedVar);
+    });
+  });
+
   describe('container auto-mapping', () => {
     let sourceRoot: IField;
     let targetRoot: IField;

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -745,6 +745,27 @@ export class MappingService {
   }
 
   /**
+   * Recursively traverses the {@link MappingTree} and collects all {@link VariableItem} instances.
+   * @param mappingTree - the mapping tree to traverse
+   * @returns flat list of all variables from all nesting levels
+   */
+
+  static getAllVariables(mappingTree: MappingTree): VariableItem[] {
+    const result: VariableItem[] = [];
+    const collect = (children: MappingItem[]) => {
+      for (const child of children) {
+        if (child instanceof VariableItem) {
+          result.push(child);
+        }
+        collect(child.children);
+      }
+    };
+
+    collect(mappingTree.children);
+    return result;
+  }
+
+  /**
    * Variables are prepended (unshift) to children, matching the XSLT requirement
    * that `xsl:variable` declarations precede other instructions.
    * @param parent - the parent container


### PR DESCRIPTION
…bles()

Add MappingService.getAllVariables() that recursively traverses the MappingTree and collects all VariableItem instances. Expose the result as a derived `variables` array in DataMapperContext via useMemo.

closes  #2844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variables used in a mapping are now automatically collected and made available throughout the data mapping experience.
  * Nested mappings, conditions, and branches are included, so variable lists stay complete even in complex setups.
  * The available variables update automatically when the mapping changes, helping keep the UI in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->