### PR TITLE
e2e(weekly): skip citrus catalog version tests

### DIFF
--- a/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
@@ -8,6 +8,10 @@ describe('Test for catalog versions', () => {
   const testData: { version: string; type: string }[] = [];
 
   catalogLibrary.definitions.forEach((library) => {
+    if (library.runtime === 'Citrus') {
+      return;
+    }
+
     const catalogVersion = library.version;
     const catalogType = library.runtime;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated catalog version test coverage to skip entries for a specific runtime, preventing invalid or unsupported test cases from being generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->