### PR TITLE
fix(Canvas): Avoid selecting a node when clicking on delete

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
@@ -362,6 +362,60 @@ describe('StepToolbar', () => {
     });
   });
 
+  describe('Event propagation', () => {
+    it('should stop click propagation to the parent for async actions (delete step)', async () => {
+      const parentOnClick = vi.fn();
+      const mockOnDeleteStep = vi.fn().mockResolvedValue(undefined);
+      mockUseDeleteStep.mockReturnValue({ onDeleteStep: mockOnDeleteStep });
+      mockGetNodeInteraction.mockReturnValue({
+        ...defaultNodeInteraction,
+        canRemoveStep: true,
+      });
+
+      await act(async () => {
+        render(
+          <div onClick={parentOnClick}>
+            <StepToolbar vizNode={mockVizNode} />
+          </div>,
+        );
+      });
+
+      const deleteButton = screen.getByTestId('Test Node|step-toolbar-button-delete');
+      await act(async () => {
+        fireEvent.click(deleteButton);
+      });
+
+      expect(mockOnDeleteStep).toHaveBeenCalledTimes(1);
+      expect(parentOnClick).not.toHaveBeenCalled();
+    });
+
+    it('should stop click propagation to the parent for async actions (add special child)', async () => {
+      const parentOnClick = vi.fn();
+      const mockOnInsertStep = vi.fn().mockResolvedValue(undefined);
+      mockUseInsertStep.mockReturnValue({ onInsertStep: mockOnInsertStep });
+      mockGetNodeInteraction.mockReturnValue({
+        ...defaultNodeInteraction,
+        canHaveSpecialChildren: true,
+      });
+
+      await act(async () => {
+        render(
+          <div onClick={parentOnClick}>
+            <StepToolbar vizNode={mockVizNode} />
+          </div>,
+        );
+      });
+
+      const addSpecialButton = screen.getByTestId('Test Node|step-toolbar-button-add-special');
+      await act(async () => {
+        fireEvent.click(addSpecialButton);
+      });
+
+      expect(mockOnInsertStep).toHaveBeenCalledTimes(1);
+      expect(parentOnClick).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Multiple buttons rendering', () => {
     it('should render all available buttons when all interactions are enabled', async () => {
       const mockOnCollapseToggle = vi.fn();

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -72,8 +72,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Duplicate"
             onClick={async (event) => {
-              await onDuplicate();
               event.stopPropagation();
+              await onDuplicate();
             }}
           />
         )}
@@ -86,8 +86,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Move before"
             onClick={async (event) => {
-              await onMoveBefore();
               event.stopPropagation();
+              await onMoveBefore();
             }}
           />
         )}
@@ -100,8 +100,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Move after"
             onClick={async (event) => {
-              await onMoveAfter();
               event.stopPropagation();
+              await onMoveAfter();
             }}
           />
         )}
@@ -114,8 +114,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Add branch"
             onClick={async (event) => {
-              await onInsertSpecial();
               event.stopPropagation();
+              await onInsertSpecial();
             }}
           />
         )}
@@ -126,9 +126,9 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-disable`}
             variant="control"
             title={isDisabled ? 'Enable step' : 'Disable step'}
-            onClick={async (event) => {
-              onToggleDisableNode();
+            onClick={(event) => {
               event.stopPropagation();
+              onToggleDisableNode();
             }}
           >
             {isDisabled ? <CheckIcon /> : <BanIcon />}
@@ -142,9 +142,9 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-enable-all`}
             variant="control"
             title="Enable all"
-            onClick={async (event) => {
-              onEnableAllSteps();
+            onClick={(event) => {
               event.stopPropagation();
+              onEnableAllSteps();
             }}
           />
         )}
@@ -157,8 +157,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title="Replace step"
             onClick={async (event) => {
-              await onReplaceNode();
               event.stopPropagation();
+              await onReplaceNode();
             }}
           />
         )}
@@ -170,8 +170,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             variant="control"
             title={isCollapsed ? 'Expand step' : 'Collapse step'}
             onClick={(event) => {
-              onCollapseToggle();
               event.stopPropagation();
+              onCollapseToggle();
             }}
           >
             {isCollapsed ? <ExpandArrowsAltIcon /> : <CompressArrowsAltIcon />}
@@ -187,8 +187,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             state="attention"
             title="Delete step"
             onClick={async (event) => {
-              await onDeleteStep();
               event.stopPropagation();
+              await onDeleteStep();
             }}
           />
         )}
@@ -202,8 +202,8 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             state="attention"
             title="Delete group"
             onClick={async (event) => {
-              await onDeleteGroup();
               event.stopPropagation();
+              await onDeleteGroup();
             }}
           />
         )}


### PR DESCRIPTION
### Context
After enabling promise-related linter rules, some events are being propagated before the async handler gets called. This causes a race condition in some cases.

### Changes
The fix in this case is to first stop the event propagation before awaiting the async handler, to ensure no further code gets executed before the handler.

fix: https://github.com/KaotoIO/kaoto/issues/3399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed step toolbar button clicks so they no longer bubble up to parent elements, preventing unintended parent interactions.
  * Improved reliability of step actions (delete, duplicate, move, replace, insert, disable, enable, and collapse/expand) to consistently stop propagation before running their respective behaviors.
* **Tests**
  * Added coverage for event propagation behavior, including scenarios where toolbar actions complete asynchronously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->