### PR TITLE
fix(linter): Enable `no-confusing-void-expression` eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,13 +10,13 @@ import tseslint from 'typescript-eslint';
 
 export default [
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
-  { 
-    languageOptions: { 
+  {
+    languageOptions: {
       globals: globals.browser,
       parserOptions: {
         project: true,
       },
-    } 
+    },
   },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
@@ -47,6 +47,7 @@ export default [
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-confusing-void-expression': 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
     },

--- a/packages/ui-tests/cypress/support/next-commands/default.ts
+++ b/packages/ui-tests/cypress/support/next-commands/default.ts
@@ -387,7 +387,7 @@ Cypress.Commands.add('assertValueCopiedToClipboard', (value) => {
       // Return the promise so Cypress awaits the clipboard read before the command resolves.
       // Otherwise the read floats and may resolve against a later copy's content, throwing an
       // uncaught AssertionError (the Chromium-only "deeply equal" failure seen in CI).
-      return await win.navigator?.clipboard?.read().then(async (text: ClipboardItems) => {
+      return win.navigator?.clipboard?.read().then(async (text: ClipboardItems) => {
         for (const item of text) {
           if (item.types.includes('web text/kaoto')) {
             const blob = await item.getType('web text/kaoto');

--- a/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
+++ b/packages/ui-tests/stories/catalog/PropertiesModal.stories.tsx
@@ -74,7 +74,9 @@ async function tileWithIconUrl(base: Omit<ITile, 'iconUrl'>, catalogKind: Catalo
 
 const Template: StoryFn<typeof PropertiesModal> = (args, context) => {
   const [isModalOpen, setIsModalOpen] = useState(true);
-  const handleClose = () => setIsModalOpen(!isModalOpen);
+  const handleClose = () => {
+    setIsModalOpen(!isModalOpen);
+  };
   const loaded = context.loaded as { tile?: ITile } | undefined;
   const tile = loaded?.tile ?? args.tile;
   return <PropertiesModal {...args} tile={tile} onClose={handleClose} isModalOpen={isModalOpen} />;

--- a/packages/ui-tests/stories/kaotoForm/PipeErrorHandler.stories.tsx
+++ b/packages/ui-tests/stories/kaotoForm/PipeErrorHandler.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: PipeErrorHandlerPage,
 } as Meta<typeof PipeErrorHandlerPage>;
 const formTabsValue: CanvasFormTabsContextResult = {} as CanvasFormTabsContextResult;
-const getErrorHandlerModel = () => {};
+const getErrorHandlerModel = () => ({});
 const onChangeModel = () => {};
 
 const camelResource = new PipeResource();

--- a/packages/ui-tests/stories/settings/AboutModal.stories.tsx
+++ b/packages/ui-tests/stories/settings/AboutModal.stories.tsx
@@ -9,7 +9,9 @@ export default {
 
 const Template: StoryFn<typeof KaotoAboutModal> = (args) => {
   const [isModalOpen, setIsModalOpen] = useState(true);
-  const handleClose = () => setIsModalOpen(!isModalOpen);
+  const handleClose = () => {
+    setIsModalOpen(!isModalOpen);
+  };
   return <KaotoAboutModal {...args} handleCloseModal={handleClose} isModalOpen={isModalOpen} />;
 };
 

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractConfigModal.tsx
@@ -50,7 +50,9 @@ const CandidateItem: FunctionComponent<CandidateItemProps> = ({ candidate, isSel
         <Radio
           isChecked={isSelected}
           name="candidate-selection"
-          onChange={() => onSelect(candidate.id)}
+          onChange={() => {
+            onSelect(candidate.id);
+          }}
           label={label}
           id={`radio-${candidate.id}`}
           data-testid={`radio-${candidate.id}`}
@@ -58,7 +60,9 @@ const CandidateItem: FunctionComponent<CandidateItemProps> = ({ candidate, isSel
       ) : (
         <Checkbox
           isChecked={isSelected}
-          onChange={() => onSelect(candidate.id)}
+          onChange={() => {
+            onSelect(candidate.id);
+          }}
           label={label}
           id={`checkbox-${candidate.id}`}
           data-testid={`checkbox-${candidate.id}`}
@@ -167,8 +171,12 @@ export const AbstractConfigModal: FunctionComponent<AbstractConfigModalProps> = 
             <SearchInput
               placeholder="Filter candidates..."
               value={searchFilter}
-              onChange={(_event, value) => setSearchFilter(value)}
-              onClear={() => setSearchFilter('')}
+              onChange={(_event, value) => {
+                setSearchFilter(value);
+              }}
+              onClear={() => {
+                setSearchFilter('');
+              }}
               data-testid={`${dataTestId}-search`}
             />
           </div>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AbstractTreeMock.tsx
@@ -95,7 +95,9 @@ export const AbstractTreeMock: FunctionComponent<AbstractTreeMockProps> = ({
       showChoicesIcon={false}
       expandable={hasChildren}
       isExpanded={isExpanded}
-      onToggle={() => toggleExpansion(fieldNode.id)}
+      onToggle={() => {
+        toggleExpansion(fieldNode.id);
+      }}
       data-testid={dataTestId || `node-${fieldNode.id}`}
     >
       {fieldNode.children?.map((child) => (
@@ -153,7 +155,7 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
   'data-testid': dataTestId,
 }) => {
   const isCollection = abstractNode.maxOccurs === -1 || abstractNode.maxOccurs > 1;
-  const instances = substitutions[abstractNode.id] ?? [];
+  const instances = useMemo(() => substitutions[abstractNode.id] ?? [], [substitutions, abstractNode.id]);
   const instructionList = instructions?.[abstractNode.id] ?? [];
   const hasInstructions = instructionList.length > 0;
   const hasInstances = instances.length > 0;
@@ -183,25 +185,37 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
       items.push({
         key: 'wrap-for-each',
         label: 'Wrap with "for-each"',
-        onClick: () => handleAddInstructionWithFields(abstractNode.id, 'for-each'),
+        onClick: () => {
+          handleAddInstructionWithFields(abstractNode.id, 'for-each');
+        },
       });
     }
     items.push({
       key: 'wrap-if',
       label: 'Wrap with "if"',
-      onClick: () => handleAddInstructionWithFields(abstractNode.id, 'if'),
+      onClick: () => {
+        handleAddInstructionWithFields(abstractNode.id, 'if');
+      },
     });
     items.push({
       key: 'wrap-choose',
       label: 'Wrap with "choose-when-otherwise"',
-      onClick: () => handleAddInstructionWithFields(abstractNode.id, 'choose'),
+      onClick: () => {
+        handleAddInstructionWithFields(abstractNode.id, 'choose');
+      },
     });
     return items;
   }, [abstractNode.id, isCollection, handleAddInstructionWithFields]);
 
   const abstractRowDocItems = useMemo(
     (): DocMenuItem[] => [
-      { key: 'select-sub', label: 'Select Substitution', onClick: () => setIsSubstituteModalOpen(true) },
+      {
+        key: 'select-sub',
+        label: 'Select Substitution',
+        onClick: () => {
+          setIsSubstituteModalOpen(true);
+        },
+      },
     ],
     [],
   );
@@ -209,7 +223,13 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
   const abstractRowMappingItems = useMemo((): MappingMenuItem[] => {
     const items = buildWrapActions();
     if (isCollection) {
-      items.push({ key: 'dup-field', label: 'Duplicate Field', onClick: () => onDuplicate(abstractNode.id) });
+      items.push({
+        key: 'dup-field',
+        label: 'Duplicate Field',
+        onClick: () => {
+          onDuplicate(abstractNode.id);
+        },
+      });
     }
     return items;
   }, [abstractNode.id, isCollection, buildWrapActions, onDuplicate]);
@@ -236,7 +256,9 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
           {
             key: 'clear-sub',
             label: 'Clear Substitution',
-            onClick: () => onClearSubstitution(abstractNode.id, inst.instanceId),
+            onClick: () => {
+              onClearSubstitution(abstractNode.id, inst.instanceId);
+            },
           },
         ];
         const mappingItems: MappingMenuItem[] = [...buildWrapActions()];
@@ -244,7 +266,9 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
           mappingItems.push({
             key: 'dup-field',
             label: 'Duplicate Field',
-            onClick: () => onDuplicate(abstractNode.id, inst.instanceId),
+            onClick: () => {
+              onDuplicate(abstractNode.id, inst.instanceId);
+            },
           });
         }
 
@@ -261,10 +285,18 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
             isCollection={isCollection}
             expandable={hasChildren}
             isExpanded={isExpanded}
-            onToggle={() => toggleExpansion(nodeKey)}
+            onToggle={() => {
+              toggleExpansion(nodeKey);
+            }}
             docMenuItems={docItems}
             mappingMenuItems={mappingItems}
-            onRemove={isCollection ? () => onRemoveInstance(abstractNode.id, inst.instanceId) : undefined}
+            onRemove={
+              isCollection
+                ? () => {
+                    onRemoveInstance(abstractNode.id, inst.instanceId);
+                  }
+                : undefined
+            }
             data-testid={`substituted-${inst.instanceId}`}
           >
             {candidate.children?.map((child) => (
@@ -306,7 +338,9 @@ const AbstractNodeRenderer: FunctionComponent<AbstractNodeRendererProps> = ({
   const substituteModal = isSubstituteModalOpen && (
     <AddFieldCandidateModal
       isOpen={isSubstituteModalOpen}
-      onClose={() => setIsSubstituteModalOpen(false)}
+      onClose={() => {
+        setIsSubstituteModalOpen(false);
+      }}
       onConfirm={handleSelectSubstitute}
       abstractNode={abstractNode}
     />
@@ -377,13 +411,27 @@ const UnsubstitutedInstanceRow: FunctionComponent<UnsubstitutedInstanceRowProps>
   );
 
   const docItems = useMemo(
-    (): DocMenuItem[] => [{ key: 'select-sub', label: 'Select Substitution', onClick: () => setIsModalOpen(true) }],
+    (): DocMenuItem[] => [
+      {
+        key: 'select-sub',
+        label: 'Select Substitution',
+        onClick: () => {
+          setIsModalOpen(true);
+        },
+      },
+    ],
     [],
   );
 
   const mappingItems = useMemo((): MappingMenuItem[] => {
     const items = buildWrapActions();
-    items.push({ key: 'dup-field', label: 'Duplicate Field', onClick: () => onDuplicate(abstractNode.id, instanceId) });
+    items.push({
+      key: 'dup-field',
+      label: 'Duplicate Field',
+      onClick: () => {
+        onDuplicate(abstractNode.id, instanceId);
+      },
+    });
     return items;
   }, [abstractNode.id, instanceId, buildWrapActions, onDuplicate]);
 
@@ -397,13 +445,17 @@ const UnsubstitutedInstanceRow: FunctionComponent<UnsubstitutedInstanceRowProps>
         isCollection={isCollection}
         docMenuItems={docItems}
         mappingMenuItems={mappingItems}
-        onRemove={() => onRemoveInstance(abstractNode.id, instanceId)}
+        onRemove={() => {
+          onRemoveInstance(abstractNode.id, instanceId);
+        }}
         data-testid={`unsubstituted-${instanceId}`}
       />
       {isModalOpen && (
         <AddFieldCandidateModal
           isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
           onConfirm={handleSelectSubstitute}
           abstractNode={abstractNode}
         />

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AddFieldCandidateModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/AddFieldCandidateModal.tsx
@@ -69,7 +69,9 @@ export const AddFieldCandidateModal: FunctionComponent<AddFieldCandidateModalPro
         <Radio
           isChecked={selected === candidate.id}
           name="add-field-candidate"
-          onChange={() => setSelected(candidate.id)}
+          onChange={() => {
+            setSelected(candidate.id);
+          }}
           label={label}
           id={`add-field-radio-${candidate.id}`}
         />
@@ -93,8 +95,12 @@ export const AddFieldCandidateModal: FunctionComponent<AddFieldCandidateModalPro
             <SearchInput
               placeholder="Filter candidates..."
               value={searchFilter}
-              onChange={(_event, value) => setSearchFilter(value)}
-              onClear={() => setSearchFilter('')}
+              onChange={(_event, value) => {
+                setSearchFilter(value);
+              }}
+              onClear={() => {
+                setSearchFilter('');
+              }}
             />
           </div>
         )}

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/FieldRow.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/FieldRow.tsx
@@ -69,9 +69,13 @@ export const FieldRow: FunctionComponent<FieldRowProps> = ({
 
   useEffect(() => {
     if (!docMenuOpen) return;
-    const close = () => setDocMenuOpen(false);
+    const close = () => {
+      setDocMenuOpen(false);
+    };
     document.addEventListener('click', close);
-    return () => document.removeEventListener('click', close);
+    return () => {
+      document.removeEventListener('click', close);
+    };
   }, [docMenuOpen]);
 
   const handleContextMenu = useCallback(

--- a/packages/ui-tests/stories/ui-mockups/datamapper/abstract/InstructionNodeMock.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/abstract/InstructionNodeMock.tsx
@@ -184,24 +184,32 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
         items.push({
           key: 'wrap-for-each',
           label: 'Wrap with "for-each"',
-          onClick: () => handleWrapField('for-each', slot),
+          onClick: () => {
+            handleWrapField('for-each', slot);
+          },
         });
       }
       items.push({
         key: 'wrap-if',
         label: 'Wrap with "if"',
-        onClick: () => handleWrapField('if', slot),
+        onClick: () => {
+          handleWrapField('if', slot);
+        },
       });
       items.push({
         key: 'wrap-choose',
         label: 'Wrap with "choose-when-otherwise"',
-        onClick: () => handleWrapField('choose', slot),
+        onClick: () => {
+          handleWrapField('choose', slot);
+        },
       });
       if (isCollection) {
         items.push({
           key: 'dup-field',
           label: 'Duplicate Field',
-          onClick: () => handleDuplicateField(slot),
+          onClick: () => {
+            handleDuplicateField(slot);
+          },
         });
       }
       return items;
@@ -228,20 +236,42 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
   );
 
   const placeholderDocItems = useMemo(
-    (): DocMenuItem[] => [{ key: 'select-sub', label: 'Select Substitution', onClick: () => setModalTarget('new') }],
+    (): DocMenuItem[] => [
+      {
+        key: 'select-sub',
+        label: 'Select Substitution',
+        onClick: () => {
+          setModalTarget('new');
+        },
+      },
+    ],
     [],
   );
 
   const buildPlaceholderMappingItems = useMemo((): MappingMenuItem[] => {
     const items: MappingMenuItem[] = [];
     if (isCollection) {
-      items.push({ key: 'wrap-for-each', label: 'Wrap with "for-each"', onClick: () => handleWrapField('for-each') });
+      items.push({
+        key: 'wrap-for-each',
+        label: 'Wrap with "for-each"',
+        onClick: () => {
+          handleWrapField('for-each');
+        },
+      });
     }
-    items.push({ key: 'wrap-if', label: 'Wrap with "if"', onClick: () => handleWrapField('if') });
+    items.push({
+      key: 'wrap-if',
+      label: 'Wrap with "if"',
+      onClick: () => {
+        handleWrapField('if');
+      },
+    });
     items.push({
       key: 'wrap-choose',
       label: 'Wrap with "choose-when-otherwise"',
-      onClick: () => handleWrapField('choose'),
+      onClick: () => {
+        handleWrapField('choose');
+      },
     });
     if (isCollection) {
       items.push({
@@ -260,7 +290,12 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
     <div className="node__container" data-testid={`instruction-${instruction.id}`}>
       <section className="abstract-tree__instruction-node" style={{ '--node-rank': rank } as React.CSSProperties}>
         {hasChildren ? (
-          <Icon className="abstract-tree__field-expand" onClick={() => setIsExpanded(!isExpanded)}>
+          <Icon
+            className="abstract-tree__field-expand"
+            onClick={() => {
+              setIsExpanded(!isExpanded);
+            }}
+          >
             {isExpanded ? <ChevronDown /> : <ChevronRight />}
           </Icon>
         ) : (
@@ -273,7 +308,9 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
           <TextInput
             type="text"
             value={expression}
-            onChange={(_e, val) => setExpression(val)}
+            onChange={(_e, val) => {
+              setExpression(val);
+            }}
             placeholder={instruction.kind === 'for-each' ? 'select expression' : 'test expression'}
             className="abstract-tree__instruction-input"
           />
@@ -303,12 +340,22 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
                 </DropdownItem>
               )}
               {canAddInstruction && (
-                <DropdownItem key="add-for-each" onClick={() => handleAddChildInstruction('for-each')}>
+                <DropdownItem
+                  key="add-for-each"
+                  onClick={() => {
+                    handleAddChildInstruction('for-each');
+                  }}
+                >
                   Add for-each
                 </DropdownItem>
               )}
               {canAddInstruction && (
-                <DropdownItem key="add-choose" onClick={() => handleAddChildInstruction('choose')}>
+                <DropdownItem
+                  key="add-choose"
+                  onClick={() => {
+                    handleAddChildInstruction('choose');
+                  }}
+                >
                   Add choose-when-otherwise
                 </DropdownItem>
               )}
@@ -325,25 +372,40 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
               {instruction.kind === 'if' && onDuplicateIf && (
                 <DropdownItem
                   key="duplicate-if"
-                  onClick={() =>
-                    onDuplicateIf(childFields.filter((slot) => slot.candidate).map((slot) => slot.candidate!.id))
-                  }
+                  onClick={() => {
+                    onDuplicateIf(childFields.filter((slot) => slot.candidate).map((slot) => slot.candidate!.id));
+                  }}
                 >
                   Duplicate &quot;if&quot;
                 </DropdownItem>
               )}
               {onWrapWith && isCollection && (
-                <DropdownItem key="wrap-for-each" onClick={() => onWrapWith('for-each')}>
+                <DropdownItem
+                  key="wrap-for-each"
+                  onClick={() => {
+                    onWrapWith('for-each');
+                  }}
+                >
                   Wrap with &quot;for-each&quot;
                 </DropdownItem>
               )}
               {onWrapWith && (
-                <DropdownItem key="wrap-if" onClick={() => onWrapWith('if')}>
+                <DropdownItem
+                  key="wrap-if"
+                  onClick={() => {
+                    onWrapWith('if');
+                  }}
+                >
                   Wrap with &quot;if&quot;
                 </DropdownItem>
               )}
               {onWrapWith && (
-                <DropdownItem key="wrap-choose" onClick={() => onWrapWith('choose')}>
+                <DropdownItem
+                  key="wrap-choose"
+                  onClick={() => {
+                    onWrapWith('choose');
+                  }}
+                >
                   Wrap with &quot;choose-when-otherwise&quot;
                 </DropdownItem>
               )}
@@ -362,7 +424,9 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
               isAbstract
               docMenuItems={placeholderDocItems}
               mappingMenuItems={buildPlaceholderMappingItems}
-              onRemove={() => setPlaceholderDismissed(true)}
+              onRemove={() => {
+                setPlaceholderDismissed(true);
+              }}
             />
           )}
           {childFields.map((slot) =>
@@ -376,11 +440,15 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
                   {
                     key: 'clear-sub',
                     label: 'Clear Substitution',
-                    onClick: () => handleClearSubstitution(slot.slotId),
+                    onClick: () => {
+                      handleClearSubstitution(slot.slotId);
+                    },
                   },
                 ]}
                 mappingMenuItems={buildFieldMappingItems(slot)}
-                onRemove={() => handleRemoveField(slot.slotId)}
+                onRemove={() => {
+                  handleRemoveField(slot.slotId);
+                }}
               />
             ) : (
               <FieldRow
@@ -390,10 +458,18 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
                 typeOrCandidates={getAbstractDisplayName(abstractNode!)}
                 isAbstract
                 docMenuItems={[
-                  { key: 'select-sub', label: 'Select Substitution', onClick: () => setModalTarget(slot.slotId) },
+                  {
+                    key: 'select-sub',
+                    label: 'Select Substitution',
+                    onClick: () => {
+                      setModalTarget(slot.slotId);
+                    },
+                  },
                 ]}
                 mappingMenuItems={buildFieldMappingItems(slot)}
-                onRemove={() => handleRemoveField(slot.slotId)}
+                onRemove={() => {
+                  handleRemoveField(slot.slotId);
+                }}
               />
             ),
           )}
@@ -402,7 +478,9 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
               key={child.id}
               instruction={child}
               rank={rank + 1}
-              onRemove={() => handleRemoveChild(child.id)}
+              onRemove={() => {
+                handleRemoveChild(child.id);
+              }}
               onDuplicateIf={
                 child.kind === 'if'
                   ? (fieldIds) => {
@@ -443,7 +521,9 @@ export const InstructionNodeMock: FunctionComponent<InstructionNodeMockProps> = 
       {modalTarget !== null && abstractNode && (
         <AddFieldCandidateModal
           isOpen={modalTarget !== null}
-          onClose={() => setModalTarget(null)}
+          onClose={() => {
+            setModalTarget(null);
+          }}
           onConfirm={handleModalConfirm}
           abstractNode={abstractNode}
         />

--- a/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceSelectionDialog.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceSelectionDialog.tsx
@@ -31,7 +31,9 @@ const OptionItem: FunctionComponent<OptionItemProps> = ({ member, isSelected, on
       <Radio
         isChecked={isSelected}
         name="choice-selection"
-        onChange={() => onSelect(member.id)}
+        onChange={() => {
+          onSelect(member.id);
+        }}
         label={
           <div className="choice-option__label">
             <span className="choice-option__name">{displayName}</span>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceToChoiceError.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/choice/ChoiceToChoiceError.tsx
@@ -21,7 +21,13 @@ export const ChoiceToChoiceError: FunctionComponent<ChoiceToChoiceErrorProps> = 
         <Alert
           variant="danger"
           title="Cannot map choice to choice"
-          actionClose={<AlertActionCloseButton onClose={() => setShowError(false)} />}
+          actionClose={
+            <AlertActionCloseButton
+              onClose={() => {
+                setShowError(false);
+              }}
+            />
+          }
           style={{ marginBottom: '1rem' }}
         >
           <p>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/choice/ConditionalMappingView.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/choice/ConditionalMappingView.tsx
@@ -61,7 +61,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
 
     updatePositions();
     window.addEventListener('resize', updatePositions);
-    return () => window.removeEventListener('resize', updatePositions);
+    return () => {
+      window.removeEventListener('resize', updatePositions);
+    };
   }, [expandedNodes, mappingLines]);
 
   const toggleNode = (nodeId: string) => {
@@ -89,7 +91,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
               <BaseNode
                 isExpandable
                 isExpanded={expandedNodes.has('source-root')}
-                onExpandChange={() => toggleNode('source-root')}
+                onExpandChange={() => {
+                  toggleNode('source-root');
+                }}
                 isDraggable={false}
                 iconType={Types.Container}
                 title={
@@ -107,7 +111,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
                     <Icon
                       className="choice-node__expand"
                       style={{ cursor: 'pointer' }}
-                      onClick={() => toggleNode('source-choice')}
+                      onClick={() => {
+                        toggleNode('source-choice');
+                      }}
                     >
                       {expandedNodes.has('source-choice') ? <ChevronDown /> : <ChevronRight />}
                     </Icon>
@@ -155,7 +161,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
                           <BaseNode
                             isExpandable
                             isExpanded={expandedNodes.has('source-address')}
-                            onExpandChange={() => toggleNode('source-address')}
+                            onExpandChange={() => {
+                              toggleNode('source-address');
+                            }}
                             isDraggable={false}
                             iconType={Types.Container}
                             title={<span className="node__spacer">address</span>}
@@ -216,7 +224,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
               <BaseNode
                 isExpandable
                 isExpanded={expandedNodes.has('target-root')}
-                onExpandChange={() => toggleNode('target-root')}
+                onExpandChange={() => {
+                  toggleNode('target-root');
+                }}
                 isDraggable={false}
                 iconType={Types.Container}
                 title={
@@ -240,7 +250,9 @@ export const ConditionalMappingView: FunctionComponent<ConditionalMappingViewPro
                       <Icon
                         className="node__spacer"
                         style={{ cursor: 'pointer' }}
-                        onClick={() => toggleNode('target-choose')}
+                        onClick={() => {
+                          toggleNode('target-choose');
+                        }}
                       >
                         {expandedNodes.has('target-choose') ? <ChevronDown /> : <ChevronRight />}
                       </Icon>
@@ -363,7 +375,13 @@ const WhenNode: FunctionComponent<WhenNodeProps> = ({ id, test, rank, fields }) 
     <div className="node__container" style={{ marginLeft: `calc(${rank} * 0.85rem)` }}>
       <div className="node__header">
         <div className="node__row" style={{ display: 'flex', alignItems: 'center', height: '2rem' }} id={id}>
-          <Icon className="node__spacer" style={{ cursor: 'pointer' }} onClick={() => setIsExpanded(!isExpanded)}>
+          <Icon
+            className="node__spacer"
+            style={{ cursor: 'pointer' }}
+            onClick={() => {
+              setIsExpanded(!isExpanded);
+            }}
+          >
             {isExpanded ? <ChevronDown /> : <ChevronRight />}
           </Icon>
           <Label isCompact color="grey">
@@ -435,7 +453,13 @@ const OtherwiseNode: FunctionComponent<OtherwiseNodeProps> = ({ id, rank, fields
     <div className="node__container" style={{ marginLeft: `calc(${rank} * 0.85rem)` }}>
       <div className="node__header">
         <div className="node__row" style={{ display: 'flex', alignItems: 'center', height: '2rem' }} id={id}>
-          <Icon className="node__spacer" style={{ cursor: 'pointer' }} onClick={() => setIsExpanded(!isExpanded)}>
+          <Icon
+            className="node__spacer"
+            style={{ cursor: 'pointer' }}
+            onClick={() => {
+              setIsExpanded(!isExpanded);
+            }}
+          >
             {isExpanded ? <ChevronDown /> : <ChevronRight />}
           </Icon>
           <Label isCompact color="grey">

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsMockup.tsx
@@ -90,7 +90,9 @@ export const CommentsMockup: FunctionComponent = () => {
 
     updatePositions();
     window.addEventListener('resize', updatePositions);
-    return () => window.removeEventListener('resize', updatePositions);
+    return () => {
+      window.removeEventListener('resize', updatePositions);
+    };
   }, [expandedNodes, mappingLines]);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -119,7 +121,9 @@ export const CommentsMockup: FunctionComponent = () => {
               <BaseNode
                 isExpandable
                 isExpanded={expandedNodes.has('source-root')}
-                onExpandChange={() => toggleNode('source-root')}
+                onExpandChange={() => {
+                  toggleNode('source-root');
+                }}
                 isDraggable={false}
                 iconType={Types.Container}
                 title={
@@ -174,7 +178,9 @@ export const CommentsMockup: FunctionComponent = () => {
               <BaseNode
                 isExpandable
                 isExpanded={expandedNodes.has('target-root')}
-                onExpandChange={() => toggleNode('target-root')}
+                onExpandChange={() => {
+                  toggleNode('target-root');
+                }}
                 isDraggable={false}
                 iconType={Types.Container}
                 title={
@@ -220,7 +226,13 @@ export const CommentsMockup: FunctionComponent = () => {
                         {comment && (
                           <ActionListItem>
                             <Tooltip content={'Comment : ' + (comment ? comment : 'No comment')}>
-                              <Button variant="plain" icon={<DocumentComment />} onClick={() => setIsModalOpen(true)} />
+                              <Button
+                                variant="plain"
+                                icon={<DocumentComment />}
+                                onClick={() => {
+                                  setIsModalOpen(true);
+                                }}
+                              />
                             </Tooltip>
                           </ActionListItem>
                         )}
@@ -239,7 +251,9 @@ export const CommentsMockup: FunctionComponent = () => {
                               />
                             )}
                             isOpen={isMenuOpen}
-                            onOpenChange={(isOpen: boolean) => setIsMenuOpen(isOpen)}
+                            onOpenChange={(isOpen: boolean) => {
+                              setIsMenuOpen(isOpen);
+                            }}
                           >
                             <DropdownList>
                               <DropdownItem>Add selector expression</DropdownItem>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.stories.tsx
@@ -20,7 +20,13 @@ const Template: StoryFn<typeof CommentsModal> = (args) => {
         Issue: <a href="https://github.com/KaotoIO/kaoto/issues/2439">https://github.com/KaotoIO/kaoto/issues/2439</a>
       </p>
       <br />
-      <Button variant="primary" onClick={() => setIsOpen(true)} style={{ marginBottom: '1rem' }}>
+      <Button
+        variant="primary"
+        onClick={() => {
+          setIsOpen(true);
+        }}
+        style={{ marginBottom: '1rem' }}
+      >
         Open Modal
       </Button>
       <CommentsModal

--- a/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/comments/CommentsModal.tsx
@@ -59,7 +59,9 @@ export const CommentsModal: FunctionComponent<CommentsModalProps> = ({
           name="comment-area"
           aria-label="Comment input area"
           value={comment}
-          onChange={(_event, value) => setComment(value)}
+          onChange={(_event, value) => {
+            setComment(value);
+          }}
           placeholder="Enter your comment..."
           data-testid="comment-area"
         />

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-override/TypeOverride.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-override/TypeOverride.stories.tsx
@@ -144,7 +144,9 @@ export const InteractiveWorkflow: StoryFn = () => {
             cursor: 'pointer',
             borderRadius: '4px',
           }}
-          onContextMenu={(e) => handleContextMenu(e, mockFields.anyTypeField)}
+          onContextMenu={(e) => {
+            handleContextMenu(e, mockFields.anyTypeField);
+          }}
         >
           <span style={{ marginRight: '8px' }}>
             <Draggable />
@@ -171,7 +173,9 @@ export const InteractiveWorkflow: StoryFn = () => {
             cursor: 'pointer',
             borderRadius: '4px',
           }}
-          onContextMenu={(e) => handleContextMenu(e, mockFields.baseTypeField)}
+          onContextMenu={(e) => {
+            handleContextMenu(e, mockFields.baseTypeField);
+          }}
         >
           <span style={{ marginRight: '8px' }}>
             <Draggable />
@@ -198,7 +202,9 @@ export const InteractiveWorkflow: StoryFn = () => {
             cursor: 'pointer',
             borderRadius: '4px',
           }}
-          onContextMenu={(e) => handleContextMenu(e, mockFields.regularField)}
+          onContextMenu={(e) => {
+            handleContextMenu(e, mockFields.regularField);
+          }}
         >
           <span style={{ marginRight: '8px' }}>
             <Draggable />
@@ -228,7 +234,9 @@ export const InteractiveWorkflow: StoryFn = () => {
             bottom: 0,
             zIndex: 999,
           }}
-          onClick={() => setShowMenu(false)}
+          onClick={() => {
+            setShowMenu(false);
+          }}
         >
           <div
             style={{
@@ -236,7 +244,9 @@ export const InteractiveWorkflow: StoryFn = () => {
               left: menuPosition.x,
               top: menuPosition.y,
             }}
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
           >
             <FieldContextMenu
               fieldName={selectedField.name}
@@ -246,7 +256,9 @@ export const InteractiveWorkflow: StoryFn = () => {
               onOverrideType={handleOverrideType}
               onForceOverrideType={handleForceOverrideType}
               onResetOverride={handleReset}
-              onClose={() => setShowMenu(false)}
+              onClose={() => {
+                setShowMenu(false);
+              }}
             />
           </div>
         </div>
@@ -262,7 +274,9 @@ export const InteractiveWorkflow: StoryFn = () => {
           xmlSchemaTypes={availableTypes.xmlSchemaTypes}
           customTypes={availableTypes.customTypes}
           onConfirm={handleConfirm}
-          onCancel={() => setShowModal(false)}
+          onCancel={() => {
+            setShowModal(false);
+          }}
           onAttachSchema={handleAttachSchema}
         />
       )}

--- a/packages/ui-tests/stories/ui-mockups/datamapper/field-override/TypeOverrideModal.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/field-override/TypeOverrideModal.tsx
@@ -136,7 +136,9 @@ export const TypeOverrideModal: FunctionComponent<ITypeOverrideModalProps> = ({
               <Radio
                 isChecked={typeSource === 'standard'}
                 name="type-source"
-                onChange={() => setTypeSource('standard')}
+                onChange={() => {
+                  setTypeSource('standard');
+                }}
                 label="XML Schema standard types"
                 id="standard-types"
                 body={
@@ -159,7 +161,9 @@ export const TypeOverrideModal: FunctionComponent<ITypeOverrideModalProps> = ({
               <Radio
                 isChecked={typeSource === 'schema'}
                 name="type-source"
-                onChange={() => setTypeSource('schema')}
+                onChange={() => {
+                  setTypeSource('schema');
+                }}
                 label="Types from attached schemas"
                 id="schema-types"
                 body={

--- a/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
@@ -184,7 +184,9 @@ const MockGroupingModal: FunctionComponent<MockGroupingModalProps> = ({ isOpen, 
                   label={STRATEGY_LABELS[s]}
                   value={s}
                   isChecked={selectedStrategy === s}
-                  onChange={() => setSelectedStrategy(s)}
+                  onChange={() => {
+                    setSelectedStrategy(s);
+                  }}
                 />
               ))}
             </div>
@@ -244,14 +246,18 @@ const MockCollectionFieldMenu: FunctionComponent<MockCollectionFieldMenuProps> =
     <ActionListItem>
       <Dropdown
         isOpen={isOpen}
-        onOpenChange={(open) => setIsOpen(open)}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+        }}
         onSelect={handleSelect}
         toggle={(toggleRef: Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
             icon={<EllipsisVIcon />}
             variant="plain"
-            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            onClick={(_e: MouseEvent) => {
+              setIsOpen(!isOpen);
+            }}
             isExpanded={isOpen}
             aria-label="Transformation Action list"
             style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
@@ -295,14 +301,20 @@ const MockInnerCollectionFieldMenu: FunctionComponent<MockInnerCollectionFieldMe
     <ActionListItem>
       <Dropdown
         isOpen={isOpen}
-        onOpenChange={(open) => setIsOpen(open)}
-        onSelect={() => setIsOpen(false)}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+        }}
+        onSelect={() => {
+          setIsOpen(false);
+        }}
         toggle={(toggleRef: Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
             icon={<EllipsisVIcon />}
             variant="plain"
-            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            onClick={(_e: MouseEvent) => {
+              setIsOpen(!isOpen);
+            }}
             isExpanded={isOpen}
             aria-label="Transformation Action list"
             style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
@@ -352,14 +364,18 @@ const MockForEachGroupMenu: FunctionComponent<MockForEachGroupMenuProps> = ({ in
     <ActionListItem>
       <Dropdown
         isOpen={isOpen}
-        onOpenChange={(open) => setIsOpen(open)}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+        }}
         onSelect={handleSelect}
         toggle={(toggleRef: Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
             icon={<EllipsisVIcon />}
             variant="plain"
-            onClick={(_e: MouseEvent) => setIsOpen(!isOpen)}
+            onClick={(_e: MouseEvent) => {
+              setIsOpen(!isOpen);
+            }}
             isExpanded={isOpen}
             aria-label="for-each-group actions"
             style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
@@ -409,8 +425,12 @@ export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
   const [forEachGroupExpanded, setForEachGroupExpanded] = useState(true);
   const [innerForEachExpanded, setInnerForEachExpanded] = useState(true);
   const [itemExpanded, setItemExpanded] = useState(true);
-  const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
   const tooltipContent = (
     <div>
@@ -474,7 +494,9 @@ export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
           isExpandable
           isExpanded={shipOrderExpanded}
           isCollection
-          onToggle={() => setShipOrderExpanded(!shipOrderExpanded)}
+          onToggle={() => {
+            setShipOrderExpanded(!shipOrderExpanded);
+          }}
         />
 
         {shipOrderExpanded && (
@@ -495,7 +517,9 @@ export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
                   title={forEachGroupLabel}
                   isExpandable
                   isExpanded={forEachGroupExpanded}
-                  onToggle={() => setForEachGroupExpanded(!forEachGroupExpanded)}
+                  onToggle={() => {
+                    setForEachGroupExpanded(!forEachGroupExpanded);
+                  }}
                   actions={
                     <>
                       <MockExpressionInput value={selectExpression} placeholder="Add Select XPath Expression" />
@@ -514,7 +538,9 @@ export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
                           title={forEachLabel}
                           isExpandable
                           isExpanded={innerForEachExpanded}
-                          onToggle={() => setInnerForEachExpanded(!innerForEachExpanded)}
+                          onToggle={() => {
+                            setInnerForEachExpanded(!innerForEachExpanded);
+                          }}
                           actions={
                             <>
                               <MockExpressionInput value="current-group()" />
@@ -530,7 +556,9 @@ export const ForEachGroupMockup: FunctionComponent<ForEachGroupMockupProps> = ({
                               isExpandable
                               isExpanded={itemExpanded}
                               isCollection
-                              onToggle={() => setItemExpanded(!itemExpanded)}
+                              onToggle={() => {
+                                setItemExpanded(!itemExpanded);
+                              }}
                             />
                             {itemExpanded && (
                               <>

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableInputPlaceholder.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableInputPlaceholder.tsx
@@ -25,6 +25,7 @@ export const VariableInputPlaceholder: FunctionComponent<VariableInputPlaceholde
     if (initialName !== '') {
       inputRef.current?.select();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const validation: 'default' | 'success' | 'error' = useMemo(() => {
@@ -49,7 +50,9 @@ export const VariableInputPlaceholder: FunctionComponent<VariableInputPlaceholde
                 ref={inputRef}
                 className={`variable-input-placeholder__input variable-input-placeholder__input--${validation}`}
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value);
+                }}
                 placeholder="variable name"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && validation === 'success') onConfirm(name);
@@ -64,7 +67,9 @@ export const VariableInputPlaceholder: FunctionComponent<VariableInputPlaceholde
                 icon={<CheckIcon />}
                 variant="link"
                 isDisabled={validation !== 'success'}
-                onClick={() => onConfirm(name)}
+                onClick={() => {
+                  onConfirm(name);
+                }}
                 aria-label="Confirm variable name"
                 data-testid="variable-name-confirm-btn"
               />

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
@@ -99,7 +99,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
 
     updatePositions();
     window.addEventListener('resize', updatePositions);
-    return () => window.removeEventListener('resize', updatePositions);
+    return () => {
+      window.removeEventListener('resize', updatePositions);
+    };
   }, [
     variables,
     isAddingTargetVar,
@@ -240,7 +242,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
               <BaseNode
                 isExpandable
                 isExpanded={isTargetExpanded}
-                onExpandChange={() => setIsTargetExpanded((p) => !p)}
+                onExpandChange={() => {
+                  setIsTargetExpanded((p) => !p);
+                }}
                 isDraggable={false}
                 iconType={Types.Container}
                 title={<span className="node__spacer">Invoice</span>}
@@ -256,7 +260,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                     <BaseNode
                       isExpandable
                       isExpanded={isSubtotalExpanded}
-                      onExpandChange={() => setIsSubtotalExpanded((p) => !p)}
+                      onExpandChange={() => {
+                        setIsSubtotalExpanded((p) => !p);
+                      }}
                       isDraggable={false}
                       iconType={Types.Decimal}
                       title={<span className="node__spacer">Subtotals</span>}
@@ -280,7 +286,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                             <div className="variable-node__actions">
                               <Dropdown
                                 isOpen={isForEachMenuOpen}
-                                onOpenChange={(isOpen) => setIsForEachMenuOpen(isOpen)}
+                                onOpenChange={(isOpen) => {
+                                  setIsForEachMenuOpen(isOpen);
+                                }}
                                 toggle={(toggleRef: Ref<HTMLButtonElement>) => (
                                   <MenuToggle
                                     icon={<EllipsisVIcon />}
@@ -320,8 +328,12 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                                 <div className="node__header">
                                   <VariableInputPlaceholder
                                     initialName={variable.name}
-                                    onConfirm={(name) => handleRenameVar(variable.id, name)}
-                                    onCancel={() => setRenamingVarInTargetId(null)}
+                                    onConfirm={(name) => {
+                                      handleRenameVar(variable.id, name);
+                                    }}
+                                    onCancel={() => {
+                                      setRenamingVarInTargetId(null);
+                                    }}
                                   />
                                 </div>
                               </div>
@@ -345,7 +357,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                                       </Tooltip>
                                       <Dropdown
                                         isOpen={targetVarMenuOpenId === variable.id}
-                                        onOpenChange={(isOpen) => setTargetVarMenuOpenId(isOpen ? variable.id : null)}
+                                        onOpenChange={(isOpen) => {
+                                          setTargetVarMenuOpenId(isOpen ? variable.id : null);
+                                        }}
                                         toggle={(toggleRef: Ref<HTMLButtonElement>) => (
                                           <MenuToggle
                                             icon={<EllipsisVIcon />}
@@ -395,7 +409,9 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                               <div className="node__header">
                                 <VariableInputPlaceholder
                                   onConfirm={handleAddVar}
-                                  onCancel={() => setIsAddingTargetVar(false)}
+                                  onCancel={() => {
+                                    setIsAddingTargetVar(false);
+                                  }}
                                 />
                               </div>
                             </div>

--- a/packages/ui/src/components/Catalog/CatalogFilter.tsx
+++ b/packages/ui/src/components/Catalog/CatalogFilter.tsx
@@ -102,7 +102,9 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
                 data-testid={`${tileGroup.name}-catalog-tab`}
                 buttonId={`toggle-group-button-${tileGroup.name}`}
                 isSelected={props.activeGroups.includes(tileGroup.name)}
-                onChange={(_event, selected: boolean) => toggleActiveGroup(selected, tileGroup.name)}
+                onChange={(_event, selected: boolean) => {
+                  toggleActiveGroup(selected, tileGroup.name);
+                }}
               />
             ))}
           </ToggleGroup>
@@ -154,7 +156,9 @@ export const CatalogFilter: FunctionComponent<CatalogFilterProps> = (props) => {
             id={tag + index}
             data-testid={`button-catalog-tag-${tag}`}
             color={props.filterTags.includes(tag) ? 'blue' : 'grey'}
-            onClick={() => onToggleTag(tag)}
+            onClick={() => {
+              onToggleTag(tag);
+            }}
             variant={props.filterTags.includes(tag) ? 'filled' : 'outline'}
           >
             {props.filterTags.includes(tag) ? <b>{tag}</b> : <>{tag}</>}

--- a/packages/ui/src/components/Catalog/Tags/CatalogTagsPanel.tsx
+++ b/packages/ui/src/components/Catalog/Tags/CatalogTagsPanel.tsx
@@ -22,7 +22,9 @@ export const CatalogTagsPanel: FunctionComponent<ICatalogTagsPanelProps> = (prop
               type="button"
               className={className}
               data-testid={'tag-' + tag}
-              onMouseDown={(ev) => ev.preventDefault()}
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+              }}
               onClick={(ev) => {
                 ev.stopPropagation(); // ignore root click, e.g. click on tile
                 props.onTagClick(ev, tag);

--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -69,7 +69,9 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       const mappingFile = await DataMapperMetadataService.loadMappingFile(ctx, meta);
       setInitialXsltFile(mappingFile);
     };
-    void initialize().then(() => setIsLoading(false));
+    void initialize().then(() => {
+      setIsLoading(false);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
+++ b/packages/ui/src/components/DataMapper/XsltDocumentRenameInput.tsx
@@ -170,7 +170,11 @@ export const XsltDocumentRenameInput: FunctionComponent<IXsltDocumentRenameInput
   return (
     <>
       {isEditing ? (
-        <Form onSubmit={(e) => e.preventDefault()}>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
           <FormGroup fieldId="xslt-document-rename-value" data-testid={props['data-testid'] + '--form'}>
             <InputGroup>
               <InputGroupItem isFill>

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -168,7 +168,9 @@ describe('DebugLayout', () => {
       act(() => {
         fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
       });
-      await waitFor(() => expect(spyOnMappingTree!.children).toHaveLength(1));
+      await waitFor(() => {
+        expect(spyOnMappingTree!.children).toHaveLength(1);
+      });
 
       mainMenuButton = screen.getByTestId('dm-debug-main-menu-button');
       act(() => {

--- a/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
@@ -33,7 +33,12 @@ export const MainMenuToolbarItem: FunctionComponent = () => {
           <ResetMappingsDropdownItem onComplete={toggleOff} key={'reset-mappings'} />
         </DropdownList>
       </Dropdown>
-      <ExportMappingFileModal isOpen={isExportFileModalOpen} onClose={() => setIsExportFileModalOpen(false)} />
+      <ExportMappingFileModal
+        isOpen={isExportFileModalOpen}
+        onClose={() => {
+          setIsExportFileModalOpen(false);
+        }}
+      />
     </ToolbarItem>
   );
 };

--- a/packages/ui/src/components/DataMapper/debug/ToggleDebugToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ToggleDebugToolbarItem.tsx
@@ -16,7 +16,9 @@ export const ToggleDebugToolbarItem: FunctionComponent = () => {
           buttonId="enable-debug-mode"
           data-testid="enable-debug-mode-btn"
           isSelected={debug}
-          onChange={() => setDebug(!debug)}
+          onChange={() => {
+            setDebug(!debug);
+          }}
         ></ToggleGroupItem>
       </ToggleGroup>
     </ToolbarItem>

--- a/packages/ui/src/components/Document/NameInput.tsx
+++ b/packages/ui/src/components/Document/NameInput.tsx
@@ -51,7 +51,9 @@ export const NameInput = forwardRef<HTMLInputElement, NameInputProps>(
           type="text"
           className={`name-input__field name-input__field--${cssClass}`}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
           onKeyDown={onKeyDown}
           placeholder={placeholder}
         />

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -186,7 +186,9 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
       <RenameParameterButton
         key="rename"
         parameterName={parameterName}
-        onRenameClick={() => onStartRename(parameterName)}
+        onRenameClick={() => {
+          onStartRename(parameterName);
+        }}
       />,
       <DeleteParameterButton key="delete" parameterName={parameterName} parameterReferenceId={documentReferenceId} />,
     ],
@@ -284,7 +286,9 @@ export const ParametersSection: FunctionComponent<ParametersSectionProps> = ({
     // Trigger layout change to update mapping lines when parameters are hidden/shown
     if (onLayoutChange) {
       // Use setTimeout to ensure state has updated before triggering layout change
-      setTimeout(() => onLayoutChange(), 0);
+      setTimeout(() => {
+        onLayoutChange();
+      }, 0);
     }
   }, [onLayoutChange]);
 

--- a/packages/ui/src/components/Document/SourceDocumentNode.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.tsx
@@ -60,7 +60,11 @@ export const SourceDocumentNode: FunctionComponent<TreeSourceNodeProps> = memo(
     const field = VisualizationUtilService.getField(nodeData);
 
     const handleKeyDown = useCallback(
-      (event: KeyboardEvent) => handleNodeKeyDown(event, () => toggleSelectedNode(nodePathString, true)),
+      (event: KeyboardEvent) => {
+        handleNodeKeyDown(event, () => {
+          toggleSelectedNode(nodePathString, true);
+        });
+      },
       [nodePathString, toggleSelectedNode],
     );
 

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -122,7 +122,11 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
     }, [nodeData, handleUpdate]);
 
     const handleKeyDown = useCallback(
-      (event: KeyboardEvent) => handleNodeKeyDown(event, () => toggleSelectedNode(nodePathString, false)),
+      (event: KeyboardEvent) => {
+        handleNodeKeyDown(event, () => {
+          toggleSelectedNode(nodePathString, false);
+        });
+      },
       [nodePathString, toggleSelectedNode],
     );
 

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -299,7 +299,9 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
                   data-testid="attach-schema-modal-option-xml"
                   isChecked={selectedSchemaType === DocumentDefinitionType.XML_SCHEMA}
                   isDisabled={filePaths.length > 0}
-                  onChange={() => setSelectedSchemaType(DocumentDefinitionType.XML_SCHEMA)}
+                  onChange={() => {
+                    setSelectedSchemaType(DocumentDefinitionType.XML_SCHEMA);
+                  }}
                 />
               </InputGroupItem>
               {showJsonSchemaOption && (
@@ -312,7 +314,9 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
                     data-testid="attach-schema-modal-option-json"
                     isChecked={selectedSchemaType === DocumentDefinitionType.JSON_SCHEMA}
                     isDisabled={filePaths.length > 0}
-                    onChange={() => setSelectedSchemaType(DocumentDefinitionType.JSON_SCHEMA)}
+                    onChange={() => {
+                      setSelectedSchemaType(DocumentDefinitionType.JSON_SCHEMA);
+                    }}
                   />
                 </InputGroupItem>
               )}

--- a/packages/ui/src/components/Document/actions/AttachSchema/SchemaFileDataList.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/SchemaFileDataList.tsx
@@ -105,7 +105,9 @@ export const SchemaFileDataList: FunctionComponent<SchemaFileDataListProps> = ({
             buttonId={`toggle-filter-${status}`}
             data-testid={`attach-schema-filter-${status}`}
             isSelected={activeFilters.has(status)}
-            onChange={() => toggleFilter(status)}
+            onChange={() => {
+              toggleFilter(status);
+            }}
           />
         ))}
       </ToggleGroup>
@@ -161,7 +163,9 @@ export const SchemaFileDataList: FunctionComponent<SchemaFileDataListProps> = ({
                       variant="plain"
                       aria-label={`Remove ${displayName}`}
                       data-testid={`attach-schema-file-remove-${displayName}`}
-                      onClick={() => onRemoveFile(item.filePath!)}
+                      onClick={() => {
+                        onRemoveFile(item.filePath!);
+                      }}
                       icon={<TrashIcon />}
                     />
                   </DataListAction>

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
@@ -21,7 +21,9 @@ function buildInlineSubstitutionActions(
 ): MenuAction[] {
   return Object.entries(candidates).map(([qname, info]) => ({
     label: info.displayName,
-    onClick: () => onSelect(qname),
+    onClick: () => {
+      onSelect(qname);
+    },
     icon: selectedQName === qname ? <CheckIcon /> : <Choices />,
     testId: `substitution-menu-item-${qname}`,
   }));

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
@@ -28,7 +28,9 @@ function buildInlineMemberActions(
 ): MenuAction[] {
   return members.map((member, index) => ({
     label: getFieldDisplayName(member),
-    onClick: () => onSelect(index),
+    onClick: () => {
+      onSelect(index);
+    },
     icon: selectedIndex === index ? <CheckIcon /> : <Choices />,
     testId: `choice-menu-item-${index}`,
   }));

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
@@ -29,7 +29,9 @@ export function useFieldOverrideMenu(nodeData: NodeData): MenuContributor {
     setIsModalOpen(true);
   }, []);
 
-  const closeModal = useCallback(() => setIsModalOpen(false), []);
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
 
   const handleResetOverride = useCallback(() => {
     const revertTarget = abstractWrapperField ?? field;

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -830,7 +830,12 @@ describe('FieldOverrideModal', () => {
     it('should show spinner and disable button while uploading schema', async () => {
       vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['types.xsd']);
       (mockApi.getResourceContent as Mock).mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve('<xs:schema/>'), 100)),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => {
+              resolve('<xs:schema/>');
+            }, 100),
+          ),
       );
 
       renderWithContext();
@@ -860,7 +865,12 @@ describe('FieldOverrideModal', () => {
 
     it('should not show spinner while file picker dialog is open', async () => {
       vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve(['types.xsd']), 200)),
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => {
+              resolve(['types.xsd']);
+            }, 200),
+          ),
       );
 
       renderWithContext();

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
@@ -252,7 +252,9 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
                   label="Override Type"
                   isChecked={overrideMode === 'type'}
                   isDisabled={hasExistingOverride && overrideMode !== 'type'}
-                  onChange={() => handleModeChange('type')}
+                  onChange={() => {
+                    handleModeChange('type');
+                  }}
                 />
               </SplitItem>
               <SplitItem>
@@ -262,7 +264,9 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
                   label="Substitute Element"
                   isChecked={overrideMode === 'substitution'}
                   isDisabled={hasExistingOverride && overrideMode !== 'substitution'}
-                  onChange={() => handleModeChange('substitution')}
+                  onChange={() => {
+                    handleModeChange('substitution');
+                  }}
                 />
               </SplitItem>
             </Split>
@@ -274,7 +278,9 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
               isOpen={isSelectOpen}
               selected={selectedKey}
               onSelect={handleTypeSelect}
-              onOpenChange={(isOpen) => setIsSelectOpen(isOpen)}
+              onOpenChange={(isOpen) => {
+                setIsSelectOpen(isOpen);
+              }}
               toggle={renderToggle}
               maxMenuHeight="240px"
               popperProps={{

--- a/packages/ui/src/components/Document/actions/FieldOverride/SchemaFileList.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/SchemaFileList.tsx
@@ -76,7 +76,9 @@ export const SchemaFileList: FunctionComponent<SchemaFileListProps> = memo(
                     variant="plain"
                     aria-label={`Remove ${displayName}`}
                     data-testid={`remove-schema-item-${displayName}`}
-                    onClick={() => onRemove(filePath)}
+                    onClick={() => {
+                      onRemove(filePath);
+                    }}
                     icon={<TrashIcon />}
                   />
                 </DataListAction>

--- a/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
@@ -24,8 +24,22 @@ vi.mock('@patternfly/react-drag-drop', () => ({
     onDrop?: (event: unknown, newItems: DraggableObject[]) => void;
   }) => (
     <div data-testid="drag-drop-sort">
-      {onDrag && <button data-testid="mock-drag-trigger" onClick={() => onDrag()} />}
-      {onDrop && <button data-testid="mock-drop-trigger" onClick={() => onDrop(undefined, [...items].reverse())} />}
+      {onDrag && (
+        <button
+          data-testid="mock-drag-trigger"
+          onClick={() => {
+            onDrag();
+          }}
+        />
+      )}
+      {onDrop && (
+        <button
+          data-testid="mock-drop-trigger"
+          onClick={() => {
+            onDrop(undefined, [...items].reverse());
+          }}
+        />
+      )}
       {items.map((item) => (
         <div key={item.id}>{item.content}</div>
       ))}

--- a/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.tsx
@@ -96,7 +96,9 @@ export const ForEachGroupModal: FunctionComponent<ForEachGroupModalProps> = ({
     (toggleRef: Ref<MenuToggleElement>) => (
       <MenuToggle
         ref={toggleRef}
-        onClick={() => setIsStrategyOpen((prev) => !prev)}
+        onClick={() => {
+          setIsStrategyOpen((prev) => !prev);
+        }}
         isExpanded={isStrategyOpen}
         data-testid="for-each-group-strategy-toggle"
       >

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -65,9 +65,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(selectorItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
   });
@@ -89,9 +89,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(ifItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
   });
@@ -113,9 +113,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(chooseItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
   });
@@ -133,9 +133,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(whenItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
 
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
@@ -154,9 +154,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(otherwiseItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
 
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
@@ -179,9 +179,9 @@ describe('MappingContextMenuAction', () => {
     act(() => {
       fireEvent.click(foreachItem.getElementsByTagName('button')[0]);
     });
-    await waitFor(() =>
-      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false'),
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
+    });
     expect(onUpdateMock.mock.calls).toHaveLength(1);
     expect(spyOnApply.mock.calls).toHaveLength(1);
   });
@@ -203,7 +203,9 @@ describe('MappingContextMenuAction', () => {
       fireEvent(actionToggle, clickEvent);
     });
 
-    await waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
   });
 
   it('should stop event propagation upon selecting a menu option', async () => {
@@ -227,7 +229,9 @@ describe('MappingContextMenuAction', () => {
       fireEvent(selectorButton, clickEvent);
     });
 
-    await waitFor(() => expect(stopPropagationSpy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
   });
 
   it('should render Add Conditional Mapping dropdown for the add mapping placeholder', async () => {
@@ -249,7 +253,9 @@ describe('MappingContextMenuAction', () => {
       fireEvent.click(forEachButton[0]);
     });
 
-    await waitFor(() => expect(onUpdateSpy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(onUpdateSpy).toHaveBeenCalled();
+    });
   });
 
   it('should apply If from the Add Conditional Mapping dropdown for the add mapping placeholder', async () => {
@@ -271,7 +277,9 @@ describe('MappingContextMenuAction', () => {
       fireEvent.click(ifButton[0]);
     });
 
-    await waitFor(() => expect(onUpdateSpy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(onUpdateSpy).toHaveBeenCalled();
+    });
     expect(spyOnApply).toHaveBeenCalledWith(nodeData);
   });
 
@@ -294,7 +302,9 @@ describe('MappingContextMenuAction', () => {
       fireEvent.click(chooseButton[0]);
     });
 
-    await waitFor(() => expect(onUpdateSpy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(onUpdateSpy).toHaveBeenCalled();
+    });
     expect(spyOnApply).toHaveBeenCalledWith(nodeData);
   });
 

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
@@ -88,7 +88,9 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
           onSelect={onSelectAction}
           toggle={renderToggle}
           isOpen={isActionMenuOpen}
-          onOpenChange={(isOpen: boolean) => setIsActionMenuOpen(isOpen)}
+          onOpenChange={(isOpen: boolean) => {
+            setIsActionMenuOpen(isOpen);
+          }}
           popperProps={DEFAULT_POPPER_PROPS}
           zIndex={100}
         >

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortKey.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortKey.tsx
@@ -101,7 +101,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
     (toggleRef: Ref<MenuToggleElement>) => (
       <MenuToggle
         ref={toggleRef}
-        onClick={() => setIsCaseOrderOpen((prev) => !prev)}
+        onClick={() => {
+          setIsCaseOrderOpen((prev) => !prev);
+        }}
         isExpanded={isCaseOrderOpen}
         isFullWidth
         data-testid={`sort-case-order-toggle-${index}`}
@@ -116,7 +118,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
     (toggleRef: Ref<MenuToggleElement>) => (
       <MenuToggle
         ref={toggleRef}
-        onClick={() => setIsStableOpen((prev) => !prev)}
+        onClick={() => {
+          setIsStableOpen((prev) => !prev);
+        }}
         isExpanded={isStableOpen}
         isFullWidth
         data-testid={`sort-stable-toggle-${index}`}
@@ -165,7 +169,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
           aria-label={`Advanced properties for sort key ${position}`}
           data-testid={`sort-advanced-${index}`}
           title="Advanced properties"
-          onClick={() => setIsAdvancedOpen((prev) => !prev)}
+          onClick={() => {
+            setIsAdvancedOpen((prev) => !prev);
+          }}
           className={
             clsx(
               isAdvancedOpen && 'sort-modal__settings-active',
@@ -178,7 +184,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
           variant="plain"
           aria-label={`Remove sort key ${position}`}
           data-testid={`sort-remove-${index}`}
-          onClick={() => onRemove(index)}
+          onClick={() => {
+            onRemove(index);
+          }}
           icon={<TrashIcon />}
         />
         {isXpathEditorOpen && xpathProxyRef.current && (
@@ -209,7 +217,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
           >
             <TypeaheadInput
               value={sortItem.lang}
-              onChange={(value) => handleAdvancedChange('lang', value)}
+              onChange={(value) => {
+                handleAdvancedChange('lang', value);
+              }}
               options={LANG_INPUT_OPTIONS}
               id={`sort-lang-${index}`}
               data-testid={`sort-lang-${index}`}
@@ -234,7 +244,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
           >
             <TypeaheadInput
               value={sortItem.dataType}
-              onChange={(value) => handleAdvancedChange('dataType', value)}
+              onChange={(value) => {
+                handleAdvancedChange('dataType', value);
+              }}
               options={DATA_TYPE_OPTIONS}
               id={`sort-data-type-${index}`}
               data-testid={`sort-data-type-${index}`}
@@ -323,7 +335,9 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
               id={`sort-collation-${index}`}
               data-testid={`sort-collation-${index}`}
               value={sortItem.collation}
-              onChange={(_event, value) => handleAdvancedChange('collation', value)}
+              onChange={(_event, value) => {
+                handleAdvancedChange('collation', value);
+              }}
               placeholder="Collation URI"
               aria-label={`Collation for sort key ${position}`}
             />

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
@@ -18,8 +18,22 @@ vi.mock('@patternfly/react-drag-drop', () => ({
     onDrop?: (event: unknown, newItems: DraggableObject[]) => void;
   }) => (
     <div data-testid="drag-drop-sort">
-      {onDrag && <button data-testid="mock-drag-trigger" onClick={() => onDrag()} />}
-      {onDrop && <button data-testid="mock-drop-trigger" onClick={() => onDrop(undefined, [...items].reverse())} />}
+      {onDrag && (
+        <button
+          data-testid="mock-drag-trigger"
+          onClick={() => {
+            onDrag();
+          }}
+        />
+      )}
+      {onDrop && (
+        <button
+          data-testid="mock-drop-trigger"
+          onClick={() => {
+            onDrop(undefined, [...items].reverse());
+          }}
+        />
+      )}
       {items.map((item) => (
         <div key={item.id}>{item.content}</div>
       ))}

--- a/packages/ui/src/components/Document/actions/MappingMenu/useMappingActionModals.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/useMappingActionModals.tsx
@@ -10,7 +10,9 @@ import { SortModal } from './Sort/SortModal';
 export function useMappingActionModals(mapping: MappingItem | undefined, onUpdate: () => void): ModalAction[] {
   /** Sort */
   const [isSortOpen, setIsSortOpen] = useState(false);
-  const closeSort = useCallback(() => setIsSortOpen(false), []);
+  const closeSort = useCallback(() => {
+    setIsSortOpen(false);
+  }, []);
 
   const sortableMapping = useMemo(() => (mapping instanceof ForEachItem ? mapping : undefined), [mapping]);
 
@@ -21,7 +23,9 @@ export function useMappingActionModals(mapping: MappingItem | undefined, onUpdat
 
   /** Comment */
   const [isCommentOpen, setIsCommentOpen] = useState(false);
-  const closeComment = useCallback(() => setIsCommentOpen(false), []);
+  const closeComment = useCallback(() => {
+    setIsCommentOpen(false);
+  }, []);
 
   const renderComment = useCallback(() => {
     if (!mapping || !isCommentOpen) return null;
@@ -32,7 +36,9 @@ export function useMappingActionModals(mapping: MappingItem | undefined, onUpdat
   const forEachGroupMapping = useMemo(() => (mapping instanceof ForEachGroupItem ? mapping : undefined), [mapping]);
 
   const [isForEachGroupConfigOpen, setIsForEachGroupConfigOpen] = useState(false);
-  const closeForEachGroupConfig = useCallback(() => setIsForEachGroupConfigOpen(false), []);
+  const closeForEachGroupConfig = useCallback(() => {
+    setIsForEachGroupConfigOpen(false);
+  }, []);
 
   const renderForEachGroupConfig = useCallback(() => {
     if (!forEachGroupMapping || !isForEachGroupConfigOpen) return null;
@@ -43,11 +49,25 @@ export function useMappingActionModals(mapping: MappingItem | undefined, onUpdat
 
   return useMemo(
     () => [
-      { kind: MappingActionKind.Sort, open: () => setIsSortOpen(true), render: renderSort },
-      { kind: MappingActionKind.Comment, open: () => setIsCommentOpen(true), render: renderComment },
+      {
+        kind: MappingActionKind.Sort,
+        open: () => {
+          setIsSortOpen(true);
+        },
+        render: renderSort,
+      },
+      {
+        kind: MappingActionKind.Comment,
+        open: () => {
+          setIsCommentOpen(true);
+        },
+        render: renderComment,
+      },
       {
         kind: MappingActionKind.ForEachGroupConfig,
-        open: () => setIsForEachGroupConfigOpen(true),
+        open: () => {
+          setIsForEachGroupConfigOpen(true);
+        },
         render: renderForEachGroupConfig,
       },
     ],

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.tsx
@@ -13,7 +13,9 @@ type XPathEditorProps = {
 };
 export const XPathEditorAction: FunctionComponent<XPathEditorProps> = ({ nodeData, mapping, onUpdate }) => {
   const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
-  const launchXPathEditor = useCallback(() => setIsEditorOpen(true), []);
+  const launchXPathEditor = useCallback(() => {
+    setIsEditorOpen(true);
+  }, []);
   const closeXPathEditor = useCallback(() => {
     setIsEditorOpen(false);
   }, []);

--- a/packages/ui/src/components/Document/actions/withFieldContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/withFieldContextMenu.tsx
@@ -38,7 +38,9 @@ export function withFieldContextMenu<P extends WithTreeNode>(
     const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
     const menuRef = useRef<HTMLDivElement>(null);
 
-    const closeMenu = useCallback(() => setIsMenuOpen(false), []);
+    const closeMenu = useCallback(() => {
+      setIsMenuOpen(false);
+    }, []);
 
     useEffect(() => {
       if (!isMenuOpen) return;

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -104,7 +104,9 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
     // The parent ExpansionPanels container listens for transitionend and flushes the queue
     // This ensures mapping lines are recalculated when browser layout is fully settled
     if (onLayoutChange) {
-      context.queueLayoutChange(() => onLayoutChange(id));
+      context.queueLayoutChange(() => {
+        onLayoutChange(id);
+      });
     }
   };
 
@@ -189,14 +191,18 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
     // This ensures mapping lines are recalculated with correct container bounds
     // when panels are dynamically added/removed or on initial render
     if (onLayoutChange) {
-      context.queueLayoutChange(() => onLayoutChange(id));
+      context.queueLayoutChange(() => {
+        onLayoutChange(id);
+      });
     }
 
     return () => {
       // Queue layout change callback before unregistering
       // When panel is removed, grid redistributes and mapping lines need to update
       if (onLayoutChange) {
-        context.queueLayoutChange(() => onLayoutChange(id));
+        context.queueLayoutChange(() => {
+          onLayoutChange(id);
+        });
       }
       context.unregister(id);
     };
@@ -208,7 +214,9 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
   // Register layout callback to receive broadcasts when any panel's layout changes
   useEffect(() => {
     if (onLayoutChange) {
-      context.registerLayoutCallback(id, () => onLayoutChange(id));
+      context.registerLayoutCallback(id, () => {
+        onLayoutChange(id);
+      });
     }
 
     return () => {

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -84,7 +84,9 @@ const clickElement = async (element: HTMLElement) => {
 
 const clickElements = async (labels: string[]) => {
   await act(() => {
-    labels.forEach((label) => screen.getByText(label).click());
+    labels.forEach((label) => {
+      screen.getByText(label).click();
+    });
     return delay(10);
   });
 };
@@ -153,7 +155,9 @@ const createTestPanelWithCallback = (callbackRef: { current: boolean }) => {
           callbackRef.current = true;
         };
         context.registerLayoutCallback(id, callback);
-        return () => context.unregisterLayoutCallback(id);
+        return () => {
+          context.unregisterLayoutCallback(id);
+        };
       }
     }, [context, id]);
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
@@ -68,7 +68,9 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
    * not the transient queue (layoutChangeQueueRef).
    */
   const executeAllLayoutCallbacks = useCallback(() => {
-    panelCallbacksRef.current.forEach((callback) => callback());
+    panelCallbacksRef.current.forEach((callback) => {
+      callback();
+    });
   }, []);
 
   /**
@@ -156,7 +158,9 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
   const flushLayoutCallbacks = useCallback(() => {
     const callbacks = [...layoutChangeQueueRef.current];
     layoutChangeQueueRef.current = [];
-    callbacks.forEach((callback) => callback());
+    callbacks.forEach((callback) => {
+      callback();
+    });
   }, []);
 
   const register = useCallback(

--- a/packages/ui/src/components/MetadataEditor/TopmostArrayTable.tsx
+++ b/packages/ui/src/components/MetadataEditor/TopmostArrayTable.tsx
@@ -63,7 +63,9 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
                   data-testid={'metadata-add-' + props.name + '-btn'}
                   icon={<PlusCircleIcon />}
                   variant="link"
-                  onClick={() => handleAddNew()}
+                  onClick={() => {
+                    handleAddNew();
+                  }}
                 />
               </Td>
             </Tr>
@@ -78,7 +80,9 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
                       data-testid={'metadata-add-' + props.name + '-btn'}
                       icon={<PlusCircleIcon />}
                       variant="link"
-                      onClick={() => handleAddNew()}
+                      onClick={() => {
+                        handleAddNew();
+                      }}
                     >
                       Add new
                     </Button>
@@ -91,7 +95,9 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
                   key={index}
                   data-testid={'metadata-row-' + index}
                   isSelectable
-                  onRowClick={() => props.onSelected(index)}
+                  onRowClick={() => {
+                    props.onSelected(index);
+                  }}
                   isRowSelected={props.selected === index}
                 >
                   {props.itemSchema.required?.map((name: string) => (
@@ -105,7 +111,9 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
                       data-testid={'metadata-delete-' + index + '-btn'}
                       icon={<TrashIcon />}
                       variant="link"
-                      onClick={() => handleTrashClick(index)}
+                      onClick={() => {
+                        handleTrashClick(index);
+                      }}
                     />
                   </Td>
                 </Tr>

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.test.tsx
@@ -90,7 +90,9 @@ describe('PropertiesModal', () => {
 
     it('renders component properties table correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Atom');
       expect(screen.getByTestId('properties-modal-description')).toHaveTextContent('Poll Atom RSS feeds.');
@@ -186,7 +188,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Asterisk');
       expect(screen.getByTestId('properties-modal-description')).toHaveTextContent(
@@ -209,7 +213,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Api Key');
       expect(screen.getByTestId('properties-modal-description')).toHaveTextContent(
@@ -244,7 +250,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
         'ASN.1 File',
@@ -269,7 +277,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
         'AWS DynamoDB Streams Source',
@@ -317,7 +327,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent(
         'NATS Sink',
@@ -340,7 +352,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Print');
       expect(screen.getByTestId('properties-modal-description')).toHaveTextContent('The print test action.');
@@ -371,7 +385,9 @@ describe('PropertiesModal', () => {
 
     it('renders property modal correctly', async () => {
       const { baseElement } = await renderModal(tile);
-      await waitFor(() => expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.queryByText('Loading properties...')).not.toBeInTheDocument();
+      });
       // info
       expect(baseElement.getElementsByClassName('pf-v6-c-modal-box__title-text').item(0)).toHaveTextContent('Iterate');
       expect(screen.getByTestId('properties-modal-description')).toHaveTextContent('The iterate test container.');

--- a/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.tsx
+++ b/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.tsx
@@ -35,11 +35,12 @@ export const PropertiesTableTree: FunctionComponent<IPropertiesTableTreeProps> =
     const isExpanded = expandedNodeId.includes(rowIndex);
 
     const treeRow: TdProps['treeRow'] = {
-      onCollapse: () =>
+      onCollapse: () => {
         setExpandedNodeId((prevExpanded) => {
           const otherExpandedNodeNames = prevExpanded.filter((row_unique_id) => row_unique_id !== rowIndex);
           return isExpanded ? otherExpandedNodeNames : [...otherExpandedNodeNames, rowIndex];
-        }),
+        });
+      },
       rowIndex,
       props: {
         isExpanded,

--- a/packages/ui/src/components/RenderingAnchor/rendering.provider.test.tsx
+++ b/packages/ui/src/components/RenderingAnchor/rendering.provider.test.tsx
@@ -111,7 +111,9 @@ describe('RenderingProvider', () => {
   function ProviderConsumer(props: { anchorTag: string; registerComponents: IRegisteredComponent[] }) {
     const { registerComponent, getRegisteredComponents } = useContext(RenderingAnchorContext);
 
-    props.registerComponents.forEach((regComponent) => registerComponent(regComponent));
+    props.registerComponents.forEach((regComponent) => {
+      registerComponent(regComponent);
+    });
 
     const components = getRegisteredComponents('form-header', vizNode);
 

--- a/packages/ui/src/components/View/MappingLink.tsx
+++ b/packages/ui/src/components/View/MappingLink.tsx
@@ -37,8 +37,12 @@ export const MappingLink: FunctionComponent<LineProps> = ({
   const controlPoint1X = x1 + (x2 - x1) * 0.1;
   const controlPoint2X = x1 + (x2 - x1) * 0.9;
 
-  const onMouseEnter = useCallback(() => setIsOver(true), []);
-  const onMouseLeave = useCallback(() => setIsOver(false), []);
+  const onMouseEnter = useCallback(() => {
+    setIsOver(true);
+  }, []);
+  const onMouseLeave = useCallback(() => {
+    setIsOver(false);
+  }, []);
   const onLineClick = useCallback(() => {
     toggleSelectedNode(targetNodePath, false);
   }, [toggleSelectedNode, targetNodePath]);

--- a/packages/ui/src/components/View/SourcePanel.test.tsx
+++ b/packages/ui/src/components/View/SourcePanel.test.tsx
@@ -74,7 +74,11 @@ describe('SourcePanel', () => {
       await vi.advanceTimersByTimeAsync(200);
       await vi.runAllTimersAsync();
       // Wait for any queued RAF callbacks
-      await new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
+      await new Promise((resolve) => {
+        queueMicrotask(() => {
+          resolve(undefined);
+        });
+      });
     });
 
     // The panel should now be collapsed (data-expanded=false)
@@ -83,7 +87,11 @@ describe('SourcePanel', () => {
 
     // Clean up
     unmount();
-    await new Promise((resolve) => queueMicrotask(() => resolve(undefined))); // Wait for cleanup RAF calls
+    await new Promise((resolve) => {
+      queueMicrotask(() => {
+        resolve(undefined);
+      });
+    }); // Wait for cleanup RAF calls
 
     // Restore original RAF
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -57,7 +57,9 @@ describe('Canvas', () => {
       await vi.runAllTimersAsync();
     });
 
-    await waitFor(async () => expect(screen.getByText('Reset View')).toBeInTheDocument());
+    await waitFor(async () => {
+      expect(screen.getByText('Reset View')).toBeInTheDocument();
+    });
     expect(result?.asFragment()).toMatchSnapshot();
   });
 
@@ -282,7 +284,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(async () => expect(screen.getByText('Open Catalog')).toBeInTheDocument());
+      await waitFor(async () => {
+        expect(screen.getByText('Open Catalog')).toBeInTheDocument();
+      });
       expect(result?.asFragment()).toMatchSnapshot();
     });
 
@@ -306,7 +310,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(async () => expect(screen.queryByText('Open Catalog')).not.toBeInTheDocument());
+      await waitFor(async () => {
+        expect(screen.queryByText('Open Catalog')).not.toBeInTheDocument();
+      });
       expect(result?.asFragment()).toMatchSnapshot();
     });
   });
@@ -336,7 +342,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(async () => expect(screen.getByTestId('visualization-empty-state')).toBeInTheDocument());
+      await waitFor(async () => {
+        expect(screen.getByTestId('visualization-empty-state')).toBeInTheDocument();
+      });
       expect(result?.asFragment()).toMatchSnapshot();
     });
 
@@ -361,7 +369,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(async () => expect(screen.getByTestId('visualization-empty-state')).toBeInTheDocument());
+      await waitFor(async () => {
+        expect(screen.getByTestId('visualization-empty-state')).toBeInTheDocument();
+      });
       expect(result?.container).toMatchSnapshot();
     });
 
@@ -490,7 +500,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(() => expect(screen.getByText('Horizontal Layout')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByText('Horizontal Layout')).toBeInTheDocument();
+      });
 
       const horizontalButton = screen.getByText('Horizontal Layout').closest('button')!;
       expect(horizontalButton).toBeInTheDocument();
@@ -530,7 +542,9 @@ describe('Canvas', () => {
         await vi.runAllTimersAsync();
       });
 
-      await waitFor(() => expect(screen.getByText('Vertical Layout')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByText('Vertical Layout')).toBeInTheDocument();
+      });
 
       const verticalButton = screen.getByText('Vertical Layout').closest('button')!;
       expect(verticalButton).toBeInTheDocument();

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ArrayBadgesField/ArrayBadgesField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ArrayBadgesField/ArrayBadgesField.tsx
@@ -71,7 +71,9 @@ export const ArrayBadgesField: FunctionComponent<ArrayBadgesFieldProps> = ({
               <TextInput
                 id={`${propName}-input`}
                 value={inputValue}
-                onChange={(_event, value) => setInputValue(value)}
+                onChange={(_event, value) => {
+                  setInputValue(value);
+                }}
                 placeholder={placeholder}
                 isDisabled={disabled}
                 aria-label={schema.title ?? propName}
@@ -92,7 +94,14 @@ export const ArrayBadgesField: FunctionComponent<ArrayBadgesFieldProps> = ({
             <div className="array-badges-field">
               <LabelGroup>
                 {sortedItems.map((item) => (
-                  <Label key={item} onClose={() => removeItem(item)} color="blue" isDisabled={disabled}>
+                  <Label
+                    key={item}
+                    onClose={() => {
+                      removeItem(item);
+                    }}
+                    color="blue"
+                    isDisabled={disabled}
+                  >
                     {item}
                   </Label>
                 ))}

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/CatalogSelectorField/CatalogSelectorField.tsx
@@ -115,7 +115,9 @@ const CatalogSelectorField: FunctionComponent<ICatalogSelectorField> = ({
         toggle={
           <MenuToggle
             ref={toggleRef}
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={() => {
+              setIsOpen(!isOpen);
+            }}
             isExpanded={isOpen}
             isDisabled={disabled}
             isFullWidth

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.hooks.ts
@@ -81,7 +81,9 @@ export const collectDirectEndpointNames = (value: unknown, names: Set<string>) =
   }
 
   if (Array.isArray(value)) {
-    value.forEach((item) => collectDirectEndpointNames(item, names));
+    value.forEach((item) => {
+      collectDirectEndpointNames(item, names);
+    });
     return;
   }
 
@@ -102,7 +104,9 @@ export const collectDirectEndpointNames = (value: unknown, names: Set<string>) =
     }
   }
 
-  Object.values(objectValue).forEach((item) => collectDirectEndpointNames(item, names));
+  Object.values(objectValue).forEach((item) => {
+    collectDirectEndpointNames(item, names);
+  });
 };
 
 const getRouteIdsByDirectName = (visualEntities?: DirectEndpointEntityLike[]) => {
@@ -142,7 +146,9 @@ export const useDirectEndpointNameOptions = ({
 }: UseDirectEndpointNameOptionsParams) => {
   const existingDirectNames = useMemo(() => {
     const names = new Set<string>();
-    visualEntities?.forEach((entity) => collectDirectEndpointNames(entity.toJSON(), names));
+    visualEntities?.forEach((entity) => {
+      collectDirectEndpointNames(entity.toJSON(), names);
+    });
     return [...names].sort((first, second) => first.localeCompare(second));
   }, [visualEntities]);
 
@@ -180,7 +186,9 @@ export const useDirectEndpointNameOptions = ({
     [onChange],
   );
 
-  const onCleanInput = useCallback(() => onChange(undefined), [onChange]);
+  const onCleanInput = useCallback(() => {
+    onChange(undefined);
+  }, [onChange]);
 
   const onCreateOption = useCallback(
     (_value?: string, filterValue?: string) => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/DirectEndpointNameField.test.tsx
@@ -75,7 +75,9 @@ describe('DirectEndpointNameField', () => {
     expect(button).toBeDisabled();
 
     fireEvent.change(input, { target: { value: 'new-endpoint' } });
-    await waitFor(() => expect(button).toBeEnabled());
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
   });
 
   it('creates a new route with direct from and typed name', async () => {
@@ -97,7 +99,9 @@ describe('DirectEndpointNameField', () => {
     const button = screen.getByRole('button', { name: 'Create Route' });
 
     fireEvent.change(input, { target: { value: 'new-route' } });
-    await waitFor(() => expect(button).toBeEnabled());
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
     fireEvent.click(button);
 
     expect(addNewEntitySpy).toHaveBeenCalledWith(EntityType.Route, {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -185,7 +185,9 @@ describe('EndpointField', () => {
       await renderField({ endpoint: undefined }, testModel);
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {
@@ -211,7 +213,9 @@ describe('EndpointField', () => {
       await renderField({ endpoint: undefined }, testModel, onPropertyChange);
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {
@@ -297,7 +301,9 @@ describe('EndpointField', () => {
       const { getInput } = await renderField({ endpoint: undefined }, testModel, onPropertyChange);
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {
@@ -345,7 +351,9 @@ describe('EndpointField', () => {
       expect(input).toHaveValue('httpClient');
 
       // Find and click the clear button
-      await waitFor(() => expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+      });
       const clearButton = screen.getByRole('button', { name: /clear/i });
 
       await act(async () => {
@@ -389,7 +397,9 @@ describe('EndpointField', () => {
       expect(input).toHaveValue('httpClient');
 
       // Open dropdown and select different endpoint
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {
@@ -451,7 +461,9 @@ describe('EndpointField', () => {
       await renderField({ endpoint: undefined }, testModel);
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {
@@ -485,7 +497,9 @@ describe('EndpointField', () => {
       await renderField({ endpoint: undefined }, testModel);
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint toggle');
 
       await act(async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
@@ -125,7 +125,9 @@ export const EndpointListField: FunctionComponent<FieldProps> = ({ propName, req
                     data-testid={'endpoint-edit-' + index + '-btn'}
                     icon={<EditIcon />}
                     variant="link"
-                    onClick={() => handleEdit(index)}
+                    onClick={() => {
+                      handleEdit(index);
+                    }}
                   />
                   <Button
                     title={`Delete ${item.name}`}

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.tsx
@@ -42,7 +42,9 @@ export const EndpointPropertiesField: FunctionComponent<FieldProps> = ({ propNam
               text="Standard"
               buttonId="standard"
               isSelected={activeView === 'standard'}
-              onChange={() => setActiveView('standard')}
+              onChange={() => {
+                setActiveView('standard');
+              }}
               data-testid={`${propName}-standard-toggle`}
             />
             <ToggleGroupItem
@@ -50,7 +52,9 @@ export const EndpointPropertiesField: FunctionComponent<FieldProps> = ({ propNam
               text="Custom"
               buttonId="custom"
               isSelected={activeView === 'custom'}
-              onChange={() => setActiveView('custom')}
+              onChange={() => {
+                setActiveView('custom');
+              }}
               data-testid={`${propName}-custom-toggle`}
             />
           </ToggleGroup>

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -14,8 +14,20 @@ vi.mock('@kaoto/forms', async () => ({
         <div data-testid={`object-field-${props.propName}`}>ObjectField: {props.propName}</div>
         <div data-testid="model-context-provider-disabled">{String(disabled)}</div>
         <div data-testid="model-context-provider-model">{JSON.stringify(value)}</div>
-        <button onClick={() => onChange({ jobParameters: { name: 'updated' } })}>Trigger property change</button>
-        <button onClick={() => onChange({ jobParameters: { name: '' } })}>Delete property</button>
+        <button
+          onClick={() => {
+            onChange({ jobParameters: { name: 'updated' } });
+          }}
+        >
+          Trigger property change
+        </button>
+        <button
+          onClick={() => {
+            onChange({ jobParameters: { name: '' } });
+          }}
+        >
+          Delete property
+        </button>
       </div>
     );
   },

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/MediaTypeField/MediaTypeField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/MediaTypeField/MediaTypeField.tsx
@@ -134,7 +134,9 @@ export const MediaTypeField: FunctionComponent<FieldProps> = ({ propName, requir
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
     <MenuToggle
       ref={toggleRef}
-      onClick={() => setIsOpen((current) => !current)}
+      onClick={() => {
+        setIsOpen((current) => !current);
+      }}
       isExpanded={isOpen}
       isFullWidth
       isDisabled={disabled}
@@ -157,7 +159,9 @@ export const MediaTypeField: FunctionComponent<FieldProps> = ({ propName, requir
         isOpen={isOpen}
         selected={selectedValues}
         onSelect={onSelect}
-        onOpenChange={(nextOpen) => setIsOpen(nextOpen)}
+        onOpenChange={(nextOpen) => {
+          setIsOpen(nextOpen);
+        }}
         toggle={toggle}
       >
         <SelectList className="media-type-field-list">
@@ -172,7 +176,9 @@ export const MediaTypeField: FunctionComponent<FieldProps> = ({ propName, requir
           <TextInput
             aria-label="Custom media type"
             value={customValue}
-            onChange={(_event, nextValue) => setCustomValue(nextValue)}
+            onChange={(_event, nextValue) => {
+              setCustomValue(nextValue);
+            }}
             onKeyDown={onCustomKeyDown}
             placeholder="Add custom media type"
             isDisabled={disabled}

--- a/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/apply-collapse-state.test.ts
@@ -167,7 +167,9 @@ describe('applyCollapseState', () => {
     } as unknown as Controller;
 
     // Should not throw
-    expect(() => applyCollapseState(controller)).not.toThrow();
+    expect(() => {
+      applyCollapseState(controller);
+    }).not.toThrow();
     expect(controller.getElements).toHaveBeenCalled();
   });
 

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
@@ -81,7 +81,9 @@ export const EntitiesList: FunctionComponent<IEntitiesList> = ({
         key={`entity-option-all`}
         entityLabel="all"
         isVisible={allEntitiesVisible}
-        onToggleVisibility={() => onToggleAll()}
+        onToggleVisibility={() => {
+          onToggleAll();
+        }}
       />
       <Divider />
       <SelectGroup className="entities-select-list">

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
@@ -94,7 +94,9 @@ export const EntitiesList: FunctionComponent<IEntitiesList> = ({
               entityLabel={docEntity.label}
               isVisible={docEntity.isVisible}
               entityIndex={index}
-              onToggleVisibility={(index) => index !== undefined && onToggleVisibility(index)}
+              onToggleVisibility={(index) => {
+                if (index !== undefined) onToggleVisibility(index);
+              }}
             />
           ))}
         </SelectList>

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesMenu.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesMenu.tsx
@@ -87,7 +87,9 @@ export const EntitiesMenu: FunctionComponent<IEntitiesMenu> = ({ documentationEn
     >
       <EntitiesList
         documentationEntities={documentationEntities}
-        onToggleVisibility={(index) => onToggleEntityVisibility(index)}
+        onToggleVisibility={(index) => {
+          onToggleEntityVisibility(index);
+        }}
         onToggleAll={onToggleAll}
       />
     </Select>

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocumentPreviewModal.tsx
@@ -134,7 +134,9 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
                   <FormGroup label="Visible Entities">
                     <EntitiesMenu
                       documentationEntities={documentationEntities}
-                      onUpdate={(docEntities) => onUpdateDocumentationEntities(docEntities)}
+                      onUpdate={(docEntities) => {
+                        onUpdateDocumentationEntities(docEntities);
+                      }}
                     />
                   </FormGroup>
                 </ToolbarItem>
@@ -149,7 +151,9 @@ export const ExportDocumentPreviewModal: FunctionComponent<IExportDocumentPrevie
                       aria-label="Download File Name"
                       type="text"
                       value={downloadFileName}
-                      onChange={(_event, value) => setDownloadFileName(value)}
+                      onChange={(_event, value) => {
+                        setDownloadFileName(value);
+                      }}
                     />
                   </FormGroup>
                 </ToolbarItem>

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/HiddenCanvas.tsx
@@ -74,7 +74,7 @@ export const HiddenCanvas: FunctionComponent<HiddenCanvasProps> = ({
     controller.fromModel(model, false);
 
     const rafId = requestAnimationFrame(() => {
-      void action(() => {
+      action(() => {
         const graph = controller.getGraph();
         graph.reset();
         graph.fit(0);

--- a/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/IntegrationTypeSelector/IntegrationTypeSelector.tsx
@@ -20,7 +20,9 @@ export const IntegrationTypeSelector: FunctionComponent<PropsWithChildren> = () 
       <IntegrationTypeSelectorToggle onSelect={checkBeforeAddNewFlow} />
       <ConfirmIntegrationTypeChangeModal
         proposedFlowType={proposedFlowType}
-        onClose={() => setProposedFlowType(undefined)}
+        onClose={() => {
+          setProposedFlowType(undefined);
+        }}
       />
     </>
   );

--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
@@ -56,7 +56,9 @@ export const NewEntity: FunctionComponent = () => {
   return (
     <MenuContainer
       isOpen={isOpen}
-      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+      }}
       menu={
         <Menu ref={menuRef} containsFlyout onSelect={onSelect}>
           <MenuContent>

--- a/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/collapse-step.hook.test.tsx
@@ -64,7 +64,7 @@ describe('useCollapseStep', () => {
   it('should collapse node, set dimensions and update the state when onCollapseNode is called', async () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -81,7 +81,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
 
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -98,7 +98,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockElement.getData = vi.fn().mockReturnValue(undefined);
 
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockElement.setDimensions).toHaveBeenCalledWith(
       new Dimensions(CanvasDefaults.DEFAULT_NODE_WIDTH, CanvasDefaults.DEFAULT_NODE_HEIGHT),
@@ -115,7 +115,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: ['mock-node-id'] });
 
-    await result.current.onExpandNode();
+    result.current.onExpandNode();
 
     expect(mockElement.setDimensions).not.toHaveBeenCalled();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
@@ -159,7 +159,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Collapse the node
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: ['mock-node-id'] });
 
@@ -168,7 +168,7 @@ describe('useCollapseStep', () => {
     mockController.setState = vi.fn();
 
     // Try to collapse again - should not update state
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockController.setState).not.toHaveBeenCalled();
   });
@@ -178,7 +178,7 @@ describe('useCollapseStep', () => {
     mockController.getState = vi.fn().mockReturnValue({ collapsedIds: [] });
 
     // Expand a node that is not collapsed
-    await result.current.onExpandNode();
+    result.current.onExpandNode();
 
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
@@ -191,7 +191,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Collapse this node - should add to existing collapsed nodes
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({
       collapsedIds: ['other-node-1', 'other-node-2', 'mock-node-id'],
@@ -206,7 +206,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Expand this node - should remove only this node
-    await result.current.onExpandNode();
+    result.current.onExpandNode();
 
     expect(mockController.setState).toHaveBeenCalledWith({
       collapsedIds: ['other-node-1', 'other-node-2'],
@@ -217,7 +217,7 @@ describe('useCollapseStep', () => {
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
     // Rapid collapse
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
 
     // Update state to reflect collapse
@@ -226,7 +226,7 @@ describe('useCollapseStep', () => {
     (mockElement.setCollapsed as Mock).mockClear();
 
     // Rapid expand
-    await result.current.onExpandNode();
+    result.current.onExpandNode();
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(false);
     expect(mockController.setState).toHaveBeenCalledWith({ collapsedIds: [] });
   });
@@ -240,7 +240,7 @@ describe('useCollapseStep', () => {
 
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     expect(mockElement.setCollapsed).toHaveBeenCalledWith(true);
     expect(mockController.setState).not.toHaveBeenCalled();
@@ -252,7 +252,7 @@ describe('useCollapseStep', () => {
 
     const { result } = renderHook(() => useCollapseStep(mockElement));
 
-    await result.current.onCollapseNode();
+    result.current.onCollapseNode();
 
     // Verify the original array was not mutated
     expect(initialState).toEqual(['node-1', 'node-2']);

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
@@ -58,12 +58,16 @@ describe('useDeleteHotkey', () => {
       capturedHandler = handler;
     });
 
-    renderHook(() => useDeleteHotkey(node, clearSelected));
+    renderHook(() => {
+      useDeleteHotkey(node, clearSelected);
+    });
     return capturedHandler!;
   }
 
   it('should bind and unbind hotkeys on mount/unmount', () => {
-    const { unmount } = renderHook(() => useDeleteHotkey(undefined, clearSelected));
+    const { unmount } = renderHook(() => {
+      useDeleteHotkey(undefined, clearSelected);
+    });
 
     expect(mockHotkeys).toHaveBeenCalledWith('Delete, backspace', expect.any(Function));
 
@@ -75,7 +79,9 @@ describe('useDeleteHotkey', () => {
     const handler = setupHotkey(undefined);
 
     const preventDefault = vi.fn();
-    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
@@ -86,7 +92,9 @@ describe('useDeleteHotkey', () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: true }));
 
     const preventDefault = vi.fn();
-    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
 
     expect(onDeleteStep).toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
@@ -97,7 +105,9 @@ describe('useDeleteHotkey', () => {
     const handler = setupHotkey(makeNode({ canRemoveFlow: true }));
 
     const preventDefault = vi.fn();
-    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).toHaveBeenCalled();
@@ -108,7 +118,9 @@ describe('useDeleteHotkey', () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: false, canRemoveFlow: false }));
 
     const preventDefault = vi.fn();
-    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
 
     expect(onDeleteStep).not.toHaveBeenCalled();
     expect(onDeleteGroup).not.toHaveBeenCalled();
@@ -119,7 +131,9 @@ describe('useDeleteHotkey', () => {
     const handler = setupHotkey(makeNode({ canRemoveStep: true }));
 
     const preventDefault = vi.fn();
-    await act(async () => handler({ preventDefault } as unknown as KeyboardEvent));
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
 
     expect(preventDefault).toHaveBeenCalled();
   });

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -184,7 +184,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    await result.current.onEnableAllSteps();
+    result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledTimes(2);
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition1, 'disabled', false);
@@ -211,7 +211,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    await result.current.onEnableAllSteps();
+    result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith(mockDefinition);
@@ -234,7 +234,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    await result.current.onEnableAllSteps();
+    result.current.onEnableAllSteps();
 
     expect(mockSetValue).toHaveBeenCalledWith({}, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith({});
@@ -246,7 +246,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    await result.current.onEnableAllSteps();
+    result.current.onEnableAllSteps();
 
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/NewFlow.tsx
@@ -54,7 +54,9 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
       </FlowTypeSelector>
       <ConfirmIntegrationTypeChangeModal
         proposedFlowType={proposedFlowType}
-        onClose={() => setProposedFlowType(undefined)}
+        onClose={() => {
+          setProposedFlowType(undefined);
+        }}
       />
     </>
   );

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -48,7 +48,9 @@ export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onCh
             enabled: false,
           },
         });
-        newEditor.onDidChangeModelContent((_e) => onChange(newEditor.getModel()?.getValue()));
+        newEditor.onDidChangeModelContent((_e) => {
+          onChange(newEditor.getModel()?.getValue());
+        });
         return newEditor;
       });
     }

--- a/packages/ui/src/components/XPath/XPathEditorLayout.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.tsx
@@ -142,7 +142,9 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({
                             <Button
                               aria-expanded={isExpanded}
                               variant="plain"
-                              onClick={() => toggleGroup(value)}
+                              onClick={() => {
+                                toggleGroup(value);
+                              }}
                               className="xpath-editor__tab__functions-list__group-toggle"
                               icon={isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
                               data-testid={`function-group-toggle-${value}`}

--- a/packages/ui/src/components/registers/RegisterComponents.tsx
+++ b/packages/ui/src/components/registers/RegisterComponents.tsx
@@ -28,7 +28,9 @@ export const RegisterComponents: FunctionComponent<PropsWithChildren> = ({ child
     },
   ]);
 
-  componentsToRegister.current.forEach((regComponent) => registerComponent(regComponent));
+  componentsToRegister.current.forEach((regComponent) => {
+    registerComponent(regComponent);
+  });
 
   return <>{children}</>;
 };

--- a/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
+++ b/packages/ui/src/dynamic-catalog/dynamic-catalog.test.ts
@@ -355,7 +355,9 @@ describe('DynamicCatalog', () => {
     });
 
     it('should allow clearing an empty cache without errors', () => {
-      expect(() => catalog.clearCache()).not.toThrow();
+      expect(() => {
+        catalog.clearCache();
+      }).not.toThrow();
     });
 
     it('should clear multiple cached entries', async () => {

--- a/packages/ui/src/hooks/previous.hook.test.ts
+++ b/packages/ui/src/hooks/previous.hook.test.ts
@@ -33,7 +33,9 @@ describe('usePrevious', () => {
   });
 
   it('should return undefined if no previous value exists', () => {
-    const { result } = renderHook(() => usePrevious(undefined));
+    const { result } = renderHook(() => {
+      usePrevious(undefined);
+    });
     expect(result.current).toBeUndefined();
   });
 });

--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
@@ -99,7 +99,9 @@ describe('useDataMapperDeleteHotkey', () => {
     });
 
     it('should delete mapping when valid target node is selected and Delete is allowed', () => {
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -110,7 +112,9 @@ describe('useDataMapperDeleteHotkey', () => {
     });
 
     it('should clear selection after deletion', () => {
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -121,7 +125,9 @@ describe('useDataMapperDeleteHotkey', () => {
     });
 
     it('should call onUpdate callback after deletion', () => {
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -140,7 +146,9 @@ describe('useDataMapperDeleteHotkey', () => {
         clearSelection: mockClearSelection,
       });
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -162,7 +170,9 @@ describe('useDataMapperDeleteHotkey', () => {
       mockFindNodeByPath.mockReturnValue(mockTreeNode);
       mockGetAllowedActions.mockReturnValue([MappingActionKind.If, MappingActionKind.Choose]);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -184,7 +194,9 @@ describe('useDataMapperDeleteHotkey', () => {
       mockFindNodeByPath.mockReturnValue(null);
       mockGetAllowedActions.mockReturnValue([MappingActionKind.Delete]);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -206,7 +218,9 @@ describe('useDataMapperDeleteHotkey', () => {
       mockFindNodeByPath.mockReturnValue(undefined);
       mockGetAllowedActions.mockReturnValue([MappingActionKind.Delete]);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -228,7 +242,9 @@ describe('useDataMapperDeleteHotkey', () => {
       mockFindNodeByPath.mockReturnValue(mockTreeNode);
       mockGetAllowedActions.mockReturnValue([MappingActionKind.Delete]);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -243,7 +259,9 @@ describe('useDataMapperDeleteHotkey', () => {
 
   describe('tree lookup', () => {
     it('should not call getTree during render', () => {
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       expect(mockGetTree).not.toHaveBeenCalled();
     });
@@ -258,7 +276,9 @@ describe('useDataMapperDeleteHotkey', () => {
       mockFindNodeByPath.mockReturnValue(mockTreeNode);
       mockGetAllowedActions.mockReturnValue([MappingActionKind.Delete]);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -276,7 +296,9 @@ describe('useDataMapperDeleteHotkey', () => {
 
       mockGetTree.mockReturnValue(undefined);
 
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       const hotkeyCallback = mockHotkeys.mock.calls[0][1] as (event: KeyboardEvent) => void;
       const mockEvent = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
@@ -290,7 +312,9 @@ describe('useDataMapperDeleteHotkey', () => {
 
   describe('hotkey registration', () => {
     it('should register hotkeys with delete and backspace keys', () => {
-      renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       expect(mockHotkeys).toHaveBeenCalled();
       const keyString = mockHotkeys.mock.calls[0][0] as string;
@@ -302,7 +326,9 @@ describe('useDataMapperDeleteHotkey', () => {
 
   describe('cleanup and unmount', () => {
     it('should unbind hotkeys on unmount', () => {
-      const { unmount } = renderHook(() => useDataMapperDeleteHotkey(mockOnUpdate));
+      const { unmount } = renderHook(() => {
+        useDataMapperDeleteHotkey(mockOnUpdate);
+      });
 
       unmount();
 

--- a/packages/ui/src/hooks/useToggle.ts
+++ b/packages/ui/src/hooks/useToggle.ts
@@ -19,12 +19,18 @@ type OnToggleReturnType = Promise<boolean> | boolean;
 
 export function useToggle(initialState: boolean, onToggle?: (toggled: boolean) => OnToggleReturnType) {
   const [state, setState] = useState(initialState);
-  useEffect(() => setState(initialState), [initialState]);
+  useEffect(() => {
+    setState(initialState);
+  }, [initialState]);
   const toggle = useCallback(async () => {
     const newState = onToggle ? await onToggle(!state) : !state;
     setState(newState);
   }, [onToggle, state]);
-  const toggleOff = useCallback(() => setState(false), []);
-  const toggleOn = useCallback(() => setState(true), []);
+  const toggleOff = useCallback(() => {
+    setState(false);
+  }, []);
+  const toggleOn = useCallback(() => {
+    setState(true);
+  }, []);
   return { state, toggle, toggleOff, toggleOn, setToggle: setState };
 }

--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -79,7 +79,9 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
                 </MenuToggle>
               )}
               isOpen={isOpen}
-              onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+              onOpenChange={(isOpen: boolean) => {
+                setIsOpen(isOpen);
+              }}
               popperProps={DEFAULT_POPPER_PROPS}
             >
               <a href="https://kaoto.io/workshop/" target="_blank" rel="noopener noreferrer">

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -496,7 +496,9 @@ describe('CamelRouteResource', () => {
       await resource.initialize();
       const beansEntity = new BeansEntity({ beans: [] });
 
-      expect(() => resource.deleteBeansEntity(beansEntity)).not.toThrow();
+      expect(() => {
+        resource.deleteBeansEntity(beansEntity);
+      }).not.toThrow();
       expect(resource.getEntities()).toHaveLength(0);
     });
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -287,7 +287,9 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
         node.data.isGroup = false;
       }
 
-      children.forEach((child) => normalizeGroups(child));
+      children.forEach((child) => {
+        normalizeGroups(child);
+      });
     };
 
     normalizeGroups(routeGroupNode);

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -235,7 +235,9 @@ export class PipeVisualEntity implements BaseVisualEntity {
     const sinkNode = await this.getVizNodeFromStep(this.pipe.spec!.sink, 'sink');
 
     pipeGroupNode.addChild(sourceNode);
-    stepNodes.forEach((stepNode) => pipeGroupNode.addChild(stepNode));
+    stepNodes.forEach((stepNode) => {
+      pipeGroupNode.addChild(stepNode);
+    });
     pipeGroupNode.addChild(sinkNode);
 
     /** If there are no steps, we link the `source` and the `sink` together */

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -541,9 +541,9 @@ describe('VisualizationNode', () => {
         description: '',
         iconUrl: '',
       });
-      const copiedContent = node.pasteBaseEntityStep(clipboardContent, AddStepMode.InsertChildStep);
-
-      expect(copiedContent).toBeUndefined();
+      expect(() => {
+        node.pasteBaseEntityStep(clipboardContent, AddStepMode.InsertChildStep);
+      }).not.toThrow();
     });
 
     it('should delegate to the BaseVisualCamelEntity to paste the step', () => {

--- a/packages/ui/src/multiplying-architecture/Bridge/editor-api.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/editor-api.tsx
@@ -58,7 +58,10 @@ export const useEditorApi = () => {
   const editorApi: SourceCodeBridgeProviderRef = useMemo(
     () => ({
       /* Callback is exposed to the Channel to set the content of the file into the current Editor. */
-      setContent: (path: string, content: string) => Promise.resolve(setContent(path, content)),
+      setContent: (path: string, content: string) => {
+        setContent(path, content);
+        return Promise.resolve();
+      },
 
       /**
        * Callback is exposed to the Channel to retrieve the current value of the Editor. It returns the value of
@@ -66,8 +69,14 @@ export const useEditorApi = () => {
        */
       getContent: () => Promise.resolve(sourceCodeRef.current),
       getPreview: () => Promise.resolve(undefined),
-      undo: (): Promise<void> => Promise.resolve(undo()),
-      redo: (): Promise<void> => Promise.resolve(redo()),
+      undo: (): Promise<void> => {
+        undo();
+        return Promise.resolve();
+      },
+      redo: (): Promise<void> => {
+        redo();
+        return Promise.resolve();
+      },
       validate: () => Promise.resolve([]),
       setTheme: () => Promise.resolve(),
     }),

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -239,7 +239,7 @@ describe('KaotoEditorApp', () => {
   });
 
   it('should set the color theme upon opening the editor', async () => {
-    await kaotoEditorApp.af_onOpen();
+    kaotoEditorApp.af_onOpen();
 
     expect(setColorScheme).toHaveBeenCalledWith(ColorScheme.Auto);
   });

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -296,7 +296,12 @@ describe('KaotoEditorApp', () => {
   it('should return empty array when getSuggestions times out', async () => {
     const mockContext = {} as SuggestionRequestContext;
     (envelopeContext.channelApi.requests.getSuggestions as Mock).mockImplementation(
-      () => new Promise((resolve) => setTimeout(() => resolve([{ label: 'test' }]), 3000)),
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => {
+            resolve([{ label: 'test' }]);
+          }, 3000),
+        ),
     );
 
     const result = await kaotoEditorApp.getSuggestions('topic', 'word', mockContext);

--- a/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestRouteEndpointField.test.tsx
@@ -59,7 +59,12 @@ describe('RestRouteEndpointField', () => {
     });
 
     // Wait for Suspense to resolve
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument(), { timeout: 3000 });
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
 
     return {
       getInput: () => screen.getByRole('textbox', { name: 'Endpoint Name' }),
@@ -192,7 +197,9 @@ describe('RestRouteEndpointField', () => {
       expect(input).toHaveValue('orders');
 
       // Find and click the clear button
-      await waitFor(() => expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+      });
       const clearButton = screen.getByRole('button', { name: /clear/i });
 
       await act(async () => {
@@ -216,7 +223,9 @@ describe('RestRouteEndpointField', () => {
       getInput(); // Ensure component is loaded
 
       // Open the dropdown
-      await waitFor(() => expect(screen.getByLabelText('Endpoint Name toggle')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByLabelText('Endpoint Name toggle')).toBeInTheDocument();
+      });
       const toggle = screen.getByLabelText('Endpoint Name toggle');
 
       await act(async () => {

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
@@ -248,7 +248,12 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
             />
           </FormGroup>
           <div className="rest-dsl-import-actions">
-            <Button variant="secondary" onClick={() => void wizard.handleParseOpenApiSpec()}>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                wizard.handleParseOpenApiSpec();
+              }}
+            >
               Parse Specification
             </Button>
             {wizard.importStatus?.type === 'error' && (

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
@@ -166,9 +166,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
       label={`${operation.method.toUpperCase()} ${operation.path}${operation.routeExists ? ' - Route exists' : ''}`}
       isChecked={operation.routeExists ? false : operation.selected}
       isDisabled={operation.routeExists}
-      onChange={(_event, checked) =>
-        wizard.handleToggleOperation(operation.operationId, operation.method, operation.path, checked)
-      }
+      onChange={(_event, checked) => {
+        wizard.handleToggleOperation(operation.operationId, operation.method, operation.path, checked);
+      }}
     />
   );
 
@@ -198,7 +198,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
               name="rest-openapi-import-source"
               label="Upload file"
               isChecked={wizard.importSource === 'file'}
-              onChange={() => wizard.handleImportSourceChange('file')}
+              onChange={() => {
+                wizard.handleImportSourceChange('file');
+              }}
             />
             {wizard.importSource === 'file' && <FileImportSource onSchemaLoaded={wizard.handleSchemaLoaded} />}
 
@@ -207,7 +209,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
               name="rest-openapi-import-source"
               label="Import from URI"
               isChecked={wizard.importSource === 'uri'}
-              onChange={() => wizard.handleImportSourceChange('uri')}
+              onChange={() => {
+                wizard.handleImportSourceChange('uri');
+              }}
             />
             {wizard.importSource === 'uri' && <UriImportSource onSchemaLoaded={wizard.handleSchemaLoaded} />}
 
@@ -216,7 +220,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
               name="rest-openapi-import-source"
               label="Import from Apicurio"
               isChecked={wizard.importSource === 'apicurio'}
-              onChange={() => wizard.handleImportSourceChange('apicurio')}
+              onChange={() => {
+                wizard.handleImportSourceChange('apicurio');
+              }}
             />
             {wizard.importSource === 'apicurio' && (
               <ApicurioImportSource
@@ -234,7 +240,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
               id="rest-openapi-spec"
               aria-label="rest-openapi-spec"
               value={wizard.openApiSpecText}
-              onChange={(_event, value) => wizard.setOpenApiSpecText(value)}
+              onChange={(_event, value) => {
+                wizard.setOpenApiSpecText(value);
+              }}
               resizeOrientation="vertical"
               rows={6}
             />
@@ -252,13 +260,17 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
               id="rest-openapi-create-rest"
               label="Create Rest DSL operations"
               isChecked={wizard.importCreateRest}
-              onChange={(_event, checked) => wizard.setImportCreateRest(checked)}
+              onChange={(_event, checked) => {
+                wizard.setImportCreateRest(checked);
+              }}
             />
             <Checkbox
               id="rest-openapi-create-routes"
               label="Create routes with direct endpoints"
               isChecked={wizard.importCreateRoutes}
-              onChange={(_event, checked) => wizard.setImportCreateRoutes(checked)}
+              onChange={(_event, checked) => {
+                wizard.setImportCreateRoutes(checked);
+              }}
             />
           </div>
           {wizard.importOperations.length > 0 && (
@@ -267,7 +279,9 @@ export const RestDslImportWizard: FunctionComponent<RestDslImportWizardProps> = 
                 id="rest-openapi-select-all"
                 label="Select all operations"
                 isChecked={wizard.importSelectAll}
-                onChange={(_event, checked) => wizard.handleToggleSelectAllOperations(checked)}
+                onChange={(_event, checked) => {
+                  wizard.handleToggleSelectAllOperations(checked);
+                }}
               />
               <div className="rest-dsl-import-list-scroll">
                 {wizard.importOperations.map((operation) => (

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
@@ -122,7 +122,9 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
           aria-label="Search Apicurio artifacts"
           placeholder="Search OpenAPI artifacts"
           value={searchTerm}
-          onChange={(_event, value) => setSearchTerm(value)}
+          onChange={(_event, value) => {
+            setSearchTerm(value);
+          }}
         />
         <Button variant="secondary" onClick={fetchArtifacts} isDisabled={isLoading}>
           Refresh
@@ -142,7 +144,9 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
                   </span>
                 }
                 isChecked={selectedId === artifact.id}
-                onChange={() => handleSelectArtifact(artifact.id)}
+                onChange={() => {
+                  handleSelectArtifact(artifact.id);
+                }}
               />
             </ListItem>
           ))}

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.test.tsx
@@ -131,14 +131,12 @@ describe('UriImportSource', () => {
     fetchSpy.mockImplementation(
       () =>
         new Promise((resolve) =>
-          setTimeout(
-            () =>
-              resolve({
-                ok: true,
-                text: vi.fn().mockResolvedValue('openapi: 3.0.0'),
-              } as unknown as Response),
-            100,
-          ),
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              text: vi.fn().mockResolvedValue('openapi: 3.0.0'),
+            } as unknown as Response);
+          }, 100),
         ),
     );
 

--- a/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/UriImportSource.tsx
@@ -57,7 +57,9 @@ export const UriImportSource: FunctionComponent<UriImportSourceProps> = ({ onSch
           id="rest-openapi-spec-uri"
           aria-label="Open API specification URI"
           value={uri}
-          onChange={(_event, value) => setUri(value)}
+          onChange={(_event, value) => {
+            setUri(value);
+          }}
           placeholder="https://example.com/openapi.yaml"
         />
         <Button variant="secondary" onClick={handleFetch} isDisabled={!uri.trim() || isLoading} isLoading={isLoading}>

--- a/packages/ui/src/pages/SourceCode/SourceCodePage.test.tsx
+++ b/packages/ui/src/pages/SourceCode/SourceCodePage.test.tsx
@@ -18,7 +18,12 @@ vi.mock('../../components/SourceCode', () => ({
   SourceCode: ({ code, onCodeChange }: { code: string; onCodeChange: (code: string) => void }) => (
     <div data-testid="source-code-component">
       <div data-testid="code-content">{code}</div>
-      <button data-testid="change-code-button" onClick={() => onCodeChange('new code')}>
+      <button
+        data-testid="change-code-button"
+        onClick={() => {
+          onCodeChange('new code');
+        }}
+      >
         Change Code
       </button>
     </div>

--- a/packages/ui/src/providers/action-confirmation-modal.provider.tsx
+++ b/packages/ui/src/providers/action-confirmation-modal.provider.tsx
@@ -100,7 +100,9 @@ export const ActionConfirmationModalContextProvider: FunctionComponent<PropsWith
           <Button
             key={actionId}
             variant={option.variant}
-            onClick={() => handleAction(actionId)}
+            onClick={() => {
+              handleAction(actionId);
+            }}
             data-testid={`action-confirmation-modal-btn-${actionId}`}
             isDanger={option.isDanger}
           >

--- a/packages/ui/src/providers/action-confirmaton-modal.provider.test.tsx
+++ b/packages/ui/src/providers/action-confirmaton-modal.provider.test.tsx
@@ -31,7 +31,9 @@ describe('ActionConfirmationModalProvider', () => {
     fireEvent.click(confirmButton);
 
     // Wait for actionConfirmation promise to resolve
-    await waitFor(() => expect(actionConfirmationResult).toEqual(ACTION_ID_CONFIRM));
+    await waitFor(() => {
+      expect(actionConfirmationResult).toEqual(ACTION_ID_CONFIRM);
+    });
   });
 
   it('calls actionConfirmation with false when Cancel button is clicked', async () => {
@@ -48,7 +50,9 @@ describe('ActionConfirmationModalProvider', () => {
     fireEvent.click(cancelButton);
 
     // Wait for actionConfirmation promise to resolve
-    await waitFor(() => expect(actionConfirmationResult).toEqual(ACTION_ID_CANCEL));
+    await waitFor(() => {
+      expect(actionConfirmationResult).toEqual(ACTION_ID_CANCEL);
+    });
   });
 
   it('should allow consumers to update the modal title and text', () => {

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -377,8 +377,16 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
                 variant={option.variant}
                 title={option.title}
                 timeout={true}
-                onTimeout={() => closeAlert(option)}
-                actionClose={<AlertActionCloseButton onClose={() => closeAlert(option)} />}
+                onTimeout={() => {
+                  closeAlert(option);
+                }}
+                actionClose={
+                  <AlertActionCloseButton
+                    onClose={() => {
+                      closeAlert(option);
+                    }}
+                  />
+                }
               >
                 {option.description && <>{option.description}</>}
               </Alert>

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -209,7 +209,7 @@ export class DataMapperMetadataService {
     await api.setMetadata(metadataId, metadata);
   }
 
-  private static doCreateDocumentMetadata(
+  private static async doCreateDocumentMetadata(
     api: IMetadataApi,
     definition: DocumentDefinition,
   ): Promise<IDocumentMetadata> {
@@ -230,11 +230,10 @@ export class DataMapperMetadataService {
             });
           })
         : [];
-    return new Promise((resolve) => {
-      void Promise.allSettled(filePromises).then(() => {
-        resolve(answer);
-      });
-    });
+
+    await Promise.allSettled(filePromises);
+
+    return answer;
   }
 
   /**

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -144,7 +144,9 @@ export class DataMapperMetadataService {
               .then((value) => {
                 if (value) definitionFiles[path] = value;
               })
-              .catch((error) => console.log(`Could not read a file "${path}": ${error}`)),
+              .catch((error) => {
+                console.log(`Could not read a file "${path}": ${error}`);
+              }),
           )
         : [];
       void Promise.allSettled(fileReadingPromises).then(() => {
@@ -223,13 +225,15 @@ export class DataMapperMetadataService {
     const filePromises =
       api.shouldSaveSchema && definition.definitionFiles
         ? Object.entries(definition.definitionFiles).map(([path, content]) => {
-            return api
-              .saveResourceContent(path, content)
-              .catch((error) => console.log(`Could not save a file "${path}": ${error}`));
+            return api.saveResourceContent(path, content).catch((error) => {
+              console.log(`Could not save a file "${path}": ${error}`);
+            });
           })
         : [];
     return new Promise((resolve) => {
-      void Promise.allSettled(filePromises).then(() => resolve(answer));
+      void Promise.allSettled(filePromises).then(() => {
+        resolve(answer);
+      });
     });
   }
 

--- a/packages/ui/src/services/documentation.service.ts
+++ b/packages/ui/src/services/documentation.service.ts
@@ -47,9 +47,9 @@ export class DocumentationService {
     documentationEntities.forEach((entity) => {
       const parsedTables = DocumentationService.parseEntity(entity);
       parsedTables &&
-        (Array.isArray(parsedTables) ? parsedTables : [parsedTables]).forEach((table) =>
-          DocumentationService.populateParsedTable(markdown, table),
-        );
+        (Array.isArray(parsedTables) ? parsedTables : [parsedTables]).forEach((table) => {
+          DocumentationService.populateParsedTable(markdown, table);
+        });
     });
     return tsMarkdown(markdown);
   }

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -484,7 +484,9 @@ describe('MappingService', () => {
 
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links).toHaveLength(11);
-      links.forEach((link) => expect(link.sourceNodePath.includes(sourceDoc.fields[0].id)).toBeTruthy());
+      links.forEach((link) => {
+        expect(link.sourceNodePath.includes(sourceDoc.fields[0].id)).toBeTruthy();
+      });
     });
 
     it('should not remove for-each mapping contents (target)', () => {
@@ -526,7 +528,9 @@ describe('MappingService', () => {
 
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       expect(links).toHaveLength(11);
-      links.forEach((link) => expect(link.targetNodePath.includes(targetDoc.fields[0].id)).toBeTruthy());
+      links.forEach((link) => {
+        expect(link.targetNodePath.includes(targetDoc.fields[0].id)).toBeTruthy();
+      });
     });
 
     it("should not remove for-each targeted field when it doesn't have children (source)", () => {

--- a/packages/ui/src/services/parsers/pipe-parser.ts
+++ b/packages/ui/src/services/parsers/pipe-parser.ts
@@ -12,7 +12,7 @@ export class PipeParser {
 
     entity.pipe.spec?.source && PipeParser.populateStep(parsedTable, 'source', entity.pipe.spec.source);
     entity.pipe.spec?.steps?.forEach((step) => {
-      return PipeParser.populateStep(parsedTable, 'step', step);
+      PipeParser.populateStep(parsedTable, 'step', step);
     });
     entity.pipe.spec?.sink && PipeParser.populateStep(parsedTable, 'sink', entity.pipe.spec.sink);
 

--- a/packages/ui/src/services/parsers/route-parser.ts
+++ b/packages/ui/src/services/parsers/route-parser.ts
@@ -107,9 +107,9 @@ export class RouteParser {
       headers: RouteParser.HEADERS_OBJECT_WITH_STEPS,
     });
 
-    interceptArray.forEach((intercept) =>
-      RouteParser.populateObjectWithSteps(parsedTable, intercept as ObjectWithSteps),
-    );
+    interceptArray.forEach((intercept) => {
+      RouteParser.populateObjectWithSteps(parsedTable, intercept as ObjectWithSteps);
+    });
 
     return parsedTable;
   }
@@ -177,7 +177,9 @@ export class RouteParser {
       headers: RouteParser.HEADERS_OBJECT_WITH_STEPS,
     });
 
-    interceptFromArray.forEach((interceptFrom) => RouteParser.populateUriOrObjectWithSteps(parsedTable, interceptFrom));
+    interceptFromArray.forEach((interceptFrom) => {
+      RouteParser.populateUriOrObjectWithSteps(parsedTable, interceptFrom);
+    });
 
     return parsedTable;
   }
@@ -212,9 +214,9 @@ export class RouteParser {
       headers: RouteParser.HEADERS_OBJECT_WITH_STEPS,
     });
 
-    interceptSendToEndpointArray.forEach((interceptSendToEndpoint) =>
-      RouteParser.populateUriOrObjectWithSteps(parsedTable, interceptSendToEndpoint),
-    );
+    interceptSendToEndpointArray.forEach((interceptSendToEndpoint) => {
+      RouteParser.populateUriOrObjectWithSteps(parsedTable, interceptSendToEndpoint);
+    });
 
     return parsedTable;
   }
@@ -242,9 +244,9 @@ export class RouteParser {
       headers: RouteParser.HEADERS_OBJECT_WITH_STEPS,
     });
 
-    onCompletionArray.forEach((onCompletion) =>
-      RouteParser.populateObjectWithSteps(parsedTable, onCompletion as ObjectWithSteps),
-    );
+    onCompletionArray.forEach((onCompletion) => {
+      RouteParser.populateObjectWithSteps(parsedTable, onCompletion as ObjectWithSteps);
+    });
 
     return parsedTable;
   }
@@ -272,9 +274,9 @@ export class RouteParser {
       headers: RouteParser.HEADERS_OBJECT_WITH_STEPS,
     });
 
-    onExceptionArray.forEach((onException) =>
-      RouteParser.populateObjectWithSteps(parsedTable, onException as ObjectWithSteps),
-    );
+    onExceptionArray.forEach((onException) => {
+      RouteParser.populateObjectWithSteps(parsedTable, onException as ObjectWithSteps);
+    });
 
     return parsedTable;
   }

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -566,21 +566,27 @@ export class MappingActionService {
         }
         return 'Configure Sort';
       },
-      apply: (_n, { openModal }) => openModal(MappingActionKind.Sort),
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.Sort);
+      },
       isAllowed: MappingActionService.mappingIsOneOf(ForEachItem),
     },
     {
       key: MappingActionKind.ForEachGroupConfig,
       testId: 'transformation-actions-foreach-group-config',
       getLabel: () => 'Configure for-each-group',
-      apply: (_n, { openModal }) => openModal(MappingActionKind.ForEachGroupConfig),
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.ForEachGroupConfig);
+      },
       isAllowed: MappingActionService.mappingIsOneOf(ForEachGroupItem),
     },
     {
       key: MappingActionKind.Comment,
       testId: 'transformation-actions-comment',
       getLabel: (n) => (n.mapping instanceof MappingItem && n.mapping.comment ? 'Edit Comment' : 'Add Comment'),
-      apply: (_n, { openModal }) => openModal(MappingActionKind.Comment),
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.Comment);
+      },
       isAllowed: (n) => n.mapping instanceof MappingItem,
     },
     {

--- a/packages/ui/src/services/visualization/tree-ui.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.test.ts
@@ -73,7 +73,9 @@ describe('TreeUIService', () => {
       const documentId = sourceDocNode.id;
       const firstChildPath = tree.root.children[0]?.path;
 
-      expect(() => TreeUIService.toggleNode(documentId, firstChildPath)).not.toThrow();
+      expect(() => {
+        TreeUIService.toggleNode(documentId, firstChildPath);
+      }).not.toThrow();
     });
 
     it('should create tree for primitive document', () => {

--- a/packages/ui/src/stubs/read-file-as-string.ts
+++ b/packages/ui/src/stubs/read-file-as-string.ts
@@ -4,8 +4,12 @@ export const readFileAsString = (file: File): Promise<string> => {
     reader.onload = (e) => {
       e.target ? resolve(e.target.result as string) : reject(new Error('Failed to read file'));
     };
-    reader.onerror = () => reject(new Error('Error reading file'));
-    reader.onabort = () => reject(new Error('File reading aborted'));
+    reader.onerror = () => {
+      reject(new Error('Error reading file'));
+    };
+    reader.onabort = () => {
+      reject(new Error('File reading aborted'));
+    };
     reader.readAsText(file);
   });
 };

--- a/packages/ui/src/utils/color-scheme.test.ts
+++ b/packages/ui/src/utils/color-scheme.test.ts
@@ -42,7 +42,9 @@ describe('color-scheme utilities', () => {
     it('does nothing if the HTML element is not found', () => {
       document.querySelector = vi.fn().mockReturnValue(null);
 
-      expect(() => setColorScheme(ColorScheme.Light)).not.toThrow();
+      expect(() => {
+        setColorScheme(ColorScheme.Light);
+      }).not.toThrow();
     });
   });
 

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.test.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedImpl.test.ts
@@ -72,7 +72,9 @@ describe('XmlSchemaNamedImpl', () => {
     it('should throw error when setting empty string as name', () => {
       const named = new XmlSchemaNamedImpl(schema, false);
 
-      expect(() => named.setName('')).toThrow('Attempt to set empty name.');
+      expect(() => {
+        named.setName('');
+      }).toThrow('Attempt to set empty name.');
     });
 
     it('should allow changing name', () => {
@@ -186,7 +188,9 @@ describe('XmlSchemaNamedImpl', () => {
 
       named.setRefObject(refBase);
 
-      expect(() => named.setName('newName')).toThrow("Attempt to set name on object with ref='xxx'");
+      expect(() => {
+        named.setName('newName');
+      }).toThrow("Attempt to set name on object with ref='xxx'");
     });
 
     it('should allow setting name when ref is null', () => {
@@ -204,7 +208,9 @@ describe('XmlSchemaNamedImpl', () => {
       const refBase = new MockRefBase();
       refBase.setTargetQName(new QName('http://test.example.com', 'refTarget'));
 
-      expect(() => named.setRefObject(refBase)).not.toThrow();
+      expect(() => {
+        named.setRefObject(refBase);
+      }).not.toThrow();
     });
 
     it('should allow setting name to null when ref exists', () => {
@@ -214,7 +220,9 @@ describe('XmlSchemaNamedImpl', () => {
 
       named.setRefObject(refBase);
 
-      expect(() => named.setName(null)).not.toThrow();
+      expect(() => {
+        named.setName(null);
+      }).not.toThrow();
     });
   });
 

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.test.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaNamedWithFormImpl.test.ts
@@ -110,9 +110,9 @@ describe('XmlSchemaNamedWithFormImpl', () => {
     it('should throw error when setting null form', () => {
       const element = new XmlSchemaNamedWithFormImpl(schema, false, true);
 
-      expect(() => element.setForm(null as unknown as XmlSchemaForm)).toThrow(
-        'form may not be null. Pass XmlSchemaForm.NONE to use schema default.',
-      );
+      expect(() => {
+        element.setForm(null as unknown as XmlSchemaForm);
+      }).toThrow('form may not be null. Pass XmlSchemaForm.NONE to use schema default.');
     });
 
     it('should update wire name when form changes', () => {

--- a/packages/ui/src/xml-schema-ts/utils/XmlSchemaRefBase.test.ts
+++ b/packages/ui/src/xml-schema-ts/utils/XmlSchemaRefBase.test.ts
@@ -93,9 +93,9 @@ describe('XmlSchemaRefBase', () => {
 
       // Try to change ref - should fail
       const qname2 = new QName('http://test.example.com', 'secondRef');
-      expect(() => refBase.setTargetQName(qname2)).toThrow(
-        'It is invalid to set the ref= name for an item that has a name.',
-      );
+      expect(() => {
+        refBase.setTargetQName(qname2);
+      }).toThrow('It is invalid to set the ref= name for an item that has a name.');
     });
 
     it('should allow setting ref when named object is anonymous', () => {
@@ -104,7 +104,9 @@ describe('XmlSchemaRefBase', () => {
 
       const qname = new QName('http://test.example.com', 'refTarget');
 
-      expect(() => refBase.setTargetQName(qname)).not.toThrow();
+      expect(() => {
+        refBase.setTargetQName(qname);
+      }).not.toThrow();
       expect(refBase.getTargetQName()).toBe(qname);
     });
 
@@ -116,7 +118,9 @@ describe('XmlSchemaRefBase', () => {
       refBase.setNamedObject(named);
       const qname = new QName('http://test.example.com', 'refTarget');
 
-      expect(() => refBase.setTargetQName(qname)).not.toThrow();
+      expect(() => {
+        refBase.setTargetQName(qname);
+      }).not.toThrow();
     });
 
     it('should allow changing ref when already set', () => {
@@ -138,7 +142,9 @@ describe('XmlSchemaRefBase', () => {
 
       // Should not throw when setting ref on anonymous object
       const qname = new QName('http://test.example.com', 'refTarget');
-      expect(() => refBase.setTargetQName(qname)).not.toThrow();
+      expect(() => {
+        refBase.setTargetQName(qname);
+      }).not.toThrow();
     });
 
     it('should enforce name/ref exclusivity when changing ref', () => {
@@ -154,9 +160,9 @@ describe('XmlSchemaRefBase', () => {
 
       // Try to change ref - should fail
       const qname2 = new QName('http://test.example.com', 'secondRef');
-      expect(() => refBase.setTargetQName(qname2)).toThrow(
-        'It is invalid to set the ref= name for an item that has a name.',
-      );
+      expect(() => {
+        refBase.setTargetQName(qname2);
+      }).toThrow('It is invalid to set the ref= name for an item that has a name.');
     });
   });
 
@@ -212,9 +218,9 @@ describe('XmlSchemaRefBase', () => {
 
       // Try to set ref again - should fail
       const newQname = new QName('http://test.example.com', 'newRef');
-      expect(() => refBase.setTargetQName(newQname)).toThrow(
-        'It is invalid to set the ref= name for an item that has a name.',
-      );
+      expect(() => {
+        refBase.setTargetQName(newQname);
+      }).toThrow('It is invalid to set the ref= name for an item that has a name.');
     });
 
     it('should allow changing ref after name is cleared', () => {
@@ -230,14 +236,18 @@ describe('XmlSchemaRefBase', () => {
 
       // Should fail to change ref with name
       const qname2 = new QName('http://test.example.com', 'ref2');
-      expect(() => refBase.setTargetQName(qname2)).toThrow();
+      expect(() => {
+        refBase.setTargetQName(qname2);
+      }).toThrow();
 
       // Clear name
       named.setName(null);
 
       // Should succeed to change ref now
       const qname3 = new QName('http://test.example.com', 'ref3');
-      expect(() => refBase.setTargetQName(qname3)).not.toThrow();
+      expect(() => {
+        refBase.setTargetQName(qname3);
+      }).not.toThrow();
       expect(refBase.getTargetQName()).toBe(qname3);
     });
 


### PR DESCRIPTION
### Context
Enable [@typescript-eslint/no-confusing-void-expressio](https://typescript-eslint.io/rules/no-confusing-void-expression/) eslint rule.

From the docs:
>`void` in TypeScript refers to a function return that is meant to be ignored. Attempting to use a void-typed value, such as storing the result of a called function in a variable, is often a sign of a programmer error. void can also be misleading for other developers even if used correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard-copy verification reliability so automated checks wait more consistently for clipboard reads.
  * Fixed action confirmation modal footer buttons so the action runs only after the button is clicked.
  * Updated editor API promise return behavior for more consistent async resolve semantics (content update, undo, redo).
* **Tests**
  * Refined many async test assertions to use clearer, block-bodied `waitFor` patterns and deterministic checks.
* **Style**
  * Reformatted numerous UI event handlers/callbacks for consistent readability (no intended user-visible behavior changes).
* **Chores**
  * Added a stricter ESLint rule to prevent confusing `void`-expression usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->