### PR TITLE
chore(sonarqube): fix readonly + refactor eslint&tsconfig

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,8 @@
 import pluginJs from '@eslint/js';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
+import pluginReact from 'eslint-plugin-react';
+import pluginReactHooks from 'eslint-plugin-react-hooks';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -11,6 +13,25 @@ export default [
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  // Enable type-aware linting (required for prefer-readonly / typescript:S2933).
+  // Scoped to package source dirs — excludes root-level config/tooling files that
+  // have no tsconfig. Each package's own tsconfig.json is resolved via project:true.
+  {
+    files: [
+      'packages/ui/src/**/*.{ts,tsx}',
+      'packages/ui-tests/cypress/**/*.{ts,tsx}',
+      'packages/ui-tests/stories/**/*.{ts,tsx}',
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/prefer-readonly': 'error',
+    },
+  },
   {
     plugins: {
       'simple-import-sort': simpleImportSort,
@@ -20,6 +41,26 @@ export default [
       '@typescript-eslint/no-unused-expressions': 'off',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+    },
+  },
+  {
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    plugins: {
+      ...pluginReact.configs.flat.recommended.plugins,
+      'react-hooks': pluginReactHooks,
+    },
+  },
+  {
+    rules: {
+      ...pluginReact.configs.flat.recommended.rules,
+      ...pluginReactHooks.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off',
+      'react/display-name': 'off',
+      'react/prop-types': 'off',
     },
   },
   eslintConfigPrettier,

--- a/packages/ui-tests/eslint.config.mjs
+++ b/packages/ui-tests/eslint.config.mjs
@@ -1,23 +1,4 @@
 // @ts-check
-import pluginReact from 'eslint-plugin-react';
-import pluginReactHooks from 'eslint-plugin-react-hooks';
 import rootConfig from '../../eslint.config.mjs';
 
-export default [
-  ...rootConfig,
-  {
-    plugins: {
-      ...pluginReact.configs.flat.recommended.plugins,
-      'react-hooks': pluginReactHooks,
-    },
-  },
-  {
-    rules: {
-      ...pluginReact.configs.flat.recommended.rules,
-      ...pluginReactHooks.configs.recommended.rules,
-      'react/react-in-jsx-scope': 'off',
-      'react/display-name': 'off',
-      'react/prop-types': 'off',
-    },
-  },
-];
+export default [...rootConfig];

--- a/packages/ui-tests/tsconfig.json
+++ b/packages/ui-tests/tsconfig.json
@@ -1,25 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["cypress", "node", "cypress-file-upload", "monaco-editor"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
+    "composite": true,
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "types": ["cypress", "node", "cypress-file-upload", "monaco-editor"]
   },
   "include": ["cypress", "**/*.ts", "stories"]
 }

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,7 +1,5 @@
 // @ts-check
 import vitest from '@vitest/eslint-plugin';
-import pluginReact from 'eslint-plugin-react';
-import pluginReactHooks from 'eslint-plugin-react-hooks';
 
 import rootConfig from '../../eslint.config.mjs';
 
@@ -14,26 +12,6 @@ export default [
     rules: {
       'vitest/prefer-to-have-length': 'error',
       'vitest/prefer-to-be': 'error',
-    },
-  },
-  {
-    settings: {
-      react: {
-        version: 'detect',
-      },
-    },
-    plugins: {
-      ...pluginReact.configs.flat.recommended.plugins,
-      'react-hooks': pluginReactHooks,
-    },
-  },
-  {
-    rules: {
-      ...pluginReact.configs.flat.recommended.rules,
-      ...pluginReactHooks.configs.recommended.rules,
-      'react/react-in-jsx-scope': 'off',
-      'react/display-name': 'off',
-      'react/prop-types': 'off',
     },
   },
 ];

--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -68,17 +68,6 @@ describe('DataMapperPage', () => {
     fileContents = {};
   });
 
-  it('should render initial XSLT mappings', async () => {
-    fileContents[metadata.xsltPath] = getShipOrderToShipOrderXslt();
-    renderWithVirtuoso(
-      <MetadataProvider api={api}>
-        <DataMapper vizNode={vizNode} />
-      </MetadataProvider>,
-    );
-    await screen.findByTestId('source-parameters-header');
-    // TODO assert mappings are restored even without loading schema... But how? Lines are not drawn...
-  });
-
   it('should render initial XSLT mappings with initial documents', async () => {
     fileContents['ShipOrder.xsd'] = getShipOrderXsd();
     fileContents[metadata.xsltPath] = getShipOrderToShipOrderXslt();
@@ -112,7 +101,6 @@ describe('DataMapperPage', () => {
     });
     /** We cannot rely on expect.assertions(6) since when there's a failure, an extra expectation is run */
     expect(executed).toBeTruthy();
-    // TODO assert mappings are restored even without loading schema... But how? Lines are not drawn...
   });
 
   it('should not render toolbar menu in embedded mode', async () => {

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.ts
@@ -2,7 +2,7 @@ import { ValidationResult, ValidationStatus } from '../../models';
 import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
 
 export class RouteIdValidator {
-  private static URI_REGEXP = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
+  private static readonly URI_REGEXP = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
 
   /**
    * Verifies that the provided name is valid

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -92,7 +92,7 @@ export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAct
 }
 
 export class VisualFlowsApi {
-  private dispatch: React.Dispatch<VisibleFlowAction>;
+  private readonly dispatch: React.Dispatch<VisibleFlowAction>;
 
   constructor(dispatch: React.Dispatch<VisibleFlowAction>) {
     this.dispatch = dispatch;

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -13,9 +13,9 @@ import { RouteTemplateBeansEntity } from './routeTemplateBeansEntity';
  * This class is to absorb a little bit of difference between beans such as {@link BeanFactory}.
  */
 export class BeansEntityHandler {
-  private type: 'beans' | 'routeTemplateBean' | undefined;
-  private beansAware: BeansAwareResource | RouteTemplateBeansAwareResource | undefined;
-  constructor(private camelResource?: KaotoResource) {
+  private readonly type: 'beans' | 'routeTemplateBean' | undefined;
+  private readonly beansAware: BeansAwareResource | RouteTemplateBeansAwareResource | undefined;
+  constructor(private readonly camelResource?: KaotoResource) {
     if (!this.camelResource) return;
     if ((this.camelResource as unknown as BeansAwareResource).createBeansEntity !== undefined) {
       this.beansAware = this.camelResource as unknown as BeansAwareResource;

--- a/packages/ui/src/xml-schema-ts/DocumentFragmentNodeList.ts
+++ b/packages/ui/src/xml-schema-ts/DocumentFragmentNodeList.ts
@@ -1,6 +1,6 @@
 export class DocumentFragmentNodeList implements NodeList {
-  private nodes: Node[] = [];
-  private fragment?: DocumentFragment;
+  private readonly nodes: Node[] = [];
+  private readonly fragment?: DocumentFragment;
   length: number;
 
   /**

--- a/packages/ui/src/xml-schema-ts/XmlSchemaGroup.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaGroup.ts
@@ -12,7 +12,7 @@ export class XmlSchemaGroup
   implements XmlSchemaNamed, XmlSchemaChoiceMember, XmlSchemaSequenceMember, XmlSchemaAllMember
 {
   private particle: XmlSchemaGroupParticle | null = null;
-  private namedDelegate: XmlSchemaNamedImpl;
+  private readonly namedDelegate: XmlSchemaNamedImpl;
 
   constructor(parent: XmlSchema) {
     super();

--- a/packages/ui/src/xml-schema-ts/XmlSchemaNotation.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaNotation.ts
@@ -6,7 +6,7 @@ import { XmlSchemaAnnotated } from './XmlSchemaAnnotated';
 export class XmlSchemaNotation extends XmlSchemaAnnotated implements XmlSchemaNamed {
   private system: string | null = null;
   private publicNotation: string | null = null;
-  private namedDelegate: XmlSchemaNamedImpl;
+  private readonly namedDelegate: XmlSchemaNamedImpl;
 
   /**
    * Creates new XmlSchemaNotation

--- a/packages/ui/src/xml-schema-ts/XmlSchemaType.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaType.ts
@@ -9,7 +9,7 @@ export class XmlSchemaType extends XmlSchemaAnnotated implements XmlSchemaNamed 
   private finalDerivation: XmlSchemaDerivationMethod;
   private finalResolved?: XmlSchemaDerivationMethod;
   private _isMixed = false;
-  private namedDelegate: XmlSchemaNamedImpl;
+  private readonly namedDelegate: XmlSchemaNamedImpl;
 
   constructor(schema: XmlSchema, topLevel: boolean) {
     super();

--- a/packages/ui/src/xml-schema-ts/annotation/XmlSchemaAnnotation.ts
+++ b/packages/ui/src/xml-schema-ts/annotation/XmlSchemaAnnotation.ts
@@ -2,7 +2,7 @@ import { XmlSchemaObject } from '../XmlSchemaObject';
 import type { XmlSchemaAnnotationItem } from './XmlSchemaAnnotationItem';
 
 export class XmlSchemaAnnotation extends XmlSchemaObject {
-  private items: XmlSchemaAnnotationItem[] = [];
+  private readonly items: XmlSchemaAnnotationItem[] = [];
 
   public getItems() {
     return this.items;

--- a/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttribute.ts
+++ b/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttribute.ts
@@ -20,8 +20,8 @@ export class XmlSchemaAttribute
   private schemaType: XmlSchemaSimpleType | null = null;
   private schemaTypeName: QName | null = null;
   private use: XmlSchemaUse;
-  private namedDelegate: XmlSchemaNamedWithFormImpl;
-  private ref: XmlSchemaRef<XmlSchemaAttribute>;
+  private readonly namedDelegate: XmlSchemaNamedWithFormImpl;
+  private readonly ref: XmlSchemaRef<XmlSchemaAttribute>;
 
   /**
    * Create a new attribute.

--- a/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttributeGroup.ts
+++ b/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttributeGroup.ts
@@ -10,8 +10,8 @@ export class XmlSchemaAttributeGroup
   implements XmlSchemaNamed, XmlSchemaAttributeGroupMember
 {
   private anyAttribute: XmlSchemaAnyAttribute | null = null;
-  private attributes: XmlSchemaAttributeGroupMember[] = [];
-  private namedDelegate: XmlSchemaNamedImpl;
+  private readonly attributes: XmlSchemaAttributeGroupMember[] = [];
+  private readonly namedDelegate: XmlSchemaNamedImpl;
 
   /**
    * Creates new XmlSchemaAttributeGroup

--- a/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttributeGroupRef.ts
+++ b/packages/ui/src/xml-schema-ts/attribute/XmlSchemaAttributeGroupRef.ts
@@ -15,7 +15,7 @@ export class XmlSchemaAttributeGroupRef
   extends XmlSchemaAttributeOrGroupRef
   implements XmlSchemaAttributeGroupMember, XmlSchemaItemWithRef<XmlSchemaAttributeGroup>
 {
-  private ref: XmlSchemaRef<XmlSchemaAttributeGroup>;
+  private readonly ref: XmlSchemaRef<XmlSchemaAttributeGroup>;
 
   /**
    * Create an attribute group reference.

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
@@ -12,11 +12,11 @@ import { XmlSchemaExternal } from './XmlSchemaExternal';
  * Consortium (W3C) redefine element.
  */
 export class XmlSchemaRedefine extends XmlSchemaExternal {
-  private attributeGroups = new Map<QName, XmlSchemaAttributeGroup>();
-  private groups = new Map<QName, XmlSchemaGroup>();
-  private schemaTypes = new Map<QName, XmlSchemaType>();
+  private readonly attributeGroups = new Map<QName, XmlSchemaAttributeGroup>();
+  private readonly groups = new Map<QName, XmlSchemaGroup>();
+  private readonly schemaTypes = new Map<QName, XmlSchemaType>();
 
-  private items: XmlSchemaObject[] = [];
+  private readonly items: XmlSchemaObject[] = [];
 
   /**
    * Creates new XmlSchemaRedefine

--- a/packages/ui/src/xml-schema-ts/particle/XmlSchemaAll.ts
+++ b/packages/ui/src/xml-schema-ts/particle/XmlSchemaAll.ts
@@ -2,7 +2,7 @@ import { XmlSchemaAllMember } from './XmlSchemaAllMember';
 import { XmlSchemaGroupParticle } from './XmlSchemaGroupParticle';
 
 export class XmlSchemaAll extends XmlSchemaGroupParticle {
-  private items: XmlSchemaAllMember[] = [];
+  private readonly items: XmlSchemaAllMember[] = [];
 
   public getItems() {
     return this.items;

--- a/packages/ui/src/xml-schema-ts/particle/XmlSchemaChoice.ts
+++ b/packages/ui/src/xml-schema-ts/particle/XmlSchemaChoice.ts
@@ -9,7 +9,7 @@ import { XmlSchemaSequenceMember } from './XmlSchemaSequenceMember';
  * This can contain any of (element|group|choice|sequence|any)*.
  */
 export class XmlSchemaChoice extends XmlSchemaGroupParticle implements XmlSchemaChoiceMember, XmlSchemaSequenceMember {
-  private items: XmlSchemaChoiceMember[] = [];
+  private readonly items: XmlSchemaChoiceMember[] = [];
 
   public getItems() {
     return this.items;

--- a/packages/ui/src/xml-schema-ts/particle/XmlSchemaElement.ts
+++ b/packages/ui/src/xml-schema-ts/particle/XmlSchemaElement.ts
@@ -30,7 +30,7 @@ export class XmlSchemaElement
    */
   private block: XmlSchemaDerivationMethod;
 
-  private constraints: XmlSchemaIdentityConstraint[] = [];
+  private readonly constraints: XmlSchemaIdentityConstraint[] = [];
 
   /**
    * Provides the default value of the element if its content is a simple type or the element's content is
@@ -61,7 +61,7 @@ export class XmlSchemaElement
    */
   private substitutionGroup: QName | null = null;
 
-  private namedDelegate: XmlSchemaNamedWithFormImpl;
+  private readonly namedDelegate: XmlSchemaNamedWithFormImpl;
 
   /**
    * Creates new XmlSchemaElement

--- a/packages/ui/src/xml-schema-ts/particle/XmlSchemaSequence.ts
+++ b/packages/ui/src/xml-schema-ts/particle/XmlSchemaSequence.ts
@@ -12,7 +12,7 @@ export class XmlSchemaSequence
   extends XmlSchemaGroupParticle
   implements XmlSchemaChoiceMember, XmlSchemaSequenceMember
 {
-  private items: XmlSchemaSequenceMember[] = [];
+  private readonly items: XmlSchemaSequenceMember[] = [];
 
   /**
    * The elements contained within the compositor. Collection of XmlSchemaElement, XmlSchemaGroupRef,

--- a/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleContentRestriction.ts
+++ b/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleContentRestriction.ts
@@ -17,7 +17,7 @@ export class XmlSchemaSimpleContentRestriction extends XmlSchemaContent {
    * Contains XmlSchemaAttribute and XmlSchemaAttributeGroupRef. Collection of attributes for the simple
    * type.
    */
-  private attributes: XmlSchemaAttributeOrGroupRef[] = [];
+  private readonly attributes: XmlSchemaAttributeOrGroupRef[] = [];
 
   /* Derived from the type specified by the base value. */
   private baseType: XmlSchemaSimpleType | null = null;
@@ -26,7 +26,7 @@ export class XmlSchemaSimpleContentRestriction extends XmlSchemaContent {
   private baseTypeName: QName | null = null;
 
   /* One or more of the facet classes: */
-  private facets: XmlSchemaFacet[] = [];
+  private readonly facets: XmlSchemaFacet[] = [];
 
   /* Allows an XmlSchemaAnyAttribute to be used for the attribute value. */
 

--- a/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction.ts
+++ b/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction.ts
@@ -6,7 +6,7 @@ import { XmlSchemaSimpleTypeContent } from './XmlSchemaSimpleTypeContent';
 export class XmlSchemaSimpleTypeRestriction extends XmlSchemaSimpleTypeContent {
   private baseType?: XmlSchemaSimpleType;
   private baseTypeName: QName | null = null;
-  private facets: XmlSchemaFacet[] = [];
+  private readonly facets: XmlSchemaFacet[] = [];
 
   getBaseType() {
     return this.baseType;

--- a/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleTypeUnion.ts
+++ b/packages/ui/src/xml-schema-ts/simple/XmlSchemaSimpleTypeUnion.ts
@@ -7,7 +7,7 @@ import type { XmlSchemaSimpleType } from './XmlSchemaSimpleType';
 import { XmlSchemaSimpleTypeContent } from './XmlSchemaSimpleTypeContent';
 
 export class XmlSchemaSimpleTypeUnion extends XmlSchemaSimpleTypeContent {
-  private baseTypes: XmlSchemaSimpleType[] = [];
+  private readonly baseTypes: XmlSchemaSimpleType[] = [];
   private memberTypesSource: string | null = null;
   private memberTypesQNames: QName[] = [];
 

--- a/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
+++ b/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
@@ -5,7 +5,7 @@ import { PrefixCollector } from './PrefixCollector';
 export class NodeNamespaceContext implements NamespacePrefixList {
   private prefixes?: string[];
 
-  private constructor(private declarations: Record<string, string>) {}
+  private constructor(private readonly declarations: Record<string, string>) {}
 
   static getNamespaceContext(pNode: Node): NodeNamespaceContext {
     const declarations: Record<string, string> = {};

--- a/packages/ui/src/xml-schema-ts/utils/ObjectMap.ts
+++ b/packages/ui/src/xml-schema-ts/utils/ObjectMap.ts
@@ -5,7 +5,7 @@ import { SchemaKey } from '../SchemaKey';
  * The Map which uses a class instance as a key where if the stringified key matches then it's considered same.
  */
 abstract class ObjectMap<K, V> {
-  private delegate = new Map<string, V>();
+  private readonly delegate = new Map<string, V>();
 
   get(key: K) {
     return this.delegate.get(this.keyToString(key));
@@ -51,8 +51,8 @@ abstract class ObjectMap<K, V> {
 
 class KeysBridge<K> implements IterableIterator<K> {
   constructor(
-    private delegateKeys: IterableIterator<string>,
-    private stringToKey: (stringifiedKey: string) => K,
+    private readonly delegateKeys: IterableIterator<string>,
+    private readonly stringToKey: (stringifiedKey: string) => K,
   ) {}
 
   [Symbol.iterator](): IterableIterator<K> {
@@ -72,8 +72,8 @@ class KeysBridge<K> implements IterableIterator<K> {
 
 class EntriesBridge<K, V> implements IterableIterator<[K, V]> {
   constructor(
-    private delegateEntries: IterableIterator<[string, V]>,
-    private stringToKey: (stringifiedKey: string) => K,
+    private readonly delegateEntries: IterableIterator<[string, V]>,
+    private readonly stringToKey: (stringifiedKey: string) => K,
   ) {}
 
   [Symbol.iterator](): IterableIterator<[K, V]> {

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.ts
@@ -12,7 +12,7 @@ export class XmlSchemaNamedImpl implements XmlSchemaNamed {
   protected refTwin?: XmlSchemaRefBase;
   // Store the name as a QName for the convenience of QName fans.
   private qname: QName | null = null;
-  private topLevel: boolean = false;
+  private readonly topLevel: boolean = false;
 
   /**
    * Create a new named object.

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.ts
@@ -9,7 +9,7 @@ import type { XmlSchemaNamedWithForm } from './XmlSchemaNamedWithForm';
  */
 export class XmlSchemaNamedWithFormImpl extends XmlSchemaNamedImpl implements XmlSchemaNamedWithForm {
   private form = XmlSchemaForm.NONE;
-  private element = false;
+  private readonly element: boolean;
   private wireName: QName | null = null;
 
   /**

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaRef.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaRef.ts
@@ -5,7 +5,7 @@ import { XmlSchemaRefBase } from './XmlSchemaRefBase';
 
 export class XmlSchemaRef<T extends XmlSchemaNamed> extends XmlSchemaRefBase {
   private targetObject: XmlSchemaNamed | null = null;
-  private targetType: XmlSchemaNamedType;
+  private readonly targetType: XmlSchemaNamedType;
 
   constructor(parent: XmlSchema, targetType: XmlSchemaNamedType) {
     super();

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,30 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-
+    "composite": true,
     /* Typings */
-    "types": [
-      "@testing-library/jest-dom",
-      "vitest/globals",
-      "@types/node",
-    ]
+    "types": ["@testing-library/jest-dom", "vitest/globals", "@types/node"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/ui/tsconfig.json" },
+    { "path": "./packages/ui-tests/tsconfig.json" }
+  ]
+}


### PR DESCRIPTION
**Changes**:

**- Centralized TypeScript config:** extracted shared compiler options into a new root-level `tsconfig.base.json`, and added a root `tsconfig.json` as a project-references entry point. Both package-level `packages/ui/tsconfig.json` and `packages/ui-tests/tsconfig.json` now extend from the base, removing duplicated settings.

**- Centralized ESLint config:** moved React, React Hooks, and type-aware linting rules (including `@typescript-eslint/prefer-readonly`) up to the root `eslint.config.mjs`. Package-level configs (`packages/ui/eslint.config.mjs`, `packages/ui-tests/eslint.config.mjs`) now simply extend the root config without repeating those rules.

**- SonarQube prefer-readonly fix:** updated class fields across the xml-schema-ts module and a few other source files to use readonly where applicable, resolving the typescript:S2933 SonarQube rule violations.

fix: https://github.com/KaotoIO/kaoto/issues/2974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved project-wide TypeScript and linting setup for more consistent code quality checks.
  * Standardized shared compiler settings across app areas and test suites.
  * Updated test linting to better support modern test patterns.
* **Bug Fixes**
  * Tightened several internal data structures and class fields to reduce accidental reassignment and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->