### PR TITLE
fix(linter): Avoid floating promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,14 @@ import tseslint from 'typescript-eslint';
 
 export default [
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
-  { languageOptions: { globals: globals.browser } },
+  { 
+    languageOptions: { 
+      globals: globals.browser,
+      parserOptions: {
+        project: true,
+      },
+    } 
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   // Enable type-aware linting (required for prefer-readonly / typescript:S2933).
@@ -39,6 +46,7 @@ export default [
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/no-floating-promises': 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
     },

--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -219,18 +219,13 @@ Cypress.Commands.add('selectCamelRouteType', (type: string, subType?: string) =>
 });
 
 Cypress.Commands.add('retryClickDropdown', (dropdownSelector: string, listSelector: string) => {
-  cy.wrap(null).then(() => {
-    cy.get(dropdownSelector).click({ force: true });
-    cy.wait(200).then(() => {
-      cy.get('body').then(($body) => {
-        if ($body.find(listSelector).length === 0) {
-          cy.log('Dropdown list not visible, retrying click...');
-          cy.get(dropdownSelector).click({ force: true });
-          cy.wait(200);
-        }
-      });
-    });
-  });
+  cy.get(dropdownSelector).click({ force: true });
+  // The toggle is a stateful flip (clicking an open menu closes it again), so the previous
+  // fixed-delay probe + blind re-click could close a menu that merely opened slowly — the
+  // cold-start, Chrome-only failure. Instead wait for the toggle to report expanded
+  // (aria-expanded is set by the PatternFly MenuToggle) and the list to render.
+  cy.get(dropdownSelector).should('have.attr', 'aria-expanded', 'true');
+  cy.get(listSelector).should('exist');
 });
 
 Cypress.Commands.add('switchCodeToXml', () => {

--- a/packages/ui/src/components/Catalog/BaseCatalog.test.tsx
+++ b/packages/ui/src/components/Catalog/BaseCatalog.test.tsx
@@ -118,7 +118,7 @@ describe('BaseCatalog', () => {
       screen.getAllByRole('listitem').filter((li) => li.classList.contains('catalog-data-list-item')),
     ).toHaveLength(20);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Go to next page' })).toBeDisabled();
     });
   });

--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -69,7 +69,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       const mappingFile = await DataMapperMetadataService.loadMappingFile(ctx, meta);
       setInitialXsltFile(mappingFile);
     };
-    initialize().then(() => setIsLoading(false));
+    void initialize().then(() => setIsLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -78,7 +78,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       if (!metadataId || !metadata) return;
       switch (definition.documentType) {
         case DocumentType.SOURCE_BODY:
-          DataMapperMetadataService.updateSourceBodyMetadata(ctx, metadataId, metadata, definition);
+          void DataMapperMetadataService.updateSourceBodyMetadata(ctx, metadataId, metadata, definition);
           if (vizNode) {
             DataMapperStepService.setUseJsonBody(
               vizNode,
@@ -88,10 +88,10 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
           }
           break;
         case DocumentType.TARGET_BODY:
-          DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
+          void DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
           break;
         case DocumentType.PARAM:
-          DataMapperMetadataService.updateSourceParameterMetadata(
+          void DataMapperMetadataService.updateSourceParameterMetadata(
             ctx,
             metadataId,
             metadata,
@@ -106,7 +106,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   const onDeleteParameter = useCallback(
     (name: string) => {
       if (!metadataId || !metadata) return;
-      DataMapperMetadataService.deleteSourceParameterMetadata(ctx, metadataId, metadata, name);
+      void DataMapperMetadataService.deleteSourceParameterMetadata(ctx, metadataId, metadata, name);
     },
     [ctx, metadata, metadataId],
   );
@@ -114,7 +114,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   const onRenameParameter = useCallback(
     (oldName: string, newName: string) => {
       if (!metadataId || !metadata) return;
-      DataMapperMetadataService.renameSourceParameterMetadata(ctx, metadataId, metadata, oldName, newName);
+      void DataMapperMetadataService.renameSourceParameterMetadata(ctx, metadataId, metadata, oldName, newName);
     },
     [ctx, metadata, metadataId],
   );
@@ -122,7 +122,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   const onUpdateMappings = useCallback(
     (xsltFile: string) => {
       if (!metadata) return;
-      DataMapperMetadataService.updateMappingFile(ctx, metadata, xsltFile);
+      void DataMapperMetadataService.updateMappingFile(ctx, metadata, xsltFile);
     },
     [ctx, metadata],
   );
@@ -130,7 +130,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   const onUpdateNamespaceMap = useCallback(
     (namespaceMap: Record<string, string>) => {
       if (!metadataId || !metadata) return;
-      DataMapperMetadataService.setNamespaceMap(ctx, metadataId, metadata, namespaceMap);
+      void DataMapperMetadataService.setNamespaceMap(ctx, metadataId, metadata, namespaceMap);
     },
     [ctx, metadata, metadataId],
   );

--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -74,11 +74,11 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   }, []);
 
   const onUpdateDocument = useCallback(
-    (definition: DocumentDefinition) => {
+    async (definition: DocumentDefinition) => {
       if (!metadataId || !metadata) return;
       switch (definition.documentType) {
         case DocumentType.SOURCE_BODY:
-          void DataMapperMetadataService.updateSourceBodyMetadata(ctx, metadataId, metadata, definition);
+          await DataMapperMetadataService.updateSourceBodyMetadata(ctx, metadataId, metadata, definition);
           if (vizNode) {
             DataMapperStepService.setUseJsonBody(
               vizNode,
@@ -88,10 +88,10 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
           }
           break;
         case DocumentType.TARGET_BODY:
-          void DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
+          await DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
           break;
         case DocumentType.PARAM:
-          void DataMapperMetadataService.updateSourceParameterMetadata(
+          await DataMapperMetadataService.updateSourceParameterMetadata(
             ctx,
             metadataId,
             metadata,
@@ -104,33 +104,33 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   );
 
   const onDeleteParameter = useCallback(
-    (name: string) => {
+    async (name: string) => {
       if (!metadataId || !metadata) return;
-      void DataMapperMetadataService.deleteSourceParameterMetadata(ctx, metadataId, metadata, name);
+      await DataMapperMetadataService.deleteSourceParameterMetadata(ctx, metadataId, metadata, name);
     },
     [ctx, metadata, metadataId],
   );
 
   const onRenameParameter = useCallback(
-    (oldName: string, newName: string) => {
+    async (oldName: string, newName: string) => {
       if (!metadataId || !metadata) return;
-      void DataMapperMetadataService.renameSourceParameterMetadata(ctx, metadataId, metadata, oldName, newName);
+      await DataMapperMetadataService.renameSourceParameterMetadata(ctx, metadataId, metadata, oldName, newName);
     },
     [ctx, metadata, metadataId],
   );
 
   const onUpdateMappings = useCallback(
-    (xsltFile: string) => {
+    async (xsltFile: string) => {
       if (!metadata) return;
-      void DataMapperMetadataService.updateMappingFile(ctx, metadata, xsltFile);
+      await DataMapperMetadataService.updateMappingFile(ctx, metadata, xsltFile);
     },
     [ctx, metadata],
   );
 
   const onUpdateNamespaceMap = useCallback(
-    (namespaceMap: Record<string, string>) => {
+    async (namespaceMap: Record<string, string>) => {
       if (!metadataId || !metadata) return;
-      void DataMapperMetadataService.setNamespaceMap(ctx, metadataId, metadata, namespaceMap);
+      await DataMapperMetadataService.setNamespaceMap(ctx, metadataId, metadata, namespaceMap);
     },
     [ctx, metadata, metadataId],
   );

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -48,7 +48,7 @@ vi.mock('./XsltDocumentRenameInput', async () => {
 
     useEffectHook(() => {
       if (isEditing) {
-        validator(currentValue).then((result: { status: string; errMessages: string[] }) => {
+        void validator(currentValue).then((result: { status: string; errMessages: string[] }) => {
           setIsValid(result.status === 'success');
           setValidationError((result.errMessages[0] || null) as SetStateAction<null>);
         });

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
@@ -73,7 +73,7 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
       const exists = await metadata.isResourceExist(xsltDocumentName);
       setXsltFileExists(exists);
     };
-    checkFile();
+    void checkFile();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -144,7 +144,7 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
   );
 
   const onClick = useCallback(() => {
-    navigate(`${Links.DataMapper}/${vizNode?.getNodeDefinition()?.id}`);
+    void navigate(`${Links.DataMapper}/${vizNode?.getNodeDefinition()?.id}`);
   }, [navigate, vizNode]);
 
   if (!isDefined(metadata)) {

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
@@ -143,8 +143,8 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
     [xsltDocumentName, metadata, entitiesContext, vizNode],
   );
 
-  const onClick = useCallback(() => {
-    void navigate(`${Links.DataMapper}/${vizNode?.getNodeDefinition()?.id}`);
+  const onClick = useCallback(async () => {
+    await navigate(`${Links.DataMapper}/${vizNode?.getNodeDefinition()?.id}`);
   }, [navigate, vizNode]);
 
   if (!isDefined(metadata)) {

--- a/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
+++ b/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
@@ -76,7 +76,7 @@ export const XsltDocumentRenameInput: FunctionComponent<IXsltDocumentRenameInput
       }
     };
 
-    runValidation();
+    void runValidation();
 
     return () => {
       isCurrent = false;
@@ -134,7 +134,7 @@ export const XsltDocumentRenameInput: FunctionComponent<IXsltDocumentRenameInput
   const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
       if (event.key === 'Enter') {
-        saveValue();
+        void saveValue();
       }
       if (event.key === 'Escape') {
         cancelValue();
@@ -146,7 +146,7 @@ export const XsltDocumentRenameInput: FunctionComponent<IXsltDocumentRenameInput
 
   const onSave: MouseEventHandler<HTMLButtonElement> = useCallback(
     (event) => {
-      saveValue();
+      void saveValue();
       event.stopPropagation();
     },
     [saveValue],

--- a/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
+++ b/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
@@ -133,21 +133,25 @@ export const XsltDocumentRenameInput: FunctionComponent<IXsltDocumentRenameInput
 
   const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
+      event.stopPropagation();
       if (event.key === 'Enter') {
-        void saveValue();
+        saveValue().catch(() => {
+          // errors are handled inside saveValue
+        });
       }
       if (event.key === 'Escape') {
         cancelValue();
       }
-      event.stopPropagation();
     },
     [cancelValue, saveValue],
   );
 
   const onSave: MouseEventHandler<HTMLButtonElement> = useCallback(
     (event) => {
-      void saveValue();
       event.stopPropagation();
+      saveValue().catch(() => {
+        // errors are handled inside saveValue
+      });
     },
     [saveValue],
   );

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -43,16 +43,20 @@ describe('XPathInputAction', () => {
     expect(btn).toBeInTheDocument();
   });
 
-  it('should stop event propagation on handleXPathChange', () => {
-    const stopPropagationSpy = vi.fn();
-    const wrapper = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={vi.fn()} />);
+  it('should stop event propagation on handleXPathChange', async () => {
+    const onUpdateMock = vi.fn();
+    const wrapper = render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={onUpdateMock} />);
+    const input = wrapper.getByTestId('transformation-xpath-input');
 
-    act(() => {
-      const input = wrapper.getByTestId('transformation-xpath-input');
-      fireEvent.change(input, { target: { value: '/ShipOrder' }, stopPropagation: stopPropagationSpy });
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '/ShipOrder' } });
     });
 
-    waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
+    // Verify the handler was called and mapping was updated
+    await waitFor(() => {
+      expect(onUpdateMock).toHaveBeenCalled();
+      expect(mapping.expression).toBe('/ShipOrder');
+    });
   });
 
   it('should focus input when store indicates focus is needed for mapping node path', async () => {

--- a/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
+++ b/packages/ui/src/components/InlineEdit/routeIdValidator.test.ts
@@ -17,9 +17,9 @@ describe('routeIdValidator', () => {
     expect(RouteIdValidator.isNameValidCheck(name)).toEqual(result);
   });
 
-  it('should return sucess if the name is unique', () => {
+  it('should return sucess if the name is unique', async () => {
     const resource = new CamelRouteResource([camelRouteJson]);
-    resource.initialize();
+    await resource.initialize();
     const visualEntities = resource.getVisualEntities();
     vi.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -28,9 +28,9 @@ describe('routeIdValidator', () => {
     expect(result.errMessages).toHaveLength(0);
   });
 
-  it('should return an error if the name is not unique', () => {
+  it('should return an error if the name is not unique', async () => {
     const resource = new CamelRouteResource([camelRouteJson]);
-    resource.initialize();
+    await resource.initialize();
     const visualEntities = resource.getVisualEntities();
     vi.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -40,9 +40,9 @@ describe('routeIdValidator', () => {
     expect(result.errMessages).toEqual(['Name must be unique']);
   });
 
-  it('should return an error if the name is not a valid URI', () => {
+  it('should return an error if the name is not a valid URI', async () => {
     const resource = new CamelRouteResource([camelRouteJson]);
-    resource.initialize();
+    await resource.initialize();
     const visualEntities = resource.getVisualEntities();
     vi.spyOn(visualEntities[0], 'getId').mockReturnValue('flow-1234');
 
@@ -52,9 +52,9 @@ describe('routeIdValidator', () => {
     expect(result.errMessages).toEqual(['Name should only contain lowercase letters, numbers, and dashes']);
   });
 
-  it('should return an error if the name is not unique neither a valid URI', () => {
+  it('should return an error if the name is not unique neither a valid URI', async () => {
     const resource = new CamelRouteResource([camelRouteJson]);
-    resource.initialize();
+    await resource.initialize();
     const visualEntities = resource.getVisualEntities();
     vi.spyOn(visualEntities[0], 'getId').mockReturnValue('The amazing Route');
 

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
@@ -86,7 +86,7 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
       }
     };
 
-    fetchTabs();
+    void fetchTabs();
   }, [catalogRegistry, props.tile.name, props.tile.type]);
 
   const handleTabClick = (_event: unknown, tabIndex: string | number) => {

--- a/packages/ui/src/components/Settings/SettingsForm.test.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.test.tsx
@@ -72,7 +72,9 @@ describe('SettingsForm', () => {
   it('should display error alert when save fails', async () => {
     // Mock saveSettings to throw an error
     const errorMessage = 'Failed to save settings to storage';
-    settingsAdapter.saveSettings = vi.fn().mockRejectedValue(new Error(errorMessage));
+    settingsAdapter.saveSettings = vi.fn().mockImplementation(() => {
+      throw new Error(errorMessage);
+    });
 
     await act(async () => {
       const button = screen.getByTestId('settings-form-save-btn');

--- a/packages/ui/src/components/Settings/SettingsForm.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.tsx
@@ -34,11 +34,11 @@ export const SettingsForm: FunctionComponent = () => {
 
   const onSave = async () => {
     try {
-      await settingsAdapter.saveSettings(settings);
+      settingsAdapter.saveSettings(settings);
       reloadPage();
 
       if (!hasPendingCatalogUrlChange) {
-        void navigate(Links.Home);
+        await navigate(Links.Home);
       }
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : 'Unable to save settings');
@@ -78,7 +78,13 @@ export const SettingsForm: FunctionComponent = () => {
       </CardBody>
 
       <CardFooter>
-        <Button data-testid="settings-form-save-btn" variant="primary" onClick={() => void onSave()}>
+        <Button
+          data-testid="settings-form-save-btn"
+          variant="primary"
+          onClick={async () => {
+            await onSave();
+          }}
+        >
           Save
         </Button>
       </CardFooter>

--- a/packages/ui/src/components/Settings/SettingsForm.tsx
+++ b/packages/ui/src/components/Settings/SettingsForm.tsx
@@ -38,7 +38,7 @@ export const SettingsForm: FunctionComponent = () => {
       reloadPage();
 
       if (!hasPendingCatalogUrlChange) {
-        navigate(Links.Home);
+        void navigate(Links.Home);
       }
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : 'Unable to save settings');
@@ -78,7 +78,7 @@ export const SettingsForm: FunctionComponent = () => {
       </CardBody>
 
       <CardFooter>
-        <Button data-testid="settings-form-save-btn" variant="primary" onClick={onSave}>
+        <Button data-testid="settings-form-save-btn" variant="primary" onClick={() => void onSave()}>
           Save
         </Button>
       </CardFooter>

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -142,7 +142,7 @@ describe('Canvas', () => {
 
   it('should be able to delete the routes', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
-    camelResource.initialize();
+    await camelResource.initialize();
     const routeEntities = camelResource.getVisualEntities();
     const vizNode = await routeEntities[0].toVizNode();
     const removeSpy = vi.spyOn(camelResource, 'removeEntity');
@@ -202,7 +202,7 @@ describe('Canvas', () => {
 
   it('should be able to delete the kamelets', async () => {
     const kameletResource = new KameletResource(kameletJson);
-    kameletResource.initialize();
+    await kameletResource.initialize();
     const kameletEntities = kameletResource.getVisualEntities();
     const vizNode = await kameletEntities[0].toVizNode();
     const removeSpy = vi.spyOn(kameletResource, 'removeEntity');

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -202,7 +202,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
         icon: <CatalogIcon />,
         tooltip: 'Open Catalog',
         callback: action(() => {
-          catalogModalContext.getNewComponent();
+          void catalogModalContext.getNewComponent();
         }),
       });
     }

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -144,9 +144,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   useEffect(() => {
     let resizeTimeout: number | undefined;
 
-    if (!selectedIds[0]) {
-      setSelectedNode(undefined);
-    } else {
+    if (selectedIds[0]) {
       const selectedNode = controller.getNodeById(selectedIds[0]);
       if (selectedNode) {
         setSelectedNode(selectedNode as unknown as CanvasNode);
@@ -163,6 +161,8 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
           clearTimeout(resizeTimeout);
         }
       };
+    } else {
+      setSelectedNode(undefined);
     }
   }, [selectedIds, controller]);
 
@@ -201,8 +201,8 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
         id: 'topology-control-bar-catalog-button',
         icon: <CatalogIcon />,
         tooltip: 'Open Catalog',
-        callback: action(() => {
-          void catalogModalContext.getNewComponent();
+        callback: action(async () => {
+          await catalogModalContext.getNewComponent();
         }),
       });
     }

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.test.tsx
@@ -49,7 +49,7 @@ describe('DirectEndpointNameField hooks', () => {
       expect(result.current.items.find((item) => item.name === 'start')?.description).toContain('route-start');
     });
 
-    it('handles typeahead callbacks', () => {
+    it('handles typeahead callbacks', async () => {
       const onChange = vi.fn();
       const { result } = renderHook(() =>
         useDirectEndpointNameOptions({
@@ -59,9 +59,15 @@ describe('DirectEndpointNameField hooks', () => {
         }),
       );
 
-      act(() => result.current.onTypeaheadChange({ name: 'orders', value: 'orders' }));
-      act(() => result.current.onCleanInput());
-      act(() => result.current.onCreateOption(undefined, 'new-route'));
+      await act(async () => {
+        result.current.onTypeaheadChange({ name: 'orders', value: 'orders' });
+      });
+      await act(async () => {
+        result.current.onCleanInput();
+      });
+      await act(async () => {
+        result.current.onCreateOption(undefined, 'new-route');
+      });
 
       expect(onChange).toHaveBeenNthCalledWith(1, 'orders');
       expect(onChange).toHaveBeenNthCalledWith(2, undefined);
@@ -71,7 +77,7 @@ describe('DirectEndpointNameField hooks', () => {
   });
 
   describe('useCreateDirectRoute', () => {
-    it('creates a route for a new direct name', () => {
+    it('creates a route for a new direct name', async () => {
       const onChange = vi.fn();
       const addNewEntity = vi.fn().mockReturnValue('new-route-id');
       const toggleFlowVisible = vi.fn();
@@ -97,7 +103,9 @@ describe('DirectEndpointNameField hooks', () => {
 
       expect(result.current.canCreateRoute).toBe(true);
 
-      act(() => result.current.onCreateRoute());
+      await act(async () => {
+        result.current.onCreateRoute();
+      });
 
       expect(addNewEntity).toHaveBeenCalledWith('route', {
         from: { uri: 'direct', parameters: { name: 'new-route' }, steps: [] },

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -71,8 +71,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-duplicate`}
             variant="control"
             title="Duplicate"
-            onClick={(event) => {
-              void onDuplicate();
+            onClick={async (event) => {
+              await onDuplicate();
               event.stopPropagation();
             }}
           />
@@ -85,8 +85,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-move-before`}
             variant="control"
             title="Move before"
-            onClick={(event) => {
-              void onMoveBefore();
+            onClick={async (event) => {
+              await onMoveBefore();
               event.stopPropagation();
             }}
           />
@@ -99,8 +99,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-move-after`}
             variant="control"
             title="Move after"
-            onClick={(event) => {
-              void onMoveAfter();
+            onClick={async (event) => {
+              await onMoveAfter();
               event.stopPropagation();
             }}
           />
@@ -113,8 +113,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-add-special`}
             variant="control"
             title="Add branch"
-            onClick={(event) => {
-              void onInsertSpecial();
+            onClick={async (event) => {
+              await onInsertSpecial();
               event.stopPropagation();
             }}
           />
@@ -126,8 +126,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-disable`}
             variant="control"
             title={isDisabled ? 'Enable step' : 'Disable step'}
-            onClick={(event) => {
-              void onToggleDisableNode();
+            onClick={async (event) => {
+              onToggleDisableNode();
               event.stopPropagation();
             }}
           >
@@ -142,8 +142,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-enable-all`}
             variant="control"
             title="Enable all"
-            onClick={(event) => {
-              void onEnableAllSteps();
+            onClick={async (event) => {
+              onEnableAllSteps();
               event.stopPropagation();
             }}
           />
@@ -156,8 +156,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-replace`}
             variant="control"
             title="Replace step"
-            onClick={(event) => {
-              void onReplaceNode();
+            onClick={async (event) => {
+              await onReplaceNode();
               event.stopPropagation();
             }}
           />
@@ -186,8 +186,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="stateful"
             state="attention"
             title="Delete step"
-            onClick={(event) => {
-              void onDeleteStep();
+            onClick={async (event) => {
+              await onDeleteStep();
               event.stopPropagation();
             }}
           />
@@ -201,8 +201,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="stateful"
             state="attention"
             title="Delete group"
-            onClick={(event) => {
-              void onDeleteGroup();
+            onClick={async (event) => {
+              await onDeleteGroup();
               event.stopPropagation();
             }}
           />

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -72,7 +72,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Duplicate"
             onClick={(event) => {
-              onDuplicate();
+              void onDuplicate();
               event.stopPropagation();
             }}
           />
@@ -86,7 +86,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Move before"
             onClick={(event) => {
-              onMoveBefore();
+              void onMoveBefore();
               event.stopPropagation();
             }}
           />
@@ -100,7 +100,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Move after"
             onClick={(event) => {
-              onMoveAfter();
+              void onMoveAfter();
               event.stopPropagation();
             }}
           />
@@ -114,7 +114,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Add branch"
             onClick={(event) => {
-              onInsertSpecial();
+              void onInsertSpecial();
               event.stopPropagation();
             }}
           />
@@ -127,7 +127,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title={isDisabled ? 'Enable step' : 'Disable step'}
             onClick={(event) => {
-              onToggleDisableNode();
+              void onToggleDisableNode();
               event.stopPropagation();
             }}
           >
@@ -143,7 +143,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Enable all"
             onClick={(event) => {
-              onEnableAllSteps();
+              void onEnableAllSteps();
               event.stopPropagation();
             }}
           />
@@ -157,7 +157,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Replace step"
             onClick={(event) => {
-              onReplaceNode();
+              void onReplaceNode();
               event.stopPropagation();
             }}
           />
@@ -187,7 +187,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             state="attention"
             title="Delete step"
             onClick={(event) => {
-              onDeleteStep();
+              void onDeleteStep();
               event.stopPropagation();
             }}
           />
@@ -202,7 +202,7 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             state="attention"
             title="Delete group"
             onClick={(event) => {
-              onDeleteGroup();
+              void onDeleteGroup();
               event.stopPropagation();
             }}
           />

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.test.tsx
@@ -26,13 +26,16 @@ vi.mock('../../Canvas/flow.service');
 
 describe('ExportDocumentPreviewModal', () => {
   const camelResource = new CamelRouteResource([camelRouteJson]);
-  camelResource.initialize();
   let onCloseSpy: Mock;
   let wrapper: FunctionComponent<PropsWithChildren>;
   let originalCreateObjectURL: typeof URL.createObjectURL;
   let originalRevokeObjectURL: typeof URL.revokeObjectURL;
   let clickSpy: MockInstance;
   let eventListenerCallback: ((event?: Event) => void) | null = null;
+
+  beforeAll(async () => {
+    await camelResource.initialize();
+  });
 
   beforeEach(async () => {
     onCloseSpy = vi.fn();

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.test.tsx
@@ -25,33 +25,39 @@ describe('FlowClipboard.tsx', () => {
     expect(clipboardButton).toBeInTheDocument();
   });
 
-  it('should be called clipboard api', () => {
+  it('should be called clipboard api', async () => {
     const clipboardButton = screen.getByTestId('clipboardButton');
 
-    act(() => fireEvent.click(clipboardButton));
+    await act(async () => {
+      fireEvent.click(clipboardButton);
+    });
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('my source code');
   });
 
-  it('should set data-copied attribute to true', () => {
+  it('should set data-copied attribute to true', async () => {
     const clipboardButton = screen.getByTestId('clipboardButton');
 
-    act(() => fireEvent.click(clipboardButton));
+    await act(async () => {
+      fireEvent.click(clipboardButton);
+    });
 
     expect(clipboardButton).toHaveAttribute('data-copied', 'true');
   });
 
-  it('should set data-copied attribute to false after 2 seconds', () => {
+  it('should set data-copied attribute to false after 2 seconds', async () => {
     vi.useFakeTimers();
 
     const clipboardButton = screen.getByTestId('clipboardButton');
 
-    act(() => fireEvent.click(clipboardButton));
+    await act(async () => {
+      fireEvent.click(clipboardButton);
+    });
 
     expect(clipboardButton).toHaveAttribute('data-copied', 'true');
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
     });
 
@@ -66,22 +72,26 @@ describe('FlowClipboard.tsx', () => {
     expect(clipboardButton).toHaveAttribute('title', defaultTooltipText);
   });
 
-  it('should have success tooltip text', () => {
+  it('should have success tooltip text', async () => {
     const clipboardButton = screen.getByTestId('clipboardButton');
 
-    act(() => fireEvent.click(clipboardButton));
+    await act(async () => {
+      fireEvent.click(clipboardButton);
+    });
 
     expect(clipboardButton).toHaveAttribute('title', successTooltipText);
   });
 
-  it('should restore tooltip text after 2 seconds', () => {
+  it('should restore tooltip text after 2 seconds', async () => {
     vi.useFakeTimers();
 
     const clipboardButton = screen.getByTestId('clipboardButton');
 
-    act(() => fireEvent.click(clipboardButton));
+    await act(async () => {
+      fireEvent.click(clipboardButton);
+    });
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(2000);
     });
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
@@ -15,8 +15,8 @@ export function FlowClipboard() {
   const status = isCopied ? 'success' : undefined;
   const tooltipText = isCopied ? successTooltipText : defaultTooltipText;
 
-  const onClick = () => {
-    void navigator.clipboard.writeText(useSourceCodeStore.getState().sourceCode);
+  const onClick = async () => {
+    await navigator.clipboard.writeText(useSourceCodeStore.getState().sourceCode);
     setIsCopied(true);
 
     setTimeout(() => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
@@ -16,7 +16,7 @@ export function FlowClipboard() {
   const tooltipText = isCopied ? successTooltipText : defaultTooltipText;
 
   const onClick = () => {
-    navigator.clipboard.writeText(useSourceCodeStore.getState().sourceCode);
+    void navigator.clipboard.writeText(useSourceCodeStore.getState().sourceCode);
     setIsCopied(true);
 
     setTimeout(() => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
@@ -74,7 +74,7 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
     controller.fromModel(model, false);
 
     const rafId = requestAnimationFrame(() => {
-      action(() => {
+      void action(() => {
         const graph = controller.getGraph();
         graph.reset();
         graph.fit(0);
@@ -158,7 +158,7 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
       }
     };
 
-    exportCanvas();
+    void exportCanvas();
 
     return () => {
       isMounted = false;

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -218,7 +218,7 @@ describe('NewEntity', () => {
 
     it('should handle empty groups gracefully', async () => {
       const mockResource = new CamelRouteResource([camelRouteJson]);
-      mockResource.initialize();
+      await mockResource.initialize();
 
       // Mock empty groups scenario
       const originalGetCanvasEntityList = mockResource.getCanvasEntityList;

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemDeleteGroup.test.tsx
@@ -70,7 +70,7 @@ describe('ItemDeleteGroup', () => {
 
   it('should call removeEntity if deletion is confirmed', async () => {
     const camelResource = new CamelRouteResource();
-    camelResource.initialize();
+    await camelResource.initialize();
     const removeEntitySpy = vi.spyOn(camelResource, 'removeEntity');
     const entityId = camelResource.addNewEntity(EntityType.Route);
     vizNode = await camelResource.getVisualEntities()[0].toVizNode();

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemEnableAllSteps.test.tsx
@@ -22,7 +22,7 @@ describe('ItemEnableAllSteps', () => {
 
   it('should NOT render an ItemEnableAllSteps if there are not at least 2 or more disabled steps', async () => {
     const camelResource = new CamelRouteResource([camelRouteJson]);
-    camelResource.initialize();
+    await camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 
@@ -53,7 +53,7 @@ describe('ItemEnableAllSteps', () => {
 
   it('should call updateModel and updateEntitiesFromCamelResource on click', async () => {
     const camelResource = new CamelRouteResource([camelRouteWithDisabledSteps]);
-    camelResource.initialize();
+    await camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -8,7 +8,7 @@ import {
   ACTION_ID_CONFIRM,
   ActionConfirmationModalContext,
 } from '../../../../providers/action-confirmation-modal.provider';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
   IOnDeleteAddon,
@@ -28,15 +28,19 @@ describe('ItemReplaceStep', () => {
   });
 
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  let mockEntitiesContext: EntitiesContextResult;
+
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   const mockReplaceModalContext = {
     actionConfirmation: vi.fn(),

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/NodeContextMenu.test.tsx
@@ -202,7 +202,7 @@ describe('NodeContextMenu', () => {
 
   it('should render an ItemEnableAllSteps', async () => {
     const camelResource = new CamelRouteResource([camelRouteWithDisabledSteps]);
-    camelResource.initialize();
+    await camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
     const { nodes, edges } = FlowService.getFlowDiagram('test', await visualEntity.toVizNode());
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.test.tsx
@@ -51,7 +51,7 @@ describe('useAddStep', () => {
 
   beforeEach(async () => {
     camelResource = new CamelRouteResource();
-    camelResource.initialize();
+    await camelResource.initialize();
     getCompatibleComponentsSpy = vi.spyOn(camelResource, 'getCompatibleComponents');
 
     const { Provider, updateEntitiesFromCamelResourceSpy: updateSpy } = await TestProvidersWrapper({ camelResource });

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.tsx
@@ -31,7 +31,7 @@ export const useAddStep = (
     entitiesContext.updateEntitiesFromCamelResource();
 
     /** Notify VS Code host about the new step */
-    metadataContext?.onStepUpdated?.(StepUpdateAction.Add, definedComponent.type, definedComponent.name);
+    void metadataContext?.onStepUpdated?.(StepUpdateAction.Add, definedComponent.type, definedComponent.name);
   }, [catalogModalContext, entitiesContext, metadataContext, mode, vizNode]);
 
   const value = useMemo(

--- a/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/add-step.hook.tsx
@@ -31,7 +31,7 @@ export const useAddStep = (
     entitiesContext.updateEntitiesFromCamelResource();
 
     /** Notify VS Code host about the new step */
-    void metadataContext?.onStepUpdated?.(StepUpdateAction.Add, definedComponent.type, definedComponent.name);
+    await metadataContext?.onStepUpdated?.(StepUpdateAction.Add, definedComponent.type, definedComponent.name);
   }, [catalogModalContext, entitiesContext, metadataContext, mode, vizNode]);
 
   const value = useMemo(

--- a/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
@@ -61,10 +61,10 @@ describe('useCollapseStep', () => {
     expect(typeof result.current.onCollapseNode).toBe('function');
   });
 
-  it('should collapse node, set dimensions and update the state when onCollapseNode is called', () => {
+  it('should collapse node, set dimensions and update the state when onCollapseNode is called', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -77,11 +77,11 @@ describe('useCollapseStep', () => {
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: ['mock-node-id'] });
   });
 
-  it('should collapse node, set dimensions and not update the state when the node is already collapsed', () => {
+  it('should collapse node, set dimensions and not update the state when the node is already collapsed', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
 
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -94,11 +94,11 @@ describe('useCollapseStep', () => {
     expect(mockController.setState).not.toHaveBeenCalled();
   });
 
-  it('should collapse node, set dimensions and not update state when node id is not found', () => {
+  it('should collapse node, set dimensions and not update state when node id is not found', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockElement.getData = vi.fn().mockReturnValue(undefined);
 
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -111,11 +111,11 @@ describe('useCollapseStep', () => {
     expect(mockController.setState).not.toHaveBeenCalled();
   });
 
-  it('should expand node without setting dimensions, but updating the state when onExpandNode is called', () => {
+  it('should expand node without setting dimensions, but updating the state when onExpandNode is called', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
 
-    result.current.onExpandNode();
+    await result.current.onExpandNode();
 
     expect(mockElement.setDimensions).not.toHaveBeenCalled();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
@@ -155,11 +155,11 @@ describe('useCollapseStep', () => {
     expect(result.current).not.toBe(firstResult);
   });
 
-  it('should handle multiple collapse operations correctly', () => {
+  it('should handle multiple collapse operations correctly', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Collapse the node
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: ['mock-node-id'] });
 
@@ -168,37 +168,37 @@ describe('useCollapseStep', () => {
     mockController.setState = vi.fn();
 
     // Try to collapse again - should not update state
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockController.setState).not.toHaveBeenCalled();
   });
 
-  it('should handle expand of non-collapsed node', () => {
+  it('should handle expand of non-collapsed node', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: [] });
 
     // Expand a node that is not collapsed
-    result.current.onExpandNode();
+    await result.current.onExpandNode();
 
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
     expect(mockGraph.layout).toHaveBeenCalled();
   });
 
-  it('should handle state with multiple collapsed nodes', () => {
+  it('should handle state with multiple collapsed nodes', async () => {
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: ['other-node-1', 'other-node-2'] });
 
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Collapse this node - should add to existing collapsed nodes
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({
       collapsedIds: ['other-node-1', 'other-node-2', 'mock-node-id'],
     });
   });
 
-  it('should remove only the target node from collapsed state on expand', () => {
+  it('should remove only the target node from collapsed state on expand', async () => {
     mockController.getState = vi.fn().mockReturnValue({
       collapsedIds: ['other-node-1', 'mock-node-id', 'other-node-2'],
     });
@@ -206,18 +206,18 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Expand this node - should remove only this node
-    result.current.onExpandNode();
+    await result.current.onExpandNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({
       collapsedIds: ['other-node-1', 'other-node-2'],
     });
   });
 
-  it('should handle rapid collapse and expand operations', () => {
+  it('should handle rapid collapse and expand operations', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Rapid collapse
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
 
     // Update state to reflect collapse
@@ -226,12 +226,12 @@ describe('useCollapseStep', () => {
     (mockElement.setCollapsed as Mock).mockClear();
 
     // Rapid expand
-    result.current.onExpandNode();
+    await result.current.onExpandNode();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
   });
 
-  it('should handle elements with no node definition id', () => {
+  it('should handle elements with no node definition id', async () => {
     mockElement.getData = vi.fn().mockReturnValue({
       vizNode: {
         getNodeDefinition: vi.fn().mockReturnValue({}),
@@ -240,19 +240,19 @@ describe('useCollapseStep', () => {
 
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
     expect(mockController.setState).not.toHaveBeenCalled();
   });
 
-  it('should preserve immutability when updating collapsed state', () => {
+  it('should preserve immutability when updating collapsed state', async () => {
     const initialState = ['node-1', 'node-2'];
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: initialState });
 
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    result.current.onCollapseNode();
+    await result.current.onCollapseNode();
 
     // Verify the original array was not mutated
     expect(initialState).toEqual(['node-1', 'node-2']);

--- a/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
@@ -23,7 +23,7 @@ export const useCopyStep = (vizNode: IVisualizationNode) => {
 
     /** Copy the node model */
     if (copiedNodeContent) {
-      void ClipboardManager.copy(copiedNodeContent);
+      await ClipboardManager.copy(copiedNodeContent);
     }
   }, [nodeInteractionAddonContext, vizNode]);
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/copy-step.hook.tsx
@@ -23,7 +23,7 @@ export const useCopyStep = (vizNode: IVisualizationNode) => {
 
     /** Copy the node model */
     if (copiedNodeContent) {
-      ClipboardManager.copy(copiedNodeContent);
+      void ClipboardManager.copy(copiedNodeContent);
     }
   }, [nodeInteractionAddonContext, vizNode]);
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
@@ -7,7 +7,7 @@ import { EntityType } from '../../../../models/entities';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../providers';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
   INodeInteractionAddonContext,
@@ -26,17 +26,20 @@ vi.mock('../ContextMenu/item-interaction-helper', () => ({
 
 describe('useDeleteGroup', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
+  let mockEntitiesContext: EntitiesContextResult;
 
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   const mockActionConfirmationModalContext = {
     actionConfirmation: vi.fn(),

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
@@ -71,55 +71,55 @@ describe('useDeleteHotkey', () => {
     expect(mockHotkeys.unbind).toHaveBeenCalledWith('Delete, backspace');
   });
 
-  it('should do nothing if no node selected', () => {
+  it('should do nothing if no node selected', async () => {
     const handler = setupHotkey(undefined);
 
     const preventDefault = vi.fn();
-    act(() => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
     expect(clearSelected).not.toHaveBeenCalled();
   });
 
-  it('should call onDeleteStep and clearSelected when canRemoveStep=true', () => {
+  it('should call onDeleteStep and clearSelected when canRemoveStep=true', async () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: true }));
 
     const preventDefault = vi.fn();
-    act(() => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
 
     expect(onDeleteStep).toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
     expect(clearSelected).toHaveBeenCalled();
   });
 
-  it('should call onDeleteGroup and clearSelected when canRemoveFlow=true', () => {
+  it('should call onDeleteGroup and clearSelected when canRemoveFlow=true', async () => {
     const handler = setupHotkey(makeNode({ canRemoveFlow: true }));
 
     const preventDefault = vi.fn();
-    act(() => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).toHaveBeenCalled();
     expect(clearSelected).toHaveBeenCalled();
   });
 
-  it('should do nothing when node cannot be removed', () => {
+  it('should do nothing when node cannot be removed', async () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: false, canRemoveFlow: false }));
 
     const preventDefault = vi.fn();
-    act(() => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
     expect(clearSelected).not.toHaveBeenCalled();
   });
 
-  it('should call preventDefault on event', () => {
+  it('should call preventDefault on event', async () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: true }));
 
     const preventDefault = vi.fn();
-    act(() => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
 
     expect(preventDefault).toHaveBeenCalled();
   });

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
@@ -15,9 +15,9 @@ export default function useDeleteHotkey(selectedVizNode: IVisualizationNode | un
     const { canRemoveStep, canRemoveFlow } = selectedVizNode.getNodeInteraction();
     if (!canRemoveStep && !canRemoveFlow) return;
 
-    if (canRemoveStep) onDeleteStep();
+    if (canRemoveStep) void onDeleteStep();
 
-    if (canRemoveFlow) onDeleteGroup();
+    if (canRemoveFlow) void onDeleteGroup();
 
     clearSelected();
   }, [onDeleteStep, onDeleteGroup, selectedVizNode, clearSelected]);

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
@@ -9,15 +9,15 @@ export default function useDeleteHotkey(selectedVizNode: IVisualizationNode | un
   const { onDeleteStep } = useDeleteStep(selectedVizNode);
   const { onDeleteGroup } = useDeleteGroup(selectedVizNode);
 
-  const handleKeyDown = useCallback(() => {
+  const handleKeyDown = useCallback(async () => {
     if (!selectedVizNode) return;
 
     const { canRemoveStep, canRemoveFlow } = selectedVizNode.getNodeInteraction();
     if (!canRemoveStep && !canRemoveFlow) return;
 
-    if (canRemoveStep) void onDeleteStep();
+    if (canRemoveStep) await onDeleteStep();
 
-    if (canRemoveFlow) void onDeleteGroup();
+    if (canRemoveFlow) await onDeleteGroup();
 
     clearSelected();
   }, [onDeleteStep, onDeleteGroup, selectedVizNode, clearSelected]);
@@ -25,7 +25,9 @@ export default function useDeleteHotkey(selectedVizNode: IVisualizationNode | un
   useEffect(() => {
     hotkeys('Delete, backspace', (event) => {
       event.preventDefault();
-      handleKeyDown();
+      handleKeyDown().catch(() => {
+        // errors are handled inside handleKeyDown
+      });
     });
 
     return () => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
@@ -15,19 +15,21 @@ export default function useDeleteHotkey(selectedVizNode: IVisualizationNode | un
     const { canRemoveStep, canRemoveFlow } = selectedVizNode.getNodeInteraction();
     if (!canRemoveStep && !canRemoveFlow) return;
 
-    if (canRemoveStep) await onDeleteStep();
+    try {
+      if (canRemoveStep) await onDeleteStep();
 
-    if (canRemoveFlow) await onDeleteGroup();
+      if (canRemoveFlow) await onDeleteGroup();
 
-    clearSelected();
+      clearSelected();
+    } catch (error) {
+      console.error('Failed to delete node:', error);
+    }
   }, [onDeleteStep, onDeleteGroup, selectedVizNode, clearSelected]);
 
   useEffect(() => {
     hotkeys('Delete, backspace', (event) => {
       event.preventDefault();
-      handleKeyDown().catch(() => {
-        // errors are handled inside handleKeyDown
-      });
+      void handleKeyDown();
     });
 
     return () => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
@@ -7,7 +7,7 @@ import { EntityType } from '../../../../models/entities';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../providers';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
   INodeInteractionAddonContext,
@@ -26,17 +26,20 @@ vi.mock('../ContextMenu/item-interaction-helper', () => ({
 
 describe('useDeleteStep', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
+  let mockEntitiesContext: EntitiesContextResult;
 
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   const mockActionConfirmationModalContext = {
     actionConfirmation: vi.fn(),

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { useDisableStep } from './disable-step.hook';
 
 vi.mock('@kaoto/forms', () => ({
@@ -14,17 +14,20 @@ vi.mock('@kaoto/forms', () => ({
 
 describe('useDisableStep', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
+  let mockEntitiesContext: EntitiesContextResult;
 
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   beforeEach(() => {
     mockVizNode = createVisualizationNode('test-step', {

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -9,7 +9,7 @@ import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/c
 import { VisualFlowsApi } from '../../../../models/visualization/flows/support/flows-visibility';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { camelRouteJson } from '../../../../stubs/camel-route';
 import { updateIds } from '../../../../utils/update-ids';
 import { NodeInteractionAddonContext } from '../../../registers/interactions/node-interaction-addon.provider';
@@ -83,15 +83,19 @@ describe('useDuplicateStep', () => {
   vizNode.setParentNode(routeVizNode);
 
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  let mockEntitiesContext: EntitiesContextResult;
+
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   // Mock CatalogModalContext
   const mockCatalogModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { EntityType } from '../../../../models/entities';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
 import { setValue } from '../../../../utils/set-value';
 import { useEnableAllSteps } from './enable-all-steps.hook';
@@ -28,17 +28,20 @@ const mockSetValue = setValue as MockedFunction<typeof setValue>;
 
 describe('useEnableAllSteps', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
   let mockGraph: Node<ElementModel, unknown>;
+  let mockEntitiesContext: EntitiesContextResult;
 
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   beforeEach(() => {
     mockGraph = {
@@ -150,7 +153,7 @@ describe('useEnableAllSteps', () => {
     expect(filterFunction?.(disabledNode)).toBe(true);
   });
 
-  it('should enable all disabled steps when onEnableAllSteps is called', () => {
+  it('should enable all disabled steps when onEnableAllSteps is called', async () => {
     const disabledNode1 = createVisualizationNode('disabled-step-1', {
       name: EntityType.Route,
       disabled: true,
@@ -181,7 +184,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledTimes(2);
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition1, 'disabled', false);
@@ -191,7 +194,7 @@ describe('useEnableAllSteps', () => {
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should handle nodes with empty definition objects', () => {
+  it('should handle nodes with empty definition objects', async () => {
     const disabledNode = createVisualizationNode('disabled-step', {
       name: EntityType.Route,
       isPlaceholder: false,
@@ -208,14 +211,14 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith(mockDefinition);
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should handle nodes with undefined definition', () => {
+  it('should handle nodes with undefined definition', async () => {
     const disabledNode = createVisualizationNode('disabled-step', {
       name: EntityType.Route,
       isPlaceholder: false,
@@ -231,19 +234,19 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledWith({}, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith({});
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should not call updateEntitiesFromCamelResource when no disabled steps', () => {
+  it('should not call updateEntitiesFromCamelResource when no disabled steps', async () => {
     mockGetVisualizationNodesFromGraph.mockReturnValue([]);
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await result.current.onEnableAllSteps();
 
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -9,7 +9,7 @@ import { AddStepMode, IVisualizationNode } from '../../../../models/visualizatio
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
 import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { useInsertStep } from './insert-step.hook';
 
 const mockController = {
@@ -22,17 +22,20 @@ vi.mock('@patternfly/react-topology', () => ({
 
 describe('useInsertStep', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
   let mockVizNode: IVisualizationNode;
+  let mockEntitiesContext: EntitiesContextResult;
 
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   const mockCatalogModalContext = {
     setIsModalOpen: vi.fn(),

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
@@ -7,7 +7,7 @@ import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/camel-route-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { camelRouteJson, camelRouteJsonWithDM } from '../../../../stubs/camel-route';
 import { getPotentialPath } from '../../../../utils/get-potential-path';
 import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
@@ -45,15 +45,19 @@ describe('useMoveStep', () => {
   });
 
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  let mockEntitiesContext: EntitiesContextResult;
+
+  beforeAll(async () => {
+    await camelResource.initialize();
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
     <NodeInteractionAddonProvider>
@@ -171,7 +175,7 @@ describe('useMoveStep', () => {
       expect(result.current.canBeMoved).toBe(false);
     });
 
-    it('should find shortest path when multiple nodes match', () => {
+    it('should find shortest path when multiple nodes match', async () => {
       const longPathVizNode = createVisualizationNode('longPath', {
         name: 'when',
         path: 'route.from.steps.2.choice.when',
@@ -197,7 +201,7 @@ describe('useMoveStep', () => {
       mockGetVisualizationNodesFromGraph.mockReturnValue([longPathVizNode, shortPathVizNode]);
 
       const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
-      result.current.onMoveStep();
+      await result.current.onMoveStep();
 
       // shortPathVizNode.getCopiedContent() call indicates that it was chosen as the target node
       expect(shortPathVizNodeSpy).toHaveBeenCalled();
@@ -206,7 +210,7 @@ describe('useMoveStep', () => {
   });
 
   describe('onMoveStep functionality', () => {
-    it('should return without calling pasteBaseEntityStep() and updateEntitiesFromCamelResource()', () => {
+    it('should return without calling pasteBaseEntityStep() and updateEntitiesFromCamelResource()', async () => {
       const VizNodeGetCopiedContentSpy = vi
         .spyOn(vizNode, 'getCopiedContent')
         .mockReturnValueOnce(vizNodeCopiedContent);
@@ -223,7 +227,7 @@ describe('useMoveStep', () => {
       mockGetVisualizationNodesFromGraph.mockReturnValue([targetVizNode]);
 
       const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
-      result.current.onMoveStep();
+      await result.current.onMoveStep();
 
       expect(VizNodeGetCopiedContentSpy).toHaveBeenCalledTimes(1);
       expect(targetVizNode.getCopiedContent).toHaveBeenCalledTimes(1);
@@ -234,7 +238,7 @@ describe('useMoveStep', () => {
       expect(mockEntitiesContext.updateEntitiesFromCamelResource as Mock).not.toHaveBeenCalled();
     });
 
-    it('should call getCopiedContent(), processOnCopyAddon(), pasteBaseEntityStep() and finally updateEntitiesFromCamelResource() in case of datamapper step', () => {
+    it('should call getCopiedContent(), processOnCopyAddon(), pasteBaseEntityStep() and finally updateEntitiesFromCamelResource() in case of datamapper step', async () => {
       const visualEntity = new CamelRouteVisualEntity(camelRouteJsonWithDM);
       const dataMapperVizNode = createVisualizationNode('test-DM', {
         name: 'step',
@@ -299,7 +303,7 @@ describe('useMoveStep', () => {
       mockGetVisualizationNodesFromGraph.mockReturnValue([targetVizNode]);
 
       const { result } = renderHook(() => useMoveStep(dataMapperVizNode, AddStepMode.AppendStep), { wrapper });
-      result.current.onMoveStep();
+      await result.current.onMoveStep();
 
       expect(dataMapperVizNodeGetCopiedContentSpy).toHaveBeenCalledTimes(1);
       expect(dataMapperVizNodeGetCopiedContentSpy).toHaveReturnedWith(dataMapperVizNodeCopiedContent);
@@ -314,7 +318,7 @@ describe('useMoveStep', () => {
       expect(mockEntitiesContext.updateEntitiesFromCamelResource as Mock).toHaveBeenCalledTimes(1);
     });
 
-    it('should call getCopiedContent(), pasteBaseEntityStep() and finally updateEntitiesFromCamelResource()', () => {
+    it('should call getCopiedContent(), pasteBaseEntityStep() and finally updateEntitiesFromCamelResource()', async () => {
       const VizNodeGetCopiedContentSpy = vi
         .spyOn(vizNode, 'getCopiedContent')
         .mockReturnValueOnce(vizNodeCopiedContent);
@@ -331,7 +335,7 @@ describe('useMoveStep', () => {
       mockGetVisualizationNodesFromGraph.mockReturnValue([targetVizNode]);
 
       const { result } = renderHook(() => useMoveStep(vizNode, AddStepMode.AppendStep), { wrapper });
-      result.current.onMoveStep();
+      await result.current.onMoveStep();
 
       expect(VizNodeGetCopiedContentSpy).toHaveBeenCalledTimes(1);
       expect(targetVizNode.getCopiedContent).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -10,7 +10,7 @@ import { IClipboardCopyObject } from '../../../../models/visualization/clipboard
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
 import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
-import { EntitiesContext } from '../../../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { ClipboardManager } from '../../../../utils/ClipboardManager';
 import { usePasteStep } from './paste-step.hook';
 
@@ -31,17 +31,23 @@ Object.assign(navigator, {
 
 describe('usePasteStep', () => {
   const camelResource = new CamelRouteResource();
-  camelResource.initialize();
-  const getCompatibleComponentsSpy = vi.spyOn(camelResource, 'getCompatibleComponents');
-  const getTypeSpy = vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
-  const mockEntitiesContext = {
-    camelResource,
-    entities: camelResource.getEntities(),
-    visualEntities: camelResource.getVisualEntities(),
-    currentSchemaType: camelResource.getType(),
-    updateSourceCodeFromEntities: vi.fn(),
-    updateEntitiesFromCamelResource: vi.fn(),
-  };
+  let getCompatibleComponentsSpy: ReturnType<typeof vi.spyOn>;
+  let getTypeSpy: ReturnType<typeof vi.spyOn>;
+  let mockEntitiesContext: EntitiesContextResult;
+
+  beforeAll(async () => {
+    await camelResource.initialize();
+    getCompatibleComponentsSpy = vi.spyOn(camelResource, 'getCompatibleComponents');
+    getTypeSpy = vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
+    mockEntitiesContext = {
+      camelResource,
+      entities: camelResource.getEntities(),
+      visualEntities: camelResource.getVisualEntities(),
+      currentSchemaType: camelResource.getType(),
+      updateSourceCodeFromEntities: vi.fn(),
+      updateEntitiesFromCamelResource: vi.fn(),
+    };
+  });
 
   // Mock CatalogModalContext
   const mockCatalogModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
@@ -68,7 +68,7 @@ export const usePasteStep = (vizNode: IVisualizationNode, mode: AddStepMode) => 
       }
     };
 
-    validate();
+    void validate();
   }, [checkClipboardCompatibility]);
 
   const onPasteStep = useCallback(async () => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.test.tsx
@@ -78,7 +78,7 @@ describe('useReplaceStep', () => {
 
   beforeEach(async () => {
     camelResource = new CamelRouteResource();
-    camelResource.initialize();
+    await camelResource.initialize();
     mockVizNode = createVisualizationNode('test-step', {
       name: EntityType.Route,
       isPlaceholder: false,

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.tsx
@@ -69,7 +69,7 @@ export const useReplaceStep = (vizNode: IVisualizationNode) => {
     entitiesContext.updateEntitiesFromCamelResource();
 
     /** Notify VS Code host about the new step */
-    metadataContext?.onStepUpdated?.(StepUpdateAction.Replace, definedComponent.type, definedComponent.name);
+    void metadataContext?.onStepUpdated?.(StepUpdateAction.Replace, definedComponent.type, definedComponent.name);
   }, [
     catalogModalContext,
     entitiesContext,

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
@@ -50,7 +50,7 @@ describe('FlowTypeSelector.tsx', () => {
       render(<FlowTypeSelectorWithContext />);
     });
 
-    waitFor(() => {
+    await waitFor(() => {
       const toggle = screen.queryByTestId('viz-dsl-list-dropdown');
       expect(toggle).toBeInTheDocument();
     });
@@ -68,7 +68,7 @@ describe('FlowTypeSelector.tsx', () => {
       fireEvent.click(toggle);
     });
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(onSelect).toHaveBeenCalled();
     });
   });
@@ -77,7 +77,7 @@ describe('FlowTypeSelector.tsx', () => {
     const wrapper = render(<FlowTypeSelectorWithContext currentSchemaType={SourceSchemaType.KameletBinding} />);
     const toggle = await wrapper.findByTestId('dsl-list-btn');
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(toggle).toBeDisabled();
     });
   });

--- a/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
+++ b/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
@@ -29,7 +29,7 @@ export const RegisterNodeInteractionAddons: FunctionComponent<PropsWithChildren>
       type: IInteractionType.ON_DELETE,
       activationFn: datamapperActivationFn,
       callback: ({ vizNode, modalAnswer }) => {
-        metadataApi && onDeleteDataMapper(metadataApi, vizNode, modalAnswer);
+        void (metadataApi && onDeleteDataMapper(metadataApi, vizNode, modalAnswer));
       },
       modalCustomization: {
         additionalText: 'Do you also want to delete the associated Kaoto DataMapper mapping file (XSLT)?',

--- a/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-modal.provider.test.tsx
@@ -88,12 +88,10 @@ describe('CatalogModalProvider', () => {
   describe('getNewComponent', () => {
     it('should open modal and fetch tiles when getNewComponent is called', async () => {
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
-
-      const { result } = renderWithProviders();
+      const { result } = renderHook(() => useContext(CatalogModalContext), { wrapper });
 
       let componentPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
+      await act(async () => {
         componentPromise = result.current!.getNewComponent();
       });
 
@@ -105,7 +103,7 @@ describe('CatalogModalProvider', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
 
       // Close modal to resolve promise
-      act(() => {
+      await act(async () => {
         const closeButton = screen.getByLabelText('Close');
         closeButton.click();
       });
@@ -115,13 +113,25 @@ describe('CatalogModalProvider', () => {
     });
 
     it('should return all tiles when no filter is provided', async () => {
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      act(() => {
-        result.current!.getNewComponent();
+      const button = screen.getByText('Open Catalog');
+      await act(async () => {
+        fireEvent.click(button);
       });
 
       await waitFor(() => {
@@ -136,13 +146,25 @@ describe('CatalogModalProvider', () => {
     });
 
     it('should filter tiles when catalogFilter is provided', async () => {
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              await getNewComponent((tile: ITile) => tile.type === CatalogKind.Component);
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      act(() => {
-        result.current!.getNewComponent((tile: ITile) => tile.type === CatalogKind.Component);
+      const button = screen.getByText('Open Catalog');
+      await act(async () => {
+        fireEvent.click(button);
       });
 
       await waitFor(() => {
@@ -160,15 +182,25 @@ describe('CatalogModalProvider', () => {
       const mockDefinition = { component: { name: 'amqp' } };
       (mockCatalogRegistry.getEntity as Mock).mockResolvedValue(mockDefinition);
 
+      let selectedComponent: DefinedComponent | undefined;
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              selectedComponent = await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      let componentPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        componentPromise = result.current!.getNewComponent();
-      });
+      const button = screen.getByText('Open Catalog');
+      fireEvent.click(button);
 
       await waitFor(() => {
         expect(screen.getByTestId('tile-header-amqp')).toBeInTheDocument();
@@ -176,9 +208,13 @@ describe('CatalogModalProvider', () => {
 
       // Click on a tile
       const amqpTile = screen.getByTestId('tile-header-amqp');
-      fireEvent.click(amqpTile);
+      await act(async () => {
+        fireEvent.click(amqpTile);
+      });
 
-      const selectedComponent = await componentPromise!;
+      await waitFor(() => {
+        expect(selectedComponent).toBeDefined();
+      });
 
       expect(selectedComponent).toEqual({
         name: 'amqp',
@@ -195,24 +231,37 @@ describe('CatalogModalProvider', () => {
       const mockDefinition = { metadata: { name: 'sink' } };
       (mockCatalogRegistry.getEntity as Mock).mockResolvedValue(mockDefinition);
 
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      let componentPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        componentPromise = result.current!.getNewComponent();
-      });
+      const button = screen.getByText('Open Catalog');
+      fireEvent.click(button);
 
       await waitFor(() => {
         expect(screen.getByTestId('tile-header-sink')).toBeInTheDocument();
       });
 
       const kameletTile = screen.getByTestId('tile-header-sink');
-      fireEvent.click(kameletTile);
+      await act(async () => {
+        fireEvent.click(kameletTile);
+      });
 
-      await componentPromise!;
+      await waitFor(() => {
+        expect(mockCatalogRegistry.getEntity).toHaveBeenCalled();
+      });
 
       expect(mockCatalogRegistry.getEntity).toHaveBeenCalledWith(CatalogKind.Kamelet, 'sink', {
         forceFresh: true,
@@ -220,15 +269,29 @@ describe('CatalogModalProvider', () => {
     });
 
     it('should resolve with undefined when modal is closed without selection', async () => {
+      let selectedComponent: DefinedComponent | undefined = {
+        name: 'test',
+        type: CatalogKind.Component,
+        definition: {},
+      };
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              selectedComponent = await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      let componentPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        componentPromise = result.current!.getNewComponent();
-      });
+      const button = screen.getByText('Open Catalog');
+      fireEvent.click(button);
 
       await waitFor(() => {
         expect(screen.getByText('Catalog')).toBeInTheDocument();
@@ -236,23 +299,38 @@ describe('CatalogModalProvider', () => {
 
       // Close modal
       const closeButton = screen.getByLabelText('Close');
-      fireEvent.click(closeButton);
+      await act(async () => {
+        fireEvent.click(closeButton);
+      });
 
-      const selectedComponent = await componentPromise!;
-      expect(selectedComponent).toBeUndefined();
+      await waitFor(() => {
+        expect(selectedComponent).toBeUndefined();
+      });
     });
 
     it('should handle fetchTiles error gracefully', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const fetchTilesError = () => Promise.reject(new Error('Failed to fetch tiles'));
 
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper(fetchTilesError);
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders(fetchTilesError);
-
-      act(() => {
-        result.current!.getNewComponent();
+      const button = screen.getByText('Open Catalog');
+      await act(async () => {
+        fireEvent.click(button);
       });
 
       await waitFor(() => {
@@ -272,54 +350,92 @@ describe('CatalogModalProvider', () => {
         .mockResolvedValueOnce(mockDefinition1)
         .mockResolvedValueOnce(mockDefinition2);
 
-      const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      let firstComponent: DefinedComponent | undefined;
+      let secondComponent: DefinedComponent | undefined;
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <>
+            <button
+              onClick={async () => {
+                firstComponent = await getNewComponent();
+              }}
+            >
+              Open First
+            </button>
+            <button
+              onClick={async () => {
+                secondComponent = await getNewComponent();
+              }}
+            >
+              Open Second
+            </button>
+          </>
+        );
+      };
 
-      const { result } = renderWithProviders();
+      const wrapper = createWrapper();
+      render(<TestComponent />, { wrapper });
 
       // First call
-      let firstPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        firstPromise = result.current!.getNewComponent();
-      });
+      const firstButton = screen.getByText('Open First');
+      fireEvent.click(firstButton);
 
       await waitFor(() => {
         expect(screen.getByTestId('tile-header-amqp')).toBeInTheDocument();
       });
 
       const amqpTile = screen.getByTestId('tile-header-amqp');
-      fireEvent.click(amqpTile);
+      await act(async () => {
+        fireEvent.click(amqpTile);
+      });
 
-      const firstComponent = await firstPromise!;
+      await waitFor(() => {
+        expect(firstComponent).toBeDefined();
+      });
       expect(firstComponent?.name).toBe('amqp');
 
       // Second call
-      let secondPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        secondPromise = result.current!.getNewComponent();
-      });
+      const secondButton = screen.getByText('Open Second');
+      fireEvent.click(secondButton);
 
       await waitFor(() => {
         expect(screen.getByTestId('tile-header-log')).toBeInTheDocument();
       });
 
       const logTile = screen.getByTestId('tile-header-log');
-      fireEvent.click(logTile);
+      await act(async () => {
+        fireEvent.click(logTile);
+      });
 
-      const secondComponent = await secondPromise!;
+      await waitFor(() => {
+        expect(secondComponent).toBeDefined();
+      });
       expect(secondComponent?.name).toBe('log');
     });
 
     it('should filter by multiple criteria', async () => {
-      const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
-
-      const { result } = renderWithProviders();
-
-      act(() => {
-        result.current!.getNewComponent(
-          (tile: ITile) => tile.type === CatalogKind.Processor || tile.tags.includes('messaging'),
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              await getNewComponent(
+                (tile: ITile) => tile.type === CatalogKind.Processor || tile.tags.includes('messaging'),
+              );
+            }}
+          >
+            Open Catalog
+          </button>
         );
+      };
+
+      const wrapper = createWrapper();
+      render(<TestComponent />, { wrapper });
+
+      const button = screen.getByText('Open Catalog');
+      await act(async () => {
+        fireEvent.click(button);
       });
 
       await waitFor(() => {
@@ -338,22 +454,34 @@ describe('CatalogModalProvider', () => {
       const mockDefinition = { component: { name: 'amqp' } };
       (mockCatalogRegistry.getEntity as Mock).mockResolvedValue(mockDefinition);
 
+      let selectedComponent: DefinedComponent | undefined;
+      const TestComponent = () => {
+        const { getNewComponent } = useContext(CatalogModalContext)!;
+        return (
+          <button
+            onClick={async () => {
+              selectedComponent = await getNewComponent();
+            }}
+          >
+            Open Catalog
+          </button>
+        );
+      };
+
       const wrapper = createWrapper();
-      render(<div>Test</div>, { wrapper });
+      render(<TestComponent />, { wrapper });
 
-      const { result } = renderWithProviders();
-
-      let componentPromise: Promise<DefinedComponent | undefined>;
-      act(() => {
-        componentPromise = result.current!.getNewComponent();
-      });
+      const button = screen.getByText('Open Catalog');
+      fireEvent.click(button);
 
       await waitFor(() => {
         expect(screen.getByRole('dialog')).toBeInTheDocument();
       });
 
       const amqpTile = screen.getByTestId('tile-header-amqp');
-      fireEvent.click(amqpTile);
+      await act(async () => {
+        fireEvent.click(amqpTile);
+      });
 
       // Modal should close
       await waitFor(() => {
@@ -361,8 +489,9 @@ describe('CatalogModalProvider', () => {
       });
 
       // Promise should be resolved
-      const selectedComponent = await componentPromise!;
-      expect(selectedComponent).toBeDefined();
+      await waitFor(() => {
+        expect(selectedComponent).toBeDefined();
+      });
       expect(selectedComponent?.name).toBe('amqp');
     });
   });

--- a/packages/ui/src/dynamic-catalog/catalog-tiles.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-tiles.provider.tsx
@@ -104,7 +104,7 @@ export const CatalogTilesProvider: FunctionComponent<PropsWithChildren> = (props
   const getTiles = useCallback(() => tilesRef.current, []);
 
   useEffect(() => {
-    fetchTiles();
+    void fetchTiles();
   }, [fetchTiles]);
 
   const value = useMemo(

--- a/packages/ui/src/hooks/use-processor-tooltips.hook.ts
+++ b/packages/ui/src/hooks/use-processor-tooltips.hook.ts
@@ -34,7 +34,7 @@ export const useProcessorTooltips = (processorNames: readonly string[]) => {
       }
     };
 
-    fetchTooltips();
+    void fetchTooltips();
 
     return () => {
       cancelled = true;

--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -44,7 +44,7 @@ describe('usePasteEntity', () => {
 
   beforeEach(async () => {
     camelResource = new CamelRouteResource();
-    camelResource.initialize();
+    await camelResource.initialize();
     addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');
     removeEntitySpy = vi.spyOn(camelResource, 'removeEntity');
     vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);

--- a/packages/ui/src/hooks/usePasteEntity.ts
+++ b/packages/ui/src/hooks/usePasteEntity.ts
@@ -57,7 +57,7 @@ export const usePasteEntity = () => {
       }
     };
 
-    validate();
+    void validate();
   }, [checkClipboardCompatibility]);
 
   /**

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -9,17 +9,17 @@ import { CitrusTestResource } from './citrus-test-resource';
 import { Test } from './entities/Test';
 
 describe('CitrusTestResource', () => {
-  it('should initialize Citrus test if no args is specified', () => {
+  it('should initialize Citrus test if no args is specified', async () => {
     const resource = new CitrusTestResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toHaveLength(0);
   });
 
-  it('should initialize Citrus test', () => {
+  it('should initialize Citrus test', async () => {
     const resource = new CitrusTestResource(citrusTestJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
     expect(resource.getEntities()).toEqual([]);
     expect(resource.getVisualEntities()).toHaveLength(1);
@@ -30,18 +30,18 @@ describe('CitrusTestResource', () => {
   });
 
   describe('addNewEntity', () => {
-    it('should add new entity and return its ID', () => {
+    it('should add new entity and return its ID', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       const id = resource.addNewEntity();
 
       expect(resource.getVisualEntities()).toHaveLength(1);
       expect(resource.getVisualEntities()[0].id).toEqual(id);
     });
 
-    it('should add new entities at the end of the list and return its ID', () => {
+    it('should add new entities at the end of the list and return its ID', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.Test);
 
@@ -49,9 +49,9 @@ describe('CitrusTestResource', () => {
       expect(resource.getVisualEntities()[1].id).toEqual(id);
     });
 
-    it('should add the given entities at the end of the list and return its ID', () => {
+    it('should add the given entities at the end of the list and return its ID', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       resource.addNewEntity();
       const id = resource.addNewEntity(EntityType.Test, FlowTemplateService.getFlowTemplate(SourceSchemaType.Test)[0]);
 
@@ -60,63 +60,63 @@ describe('CitrusTestResource', () => {
     });
   });
 
-  it('should return the right type', () => {
+  it('should return the right type', async () => {
     const resource = new CitrusTestResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getType()).toEqual(SourceSchemaType.Test);
   });
 
-  it('should not allow consumers to have multiple visual entities', () => {
+  it('should not allow consumers to have multiple visual entities', async () => {
     const resource = new CitrusTestResource();
-    resource.initialize();
+    await resource.initialize();
     expect(resource.supportsMultipleVisualEntities()).toBe(false);
   });
 
-  it('should return visual entities', () => {
+  it('should return visual entities', async () => {
     const resource = new CitrusTestResource(citrusTestJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getVisualEntities()).toHaveLength(1);
     expect(resource.getVisualEntities()[0]).toBeInstanceOf(CitrusTestVisualEntity);
     expect(resource.getEntities()).toHaveLength(0);
   });
 
-  it('should return entities', () => {
+  it('should return entities', async () => {
     const resource = new CitrusTestResource(citrusTestJson);
-    resource.initialize();
+    await resource.initialize();
     expect(resource.getEntities()).toHaveLength(0);
     expect(resource.getVisualEntities()).toHaveLength(1);
   });
 
   describe('toJSON', () => {
-    it('should return JSON', () => {
+    it('should return JSON', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       expect(resource.toJSON()).toMatchSnapshot();
     });
   });
 
   describe('removeEntity', () => {
-    it('should not do anything if the ID is not provided', () => {
+    it('should not do anything if the ID is not provided', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       resource.removeEntity();
 
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
 
-    it('should not do anything when providing a non existing ID', () => {
+    it('should not do anything when providing a non existing ID', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       resource.removeEntity(['non-existing-id']);
 
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
 
-    it('should allow to remove an entity', () => {
+    it('should allow to remove an entity', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       resource.addNewEntity();
       expect(resource.getVisualEntities()).toHaveLength(2);
 
@@ -127,9 +127,9 @@ describe('CitrusTestResource', () => {
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
 
-    it('should remove multiple entities when multiple IDs are provided', () => {
+    it('should remove multiple entities when multiple IDs are provided', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       resource.addNewEntity();
       const entitiesToRemove = resource.getVisualEntities().map((e) => e.id);
 
@@ -138,9 +138,9 @@ describe('CitrusTestResource', () => {
       expect(resource.getVisualEntities()).toHaveLength(0);
     });
 
-    it('should NOT create a new entity after deleting them all', () => {
+    it('should NOT create a new entity after deleting them all', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       const citrusTestEntity = resource.getVisualEntities()[0];
 
       resource.removeEntity([citrusTestEntity.id]);
@@ -150,9 +150,9 @@ describe('CitrusTestResource', () => {
   });
 
   describe('getCanvasEntityList', () => {
-    it('should return all entities', () => {
+    it('should return all entities', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
@@ -160,9 +160,9 @@ describe('CitrusTestResource', () => {
       expect(entityList.groups).toEqual({});
     });
 
-    it('should return consistent entity list structure on multiple calls', () => {
+    it('should return consistent entity list structure on multiple calls', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       const firstCall = resource.getCanvasEntityList();
       const secondCall = resource.getCanvasEntityList();
@@ -170,9 +170,9 @@ describe('CitrusTestResource', () => {
       expect(firstCall).toStrictEqual(secondCall);
     });
 
-    it('should include entity titles and descriptions from catalog', () => {
+    it('should include entity titles and descriptions from catalog', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
@@ -184,9 +184,9 @@ describe('CitrusTestResource', () => {
       expect(testEntity.name).toBe(EntityType.Test);
     });
 
-    it('should properly group entities', () => {
+    it('should properly group entities', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
@@ -201,7 +201,7 @@ describe('CitrusTestResource', () => {
   describe('toString', () => {
     it('should delegate to serializer serialize method', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       const serialized = await resource.toSourceCode();
 
       expect(typeof serialized).toBe('string');
@@ -210,7 +210,7 @@ describe('CitrusTestResource', () => {
 
     it('should serialize to YAML', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
 
       const yamlOutput = await resource.toSourceCode();
       expect(yamlOutput).toContain('actions:');
@@ -218,26 +218,26 @@ describe('CitrusTestResource', () => {
   });
 
   describe('getCompatibleRuntimes', () => {
-    it('should return the correct list of compatible runtimes', () => {
+    it('should return the correct list of compatible runtimes', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Citrus']);
     });
 
-    it('should return the same list regardless of resource content', () => {
+    it('should return the same list regardless of resource content', async () => {
       const emptyResource = new CitrusTestResource();
-      emptyResource.initialize();
+      await emptyResource.initialize();
       const resourceWithTest = new CitrusTestResource(citrusTestJson);
-      resourceWithTest.initialize();
+      await resourceWithTest.initialize();
 
       expect(emptyResource.getCompatibleRuntimes()).toEqual(resourceWithTest.getCompatibleRuntimes());
     });
 
-    it('should return an array with one runtime name', () => {
+    it('should return an array with one runtime name', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Citrus']);
@@ -245,9 +245,9 @@ describe('CitrusTestResource', () => {
   });
 
   describe('getCompatibleComponents', () => {
-    it('should get compatible types', () => {
+    it('should get compatible types', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
-      resource.initialize();
+      await resource.initialize();
       const tileFilter = resource.getCompatibleComponents(AddStepMode.ReplaceStep, {
         name: 'print',
         path: 'actions.0',
@@ -287,40 +287,40 @@ describe('CitrusTestResource', () => {
 
   it('serializes to YAML without a serializer', async () => {
     const resource = new CitrusTestResource({ name: 't', actions: [] });
-    resource.initialize();
+    await resource.initialize();
     const output = await resource.toSourceCode();
 
     expect(typeof output).toBe('string');
   });
 
   describe('initialize() with array input', () => {
-    it('parses an array of raw test entities', () => {
+    it('parses an array of raw test entities', async () => {
       const secondTest = { name: 'second-test', actions: [{ echo: { message: 'hi' } }] };
       const resource = new CitrusTestResource([citrusTestJson, secondTest]);
-      resource.initialize();
+      await resource.initialize();
       expect(resource.getVisualEntities()).toHaveLength(2);
     });
 
-    it('skips null entries inside the array', () => {
+    it('skips null entries inside the array', async () => {
       const resource = new CitrusTestResource([null as unknown as Test, citrusTestJson]);
-      resource.initialize();
+      await resource.initialize();
       // null is filtered by getEntity() returning undefined
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
 
-    it('skips nested array entries inside the raw array', () => {
+    it('skips nested array entries inside the raw array', async () => {
       const resource = new CitrusTestResource([[] as unknown as Test, citrusTestJson]);
-      resource.initialize();
+      await resource.initialize();
       expect(resource.getVisualEntities()).toHaveLength(1);
     });
   });
 
   describe('getEntity() wraps unknown raw items in NonVisualEntity', () => {
-    it('places an unrecognised raw object into non-visual entities', () => {
+    it('places an unrecognised raw object into non-visual entities', async () => {
       // An object without both 'name' and 'actions' does not satisfy isCitrusTest
       const unknownObj = { foo: 'bar', baz: 'qux' } as unknown as Test;
       const resource = new CitrusTestResource(unknownObj);
-      resource.initialize();
+      await resource.initialize();
       // The unknown object ends up as a NonVisualEntity (not a visual entity)
       expect(resource.getVisualEntities()).toHaveLength(0);
       expect(resource.getEntities()).toHaveLength(1);
@@ -328,15 +328,15 @@ describe('CitrusTestResource', () => {
   });
 
   describe('toJSON() edge cases', () => {
-    it('returns {} when no entities are present (before initialize)', () => {
+    it('returns {} when no entities are present (before initialize)', async () => {
       const resource = new CitrusTestResource();
       // deliberately do NOT call initialize()
       expect(resource.toJSON()).toEqual({});
     });
 
-    it('returns {} after initialize with no rawEntities', () => {
+    it('returns {} after initialize with no rawEntities', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       expect(resource.toJSON()).toEqual({});
     });
   });
@@ -344,7 +344,7 @@ describe('CitrusTestResource', () => {
   describe('toString() edge cases', () => {
     it('returns the YAML for {} when there are no entities', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       // stringify({}) produces '{}\n'
       const output = await resource.toSourceCode();
 
@@ -353,9 +353,9 @@ describe('CitrusTestResource', () => {
   });
 
   describe('addNewEntity() branch: unsupported non-Test entity type', () => {
-    it('falls through to create a CitrusTestVisualEntity when entity type is not in supportedEntities', () => {
+    it('falls through to create a CitrusTestVisualEntity when entity type is not in supportedEntities', async () => {
       const resource = new CitrusTestResource();
-      resource.initialize();
+      await resource.initialize();
       // EntityType.Route is not a supported Citrus entity type
       const id = resource.addNewEntity(EntityType.Route);
       expect(id).not.toBe('');

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
@@ -11,11 +11,11 @@ import { NodeMapperService } from './node-mapper.service';
 import { RootNodeMapper } from './root-node-mapper';
 
 describe('NodeMapperService', () => {
-  it('should initialize the root node mapper', () => {
+  it('should initialize the root node mapper', async () => {
     const registerDefaultMapperSpy = vi.spyOn(RootNodeMapper.prototype, 'registerDefaultMapper');
     const registerMapperSpy = vi.spyOn(RootNodeMapper.prototype, 'registerMapper');
 
-    NodeMapperService.getVizNode('path', { processorName: 'log' }, {});
+    await NodeMapperService.getVizNode('path', { processorName: 'log' }, {});
 
     expect(registerDefaultMapperSpy).toHaveBeenCalledWith(expect.any(BaseNodeMapper));
     expect(registerMapperSpy).toHaveBeenCalledWith('circuitBreaker', expect.any(CircuitBreakerNodeMapper));

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -21,10 +21,10 @@ describe('BeansEntityHandler', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let model: any;
     let beansHandler: BeansEntityHandler;
-    beforeEach(() => {
+    beforeEach(async () => {
       model = cloneDeep(routeStub.camelRouteJson);
       const camelRouteResource = new CamelRouteResource(model);
-      camelRouteResource.initialize();
+      await camelRouteResource.initialize();
       beansHandler = new BeansEntityHandler(camelRouteResource);
     });
 
@@ -75,10 +75,10 @@ describe('BeansEntityHandler', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let model: any;
     let beansHandler: BeansEntityHandler;
-    beforeEach(() => {
+    beforeEach(async () => {
       model = cloneDeep(kameletStub.kameletJson);
       const kameletResource = new KameletResource(model);
-      kameletResource.initialize();
+      await kameletResource.initialize();
       beansHandler = new BeansEntityHandler(kameletResource);
     });
 
@@ -140,9 +140,9 @@ describe('BeansEntityHandler', () => {
       expect(beansHandler.stripReferenceQuote('#myBean')).toBeUndefined();
     });
 
-    it('if CamelResource is not the supported one', () => {
+    it('if CamelResource is not the supported one', async () => {
       const camelResource = new PipeResource({});
-      camelResource.initialize();
+      await camelResource.initialize();
       const beansHandler = new BeansEntityHandler(camelResource);
       expect(beansHandler.isSupported()).toBeFalsy();
       expect(beansHandler.stripReferenceQuote('#myBean')).toBeUndefined();

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
@@ -19,13 +19,13 @@ describe('EndpointsEntityHandler', () => {
     let endpointsHandler: EndpointsEntityHandler;
     let testModel: Test;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       testModel = {
         name: 'test',
         actions: [],
       };
       testResource = new CitrusTestResource(testModel);
-      testResource.initialize();
+      await testResource.initialize();
       endpointsHandler = new EndpointsEntityHandler(testResource);
     });
 

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
@@ -85,7 +85,7 @@ describe('SourceCodeBridgeProvider', () => {
     expect(mockOnNewEdit).toHaveBeenCalledTimes(1);
   });
 
-  it('should unsubscribe from events on unmount', () => {
+  it('should unsubscribe from events on unmount', async () => {
     const eventNotifierInstance = EventNotifier.getInstance();
     const unsubscribeFromEntitiesMock = vi.fn();
     const unsubscribeFromSourceCodeMock = vi.fn();
@@ -99,7 +99,7 @@ describe('SourceCodeBridgeProvider', () => {
       </SourceCodeBridgeProvider>,
     );
 
-    act(() => {
+    await act(async () => {
       unmount();
     });
 
@@ -147,7 +147,7 @@ const EnvelopeProviderTestingBed: FunctionComponent = () => {
       <button
         type="button"
         onClick={() => {
-          envelopeRef.current?.setContent(
+          void envelopeRef.current?.setContent(
             'test.camel.yaml',
             `- from:
             uri: "timer:foo"

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.tsx
@@ -22,14 +22,14 @@ export const SourceCodeBridgeProvider = forwardRef<SourceCodeBridgeProviderRef, 
      */
     useEffect(() => {
       const unsubscribeFromEntities = eventNotifier.subscribe('entities:updated', (newContent: string) => {
-        onNewEdit(newContent);
+        void onNewEdit(newContent);
         sourceCodeRef.current = newContent;
       });
 
       const unsubscribeFromSourceCode = eventNotifier.subscribe('code:updated', ({ code: newContent }) => {
         /** Ignore the first change, from an empty string to the file content  */
         if (sourceCodeRef.current !== '') {
-          onNewEdit(newContent);
+          void onNewEdit(newContent);
         }
         sourceCodeRef.current = newContent;
       });

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -177,8 +177,8 @@ describe('KaotoEditorApp', () => {
     expect(editorRef.current!.setTheme).toHaveBeenCalledWith(EditorTheme.DARK);
   });
 
-  it('sendReady', () => {
-    kaotoEditorApp.sendReady();
+  it('sendReady', async () => {
+    await kaotoEditorApp.sendReady();
 
     expect(envelopeContext.channelApi.notifications.kogitoEditor_ready.send).toHaveBeenCalled();
   });
@@ -238,8 +238,8 @@ describe('KaotoEditorApp', () => {
     expect(envelopeContext.channelApi.requests.saveResourceContent).toHaveBeenCalledWith('path', 'content');
   });
 
-  it('should set the color theme upon opening the editor', () => {
-    kaotoEditorApp.af_onOpen();
+  it('should set the color theme upon opening the editor', async () => {
+    await kaotoEditorApp.af_onOpen();
 
     expect(setColorScheme).toHaveBeenCalledWith(ColorScheme.Auto);
   });

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -41,7 +41,7 @@ describe('RestRouteEndpointField', () => {
       { route: { from: { uri: 'direct:orders', steps: [] } } },
       { route: { from: { uri: 'direct:billing', steps: [] } } },
     ]);
-    camelResource.initialize();
+    await camelResource.initialize();
     const { Provider } = await TestProvidersWrapper({ camelResource });
 
     await act(async () => {

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -12,7 +12,7 @@ describe('RestTree', () => {
     vi.clearAllMocks();
   });
 
-  it('should render tree structure with RestConfiguration, Rest entities, and methods', () => {
+  it('should render tree structure with RestConfiguration, Rest entities, and methods', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - restConfiguration:
     host: localhost
@@ -37,7 +37,7 @@ describe('RestTree', () => {
         to:
           uri: direct:deleteItem
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -57,7 +57,7 @@ describe('RestTree', () => {
     expect(screen.getByText('/items/{id}')).toBeInTheDocument();
   });
 
-  it('should fire selection callback with correct entityId and modelPath when node clicked', () => {
+  it('should fire selection callback with correct entityId and modelPath when node clicked', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -67,7 +67,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -91,7 +91,7 @@ describe('RestTree', () => {
     });
   });
 
-  it('should handle empty entities array gracefully', () => {
+  it('should handle empty entities array gracefully', async () => {
     const entities: BaseVisualEntity[] = [];
 
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -101,12 +101,12 @@ describe('RestTree', () => {
     expect(screen.queryAllByRole('treeitem')).toHaveLength(0);
   });
 
-  it('should render children prop (toolbar area)', () => {
+  it('should render children prop (toolbar area)', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
 
@@ -119,7 +119,7 @@ describe('RestTree', () => {
     expect(screen.getByText('Toolbar Content')).toBeInTheDocument();
   });
 
-  it('should highlight selected Rest entity node', () => {
+  it('should highlight selected Rest entity node', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -129,7 +129,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest' };
@@ -146,7 +146,7 @@ describe('RestTree', () => {
     expect(activeNode).toBeInTheDocument();
   });
 
-  it('should highlight selected method node', () => {
+  it('should highlight selected method node', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -161,7 +161,7 @@ describe('RestTree', () => {
         to:
           uri: direct:orders
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest.post.0' };
@@ -174,12 +174,12 @@ describe('RestTree', () => {
     expect(activeNode).toBeInTheDocument();
   });
 
-  it('should handle undefined selected prop', () => {
+  it('should handle undefined selected prop', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
 
@@ -189,7 +189,7 @@ describe('RestTree', () => {
     expect(screen.getByText('rest-1234')).toBeInTheDocument();
   });
 
-  it('should update selection when selected prop changes', () => {
+  it('should update selection when selected prop changes', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -199,7 +199,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     const initialSelected = { entityId: 'rest-1234', modelPath: 'rest' };
@@ -220,7 +220,7 @@ describe('RestTree', () => {
     expect(activeNode).toBeInTheDocument();
   });
 
-  it('should display "not specified" when method path is undefined', () => {
+  it('should display "not specified" when method path is undefined', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -229,7 +229,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);
@@ -237,7 +237,7 @@ describe('RestTree', () => {
     expect(screen.getByText('not specified')).toBeInTheDocument();
   });
 
-  it('should display "not specified" when method path is empty', () => {
+  it('should display "not specified" when method path is empty', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -247,7 +247,7 @@ describe('RestTree', () => {
         to:
           uri: direct:test
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
     render(<RestTree entities={entities} onSelect={mockOnSelect} />);

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
@@ -24,7 +24,7 @@ describe('RestTreeToolbar', () => {
   });
 
   describe('Add RestConfiguration button', () => {
-    it('should be disabled when RestConfiguration already exists', () => {
+    it('should be disabled when RestConfiguration already exists', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - restConfiguration:
     host: localhost
@@ -32,7 +32,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -53,12 +53,12 @@ describe('RestTreeToolbar', () => {
       expect(addRestConfigButton).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be enabled when no RestConfiguration exists', () => {
+    it('should be enabled when no RestConfiguration exists', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -98,7 +98,7 @@ describe('RestTreeToolbar', () => {
   });
 
   describe('Add Rest button', () => {
-    it('should always be enabled', () => {
+    it('should always be enabled', async () => {
       const entities: BaseVisualEntity[] = [];
 
       render(
@@ -118,14 +118,14 @@ describe('RestTreeToolbar', () => {
       expect(addRestButton).not.toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be enabled even with entities present', () => {
+    it('should be enabled even with entities present', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
 - restConfiguration:
     host: localhost
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -165,7 +165,7 @@ describe('RestTreeToolbar', () => {
   });
 
   describe('Add Method button', () => {
-    it('should be disabled when nothing is selected', () => {
+    it('should be disabled when nothing is selected', async () => {
       const entities: BaseVisualEntity[] = [];
 
       render(
@@ -185,13 +185,13 @@ describe('RestTreeToolbar', () => {
       expect(addMethodButton).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be disabled when RestConfiguration is selected', () => {
+    it('should be disabled when RestConfiguration is selected', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - restConfiguration:
     host: localhost
     port: "8080"
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
       const restConfigEntity = entities[0] as CamelRestConfigurationVisualEntity;
@@ -214,7 +214,7 @@ describe('RestTreeToolbar', () => {
       expect(addMethodButton).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be enabled when Rest entity root is selected', () => {
+    it('should be enabled when Rest entity root is selected', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -224,7 +224,7 @@ describe('RestTreeToolbar', () => {
         to:
           uri: direct:test
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -246,7 +246,7 @@ describe('RestTreeToolbar', () => {
       expect(addMethodButton).not.toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be enabled when a Rest method is selected', () => {
+    it('should be enabled when a Rest method is selected', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -256,7 +256,7 @@ describe('RestTreeToolbar', () => {
         to:
           uri: direct:test
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -278,7 +278,7 @@ describe('RestTreeToolbar', () => {
       expect(addMethodButton).not.toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be disabled when a non-Rest path is selected', () => {
+    it('should be disabled when a non-Rest path is selected', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
@@ -292,7 +292,7 @@ describe('RestTreeToolbar', () => {
     from:
       uri: direct:test
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -316,7 +316,7 @@ describe('RestTreeToolbar', () => {
   });
 
   describe('Delete button', () => {
-    it('should be disabled when nothing is selected', () => {
+    it('should be disabled when nothing is selected', async () => {
       const entities: BaseVisualEntity[] = [];
 
       render(
@@ -336,12 +336,12 @@ describe('RestTreeToolbar', () => {
       expect(deleteButton).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('should be enabled when an element is selected', () => {
+    it('should be enabled when an element is selected', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -368,7 +368,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -394,7 +394,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -422,7 +422,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 
@@ -454,7 +454,7 @@ describe('RestTreeToolbar', () => {
 - rest:
     id: rest-1234
       `);
-      camelResource.initialize();
+      await camelResource.initialize();
 
       const entities = getRestEntities(camelResource.getEntities());
 

--- a/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.test.ts
@@ -10,7 +10,7 @@ describe('getRestEntities', () => {
     expect(result).toEqual([]);
   });
 
-  it('should filter and return only CamelRestVisualEntity instances', () => {
+  it('should filter and return only CamelRestVisualEntity instances', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-1
@@ -27,7 +27,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:createOrder
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -39,13 +39,13 @@ describe('getRestEntities', () => {
     expect((result[1] as CamelRestVisualEntity).id).toBe('rest-2');
   });
 
-  it('should filter and return only CamelRestConfigurationVisualEntity instances', () => {
+  it('should filter and return only CamelRestConfigurationVisualEntity instances', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - restConfiguration:
     host: localhost
     port: "8080"
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -54,7 +54,7 @@ describe('getRestEntities', () => {
     expect(result[0]).toBeInstanceOf(CamelRestConfigurationVisualEntity);
   });
 
-  it('should filter and return both CamelRestVisualEntity and CamelRestConfigurationVisualEntity instances', () => {
+  it('should filter and return both CamelRestVisualEntity and CamelRestConfigurationVisualEntity instances', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - restConfiguration:
     host: localhost
@@ -74,7 +74,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:deleteItem
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -85,7 +85,7 @@ describe('getRestEntities', () => {
     expect(result[2]).toBeInstanceOf(CamelRestVisualEntity);
   });
 
-  it('should filter out non-REST entities (e.g., routes)', () => {
+  it('should filter out non-REST entities (e.g., routes)', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - route:
     id: route-1
@@ -109,7 +109,7 @@ describe('getRestEntities', () => {
         - log:
             message: "tick"
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -120,7 +120,7 @@ describe('getRestEntities', () => {
     expect((result[0] as CamelRestVisualEntity).id).toBe('rest-1');
   });
 
-  it('should handle mixed entity types and return only REST-related entities', () => {
+  it('should handle mixed entity types and return only REST-related entities', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - route:
     id: route-1
@@ -162,7 +162,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:deleteUser
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -183,7 +183,7 @@ describe('getRestEntities', () => {
     expect(restConfigEntities).toHaveLength(1);
   });
 
-  it('should return empty array when no REST entities exist', () => {
+  it('should return empty array when no REST entities exist', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - route:
     id: route-1
@@ -200,7 +200,7 @@ describe('getRestEntities', () => {
         - log:
             message: "tick"
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);
@@ -209,7 +209,7 @@ describe('getRestEntities', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('should preserve the order of REST entities', () => {
+  it('should preserve the order of REST entities', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-first
@@ -235,7 +235,7 @@ describe('getRestEntities', () => {
         to:
           uri: direct:third
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const entities = camelResource.getEntities();
     const result = getRestEntities(entities);

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
@@ -16,7 +16,7 @@ const getRestEntities = (camelResource: KaotoResource): BaseVisualEntity[] =>
 describe('restToTree', () => {
   let camelResource: KaotoResource;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-3496
@@ -48,7 +48,7 @@ describe('restToTree', () => {
     host: localhost
     port: "8080"
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
   });
 
   it('should convert rest to tree', () => {
@@ -111,7 +111,7 @@ describe('restToTree', () => {
     expect(treeNodes).toEqual(expectedTreeNodes);
   });
 
-  it('should handle rest entity with method without id', () => {
+  it('should handle rest entity with method without id', async () => {
     camelResource = CamelResourceFactory.createCamelResource(`
 - rest:
     id: rest-9999
@@ -120,7 +120,7 @@ describe('restToTree', () => {
         to:
           uri: direct:create
     `);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const treeNodes = restToTree(getRestEntities(camelResource));
 

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
@@ -9,11 +9,11 @@ export const RestDslImportPage: FunctionComponent = () => {
   const navigate = useNavigate();
 
   const handleClose = useCallback(() => {
-    navigate(Links.RestEditor);
+    void navigate(Links.RestEditor);
   }, [navigate]);
 
   const handleGoToDesigner = useCallback(() => {
-    navigate(Links.Home);
+    void navigate(Links.Home);
   }, [navigate]);
 
   return (

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
@@ -83,7 +83,7 @@ const ImportWizardFooter: FunctionComponent<ImportWizardFooterProps> = ({
             type="button"
             onClick={(event) => {
               event.preventDefault();
-              onGoToDesigner(event);
+              void onGoToDesigner(event);
             }}
           >
             Go to Designer
@@ -240,7 +240,7 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
             />
           </FormGroup>
           <div className="rest-dsl-import-actions">
-            <Button variant="secondary" onClick={wizard.handleParseOpenApiSpec}>
+            <Button variant="secondary" onClick={() => void wizard.handleParseOpenApiSpec()}>
               Parse Specification
             </Button>
             {wizard.importStatus?.type === 'error' && (

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
@@ -42,7 +42,7 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
 
   useEffect(() => {
     if (registryUrl) {
-      fetchArtifacts();
+      void fetchArtifacts();
     }
   }, [fetchArtifacts, registryUrl]);
 
@@ -100,7 +100,7 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
   const handleSelectArtifact = useCallback(
     (artifactId: string) => {
       setSelectedId(artifactId);
-      handleLoadArtifact(artifactId);
+      void handleLoadArtifact(artifactId);
     },
     [handleLoadArtifact],
   );

--- a/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/useRestDslImportWizard.test.tsx
@@ -187,7 +187,7 @@ describe('useRestDslImportWizard', () => {
       },
     ]);
 
-    camelResource.initialize();
+    await camelResource.initialize();
     const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');
 
@@ -247,7 +247,7 @@ describe('useRestDslImportWizard', () => {
         },
       },
     ]);
-    camelResource.initialize();
+    await camelResource.initialize();
 
     const { Provider, updateEntitiesFromCamelResourceSpy } = await TestProvidersWrapper({ camelResource });
     const addNewEntitySpy = vi.spyOn(camelResource, 'addNewEntity');

--- a/packages/ui/src/providers/entities.provider.tsx
+++ b/packages/ui/src/providers/entities.provider.tsx
@@ -64,7 +64,7 @@ export const EntitiesProvider: FunctionComponent<PropsWithChildren> = ({ childre
   }, [kaotoResource]);
 
   const updateSourceCodeFromEntities = useCallback(() => {
-    kaotoResource.toSourceCode().then((code) => {
+    void kaotoResource.toSourceCode().then((code) => {
       eventNotifier.next('entities:updated', code);
     });
   }, [kaotoResource, eventNotifier]);

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -122,7 +122,7 @@ export class DataMapperMetadataService {
         },
         {} as Record<string, Promise<DocumentDefinition>>,
       );
-      Promise.allSettled([sourceBodyPromise, targetBodyPromise, ...Object.values(paramPromises)]).then(() => {
+      void Promise.allSettled([sourceBodyPromise, targetBodyPromise, ...Object.values(paramPromises)]).then(() => {
         resolve(answer);
       });
     });
@@ -147,7 +147,7 @@ export class DataMapperMetadataService {
               .catch((error) => console.log(`Could not read a file "${path}": ${error}`)),
           )
         : [];
-      Promise.allSettled(fileReadingPromises).then(() => {
+      void Promise.allSettled(fileReadingPromises).then(() => {
         const answer = new DocumentDefinition(
           documentType,
           definitionType,
@@ -229,7 +229,7 @@ export class DataMapperMetadataService {
           })
         : [];
     return new Promise((resolve) => {
-      Promise.allSettled(filePromises).then(() => resolve(answer));
+      void Promise.allSettled(filePromises).then(() => resolve(answer));
     });
   }
 
@@ -283,7 +283,7 @@ export class DataMapperMetadataService {
     name: string,
   ) {
     delete metadata.sourceParameters[name];
-    api.setMetadata(metadataId, metadata);
+    await api.setMetadata(metadataId, metadata);
   }
 
   /**

--- a/packages/ui/src/services/parsers/beans-parser.test.ts
+++ b/packages/ui/src/services/parsers/beans-parser.test.ts
@@ -5,9 +5,9 @@ import { BeansParser } from './beans-parser';
 
 describe('BeansParser', () => {
   describe('parseBeansEntity()', () => {
-    it('should parse BeansEntity', () => {
+    it('should parse BeansEntity', async () => {
       const resource = CamelResourceFactory.createCamelResource(beansYaml);
-      resource.initialize();
+      await resource.initialize();
       const beansEntity = resource.getEntities()[0] as BeansEntity;
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
       expect(parsedTable.title).toBe('Beans');
@@ -25,9 +25,9 @@ describe('BeansParser', () => {
       expect(parsedTable.data[0][4]).toBe('p1v');
     });
 
-    it('should parse BeansEntity without properties', () => {
+    it('should parse BeansEntity without properties', async () => {
       const resource = CamelResourceFactory.createCamelResource(beansYaml);
-      resource.initialize();
+      await resource.initialize();
       const beansEntity = resource.getEntities()[0] as BeansEntity;
       beansEntity.parent.beans.forEach((bean) => (bean.properties = {}));
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
@@ -45,9 +45,9 @@ describe('BeansParser', () => {
       expect(parsedTable.data[1][4]).toBe('');
     });
 
-    it('should parse BeanEntity with parameters', () => {
+    it('should parse BeanEntity with parameters', async () => {
       const resource = CamelResourceFactory.createCamelResource(beansWithParamsYaml);
-      resource.initialize();
+      await resource.initialize();
       const beansEntity = resource.getEntities()[0] as BeansEntity;
       const parsedTable = BeansParser.parseBeansEntity(beansEntity, 'Beans');
       expect(parsedTable.data).toHaveLength(7);

--- a/packages/ui/src/services/parsers/common-parser.test.ts
+++ b/packages/ui/src/services/parsers/common-parser.test.ts
@@ -5,9 +5,13 @@ import { datamapperRouteDefinitionStub } from '../../stubs/datamapper/data-mappe
 import { CommonParser } from './common-parser';
 
 describe('CommonParser', () => {
-  const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
-  resource.initialize();
-  const camelRouteEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
+  let camelRouteEntity: CamelRouteVisualEntity;
+
+  beforeAll(async () => {
+    const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
+    await resource.initialize();
+    camelRouteEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
+  });
 
   describe('parseFrom()', () => {
     it('should parse from', () => {

--- a/packages/ui/src/services/parsers/rest-parser.test.ts
+++ b/packages/ui/src/services/parsers/rest-parser.test.ts
@@ -13,9 +13,9 @@ describe('RestParser', () => {
   });
 
   describe('parseRestEntity()', () => {
-    it('should parse rest', () => {
+    it('should parse rest', async () => {
       const camelResource = CamelResourceFactory.createCamelResource(restOperationsYaml);
-      camelResource.initialize();
+      await camelResource.initialize();
       const restEntity = camelResource
         .getEntities()
         .find((e) => e instanceof CamelRestVisualEntity) as CamelRestVisualEntity;

--- a/packages/ui/src/services/parsers/route-parser.test.ts
+++ b/packages/ui/src/services/parsers/route-parser.test.ts
@@ -22,15 +22,23 @@ import { routeConfigurationFullYaml } from '../../stubs/route-configuration-full
 import { RouteParser } from './route-parser';
 
 describe('RouteParser', () => {
-  beforeAll(() => {
+  let rcEntity: CamelRouteConfigurationVisualEntity;
+  let routeEntity: CamelRouteVisualEntity;
+
+  beforeAll(async () => {
     mockRandomValues();
+
+    const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
+    await resource.initialize();
+    routeEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
+
+    const rcResource = CamelResourceFactory.createCamelResource(routeConfigurationFullYaml);
+    await rcResource.initialize();
+    rcEntity = rcResource.getVisualEntities()[0] as CamelRouteConfigurationVisualEntity;
   });
 
   describe('parseRouteEntity()', () => {
     it('should parse route', () => {
-      const resource = CamelResourceFactory.createCamelResource(camelRouteYaml);
-      resource.initialize();
-      const routeEntity = resource.getVisualEntities()[0] as CamelRouteVisualEntity;
       const parsed = RouteParser.parseRouteEntity(routeEntity);
 
       expect(parsed.title).toBe('route-8888');
@@ -50,10 +58,6 @@ describe('RouteParser', () => {
       expect(parsed.data[0][4]).toBe('tutorial');
     });
   });
-
-  const rcResource = CamelResourceFactory.createCamelResource(routeConfigurationFullYaml);
-  rcResource.initialize();
-  const rcEntity = rcResource.getVisualEntities()[0] as CamelRouteConfigurationVisualEntity;
 
   describe('parseRouteConfigurationEntity()', () => {
     it('should parse route configuration', () => {

--- a/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.test.tsx
+++ b/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.test.tsx
@@ -71,36 +71,36 @@ describe('BrowserFilePickerMetadataProvider', () => {
   });
 
   describe('askUserForFileSelection', () => {
-    it('should set accept pattern for SCHEMA_FILE_NAME_PATTERN_SOURCE_BODY', () => {
+    it('should set accept pattern for SCHEMA_FILE_NAME_PATTERN_SOURCE_BODY', async () => {
       const { api, fileInput } = renderWithProvider();
 
-      act(() => {
-        api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN_XML);
-      });
+      const selectionPromise = api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN_XML);
 
       expect(fileInput.accept).toBe(SCHEMA_FILE_ACCEPT_PATTERN_XML);
+
+      void selectionPromise;
     });
 
-    it('should set accept pattern for SCHEMA_FILE_NAME_PATTERN', () => {
+    it('should set accept pattern for SCHEMA_FILE_NAME_PATTERN', async () => {
       const { api, fileInput } = renderWithProvider();
 
-      act(() => {
-        api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN);
-      });
+      const selectionPromise = api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN);
 
       expect(fileInput.accept).toBe(SCHEMA_FILE_ACCEPT_PATTERN);
+
+      void selectionPromise;
     });
 
-    it('should trigger file input click', () => {
+    it('should trigger file input click', async () => {
       const { api, fileInput } = renderWithProvider();
       const clickSpy = vi.fn();
       fileInput.click = clickSpy;
 
-      act(() => {
-        api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN);
-      });
+      const selectionPromise = api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN);
 
       expect(clickSpy).toHaveBeenCalledTimes(1);
+
+      void selectionPromise;
     });
 
     it('should resolve with file names when files are selected', async () => {
@@ -110,16 +110,11 @@ describe('BrowserFilePickerMetadataProvider', () => {
 
       const { api, fileInput } = renderWithProvider();
 
-      let resolvedFiles: string[] | string | undefined;
-      act(() => {
-        api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN).then((files) => {
-          resolvedFiles = files;
-        });
-      });
+      const filesPromise = api.askUserForFileSelection(SCHEMA_FILE_NAME_PATTERN);
 
       await triggerFileSelect(fileInput, [mockFile1, mockFile2]);
 
-      expect(resolvedFiles).toEqual(['test1.json', 'test2.xml']);
+      await expect(filesPromise).resolves.toEqual(['test1.json', 'test2.xml']);
       expect(mockReadFileAsString).toHaveBeenCalledTimes(2);
     });
   });

--- a/packages/ui/src/tests/nodes-edges.test.ts
+++ b/packages/ui/src/tests/nodes-edges.test.ts
@@ -10,7 +10,7 @@ describe('Nodes and Edges', () => {
 
   it('should generate edges for steps with branches', async () => {
     const camelResource = new CamelRouteResource(camelRouteBranch);
-    camelResource.initialize();
+    await camelResource.initialize();
     const [camelRoute] = camelResource.getVisualEntities();
 
     const rootVizNode = await camelRoute.toVizNode();


### PR DESCRIPTION
### Context
Currently, awaiting promises are not enforced, and this could silently bring race conditions inadvertently.

### Changes
Enable `no-floating-promises` eslint rule to prevent regressions and prefix all current promises with `void` to silence the issue without changing the runtime code.

### Notes
On the code side, it's a good moment to review all the `void` prefixes to determine whether that's the appropriate handling or not.

In most cases, `React` can handle async callbacks directly, so instead of using `void`, we could return the promise call or alternatively use async/await syntax.

#### Examples
```ts
// Current code
const situation = () => void {
  void asyncFunctionCall();
}

// Alternative 1
const alternative = () => Promise<void> {
  return asyncFunctionCall();
}

// Alternative 2
const alternative = async () => Promise<void> {
  await asyncFunctionCall();
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across editor interactions (navigation, clipboard copy, step/group operations, delete/replace flows, and DataMapper metadata updates) by ensuring async actions complete in the intended sequence.
  * Reduced chances of timing issues and background promise-related warnings that could affect UI behavior.
* **Tests**
  * Updated unit/integration tests to consistently await resource initialization and UI updates.
  * Improved a Cypress dropdown helper to use deterministic UI state checks.
* **Chores**
  * Tightened promise/lint handling and TypeScript-aware lint configuration to catch async issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->