### PR TITLE
chore(test): Cleanup unnecessary vi imports

### DIFF
--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -3,7 +3,6 @@ vi.mock('./utils/color-scheme', () => ({
 }));
 
 import { act, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import App from './App';
 import { ColorScheme } from './models';

--- a/packages/ui/src/camel-utils/camel-random-id.test.ts
+++ b/packages/ui/src/camel-utils/camel-random-id.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { getCamelRandomId, getHexaDecimalRandomId } from './camel-random-id';
 
 describe('camel-random-id', () => {

--- a/packages/ui/src/components/Catalog/BaseCatalog.test.tsx
+++ b/packages/ui/src/components/Catalog/BaseCatalog.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { longTileList } from '../../stubs';
 import { BaseCatalog } from './BaseCatalog';

--- a/packages/ui/src/components/Catalog/DataListItem.test.tsx
+++ b/packages/ui/src/components/Catalog/DataListItem.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { ITile } from './Catalog.models';
 import { CatalogDataListItem } from './DataListItem';

--- a/packages/ui/src/components/Catalog/Tags/CatalogTagsPanel.test.tsx
+++ b/packages/ui/src/components/Catalog/Tags/CatalogTagsPanel.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CatalogTagsPanel } from './CatalogTagsPanel';
 

--- a/packages/ui/src/components/Catalog/Tile.test.tsx
+++ b/packages/ui/src/components/Catalog/Tile.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { ITile } from './Catalog.models';
 import { Tile } from './Tile';

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, SetStateAction } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { IVisualizationNode } from '../../models';
 import { SourceSchemaType } from '../../models/camel';

--- a/packages/ui/src/components/DataMapper/DataMapperModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperModal.test.tsx
@@ -9,7 +9,6 @@ import {
   TouchEvent,
   useCallback,
 } from 'react';
-import { vi } from 'vitest';
 
 import { DataMapperModal } from './DataMapperModal';
 

--- a/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.test.tsx
+++ b/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
 
 import { ValidationResult, ValidationStatus } from '../../models';
 import { XsltDocumentRenameInput } from './XsltDocumentRenameInput';

--- a/packages/ui/src/components/DataMapper/debug/DataMapperDebugger.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DataMapperDebugger.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { DataMapperDebugger } from './DataMapperDebugger';
 

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import { MappingTree } from '../../../models/datamapper/mapping';

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileDropdownItem.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { ExportMappingFileDropdownItem } from './ExportMappingFileDropdownItem';
 

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';

--- a/packages/ui/src/components/DataMapper/on-delete-datamapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-delete-datamapper.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { createVisualizationNode } from '../../models';
 import { IMetadataApi } from '../../providers';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';

--- a/packages/ui/src/components/DataMapper/on-duplicate-datamapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-duplicate-datamapper.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { IVisualizationNode } from '../../models';
 import { SourceSchemaType } from '../../models/camel/source-schema-type';
 import { DocumentDefinitionType } from '../../models/datamapper';

--- a/packages/ui/src/components/DataMapper/on-paste-data-mapper.test.ts
+++ b/packages/ui/src/components/DataMapper/on-paste-data-mapper.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { IVisualizationNode } from '../../models';
 import { SourceSchemaType } from '../../models/camel/source-schema-type';
 import { DocumentDefinitionType } from '../../models/datamapper';

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { IField } from '../../../models/datamapper/document';
 import { DocumentNodeData, FieldNodeData } from '../../../models/datamapper/visualization';

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { IField } from '../../../models/datamapper/document';
 import { FieldItem, MappingTree } from '../../../models/datamapper/mapping';
 import {

--- a/packages/ui/src/components/Document/NameInputPlaceholder.test.tsx
+++ b/packages/ui/src/components/Document/NameInputPlaceholder.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { NameValidation, NameValidationStatus } from '../../models/datamapper/visualization';
 import { NameInputPlaceholder } from './NameInputPlaceholder';

--- a/packages/ui/src/components/Document/NodeContainer.test.tsx
+++ b/packages/ui/src/components/Document/NodeContainer.test.tsx
@@ -1,6 +1,6 @@
 import { useDroppable } from '@dnd-kit/core';
 import { render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { NodeData } from '../../models/datamapper/visualization';
 import { DataMapperDndContext } from '../../providers/datamapper-dnd.provider';

--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DocumentDefinitionType, FieldOverrideVariant, IField, NodePath, Types } from '../../../models/datamapper';
 import {

--- a/packages/ui/src/components/Document/ParameterInputPlaceholder.test.tsx
+++ b/packages/ui/src/components/Document/ParameterInputPlaceholder.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { DataMapperProvider } from '../../providers/datamapper.provider';

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { VirtuosoMockContext } from 'react-virtuoso';
-import { vi } from 'vitest';
 
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import {
   BODY_DOCUMENT_ID,

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import {
   BODY_DOCUMENT_ID,

--- a/packages/ui/src/components/Document/VariableInputPlaceholder.test.tsx
+++ b/packages/ui/src/components/Document/VariableInputPlaceholder.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
 import { MappingTree } from '../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentType } from '../../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/ChoiceSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/ChoiceSelectionModal.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { IField } from '../../../models/datamapper/document';
 import { ChoiceSelectionModal } from './ChoiceSelectionModal';

--- a/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
 import { ForEachItem, MappingTree, ValueSelector } from '../../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentType, IDocument, PrimitiveDocument } from '../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/DocumentActions.test.tsx
+++ b/packages/ui/src/components/Document/actions/DocumentActions.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { DocumentNodeData } from '../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';

--- a/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { FieldContextMenu, MenuGroup } from './FieldContextMenu';
 

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper';
 import { DocumentTree } from '../../../../models/datamapper/document-tree';

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { DocumentTree } from '../../../../models/datamapper/document-tree';
 import { Types } from '../../../../models/datamapper/types';

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
 import { DocumentTree } from '../../../../models/datamapper/document-tree';

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IField } from '../../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/FieldOverride/SchemaFileList.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/SchemaFileList.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
 
 import { SchemaFileList } from './SchemaFileList';
 

--- a/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../../models/datamapper/document';
 import { MappingTree, ValueSelector } from '../../../../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
@@ -1,7 +1,6 @@
 import { DraggableObject } from '@patternfly/react-drag-drop';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../../../hooks/useDataMapper';
 import {

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -1,7 +1,6 @@
 import { DraggableObject } from '@patternfly/react-drag-drop';
 import { act, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent } from 'react';
-import { vi } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
 import { ChooseItem, FieldItem, ForEachItem, MappingTree, SortItem } from '../../../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
@@ -1,7 +1,6 @@
 import { DraggableObject } from '@patternfly/react-drag-drop';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/useSortKeyItems.test.ts
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/useSortKeyItems.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/RenameParameterButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/RenameParameterButton.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import {

--- a/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { Types } from '../../../models/datamapper';
 import { IField } from '../../../models/datamapper/document';

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import {
   BODY_DOCUMENT_ID,

--- a/packages/ui/src/components/Document/actions/TypeaheadInput.test.tsx
+++ b/packages/ui/src/components/Document/actions/TypeaheadInput.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { TypeaheadInput, TypeaheadInputOption } from './TypeaheadInput';
 

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
 import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
 import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';

--- a/packages/ui/src/components/Document/actions/utils.test.ts
+++ b/packages/ui/src/components/Document/actions/utils.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DocumentType } from '../../../models/datamapper/document';
 import { DataMapperStepService } from '../../../services/datamapper-step.service';
 import {

--- a/packages/ui/src/components/Document/document-node.utils.test.ts
+++ b/packages/ui/src/components/Document/document-node.utils.test.ts
@@ -1,5 +1,4 @@
 import { KeyboardEvent } from 'react';
-import { vi } from 'vitest';
 
 import { handleNodeKeyDown } from './document-node.utils';
 

--- a/packages/ui/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/ui/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import { useState } from 'react';
-import { vi } from 'vitest';
 
 import { ErrorBoundary } from './ErrorBoundary';
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionContext.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionContext.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import { useContext } from 'react';
-import { vi } from 'vitest';
 
 import { ExpansionContext } from './ExpansionContext';
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ExpansionContext } from './ExpansionContext';
 import { ExpansionPanel } from './ExpansionPanel';

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -1,6 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
 import { useContext, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { ExpansionContext } from './ExpansionContext';
 import { ExpansionPanel } from './ExpansionPanel';

--- a/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
+++ b/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react';
-import { vi } from 'vitest';
 
 import { CamelRouteVisualEntity, createVisualizationNode, IVisualizationNode } from '../../models';
 import { TestProvidersWrapper } from '../../stubs';

--- a/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/packages/ui/src/components/InlineEdit/InlineEdit.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent } from '@testing-library/dom';
 import { act, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { InlineEdit } from './InlineEdit';
 import { minLengthValidator } from './min-length-validator';

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { ValidationStatus } from '../../models';
 import { CamelRouteResource } from '../../models/camel';
 import { camelRouteJson } from '../../stubs';

--- a/packages/ui/src/components/LoadDefaultCatalog/LoadDefaultCatalog.test.tsx
+++ b/packages/ui/src/components/LoadDefaultCatalog/LoadDefaultCatalog.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { AbstractSettingsAdapter, DefaultSettingsAdapter } from '../../models/settings';
 import { ReloadContext, SettingsProvider } from '../../providers';

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
@@ -2,7 +2,6 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { screen, waitFor } from '@testing-library/dom';
 import { act, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CatalogContext } from '../../dynamic-catalog/catalog.provider';
 import { IDynamicCatalogRegistry } from '../../dynamic-catalog/models';

--- a/packages/ui/src/components/PropertiesModal/camel-to-table.adapter.test.ts
+++ b/packages/ui/src/components/PropertiesModal/camel-to-table.adapter.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   CatalogKind,
   ICamelComponentApi,

--- a/packages/ui/src/components/RenderingAnchor/RenderingAnchor.test.tsx
+++ b/packages/ui/src/components/RenderingAnchor/RenderingAnchor.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../models';
 import { RenderingAnchorContext } from './rendering.provider';

--- a/packages/ui/src/components/ResizableSplitPanels/ResizableSplitPanels.test.tsx
+++ b/packages/ui/src/components/ResizableSplitPanels/ResizableSplitPanels.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { ResizableSplitPanels } from './ResizableSplitPanels';
 

--- a/packages/ui/src/components/Settings/SettingsForm.test.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.test.tsx
@@ -1,7 +1,7 @@
 import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { AbstractSettingsAdapter, DefaultSettingsAdapter } from '../../models/settings';
 import { ReloadContext, SettingsProvider } from '../../providers';

--- a/packages/ui/src/components/View/MappingLink.test.tsx
+++ b/packages/ui/src/components/View/MappingLink.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { MappingLineStyle } from '../../models/datamapper';
 import { useDocumentTreeStore } from '../../store';

--- a/packages/ui/src/components/View/MappingLinkContainer.test.tsx
+++ b/packages/ui/src/components/View/MappingLinkContainer.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { IMappingLink, MappingLineStyle } from '../../models/datamapper';
 import { MappingLinksContainer } from './MappingLinkContainer';

--- a/packages/ui/src/components/View/SourcePanel.test.tsx
+++ b/packages/ui/src/components/View/SourcePanel.test.tsx
@@ -1,5 +1,4 @@
 import { act, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -1,7 +1,6 @@
 import { VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { vi } from 'vitest';
 
 import { CatalogModalContext } from '../../../dynamic-catalog/catalog-modal.provider';
 import { CamelRouteResource, KameletResource } from '../../../models/camel';

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -1,7 +1,6 @@
 import { CanvasFormTabsProvider } from '@kaoto/forms';
 import { act, fireEvent, render } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../models/camel';
 import { EntityType } from '../../../models/entities';

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -3,7 +3,6 @@ import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { CanvasFormTabsContext, CanvasFormTabsProvider } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import {
   CamelCatalogService,

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -3,7 +3,6 @@ import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { CanvasFormTabsContext } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import {
   CamelCatalogService,

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/FormTest.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/FormTest.tsx
@@ -2,7 +2,6 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { KaotoForm } from '@kaoto/forms';
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../models';
 import { getFirstCatalogMap } from '../../../../../stubs/test-load-catalog';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ArrayBadgesField/ArrayBadgesField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ArrayBadgesField/ArrayBadgesField.test.tsx
@@ -1,6 +1,5 @@
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoSchemaDefinition } from '../../../../../../models';
 import { ArrayBadgesField } from './ArrayBadgesField';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
@@ -4,7 +4,7 @@ import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, ReactElement } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useEntityContext } from '../../../../../../hooks/useEntityContext/useEntityContext';
 import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/NewBeanModal.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/NewBeanModal.test.tsx
@@ -2,7 +2,6 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { resolveSchemaWithRef, SuggestionRegistryProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoSchemaDefinition } from '../../../../../../models';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.test.tsx
@@ -1,7 +1,6 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoSchemaDefinition } from '../../../../../../models';
 import { RuntimeContext } from '../../../../../../providers/runtime.provider';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
@@ -1,5 +1,4 @@
 import { act, renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { EntitiesContextResult } from '../../../../../providers/entities.provider';
 import { VisibleFlowsContextResult } from '../../../../../providers/visible-flows.provider';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
@@ -2,7 +2,6 @@ import { CamelYamlDsl, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -4,7 +4,7 @@ import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -4,7 +4,7 @@ import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/NewEndpointModal.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/NewEndpointModal.test.tsx
@@ -2,7 +2,7 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogModalContext } from '../../../../../../dynamic-catalog/catalog-modal.provider';
 import { CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
@@ -1,7 +1,6 @@
 import { SchemaContext } from '@kaoto/forms';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { vi } from 'vitest';
 
 import { EndpointPropertiesField } from './EndpointPropertiesField';
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -1,6 +1,6 @@
 import { FieldProps, ModelContextProvider, SchemaProvider, setValue, useFieldValue } from '@kaoto/forms';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 import { MultiValuePropertyEditor } from './MultiValuePropertyEditor';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -8,7 +8,6 @@ import {
 } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { setHeaderExpressionSchema } from '../../../../../../stubs/expression-definition-schema';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/MediaTypeField/MediaTypeField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/MediaTypeField/MediaTypeField.test.tsx
@@ -1,6 +1,5 @@
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoSchemaDefinition } from '../../../../../../models';
 import { DefaultSettingsAdapter } from '../../../../../../models/settings';

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/UriField/UriField.test.tsx
@@ -1,7 +1,6 @@
 import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
-import { vi } from 'vitest';
 
 import { UriField } from './UriField';
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/SuggestionsProvider.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/SuggestionsProvider.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { vi } from 'vitest';
 
 import { IMetadataApi, MetadataContext } from '../../../../../providers';
 import { getPropertiesSuggestionProvider } from './suggestions/properties.suggestions';

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/properties.suggestions.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/properties.suggestions.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { IMetadataApi } from '../../../../../../providers';
 import { getPropertiesSuggestionProvider } from './properties.suggestions';
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
@@ -1,6 +1,5 @@
 import { CatalogLibrary } from '@kaoto/camel-catalog/catalog-index.d.ts';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { IMetadataApi } from '../../../../../../providers';

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { IVisualizationNode } from '../../../../models';
 import { useDeleteGroup } from '../../Custom/hooks/delete-group.hook';

--- a/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
@@ -1,6 +1,6 @@
 import type { Controller } from '@patternfly/react-topology';
 import { Dimensions, ModelKind } from '@patternfly/react-topology';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { applyCollapseState } from './apply-collapse-state';
 import { CanvasDefaults } from './canvas.defaults';

--- a/packages/ui/src/components/Visualization/Canvas/controller.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/controller.service.test.ts
@@ -1,5 +1,4 @@
 import { DagreGroupsLayout, ModelKind, Visualization } from '@patternfly/react-topology';
-import { vi } from 'vitest';
 
 import { CustomGroupWithSelection } from '../Custom';
 import { CustomEdge } from '../Custom/Edge/CustomEdge';

--- a/packages/ui/src/components/Visualization/ConfirmIntegrationTypeChangeModal/ConfirmIntegrationTypeChangeModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ConfirmIntegrationTypeChangeModal/ConfirmIntegrationTypeChangeModal.test.tsx
@@ -1,6 +1,5 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { SourceSchemaType } from '../../../models/camel';
 import { RuntimeContext } from '../../../providers';

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import {
   CamelRouteResource,

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
@@ -1,6 +1,5 @@
 import { VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { toBlob } from 'html-to-image';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { DocumentationService } from '../../../../services/documentation.service';

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { useSourceCodeStore } from '../../../../store';
 import { defaultTooltipText, FlowClipboard, successTooltipText } from './FlowClipboard';

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.test.tsx
@@ -1,7 +1,7 @@
 import { useVisualizationController } from '@patternfly/react-topology';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { toBlob } from 'html-to-image';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { TestProvidersWrapper } from '../../../../stubs';
 import { FlowExportImage } from './FlowExportImage';

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.test.tsx
@@ -1,7 +1,7 @@
 import { GRAPH_LAYOUT_END_EVENT, useEventListener } from '@patternfly/react-topology';
 import { act, render, waitFor } from '@testing-library/react';
 import { toBlob } from 'html-to-image';
-import { Mock, MockInstance, vi } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';
 import { TestProvidersWrapper } from '../../../../stubs';

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -1,6 +1,5 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoResource } from '../../../../models/kaoto-resource';
 import { RuntimeContext } from '../../../../providers';

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelectorToggle/IntegrationTypeSelectorToggle.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { configureSourceSchemaTypes, TestProvidersWrapper, TestRuntimeProviderWrapper } from '../../../../../stubs';
 import { IntegrationTypeSelectorToggle } from './IntegrationTypeSelectorToggle';

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel';

--- a/packages/ui/src/components/Visualization/ContextToolbar/SelectedRuntime/SelectedRuntime.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/SelectedRuntime/SelectedRuntime.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useRuntimeContext } from '../../../../hooks/useRuntimeContext/useRuntimeContext';
 import { Links } from '../../../../router/links.models';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemCopyStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemCopyStep.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { createVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteStep.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDuplicateStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDuplicateStep.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { createVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemHideOtherFlows.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemMoveStep.test.tsx
@@ -1,6 +1,6 @@
 import { AngleDoubleDownIcon, AngleDoubleUpIcon } from '@patternfly/react-icons';
 import { fireEvent, render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { AddStepMode, createVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemPasteStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemPasteStep.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { AddStepMode, createVisualizationNode } from '../../../../models';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { createVisualizationNode, DefinedComponent, IVisualizationNode } from '../../../../models';

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -3,7 +3,7 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { ElementModel, GraphElement, Model, VisualizationProvider } from '@patternfly/react-topology';
 import { render } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import {
   CamelCatalogService,

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/item-interaction-helper.test.ts
@@ -1,5 +1,4 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { vi } from 'vitest';
 
 import { createVisualizationNode } from '../../../../models';
 import { SourceSchemaType } from '../../../../models/camel/source-schema-type';

--- a/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Edge/CustomEdge.test.tsx
@@ -1,7 +1,6 @@
 import { BaseEdge, BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, render } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { TestProvidersWrapper } from '../../../../stubs';

--- a/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
 import { GraphContextMenuFn } from './CustomGraph';

--- a/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/ItemPasteEntity.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { usePasteEntity } from '../../../../hooks/usePasteEntity';
 import { ItemPasteEntity } from './ItemPasteEntity';

--- a/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { EntityType } from '../../../../models/entities';
 import { generateEntityContextMenu } from './generateEntityContextMenu';

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroup.test.tsx
@@ -1,6 +1,5 @@
 import { BaseEdge, BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { TestProvidersWrapper } from '../../../../stubs';
 import { ControllerService } from '../../Canvas/controller.service';

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -2,7 +2,7 @@ import * as ReactTopology from '@patternfly/react-topology';
 import { BaseEdge, BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { NodeToolbarTrigger, SettingsModel } from '../../../../models/settings/settings.model';

--- a/packages/ui/src/components/Visualization/Custom/NoBendingEdge.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/NoBendingEdge.test.ts
@@ -1,5 +1,5 @@
 import { getTopCollapsedParent, Point } from '@patternfly/react-topology';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { NoBendpointsEdge } from './NoBendingEdge';
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
@@ -1,7 +1,6 @@
 import { BaseEdge, BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode } from '../../../../models';
 import { TestProvidersWrapper } from '../../../../stubs';

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
@@ -1,5 +1,5 @@
 import { waitFor } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
@@ -1,6 +1,5 @@
 import { BaseGraph, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { createVisualizationNode, IVisualizationNode, IVisualizationNodeData } from '../../../../models';
 import { PlaceholderType } from '../../../../models/placeholder.constants';

--- a/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
@@ -1,5 +1,5 @@
 import { Edge, EdgeModel } from '@patternfly/react-topology';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogModalContextValue } from '../../../dynamic-catalog/catalog-modal.provider';
 import { AddStepMode, IVisualizationNode } from '../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ITile } from '../../../../components/Catalog/Catalog.models';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';

--- a/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
@@ -1,7 +1,7 @@
 import type { Controller, ElementModel, Graph, GraphElement, Node } from '@patternfly/react-topology';
 import { Dimensions } from '@patternfly/react-topology';
 import { renderHook } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { useCollapseStep } from './collapse-step.hook';

--- a/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.test.tsx
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import hotkeys from 'hotkeys-js';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { IVisualizationNode } from '../../../../models';
 import { useDeleteGroup } from './delete-group.hook';

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
@@ -1,7 +1,6 @@
 import { setValue } from '@kaoto/forms';
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -1,7 +1,6 @@
 import { ElementModel, Node } from '@patternfly/react-topology';
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../models/entities';

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { ITile } from '../../../../components/Catalog/Catalog.models';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { SourceSchemaType } from '../../../../models/camel/source-schema-type';

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ITile } from '../../../../components/Catalog/Catalog.models';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-graph-layout.hook.test.ts
@@ -1,6 +1,6 @@
 import { useVisualizationController } from '@patternfly/react-topology';
 import { renderHook } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { LayoutType } from '../../Canvas/canvas.models';
 import { useGraphLayout } from './use-graph-layout.hook';

--- a/packages/ui/src/components/Visualization/Custom/target-anchor.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/target-anchor.test.ts
@@ -1,5 +1,4 @@
 import { Node, Point, Rect } from '@patternfly/react-topology';
-import { vi } from 'vitest';
 
 import { TargetAnchor } from './target-anchor';
 

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
 import { KaotoSchemaDefinition } from '../../../../models/kaoto-schema';

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.test.tsx
@@ -1,6 +1,5 @@
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource, SourceSchemaType } from '../../../../models/camel';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows';

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -1,7 +1,7 @@
 import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { Ref } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { sourceSchemaConfig, SourceSchemaType } from '../../../models/camel';
 import { EntitiesContext, EntitiesContextResult } from '../../../providers/entities.provider';

--- a/packages/ui/src/components/Visualization/Visualization.test.tsx
+++ b/packages/ui/src/components/Visualization/Visualization.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
-import { vi } from 'vitest';
 
 import { useVisibleVizNodes } from '../../hooks/use-visible-viz-nodes';
 import { IVisualizationNode } from '../../models/visualization/base-visual-entity';

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';

--- a/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';

--- a/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren, useContext } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ITile } from '../components/Catalog';
 import { CatalogKind, DefinedComponent } from '../models';

--- a/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
@@ -2,7 +2,7 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { useContext } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { camelComponentToTile, camelProcessorToTile, citrusComponentToTile, kameletToTile } from '../camel-utils';
 import {

--- a/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.test.tsx
@@ -1,7 +1,7 @@
 import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
 import { CatalogDefinition, CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
-import { Mock } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ReloadContext } from '../providers/reload.provider';
 import { TestRuntimeProviderWrapper } from '../stubs';

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog-registry.test.ts
@@ -1,5 +1,4 @@
 import { KaotoFunction } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import {
   ICamelComponentDefinition,

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DynamicCatalog } from './dynamic-catalog';
 import { ICatalogProvider } from './models';
 

--- a/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-camel-catalog.test.ts
@@ -1,6 +1,5 @@
 import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../models';
 import { getFirstCatalogMap } from '../../stubs/test-load-catalog';

--- a/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-citrus-catalog.test.ts
@@ -1,6 +1,5 @@
 import catalogLibraryJson from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../models';
 import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../models/citrus/citrus-catalog-index';

--- a/packages/ui/src/dynamic-catalog/use-catalog-tiles.hook.test.tsx
+++ b/packages/ui/src/dynamic-catalog/use-catalog-tiles.hook.test.tsx
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { vi } from 'vitest';
 
 import { CatalogTilesContext } from './catalog-tiles.provider';
 import { useCatalogTiles } from './use-catalog-tiles.hook';

--- a/packages/ui/src/hooks/undo-redo.hook.test.ts
+++ b/packages/ui/src/hooks/undo-redo.hook.test.ts
@@ -1,5 +1,4 @@
 import { act, renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { useSourceCodeStore } from '../store';
 import { EventNotifier } from '../utils';

--- a/packages/ui/src/hooks/use-processor-tooltips.hook.test.ts
+++ b/packages/ui/src/hooks/use-processor-tooltips.hook.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { getProcessorIconTooltipRequest } from '../models/visualization/flows/nodes/resolvers/tooltip-resolver/getProcessorIconTooltipRequest';
 import { useProcessorTooltips } from './use-processor-tooltips.hook';

--- a/packages/ui/src/hooks/use-visible-viz-nodes.test.ts
+++ b/packages/ui/src/hooks/use-visible-viz-nodes.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { BaseVisualEntity, IVisualizationNode } from '../models/visualization/base-visual-entity';
 import { IVisibleFlows } from '../utils/init-visible-flows';

--- a/packages/ui/src/hooks/useConnectionPortSync.hook.test.tsx
+++ b/packages/ui/src/hooks/useConnectionPortSync.hook.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, renderHook } from '@testing-library/react';
 import React from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DocumentTreeState, useDocumentTreeStore } from '../store/document-tree.store';
 import { useConnectionPortSync } from './useConnectionPortSync.hook';

--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import hotkeys from 'hotkeys-js';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { IDocument } from '../models/datamapper';
 import { MappingActionKind } from '../models/datamapper/mapping-action';

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { EntitiesProvider } from '../../providers/entities.provider';
 import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';

--- a/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
+++ b/packages/ui/src/hooks/useKaotoResourceContext/useKaotoResourceContext.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { Mock } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { KaotoResourceProvider } from '../../providers/kaoto-resource.provider';
 import { SourceCodeSync } from '../../providers/source-code-sync';

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { SourceSchemaType } from '../models/camel/source-schema-type';

--- a/packages/ui/src/hooks/useReloadContext/useReloadContext.test.tsx
+++ b/packages/ui/src/hooks/useReloadContext/useReloadContext.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ReloadContext } from '../../providers';
 import { errorMessage, useReloadContext } from './useReloadContext';

--- a/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
+++ b/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
@@ -1,7 +1,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { act, renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { SourceSchemaType } from '../../models/camel';
 import { KaotoResource } from '../../models/kaoto-resource';

--- a/packages/ui/src/layout/Shell.test.tsx
+++ b/packages/ui/src/layout/Shell.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useLocalStorage } from '../hooks/local-storage.hook';
 import { Shell } from './Shell';

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -1,5 +1,4 @@
 import { cloneDeep } from 'lodash';
-import { vi } from 'vitest';
 
 import { mockRandomValues } from '../../stubs';
 import { kameletJson } from '../../stubs/kamelet-route';

--- a/packages/ui/src/models/camel/parsers/to.parser.test.ts
+++ b/packages/ui/src/models/camel/parsers/to.parser.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, To } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
 import { DynamicCatalog } from '../../../dynamic-catalog/dynamic-catalog';

--- a/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
+++ b/packages/ui/src/models/settings/localstorage-settings-adapter.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { LocalStorageKeys } from '../local-storage-keys';
 import { LocalStorageSettingsAdapter } from './localstorage-settings-adapter';
 import { CanvasLayoutDirection, ColorScheme, NodeLabelType, NodeToolbarTrigger, SettingsModel } from './settings.model';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { mockRandomValues } from '../../../stubs';
 import { IVisualizationNodeData } from '../base-visual-entity';
 import { CamelInterceptFromVisualEntity } from './camel-intercept-from-visual-entity';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { mockRandomValues } from '../../../stubs';
 import { IVisualizationNodeData } from '../base-visual-entity';
 import { CamelInterceptSendToEndpointVisualEntity } from './camel-intercept-send-to-endpoint-visual-entity';

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { mockRandomValues } from '../../../stubs';
 import { IVisualizationNodeData } from '../base-visual-entity';
 import { CamelInterceptVisualEntity } from './camel-intercept-visual-entity';

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -1,5 +1,4 @@
 import { OnCompletion } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { mockRandomValues } from '../../../stubs';
 import { IVisualizationNodeData } from '../base-visual-entity';

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition, Rest, To2 } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { restStub } from '../../../stubs/rest';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, RouteConfigurationDefinition } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { routeConfigurationStub } from '../../../stubs/route-configuration';
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -1,6 +1,5 @@
 import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
-import { vi } from 'vitest';
 
 import { mockRandomValues } from '../../../stubs';
 import { camelFromJson } from '../../../stubs/camel-from';

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
-import { vi } from 'vitest';
 
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { citrusTestJson } from '../../../stubs/citrus-test';

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { mockRandomValues } from '../../../stubs';
 import { camelFromJson } from '../../../stubs/camel-from';

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.test.ts
@@ -1,5 +1,4 @@
 import { RouteDefinition } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 import { parse } from 'yaml';
 
 import { DATAMAPPER_ID_PREFIX } from '../../../../../utils';

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
@@ -1,4 +1,4 @@
-import { MockInstance, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 import { CatalogKind } from '../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { BaseNodeMapper } from './mappers/base-node-mapper';
 import { ChoiceNodeMapper } from './mappers/choice-node-mapper';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/catalog-resolver.factory.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../catalog-kind';
 import { CatalogResolverFactory } from './catalog-resolver.factory';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/icon-resolver/getIconRequest.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/icon-resolver/getIconRequest.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogKind } from '../../../../../catalog-kind';
 import { getIconRequest } from './getIconRequest';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/schema-resolver/node-schema-resolver.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/schema-resolver/node-schema-resolver.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { ICamelProcessorDefinition } from '../../../../../camel/camel-processors-catalog';
 import { CatalogKind } from '../../../../../catalog-kind';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/getTitleRequest.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { CatalogKind } from '../../../../../catalog-kind';
 import { getTitleRequest } from './getTitleRequest';
 import { NodeTitleResolver } from './node-title-resolver';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/title-resolver/node-title-resolver.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../catalog-kind';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getProcessorIconTooltipRequest.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getProcessorIconTooltipRequest.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { getProcessorIconTooltipRequest } from './getProcessorIconTooltipRequest';
 import { ProcessorIconTooltipResolver } from './processor-icon-tooltip-resolver';
 

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getTooltipRequest.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/getTooltipRequest.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../catalog-kind';

--- a/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/processor-icon-tooltip-resolver.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/resolvers/tooltip-resolver/processor-icon-tooltip-resolver.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../catalog-kind';

--- a/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { noopNodeMapper } from './mappers/testing/noop-node-mapper';
 import { RootNodeMapper } from './root-node-mapper';
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -1,7 +1,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, Pipe } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { pipeJson } from '../../../stubs/pipe';

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { DynamicCatalog } from '../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';

--- a/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { getFirstCitrusCatalogMap } from '../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../catalog-kind';

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { VisibleFlowAction, VisibleFlowsReducer, VisualFlowsApi } from './flows-visibility';
 

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
@@ -1,6 +1,5 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../catalog-kind';

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -1,5 +1,4 @@
 import { cloneDeep } from 'lodash';
-import { vi } from 'vitest';
 
 import { camelRouteJson } from '../../stubs/camel-route';
 import { SourceSchemaType } from '../camel';

--- a/packages/ui/src/multiplying-architecture/Bridge/KaotoBridge.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/KaotoBridge.test.tsx
@@ -1,7 +1,6 @@
 import { ChannelType } from '@kie-tools-core/editor/dist/api';
 import { render } from '@testing-library/react';
 import { ComponentProps } from 'react';
-import { vi } from 'vitest';
 
 import { KaotoBridge } from './KaotoBridge';
 

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
@@ -1,6 +1,5 @@
 import { act, render } from '@testing-library/react';
 import { FunctionComponent, useRef } from 'react';
-import { vi } from 'vitest';
 
 import { SourceCodeSync } from '../../providers/source-code-sync';
 import { useSourceCodeStore } from '../../store';

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -13,7 +13,7 @@ import { I18nService } from '@kie-tools-core/i18n/dist/envelope/I18nService';
 import { KeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService';
 import { OperatingSystem } from '@kie-tools-core/operating-system/dist/OperatingSystem';
 import { RefObject } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogKind, StepUpdateAction } from '../models';
 import { AbstractSettingsAdapter, ColorScheme, DefaultSettingsAdapter } from '../models/settings';

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.test.ts
@@ -1,7 +1,6 @@
 vi.mock('./KaotoEditorApp');
 vi.mock('react-router-dom');
 import { EditorInitArgs, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
-import { vi } from 'vitest';
 
 import { CanvasLayoutDirection, ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger } from '../models';
 import { KaotoEditorApp } from './KaotoEditorApp';

--- a/packages/ui/src/pages/Catalog/CatalogPage.test.tsx
+++ b/packages/ui/src/pages/Catalog/CatalogPage.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { ITile } from '../../components/Catalog';
 import { CatalogTilesContext } from '../../dynamic-catalog/catalog-tiles.provider';

--- a/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { PipeResource } from '../../models/camel';
 import { CatalogKind } from '../../models/catalog-kind';

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { PipeResource } from '../../models/camel';
 import { CatalogKind } from '../../models/catalog-kind';

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, Rest } from '@kaoto/camel-catalog/types';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelCatalogService } from '../../models';
 import { CamelResourceFactory } from '../../models/camel/camel-resource-factory';

--- a/packages/ui/src/pages/RestDslEditor/components/AddMethodModal.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/AddMethodModal.test.tsx
@@ -1,7 +1,6 @@
 import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { AddMethodModal } from './AddMethodModal';
 

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -4,7 +4,7 @@ import { ModelContextProvider, SchemaProvider } from '@kaoto/forms';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
 import { Suspense } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
 import { DynamicCatalog } from '../../../dynamic-catalog/dynamic-catalog';

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
@@ -1,6 +1,5 @@
 import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { RestDslImportWizard } from './RestDslImportWizard';
 import { useRestDslImportWizard } from './useRestDslImportWizard';

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { ApicurioImportSource } from './ApicurioImportSource';
 

--- a/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/FileImportSource.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { FileImportSource } from './FileImportSource';
 

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { UriImportSource } from './UriImportSource';
 

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { OpenApi } from 'openapi-v3';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { CamelRouteResource } from '../../models/camel/camel-route-resource';
 import { KaotoResource } from '../../models/kaoto-resource';

--- a/packages/ui/src/providers/data-mapping-links.provider.test.tsx
+++ b/packages/ui/src/providers/data-mapping-links.provider.test.tsx
@@ -1,6 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
 import { useContext } from 'react';
-import { vi } from 'vitest';
 
 import { useDocumentTreeStore } from '../store';
 import { MappingLinksContext, MappingLinksProvider } from './data-mapping-links.provider';

--- a/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
@@ -2,7 +2,7 @@ import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { AlertVariant } from '@patternfly/react-core';
 import { act, render } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { useDataMapper } from '../hooks/useDataMapper';
 import { MappingTree } from '../models/datamapper/mapping';

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -1,6 +1,5 @@
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { act, useContext, useEffect } from 'react';
-import { vi } from 'vitest';
 
 import { useDataMapper } from '../hooks/useDataMapper';
 import { SendAlertProps } from '../models/datamapper';

--- a/packages/ui/src/providers/dnd/DataMapperDndMonitor.test.tsx
+++ b/packages/ui/src/providers/dnd/DataMapperDndMonitor.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { DataMapperDnDMonitor } from './DataMapperDndMonitor';
 

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.test.ts
@@ -1,5 +1,5 @@
 import { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { DocumentType, IField } from '../../models/datamapper/document';
 import { IExpressionHolder, IFunctionDefinition, MappingItem, MappingTree } from '../../models/datamapper/mapping';

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
@@ -1,5 +1,5 @@
 import { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { MappingTree } from '../../models/datamapper/mapping';
 import { NodeData } from '../../models/datamapper/visualization';

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
 import { PropsWithChildren, useContext } from 'react';
-import { vi } from 'vitest';
 import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../models/camel/camel-route-resource';

--- a/packages/ui/src/providers/keyboard-shortcuts.provider.test.tsx
+++ b/packages/ui/src/providers/keyboard-shortcuts.provider.test.tsx
@@ -1,6 +1,5 @@
 import { act, render } from '@testing-library/react';
 import hotkeys from 'hotkeys-js';
-import { vi } from 'vitest';
 
 import { KeyboardShortcutsProvider } from './keyboard-shortcuts.provider';
 

--- a/packages/ui/src/providers/reload.provider.test.tsx
+++ b/packages/ui/src/providers/reload.provider.test.tsx
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
 import { useContext } from 'react';
-import { vi } from 'vitest';
 
 import { ReloadContext, ReloadProvider } from './reload.provider';
 

--- a/packages/ui/src/providers/runtime.provider.test.tsx
+++ b/packages/ui/src/providers/runtime.provider.test.tsx
@@ -2,7 +2,6 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { vi } from 'vitest';
 
 import { useRuntimeContext } from '../hooks/useRuntimeContext/useRuntimeContext';
 import { SourceSchemaType } from '../models/camel';

--- a/packages/ui/src/providers/schemas.provider.test.tsx
+++ b/packages/ui/src/providers/schemas.provider.test.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogDefinition } from '@kaoto/camel-catalog/types';
 import { act, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { KaotoSchemaDefinition } from '../models';
 import { TestRuntimeProviderWrapper } from '../stubs';

--- a/packages/ui/src/providers/source-code-local-storage.provider.test.tsx
+++ b/packages/ui/src/providers/source-code-local-storage.provider.test.tsx
@@ -1,5 +1,4 @@
 import { act, render } from '@testing-library/react';
-import { vi } from 'vitest';
 
 import { LocalStorageKeys } from '../models';
 import { EventNotifier } from '../utils/event-notifier';

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -16,7 +16,6 @@
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, DoTry } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind, ICamelProcessorProperty } from '../../../models';
 import {

--- a/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
@@ -16,7 +16,6 @@
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CamelRouteVisualEntity, CatalogKind } from '../../../models';
 import { EntityOrderingService } from '../../../models/camel/entity-ordering.service';

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -16,7 +16,6 @@
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CamelCatalogService, CatalogKind } from '../../../models';
 import {

--- a/packages/ui/src/services/datamapper-metadata.service.test.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { BODY_DOCUMENT_ID, DocumentDefinition, DocumentDefinitionType, DocumentType } from '../models/datamapper';
 import {
   IChoiceSelection,

--- a/packages/ui/src/services/datamapper-step.service.test.ts
+++ b/packages/ui/src/services/datamapper-step.service.test.ts
@@ -1,5 +1,5 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CatalogKind, createVisualizationNode, IVisualizationNode } from '../models';
 import { CamelCatalogService } from '../models/visualization/flows/camel-catalog.service';

--- a/packages/ui/src/services/document/document-util.service.test.ts
+++ b/packages/ui/src/services/document/document-util.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/document/document.service.test.ts
+++ b/packages/ui/src/services/document/document.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { DocumentDefinitionType, DocumentType, IDocument, IField } from '../../models/datamapper/document';
 import {
   ChooseItem,

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BaseField,
   BODY_DOCUMENT_ID,

--- a/packages/ui/src/services/visualization/tree-parsing.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-parsing.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/visualization/tree-ui.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import {
   BODY_DOCUMENT_ID,
   DocumentDefinition,

--- a/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.test.tsx
+++ b/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.test.tsx
@@ -1,6 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
 import { useContext } from 'react';
-import { vi } from 'vitest';
 
 import { CatalogKind, StepUpdateAction } from '../models';
 import {

--- a/packages/ui/src/stubs/TestProvidersWrapper.tsx
+++ b/packages/ui/src/stubs/TestProvidersWrapper.tsx
@@ -1,6 +1,6 @@
 import { SuggestionRegistryProvider } from '@kaoto/forms';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { KaotoResource } from '../models/kaoto-resource';

--- a/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
+++ b/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
@@ -1,7 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { vi } from 'vitest';
 
 import { IRuntimeContext, RuntimeContext } from '../providers/runtime.provider';
 import { CatalogSchemaLoader } from '../utils';

--- a/packages/ui/src/stubs/mock-random-values.ts
+++ b/packages/ui/src/stubs/mock-random-values.ts
@@ -1,7 +1,5 @@
 import { subtle } from 'node:crypto';
 
-import { vi } from 'vitest';
-
 export const mockRandomValues = (ids = [12345678]) => {
   vi.spyOn(globalThis, 'crypto', 'get').mockImplementation(
     () => ({ getRandomValues: () => ids, subtle }) as unknown as Crypto,

--- a/packages/ui/src/utils/ClipboardManager.test.ts
+++ b/packages/ui/src/utils/ClipboardManager.test.ts
@@ -1,4 +1,4 @@
-import { Mock, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 import { SourceSchemaType } from '../models/camel/source-schema-type';
 import { IClipboardCopyObject } from '../models/visualization/clipboard';

--- a/packages/ui/src/utils/catalog-schema-loader.test.ts
+++ b/packages/ui/src/utils/catalog-schema-loader.test.ts
@@ -1,5 +1,4 @@
 import { CatalogDefinitionEntry } from '@kaoto/camel-catalog/types';
-import { vi } from 'vitest';
 
 import { CatalogSchemaLoader } from './catalog-schema-loader';
 

--- a/packages/ui/src/utils/color-scheme.test.ts
+++ b/packages/ui/src/utils/color-scheme.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { ColorScheme } from '../models';
 import { DARK_MODE_PATTERN_FLY_CLASS_NAME, isDarkModeEnabled, setColorScheme } from './color-scheme';
 

--- a/packages/ui/src/utils/event-notifier.test.ts
+++ b/packages/ui/src/utils/event-notifier.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { EventNotifier } from './event-notifier';
 
 describe('EventNotifier', () => {

--- a/packages/ui/src/utils/get-viznodes-from-graph.test.ts
+++ b/packages/ui/src/utils/get-viznodes-from-graph.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { Graph, Model } from '@patternfly/react-topology';
-import { vi } from 'vitest';
 
 import { ControllerService } from '../components/Visualization/Canvas/controller.service';
 import { FlowService } from '../components/Visualization/Canvas/flow.service';

--- a/packages/ui/src/utils/promise-timeout.test.ts
+++ b/packages/ui/src/utils/promise-timeout.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { promiseTimeout } from './promise-timeout';
 
 describe('promiseTimeout', () => {

--- a/packages/ui/src/utils/update-ids.test.ts
+++ b/packages/ui/src/utils/update-ids.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { getCamelRandomId } from '../camel-utils/camel-random-id';
 import { updateIds } from './update-ids';
 

--- a/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.test.ts
+++ b/packages/ui/src/xml-schema-ts/extensions/ExtensionRegistry.test.ts
@@ -1,5 +1,3 @@
-import { vi } from 'vitest';
-
 import { QName } from '../QName';
 import { XmlSchemaObject } from '../XmlSchemaObject';
 import { ExtensionDeserializer } from './ExtensionDeserializer';

--- a/packages/ui/vitest-mocks-setup.ts
+++ b/packages/ui/vitest-mocks-setup.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { vi } from 'vitest';
+
 
 // This file contains all vi.mock() calls and runs before other setup files
 // to ensure mocks are properly hoisted


### PR DESCRIPTION
### Context
After migrating to `vitest`, there are some files that require cleanups. We're using `globals: true`, and this provide the `vi` helper in all test modules, therefore there's no need for importing it.