### PR TITLE
chore(tests): Refactor test files

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -1,5 +1,6 @@
+import { fail } from 'node:assert';
+
 import { render, screen, waitFor } from '@testing-library/react';
-import { fail } from 'assert';
 import { VirtuosoMockContext } from 'react-virtuoso';
 
 import { IVisualizationNode } from '../../models';
@@ -63,35 +64,6 @@ describe('DataMapperPage', () => {
   };
 
   beforeEach(() => {
-    // Mock RAF to execute immediately for tests that don't use fake timers
-    const rafMock = (cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
-    };
-    const cafMock = () => {};
-
-    // Use Object.defineProperty for more persistent mocks that survive async callbacks
-    Object.defineProperty(globalThis, 'requestAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: rafMock,
-    });
-    Object.defineProperty(globalThis, 'cancelAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: cafMock,
-    });
-    Object.defineProperty(window, 'requestAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: rafMock,
-    });
-    Object.defineProperty(window, 'cancelAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: cafMock,
-    });
-
     metadata = defaultMetadata;
     fileContents = {};
   });

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -9,37 +9,6 @@ import { ExpansionPanels } from '../ExpansionPanels/ExpansionPanels';
 import { ParametersSection } from './Parameters';
 
 describe('ParametersSection', () => {
-  beforeEach(() => {
-    // Mock RAF to execute immediately for tests that don't use fake timers
-    const rafMock = (cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
-    };
-    const cafMock = () => {};
-
-    // Use Object.defineProperty for more persistent mocks that survive async callbacks
-    Object.defineProperty(globalThis, 'requestAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: rafMock,
-    });
-    Object.defineProperty(globalThis, 'cancelAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: cafMock,
-    });
-    Object.defineProperty(window, 'requestAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: rafMock,
-    });
-    Object.defineProperty(window, 'cancelAnimationFrame', {
-      writable: true,
-      configurable: true,
-      value: cafMock,
-    });
-  });
-
   // Helper to wrap components with VirtuosoMockContext for testing
   const renderWithVirtuoso = (component: React.ReactElement) => {
     return render(component, {

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -7,6 +7,7 @@ import { DocumentNodeData } from '../../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
 import { ChoiceSelectionService } from '../../../../services/document/choice-selection.service';
+import { XmlSchemaField } from '../../../../services/document/xml-schema/xml-schema-document.model';
 import { TreeParsingService } from '../../../../services/visualization/tree-parsing.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { SourceDocumentNodeWithContextMenu } from '../../SourceDocumentNode';
@@ -21,48 +22,26 @@ describe('useChoiceContextMenu', () => {
   const createChoiceFieldNode = (selectMember = false) => {
     const document = TestUtil.createSourceOrderDoc();
     const parentField = document.fields[0];
-    const choiceField = {
-      name: 'contactChoice',
-      displayName: 'Contact Choice',
-      type: Types.Container,
-      wrapperKind: 'choice' as const,
-      namedTypeFragmentRefs: [],
-      parent: parentField,
-      ownerDocument: document,
-      fields: [] as Record<string, unknown>[],
-      selectedMemberIndex: selectMember ? 1 : undefined,
-    };
-    const members = [
-      {
-        name: 'email',
-        displayName: 'Email',
-        type: Types.String,
-        fields: [],
-        namedTypeFragmentRefs: [],
-        parent: choiceField,
-        ownerDocument: document,
-      },
-      {
-        name: 'phone',
-        displayName: 'Phone',
-        type: Types.String,
-        fields: [],
-        namedTypeFragmentRefs: [],
-        parent: choiceField,
-        ownerDocument: document,
-      },
-      {
-        name: 'fax',
-        displayName: 'Fax',
-        type: Types.String,
-        fields: [],
-        namedTypeFragmentRefs: [],
-        parent: choiceField,
-        ownerDocument: document,
-      },
-    ];
-    choiceField.fields = members;
-    parentField.fields.push(choiceField as never);
+    const choiceField = new XmlSchemaField(parentField, 'contactChoice', false);
+    choiceField.displayName = 'Contact Choice';
+    choiceField.type = Types.Container;
+    choiceField.wrapperKind = 'choice';
+    choiceField.selectedMemberIndex = selectMember ? 1 : undefined;
+
+    const emailField = new XmlSchemaField(choiceField, 'email', false);
+    emailField.displayName = 'Email';
+    emailField.type = Types.String;
+
+    const phoneField = new XmlSchemaField(choiceField, 'phone', false);
+    phoneField.displayName = 'Phone';
+    phoneField.type = Types.String;
+
+    const faxField = new XmlSchemaField(choiceField, 'fax', false);
+    faxField.displayName = 'Fax';
+    faxField.type = Types.String;
+
+    choiceField.fields = [emailField, phoneField, faxField];
+    parentField.fields.push(choiceField);
 
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
@@ -76,28 +55,20 @@ describe('useChoiceContextMenu', () => {
   const createLargeChoiceFieldNode = (size = 11) => {
     const document = TestUtil.createSourceOrderDoc();
     const parentField = document.fields[0];
-    const choiceField = {
-      name: 'largeChoice',
-      displayName: 'Large Choice',
-      type: Types.Container,
-      wrapperKind: 'choice' as const,
-      namedTypeFragmentRefs: [],
-      parent: parentField,
-      ownerDocument: document,
-      fields: [] as Record<string, unknown>[],
-      selectedMemberIndex: undefined,
-    };
-    const members = Array.from({ length: size }, (_, i) => ({
-      name: `member${i}`,
-      displayName: `Member ${i}`,
-      type: Types.String,
-      fields: [],
-      namedTypeFragmentRefs: [],
-      parent: choiceField,
-      ownerDocument: document,
-    }));
+    const choiceField = new XmlSchemaField(parentField, 'largeChoice', false);
+    choiceField.displayName = 'Large Choice';
+    choiceField.type = Types.Container;
+    choiceField.wrapperKind = 'choice';
+    choiceField.selectedMemberIndex = undefined;
+
+    const members = Array.from({ length: size }, (_, i) => {
+      const member = new XmlSchemaField(choiceField, `member${i}`, false);
+      member.displayName = `Member ${i}`;
+      member.type = Types.String;
+      return member;
+    });
     choiceField.fields = members;
-    parentField.fields.push(choiceField as never);
+    parentField.fields.push(choiceField);
 
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
@@ -256,18 +227,12 @@ describe('useChoiceContextMenu', () => {
   it('should show empty menu for choice wrapper with no members and no selection', () => {
     const document = TestUtil.createSourceOrderDoc();
     const parentField = document.fields[0];
-    const choiceField = {
-      name: 'emptyChoice',
-      displayName: 'Empty Choice',
-      type: Types.Container,
-      wrapperKind: 'choice' as const,
-      namedTypeFragmentRefs: [],
-      parent: parentField,
-      ownerDocument: document,
-      fields: [],
-      selectedMemberIndex: undefined,
-    };
-    parentField.fields.push(choiceField as never);
+    const choiceField = new XmlSchemaField(parentField, 'emptyChoice', false);
+    choiceField.displayName = 'Empty Choice';
+    choiceField.type = Types.Container;
+    choiceField.wrapperKind = 'choice';
+    choiceField.selectedMemberIndex = undefined;
+    parentField.fields.push(choiceField);
 
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
@@ -378,70 +343,38 @@ describe('useChoiceContextMenu', () => {
     const createNestedChoiceFieldNode = (selectInner = false) => {
       const document = TestUtil.createSourceOrderDoc();
       const parentField = document.fields[0];
-      const outerChoiceField = {
-        name: 'outerChoice',
-        displayName: 'Outer Choice',
-        type: Types.Container,
-        wrapperKind: 'choice' as const,
-        namedTypeFragmentRefs: [],
-        parent: parentField,
-        ownerDocument: document,
-        fields: [] as Record<string, unknown>[],
-        selectedMemberIndex: undefined as number | undefined,
-      };
-      const innerChoiceField = {
-        name: 'innerChoice',
-        displayName: 'Inner Choice',
-        type: Types.Container,
-        wrapperKind: 'choice' as const,
-        namedTypeFragmentRefs: [],
-        parent: outerChoiceField,
-        ownerDocument: document,
-        fields: [] as Record<string, unknown>[],
-        selectedMemberIndex: selectInner ? 0 : undefined,
-      };
-      const innerMembers = [
-        {
-          name: 'innerA',
-          displayName: 'InnerA',
-          type: Types.String,
-          fields: [],
-          namedTypeFragmentRefs: [],
-          parent: innerChoiceField,
-          ownerDocument: document,
-        },
-        {
-          name: 'innerB',
-          displayName: 'InnerB',
-          type: Types.String,
-          fields: [],
-          namedTypeFragmentRefs: [],
-          parent: innerChoiceField,
-          ownerDocument: document,
-        },
-        {
-          name: 'innerC',
-          displayName: 'InnerC',
-          type: Types.String,
-          fields: [],
-          namedTypeFragmentRefs: [],
-          parent: innerChoiceField,
-          ownerDocument: document,
-        },
-      ];
-      innerChoiceField.fields = innerMembers;
-      const plainMember = {
-        name: 'plain',
-        displayName: 'Plain',
-        type: Types.String,
-        fields: [],
-        namedTypeFragmentRefs: [],
-        parent: outerChoiceField,
-        ownerDocument: document,
-      };
-      outerChoiceField.fields = [innerChoiceField, plainMember];
+      const outerChoiceField = new XmlSchemaField(parentField, 'outerChoice', false);
+      outerChoiceField.displayName = 'Outer Choice';
+      outerChoiceField.type = Types.Container;
+      outerChoiceField.wrapperKind = 'choice';
       outerChoiceField.selectedMemberIndex = 0;
-      parentField.fields.push(outerChoiceField as never);
+
+      const innerChoiceField = new XmlSchemaField(outerChoiceField, 'innerChoice', false);
+      innerChoiceField.displayName = 'Inner Choice';
+      innerChoiceField.type = Types.Container;
+      innerChoiceField.wrapperKind = 'choice';
+      innerChoiceField.selectedMemberIndex = selectInner ? 0 : undefined;
+
+      const innerAField = new XmlSchemaField(innerChoiceField, 'innerA', false);
+      innerAField.displayName = 'InnerA';
+      innerAField.type = Types.String;
+
+      const innerBField = new XmlSchemaField(innerChoiceField, 'innerB', false);
+      innerBField.displayName = 'InnerB';
+      innerBField.type = Types.String;
+
+      const innerCField = new XmlSchemaField(innerChoiceField, 'innerC', false);
+      innerCField.displayName = 'InnerC';
+      innerCField.type = Types.String;
+
+      innerChoiceField.fields = [innerAField, innerBField, innerCField];
+
+      const plainMember = new XmlSchemaField(outerChoiceField, 'plain', false);
+      plainMember.displayName = 'Plain';
+      plainMember.type = Types.String;
+
+      outerChoiceField.fields = [innerChoiceField, plainMember];
+      parentField.fields.push(outerChoiceField);
 
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
@@ -4,6 +4,7 @@ import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
 import { MappingTree } from '../../../../models/datamapper/mapping';
 import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
+import { IDataMapperContext } from '../../../../providers/datamapper.provider';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { QName } from '../../../../xml-schema-ts/QName';
@@ -70,7 +71,7 @@ describe('FieldOverride', () => {
     vi.mocked(useDataMapper).mockReturnValue({
       mappingTree: testMappingTree,
       updateDocument: mockUpdateDocument,
-    } as never);
+    } as Partial<IDataMapperContext> as IDataMapperContext);
   });
 
   it('should pass field to FieldOverrideModal when open', () => {

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -4,8 +4,9 @@ import type { Mock } from 'vitest';
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IField } from '../../../../models/datamapper/document';
 import { MappingTree } from '../../../../models/datamapper/mapping';
-import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldSubstituteInfo, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
 import { IMetadataApi, MetadataContext } from '../../../../providers';
+import { IDataMapperContext } from '../../../../providers/datamapper.provider';
 import { DataMapperMetadataService } from '../../../../services/datamapper-metadata.service';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
@@ -29,7 +30,7 @@ describe('FieldOverrideModal', () => {
     vi.mocked(useDataMapper).mockReturnValue({
       mappingTree: testMappingTree,
       updateDocument: vi.fn(),
-    } as never);
+    } as Partial<IDataMapperContext> as IDataMapperContext);
 
     testField = testTargetDoc.fields[0];
     testField.typeOverride = FieldOverrideVariant.NONE;
@@ -397,7 +398,7 @@ describe('FieldOverrideModal', () => {
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       const getSubstitutionSpy = vi
         .spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates')
-        .mockReturnValue(mockSubstitutionCandidates as never);
+        .mockReturnValue(mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>);
 
       render(
         <FieldOverrideModal
@@ -420,7 +421,7 @@ describe('FieldOverrideModal', () => {
     it('should show substitution placeholder when mode is switched', () => {
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -444,7 +445,7 @@ describe('FieldOverrideModal', () => {
       const onSaveMock = vi.fn();
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -499,7 +500,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockTypeCandidates);
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -541,7 +542,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -568,7 +569,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -590,7 +591,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -623,7 +624,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockTypeCandidates);
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(
@@ -647,7 +648,7 @@ describe('FieldOverrideModal', () => {
 
       vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
       vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(
-        mockSubstitutionCandidates as never,
+        mockSubstitutionCandidates as Record<string, IFieldSubstituteInfo>,
       );
 
       render(

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/useSortKeyItems.test.ts
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/useSortKeyItems.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { useDataMapper } from '../../../../../hooks/useDataMapper';
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../../models/datamapper/document';
 import { ForEachItem, MappingTree } from '../../../../../models/datamapper/mapping';
+import { IDataMapperContext } from '../../../../../providers/datamapper.provider';
 import { TestUtil } from '../../../../../stubs/datamapper/data-mapper';
 import { useSortKeyItems } from './useSortKeyItems';
 
@@ -21,7 +22,7 @@ describe('useSortKeyItems', () => {
       sourceBodyDocument: sourceDoc,
       sourceParameterMap: new Map(),
       mappingTree,
-    } as never);
+    } as Partial<IDataMapperContext> as IDataMapperContext);
   });
 
   it('should return empty items when expression is empty', () => {

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
@@ -66,6 +66,17 @@ describe('PropertiesModal', () => {
     } as unknown as IDynamicCatalogRegistry;
   });
 
+  const renderModal = async (tile: ITile) => {
+    const { baseElement } = await act(async () =>
+      render(
+        <CatalogContext.Provider value={mockCatalogRegistry}>
+          <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
+        </CatalogContext.Provider>,
+      ),
+    );
+    return { baseElement };
+  };
+
   describe('Component tile', () => {
     const tile: ITile = {
       type: CatalogKind.Component,
@@ -78,14 +89,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders component properties table correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Atom');
@@ -181,14 +185,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Asterisk');
@@ -211,14 +208,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Api Key');
@@ -253,14 +243,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
@@ -285,14 +268,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
@@ -340,14 +316,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
@@ -370,14 +339,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Print');
@@ -408,14 +370,7 @@ describe('PropertiesModal', () => {
     };
 
     it('renders property modal correctly', async () => {
-      // modal uses React portals so baseElement needs to be used here
-      const { baseElement } = await act(async () =>
-        render(
-          <CatalogContext.Provider value={mockCatalogRegistry}>
-            <PropertiesModal tile={tile} isModalOpen onClose={vi.fn()} />
-          </CatalogContext.Provider>,
-        ),
-      );
+      const { baseElement } = await renderModal(tile);
       await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Iterate');

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -22,37 +22,6 @@ beforeAll(() => {
   };
 });
 
-// Mock RAF to execute immediately for tests that don't use fake timers
-beforeEach(() => {
-  const rafMock = (cb: FrameRequestCallback) => {
-    cb(0);
-    return 0;
-  };
-  const cafMock = () => {};
-
-  // Use Object.defineProperty for more persistent mocks that survive async callbacks
-  Object.defineProperty(globalThis, 'requestAnimationFrame', {
-    writable: true,
-    configurable: true,
-    value: rafMock,
-  });
-  Object.defineProperty(globalThis, 'cancelAnimationFrame', {
-    writable: true,
-    configurable: true,
-    value: cafMock,
-  });
-  Object.defineProperty(window, 'requestAnimationFrame', {
-    writable: true,
-    configurable: true,
-    value: rafMock,
-  });
-  Object.defineProperty(window, 'cancelAnimationFrame', {
-    writable: true,
-    configurable: true,
-    value: cafMock,
-  });
-});
-
 describe('SourceTargetView', () => {
   // Helper to wrap components with VirtuosoMockContext for testing
   const renderWithVirtuoso = (component: React.ReactElement) => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -56,8 +56,8 @@ describe('MultiValuePropertyEditor', () => {
 
     readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
     getMultiValueSerializedDefinitionSpy.mockReturnValue({
-      parameters: { 'job.name': 'updated' } as never,
-    });
+      parameters: { 'job.name': 'updated' },
+    } as unknown as Record<string, string>);
   });
 
   it('should render the transformed model and disabled state', () => {
@@ -104,8 +104,8 @@ describe('MultiValuePropertyEditor', () => {
   it('should delete property key when value is empty string', () => {
     readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
     getMultiValueSerializedDefinitionSpy.mockReturnValue({
-      parameters: { 'job.description': 'test' } as never,
-    });
+      parameters: { 'job.description': 'test' },
+    } as unknown as Record<string, string>);
 
     renderComponent({
       model: { parameters: { 'job.name': 'daily', 'job.description': 'test' } },

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -1,5 +1,5 @@
 import * as ReactTopology from '@patternfly/react-topology';
-import { BaseEdge, BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
+import { BaseEdge, BaseGraph, BaseNode, ElementContext, Rect, VisualizationProvider } from '@patternfly/react-topology';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import type { Mock } from 'vitest';
@@ -252,7 +252,7 @@ describe('CustomGroupExpanded', () => {
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode: groupVizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
     vi.spyOn(element, 'getId').mockReturnValue('node-choice-1');
-    vi.spyOn(element, 'getBounds').mockReturnValue({ x: 0, y: 0, width: 100, height: 50 } as never);
+    vi.spyOn(element, 'getBounds').mockReturnValue(new Rect(0, 0, 100, 50));
 
     await renderInContext(<CustomGroupExpanded element={element} />);
 

--- a/packages/ui/src/components/Visualization/Custom/NoBendingEdge.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/NoBendingEdge.test.ts
@@ -1,4 +1,4 @@
-import { getTopCollapsedParent, Point } from '@patternfly/react-topology';
+import { getTopCollapsedParent, Graph, Node, Point } from '@patternfly/react-topology';
 import type { Mock } from 'vitest';
 
 import { NoBendpointsEdge } from './NoBendingEdge';
@@ -24,13 +24,13 @@ describe('NoBendpointsEdge', () => {
 
   const setupSelfLoop = (layout: string, parentType: string) => {
     const parent = mockParent(parentType, { x: 10, y: 20 }, { width: 100, height: 50 });
-    const mockNode = {};
+    const mockNode = {} as unknown as Node;
     mockGetTopCollapsedParent.mockReturnValue(parent);
-    vi.spyOn(edge, 'getSource').mockReturnValue(mockNode as never);
-    vi.spyOn(edge, 'getTarget').mockReturnValue(mockNode as never);
+    vi.spyOn(edge, 'getSource').mockReturnValue(mockNode);
+    vi.spyOn(edge, 'getTarget').mockReturnValue(mockNode);
     vi.spyOn(edge, 'getGraph').mockReturnValue({
       getLayout: () => layout,
-    } as never);
+    } as unknown as Graph);
   };
 
   beforeEach(() => {
@@ -99,10 +99,10 @@ describe('NoBendpointsEdge', () => {
 
   describe('non-self-loop', () => {
     it('getStartPoint should delegate to super', () => {
-      const mockSource = { id: 'source' };
-      const mockTarget = { id: 'target' };
-      vi.spyOn(edge, 'getSource').mockReturnValue(mockSource as never);
-      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget as never);
+      const mockSource = { id: 'source' } as unknown as Node;
+      const mockTarget = { id: 'target' } as unknown as Node;
+      vi.spyOn(edge, 'getSource').mockReturnValue(mockSource);
+      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget);
 
       const superStartPoint = new Point(0, 0);
       vi.spyOn(Object.getPrototypeOf(NoBendpointsEdge.prototype), 'getStartPoint').mockReturnValue(superStartPoint);
@@ -111,10 +111,10 @@ describe('NoBendpointsEdge', () => {
     });
 
     it('getEndPoint should delegate to super', () => {
-      const mockSource = { id: 'source' };
-      const mockTarget = { id: 'target' };
-      vi.spyOn(edge, 'getSource').mockReturnValue(mockSource as never);
-      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget as never);
+      const mockSource = { id: 'source' } as unknown as Node;
+      const mockTarget = { id: 'target' } as unknown as Node;
+      vi.spyOn(edge, 'getSource').mockReturnValue(mockSource);
+      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget);
 
       const superEndPoint = new Point(5, 5);
       vi.spyOn(Object.getPrototypeOf(NoBendpointsEdge.prototype), 'getEndPoint').mockReturnValue(superEndPoint);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
@@ -1,9 +1,15 @@
+import { ElementModel, GraphElement } from '@patternfly/react-topology';
 import { waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { IOnCopyAddon } from '../../../registers/interactions/node-interaction-addon.model';
+import { EntitiesContextResult } from '../../../../providers/entities.provider';
+import {
+  INodeInteractionAddonContext,
+  IOnCopyAddon,
+} from '../../../registers/interactions/node-interaction-addon.model';
+import { CanvasNode } from '../../Canvas/canvas.models';
 import { NoBendpointsEdge } from '../NoBendingEdge';
 import { checkNodeDropCompatibility, getNodeDragAndDropDirection, handleValidNodeDrop } from './CustomNodeUtils';
 
@@ -286,16 +292,18 @@ describe('CustomNodeUtils', () => {
   describe('handleValidNodeDrop', () => {
     const noopGetOnCopyAddons = () => [] as IOnCopyAddon[];
 
-    const createMockDraggedElement = (vizNode: IVisualizationNode) => ({
-      getData: vi.fn().mockReturnValue({ vizNode }),
-      getController: vi.fn().mockReturnValue({
-        fromModel: vi.fn(),
-      }),
-    });
+    const createMockDraggedElement = (vizNode: IVisualizationNode): GraphElement<ElementModel, CanvasNode['data']> =>
+      ({
+        getData: vi.fn().mockReturnValue({ vizNode }),
+        getController: vi.fn().mockReturnValue({
+          fromModel: vi.fn(),
+        }),
+      }) as unknown as GraphElement<ElementModel, CanvasNode['data']>;
 
-    const createMockDropResultNode = (vizNode: IVisualizationNode) => ({
-      getData: vi.fn().mockReturnValue({ vizNode }),
-    });
+    const createMockDropResultNode = (vizNode: IVisualizationNode): GraphElement<ElementModel, unknown> =>
+      ({
+        getData: vi.fn().mockReturnValue({ vizNode }),
+      }) as unknown as GraphElement<ElementModel, unknown>;
 
     const createMockEntitiesContext = () => ({
       camelResource: { removeEntity: vi.fn() },
@@ -313,10 +321,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.pasteBaseEntityStep).not.toHaveBeenCalled();
@@ -331,10 +339,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.pasteBaseEntityStep).not.toHaveBeenCalled();
@@ -349,10 +357,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.pasteBaseEntityStep).toHaveBeenCalledWith('test-content', AddStepMode.AppendStep);
@@ -372,10 +380,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.removeChild).toHaveBeenCalled();
@@ -397,10 +405,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.pasteBaseEntityStep).toHaveBeenCalledWith('test-content', AddStepMode.AppendStep);
@@ -426,10 +434,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(choiceVizNode.pasteBaseEntityStep).toHaveBeenCalledWith(
@@ -466,10 +474,10 @@ describe('CustomNodeUtils', () => {
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        dropResult as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(otherwiseContainer.removeChild).toHaveBeenCalled();
@@ -496,14 +504,14 @@ describe('CustomNodeUtils', () => {
       const draggedElement = createMockDraggedElement(vizNode1);
       const edge = new NoBendpointsEdge();
       const mockTarget = { getData: vi.fn().mockReturnValue({ vizNode: vizNode2 }) };
-      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget as never);
+      vi.spyOn(edge, 'getTarget').mockReturnValue(mockTarget as unknown as ReturnType<typeof edge.getTarget>);
       const entitiesContext = createMockEntitiesContext();
 
       handleValidNodeDrop(
-        draggedElement as never,
-        edge as never,
-        entitiesContext as never,
-        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as never,
+        draggedElement,
+        edge,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
       );
 
       expect(vizNode2.pasteBaseEntityStep).toHaveBeenCalledWith('test-content', AddStepMode.PrependStep);

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
@@ -1,10 +1,18 @@
-import { BaseGraph, BaseNode, ElementContext, VisualizationProvider } from '@patternfly/react-topology';
+import {
+  BaseGraph,
+  BaseNode,
+  ElementContext,
+  ElementModel,
+  GraphElement,
+  VisualizationProvider,
+} from '@patternfly/react-topology';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { createVisualizationNode, IVisualizationNode, IVisualizationNodeData } from '../../../../models';
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { TestProvidersWrapper } from '../../../../stubs';
 import { ControllerService } from '../../../../testing-api';
+import { CanvasNode } from '../../Canvas/canvas.models';
 import { PlaceholderNode, PlaceholderNodeObserver } from './PlaceholderNode';
 
 /**
@@ -20,8 +28,13 @@ const { mockOnReplaceNode, mockOnInsertStep, MockElementContext, MockBaseEdge, M
   const { createContext } = require('react');
   const MockElementContext = createContext(null);
 
+  interface MockData {
+    vizNode?: IVisualizationNodeData;
+    [key: string]: unknown;
+  }
+
   class MockBaseElement {
-    _data: Record<string, unknown> = {};
+    _data: MockData = {};
     _type = '';
     _bounds = { x: 0, y: 0, width: 90, height: 75 };
     _id = 'mock-element-id';
@@ -32,10 +45,10 @@ const { mockOnReplaceNode, mockOnInsertStep, MockElementContext, MockBaseEdge, M
     setType(type: string) {
       this._type = type;
     }
-    getData() {
+    getData(): MockData {
       return this._data;
     }
-    setData(data: Record<string, unknown>) {
+    setData(data: MockData) {
       this._data = data;
     }
     getId() {
@@ -183,11 +196,11 @@ describe('PlaceholderNode', () => {
 
   it('should throw an error if not used on Node elements', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const edgeElement = new MockBaseEdge();
+    const edgeElement = new MockBaseEdge() as unknown as GraphElement<ElementModel, CanvasNode['data']>;
 
     expect(() => {
       act(() => {
-        render(<PlaceholderNodeObserver element={edgeElement as never} />);
+        render(<PlaceholderNodeObserver element={edgeElement} />);
       });
     }).toThrow('PlaceholderNode must be used only on Node elements');
   });
@@ -206,7 +219,7 @@ describe('PlaceholderNode', () => {
     const wrapper = render(
       <Provider>
         <MockElementContext.Provider value={element}>
-          <PlaceholderNodeObserver element={element as never} />
+          <PlaceholderNodeObserver element={element as unknown as GraphElement<ElementModel, CanvasNode['data']>} />
         </MockElementContext.Provider>
       </Provider>,
     );
@@ -228,7 +241,7 @@ describe('PlaceholderNode', () => {
     vi.spyOn(vizNode, 'getId').mockReturnValue('route-1234');
 
     const parentElement = new BaseGraph();
-    const element = new MockBaseNode();
+    const element = new MockBaseNode() as unknown as GraphElement<ElementModel, CanvasNode['data']>;
     const controller = ControllerService.createController();
     parentElement.setController(controller);
     element.setController(controller);
@@ -241,8 +254,8 @@ describe('PlaceholderNode', () => {
     render(
       <Provider>
         <VisualizationProvider controller={controller}>
-          <ElementContext.Provider value={element as never}>
-            <PlaceholderNode element={element as never} />
+          <ElementContext.Provider value={element}>
+            <PlaceholderNode element={element} />
           </ElementContext.Provider>
         </VisualizationProvider>
       </Provider>,
@@ -255,7 +268,7 @@ describe('PlaceholderNode', () => {
   describe('isSpecialChildPlaceholder', () => {
     const setupWithVizNode = async (vizNodeData: Partial<IVisualizationNodeData>) => {
       const parentElement = new BaseGraph();
-      const element = new BaseNode();
+      const element = new BaseNode() as unknown as GraphElement<ElementModel, CanvasNode['data']>;
       const controller = ControllerService.createController();
       parentElement.setController(controller);
       element.setController(controller);
@@ -273,8 +286,8 @@ describe('PlaceholderNode', () => {
 
       return render(
         <Provider>
-          <ElementContext.Provider value={element as never}>
-            <PlaceholderNodeObserver element={element as never} />
+          <ElementContext.Provider value={element}>
+            <PlaceholderNodeObserver element={element} />
           </ElementContext.Provider>
         </Provider>,
       );

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -7,7 +7,7 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { StepUpdateAction } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../models/entities';
-import { AddStepMode } from '../../../../models/visualization/base-visual-entity';
+import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { IMetadataApi, MetadataContext } from '../../../../providers/metadata.provider';
 import { TestProvidersWrapper } from '../../../../stubs';
@@ -17,6 +17,8 @@ describe('useAddStep', () => {
   let camelResource: CamelRouteResource;
   let getCompatibleComponentsSpy: Mock;
   let updateEntitiesFromCamelResourceSpy: Mock;
+  let vizNode: IVisualizationNode;
+  let addBaseEntityStepSpy!: ReturnType<typeof vi.spyOn>;
 
   const mockCatalogModalContext = {
     setIsModalOpen: vi.fn(),
@@ -62,6 +64,17 @@ describe('useAddStep', () => {
         </CatalogModalContext.Provider>
       </Provider>
     );
+
+    vizNode = createVisualizationNode('test', {
+      name: EntityType.Route,
+      isPlaceholder: false,
+      isGroup: false,
+      iconUrl: '',
+      title: '',
+      description: '',
+    });
+    addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
+    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
   });
 
   afterEach(() => {
@@ -69,14 +82,6 @@ describe('useAddStep', () => {
   });
 
   it('should return onAddStep function', () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), { wrapper });
 
     expect(result.current.onAddStep).toBeDefined();
@@ -84,14 +89,6 @@ describe('useAddStep', () => {
   });
 
   it('should maintain stable reference when dependencies do not change', () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
     const { result, rerender } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), { wrapper });
 
     const firstResult = result.current;
@@ -101,29 +98,12 @@ describe('useAddStep', () => {
   });
 
   it('should use AppendStep mode as default when mode is not provided', () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
     const { result } = renderHook(() => useAddStep(vizNode), { wrapper });
 
     expect(result.current.onAddStep).toBeDefined();
   });
 
   it('should return early when entitiesContext is null', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-
     // Create a wrapper that provides null entities context
     const { Provider: NullEntitiesProvider } = await TestProvidersWrapper({
       camelResource,
@@ -148,17 +128,6 @@ describe('useAddStep', () => {
   });
 
   it('should get compatible components and open catalog modal', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-    const addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
-
-    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), { wrapper });
@@ -177,17 +146,6 @@ describe('useAddStep', () => {
   });
 
   it('should work with PrependStep mode', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-    const addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
-
-    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.PrependStep), { wrapper });
@@ -198,44 +156,11 @@ describe('useAddStep', () => {
     expect(addBaseEntityStepSpy).toHaveBeenCalledWith(mockDefinedComponent, AddStepMode.PrependStep);
   });
 
-  it('should return early when catalog modal returns no component', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-    const addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
-
-    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
-    mockCatalogModalContext.getNewComponent.mockResolvedValue(null);
-
-    const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), { wrapper });
-
-    await result.current.onAddStep();
-
-    expect(getCompatibleComponentsSpy).toHaveBeenCalledWith(AddStepMode.AppendStep, vizNode.data);
-    expect(mockCatalogModalContext.getNewComponent).toHaveBeenCalledWith(mockCompatibleComponents);
-    expect(addBaseEntityStepSpy).not.toHaveBeenCalled();
-    expect(updateEntitiesFromCamelResourceSpy).not.toHaveBeenCalled();
-    expect(mockMetadataContext.onStepUpdated).not.toHaveBeenCalled();
-  });
-
-  it('should return early when catalog modal returns undefined', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-    const addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
-
-    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
-    mockCatalogModalContext.getNewComponent.mockResolvedValue(undefined);
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('should return early when catalog modal returns %s', async (_label, returnValue) => {
+    mockCatalogModalContext.getNewComponent.mockResolvedValue(returnValue);
 
     const { result } = renderHook(() => useAddStep(vizNode, AddStepMode.AppendStep), { wrapper });
 
@@ -247,17 +172,6 @@ describe('useAddStep', () => {
   });
 
   it('should handle missing metadata context gracefully', async () => {
-    const vizNode = createVisualizationNode('test', {
-      name: EntityType.Route,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-    const addBaseEntityStepSpy = vi.spyOn(vizNode, 'addBaseEntityStep');
-
-    getCompatibleComponentsSpy.mockReturnValue(mockCompatibleComponents);
     mockCatalogModalContext.getNewComponent.mockResolvedValue(mockDefinedComponent);
 
     const { Provider, updateEntitiesFromCamelResourceSpy: localUpdateSpy } = await TestProvidersWrapper({

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -6,6 +6,7 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { AddStepMode } from '../../../../models/visualization/base-visual-entity';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/camel-route-visual-entity';
+import { VisualFlowsApi } from '../../../../models/visualization/flows/support/flows-visibility';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
 import { EntitiesContext } from '../../../../providers/entities.provider';
@@ -110,7 +111,7 @@ describe('useDuplicateStep', () => {
     allFlowsVisible: true,
     visualFlowsApi: {
       toggleFlowVisible: vi.fn(),
-    } as never,
+    } as unknown as VisualFlowsApi,
   };
 
   const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -5,6 +5,7 @@ import type { Mock } from 'vitest';
 import { CamelRouteResource } from '../models/camel/camel-route-resource';
 import { SourceSchemaType } from '../models/camel/source-schema-type';
 import { IClipboardCopyObject } from '../models/visualization/clipboard';
+import { CamelRouteVisualEntity } from '../models/visualization/flows/camel-route-visual-entity';
 import { VisualFlowsApi } from '../models/visualization/flows/support/flows-visibility';
 import {
   ACTION_ID_CANCEL,
@@ -203,7 +204,9 @@ describe('usePasteEntity', () => {
     it('should prompt for replacement when pasting to single-entity resource with existing entity', async () => {
       vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
       vi.spyOn(ClipboardManager, 'paste').mockResolvedValue(copiedRouteContent);
-      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([{ id: 'existing-entity' }] as never);
+      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([
+        { id: 'existing-entity' } as unknown as CamelRouteVisualEntity,
+      ]);
       mockActionConfirmationContext.actionConfirmation.mockResolvedValue(ACTION_ID_CONFIRM);
       addNewEntitySpy.mockReturnValue('new-route-id');
 
@@ -229,7 +232,9 @@ describe('usePasteEntity', () => {
     it('should not paste when user cancels replacement', async () => {
       vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
       vi.spyOn(ClipboardManager, 'paste').mockResolvedValue(copiedRouteContent);
-      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([{ id: 'existing-entity' }] as never);
+      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([
+        { id: 'existing-entity' } as unknown as CamelRouteVisualEntity,
+      ]);
       mockActionConfirmationContext.actionConfirmation.mockResolvedValue(ACTION_ID_CANCEL);
 
       const { result } = renderHook(() => usePasteEntity(), { wrapper });
@@ -352,7 +357,9 @@ describe('usePasteEntity', () => {
       supportsMultipleVisualEntitiesSpy.mockReturnValue(false);
       vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
       vi.spyOn(ClipboardManager, 'paste').mockResolvedValue(copiedRouteContent);
-      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([{ id: 'existing-entity' }] as never);
+      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([
+        { id: 'existing-entity' } as unknown as CamelRouteVisualEntity,
+      ]);
 
       const { result } = renderHook(() => usePasteEntity(), { wrapper: wrapperWithoutActionConfirmation });
 

--- a/packages/ui/src/models/datamapper/mapping.test.ts
+++ b/packages/ui/src/models/datamapper/mapping.test.ts
@@ -1,4 +1,4 @@
-import { DocumentDefinitionType, DocumentType } from './document';
+import { DocumentDefinitionType, DocumentType, IField } from './document';
 import {
   ChooseItem,
   ForEachGroupItem,
@@ -69,7 +69,7 @@ describe('mapping.ts', () => {
   describe('ChooseItem', () => {
     it('doClone() should create a new ChooseItem with the same field', () => {
       const field = { id: 'testField', name: 'testField', isAttribute: false, fields: [], type: 'string' };
-      const item = new ChooseItem(tree, field as never);
+      const item = new ChooseItem(tree, field as unknown as IField);
       const cloned = item.clone() as ChooseItem;
 
       expect(cloned).not.toBe(item);

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { CamelRouteResource } from '../../models/camel/camel-route-resource';
 import { KaotoResource } from '../../models/kaoto-resource';
+import { AbstractSettingsAdapter } from '../../models/settings/settings.model';
 import { EntitiesContextResult, SettingsContext } from '../../providers';
 import { TestProvidersWrapper } from '../../stubs/TestProvidersWrapper';
 import { useRestDslImportWizard } from './useRestDslImportWizard';
@@ -30,7 +31,8 @@ describe('useRestDslImportWizard', () => {
 
   const mockSettingsContext = {
     getSettings: () => ({ rest: { apicurioRegistryUrl: '', customMediaTypes: [] } }),
-  } as never;
+    saveSettings: () => {},
+  } as unknown as AbstractSettingsAdapter;
 
   describe('handleSchemaLoaded', () => {
     it('parses valid OpenAPI spec and updates state', () => {

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -37,6 +37,7 @@ import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.mo
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
 import { MappingSerializerService } from '../mapping/mapping-serializer.service';
 import { XPathService } from '../xpath/xpath.service';
+import { ValidatedXPathParseResult } from '../xpath/xpath-model';
 import { MappingLinksService } from './mapping-links.service';
 
 describe('MappingLinksService', () => {
@@ -542,10 +543,9 @@ describe('MappingLinksService', () => {
 
   describe('when XPath validation fails', () => {
     it('should return empty links for invalid XPath expressions', () => {
-      const validateSpy = vi.spyOn(XPathService, 'validate').mockReturnValue({
-        getExprNode: () => null,
-        dataMapperErrors: [],
-      } as never);
+      const mockValidationResult = new ValidatedXPathParseResult();
+      // No parserResult → getExprNode() returns undefined (treated as invalid)
+      const validateSpy = vi.spyOn(XPathService, 'validate').mockReturnValue(mockValidationResult);
 
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links).toHaveLength(0);


### PR DESCRIPTION
Refactors 19 test files across the ui package to reduce boilerplate and improve type safety. Key changes include:

Replaced as never type casts with proper type assertions using GraphElement<ElementModel, CanvasNode['data']> and similar explicit types
Introduced typed mock data interfaces (e.g., MockData) to replace loose Record<string, unknown> typings
Removed redundant test setup and simplified test structure across DataMapper, Document, FieldContextMenu, PropertiesModal, Visualization, and other components
Net result: -254 lines across the test suite with no loss of coverage.


fix: https://github.com/KaotoIO/kaoto/issues/3379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and TypeScript typing across UI, visualization, and document workflows.
  * Simplified several test setups and reduced duplicated boilerplate.
  * Updated mocked test data to better match real application shapes.
  * Removed some legacy animation-frame test mocking for cleaner execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->