### PR TITLE
fix(Shell): Fix navigation bar not expanding on mobile

### DIFF
--- a/packages/ui/src/layout/Shell.tsx
+++ b/packages/ui/src/layout/Shell.tsx
@@ -8,6 +8,8 @@ import { LocalStorageKeys } from '../models';
 import { Navigation } from './Navigation';
 import { TopBar } from './TopBar';
 
+const NOOP_PAGE_RESIZE = () => {};
+
 export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
   const defaultNavState = useMemo(() => {
     if (globalThis.innerWidth !== undefined) {
@@ -24,7 +26,16 @@ export const Shell: FunctionComponent<PropsWithChildren> = (props) => {
   }, [isNavOpen, setIsNavOpen]);
 
   return (
-    <Page isContentFilled masthead={<TopBar navToggle={navToggle} />} sidebar={<Navigation isNavOpen={isNavOpen} />}>
+    <Page
+      isContentFilled
+      // `onPageResize` makes PatternFly's Page install its ResizeObserver and track mobile view,
+      // which is required for PageSidebar to receive `isMobile` and apply the `pf-m-expanded`
+      // modifier. Without it the off-canvas sidebar can never slide into view on small screens.
+      // relates: https://github.com/KaotoIO/kaoto/issues/3401
+      onPageResize={NOOP_PAGE_RESIZE}
+      masthead={<TopBar navToggle={navToggle} />}
+      sidebar={<Navigation isNavOpen={isNavOpen} />}
+    >
       <PageSection isFilled hasBodyWrapper={false} className="shell__page-section">
         {props.children}
       </PageSection>


### PR DESCRIPTION
### Context
On small/narrow screens (viewport width < 1200px), clicking the navigation toggle (the hamburger "Global navigation" button in the masthead) does not open the navigation sidebar. The toggle works correctly on wide screens (≥ 1200px).

### Changes
The fix is to add a `onPageResize` handler to let patternfly recalculate the viewport.

fix: https://github.com/KaotoIO/kaoto/issues/3401