### PR TITLE
chore(xml): Migrate XML Serializer to async

### DIFF
--- a/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
@@ -1,8 +1,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
-import { CatalogKind } from '../catalog-kind';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { EntityType } from '../entities';
 import { CamelCatalogService } from '../visualization/flows';
 import { CamelXMLRouteResource } from './camel-xml-route-resource';
@@ -15,7 +14,7 @@ describe('CamelXMLRouteResource', () => {
     const resource = new CamelXMLRouteResource(xml);
 
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
 
     await resource.initialize();
 
@@ -28,7 +27,7 @@ describe('CamelXMLRouteResource', () => {
 
   it('reports XML and serializes back to XML', async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
     const resource = new CamelXMLRouteResource(xml);
     await resource.initialize();
 
@@ -108,7 +107,7 @@ describe('CamelXMLRouteResource', () => {
 
   it('includes Beans entities in toString() output', async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
     const beansXml = `<camel><bean type="com.example.MyBean"/></camel>`;
     const resource = new CamelXMLRouteResource(beansXml);
     await resource.initialize();

--- a/packages/ui/src/models/camel/camel-xml-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.ts
@@ -67,7 +67,8 @@ export class CamelXMLRouteResource extends CamelRouteResource {
 
   override async initialize(): Promise<void> {
     const parser = new KaotoXmlParser();
-    this.setRawEntities(parser.parseXML(this.code) as CamelYamlDsl);
+    const rawEntities = (await parser.parseXML(this.code)) as unknown as CamelYamlDsl;
+    this.setRawEntities(rawEntities);
     await super.initialize();
   }
 
@@ -77,7 +78,7 @@ export class CamelXMLRouteResource extends CamelRouteResource {
     ) as EntityDefinition[];
     entities.push(...(this.getVisualEntities() as EntityDefinition[]));
 
-    const xmlDocument = KaotoXmlSerializer.serialize(entities, this.rootElementDefinitions);
+    const xmlDocument = await KaotoXmlSerializer.serialize(entities, this.rootElementDefinitions);
     const xmlString = this.xmlSerializer.serializeToString(xmlDocument);
     const formatted = xmlFormat(xmlString);
     return this.getXmlDeclaration() + insertXmlComments(formatted, this.comments);

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -319,9 +319,7 @@ export class CamelComponentSchemaService {
       );
 
       if (catalogLookup.definition !== undefined && componentSchema !== undefined) {
-        if (!schema.properties) {
-          schema.properties = {};
-        }
+        schema.properties ??= {};
         if (!schema.properties.parameters) {
           schema.properties.parameters = { type: 'object', properties: {} };
         }

--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
@@ -21,10 +21,9 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { parse } from 'yaml';
 
-import { CamelCatalogService, CatalogKind } from '../../models';
 import { doTryCamelRouteJson, doTryCamelRouteXml } from '../../stubs';
 import { beanWithConstructorAandProperties, beanWithConstructorAandPropertiesXML } from '../../stubs/beans';
-import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { isXML, KaotoXmlParser } from './kaoto-xml-parser';
 
 describe('XmlParser', () => {
@@ -36,12 +35,12 @@ describe('XmlParser', () => {
   beforeAll(async () => {
     parser = new KaotoXmlParser();
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('parses XML with a single route correctly', () => {
+  it('parses XML with a single route correctly', async () => {
     const xml = `<camel><routes><route><from uri="direct:start" /></route></routes></camel>`;
-    const result = parser.parseXML(xml);
+    const result = await parser.parseXML(xml);
 
     expect(result).toBeDefined();
     expect(result).toEqual([
@@ -53,9 +52,9 @@ describe('XmlParser', () => {
     ]);
   });
 
-  it('parses XML with multiple routes correctly', () => {
+  it('parses XML with multiple routes correctly', async () => {
     const xml = `<routes><route id="test"><from uri="direct:first" /></route><route><from uri="direct:second" /></route></routes>`;
-    const result = parser.parseXML(xml);
+    const result = await parser.parseXML(xml);
     expect(result).toEqual([
       {
         route: { id: 'test', from: { uri: 'direct:first', steps: [] } },
@@ -68,9 +67,9 @@ describe('XmlParser', () => {
     ]);
   });
 
-  it('returns an empty array for XML with no routes', () => {
+  it('returns an empty array for XML with no routes', async () => {
     const xml = `<routes></routes>`;
-    const result = parser.parseXML(xml);
+    const result = await parser.parseXML(xml);
     expect(result).toEqual([]);
   });
 
@@ -84,24 +83,24 @@ describe('XmlParser', () => {
     expect(isXML(xml)).toBe(false);
   });
 
-  it('parses XML with doTry correctly', () => {
-    const result = parser.parseXML(doTryCamelRouteXml);
+  it('parses XML with doTry correctly', async () => {
+    const result = await parser.parseXML(doTryCamelRouteXml);
     expect(result).toEqual([doTryCamelRouteJson]);
   });
 
-  it('parse beans correctly', () => {
-    const result = parser.parseXML(beanWithConstructorAandPropertiesXML);
+  it('parse beans correctly', async () => {
+    const result = await parser.parseXML(beanWithConstructorAandPropertiesXML);
     expect(result).toEqual([beanWithConstructorAandProperties]);
   });
 
-  it.each(xmlFiles)('XML to YAML comparison parses and compares %s correctly', (xmlFile) => {
+  it.each(xmlFiles)('XML to YAML comparison parses and compares %s correctly', async (xmlFile) => {
     const xmlFilePath = path.join(xmlDir, xmlFile);
     const yamlFilePath = path.join(yamlDir, xmlFile.replace('.xml', '.yaml'));
 
     const xmlContent = fs.readFileSync(xmlFilePath, 'utf-8');
     const expectedYamlContent = fs.readFileSync(yamlFilePath, 'utf-8');
     const expectedYaml = parse(expectedYamlContent);
-    const result = parser.parseXML(xmlContent);
+    const result = await parser.parseXML(xmlContent);
 
     expect(result).toEqual(expectedYaml);
   });

--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import fs from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
@@ -26,11 +26,11 @@ import { beanWithConstructorAandProperties, beanWithConstructorAandPropertiesXML
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { isXML, KaotoXmlParser } from './kaoto-xml-parser';
 
-describe('XmlParser', () => {
+describe('XmlParser', async () => {
   let parser: KaotoXmlParser;
   const xmlDir = path.join(__dirname, '../../stubs/xml');
   const yamlDir = path.join(__dirname, '../../stubs/yaml');
-  const xmlFiles = fs.readdirSync(xmlDir).filter((file) => file.endsWith('.xml'));
+  const xmlFiles = (await readdir(xmlDir)).filter((file) => file.endsWith('.xml'));
 
   beforeAll(async () => {
     parser = new KaotoXmlParser();
@@ -94,11 +94,15 @@ describe('XmlParser', () => {
   });
 
   it.each(xmlFiles)('XML to YAML comparison parses and compares %s correctly', async (xmlFile) => {
+    expect.assertions(1);
     const xmlFilePath = path.join(xmlDir, xmlFile);
     const yamlFilePath = path.join(yamlDir, xmlFile.replace('.xml', '.yaml'));
 
-    const xmlContent = fs.readFileSync(xmlFilePath, 'utf-8');
-    const expectedYamlContent = fs.readFileSync(yamlFilePath, 'utf-8');
+    const [xmlContent, expectedYamlContent] = await Promise.all([
+      readFile(xmlFilePath, 'utf-8'),
+      readFile(yamlFilePath, 'utf-8'),
+    ]);
+
     const expectedYaml = parse(expectedYamlContent);
     const result = await parser.parseXML(xmlContent);
 

--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.ts
@@ -40,7 +40,7 @@ export class KaotoXmlParser {
     'interceptSendToEndpoint',
     'onCompletion',
   ];
-  static domParser = new DOMParser();
+  static readonly domParser = new DOMParser();
   routeXmlParser: RouteXmlParser;
   beanParser: BeansXmlParser;
 
@@ -49,7 +49,7 @@ export class KaotoXmlParser {
     this.beanParser = new BeansXmlParser();
   }
 
-  parseXML(xml: string): unknown {
+  async parseXML(xml: string): Promise<unknown> {
     try {
       const xmlDoc = KaotoXmlParser.domParser.parseFromString(xml, 'application/xml');
       return this.parseFromXmlDocument(xmlDoc);
@@ -58,53 +58,50 @@ export class KaotoXmlParser {
     }
   }
 
-  parseFromXmlDocument(xmlDoc: Document): unknown {
+  async parseFromXmlDocument(xmlDoc: Document): Promise<unknown> {
     const rawEntities = [];
     const rootCamelElement = xmlDoc.getElementsByTagName('camel')[0];
     const children = rootCamelElement ? rootCamelElement.children : xmlDoc.children;
 
     // Process route entities
-    Array.from(xmlDoc.getElementsByTagName('route')).forEach((routeElement) => {
-      const route = RouteXmlParser.parse(routeElement);
+    for (const routeElement of Array.from(xmlDoc.getElementsByTagName('route'))) {
+      const route = await RouteXmlParser.parse(routeElement);
       rawEntities.push({ route });
-    });
+    }
 
     // Process beans (bean factory)
     const beansSection = xmlDoc.getElementsByTagName('beans')[0];
-    const beans: BeanFactory[] = beansSection ? this.beanParser.transformBeansSection(beansSection) : [];
+    const beans: BeanFactory[] = beansSection ? await this.beanParser.transformBeansSection(beansSection) : [];
     // process beans outside of beans section
-    Array.from(children)
-      .filter((child) => child.tagName === 'bean')
-      .forEach((beanElement) => {
-        beans.push(BeansXmlParser.transformBeanFactory(beanElement));
-      });
+    for (const beanElement of Array.from(children).filter((child) => child.tagName === 'bean')) {
+      beans.push(await BeansXmlParser.transformBeanFactory(beanElement));
+    }
 
     if (beans.length > 0) {
       rawEntities.push({ beans });
     }
 
     // Process rest entities
-    Array.from(xmlDoc.getElementsByTagName('rest')).forEach((restElement) => {
-      const rest = RestXmlParser.parse(restElement);
+    for (const restElement of Array.from(xmlDoc.getElementsByTagName('rest'))) {
+      const rest = await RestXmlParser.parse(restElement);
       rawEntities.push({ rest });
-    });
+    }
 
     // Process route configurations
-    Array.from(xmlDoc.getElementsByTagName('routeConfiguration')).forEach((routeConf) => {
-      const routeConfiguration = RouteXmlParser.parseRouteConfiguration(routeConf);
+    for (const routeConf of Array.from(xmlDoc.getElementsByTagName('routeConfiguration'))) {
+      const routeConfiguration = await RouteXmlParser.parseRouteConfiguration(routeConf);
       rawEntities.push({ routeConfiguration });
-    });
+    }
 
     // rest of the elements
-
-    Array.from(children).forEach((child) => {
+    for (const child of Array.from(children)) {
       if (KaotoXmlParser.PARSABLE_ELEMENTS.includes(child.tagName)) {
-        const entity = StepParser.parseElement(child);
+        const entity = await StepParser.parseElement(child);
         if (entity) {
           rawEntities.push({ [child.tagName]: entity });
         }
       }
-    });
+    }
 
     return rawEntities;
   }

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.test.ts
@@ -17,8 +17,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { BeansXmlParser } from './beans-xml-parser';
 
 export const getElementFromXml = (xml: string): Element => {
@@ -30,7 +29,7 @@ export const getElementFromXml = (xml: string): Element => {
 describe('BeanXmlParser', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it('parse bean constructors properly', () => {

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
@@ -16,15 +16,17 @@
 
 import { BeanFactory } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
 import { extractAttributesFromXmlElement } from '../utils/xml-utils';
 
 export class BeansXmlParser {
   beans: BeanFactory[] = [];
 
-  static transformBeanFactory(beanElement: Element): BeanFactory {
+  static async transformBeanFactory(beanElement: Element): Promise<BeanFactory> {
     // Initialize the bean object
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, 'beanFactory')?.properties;
+    const beanFactoryDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'beanFactory');
+    const properties = beanFactoryDefinition?.properties;
     const bean: BeanFactory = extractAttributesFromXmlElement(beanElement, properties) as unknown as BeanFactory;
 
     // Special case for 'name/id' and 'type/class'
@@ -82,15 +84,15 @@ export class BeansXmlParser {
   }
 
   // This might required support for nested beans, if not change to static
-  transformBeansSection(beansSection: Element): BeanFactory[] {
+  async transformBeansSection(beansSection: Element): Promise<BeanFactory[]> {
     // Process all bean elements and populate beanFactories
     this.beans = [];
     const beanElements = Array.from(beansSection.children);
 
-    beanElements.forEach((beanElement) => {
-      const processedBean = BeansXmlParser.transformBeanFactory(beanElement);
+    for (const beanElement of beanElements) {
+      const processedBean = await BeansXmlParser.transformBeanFactory(beanElement);
       this.beans.push(processedBean);
-    });
+    }
 
     return this.beans;
   }

--- a/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/beans-xml-parser.ts
@@ -21,8 +21,6 @@ import { CatalogKind } from '../../../models';
 import { extractAttributesFromXmlElement } from '../utils/xml-utils';
 
 export class BeansXmlParser {
-  beans: BeanFactory[] = [];
-
   static async transformBeanFactory(beanElement: Element): Promise<BeanFactory> {
     // Initialize the bean object
     const beanFactoryDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'beanFactory');
@@ -86,15 +84,15 @@ export class BeansXmlParser {
   // This might required support for nested beans, if not change to static
   async transformBeansSection(beansSection: Element): Promise<BeanFactory[]> {
     // Process all bean elements and populate beanFactories
-    this.beans = [];
+    const beanFactories: BeanFactory[] = [];
     const beanElements = Array.from(beansSection.children);
 
     for (const beanElement of beanElements) {
       const processedBean = await BeansXmlParser.transformBeanFactory(beanElement);
-      this.beans.push(processedBean);
+      beanFactories.push(processedBean);
     }
 
-    return this.beans;
+    return beanFactories;
   }
 
   private static parseScript(beanElement: Element): string | undefined {

--- a/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.test.ts
@@ -17,8 +17,9 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { ExpressionParser } from './expression-parser';
 
 describe('Expression parser', () => {
@@ -26,10 +27,10 @@ describe('Expression parser', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('should parse simple expression', () => {
+  it('should parse simple expression', async () => {
     const expression = xmlParser.parseFromString(
       `
           <simple>{in.body} contains 'Hello'</simple>
@@ -37,33 +38,33 @@ describe('Expression parser', () => {
       'application/xml',
     ).documentElement;
 
-    const result = ExpressionParser.parse(expression);
+    const result = await ExpressionParser.parse(expression);
     expect(result).toEqual({ simple: { expression: "{in.body} contains 'Hello'" } });
   });
 
-  it('should parse expression type element', () => {
+  it('should parse expression type element', async () => {
     const parentElement = xmlParser.parseFromString(
       `<choice><when><xpath>/order/customer</xpath></when></choice>
       `,
       'application/xml',
     ).documentElement;
-    const props = CamelCatalogService.getComponent(CatalogKind.Processor, 'when')?.properties;
-    const result = ExpressionParser.parse(parentElement, props?.expression, 'when');
+    const props = (await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'when'))?.properties;
+    const result = await ExpressionParser.parse(parentElement, props?.expression, 'when');
     expect(result).toEqual({ xpath: { expression: '/order/customer' } });
   });
 
-  it('should not parse made up expression', () => {
+  it('should not parse made up expression', async () => {
     const parentElement = xmlParser.parseFromString(
       `<choice><when><nonExistent>/order/customer</nonExistent></when></choice>
       `,
       'application/xml',
     ).documentElement;
-    const props = CamelCatalogService.getComponent(CatalogKind.Processor, 'when')?.properties;
-    const result = ExpressionParser.parse(parentElement, props?.expression, 'when');
+    const props = (await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'when'))?.properties;
+    const result = await ExpressionParser.parse(parentElement, props?.expression, 'when');
     expect(result).toBeUndefined();
   });
 
-  it('should trim whitespace and newlines from expression text content', () => {
+  it('should trim whitespace and newlines from expression text content', async () => {
     const expression = xmlParser.parseFromString(
       `
           <simple>
@@ -73,7 +74,7 @@ describe('Expression parser', () => {
       'application/xml',
     ).documentElement;
 
-    const result = ExpressionParser.parse(expression);
+    const result = await ExpressionParser.parse(expression);
     expect(result).toEqual({ simple: { expression: '${header.foo} == 1' } });
   });
 });

--- a/packages/ui/src/serializers/xml/parsers/expression-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/expression-parser.ts
@@ -16,15 +16,16 @@
 
 import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind, ICamelProcessorProperty } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind, ICamelProcessorProperty } from '../../../models';
 import { collectNamespaces, extractAttributesFromXmlElement } from '../utils/xml-utils';
 
 export class ExpressionParser {
-  static parse(
+  static async parse(
     parentElement: Element,
     properties?: ICamelProcessorProperty,
     tagName?: string,
-  ): ExpressionDefinition | undefined {
+  ): Promise<ExpressionDefinition | undefined> {
     // Find the element to parse, expression type elements are defined differently depending on the component
     const element = tagName ? parentElement.getElementsByTagName(tagName)[0] : parentElement;
     if (!element) return undefined;
@@ -39,12 +40,15 @@ export class ExpressionParser {
     return this.buildExpressionDefinition(expressionElement);
   }
 
-  private static buildExpressionDefinition(expressionElement: Element): ExpressionDefinition | undefined {
+  private static async buildExpressionDefinition(
+    expressionElement: Element,
+  ): Promise<ExpressionDefinition | undefined> {
     const expressionType = expressionElement.tagName;
-    const expressionTypeProperties = CamelCatalogService.getComponent(
+    const expressionTypeDefinition = await DynamicCatalogRegistry.get().getEntity(
       CatalogKind.Processor,
       expressionType,
-    )?.properties;
+    );
+    const expressionTypeProperties = expressionTypeDefinition?.properties;
 
     const expressionAttributes = extractAttributesFromXmlElement(expressionElement, expressionTypeProperties);
     const namespaces = expressionTypeProperties?.namespace ? collectNamespaces(expressionElement) : [];

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
@@ -20,24 +20,23 @@ import path from 'node:path';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
 import { restWithVerbsStup } from '../../../stubs/rest';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { RestXmlParser } from './rest-xml-parser';
 
 describe('Rest XML Parser', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('should parse rest verbs correctly', () => {
+  it('should parse rest verbs correctly', async () => {
     const xmlFilePath = path.join(__dirname, '../../../stubs/xml/rest.xml');
     const xml = fs.readFileSync(xmlFilePath, 'utf-8');
 
     const doc = new DOMParser().parseFromString(xml, 'application/xml');
     const restElement = doc.getElementsByTagName('rest')[0];
-    const result = RestXmlParser.parse(restElement);
+    const result = await RestXmlParser.parse(restElement);
 
     expect(result).toEqual(restWithVerbsStup);
   });

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.test.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { restWithVerbsStup } from '../../../stubs/rest';
+import { restWithSecurityRequirementsStub, restWithVerbsStup } from '../../../stubs/rest';
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { RestXmlParser } from './rest-xml-parser';
 
@@ -39,5 +39,16 @@ describe('Rest XML Parser', () => {
     const result = await RestXmlParser.parse(restElement);
 
     expect(result).toEqual(restWithVerbsStup);
+  });
+
+  it('should parse securityRequirements correctly', async () => {
+    const xmlFilePath = path.join(__dirname, '../../../stubs/xml/rest-with-security-requirements.xml');
+    const xml = fs.readFileSync(xmlFilePath, 'utf-8');
+
+    const doc = new DOMParser().parseFromString(xml, 'application/xml');
+    const restElement = doc.getElementsByTagName('rest')[0];
+    const result = await RestXmlParser.parse(restElement);
+
+    expect(result).toEqual(restWithSecurityRequirementsStub);
   });
 });

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
@@ -136,7 +136,11 @@ export class RestXmlParser {
     const properties = restDefinition?.properties;
 
     if (securityRequirements) {
-      await StepParser.parseElementsArray('security', restElement, properties!.securityRequirements);
+      return (await StepParser.parseElementsArray(
+        'security',
+        securityRequirements,
+        properties!.securityRequirements,
+      )) as unknown as RestSecurity[];
     }
     return undefined;
   }

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
@@ -82,7 +82,7 @@ export class RestXmlParser {
   // Transform the <param> elements inside each verb
   static async parseParams(verbElement: Element): Promise<Param[]> {
     return Promise.all(
-      Array.from(verbElement.getElementsByTagName('param')).map(
+      Array.from(verbElement.getElementsByTagName('param' as string)).map(
         (paramElement) => StepParser.parseElement(paramElement) as Promise<Param>,
       ),
     );

--- a/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/rest-xml-parser.ts
@@ -16,7 +16,8 @@
 
 import { Param, ResponseMessage, Rest, RestSecurity, SecurityDefinitions } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
 import { REST_DSL_VERBS } from '../../../models/special-processors.constants';
 import { extractAttributesFromXmlElement } from '../utils/xml-utils';
 import { RouteXmlParser } from './route-xml-parser';
@@ -26,105 +27,116 @@ export class RestXmlParser {
   routeXmlParser = new RouteXmlParser();
 
   // Main transformation for <rest> elements
-  static parse(restElement: Element): Rest {
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, 'rest')?.properties;
+  static async parse(restElement: Element): Promise<Rest> {
+    const restDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'rest');
+    const properties = restDefinition?.properties;
 
     return {
       ...extractAttributesFromXmlElement(restElement, properties),
-      ...this.parseRestVerbs(restElement),
-      securityDefinitions: this.parseSecurityDefinitions(restElement) as unknown as SecurityDefinitions,
-      securityRequirements: this.parseSecurityRequirements(restElement),
+      ...(await this.parseRestVerbs(restElement)),
+      securityDefinitions: (await this.parseSecurityDefinitions(restElement)) as unknown as SecurityDefinitions,
+      securityRequirements: await this.parseSecurityRequirements(restElement),
     };
   }
 
   // Transform verbs like <get>, <post>, etc.
-  private static parseRestVerbs(restElement: Element): Rest {
+  private static async parseRestVerbs(restElement: Element): Promise<Rest> {
     const verbs: { [key: string]: unknown } = {};
 
     // For each verb, look for its elements and transform them
-    REST_DSL_VERBS.forEach((verb) => {
+    for (const verb of REST_DSL_VERBS) {
       const verbInstances = Array.from(restElement.getElementsByTagName(verb));
       if (verbInstances.length > 0) {
-        verbs[verb] = verbInstances.map((verbElement: Element) => this.parseRestVerb(verbElement));
+        verbs[verb] = await Promise.all(verbInstances.map((verbElement: Element) => this.parseRestVerb(verbElement)));
       }
-    });
+    }
 
     return verbs as unknown as Rest;
   }
 
-  static parseRestVerb(verbElement: Element) {
-    const verb = StepParser.parseElement(verbElement) as { [key: string]: unknown };
+  static async parseRestVerb(verbElement: Element) {
+    const verb = (await StepParser.parseElement(verbElement)) as { [key: string]: unknown };
     //in older catalogs (in 4.9) are missing properites: param, security, responseMessage
-    this.decorateVerb(verb, verbElement);
+    await this.decorateVerb(verb, verbElement);
 
     return verb;
   }
 
-  static decorateVerb(partial: { [key: string]: unknown }, verbElement: Element) {
-    const param = this.parseParams(verbElement);
+  static async decorateVerb(partial: { [key: string]: unknown }, verbElement: Element) {
+    const param = await this.parseParams(verbElement);
     if (param.length > 0) {
       partial['param'] = param;
     }
 
-    const security = this.transformSecurity(verbElement);
+    const security = await this.transformSecurity(verbElement);
     if (security.length > 0) {
       partial['security'] = security;
     }
 
-    const responseMessages = this.parseResponseMessages(verbElement);
+    const responseMessages = await this.parseResponseMessages(verbElement);
     if (responseMessages.length > 0) {
       partial['responseMessage'] = responseMessages;
     }
   }
 
   // Transform the <param> elements inside each verb
-  static parseParams(verbElement: Element): Param[] {
-    return Array.from(verbElement.getElementsByTagName('param')).map(
-      (paramElement) => StepParser.parseElement(paramElement) as Param,
+  static async parseParams(verbElement: Element): Promise<Param[]> {
+    return Promise.all(
+      Array.from(verbElement.getElementsByTagName('param')).map(
+        (paramElement) => StepParser.parseElement(paramElement) as Promise<Param>,
+      ),
     );
   }
 
   // New: Transform <security> elements inside verbs
-  static transformSecurity(verbElement: Element): RestSecurity[] {
-    return Array.from(verbElement.getElementsByTagName('security')).map(
-      (securityElement) => StepParser.parseElement(securityElement) as RestSecurity,
+  static async transformSecurity(verbElement: Element): Promise<RestSecurity[]> {
+    return Promise.all(
+      Array.from(verbElement.getElementsByTagName('security')).map(
+        (securityElement) => StepParser.parseElement(securityElement) as Promise<RestSecurity>,
+      ),
     );
   }
 
   // New: Transform <responseMessage> elements inside verbs
-  private static parseResponseMessages(verbElement: Element): ResponseMessage[] {
-    return Array.from(verbElement.getElementsByTagName('responseMessage')).map((responseMessageElement) => {
-      return StepParser.parseElement(responseMessageElement) as ResponseMessage;
-    });
+  private static async parseResponseMessages(verbElement: Element): Promise<ResponseMessage[]> {
+    return Promise.all(
+      Array.from(verbElement.getElementsByTagName('responseMessage')).map(
+        (responseMessageElement) => StepParser.parseElement(responseMessageElement) as Promise<ResponseMessage>,
+      ),
+    );
   }
 
-  private static parseSecurityDefinitions(restElement: Element): SecurityDefinitions | undefined {
+  private static async parseSecurityDefinitions(restElement: Element): Promise<SecurityDefinitions | undefined> {
     const securityDefinitionsElements = Array.from(
       restElement.getElementsByTagName('securityDefinitions')[0]?.children || [],
     );
 
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, 'securityDefinitions')?.properties
-      .securityDefinitions;
+    const securityDefinitionsDefinition = await DynamicCatalogRegistry.get().getEntity(
+      CatalogKind.Processor,
+      'securityDefinitions',
+    );
+    const properties = securityDefinitionsDefinition?.properties.securityDefinitions;
 
     let securityDefinitions: SecurityDefinitions = {};
     if (securityDefinitionsElements.length === 0) return undefined;
-    securityDefinitionsElements
-      .filter((el) => properties?.oneOf?.includes(el.tagName))
-      .forEach((securityDefinition) => {
-        securityDefinitions = {
-          ...securityDefinitions,
-          [securityDefinition.tagName]: StepParser.parseElement(securityDefinition),
-        };
-      });
+    for (const securityDefinition of securityDefinitionsElements.filter((el) =>
+      properties?.oneOf?.includes(el.tagName),
+    )) {
+      securityDefinitions = {
+        ...securityDefinitions,
+        [securityDefinition.tagName]: await StepParser.parseElement(securityDefinition),
+      };
+    }
     return securityDefinitions;
   }
 
-  private static parseSecurityRequirements(restElement: Element): RestSecurity[] | undefined {
+  private static async parseSecurityRequirements(restElement: Element): Promise<RestSecurity[] | undefined> {
     const securityRequirements = restElement.getElementsByTagName('securityRequirements')[0];
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, 'rest')?.properties;
+    const restDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'rest');
+    const properties = restDefinition?.properties;
 
     if (securityRequirements) {
-      StepParser.parseElementsArray('security', restElement, properties!.securityRequirements);
+      await StepParser.parseElementsArray('security', restElement, properties!.securityRequirements);
     }
     return undefined;
   }

--- a/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
@@ -17,8 +17,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { KaotoXmlParser } from '../kaoto-xml-parser';
 import { RouteXmlParser } from './route-xml-parser';
 
@@ -31,10 +30,10 @@ export const getElementFromXml = (xml: string): Element => {
 describe('RouteXmlParser', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('transforms intercept element correctly', () => {
+  it('transforms intercept element correctly', async () => {
     const interceptElement = getElementFromXml(` <intercept id="intercept1">
       <onWhen>
           <simple>\${in.body} contains 'Hello'</simple>
@@ -42,7 +41,7 @@ describe('RouteXmlParser', () => {
       <to uri="mock:intercepted"/>
   </intercept>`);
 
-    const result = RouteXmlParser.parseRouteConfigurationElement(interceptElement, 'intercept');
+    const result = await RouteXmlParser.parseRouteConfigurationElement(interceptElement, 'intercept');
     expect(result).toEqual({
       intercept: {
         id: 'intercept1',
@@ -52,11 +51,11 @@ describe('RouteXmlParser', () => {
     });
   });
 
-  it('transforms interceptFrom element correctly', () => {
+  it('transforms interceptFrom element correctly', async () => {
     const interceptFromElement = getElementFromXml(`<interceptFrom id="interceptFrom1" uri="jms*">
     <to uri="log:incoming"/>
   </interceptFrom>`);
-    const result = RouteXmlParser.parseRouteConfigurationElement(interceptFromElement, 'interceptFrom');
+    const result = await RouteXmlParser.parseRouteConfigurationElement(interceptFromElement, 'interceptFrom');
     expect(result).toEqual({
       interceptFrom: {
         id: 'interceptFrom1',
@@ -66,14 +65,14 @@ describe('RouteXmlParser', () => {
     });
   });
 
-  it('transforms interceptSendToEndpoint element correctly', () => {
+  it('transforms interceptSendToEndpoint element correctly', async () => {
     const interceptSendToEndpointElement = getElementFromXml(`
       <interceptSendToEndpoint uri="kafka*" afterUri="bean:afterKafka">
     <to uri="bean:beforeKafka"/>
       </interceptSendToEndpoint>
     `);
 
-    const result = RouteXmlParser.parseRouteConfigurationElement(
+    const result = await RouteXmlParser.parseRouteConfigurationElement(
       interceptSendToEndpointElement,
       'interceptSendToEndpoint',
     );
@@ -92,7 +91,7 @@ describe('RouteXmlParser', () => {
     });
   });
 
-  it('transforms xpath with namespaces set', () => {
+  it('transforms xpath with namespaces set', async () => {
     const parser = new KaotoXmlParser();
     const namespaceDocument = new DOMParser().parseFromString(
       `
@@ -113,7 +112,7 @@ describe('RouteXmlParser', () => {
       'application/xml',
     );
 
-    const result = parser.parseFromXmlDocument(namespaceDocument);
+    const result = await parser.parseFromXmlDocument(namespaceDocument);
     expect(result).toEqual([
       {
         route: {

--- a/packages/ui/src/serializers/xml/parsers/route-xml-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/route-xml-parser.ts
@@ -24,23 +24,23 @@ import {
 import { StepParser } from './step-parser';
 
 export class RouteXmlParser {
-  static parseRouteConfigurationElement(routeConfigElement: Element, elementName: string): unknown {
+  static async parseRouteConfigurationElement(routeConfigElement: Element, elementName: string): Promise<unknown> {
     return {
-      [elementName]: StepParser.parseElement(routeConfigElement),
+      [elementName]: await StepParser.parseElement(routeConfigElement),
     };
   }
 
-  static parseRouteConfiguration(routeConfigElement: Element): RouteConfigurationDefinition {
+  static async parseRouteConfiguration(routeConfigElement: Element): Promise<RouteConfigurationDefinition> {
     return StepParser.parseElement(routeConfigElement, (element: Element) => {
       return this.parseRouteConfigurationElement(element, element.tagName);
-    }) as RouteConfigurationDefinition;
+    }) as Promise<RouteConfigurationDefinition>;
   }
 
-  static parse(routeElement: Element): RouteDefinition {
+  static async parse(routeElement: Element): Promise<RouteDefinition> {
     const fromElement: Element = routeElement.getElementsByTagName('from')[0];
 
-    const from = StepParser.parseElement(fromElement) as FromDefinition;
-    const routeDef = StepParser.parseElement(routeElement) as { [key: string]: unknown };
+    const from = (await StepParser.parseElement(fromElement)) as FromDefinition;
+    const routeDef = (await StepParser.parseElement(routeElement)) as { [key: string]: unknown };
 
     from.steps = routeDef.steps as ProcessorDefinition[] | [];
     routeDef.steps = undefined;

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -17,7 +17,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, DoTry } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind, ICamelProcessorProperty } from '../../../models';
+import { ICamelProcessorProperty } from '../../../models';
 import {
   aggregateEntity,
   choiceEntity,
@@ -58,7 +58,7 @@ import {
   splitXml,
   throttleXml,
 } from '../../../stubs/eip-xml-snippets';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { getDocument } from '../serializers/serializer-test-utils';
 import { getElementFromXml } from './route-xml-parser.test';
 import { StepParser } from './step-parser';
@@ -76,11 +76,11 @@ describe('parser basics', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   describe('parseSteps', () => {
-    it('should parse simple processor steps', () => {
+    it('should parse simple processor steps', async () => {
       const parent = mockDocument.createElement('route');
       const log = mockDocument.createElement('log');
       log.setAttribute('message', 'Hello');
@@ -88,68 +88,68 @@ describe('parser basics', () => {
 
       const processorKeys = ['log'];
 
-      const result = StepParser.parseSteps(parent, processorKeys);
+      const result = await StepParser.parseSteps(parent, processorKeys);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('log');
       expect(result[0].log).toHaveProperty('message', 'Hello');
     });
 
-    it('should skip elements in SKIP_KEYS', () => {
+    it('should skip elements in SKIP_KEYS', async () => {
       const parent = mockDocument.createElement('route');
       const doCatch = mockDocument.createElement('doCatch');
       parent.appendChild(doCatch);
 
       const processorKeys = ['doCatch'];
 
-      const result = StepParser.parseSteps(parent, processorKeys);
+      const result = await StepParser.parseSteps(parent, processorKeys);
 
       expect(result).toHaveLength(0);
     });
   });
 
-  it('should return a valid processor model for log', () => {
+  it('should return a valid processor model for log', async () => {
     const element = getDocument().createElement('log');
-    const result = StepParser.getProcessorModel(element);
+    const result = await StepParser.getProcessorModel(element);
 
     expect(result.processorName).toBe('log');
     expect(result.processorModel).toBeDefined();
   });
 
-  it('should handle onWhen elements properly', () => {
+  it('should handle onWhen elements properly', async () => {
     const element = getDocument().createElement('onWhen');
-    const result = StepParser.getProcessorModel(element);
+    const result = await StepParser.getProcessorModel(element);
 
     expect(result.processorName).toBe('onWhen');
     expect(result.processorModel).toBeDefined();
   });
 
   describe('parseElement', () => {
-    it('should parse element with attributes', () => {
+    it('should parse element with attributes', async () => {
       const element = mockDocument.createElement('log');
       element.setAttribute('message', 'test');
 
-      const result = StepParser.parseElement(element);
+      const result = await StepParser.parseElement(element);
       expect(result).toHaveProperty('message', 'test');
     });
 
-    it('should handle undefined element', () => {
-      const result = StepParser.parseElement(undefined as unknown as Element);
+    it('should handle undefined element', async () => {
+      const result = await StepParser.parseElement(undefined as unknown as Element);
       expect(result).toEqual({});
     });
 
-    it('should parse element with expression', () => {
+    it('should parse element with expression', async () => {
       const element = mockDocument.createElement('choice');
       const when = mockDocument.createElement('when');
       element.appendChild(when);
 
-      const result = StepParser.parseElement(element);
+      const result = await StepParser.parseElement(element);
       expect(result).toHaveProperty('when');
     });
   });
 
   describe('parseElementType', () => {
-    it('should parse object type element', () => {
+    it('should parse object type element', async () => {
       const element = mockDocument.createElement('choice');
       const when = mockDocument.createElement('when');
       element.appendChild(when);
@@ -159,12 +159,12 @@ describe('parser basics', () => {
         oneOf: ['when'],
       } as unknown as ICamelProcessorProperty;
 
-      const result = StepParser.parseElementType('when', element, properties);
+      const result = await StepParser.parseElementType('when', element, properties);
       expect(result).toBeDefined();
       expect(result?.key).toBe('when');
     });
 
-    it('should parse array type element', () => {
+    it('should parse array type element', async () => {
       const element = mockDocument.createElement('choice');
       const when1 = mockDocument.createElement('when');
       const when2 = mockDocument.createElement('when');
@@ -176,14 +176,14 @@ describe('parser basics', () => {
         oneOf: ['when'],
       } as unknown as ICamelProcessorProperty;
 
-      const result = StepParser.parseElementType('when', element, properties);
+      const result = await StepParser.parseElementType('when', element, properties);
       expect(result).toBeDefined();
       expect(Array.isArray(result?.value)).toBe(true);
     });
   });
 
   describe('decorateDoTry', () => {
-    it('should properly decorate doTry element with doCatch and doFinally', () => {
+    it('should properly decorate doTry element with doCatch and doFinally', async () => {
       const doTryElement = mockDocument.createElement('doTry');
       const doCatch = mockDocument.createElement('doCatch');
       const doFinally = mockDocument.createElement('doFinally');
@@ -193,18 +193,18 @@ describe('parser basics', () => {
 
       const processor = {} as DoTry;
 
-      StepParser.decorateDoTry(doTryElement, processor);
+      await StepParser.decorateDoTry(doTryElement, processor);
 
       expect(processor.doCatch).toBeDefined();
       expect(Array.isArray(processor.doCatch)).toBe(true);
       expect(processor.doFinally).toBeDefined();
     });
 
-    it('should handle doTry without doCatch or doFinally', () => {
+    it('should handle doTry without doCatch or doFinally', async () => {
       const doTryElement = mockDocument.createElement('doTry');
       const processor = {} as DoTry;
 
-      StepParser.decorateDoTry(doTryElement, processor);
+      await StepParser.decorateDoTry(doTryElement, processor);
 
       expect(processor.doCatch).toEqual([]);
       expect(processor.doFinally).toBeUndefined();
@@ -212,38 +212,38 @@ describe('parser basics', () => {
   });
 
   describe('special cases', () => {
-    it('should handle intercept elements', () => {
+    it('should handle intercept elements', async () => {
       const interceptElement = mockDocument.createElement('interceptFrom');
       const whenElement = mockDocument.createElement('onWhen');
       interceptElement.appendChild(whenElement);
 
-      const result = StepParser.parseElement(interceptElement) as { onWhen?: unknown };
+      const result = (await StepParser.parseElement(interceptElement)) as { onWhen?: unknown };
       expect(result.onWhen).toBeDefined();
     });
 
-    it('should handle intercept elements', () => {
+    it('should handle intercept elements', async () => {
       const interceptElement = getDocument(
         '<intercept id="intercept1"><onWhen><simple>${in.body} contains \'Hello\'</simple></onWhen><to uri="mock:intercepted"/></intercept>',
       ).documentElement;
 
-      const result = StepParser.parseElement(interceptElement) as { onWhen?: unknown };
+      const result = (await StepParser.parseElement(interceptElement)) as { onWhen?: unknown };
       expect(result.onWhen).toBeDefined();
     });
 
-    it('should handle intercept elements without when element', () => {
+    it('should handle intercept elements without when element', async () => {
       const interceptElement = mockDocument.createElement('interceptFrom');
       const processor = {};
 
-      StepParser['decorateIntercept'](interceptElement, processor);
+      await StepParser['decorateIntercept'](interceptElement, processor);
 
       expect(processor).toEqual({});
     });
 
-    it('should handle missing catalog entries', () => {
+    it('should handle missing catalog entries', async () => {
       const unknownElement = mockDocument.createElement('unknownProcessor');
       unknownElement.setAttribute('someAttr', 'value');
 
-      const result = StepParser.parseElement(unknownElement) as { someAttr?: string };
+      const result = (await StepParser.parseElement(unknownElement)) as { someAttr?: string };
       expect(result.someAttr).toBe('value');
     });
 
@@ -269,7 +269,7 @@ describe('parser basics', () => {
       expect(processor).toEqual({});
     });
 
-    it('should read compensation/completion uri from nested elements (legacy Camel < 4.20 format)', () => {
+    it('should read compensation/completion uri from nested elements (legacy Camel < 4.20 format)', async () => {
       const sagaXml = `
         <saga>
           <compensation uri="direct:compensate"/>
@@ -277,7 +277,7 @@ describe('parser basics', () => {
         </saga>`;
       const element = getElementFromXml(sagaXml);
 
-      const result = StepParser.parseElement(element) as { compensation?: string; completion?: string };
+      const result = (await StepParser.parseElement(element)) as { compensation?: string; completion?: string };
 
       expect(result.compensation).toBe('direct:compensate');
       expect(result.completion).toBe('direct:complete');
@@ -305,7 +305,7 @@ describe('parser basics', () => {
   });
 
   describe('parseElementsArray', () => {
-    it('should parse array of string elements', () => {
+    it('should parse array of string elements', async () => {
       const parent = mockDocument.createElement('parent');
       const child1 = mockDocument.createElement('item');
       const child2 = mockDocument.createElement('item');
@@ -318,11 +318,11 @@ describe('parser basics', () => {
         javaType: 'java.util.List<java.lang.String>',
       } as unknown as ICamelProcessorProperty;
 
-      const result = StepParser.parseElementsArray('item', parent, properties);
+      const result = await StepParser.parseElementsArray('item', parent, properties);
       expect(result).toEqual(['value1', 'value2']);
     });
 
-    it('should use transformer if provided', () => {
+    it('should use transformer if provided', async () => {
       const parent = mockDocument.createElement('parent');
       const child = mockDocument.createElement('item');
       parent.appendChild(child);
@@ -330,7 +330,7 @@ describe('parser basics', () => {
       const transformer = vi.fn().mockReturnValue({ transformed: true });
       const properties = {} as unknown as ICamelProcessorProperty;
 
-      StepParser.parseElementsArray('item', parent, properties, transformer);
+      await StepParser.parseElementsArray('item', parent, properties, transformer);
       expect(transformer).toHaveBeenCalledWith(child);
     });
   });
@@ -340,10 +340,10 @@ describe('ProcessorParser', () => {
   beforeAll(async () => {
     vi.resetAllMocks();
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('transforms onException element correctly', () => {
+  it('transforms onException element correctly', async () => {
     const onExceptionElement = getElementFromXml(`
     <onException>
       <exception>java.lang.Exception</exception>
@@ -354,7 +354,7 @@ describe('ProcessorParser', () => {
     </onException>
   `);
 
-    const result = StepParser.parseElement(onExceptionElement);
+    const result = await StepParser.parseElement(onExceptionElement);
     expect(result).toEqual({
       exception: ['java.lang.Exception'],
       handled: { constant: { expression: 'true' } },
@@ -362,20 +362,20 @@ describe('ProcessorParser', () => {
     });
   });
 
-  it('transforms onCompletion element correctly', () => {
+  it('transforms onCompletion element correctly', async () => {
     const onCompletionElement = getElementFromXml(`
     <onCompletion>
       <to uri="mock:completion"/>
     </onCompletion>
   `);
 
-    const result = StepParser.parseElement(onCompletionElement);
+    const result = await StepParser.parseElement(onCompletionElement);
     expect(result).toEqual({
       steps: [{ to: { uri: 'mock:completion' } }],
     });
   });
 
-  it('transforms choice element correctly', () => {
+  it('transforms choice element correctly', async () => {
     const choiceElement = getElementFromXml(`
     <choice>
       <when>
@@ -388,7 +388,7 @@ describe('ProcessorParser', () => {
     </choice>
   `);
 
-    const result = StepParser.parseElement(choiceElement);
+    const result = await StepParser.parseElement(choiceElement);
     expect(result).toEqual({
       when: [
         {
@@ -404,11 +404,11 @@ describe('ProcessorParser', () => {
 });
 
 describe('Route EIPs xml parsing', () => {
-  let transformElement: (element: string) => unknown;
+  let transformElement: (element: string) => Promise<unknown>;
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
 
     transformElement = (element: string) => {
       const xmlDoc = getElementFromXml(element);
@@ -437,14 +437,14 @@ describe('Route EIPs xml parsing', () => {
     { name: 'throttle', xml: throttleXml, entity: throttleEntity },
   ];
 
-  it.each(testCases)('Parse $name', ({ xml, entity }) => {
-    const result = transformElement(xml);
+  it.each(testCases)('Parse $name', async ({ xml, entity }) => {
+    const result = await transformElement(xml);
     expect(result).toEqual(entity);
   });
 });
 
 describe('Route EIPs xml parsing with the simulated old catalog', () => {
-  let transformElement: (element: string) => unknown;
+  let transformElement: (element: string) => Promise<unknown>;
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
@@ -455,7 +455,7 @@ describe('Route EIPs xml parsing with the simulated old catalog', () => {
 
     expect(catalogsMap.modelCatalogMap['doTry'].properties.doCatch).toBeUndefined();
     expect(catalogsMap.modelCatalogMap['onWhen']).toBeUndefined();
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
 
     transformElement = (element: string) => {
       const xmlDoc = getElementFromXml(element);
@@ -463,25 +463,25 @@ describe('Route EIPs xml parsing with the simulated old catalog', () => {
     };
   });
 
-  it('should handle onWhen elements properly', () => {
+  it('should handle onWhen elements properly', async () => {
     const element = getDocument().createElement('onWhen');
-    const result = StepParser.getProcessorModel(element);
+    const result = await StepParser.getProcessorModel(element);
 
     expect(result.processorName).toBe('when');
     expect(result.processorModel).toBeDefined();
   });
 
-  it('test test doTry', () => {
-    const result = transformElement(doTryXml);
+  it('test test doTry', async () => {
+    const result = await transformElement(doTryXml);
     expect(result).toEqual(doTryEntity);
   });
 
-  it('should handle intercept elements', () => {
+  it('should handle intercept elements', async () => {
     const interceptElement = getDocument(
       '<intercept id="intercept1"><when><simple>${in.body} contains \'Hello\'</simple></when><to uri="mock:intercepted"/></intercept>',
     ).documentElement;
 
-    const result = StepParser.parseElement(interceptElement) as { when?: unknown };
+    const result = (await StepParser.parseElement(interceptElement)) as { when?: unknown };
     expect(result.when).toBeDefined();
   });
 });

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -16,47 +16,50 @@
 
 import { DoCatch, DoTry, ProcessorDefinition, When1 as When } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind, ICamelProcessorDefinition, ICamelProcessorProperty } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind, ICamelProcessorDefinition, ICamelProcessorProperty } from '../../../models';
 import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
 import { ARRAY_TYPE_NAMES, extractAttributesFromXmlElement, PROCESSOR_NAMES } from '../utils/xml-utils';
 import { ExpressionParser } from './expression-parser';
 
-export type ElementTransformer = (element: Element) => unknown;
+export type ElementTransformer = (element: Element) => Promise<unknown>;
 
 export class StepParser {
   private static readonly SKIP_KEYS = ['doCatch', 'doFinally', 'onFallback', 'when', 'onWhen'];
 
-  static parseSteps(parentElement: Element, processorKeys: string[]): ProcessorDefinition[] {
-    return Array.from(parentElement.children)
-      .filter((child) => {
-        // onFallback is listed as a processor in the catalog, but it is not a processor. RouteXmlParser. is already fixed in the main branch of the camel
-        return processorKeys.includes(child.tagName) && !this.SKIP_KEYS.includes(child.tagName); // Filter out elements not needed
-      })
-      .map((child) => {
+  static async parseSteps(parentElement: Element, processorKeys: string[]): Promise<ProcessorDefinition[]> {
+    const children = Array.from(parentElement.children).filter((child) => {
+      // onFallback is listed as a processor in the catalog, but it is not a processor. RouteXmlParser. is already fixed in the main branch of the camel
+      return processorKeys.includes(child.tagName) && !this.SKIP_KEYS.includes(child.tagName); // Filter out elements not needed
+    });
+
+    return Promise.all(
+      children.map(async (child) => {
         const step: ProcessorDefinition = {
-          [child.tagName as keyof ProcessorDefinition]: this.parseElement(child),
+          [child.tagName as keyof ProcessorDefinition]: await this.parseElement(child),
         };
         return step;
-      });
+      }),
+    );
   }
 
-  static getProcessorModel(element: Element): {
+  static async getProcessorModel(element: Element): Promise<{
     processorName: string;
     processorModel: ICamelProcessorDefinition | undefined;
-  } {
+  }> {
     let processorName = PROCESSOR_NAMES.get(element.tagName) ?? element.tagName;
-    let processorModel = CamelCatalogService.getComponent(CatalogKind.Processor, processorName);
+    let processorModel = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, processorName);
     if (processorName === 'onWhen' && !processorModel) {
-      processorModel = CamelCatalogService.getComponent(CatalogKind.Processor, 'when');
+      processorModel = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'when');
       processorName = 'when';
     }
     return { processorName, processorModel };
   }
 
-  static parseElement(element: Element, transformer?: ElementTransformer): unknown {
+  static async parseElement(element: Element, transformer?: ElementTransformer): Promise<unknown> {
     if (!element) return {};
 
-    const { processorName, processorModel } = this.getProcessorModel(element);
+    const { processorName, processorModel } = await this.getProcessorModel(element);
 
     //Some elements are not defined in the catalog even if they are defined in the schemas, so we need to extract them as plain objects
     if (!processorModel) {
@@ -65,7 +68,7 @@ export class StepParser {
 
     let processor: { [key: string]: unknown } = {};
 
-    Object.entries(processorModel.properties).forEach(([name, properties]) => {
+    for (const [name, properties] of Object.entries(processorModel.properties)) {
       switch (properties.kind) {
         case 'value':
           processor[name] = element.textContent;
@@ -77,33 +80,33 @@ export class StepParser {
           break;
         case 'expression':
           if (name === 'expression') {
-            processor = { ...processor, ...ExpressionParser.parse(element, properties) };
-          } else processor[name] = ExpressionParser.parse(element, properties, name);
+            processor = { ...processor, ...(await ExpressionParser.parse(element, properties)) };
+          } else processor[name] = await ExpressionParser.parse(element, properties, name);
           break;
 
         case 'element':
           {
-            const elementType = this.parseElementType(name, element, properties, transformer);
+            const elementType = await this.parseElementType(name, element, properties, transformer);
             if (elementType) {
               processor[elementType.key] = elementType.value;
             }
           }
           break;
       }
-    });
+    }
 
     // handle cases that aren't defined in catalog or are defined incorrectly
-    this.handleSpecialCases(processorName, element, processor, processorModel.properties);
+    await this.handleSpecialCases(processorName, element, processor, processorModel.properties);
 
     return processor;
   }
 
-  static parseElementType(
+  static async parseElementType(
     name: string,
     element: Element,
     properties: ICamelProcessorProperty,
     transformer?: ElementTransformer,
-  ): { key: string; value: unknown } | undefined {
+  ): Promise<{ key: string; value: unknown } | undefined> {
     if (properties.type === 'object') {
       return this.parseObjectType(name, element, properties);
     }
@@ -137,45 +140,45 @@ export class StepParser {
     return element.getElementsByTagName(name)[0];
   }
 
-  private static parseObjectType(
+  private static async parseObjectType(
     name: string,
     element: Element,
     properties: ICamelProcessorProperty,
-  ): { key: string; value: unknown } | undefined {
+  ): Promise<{ key: string; value: unknown } | undefined> {
     const singleElement = this.findSingleElement(element, properties, name);
 
     return singleElement
       ? {
           key: singleElement.tagName,
-          value: this.parseElement(singleElement),
+          value: await this.parseElement(singleElement),
         }
       : undefined;
   }
 
-  private static parseArrayType(
+  private static async parseArrayType(
     name: string,
     element: Element,
     properties: ICamelProcessorProperty,
     transformer?: ElementTransformer,
-  ): { key: string; value: unknown } {
+  ): Promise<{ key: string; value: unknown }> {
     if (name === 'outputs') {
       // if outputs is specified then the processor has steps
 
-      const steps = this.parseSteps(element, properties.oneOf!);
+      const steps = await this.parseSteps(element, properties.oneOf!);
       if (steps.length > 0 || properties.required) return { key: 'steps', value: steps };
     }
-    const arrayClause = this.parseElementsArray(name, element, properties, transformer);
+    const arrayClause = await this.parseElementsArray(name, element, properties, transformer);
 
     if (arrayClause.length > 0) return { key: name, value: arrayClause };
     return { key: name, value: properties.required ? [] : undefined };
   }
 
-  static parseElementsArray(
+  static async parseElementsArray(
     name: string,
     element: Element,
     properties: ICamelProcessorProperty,
     transformer = (el: Element) => this.parseElement(el),
-  ): unknown[] {
+  ): Promise<unknown[]> {
     const arrayElementName = ARRAY_TYPE_NAMES.get(name) ?? name;
     let children;
     if (properties.oneOf) {
@@ -188,18 +191,20 @@ export class StepParser {
 
     if (!children) return [];
 
-    return Array.from(children).map((el) =>
-      properties.javaType === 'java.util.List<java.lang.String>' ? el.textContent : transformer(el),
+    return Promise.all(
+      Array.from(children).map((el) =>
+        properties.javaType === 'java.util.List<java.lang.String>' ? el.textContent : transformer(el),
+      ),
     );
   }
 
-  static decorateDoTry(doTryElement: Element, processor: DoTry) {
+  static async decorateDoTry(doTryElement: Element, processor: DoTry) {
     const doCatchArray: DoCatch[] = [];
     let doFinallyElement = undefined;
 
-    Array.from(doTryElement.children).forEach((child) => {
+    for (const child of Array.from(doTryElement.children)) {
       const tagNameLower = child.tagName;
-      const element = this.parseElement(child);
+      const element = await this.parseElement(child);
 
       if (child.tagName === 'doCatch') {
         //set to undefined because onWhen definition doesn't have steps. It's a special case
@@ -208,13 +213,13 @@ export class StepParser {
       } else if (tagNameLower === 'doFinally') {
         doFinallyElement = element;
       }
-    });
+    }
 
     processor['doCatch'] = doCatchArray;
-    processor['doFinally'] = doFinallyElement;
+    processor['doFinally'] = doFinallyElement as DoTry['doFinally'];
   }
 
-  private static handleSpecialCases(
+  private static async handleSpecialCases(
     processorName: string,
     element: Element,
     processor: { [p: string]: unknown },
@@ -222,10 +227,10 @@ export class StepParser {
   ) {
     //  doTry properties are missing in the catalog up to 4.9
     if (processorName === 'doTry' && !processorProperties['doCatch'] && !processorProperties['doFinally']) {
-      this.decorateDoTry(element, processor);
+      await this.decorateDoTry(element, processor);
     }
     if (processorName.includes('intercept') && !processorProperties['onWhen']) {
-      this.decorateIntercept(element, processor);
+      await this.decorateIntercept(element, processor);
     }
     // saga compensation/completion changed from nested elements to attributes in Camel 4.20.0
     if (processorName === 'saga') {
@@ -249,13 +254,13 @@ export class StepParser {
     }
   }
 
-  private static decorateIntercept(element: Element, processor: { [p: string]: unknown }) {
+  private static async decorateIntercept(element: Element, processor: { [p: string]: unknown }) {
     //if when is defined or newer catalog is used, we don't need to parse it again
     if (processor['when'] || processor['onWhen']) return;
 
     const whenElement = element.getElementsByTagName('when')[0];
     if (whenElement) {
-      const when = this.parseElement(whenElement) as { [key: string]: unknown; steps?: [] };
+      const when = (await this.parseElement(whenElement)) as { [key: string]: unknown; steps?: [] };
       when['steps'] = undefined;
       processor['when'] = when;
     }

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -177,7 +177,7 @@ export class StepParser {
     name: string,
     element: Element,
     properties: ICamelProcessorProperty,
-    transformer = (el: Element) => this.parseElement(el),
+    transformer: ElementTransformer = (el: Element) => this.parseElement(el),
   ): Promise<unknown[]> {
     const arrayElementName = ARRAY_TYPE_NAMES.get(name) ?? name;
     let children;
@@ -193,7 +193,7 @@ export class StepParser {
 
     return Promise.all(
       Array.from(children).map((el) =>
-        properties.javaType === 'java.util.List<java.lang.String>' ? el.textContent : transformer(el),
+        properties.javaType === 'java.util.List<java.lang.String>' ? Promise.resolve(el.textContent) : transformer(el),
       ),
     );
   }

--- a/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.test.ts
@@ -17,8 +17,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { BeansXmlSerializer } from './beans-xml-serializer';
 import { getDocument, testSerializer } from './serializer-test-utils';
 
@@ -26,10 +25,10 @@ describe('BeanXmlParser', () => {
   const doc = getDocument();
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('parse bean constructors properly', () => {
+  it('parse bean constructors properly', async () => {
     const entity = {
       name: 'beanFromProps',
       type: 'com.acme.MyBean',
@@ -51,12 +50,12 @@ describe('BeanXmlParser', () => {
   </properties>
 </bean>`;
 
-    const bean = BeansXmlSerializer.serialize(entity, doc);
+    const bean = await BeansXmlSerializer.serialize(entity, doc);
     expect(bean).toBeDefined();
     testSerializer(expected, bean!);
   });
 
-  it('parse bean properties properly', () => {
+  it('parse bean properties properly', async () => {
     const bean = {
       name: 'beanFromProps',
       type: 'com.acme.MyBean',
@@ -65,7 +64,7 @@ describe('BeanXmlParser', () => {
       properties: { field1: 'f1_p', field2: { nested1: 'p2', nested2: { nested3: 'value' } } },
     };
 
-    const result = BeansXmlSerializer.serialize(bean, doc);
+    const result = await BeansXmlSerializer.serialize(bean, doc);
     const expected = `<bean name="beanFromProps" 
       type="com.acme.MyBean" builderClass="com.acme.MyBeanBuilder" builderMethod="createMyBean">
   <properties>

--- a/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/beans-xml-serializer.ts
@@ -16,16 +16,18 @@
 
 import { BeanFactory } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
 import { ElementType, StepXmlSerializer } from './step-xml-serializer';
 
 export class BeansXmlSerializer {
-  static serialize(beanElement: BeanFactory, doc: Document): Element | undefined {
+  static async serialize(beanElement: BeanFactory, doc: Document): Promise<Element | undefined> {
     const bean = doc.createElement('bean');
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, 'beanFactory')?.properties;
+    const beanFactoryDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, 'beanFactory');
+    const properties = beanFactoryDefinition?.properties;
     if (!properties) return undefined;
 
-    StepXmlSerializer.serializeObjectProperties(bean, doc, beanElement as unknown as ElementType, properties);
+    await StepXmlSerializer.serializeObjectProperties(bean, doc, beanElement as unknown as ElementType, properties);
 
     if (beanElement['constructors']) {
       bean.appendChild(this.serializeConstructors(beanElement['constructors'], doc));

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
@@ -17,8 +17,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { ExpressionXmlSerializer } from './expression-xml-serializer';
 import { getDocument, testSerializer } from './serializer-test-utils';
 
@@ -27,10 +26,10 @@ describe('ExpressionSerialisation tests', () => {
   const doc = getDocument();
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('serialize simple expression', () => {
+  it('serialize simple expression', async () => {
     const entity = {
       constant: {
         expression: 'a=b',
@@ -38,21 +37,21 @@ describe('ExpressionSerialisation tests', () => {
     };
     const expected = `<when><constant>a=b</constant></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize simple expression with empty expression', () => {
+  it('serialize simple expression with empty expression', async () => {
     const entity = {
       constant: {},
     };
     const expected = `<when><constant/></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize simple expression with empty expression different format', () => {
+  it('serialize simple expression with empty expression different format', async () => {
     const entity = {
       expression: {
         constant: {},
@@ -60,11 +59,11 @@ describe('ExpressionSerialisation tests', () => {
     };
     const expected = `<when><constant/></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize simple expression with expression different format', () => {
+  it('serialize simple expression with expression different format', async () => {
     const entity = {
       expression: {
         simple: { expression: 'a=b' },
@@ -72,22 +71,22 @@ describe('ExpressionSerialisation tests', () => {
     };
     const expected = `<when><simple>a=b</simple></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize simple expression with text definition', () => {
+  it('serialize simple expression with text definition', async () => {
     const entity = {
       simple: 'a=b',
     };
 
     const expected = `<when><simple>a=b</simple></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize expression with attributes', () => {
+  it('serialize expression with attributes', async () => {
     const entity = {
       csimple: {
         expression: '${body}',
@@ -96,11 +95,11 @@ describe('ExpressionSerialisation tests', () => {
     };
     const expected = `<when><csimple resultType="String">\${body}</csimple></when>`;
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize expression with namespace', () => {
+  it('serialize expression with namespace', async () => {
     const entity = {
       csimple: {
         expression: '${body}',
@@ -110,12 +109,12 @@ describe('ExpressionSerialisation tests', () => {
     const expected = `<when><csimple>\${body}</csimple></when>`;
     const element = doc.createElement('when');
     const routeParent = doc.createElement('route');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element, routeParent);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element, routeParent);
     testSerializer(expected, element);
     expect(routeParent.getAttribute('xmlns:ns1')).toBe('http://example.com/ns1');
   });
 
-  it('serialize expression with different key', () => {
+  it('serialize expression with different key', async () => {
     const entity = {
       completionPredicate: {
         constant: { expression: 'predicate' },
@@ -123,18 +122,18 @@ describe('ExpressionSerialisation tests', () => {
     };
     const expected = `<aggregate><completionPredicate><constant>predicate</constant></completionPredicate></aggregate>`;
     const element = doc.createElement('aggregate');
-    ExpressionXmlSerializer.serialize('completionPredicate', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('completionPredicate', entity, oneOf, doc, element);
     testSerializer(expected, element);
   });
 
-  it('serialize expression with unknown type', () => {
+  it('serialize expression with unknown type', async () => {
     const entity = {
       unknown: {
         expression: 'unknown',
       },
     };
     const element = doc.createElement('when');
-    ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
+    await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     expect(element.children).toHaveLength(0);
   });
 });

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
 import { setNamespaces } from '../utils/xml-utils';
 
 type Expression = { expression: string; [key: string]: unknown };
 
 export class ExpressionXmlSerializer {
-  static serialize(
+  static async serialize(
     key: string,
     stepWithExpression: unknown,
     oneOf: string[] | undefined,
@@ -42,7 +43,7 @@ export class ExpressionXmlSerializer {
 
     let expression: Element;
     if (key === 'expression') {
-      expression = ExpressionXmlSerializer.createExpressionElement(
+      expression = await ExpressionXmlSerializer.createExpressionElement(
         expressionType,
         expressionDefinition,
         doc,
@@ -52,21 +53,22 @@ export class ExpressionXmlSerializer {
       //for cases like correlationExpression etc...
       expression = doc.createElement(key);
       expression.append(
-        ExpressionXmlSerializer.createExpressionElement(expressionType, expressionDefinition, doc, routeParent),
+        await ExpressionXmlSerializer.createExpressionElement(expressionType, expressionDefinition, doc, routeParent),
       );
     }
 
     element.appendChild(expression);
   }
 
-  static createExpressionElement(
+  static async createExpressionElement(
     expressionType: string,
     expressionObject: Expression | string,
     doc: Document,
     routeParent?: Element,
-  ): Element {
+  ): Promise<Element> {
     const expressionElement = doc.createElement(expressionType);
-    const properties = CamelCatalogService.getComponent(CatalogKind.Processor, expressionType)?.properties;
+    const expressionDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, expressionType);
+    const properties = expressionDefinition?.properties;
 
     expressionElement.textContent =
       typeof expressionObject === 'string' ? expressionObject : expressionObject.expression;

--- a/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.test.ts
@@ -17,12 +17,12 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CamelRouteVisualEntity, CatalogKind } from '../../../models';
+import { CamelRouteVisualEntity } from '../../../models';
 import { EntityOrderingService } from '../../../models/camel/entity-ordering.service';
 import { EntityType } from '../../../models/entities';
 import { CamelErrorHandlerVisualEntity } from '../../../models/visualization/flows/camel-error-handler-visual-entity';
 import { BeansEntity } from '../../../models/visualization/metadata';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { EntityDefinition } from './entitiy-definition';
 import { KaotoXmlSerializer } from './kaoto-xml-serializer';
 import { normalizeXml } from './serializer-test-utils';
@@ -35,10 +35,10 @@ describe('ToXMLConverter', () => {
     domParser = new DOMParser();
     xmlSerializer = new XMLSerializer();
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('Convert single route entity to XML correctly', () => {
+  it('Convert single route entity to XML correctly', async () => {
     const doc = domParser.parseFromString(
       `<camel xmlns="http://camel.apache.org/schema/spring"><route id="route-1"><from uri="direct:start"/><to uri="direct:end"/></route></camel>`,
       'application/xml',
@@ -54,11 +54,11 @@ describe('ToXMLConverter', () => {
       },
     };
 
-    const result = KaotoXmlSerializer.serialize([entity as unknown as CamelRouteVisualEntity]);
+    const result = await KaotoXmlSerializer.serialize([entity as unknown as CamelRouteVisualEntity]);
     expect(xmlSerializer.serializeToString(result)).toEqual(xmlSerializer.serializeToString(doc));
   });
 
-  it('Convert error handler to XML correctly', () => {
+  it('Convert error handler to XML correctly', async () => {
     const doc = domParser.parseFromString(
       `<camel xmlns="http://camel.apache.org/schema/spring"><errorHandler><deadLetterChannel deadLetterUri="mock:dead"><redeliveryPolicy maximumRedeliveries="3" redeliveryDelay="250"/></deadLetterChannel></errorHandler></camel>`,
       'application/xml',
@@ -74,11 +74,11 @@ describe('ToXMLConverter', () => {
       },
     };
 
-    const result = KaotoXmlSerializer.serialize([entity as unknown as CamelErrorHandlerVisualEntity]);
+    const result = await KaotoXmlSerializer.serialize([entity as unknown as CamelErrorHandlerVisualEntity]);
     expect(xmlSerializer.serializeToString(result)).toEqual(xmlSerializer.serializeToString(doc));
   });
 
-  it('Convert beans ', () => {
+  it('Convert beans ', async () => {
     const doc = domParser.parseFromString(
       `<camel xmlns="http://camel.apache.org/schema/spring">
 <bean name="test" type="bean" destroyMethod="destroy" factoryBean="ff" builderClass="com.example.MyBean">
@@ -106,12 +106,12 @@ describe('ToXMLConverter', () => {
       },
     };
 
-    const result = KaotoXmlSerializer.serialize([entity as unknown as BeansEntity]);
+    const result = await KaotoXmlSerializer.serialize([entity as unknown as BeansEntity]);
     expect(xmlSerializer.serializeToString(result)).toEqual(normalizeXml(xmlSerializer.serializeToString(doc)));
   });
 
   describe('Entity ordering in XML serialization', () => {
-    it('should serialize entities in XML schema order', () => {
+    it('should serialize entities in XML schema order', async () => {
       const mixedEntities = [
         {
           type: EntityType.Route,
@@ -145,7 +145,7 @@ describe('ToXMLConverter', () => {
         },
       ];
 
-      const result = KaotoXmlSerializer.serialize(mixedEntities as EntityDefinition[]);
+      const result = await KaotoXmlSerializer.serialize(mixedEntities as EntityDefinition[]);
       const xmlString = xmlSerializer.serializeToString(result);
       const resultDoc = domParser.parseFromString(xmlString, 'application/xml');
       const children = Array.from(resultDoc.documentElement.children);
@@ -156,7 +156,7 @@ describe('ToXMLConverter', () => {
       expect(children[3].tagName).toBe('route');
     });
 
-    it('should preserve order within same entity types during serialization', () => {
+    it('should preserve order within same entity types during serialization', async () => {
       const multipleRoutes = [
         {
           type: EntityType.Route,
@@ -187,7 +187,7 @@ describe('ToXMLConverter', () => {
         },
       ] as unknown as EntityDefinition[];
 
-      const result = KaotoXmlSerializer.serialize(multipleRoutes);
+      const result = await KaotoXmlSerializer.serialize(multipleRoutes);
       const xmlString = xmlSerializer.serializeToString(result);
       const resultDoc = domParser.parseFromString(xmlString, 'application/xml');
       const routeElements = Array.from(resultDoc.querySelectorAll('route'));
@@ -197,7 +197,7 @@ describe('ToXMLConverter', () => {
       expect(routeElements[2].getAttribute('id')).toBe('route-2');
     });
 
-    it('should use EntityOrderingService for sorting entities', () => {
+    it('should use EntityOrderingService for sorting entities', async () => {
       const sortSpy = vi.spyOn(EntityOrderingService, 'sortEntitiesForSerialization');
 
       const entities = [
@@ -212,14 +212,14 @@ describe('ToXMLConverter', () => {
         },
       ] as unknown as EntityDefinition[];
 
-      KaotoXmlSerializer.serialize(entities);
+      await KaotoXmlSerializer.serialize(entities);
 
       expect(sortSpy).toHaveBeenCalledWith(entities);
 
       sortSpy.mockRestore();
     });
 
-    it('should handle complex mixed entity ordering with preserved internal order', () => {
+    it('should handle complex mixed entity ordering with preserved internal order', async () => {
       const complexMixedEntities = [
         {
           type: EntityType.RouteConfiguration,
@@ -262,7 +262,7 @@ describe('ToXMLConverter', () => {
         },
       ] as unknown as EntityDefinition[];
 
-      const result = KaotoXmlSerializer.serialize(complexMixedEntities);
+      const result = await KaotoXmlSerializer.serialize(complexMixedEntities);
       const xmlString = xmlSerializer.serializeToString(result);
       const resultDoc = domParser.parseFromString(xmlString, 'application/xml');
       const children = Array.from(resultDoc.documentElement.children);
@@ -278,7 +278,7 @@ describe('ToXMLConverter', () => {
       expect(children[4].getAttribute('id')).toBe('route-2');
     });
 
-    it('should handle beans element placement correctly', () => {
+    it('should handle beans element placement correctly', async () => {
       const entitiesWithBeans = [
         {
           type: EntityType.Route,
@@ -308,7 +308,7 @@ describe('ToXMLConverter', () => {
         },
       ] as unknown as EntityDefinition[];
 
-      const result = KaotoXmlSerializer.serialize(entitiesWithBeans);
+      const result = await KaotoXmlSerializer.serialize(entitiesWithBeans);
       const xmlString = xmlSerializer.serializeToString(result);
       const resultDoc = domParser.parseFromString(xmlString, 'application/xml');
       const children = Array.from(resultDoc.documentElement.children);
@@ -321,7 +321,7 @@ describe('ToXMLConverter', () => {
       expect(beanElement.getAttribute('name')).toBe('testBean');
     });
 
-    it('should maintain existing behavior for single entity types', () => {
+    it('should maintain existing behavior for single entity types', async () => {
       const singleRouteEntity = [
         {
           type: EntityType.Route,
@@ -334,7 +334,7 @@ describe('ToXMLConverter', () => {
         },
       ];
 
-      const result = KaotoXmlSerializer.serialize(singleRouteEntity as EntityDefinition[]);
+      const result = await KaotoXmlSerializer.serialize(singleRouteEntity as EntityDefinition[]);
       const xmlString = xmlSerializer.serializeToString(result);
       const resultDoc = domParser.parseFromString(xmlString, 'application/xml');
 

--- a/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/kaoto-xml-serializer.ts
@@ -24,19 +24,23 @@ import { RestXmlSerializer } from './rest-xml-serializer';
 import { ElementType, StepXmlSerializer } from './step-xml-serializer';
 
 export class KaotoXmlSerializer {
-  static serializeRoute(route: RouteDefinition, doc: Document): Element {
-    const routeElement = StepXmlSerializer.serialize('route', route as unknown as { [key: string]: unknown }, doc);
+  static async serializeRoute(route: RouteDefinition, doc: Document): Promise<Element> {
+    const routeElement = await StepXmlSerializer.serialize(
+      'route',
+      route as unknown as { [key: string]: unknown },
+      doc,
+    );
 
-    const steps = StepXmlSerializer.serializeSteps(route.from.steps as ElementType[], doc, routeElement);
+    const steps = await StepXmlSerializer.serializeSteps(route.from.steps as ElementType[], doc, routeElement);
     routeElement.append(...steps);
 
     return routeElement;
   }
 
-  static serialize(
+  static async serialize(
     entityDefinitions: EntityDefinition[],
     rootElementDefinitions?: { name: string; value: string }[],
-  ): Document {
+  ): Promise<Document> {
     const parser = new DOMParser();
     const doc: XMLDocument = parser.parseFromString('<camel></camel>', 'text/xml');
     const rootElement = doc.documentElement;
@@ -51,35 +55,40 @@ export class KaotoXmlSerializer {
 
     const sortedEntities = EntityOrderingService.sortEntitiesForSerialization(entityDefinitions);
 
-    sortedEntities.forEach((entity) => {
+    for (const entity of sortedEntities) {
       const entityType = entity.type;
 
       switch (entity.type) {
         case EntityType.Beans:
-          entity.parent.beans.forEach((bean) => {
-            const beanElement = BeansXmlSerializer.serialize(bean, doc);
+          for (const bean of entity.parent.beans) {
+            const beanElement = await BeansXmlSerializer.serialize(bean, doc);
             if (beanElement) rootElement.appendChild(beanElement);
-          });
+          }
           break;
         case EntityType.Route:
           {
-            const routeElement = this.serializeRoute(entity.entityDef[EntityType.Route], doc);
+            const routeElement = await this.serializeRoute(entity.entityDef[EntityType.Route], doc);
             rootElement.appendChild(routeElement);
           }
           break;
         case EntityType.ErrorHandler:
           {
-            const element = StepXmlSerializer.serialize(entityType, entity.errorHandlerDef, doc, rootElement);
+            const element = await StepXmlSerializer.serialize(entityType, entity.errorHandlerDef, doc, rootElement);
             rootElement.appendChild(element);
           }
           break;
         case EntityType.Rest:
-          rootElement.appendChild(RestXmlSerializer.serialize(entity.restDef, doc));
+          rootElement.appendChild(await RestXmlSerializer.serialize(entity.restDef, doc));
           break;
 
         case EntityType.RestConfiguration:
           {
-            const element = StepXmlSerializer.serialize(entityType, entity.restConfigurationDef, doc, rootElement);
+            const element = await StepXmlSerializer.serialize(
+              entityType,
+              entity.restConfigurationDef,
+              doc,
+              rootElement,
+            );
             rootElement.appendChild(element);
           }
           break;
@@ -90,11 +99,11 @@ export class KaotoXmlSerializer {
         case EntityType.OnCompletion:
         case EntityType.RouteConfiguration:
         case EntityType.OnException: {
-          const element = StepXmlSerializer.serialize(entityType, entity.entityDef, doc, rootElement);
+          const element = await StepXmlSerializer.serialize(entityType, entity.entityDef, doc, rootElement);
           rootElement.appendChild(element);
         }
       }
-    });
+    }
 
     return doc;
   }

--- a/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.test.ts
@@ -20,9 +20,8 @@ import path from 'node:path';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
 import { restWithVerbsStup } from '../../../stubs/rest';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { RestXmlSerializer } from './rest-xml-serializer';
 import { getDocument, testSerializer, testSerializerWithObjectComparison } from './serializer-test-utils';
 
@@ -30,10 +29,10 @@ describe('RestXmlParser tests with latest catalog', () => {
   const doc = getDocument();
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('serialize param', () => {
+  it('serialize param', async () => {
     const entity = {
       get: [
         {
@@ -49,16 +48,16 @@ describe('RestXmlParser tests with latest catalog', () => {
        <param name="name" type="query" required="true"/>
        <param name="name2" type="query" defaultValue="blah" required="true"/>
     </get></rest>`;
-    const rest = RestXmlSerializer.serialize(entity, doc);
+    const rest = await RestXmlSerializer.serialize(entity, doc);
     expect(rest).toBeDefined();
     testSerializer(expected, rest);
   });
 
-  it('serialize full rest', () => {
+  it('serialize full rest', async () => {
     const xmlFilePath = path.join(__dirname, '../../../stubs/xml/rest.xml');
     const expected = fs.readFileSync(xmlFilePath, 'utf-8');
 
-    const rest = RestXmlSerializer.serialize(restWithVerbsStup, doc);
+    const rest = await RestXmlSerializer.serialize(restWithVerbsStup, doc);
     expect(rest).toBeDefined();
     testSerializer(expected, rest);
   });
@@ -75,10 +74,10 @@ describe('simulate old catalog', () => {
     delete catalogsMap.modelCatalogMap['get'].properties.security;
     expect(catalogsMap.modelCatalogMap['get'].properties.param).toBeUndefined();
 
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  it('serialize param', () => {
+  it('serialize param', async () => {
     const entity = {
       get: [
         {
@@ -94,17 +93,17 @@ describe('simulate old catalog', () => {
        <param name="name" type="query" required="true"/>
        <param name="name2" type="query" defaultValue="blah" required="true"/>
     </get></rest>`;
-    const rest = RestXmlSerializer.serialize(entity, doc);
+    const rest = await RestXmlSerializer.serialize(entity, doc);
     expect(rest).toBeDefined();
     testSerializer(expected, rest);
     testSerializerWithObjectComparison(expected, rest);
   });
 
-  it('serialize full rest', () => {
+  it('serialize full rest', async () => {
     const xmlFilePath = path.join(__dirname, '../../../stubs/xml/rest.xml');
     const expected = fs.readFileSync(xmlFilePath, 'utf-8');
 
-    const rest = RestXmlSerializer.serialize(restWithVerbsStup, doc);
+    const rest = await RestXmlSerializer.serialize(restWithVerbsStup, doc);
     expect(rest).toBeDefined();
     testSerializerWithObjectComparison(expected, rest);
   });

--- a/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/rest-xml-serializer.ts
@@ -16,7 +16,8 @@
 
 import { Rest } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind } from '../../../models';
 import { REST_DSL_VERBS, REST_ELEMENT_NAME } from '../../../models/special-processors.constants';
 import { StepXmlSerializer } from './step-xml-serializer';
 
@@ -24,38 +25,40 @@ export class RestXmlSerializer {
   //properties that are missing in the catalog (up to 4.9)
   private static readonly MISSING_PROPERTIES = ['param', 'security', 'responseMessage'];
 
-  static serialize(rest: { [key: string]: unknown }, doc: Document): Element {
-    const element = StepXmlSerializer.serialize(REST_ELEMENT_NAME, rest, doc);
+  static async serialize(rest: { [key: string]: unknown }, doc: Document): Promise<Element> {
+    const element = await StepXmlSerializer.serialize(REST_ELEMENT_NAME, rest, doc);
 
     let restObject = rest as unknown as Rest;
     if (rest.rest) restObject = rest.rest as unknown as Rest;
 
-    this.handleSecurityDefinitions(element, restObject, doc);
+    await this.handleSecurityDefinitions(element, restObject, doc);
 
-    REST_DSL_VERBS.forEach((verb) => {
+    for (const verb of REST_DSL_VERBS) {
       const verbKey = verb as keyof Rest;
       if (restObject[verbKey]) {
-        (restObject[verbKey] as { [key: string]: unknown }[]).forEach((verbInstance: { [key: string]: unknown }) => {
-          const verbElement = StepXmlSerializer.serialize(verb, verbInstance, doc, element);
-          this.handleMissingProperties(verbElement, verbInstance, doc);
+        for (const verbInstance of restObject[verbKey] as { [key: string]: unknown }[]) {
+          const verbElement = await StepXmlSerializer.serialize(verb, verbInstance, doc, element);
+          await this.handleMissingProperties(verbElement, verbInstance, doc);
           element.appendChild(verbElement);
-        });
+        }
       }
-    });
+    }
 
     return element;
   }
-  private static handleMissingProperties(element: Element, rest: { [key: string]: unknown }, doc: Document) {
+
+  private static async handleMissingProperties(element: Element, rest: { [key: string]: unknown }, doc: Document) {
     for (const prop of this.MISSING_PROPERTIES) {
       if (!rest[prop] || this.containsMissingProperty(prop, element)) continue;
       // if the property is in catalog, it's already handled by step serializer
-      if (CamelCatalogService.getComponent(CatalogKind.Processor, prop)?.properties[prop]) continue;
+      const propDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Processor, prop);
+      if (propDefinition?.properties[prop]) continue;
 
-      (rest[prop] as unknown[]).forEach((propInstance) => {
+      for (const propInstance of rest[prop] as unknown[]) {
         element.appendChild(
-          StepXmlSerializer.serialize(prop, propInstance as { [key: string]: unknown }, doc, element),
+          await StepXmlSerializer.serialize(prop, propInstance as { [key: string]: unknown }, doc, element),
         );
-      });
+      }
     }
   }
 
@@ -63,7 +66,7 @@ export class RestXmlSerializer {
     return Array.from(element.children).some((child) => child.tagName === prop);
   }
 
-  private static handleSecurityDefinitions(element: Element, rest: Rest, doc: Document) {
+  private static async handleSecurityDefinitions(element: Element, rest: Rest, doc: Document) {
     if (!rest.securityDefinitions) return;
 
     let securityDefinitionsElement = element.getElementsByTagName('securityDefinitions')[0];
@@ -71,11 +74,11 @@ export class RestXmlSerializer {
       securityDefinitionsElement = doc.createElement('securityDefinitions');
     }
 
-    Object.entries(rest.securityDefinitions).forEach(([key, value]) => {
-      const securityElement = StepXmlSerializer.serialize(key, value as { [key: string]: unknown }, doc, element);
+    for (const [key, value] of Object.entries(rest.securityDefinitions)) {
+      const securityElement = await StepXmlSerializer.serialize(key, value as { [key: string]: unknown }, doc, element);
 
       if (securityElement) securityDefinitionsElement.appendChild(securityElement);
-    });
+    }
 
     element.appendChild(securityDefinitionsElement);
   }

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -17,7 +17,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../models';
 import {
   aggregateEntity,
   choiceEntity,
@@ -58,7 +57,7 @@ import {
   splitXml,
   throttleXml,
 } from '../../../stubs/eip-xml-snippets';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { XmlFormatter } from '../utils/xml-formatter';
 import { getDocument } from './serializer-test-utils';
 import { ElementType, StepXmlSerializer } from './step-xml-serializer';
@@ -76,9 +75,7 @@ describe('step-xml-serializer tests', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
-    CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
-    CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, catalogsMap.kameletsCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
     domParser = new DOMParser();
     xmlSerializer = new XMLSerializer();
   });
@@ -99,10 +96,10 @@ describe('step-xml-serializer tests', () => {
       { name: 'convertBodyTo', stepString: 'string', attributeName: 'type' },
     ];
 
-    it.each(testCases)('serializes $name with string definition', ({ name, stepString, attributeName }) => {
+    it.each(testCases)('serializes $name with string definition', async ({ name, stepString, attributeName }) => {
       const step = stepString as unknown as ElementType;
 
-      const result = StepXmlSerializer.serialize(name, step, getDocument());
+      const result = await StepXmlSerializer.serialize(name, step, getDocument());
 
       expect(result.tagName).toBe(name);
       expect(result.getAttribute(attributeName)).toBe(stepString);
@@ -110,7 +107,7 @@ describe('step-xml-serializer tests', () => {
   });
 
   describe('Basic serialization', () => {
-    it('serializes a to step with URI', () => {
+    it('serializes a to step with URI', async () => {
       const toStep = {
         uri: 'file:output',
         parameters: {
@@ -120,29 +117,29 @@ describe('step-xml-serializer tests', () => {
         },
       };
 
-      const result = StepXmlSerializer.serialize('to', toStep, getDocument());
+      const result = await StepXmlSerializer.serialize('to', toStep, getDocument());
       expect(result.tagName).toBe('to');
       expect(result.getAttribute('uri')).toBe('file:output?fileName=output.txt&fileExist=Append');
     });
 
-    it('serializes a step with attributes', () => {
+    it('serializes a step with attributes', async () => {
       const logStep = {
         message: 'Hello World',
         logName: 'testLogger',
       };
 
-      const result = StepXmlSerializer.serialize('log', logStep, getDocument());
+      const result = await StepXmlSerializer.serialize('log', logStep, getDocument());
       expect(result.tagName).toBe('log');
       expect(result.getAttribute('message')).toBe('Hello World');
       expect(result.getAttribute('logName')).toBe('testLogger');
     });
 
-    it('serializes a step with nested elements', () => {
+    it('serializes a step with nested elements', async () => {
       const parentStep = {
         steps: [{ to: { uri: 'direct:first' } }, { to: { uri: 'direct:second' } }],
       };
 
-      const result = StepXmlSerializer.serialize('route', parentStep, getDocument());
+      const result = await StepXmlSerializer.serialize('route', parentStep, getDocument());
       expect(result.tagName).toBe('route');
       expect(result.children).toHaveLength(2);
       expect(result.children[0].tagName).toBe('to');
@@ -151,7 +148,7 @@ describe('step-xml-serializer tests', () => {
       expect(result.children[1].getAttribute('uri')).toBe('direct:second');
     });
 
-    it('creates URI from component parameters correctly', () => {
+    it('creates URI from component parameters correctly', async () => {
       const fileStep = {
         uri: 'file:data',
         parameters: {
@@ -161,12 +158,12 @@ describe('step-xml-serializer tests', () => {
         },
       };
 
-      const result = StepXmlSerializer.serialize('from', fileStep, getDocument());
+      const result = await StepXmlSerializer.serialize('from', fileStep, getDocument());
       expect(result.tagName).toBe('from');
       expect(result.getAttribute('uri')).toBe('file:data?noop=true&recursive=true&delete=false');
     });
 
-    it('creates URI from kamelet parameters correctly', () => {
+    it('creates URI from kamelet parameters correctly', async () => {
       const kameletStep = {
         uri: 'kamelet:log-action',
         parameters: {
@@ -176,14 +173,14 @@ describe('step-xml-serializer tests', () => {
         },
       };
 
-      const result = StepXmlSerializer.serialize('from', kameletStep, getDocument());
+      const result = await StepXmlSerializer.serialize('from', kameletStep, getDocument());
       expect(result.tagName).toBe('from');
       expect(result.getAttribute('uri')).toBe('kamelet:log-action?level=DEBUG&multiline=true&showHeaders=false');
     });
 
     it('should not call decorateDoTry when doCatch and doFinally are in the catalog', () => {
       const decorateDoTrySpy = vi.spyOn(StepXmlSerializer, 'decorateDoTry');
-      StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
+      void StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
 
       expect(decorateDoTrySpy).not.toHaveBeenCalled();
       decorateDoTrySpy.mockRestore();
@@ -212,9 +209,9 @@ describe('step-xml-serializer tests', () => {
       { name: 'throttle', xml: throttleXml, entity: throttleEntity },
     ];
 
-    it.each(testCases)('Parse $name', ({ name, xml, entity }) => {
+    it.each(testCases)('Parse $name', async ({ name, xml, entity }) => {
       const document = domParser.parseFromString('', 'application/xml');
-      const result = StepXmlSerializer.serialize(name, entity as unknown as ElementType, document);
+      const result = await StepXmlSerializer.serialize(name, entity as unknown as ElementType, document);
       const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
       const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
       const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
@@ -229,13 +226,13 @@ describe('step-xml-serializer tests', () => {
       delete catalogsMap.modelCatalogMap['doTry'].properties.doFinally;
 
       expect(catalogsMap.modelCatalogMap['doTry'].properties.doCatch).toBeUndefined();
-      CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+      setupDynamicCatalogRegistry(catalogsMap);
     });
 
-    it('should call decorateDoTry when doCatch and doFinally are not in the catalog', () => {
+    it('should call decorateDoTry when doCatch and doFinally are not in the catalog', async () => {
       const decorateDoTrySpy = vi.spyOn(StepXmlSerializer, 'decorateDoTry');
       const document = getDocument();
-      StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, document);
+      await StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, document);
 
       expect(decorateDoTrySpy).toHaveBeenCalledTimes(1);
       expect(decorateDoTrySpy).toHaveBeenCalledWith(
@@ -247,8 +244,8 @@ describe('step-xml-serializer tests', () => {
       decorateDoTrySpy.mockRestore();
     });
 
-    it('should decorate doTry element correctly', () => {
-      const result = StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
+    it('should decorate doTry element correctly', async () => {
+      const result = await StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
       const doCatchElement = result.getElementsByTagName('doCatch')[0];
 
       expect(doCatchElement).toBeDefined();
@@ -256,20 +253,20 @@ describe('step-xml-serializer tests', () => {
     });
   });
 
-  it('should serialize unknown type with non-object value', () => {
+  it('should serialize unknown type with non-object value', async () => {
     const unknownStep = {
       someAttribute: 'value',
       anotherAttribute: 123,
     };
 
-    const result = StepXmlSerializer.serialize('unknownProcessor', unknownStep, getDocument());
+    const result = await StepXmlSerializer.serialize('unknownProcessor', unknownStep, getDocument());
 
     expect(result.tagName).toBe('unknownProcessor');
     expect(result.getAttribute('someAttribute')).toBe('value');
     expect(result.getAttribute('anotherAttribute')).toBe('123');
   });
 
-  it('should serialize object type with javaType string', () => {
+  it('should serialize object type with javaType string', async () => {
     const step = {
       name: 'myHeader',
       expression: {
@@ -279,7 +276,7 @@ describe('step-xml-serializer tests', () => {
       },
     };
 
-    const result = StepXmlSerializer.serialize('setHeader', step, getDocument());
+    const result = await StepXmlSerializer.serialize('setHeader', step, getDocument());
 
     expect(result.tagName).toBe('setHeader');
     expect(result.getAttribute('name')).toBe('myHeader');
@@ -288,23 +285,23 @@ describe('step-xml-serializer tests', () => {
     expect(constantElement.textContent).toBe('test value');
   });
 
-  it('should return uri when componentName is undefined', () => {
+  it('should return uri when componentName is undefined', async () => {
     const step = {
       uri: 'unknown:component',
     };
 
-    const result = StepXmlSerializer.createUriFromParameters(step);
+    const result = await StepXmlSerializer.createUriFromParameters(step);
 
     expect(result).toBe('unknown:component');
   });
 
-  it('should handle saga with compensation as attribute in catalog', () => {
+  it('should handle saga with compensation as attribute in catalog', async () => {
     const sagaStep = {
       compensation: 'direct:compensation',
       completion: 'direct:completion',
     };
 
-    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+    const result = await StepXmlSerializer.serialize('saga', sagaStep, getDocument());
 
     expect(result.tagName).toBe('saga');
     expect(result.getAttribute('compensation')).toBe('direct:compensation');
@@ -320,14 +317,14 @@ describe('step-xml-serializer tests', () => {
     const originalSagaProps = { ...catalogsMap.modelCatalogMap['saga'].properties };
     delete catalogsMap.modelCatalogMap['saga'].properties.compensation;
     delete catalogsMap.modelCatalogMap['saga'].properties.completion;
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
 
     const sagaStep = {
       compensation: 'direct:compensation',
       completion: 'direct:completion',
     };
 
-    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+    const result = await StepXmlSerializer.serialize('saga', sagaStep, getDocument());
 
     expect(result.tagName).toBe('saga');
     const compensationElement = result.getElementsByTagName('compensation')[0];
@@ -339,7 +336,7 @@ describe('step-xml-serializer tests', () => {
 
     // Restore original properties
     catalogsMap.modelCatalogMap['saga'].properties = originalSagaProps;
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it('should serialize saga nested elements when compensation/completion are legacy object-shaped values', async () => {
@@ -348,7 +345,7 @@ describe('step-xml-serializer tests', () => {
     const originalSagaProps = { ...catalogsMap.modelCatalogMap['saga'].properties };
     delete catalogsMap.modelCatalogMap['saga'].properties.compensation;
     delete catalogsMap.modelCatalogMap['saga'].properties.completion;
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
 
     // Legacy model represented these as { uri } objects rather than plain strings
     const sagaStep = {
@@ -356,7 +353,7 @@ describe('step-xml-serializer tests', () => {
       completion: { uri: 'direct:completion' },
     } as unknown as Parameters<typeof StepXmlSerializer.serialize>[1];
 
-    const result = StepXmlSerializer.serialize('saga', sagaStep, getDocument());
+    const result = await StepXmlSerializer.serialize('saga', sagaStep, getDocument());
 
     const compensationElement = result.getElementsByTagName('compensation')[0];
     const completionElement = result.getElementsByTagName('completion')[0];
@@ -365,6 +362,6 @@ describe('step-xml-serializer tests', () => {
 
     // Restore original properties
     catalogsMap.modelCatalogMap['saga'].properties = originalSagaProps;
-    CamelCatalogService.setCatalogKey(CatalogKind.Processor, catalogsMap.modelCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 });

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -559,4 +559,48 @@ describe('step-xml-serializer tests', () => {
     expect(result.tagName).toBe('log');
     expect(result.getAttribute('message')).toBe('nested');
   });
+
+  it('serializes unknown type with an object-valued child as a nested element', async () => {
+    // Exercises the typeof value === 'object' branch in serializeUnknownType (line 102-103):
+    // when a processor has no catalog definition and one of its values is itself an object,
+    // it must be recursed into as a child element rather than stringified as an attribute.
+    const unknownStep = {
+      primitiveAttr: 'hello',
+      nestedObj: { innerAttr: 'world' },
+    };
+
+    const result = await StepXmlSerializer.serialize(
+      'unknownProcessor',
+      unknownStep as unknown as ElementType,
+      getDocument(),
+    );
+
+    expect(result.tagName).toBe('unknownProcessor');
+    expect(result.getAttribute('primitiveAttr')).toBe('hello');
+    const nested = result.getElementsByTagName('nestedObj')[0];
+    expect(nested).toBeDefined();
+    expect(nested.getAttribute('innerAttr')).toBe('world');
+  });
+
+  it('wraps allowableValues children inside a parent element when childName differs from key', async () => {
+    // Exercises the childName !== key branch in serializeArrayType (lines 164-166):
+    // ARRAY_TYPE_NAMES maps 'allowableValues' → 'value', so the array items are serialized
+    // as <value> children wrapped inside an <allowableValues> container element.
+    // `param` is the real catalog processor that exposes this property.
+    const paramStep = {
+      name: 'myParam',
+      allowableValues: ['one', 'two', 'three'],
+    };
+
+    const result = await StepXmlSerializer.serialize('param', paramStep as unknown as ElementType, getDocument());
+
+    expect(result.tagName).toBe('param');
+    const container = result.getElementsByTagName('allowableValues')[0];
+    expect(container).toBeDefined();
+    const valueEls = container.getElementsByTagName('value');
+    expect(valueEls).toHaveLength(3);
+    expect(valueEls[0].textContent).toBe('one');
+    expect(valueEls[1].textContent).toBe('two');
+    expect(valueEls[2].textContent).toBe('three');
+  });
 });

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.test.ts
@@ -17,6 +17,11 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
+import { CamelComponentsProvider } from '../../../dynamic-catalog/providers/camel-components.provider';
+import { CamelKameletsProvider } from '../../../dynamic-catalog/providers/camel-kamelets.provider';
+import { CatalogKind } from '../../../models';
 import {
   aggregateEntity,
   choiceEntity,
@@ -80,143 +85,138 @@ describe('step-xml-serializer tests', () => {
     xmlSerializer = new XMLSerializer();
   });
 
-  describe('serialize steps with string definitions', () => {
-    const testCases = [
-      { name: 'to', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
-      { name: 'toD', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
-      { name: 'log', stepString: 'message', attributeName: 'message' },
-      { name: 'customLoadBalancer', stepString: 'ref', attributeName: 'ref' },
-      { name: 'setExchangePattern', stepString: 'a*=b', attributeName: 'pattern' },
-      { name: 'routeBuilder', stepString: 'customBuilder', attributeName: 'ref' },
-      { name: 'removeVariable', stepString: 'variable', attributeName: 'name' },
-      { name: 'removeProperty', stepString: 'variable', attributeName: 'name' },
-      { name: 'removeProperties', stepString: 'a*', attributeName: 'pattern' },
-      { name: 'removeHeaders', stepString: 'a*', attributeName: 'pattern' },
-      { name: 'removeHeader', stepString: 'header', attributeName: 'name' },
-      { name: 'convertBodyTo', stepString: 'string', attributeName: 'type' },
-    ];
-
-    it.each(testCases)('serializes $name with string definition', async ({ name, stepString, attributeName }) => {
+  const STRING_STEP_DEFINITIONS_TEST_CASES = [
+    { name: 'to', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
+    { name: 'toD', stepString: 'file:output?fileName=output.txt&fileExist=Append', attributeName: 'uri' },
+    { name: 'log', stepString: 'message', attributeName: 'message' },
+    { name: 'customLoadBalancer', stepString: 'ref', attributeName: 'ref' },
+    { name: 'setExchangePattern', stepString: 'a*=b', attributeName: 'pattern' },
+    { name: 'routeBuilder', stepString: 'customBuilder', attributeName: 'ref' },
+    { name: 'removeVariable', stepString: 'variable', attributeName: 'name' },
+    { name: 'removeProperty', stepString: 'variable', attributeName: 'name' },
+    { name: 'removeProperties', stepString: 'a*', attributeName: 'pattern' },
+    { name: 'removeHeaders', stepString: 'a*', attributeName: 'pattern' },
+    { name: 'removeHeader', stepString: 'header', attributeName: 'name' },
+    { name: 'convertBodyTo', stepString: 'string', attributeName: 'type' },
+  ];
+  it.each(STRING_STEP_DEFINITIONS_TEST_CASES)(
+    'serializes $name with string definition',
+    async ({ name, stepString, attributeName }) => {
       const step = stepString as unknown as ElementType;
 
       const result = await StepXmlSerializer.serialize(name, step, getDocument());
 
       expect(result.tagName).toBe(name);
       expect(result.getAttribute(attributeName)).toBe(stepString);
-    });
+    },
+  );
+
+  it('serializes a to step with URI', async () => {
+    const toStep = {
+      uri: 'file:output',
+      parameters: {
+        fileName: 'output.txt',
+        directoryName: 'output',
+        fileExist: 'Append',
+      },
+    };
+
+    const result = await StepXmlSerializer.serialize('to', toStep, getDocument());
+    expect(result.tagName).toBe('to');
+    expect(result.getAttribute('uri')).toBe('file:output?fileName=output.txt&fileExist=Append');
   });
 
-  describe('Basic serialization', () => {
-    it('serializes a to step with URI', async () => {
-      const toStep = {
-        uri: 'file:output',
-        parameters: {
-          fileName: 'output.txt',
-          directoryName: 'output',
-          fileExist: 'Append',
-        },
-      };
+  it('serializes a step with attributes', async () => {
+    const logStep = {
+      message: 'Hello World',
+      logName: 'testLogger',
+    };
 
-      const result = await StepXmlSerializer.serialize('to', toStep, getDocument());
-      expect(result.tagName).toBe('to');
-      expect(result.getAttribute('uri')).toBe('file:output?fileName=output.txt&fileExist=Append');
-    });
-
-    it('serializes a step with attributes', async () => {
-      const logStep = {
-        message: 'Hello World',
-        logName: 'testLogger',
-      };
-
-      const result = await StepXmlSerializer.serialize('log', logStep, getDocument());
-      expect(result.tagName).toBe('log');
-      expect(result.getAttribute('message')).toBe('Hello World');
-      expect(result.getAttribute('logName')).toBe('testLogger');
-    });
-
-    it('serializes a step with nested elements', async () => {
-      const parentStep = {
-        steps: [{ to: { uri: 'direct:first' } }, { to: { uri: 'direct:second' } }],
-      };
-
-      const result = await StepXmlSerializer.serialize('route', parentStep, getDocument());
-      expect(result.tagName).toBe('route');
-      expect(result.children).toHaveLength(2);
-      expect(result.children[0].tagName).toBe('to');
-      expect(result.children[0].getAttribute('uri')).toBe('direct:first');
-      expect(result.children[1].tagName).toBe('to');
-      expect(result.children[1].getAttribute('uri')).toBe('direct:second');
-    });
-
-    it('creates URI from component parameters correctly', async () => {
-      const fileStep = {
-        uri: 'file:data',
-        parameters: {
-          noop: true,
-          recursive: true,
-          delete: false,
-        },
-      };
-
-      const result = await StepXmlSerializer.serialize('from', fileStep, getDocument());
-      expect(result.tagName).toBe('from');
-      expect(result.getAttribute('uri')).toBe('file:data?noop=true&recursive=true&delete=false');
-    });
-
-    it('creates URI from kamelet parameters correctly', async () => {
-      const kameletStep = {
-        uri: 'kamelet:log-action',
-        parameters: {
-          level: 'DEBUG',
-          multiline: true,
-          showHeaders: false,
-        },
-      };
-
-      const result = await StepXmlSerializer.serialize('from', kameletStep, getDocument());
-      expect(result.tagName).toBe('from');
-      expect(result.getAttribute('uri')).toBe('kamelet:log-action?level=DEBUG&multiline=true&showHeaders=false');
-    });
-
-    it('should not call decorateDoTry when doCatch and doFinally are in the catalog', () => {
-      const decorateDoTrySpy = vi.spyOn(StepXmlSerializer, 'decorateDoTry');
-      void StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
-
-      expect(decorateDoTrySpy).not.toHaveBeenCalled();
-      decorateDoTrySpy.mockRestore();
-    });
+    const result = await StepXmlSerializer.serialize('log', logStep, getDocument());
+    expect(result.tagName).toBe('log');
+    expect(result.getAttribute('message')).toBe('Hello World');
+    expect(result.getAttribute('logName')).toBe('testLogger');
   });
 
-  describe('Serialize EIP elements', () => {
-    const testCases = [
-      { name: 'aggregate', xml: aggregateXml, entity: aggregateEntity },
-      { name: 'circuitBreaker', xml: circuitBreakerXml, entity: circuitBreakerEntity },
-      { name: 'filter', xml: filterXml, entity: filterEntity },
-      { name: 'loadBalance', xml: loadBalanceXml, entity: loadBalanceEntity },
-      { name: 'loop', xml: loopXml, entity: loopEntity },
-      { name: 'multicast', xml: multicastXml, entity: multicastEntity },
-      { name: 'pipeline', xml: pipelineXml, entity: pipelineEntity },
-      { name: 'resequence', xml: resequenceXml, entity: resequenceEntity },
-      { name: 'saga', xml: sagaXml, entity: sagaEntity },
-      { name: 'split', xml: splitXml, entity: splitEntity },
-      { name: 'choice', xml: choiceXml, entity: choiceEntity },
-      { name: 'doTry', xml: doTryXml, entity: doTryEntity },
-      { name: 'errorHandler', xml: deadLetterChannelXml, entity: deadLetterChannelEntity },
-      { name: 'enrich', xml: enrichXml, entity: enrichEntity },
-      { name: 'dynamicRouter', xml: dynamicRouterXml, entity: dynamicRouterEntity },
-      { name: 'recipientList', xml: recipientListXml, entity: recipientListEntity },
-      { name: 'routingSlip', xml: routingSlipXml, entity: routingSlipEntity },
-      { name: 'throttle', xml: throttleXml, entity: throttleEntity },
-    ];
+  it('serializes a step with nested elements', async () => {
+    const parentStep = {
+      steps: [{ to: { uri: 'direct:first' } }, { to: { uri: 'direct:second' } }],
+    };
 
-    it.each(testCases)('Parse $name', async ({ name, xml, entity }) => {
-      const document = domParser.parseFromString('', 'application/xml');
-      const result = await StepXmlSerializer.serialize(name, entity as unknown as ElementType, document);
-      const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
-      const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
-      const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
-      expect(resultString).toEqual(expectedString);
-    });
+    const result = await StepXmlSerializer.serialize('route', parentStep, getDocument());
+    expect(result.tagName).toBe('route');
+    expect(result.children).toHaveLength(2);
+    expect(result.children[0].tagName).toBe('to');
+    expect(result.children[0].getAttribute('uri')).toBe('direct:first');
+    expect(result.children[1].tagName).toBe('to');
+    expect(result.children[1].getAttribute('uri')).toBe('direct:second');
+  });
+
+  it('creates URI from component parameters correctly', async () => {
+    const fileStep = {
+      uri: 'file:data',
+      parameters: {
+        noop: true,
+        recursive: true,
+        delete: false,
+      },
+    };
+
+    const result = await StepXmlSerializer.serialize('from', fileStep, getDocument());
+    expect(result.tagName).toBe('from');
+    expect(result.getAttribute('uri')).toBe('file:data?noop=true&recursive=true&delete=false');
+  });
+
+  it('creates URI from kamelet parameters correctly', async () => {
+    const kameletStep = {
+      uri: 'kamelet:log-action',
+      parameters: {
+        level: 'DEBUG',
+        multiline: true,
+        showHeaders: false,
+      },
+    };
+
+    const result = await StepXmlSerializer.serialize('from', kameletStep, getDocument());
+    expect(result.tagName).toBe('from');
+    expect(result.getAttribute('uri')).toBe('kamelet:log-action?level=DEBUG&multiline=true&showHeaders=false');
+  });
+
+  it('should not call decorateDoTry when doCatch and doFinally are in the catalog', () => {
+    const decorateDoTrySpy = vi.spyOn(StepXmlSerializer, 'decorateDoTry');
+    void StepXmlSerializer.serialize('doTry', doTryEntity as unknown as ElementType, getDocument());
+
+    expect(decorateDoTrySpy).not.toHaveBeenCalled();
+    decorateDoTrySpy.mockRestore();
+  });
+
+  const EIP_DEFINITIONS_TEST_CASES = [
+    { name: 'aggregate', xml: aggregateXml, entity: aggregateEntity },
+    { name: 'circuitBreaker', xml: circuitBreakerXml, entity: circuitBreakerEntity },
+    { name: 'filter', xml: filterXml, entity: filterEntity },
+    { name: 'loadBalance', xml: loadBalanceXml, entity: loadBalanceEntity },
+    { name: 'loop', xml: loopXml, entity: loopEntity },
+    { name: 'multicast', xml: multicastXml, entity: multicastEntity },
+    { name: 'pipeline', xml: pipelineXml, entity: pipelineEntity },
+    { name: 'resequence', xml: resequenceXml, entity: resequenceEntity },
+    { name: 'saga', xml: sagaXml, entity: sagaEntity },
+    { name: 'split', xml: splitXml, entity: splitEntity },
+    { name: 'choice', xml: choiceXml, entity: choiceEntity },
+    { name: 'doTry', xml: doTryXml, entity: doTryEntity },
+    { name: 'errorHandler', xml: deadLetterChannelXml, entity: deadLetterChannelEntity },
+    { name: 'enrich', xml: enrichXml, entity: enrichEntity },
+    { name: 'dynamicRouter', xml: dynamicRouterXml, entity: dynamicRouterEntity },
+    { name: 'recipientList', xml: recipientListXml, entity: recipientListEntity },
+    { name: 'routingSlip', xml: routingSlipXml, entity: routingSlipEntity },
+    { name: 'throttle', xml: throttleXml, entity: throttleEntity },
+  ];
+  it.each(EIP_DEFINITIONS_TEST_CASES)('Parse $name', async ({ name, xml, entity }) => {
+    const document = domParser.parseFromString('', 'application/xml');
+    const result = await StepXmlSerializer.serialize(name, entity as unknown as ElementType, document);
+    const expected = domParser.parseFromString(xml, 'application/xml').documentElement;
+    const resultString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(result)));
+    const expectedString = normalizeLineEndings(XmlFormatter.formatXml(xmlSerializer.serializeToString(expected)));
+    expect(resultString).toEqual(expectedString);
   });
 
   describe('Test with simulated old catalog', () => {
@@ -283,16 +283,6 @@ describe('step-xml-serializer tests', () => {
     const constantElement = result.getElementsByTagName('constant')[0];
     expect(constantElement).toBeDefined();
     expect(constantElement.textContent).toBe('test value');
-  });
-
-  it('should return uri when componentName is undefined', async () => {
-    const step = {
-      uri: 'unknown:component',
-    };
-
-    const result = await StepXmlSerializer.createUriFromParameters(step);
-
-    expect(result).toBe('unknown:component');
   });
 
   it('should handle saga with compensation as attribute in catalog', async () => {
@@ -363,5 +353,210 @@ describe('step-xml-serializer tests', () => {
     // Restore original properties
     catalogsMap.modelCatalogMap['saga'].properties = originalSagaProps;
     setupDynamicCatalogRegistry(catalogsMap);
+  });
+
+  describe('serializeTextType (element kind with javaType java.lang.String)', () => {
+    it('serializes an element-kind String property as a child text element', async () => {
+      // beanFactory.script has kind=element, javaType=java.lang.String in the real catalog
+      const beanStep = {
+        name: 'myBean',
+        type: 'com.example.MyBean',
+        script: 'return body;',
+      };
+
+      const result = await StepXmlSerializer.serialize('beanFactory', beanStep, getDocument());
+
+      expect(result.tagName).toBe('beanFactory');
+      const scriptEl = result.getElementsByTagName('script')[0];
+      expect(scriptEl).toBeDefined();
+      expect(scriptEl.textContent).toBe('return body;');
+    });
+
+    it('does not create script child element when script is absent', async () => {
+      const beanStep = { name: 'myBean', type: 'com.example.MyBean' };
+
+      const result = await StepXmlSerializer.serialize('beanFactory', beanStep, getDocument());
+
+      expect(result.getElementsByTagName('script')).toHaveLength(0);
+    });
+  });
+
+  it('serializes exception list as individual string child elements', async () => {
+    // doCatch has `exception` with javaType=java.util.List<java.lang.String>, kind=element
+    const doCatchStep = {
+      exception: ['java.lang.RuntimeException', 'java.io.IOException'],
+      steps: [],
+    };
+
+    const result = await StepXmlSerializer.serialize('doCatch', doCatchStep, getDocument());
+
+    const exceptionEls = result.getElementsByTagName('exception');
+    expect(exceptionEls).toHaveLength(2);
+    expect(exceptionEls[0].textContent).toBe('java.lang.RuntimeException');
+    expect(exceptionEls[1].textContent).toBe('java.io.IOException');
+  });
+
+  it('does not serialize Map-typed element properties', async () => {
+    // beanFactory has `properties` with javaType=java.util.Map<java.lang.String, java.lang.Object>
+    const beanStep = {
+      name: 'myBean',
+      type: 'com.example.MyBean',
+      properties: { key1: 'value1' },
+    };
+
+    const result = await StepXmlSerializer.serialize('beanFactory', beanStep, getDocument());
+
+    expect(result.tagName).toBe('beanFactory');
+    expect(result.getAttribute('name')).toBe('myBean');
+    // The Map property must not be serialized as a child element
+    expect(result.getElementsByTagName('properties')).toHaveLength(0);
+  });
+
+  describe('serializeSteps edge cases', () => {
+    it('returns empty array for undefined steps', async () => {
+      const result = await StepXmlSerializer.serializeSteps(undefined as unknown as ElementType[], getDocument());
+
+      expect(result).toEqual([]);
+    });
+
+    it('skips null/undefined entries inside the steps array', async () => {
+      const steps = [null, undefined, { to: { uri: 'direct:valid' } }] as unknown as ElementType[];
+
+      const result = await StepXmlSerializer.serializeSteps(steps, getDocument());
+
+      expect(result).toHaveLength(1);
+      expect(result[0].tagName).toBe('to');
+      expect(result[0].getAttribute('uri')).toBe('direct:valid');
+    });
+  });
+
+  describe('createUriFromParameters', () => {
+    it('should return uri when componentName is undefined', async () => {
+      const step = {
+        uri: 'unknown:component',
+      };
+
+      const result = await StepXmlSerializer.createUriFromParameters(step);
+
+      expect(result).toBe('unknown:component');
+    });
+
+    it('returns plain uri when kamelet definition exists but has no parameters', async () => {
+      // kamelet is present in catalog, no parameters → returns bare URI
+      const step = { uri: 'kamelet:log-action' };
+
+      const result = await StepXmlSerializer.createUriFromParameters(step);
+
+      expect(result).toBe('kamelet:log-action');
+    });
+
+    it('uses kamelet component syntax when kamelet name is not in the Kamelet catalog', async () => {
+      // Use a kamelet: URI whose name does not exist in the Kamelet catalog.
+      // The code falls through to the `kamelet` Component which has syntax kamelet:templateId/routeId.
+      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+      // Remove the specific kamelet to force fallback to the kamelet component
+      const originalKameletsCatalog = { ...catalogsMap.kameletsCatalogMap };
+      delete catalogsMap.kameletsCatalogMap['log-action'];
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Kamelet,
+        new DynamicCatalog(new CamelKameletsProvider(catalogsMap.kameletsCatalogMap)),
+      );
+
+      const step = {
+        uri: 'kamelet:log-action',
+        parameters: { level: 'DEBUG' },
+      };
+
+      const result = await StepXmlSerializer.createUriFromParameters(step);
+
+      // The kamelet component syntax resolves templateId/routeId from parameters;
+      // since neither key is in our parameters the path still appends query params.
+      expect(result).toContain('level=DEBUG');
+
+      // Restore
+      catalogsMap.kameletsCatalogMap = originalKameletsCatalog;
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Kamelet,
+        new DynamicCatalog(new CamelKameletsProvider(catalogsMap.kameletsCatalogMap)),
+      );
+    });
+
+    it('uses fallback getUriStringFromParameters when component has no syntax but step has parameters', async () => {
+      // Mutate the file component's syntax in-place to undefined to trigger the fallback at line 271
+      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+      const fileComponent = catalogsMap.componentCatalogMap['file'].component;
+      const originalSyntax = fileComponent.syntax;
+      (fileComponent as unknown as Record<string, unknown>).syntax = undefined;
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Component,
+        new DynamicCatalog(new CamelComponentsProvider(catalogsMap.componentCatalogMap)),
+      );
+
+      const step = {
+        uri: 'file:data',
+        parameters: { noop: true },
+      };
+
+      const result = await StepXmlSerializer.createUriFromParameters(step);
+
+      expect(result).toContain('file:data');
+      expect(result).toContain('noop=true');
+
+      // Restore
+      (fileComponent as unknown as Record<string, unknown>).syntax = originalSyntax;
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Component,
+        new DynamicCatalog(new CamelComponentsProvider(catalogsMap.componentCatalogMap)),
+      );
+    });
+
+    it('returns bare uri when component has no syntax and step has no parameters', async () => {
+      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+      const fileComponent = catalogsMap.componentCatalogMap['file'].component;
+      const originalSyntax = fileComponent.syntax;
+      (fileComponent as unknown as Record<string, unknown>).syntax = undefined;
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Component,
+        new DynamicCatalog(new CamelComponentsProvider(catalogsMap.componentCatalogMap)),
+      );
+
+      const step = { uri: 'file:data' };
+
+      const result = await StepXmlSerializer.createUriFromParameters(step);
+
+      expect(result).toBe('file:data');
+
+      // Restore
+      (fileComponent as unknown as Record<string, unknown>).syntax = originalSyntax;
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Component,
+        new DynamicCatalog(new CamelComponentsProvider(catalogsMap.componentCatalogMap)),
+      );
+    });
+  });
+
+  it('serializes loadBalance by finding the matching oneOf key when the primary key is absent', async () => {
+    // `loadBalance` has `loadBalancerType` with oneOf: [customLoadBalancer, failoverLoadBalancer, ...]
+    // When processor.loadBalancerType is undefined but processor.customLoadBalancer is set,
+    // the oneOf lookup branch is exercised.
+    const loadBalanceStep = {
+      customLoadBalancer: { ref: 'myBalancer' },
+    };
+
+    const result = await StepXmlSerializer.serialize('loadBalance', loadBalanceStep, getDocument());
+
+    expect(result.tagName).toBe('loadBalance');
+    expect(result.getElementsByTagName('customLoadBalancer')).toHaveLength(1);
+  });
+
+  it('unwraps a self-nested element before serializing', async () => {
+    // When camelElement[elementName] exists, the code reassigns camelElement to the nested value.
+    // Simulate this: serialize 'log' but pass { log: { message: 'nested' } }
+    const step = { log: { message: 'nested' } } as unknown as ElementType;
+
+    const result = await StepXmlSerializer.serialize('log', step, getDocument());
+
+    expect(result.tagName).toBe('log');
+    expect(result.getAttribute('message')).toBe('nested');
   });
 });

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -16,7 +16,8 @@
 
 import { DoTry } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind, ICamelProcessorProperty } from '../../../models';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CatalogKind, ICamelProcessorProperty } from '../../../models';
 import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
 import { CamelUriHelper, ParsedParameters } from '../../../utils';
 import { ARRAY_TYPE_NAMES, PROCESSOR_NAMES } from '../utils/xml-utils';
@@ -25,7 +26,7 @@ import { ExpressionXmlSerializer } from './expression-xml-serializer';
 export type ElementType = { [key: string]: unknown; steps?: ElementType[] };
 
 export class StepXmlSerializer {
-  static serializeObjectProperties(
+  static async serializeObjectProperties(
     element: Element,
     doc: Document,
     processor: ElementType,
@@ -39,21 +40,26 @@ export class StepXmlSerializer {
           break;
 
         case 'attribute':
-          this.serializeAttribute(element, key, processor, props, processor[key]);
+          await this.serializeAttribute(element, key, processor, props, processor[key]);
           break;
 
         case 'expression':
-          ExpressionXmlSerializer.serialize(key, processor, props.oneOf, doc, element, routeParent);
+          await ExpressionXmlSerializer.serialize(key, processor, props.oneOf, doc, element, routeParent);
           break;
 
         case 'element':
-          this.serializeElementType(element, key, processor, props, doc, routeParent);
+          await this.serializeElementType(element, key, processor, props, doc, routeParent);
           break;
       }
     }
   }
 
-  static serialize(elementName: string, camelElement: ElementType, doc: Document, parent?: Element): Element {
+  static async serialize(
+    elementName: string,
+    camelElement: ElementType,
+    doc: Document,
+    parent?: Element,
+  ): Promise<Element> {
     const element = doc.createElement(elementName);
 
     //unidentified might be when a new element is added from the form
@@ -64,21 +70,22 @@ export class StepXmlSerializer {
     }
     const routeParent = elementName === 'route' ? element : parent;
 
-    const properties = CamelCatalogService.getComponent(
+    const processorDefinition = await DynamicCatalogRegistry.get().getEntity(
       CatalogKind.Processor,
       PROCESSOR_NAMES.get(elementName) ?? elementName,
-    )?.properties;
+    );
+    const properties = processorDefinition?.properties;
 
     if (!properties) {
-      this.serializeUnknownType(element, camelElement, doc, routeParent);
+      await this.serializeUnknownType(element, camelElement, doc, routeParent);
       return element;
     }
 
-    this.serializeObjectProperties(element, doc, camelElement, properties, routeParent);
+    await this.serializeObjectProperties(element, doc, camelElement, properties, routeParent);
 
     // process doTry element only when doCatch and doFinally are not present in the catalog
     if (elementName === 'doTry' && !properties['doCatch'] && !properties['doFinally']) {
-      this.decorateDoTry(camelElement as DoTry, element, doc);
+      await this.decorateDoTry(camelElement as DoTry, element, doc);
     }
 
     // saga compensation/completion: support both old (nested elements) and new (attributes) formats
@@ -89,10 +96,10 @@ export class StepXmlSerializer {
     return element;
   }
 
-  private static serializeUnknownType(element: Element, obj: ElementType, doc: Document, routeParent?: Element) {
+  private static async serializeUnknownType(element: Element, obj: ElementType, doc: Document, routeParent?: Element) {
     for (const [key, value] of Object.entries(obj)) {
       if (typeof value === 'object') {
-        const childElement = this.serialize(key, value as ElementType, doc, routeParent);
+        const childElement = await this.serialize(key, value as ElementType, doc, routeParent);
         element.appendChild(childElement);
       } else {
         element.setAttribute(key, String(value));
@@ -100,7 +107,7 @@ export class StepXmlSerializer {
     }
   }
 
-  private static serializeElementType(
+  private static async serializeElementType(
     element: Element,
     key: string,
     processor: ElementType,
@@ -111,13 +118,13 @@ export class StepXmlSerializer {
     // skip serialization of map types usually they are handled differently
     if (properties.javaType.includes('java.util.Map')) return;
     if (properties.type === 'array') {
-      this.serializeArrayType(element, key, processor, properties, doc, routeParent);
+      await this.serializeArrayType(element, key, processor, properties, doc, routeParent);
     } else {
-      this.serializeObjectType(element, key, processor, properties, doc, routeParent);
+      await this.serializeObjectType(element, key, processor, properties, doc, routeParent);
     }
   }
 
-  private static serializeArrayType(
+  private static async serializeArrayType(
     element: Element,
     key: string,
     processor: ElementType,
@@ -126,7 +133,7 @@ export class StepXmlSerializer {
     routeParent?: Element,
   ) {
     if (key === 'outputs' && processor['steps']) {
-      const steps = this.serializeSteps(processor['steps'], doc, routeParent);
+      const steps = await this.serializeSteps(processor['steps'], doc, routeParent);
       element.append(...steps);
       return;
     }
@@ -137,16 +144,18 @@ export class StepXmlSerializer {
     const childName = ARRAY_TYPE_NAMES.get(key) ?? key;
     const isStringList = props.javaType === 'java.util.List<java.lang.String>';
 
-    const children = (value as ElementType[]).map((v) => {
-      let childElement;
-      if (isStringList) {
-        childElement = doc.createElement(childName);
-        childElement.textContent = v as unknown as string;
-        return childElement;
-      }
+    const children = await Promise.all(
+      (value as ElementType[]).map(async (v) => {
+        let childElement;
+        if (isStringList) {
+          childElement = doc.createElement(childName);
+          childElement.textContent = v as unknown as string;
+          return childElement;
+        }
 
-      return this.serialize(childName, v, doc, routeParent);
-    });
+        return this.serialize(childName, v, doc, routeParent);
+      }),
+    );
 
     //  Append children based on naming convention
     if (childName === key) {
@@ -158,7 +167,7 @@ export class StepXmlSerializer {
     }
   }
 
-  private static serializeObjectType(
+  private static async serializeObjectType(
     element: Element,
     key: string,
     processor: ElementType,
@@ -173,12 +182,17 @@ export class StepXmlSerializer {
 
     const childElementKey = processor[key] ? key : properties.oneOf?.find((key) => processor[key] !== undefined);
     if (childElementKey) {
-      const childElement = this.serialize(childElementKey, processor[childElementKey] as ElementType, doc, routeParent);
+      const childElement = await this.serialize(
+        childElementKey,
+        processor[childElementKey] as ElementType,
+        doc,
+        routeParent,
+      );
       element.appendChild(childElement);
     }
   }
 
-  static serializeSteps(steps: ElementType[], doc: Document, routeParent?: Element): Element[] {
+  static async serializeSteps(steps: ElementType[], doc: Document, routeParent?: Element): Promise<Element[]> {
     if (!steps) return [];
     const stepElements: Element[] = [];
 
@@ -186,50 +200,70 @@ export class StepXmlSerializer {
       // in case of empty step
       if (!step) continue;
 
-      Object.entries(step).forEach(([stepKey, stepValue]) => {
-        const step = stepValue as ElementType;
-        const stepElement = this.serialize(stepKey, step, doc, routeParent);
-        if (step.uri) {
-          const uri = this.createUriFromParameters(step);
+      for (const [stepKey, stepValue] of Object.entries(step)) {
+        const stepObj = stepValue as ElementType;
+        const stepElement = await this.serialize(stepKey, stepObj, doc, routeParent);
+        if (stepObj.uri) {
+          const uri = await this.createUriFromParameters(stepObj);
           stepElement.setAttribute('uri', uri);
         }
         stepElements.push(stepElement);
-      });
+      }
     }
 
     return stepElements;
   }
 
-  static createUriFromParameters(step: ElementType): string {
+  static async createUriFromParameters(step: ElementType): Promise<string> {
     const uri = step.uri as string;
     const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup('from', step);
     if (camelElementLookup.componentName === undefined) {
       return uri;
     }
 
-    const catalogLookup = CamelCatalogService.getCatalogLookup(camelElementLookup.componentName);
-    if (
-      catalogLookup.catalogKind === CatalogKind.Component &&
-      catalogLookup.definition?.component.syntax !== undefined
-    ) {
-      const requiredParameters: string[] = [];
-      const defaultValues: ParsedParameters = {};
-      if (catalogLookup.definition?.properties !== undefined) {
-        Object.entries(catalogLookup.definition.properties).forEach(([key, value]) => {
+    const componentName = camelElementLookup.componentName;
+    if (componentName.startsWith('kamelet:')) {
+      const kameletName = componentName.replace('kamelet:', '');
+      const kameletDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Kamelet, kameletName);
+      if (kameletDefinition) {
+        // Kamelets don't use syntax-based URI building
+        if (step.parameters && Object.keys(step.parameters).length > 0) {
+          return CamelUriHelper.getUriStringFromParameters(uri, '', step.parameters as ParsedParameters);
+        }
+        return uri;
+      }
+      // fallback to kamelet component
+      const kameletComponentDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, 'kamelet');
+      if (kameletComponentDefinition?.component.syntax !== undefined) {
+        const requiredParameters: string[] = [];
+        const defaultValues: ParsedParameters = {};
+        Object.entries(kameletComponentDefinition.properties ?? {}).forEach(([key, value]) => {
           if (value.required) requiredParameters.push(key);
           if (value.defaultValue) defaultValues[key] = value.defaultValue;
         });
+        return CamelUriHelper.getUriStringFromParameters(
+          uri,
+          kameletComponentDefinition.component.syntax,
+          step.parameters as ParsedParameters,
+          { requiredParameters, defaultValues },
+        );
       }
-
-      return CamelUriHelper.getUriStringFromParameters(
-        uri,
-        catalogLookup.definition.component.syntax,
-        step.parameters as ParsedParameters,
-        {
-          requiredParameters,
-          defaultValues,
-        },
-      );
+    } else {
+      const componentDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName);
+      if (componentDefinition?.component.syntax !== undefined) {
+        const requiredParameters: string[] = [];
+        const defaultValues: ParsedParameters = {};
+        Object.entries(componentDefinition.properties ?? {}).forEach(([key, value]) => {
+          if (value.required) requiredParameters.push(key);
+          if (value.defaultValue) defaultValues[key] = value.defaultValue;
+        });
+        return CamelUriHelper.getUriStringFromParameters(
+          uri,
+          componentDefinition.component.syntax,
+          step.parameters as ParsedParameters,
+          { requiredParameters, defaultValues },
+        );
+      }
     }
 
     // This fallback applies only when the component does not define a syntax (e.g., for Kamelets or Components without syntax).
@@ -240,13 +274,13 @@ export class StepXmlSerializer {
     return uri;
   }
 
-  private static serializeAttribute(
+  private static async serializeAttribute(
     element: Element,
     key: string,
     processor: ElementType | string,
     props: ICamelProcessorProperty,
     attributeValue: unknown,
-  ): void {
+  ): Promise<void> {
     if (typeof processor === 'string') {
       if (props.required) element.setAttribute(key, processor);
       return;
@@ -254,16 +288,16 @@ export class StepXmlSerializer {
 
     if (!attributeValue) return;
 
-    const value = key === 'uri' ? this.createUriFromParameters(processor) : String(attributeValue);
+    const value = key === 'uri' ? await this.createUriFromParameters(processor) : String(attributeValue);
     element.setAttribute(key, value);
   }
 
-  static decorateDoTry(doTry: DoTry, doTryElement: Element, doc: Document): Element {
-    doTry.doCatch?.forEach((doCatch) => {
-      doTryElement.append(this.serialize('doCatch', doCatch as ElementType, doc));
-    });
+  static async decorateDoTry(doTry: DoTry, doTryElement: Element, doc: Document): Promise<Element> {
+    for (const doCatch of doTry.doCatch ?? []) {
+      doTryElement.append(await this.serialize('doCatch', doCatch as ElementType, doc));
+    }
 
-    doTryElement.append(this.serialize('doFinally', doTry.doFinally as ElementType, doc));
+    doTryElement.append(await this.serialize('doFinally', doTry.doFinally as ElementType, doc));
     return doTryElement;
   }
 

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -25,6 +25,14 @@ import { ExpressionXmlSerializer } from './expression-xml-serializer';
 
 export type ElementType = { [key: string]: unknown; steps?: ElementType[] };
 
+/**
+ * Value of a property whose catalog `kind` is `attribute`. Such properties map to JAXB
+ * `@XmlAttribute` and are therefore always serialized as scalars in XML. Even object-typed
+ * bean references (e.g. aggregationStrategy, executorService) are represented as `#`-prefixed
+ * strings in the model, never as nested objects.
+ */
+export type AttributeValue = string | number | boolean | undefined;
+
 export class StepXmlSerializer {
   static async serializeObjectProperties(
     element: Element,
@@ -40,7 +48,7 @@ export class StepXmlSerializer {
           break;
 
         case 'attribute':
-          await this.serializeAttribute(element, key, processor, props, processor[key]);
+          await this.serializeAttribute(element, key, processor, props, processor[key] as AttributeValue);
           break;
 
         case 'expression':
@@ -263,7 +271,7 @@ export class StepXmlSerializer {
     key: string,
     processor: ElementType | string,
     props: ICamelProcessorProperty,
-    attributeValue: unknown,
+    attributeValue: AttributeValue,
   ): Promise<void> {
     if (typeof processor === 'string') {
       if (props.required) element.setAttribute(key, processor);

--- a/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
+++ b/packages/ui/src/serializers/xml/serializers/step-xml-serializer.ts
@@ -17,7 +17,7 @@
 import { DoTry } from '@kaoto/camel-catalog/types';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
-import { CatalogKind, ICamelProcessorProperty } from '../../../models';
+import { CatalogKind, ICamelComponentDefinition, ICamelProcessorProperty } from '../../../models';
 import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
 import { CamelUriHelper, ParsedParameters } from '../../../utils';
 import { ARRAY_TYPE_NAMES, PROCESSOR_NAMES } from '../utils/xml-utils';
@@ -217,61 +217,45 @@ export class StepXmlSerializer {
   static async createUriFromParameters(step: ElementType): Promise<string> {
     const uri = step.uri as string;
     const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup('from', step);
-    if (camelElementLookup.componentName === undefined) {
-      return uri;
+    if (camelElementLookup.componentName === undefined) return uri;
+
+    const catalogResult = await CamelComponentSchemaService.resolveCatalogLookup(camelElementLookup.componentName);
+
+    if (catalogResult?.catalogKind === CatalogKind.Kamelet && catalogResult.definition !== undefined) {
+      // Kamelets don't use syntax-based URI building
+      return step.parameters && Object.keys(step.parameters).length > 0
+        ? CamelUriHelper.getUriStringFromParameters(uri, '', step.parameters as ParsedParameters)
+        : uri;
     }
 
-    const componentName = camelElementLookup.componentName;
-    if (componentName.startsWith('kamelet:')) {
-      const kameletName = componentName.replace('kamelet:', '');
-      const kameletDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Kamelet, kameletName);
-      if (kameletDefinition) {
-        // Kamelets don't use syntax-based URI building
-        if (step.parameters && Object.keys(step.parameters).length > 0) {
-          return CamelUriHelper.getUriStringFromParameters(uri, '', step.parameters as ParsedParameters);
-        }
-        return uri;
-      }
-      // fallback to kamelet component
-      const kameletComponentDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, 'kamelet');
-      if (kameletComponentDefinition?.component.syntax !== undefined) {
-        const requiredParameters: string[] = [];
-        const defaultValues: ParsedParameters = {};
-        Object.entries(kameletComponentDefinition.properties ?? {}).forEach(([key, value]) => {
-          if (value.required) requiredParameters.push(key);
-          if (value.defaultValue) defaultValues[key] = value.defaultValue;
-        });
-        return CamelUriHelper.getUriStringFromParameters(
-          uri,
-          kameletComponentDefinition.component.syntax,
-          step.parameters as ParsedParameters,
-          { requiredParameters, defaultValues },
-        );
-      }
-    } else {
-      const componentDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName);
-      if (componentDefinition?.component.syntax !== undefined) {
-        const requiredParameters: string[] = [];
-        const defaultValues: ParsedParameters = {};
-        Object.entries(componentDefinition.properties ?? {}).forEach(([key, value]) => {
-          if (value.required) requiredParameters.push(key);
-          if (value.defaultValue) defaultValues[key] = value.defaultValue;
-        });
-        return CamelUriHelper.getUriStringFromParameters(
-          uri,
-          componentDefinition.component.syntax,
-          step.parameters as ParsedParameters,
-          { requiredParameters, defaultValues },
-        );
-      }
+    const componentDefinition = catalogResult?.definition as ICamelComponentDefinition | undefined;
+    if (componentDefinition?.component.syntax !== undefined) {
+      return this.buildUriFromComponentDefinition(uri, step.parameters as ParsedParameters, componentDefinition);
     }
 
     // This fallback applies only when the component does not define a syntax (e.g., for Kamelets or Components without syntax).
-    if (step.parameters && Object.keys(step.parameters).length > 0) {
-      return CamelUriHelper.getUriStringFromParameters(uri, '', step.parameters as ParsedParameters);
-    }
+    return step.parameters && Object.keys(step.parameters).length > 0
+      ? CamelUriHelper.getUriStringFromParameters(uri, '', step.parameters as ParsedParameters)
+      : uri;
+  }
 
-    return uri;
+  private static buildUriFromComponentDefinition(
+    uri: string,
+    parameters: ParsedParameters | undefined,
+    componentDefinition: ICamelComponentDefinition,
+  ): string {
+    const { requiredParameters, defaultValues } = Object.entries(componentDefinition.properties ?? {}).reduce(
+      (acc, [key, value]) => {
+        if (value.required) acc.requiredParameters.push(key);
+        if (value.defaultValue !== undefined) acc.defaultValues[key] = value.defaultValue;
+        return acc;
+      },
+      { requiredParameters: [] as string[], defaultValues: {} as ParsedParameters },
+    );
+    return CamelUriHelper.getUriStringFromParameters(uri, componentDefinition.component.syntax!, parameters, {
+      requiredParameters,
+      defaultValues,
+    });
   }
 
   private static async serializeAttribute(

--- a/packages/ui/src/stubs/rest.ts
+++ b/packages/ui/src/stubs/rest.ts
@@ -22,12 +22,20 @@ export const restWithVerbsStup = {
       ],
     },
   },
+  securityRequirements: undefined,
   get: [
     {
       path: '/hello',
       param: [
-        { name: 'name', type: 'query', required: 'true' },
-        { name: 'name2', type: 'query', required: 'true', defaultValue: 'blah' },
+        { name: 'name', type: 'query', required: 'true', allowableValues: undefined, examples: undefined },
+        {
+          name: 'name2',
+          type: 'query',
+          required: 'true',
+          defaultValue: 'blah',
+          allowableValues: undefined,
+          examples: undefined,
+        },
       ],
       security: [{ key: 'hello', scopes: 'scope' }],
       responseMessage: [
@@ -49,8 +57,52 @@ export const restWithVerbsStup = {
       ],
       to: { uri: 'direct:hello' },
     },
-    // <post path=\"/bye\"><to uri=\"mock:update\"/></post></rest></camel>"
-    { path: '/bye', consumes: 'application/json', to: { uri: 'direct:bye' } },
+    {
+      path: '/bye',
+      consumes: 'application/json',
+      param: undefined,
+      responseMessage: undefined,
+      security: undefined,
+      to: { uri: 'direct:bye' },
+    },
   ],
-  post: [{ path: '/bye', to: { uri: 'mock:update' } }],
+  post: [
+    {
+      path: '/bye',
+      param: undefined,
+      responseMessage: undefined,
+      security: undefined,
+      to: { uri: 'mock:update' },
+    },
+  ],
+};
+
+export const restWithSecurityRequirementsStub = {
+  path: '/api',
+  securityDefinitions: {
+    apiKey: {
+      key: 'api_key',
+      name: 'api_key',
+      inHeader: 'true',
+    },
+    oauth2: {
+      key: 'oauth2',
+      flow: 'application',
+      tokenUrl: 'https://oauth.example.com/token',
+      scopes: [
+        { key: 'read', value: 'Read access' },
+        { key: 'write', value: 'Write access' },
+      ],
+    },
+  },
+  securityRequirements: [{ key: 'api_key' }, { key: 'oauth2', scopes: 'read,write' }],
+  get: [
+    {
+      path: '/users',
+      param: undefined,
+      responseMessage: undefined,
+      security: undefined,
+      to: { uri: 'direct:getUsers' },
+    },
+  ],
 };

--- a/packages/ui/src/stubs/xml/rest-with-security-requirements.xml
+++ b/packages/ui/src/stubs/xml/rest-with-security-requirements.xml
@@ -1,0 +1,16 @@
+<rest path="/api">
+    <securityDefinitions>
+        <apiKey key="api_key" name="api_key" inHeader="true"/>
+        <oauth2 key="oauth2" tokenUrl="https://oauth.example.com/token" flow="application">
+            <scopes key="read" value="Read access"/>
+            <scopes key="write" value="Write access"/>
+        </oauth2>
+    </securityDefinitions>
+    <securityRequirements>
+        <security key="api_key"/>
+        <security key="oauth2" scopes="read,write"/>
+    </securityRequirements>
+    <get path="/users">
+        <to uri="direct:getUsers"/>
+    </get>
+</rest>

--- a/packages/ui/src/stubs/yaml/rest-with-security-requirements.yaml
+++ b/packages/ui/src/stubs/yaml/rest-with-security-requirements.yaml
@@ -1,0 +1,24 @@
+- rest:
+    path: '/api'
+    securityDefinitions:
+      apiKey:
+        key: api_key
+        name: api_key
+        inHeader: 'true'
+      oauth2:
+        key: oauth2
+        flow: application
+        tokenUrl: https://oauth.example.com/token
+        scopes:
+          - key: read
+            value: Read access
+          - key: write
+            value: Write access
+    securityRequirements:
+      - key: api_key
+      - key: oauth2
+        scopes: read,write
+    get:
+      - path: '/users'
+        to:
+          uri: direct:getUsers


### PR DESCRIPTION
### Context
After migrating `KaotoResource#initialize()` and `KaotoResource#toSourceCode` to `async`, now we can migrate the XML parsing logic to `async`

fix: https://github.com/KaotoIO/kaoto/issues/3151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XML parsing and serialization now run asynchronously, covering routes, steps, beans, expressions, and REST documents.
  * REST XML/YAML fixtures and stubs now include security requirements scenarios (including `apiKey` and `oauth2`).

* **Bug Fixes**
  * Improved XML import/export round-tripping, including nested elements, namespaces, beans, special route constructs, and security definitions.
  * Enhanced handling for missing catalog properties during REST/step processing.

* **Tests**
  * Updated XML parser/serializer test suites to match the new async execution model and dynamic registry setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->