### PR TITLE
chore(test): refactor create mock entities context

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -9,6 +9,7 @@ import {
   ActionConfirmationModalContext,
 } from '../../../../providers/action-confirmation-modal.provider';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import {
   IInteractionType,
   IOnDeleteAddon,
@@ -31,15 +32,7 @@ describe('ItemReplaceStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   const mockReplaceModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-group.hook.test.tsx
@@ -8,6 +8,7 @@ import { IVisualizationNode } from '../../../../models/visualization/base-visual
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../providers';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import {
   IInteractionType,
   INodeInteractionAddonContext,
@@ -30,15 +31,7 @@ describe('useDeleteGroup', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   const mockActionConfirmationModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-step.hook.test.tsx
@@ -8,6 +8,7 @@ import { IVisualizationNode } from '../../../../models/visualization/base-visual
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../providers';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import {
   IInteractionType,
   INodeInteractionAddonContext,
@@ -30,15 +31,7 @@ describe('useDeleteStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   const mockActionConfirmationModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
@@ -6,6 +6,7 @@ import { CamelRouteResource } from '../../../../models/camel/camel-route-resourc
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs/create-mock-entities-context';
 import { useDisableStep } from './disable-step.hook';
 
 vi.mock('@kaoto/forms', () => ({
@@ -18,15 +19,7 @@ describe('useDisableStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   beforeEach(() => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -10,7 +10,7 @@ import { VisualFlowsApi } from '../../../../models/visualization/flows/support/f
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { VisibleFlowsContext, VisibleFlowsContextResult } from '../../../../providers';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
-import { camelRouteJson } from '../../../../stubs/camel-route';
+import { camelRouteJson, createMockEntitiesContext } from '../../../../stubs';
 import { updateIds } from '../../../../utils/update-ids';
 import { NodeInteractionAddonContext } from '../../../registers/interactions/node-interaction-addon.provider';
 import { useDuplicateStep } from './duplicate-step.hook';
@@ -86,15 +86,7 @@ describe('useDuplicateStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   // Mock CatalogModalContext

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -6,6 +6,7 @@ import { CamelRouteResource } from '../../../../models/camel/camel-route-resourc
 import { EntityType } from '../../../../models/entities';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
 import { setValue } from '../../../../utils/set-value';
 import { useEnableAllSteps } from './enable-all-steps.hook';
@@ -32,15 +33,7 @@ describe('useEnableAllSteps', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   beforeEach(() => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -10,6 +10,7 @@ import { CamelComponentSchemaService } from '../../../../models/visualization/fl
 import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import { useInsertStep } from './insert-step.hook';
 
 const mockController = {
@@ -26,15 +27,7 @@ describe('useInsertStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   const mockCatalogModalContext = {

--- a/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/move-step.hook.test.tsx
@@ -8,7 +8,7 @@ import { AddStepMode, IVisualizationNode } from '../../../../models/visualizatio
 import { CamelRouteVisualEntity } from '../../../../models/visualization/flows/camel-route-visual-entity';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
-import { camelRouteJson, camelRouteJsonWithDM } from '../../../../stubs/camel-route';
+import { camelRouteJson, camelRouteJsonWithDM, createMockEntitiesContext } from '../../../../stubs';
 import { getPotentialPath } from '../../../../utils/get-potential-path';
 import { getVisualizationNodesFromGraph } from '../../../../utils/get-viznodes-from-graph';
 import { NodeInteractionAddonProvider } from '../../../registers/interactions/node-interaction-addon.provider';
@@ -48,15 +48,7 @@ describe('useMoveStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
   });
 
   const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -11,6 +11,7 @@ import { CamelComponentSchemaService } from '../../../../models/visualization/fl
 import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
+import { createMockEntitiesContext } from '../../../../stubs';
 import { ClipboardManager } from '../../../../utils/ClipboardManager';
 import { usePasteStep } from './paste-step.hook';
 
@@ -36,17 +37,9 @@ describe('usePasteStep', () => {
   let mockEntitiesContext: EntitiesContextResult;
 
   beforeAll(async () => {
-    await camelResource.initialize();
+    mockEntitiesContext = await createMockEntitiesContext(camelResource);
     getCompatibleComponentsSpy = vi.spyOn(camelResource, 'getCompatibleComponents');
     getTypeSpy = vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Route);
-    mockEntitiesContext = {
-      camelResource,
-      entities: camelResource.getEntities(),
-      visualEntities: camelResource.getVisualEntities(),
-      currentSchemaType: camelResource.getType(),
-      updateSourceCodeFromEntities: vi.fn(),
-      updateEntitiesFromCamelResource: vi.fn(),
-    };
   });
 
   // Mock CatalogModalContext

--- a/packages/ui/src/stubs/create-mock-entities-context.ts
+++ b/packages/ui/src/stubs/create-mock-entities-context.ts
@@ -1,0 +1,14 @@
+import { CamelRouteResource } from '../models/camel/camel-route-resource';
+import { EntitiesContextResult } from '../providers/entities.provider';
+
+export const createMockEntitiesContext = async (camelResource: CamelRouteResource): Promise<EntitiesContextResult> => {
+  await camelResource.initialize();
+  return {
+    camelResource,
+    entities: camelResource.getEntities(),
+    visualEntities: camelResource.getVisualEntities(),
+    currentSchemaType: camelResource.getType(),
+    updateSourceCodeFromEntities: vi.fn(),
+    updateEntitiesFromCamelResource: vi.fn(),
+  };
+};

--- a/packages/ui/src/stubs/index.ts
+++ b/packages/ui/src/stubs/index.ts
@@ -1,4 +1,5 @@
 export * from './camel-route';
+export * from './create-mock-entities-context';
 export * from './kamelet-binding-route';
 export * from './kamelet-route';
 export * from './mock-random-values';


### PR DESCRIPTION
Refactor test helper: extract `createMockEntitiesContext `stub

Introduces a shared `createMockEntitiesContext` stub factory that builds a mock `EntitiesContextResult` from a given `CamelRouteResource`. Nine test files that previously duplicated this setup inline are updated to use the new helper, removing ~50 lines of repeated boilerplate.

Depends on: https://github.com/KaotoIO/kaoto/pull/3383

fix: https://github.com/KaotoIO/kaoto/issues/3406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified several visualization hook tests by switching to a shared mock setup.
  * Improved consistency across test cases and reduced duplicated test code.

* **Chores**
  * Added a reusable helper for creating mock entities contexts and made it available through shared test stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->