### PR TITLE
feat(DataMapper): Loading state when uploading schema in modals

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -1129,5 +1129,140 @@ describe('AttachSchemaModal', () => {
       expect(modal).toBeInTheDocument();
       expect(modal!.textContent).toContain('Parameter: myParam');
     });
+
+    describe('Loading state', () => {
+      it('should disable button and show loading text after file selection', async () => {
+        // Mock slow document creation to capture loading state
+        let resolveCreate: (value: unknown) => void;
+        const createPromise = new Promise((resolve) => {
+          resolveCreate = resolve;
+        });
+        vi.spyOn(DocumentService, 'createDocument').mockReturnValue(createPromise as Promise<never>);
+        mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
+
+        render(
+          <BrowserFilePickerMetadataProvider>
+            <DataMapperProvider>
+              <AttachSchemaModal
+                isModalOpen={true}
+                onModalClose={vi.fn()}
+                documentType={DocumentType.SOURCE_BODY}
+                documentId={BODY_DOCUMENT_ID}
+                documentReferenceId={BODY_DOCUMENT_ID}
+                actionName="Attach"
+                documentTypeLabel="Source"
+              />
+            </DataMapperProvider>
+          </BrowserFilePickerMetadataProvider>,
+        );
+
+        const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
+
+        // Button should be enabled initially with normal text
+        expect(importButton).not.toBeDisabled();
+        expect(importButton.textContent).toBe('Upload schema file(s)');
+
+        act(() => {
+          fireEvent.click(importButton);
+        });
+
+        const fileInput = await screen.findByTestId('attach-schema-file-input');
+        const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+
+        await act(async () => {
+          fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
+          // Give time for state updates
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+
+        // After file selection, button should show loading state
+        expect(importButton).toBeDisabled();
+        expect(importButton.textContent).toContain('Uploading schema file(s)...');
+        expect(screen.getByLabelText('Uploading schema file(s)')).toBeInTheDocument();
+
+        // Resolve the document creation
+        act(() => {
+          resolveCreate!({ validationStatus: 'success', document: {}, documentDefinition: {} });
+        });
+
+        // Wait for processing to complete
+        await waitFor(() => {
+          expect(screen.queryByLabelText('Uploading schema file(s)')).not.toBeInTheDocument();
+          expect(importButton).not.toBeDisabled();
+          expect(importButton.textContent).toBe('Upload schema file(s)');
+        });
+      });
+
+      it('should not show loading state while file picker is open', async () => {
+        mockReadFileAsString.mockResolvedValue(getShipOrderXsd());
+
+        render(
+          <BrowserFilePickerMetadataProvider>
+            <DataMapperProvider>
+              <AttachSchemaModal
+                isModalOpen={true}
+                onModalClose={vi.fn()}
+                documentType={DocumentType.SOURCE_BODY}
+                documentId={BODY_DOCUMENT_ID}
+                documentReferenceId={BODY_DOCUMENT_ID}
+                actionName="Attach"
+                documentTypeLabel="Source"
+              />
+            </DataMapperProvider>
+          </BrowserFilePickerMetadataProvider>,
+        );
+
+        const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
+
+        act(() => {
+          fireEvent.click(importButton);
+        });
+
+        // Loading state should not appear immediately when file picker opens
+        expect(screen.queryByLabelText('Uploading schema file(s)')).not.toBeInTheDocument();
+        expect(importButton).not.toBeDisabled();
+        expect(importButton.textContent).toBe('Upload schema file(s)');
+      });
+
+      it('should clear loading state even if processing fails', async () => {
+        mockReadFileAsString.mockRejectedValue(new Error('File read error'));
+
+        render(
+          <BrowserFilePickerMetadataProvider>
+            <DataMapperProvider>
+              <AttachSchemaModal
+                isModalOpen={true}
+                onModalClose={vi.fn()}
+                documentType={DocumentType.SOURCE_BODY}
+                documentId={BODY_DOCUMENT_ID}
+                documentReferenceId={BODY_DOCUMENT_ID}
+                actionName="Attach"
+                documentTypeLabel="Source"
+              />
+            </DataMapperProvider>
+          </BrowserFilePickerMetadataProvider>,
+        );
+
+        const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
+
+        act(() => {
+          fireEvent.click(importButton);
+        });
+
+        const fileInput = await screen.findByTestId('attach-schema-file-input');
+        const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+
+        await act(async () => {
+          fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
+        });
+
+        // Wait for error handling and loading state to clear
+        await waitFor(() => {
+          expect(screen.queryByLabelText('Uploading schema file(s)')).not.toBeInTheDocument();
+          expect(importButton).not.toBeDisabled();
+          expect(importButton.textContent).toBe('Upload schema file(s)');
+        });
+      });
+    });
   });
 });

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -9,6 +9,7 @@ import {
   ModalFooter,
   ModalHeader,
   Radio,
+  Spinner,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -57,6 +58,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   );
   const [filePaths, setFilePaths] = useState<string[]>([]);
   const [createDocumentResult, setCreateDocumentResult] = useState<CreateDocumentResult | null>(null);
+  const [isUploadingSchema, setIsUploadingSchema] = useState(false);
 
   const fileNamePattern = useMemo(() => {
     if (documentType === DocumentType.SOURCE_BODY) {
@@ -99,24 +101,35 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   );
 
   const onFileUpload = useCallback(async () => {
-    const { paths: newPaths, error } = await pickAndValidateSchemaFiles(api, fileNamePattern, documentType, filePaths);
+    try {
+      const { paths: newPaths, error } = await pickAndValidateSchemaFiles(
+        api,
+        fileNamePattern,
+        documentType,
+        filePaths,
+      );
 
-    if (error) {
-      setCreateDocumentResult({ validationStatus: 'error', errors: [{ message: error }] });
-      return;
-    }
-
-    if (newPaths.length === 0) return;
-
-    const combined = [...filePaths];
-    for (const p of newPaths) {
-      if (!combined.includes(p)) {
-        combined.push(p);
+      if (error) {
+        setCreateDocumentResult({ validationStatus: 'error', errors: [{ message: error }] });
+        return;
       }
-    }
 
-    setFilePaths(combined);
-    await validateAndCreateDocument(combined);
+      if (newPaths.length === 0) return;
+
+      setIsUploadingSchema(true);
+
+      const combined = [...filePaths];
+      for (const p of newPaths) {
+        if (!combined.includes(p)) {
+          combined.push(p);
+        }
+      }
+
+      setFilePaths(combined);
+      await validateAndCreateDocument(combined);
+    } finally {
+      setIsUploadingSchema(false);
+    }
   }, [api, fileNamePattern, documentType, filePaths, validateAndCreateDocument]);
 
   const onRemoveFile = useCallback(
@@ -238,11 +251,14 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
               <InputGroupItem>
                 <Button
                   data-testid="attach-schema-modal-btn-file"
-                  icon={<FileImportIcon />}
+                  icon={
+                    isUploadingSchema ? <Spinner size="sm" aria-label="Uploading schema file(s)" /> : <FileImportIcon />
+                  }
                   variant="secondary"
                   onClick={onFileUpload}
+                  isDisabled={isUploadingSchema}
                 >
-                  Upload schema file(s)
+                  {isUploadingSchema ? 'Uploading schema file(s)...' : 'Upload schema file(s)'}
                 </Button>
               </InputGroupItem>
               {filePaths.length > 0 && (

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -825,5 +825,127 @@ describe('FieldOverrideModal', () => {
         expect(onAttachMock).not.toHaveBeenCalled();
       });
     });
+
+    it('should show spinner and disable button while uploading schema', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['types.xsd']);
+      (mockApi.getResourceContent as Mock).mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve('<xs:schema/>'), 100)),
+      );
+
+      renderWithContext();
+
+      const uploadButton = screen.getByTestId('upload-schema-button');
+
+      // Button should be enabled initially
+      expect(uploadButton).not.toBeDisabled();
+
+      act(() => {
+        fireEvent.click(uploadButton);
+      });
+
+      // After file selection, spinner should appear and button should be disabled
+      await waitFor(() => {
+        const spinner = screen.getByLabelText('Uploading schema files');
+        expect(spinner).toBeInTheDocument();
+        expect(uploadButton).toBeDisabled();
+      });
+
+      // Wait for upload to complete
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Uploading schema files')).not.toBeInTheDocument();
+        expect(uploadButton).not.toBeDisabled();
+      });
+    });
+
+    it('should not show spinner while file picker dialog is open', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(['types.xsd']), 200)),
+      );
+
+      renderWithContext();
+
+      const uploadButton = screen.getByTestId('upload-schema-button');
+
+      act(() => {
+        fireEvent.click(uploadButton);
+      });
+
+      // Spinner should not appear while file picker is open
+      expect(screen.queryByLabelText('Uploading schema files')).not.toBeInTheDocument();
+      expect(uploadButton).not.toBeDisabled();
+    });
+
+    it('should clear loading state when upload fails', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['bad.xsd']);
+      (mockApi.getResourceContent as Mock).mockRejectedValue(new Error('Network error'));
+
+      renderWithContext();
+
+      const uploadButton = screen.getByTestId('upload-schema-button');
+
+      await act(async () => {
+        fireEvent.click(uploadButton);
+      });
+
+      // Loading state should be cleared even after error
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Uploading schema files')).not.toBeInTheDocument();
+        expect(uploadButton).not.toBeDisabled();
+      });
+
+      // Error message should be displayed
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to upload/)).toBeInTheDocument();
+      });
+    });
+
+    it('should clear loading state when validation fails', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['invalid.txt']);
+
+      renderWithContext();
+
+      const uploadButton = screen.getByTestId('upload-schema-button');
+
+      await act(async () => {
+        fireEvent.click(uploadButton);
+      });
+
+      // Loading state should not appear for validation errors (fails before loading starts)
+      expect(screen.queryByLabelText('Uploading schema files')).not.toBeInTheDocument();
+      expect(uploadButton).not.toBeDisabled();
+
+      // Validation error should be displayed
+      await waitFor(() => {
+        expect(screen.getByText(/Unknown file extension/)).toBeInTheDocument();
+      });
+    });
+
+    it('should clear loading state when schema attachment fails', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['bad.xsd']);
+      (mockApi.getResourceContent as Mock).mockResolvedValue('<xs:schema/>');
+
+      const onAttachMock = vi.fn().mockImplementation(() => {
+        throw new Error('Invalid schema structure');
+      });
+
+      renderWithContext({ onAttach: onAttachMock });
+
+      const uploadButton = screen.getByTestId('upload-schema-button');
+
+      await act(async () => {
+        fireEvent.click(uploadButton);
+      });
+
+      // Loading state should be cleared after attachment error
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Uploading schema files')).not.toBeInTheDocument();
+        expect(uploadButton).not.toBeDisabled();
+      });
+
+      // Error message should be displayed
+      await waitFor(() => {
+        expect(screen.getByText(/Invalid schema: Invalid schema structure/)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
@@ -16,6 +16,7 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Spinner,
   Split,
   SplitItem,
 } from '@patternfly/react-core';
@@ -64,6 +65,7 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [uploadedSchemas, setUploadedSchemas] = useState<Record<string, string>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [isUploadingSchema, setIsUploadingSchema] = useState(false);
 
   const selectedCandidate = selectedKey ? (candidates[selectedKey] ?? null) : null;
 
@@ -144,6 +146,8 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
 
       if (newPaths.length === 0) return;
 
+      setIsUploadingSchema(true);
+
       const newSchemas = await readSchemaFiles(newPaths);
       if (!newSchemas || Object.keys(newSchemas).length === 0) return;
 
@@ -159,6 +163,8 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       setUploadError(`Failed to upload: ${message}`);
+    } finally {
+      setIsUploadingSchema(false);
     }
   }, [api, uploadedSchemas, field, readSchemaFiles, onAttach, reloadCandidates, overrideMode]);
 
@@ -296,13 +302,14 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
             {/* Removal of individual schema files from this modal is intentionally not supported — files are managed via the document-level attach/detach flow */}
             <SchemaFileList existingFiles={existingFiles} pendingUploads={[]} onRemove={() => {}} />
             <Button
-              icon={<FileImportIcon />}
+              icon={isUploadingSchema ? <Spinner size="sm" aria-label="Uploading schema files" /> : <FileImportIcon />}
               onClick={handleSchemaUpload}
+              isDisabled={isUploadingSchema}
               aria-label="Upload schema file"
               data-testid="upload-schema-button"
               variant="secondary"
             >
-              Upload Schema
+              {isUploadingSchema ? 'Uploading Schema...' : 'Upload Schema'}
             </Button>
             <FormHelperText>
               <HelperText>


### PR DESCRIPTION
Resolves: [#3346](https://github.com/KaotoIO/kaoto/issues/3346)


https://github.com/user-attachments/assets/4f7a3c74-c890-44f6-8c09-14fa99a64b62


https://github.com/user-attachments/assets/340e7bc6-6693-4714-a9ab-b34a66c81a77



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema upload handling: the upload button now shows a spinner/loading message, disables during processing, and restores correctly afterward.
  * Improved robustness of cleanup for failed, canceled, or validation-failed schema uploads so the loading indicator doesn’t get stuck.
  * Prevented loading feedback from appearing while the file picker dialog is still open (before selection/processing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->