### PR TITLE
chore(DataMapper): Abstract UX: S2: Model — Abstract selection proper…

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
@@ -10,6 +10,7 @@ import { FieldOverrideService } from '../../../../services/document/field-overri
 import { XmlSchemaDocumentService } from '../../../../services/document/xml-schema/xml-schema-document.service';
 import { TreeParsingService } from '../../../../services/visualization/tree-parsing.service';
 import { getFieldSubstitutionXsd } from '../../../../stubs/datamapper/data-mapper';
+import { QName } from '../../../../xml-schema-ts/QName';
 import { SourceDocumentNodeWithContextMenu } from '../../SourceDocumentNode';
 
 const NS_SUBSTITUTION = 'http://www.example.com/SUBSTITUTION';
@@ -38,8 +39,7 @@ describe('useAbstractFieldSubstitutionMenu', () => {
     const abstractAnimalField = document.fields[0];
 
     if (selectMember) {
-      const catIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Cat');
-      abstractAnimalField.selectedMemberIndex = catIndex;
+      abstractAnimalField.selectedMemberQName = new QName(NS_SUBSTITUTION, 'Cat');
     }
 
     const documentNodeData = new DocumentNodeData(document);

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
@@ -6,6 +6,7 @@ import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
 import { IFieldSubstituteInfo } from '../../../../models/datamapper/types';
 import { NodeData } from '../../../../models/datamapper/visualization';
+import { DocumentUtilService } from '../../../../services/document/document-util.service';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { MenuAction, MenuGroup } from '../FieldContextMenu';
 import { SubstitutionSelectionModal } from '../SubstitutionSelectionModal';
@@ -81,8 +82,8 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
   }, [abstractWrapperField, mappingTree.namespaceMap]);
 
   const selectedQName = useMemo(() => {
-    if (abstractWrapperField?.selectedMemberIndex === undefined) return undefined;
-    const selectedField = abstractWrapperField.fields[abstractWrapperField.selectedMemberIndex];
+    if (!abstractWrapperField) return undefined;
+    const selectedField = DocumentUtilService.getSelectedMember(abstractWrapperField);
     if (!selectedField) return undefined;
     return findCandidateQName(candidates, selectedField);
   }, [abstractWrapperField, candidates]);

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
@@ -43,8 +43,7 @@ describe('useFieldOverrideMenu', () => {
     const document = result.document;
     const abstractAnimalField = document.fields[0].fields.find((f) => f.wrapperKind === 'abstract')!;
     if (selectCandidate) {
-      const catIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Cat');
-      abstractAnimalField.selectedMemberIndex = catIndex;
+      abstractAnimalField.selectedMemberQName = new QName(NS_SUBSTITUTION, 'Cat');
     }
 
     const documentNodeData = new DocumentNodeData(document);

--- a/packages/ui/src/components/Document/actions/FieldOverride/revert-override.ts
+++ b/packages/ui/src/components/Document/actions/FieldOverride/revert-override.ts
@@ -12,7 +12,7 @@ export function revertOverride(
   namespaceMap: Record<string, string>,
   updateDocument: (document: IDocument, definition: DocumentDefinition, previousRefId: string) => void,
 ): void {
-  const hasAbstractSubstitution = field.wrapperKind === 'abstract' && field.selectedMemberIndex !== undefined;
+  const hasAbstractSubstitution = field.wrapperKind === 'abstract' && field.selectedMemberQName !== undefined;
   if (field.typeOverride === FieldOverrideVariant.NONE && !hasAbstractSubstitution) return;
 
   const document = field.ownerDocument;

--- a/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
@@ -9,7 +9,7 @@ import { SubstitutionSelectionModal } from './SubstitutionSelectionModal';
 describe('SubstitutionSelectionModal', () => {
   const createMockAbstractField = (
     candidates: Array<{ qname: string; displayName: string; namespaceURI?: string; localPart?: string }>,
-    selectedMemberIndex?: number,
+    selectedMemberQName?: QName,
   ): { abstractField: IField; candidatesMap: Record<string, IFieldSubstituteInfo> } => {
     const fields = candidates.map((c) => ({
       name: c.localPart || c.qname.split(':')[1] || c.qname,
@@ -37,7 +37,7 @@ describe('SubstitutionSelectionModal', () => {
         displayName: 'Test Abstract',
         wrapperKind: 'abstract',
         fields,
-        selectedMemberIndex,
+        selectedMemberQName,
       } as unknown as IField,
       candidatesMap,
     };
@@ -127,7 +127,7 @@ describe('SubstitutionSelectionModal', () => {
         { qname: 'ns:Email', displayName: 'Email', localPart: 'Email', namespaceURI: 'http://example.com' },
         { qname: 'ns:Phone', displayName: 'Phone', localPart: 'Phone', namespaceURI: 'http://example.com' },
       ],
-      1,
+      new QName('http://example.com', 'Phone'),
     );
     render(
       <SubstitutionSelectionModal
@@ -165,7 +165,7 @@ describe('SubstitutionSelectionModal', () => {
         { qname: 'ns:Email', displayName: 'Email', localPart: 'Email', namespaceURI: 'http://example.com' },
         { qname: 'ns:Phone', displayName: 'Phone', localPart: 'Phone', namespaceURI: 'http://example.com' },
       ],
-      0,
+      new QName('http://example.com', 'Email'),
     );
     render(
       <SubstitutionSelectionModal
@@ -208,7 +208,7 @@ describe('SubstitutionSelectionModal', () => {
         { qname: 'ns:Email', displayName: 'Email', localPart: 'Email', namespaceURI: 'http://example.com' },
         { qname: 'ns:Phone', displayName: 'Phone', localPart: 'Phone', namespaceURI: 'http://example.com' },
       ],
-      1,
+      new QName('http://example.com', 'Phone'),
     );
     render(
       <SubstitutionSelectionModal
@@ -370,7 +370,7 @@ describe('SubstitutionSelectionModal', () => {
     const { abstractField, candidatesMap } = createMockAbstractField([
       { qname: 'ns:Email', displayName: 'Email', localPart: 'Email', namespaceURI: 'http://example.com' },
     ]);
-    abstractField.selectedMemberIndex = undefined;
+    abstractField.selectedMemberQName = undefined;
 
     render(
       <SubstitutionSelectionModal

--- a/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.tsx
+++ b/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useMemo } from 'react';
 
 import { IField } from '../../../models/datamapper/document';
 import { IFieldSubstituteInfo } from '../../../models/datamapper/types';
+import { DocumentUtilService } from '../../../services/document/document-util.service';
 import { findCandidateQName } from './FieldContextMenu/menu-utils';
 import { MemberSelectionModal } from './MemberSelectionModal';
 
@@ -33,11 +34,10 @@ export const SubstitutionSelectionModal: FunctionComponent<SubstitutionSelection
   );
 
   const selectedValue = useMemo(() => {
-    if (abstractField.selectedMemberIndex === undefined) return null;
-    const selectedField = abstractField.fields[abstractField.selectedMemberIndex];
+    const selectedField = DocumentUtilService.getSelectedMember(abstractField);
     if (!selectedField) return null;
     return findCandidateQName(candidates, selectedField) ?? null;
-  }, [abstractField.selectedMemberIndex, abstractField.fields, candidates]);
+  }, [abstractField, candidates]);
 
   return (
     <MemberSelectionModal<string>

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -125,8 +125,15 @@ export interface IField {
   predicates: Predicate[];
   /** Discriminator for synthetic wrapper fields: `'choice'` for xs:choice compositors, `'abstract'` for abstract element wrappers */
   wrapperKind?: WrapperKind;
-  /** Index of selected member (0-based), undefined = show all */
+  /** Index of selected member (0-based), undefined = show all. Used by choice wrappers. */
   selectedMemberIndex?: number;
+  /**
+   * QName of the selected substitution candidate. Used by abstract wrappers only.
+   * Abstract wrappers use name-based selection because their candidate set is open-ended —
+   * new candidates can appear when additional schemas are attached, which would invalidate
+   * positional indices. QName-based selection is stable across wrapper child rebuilds.
+   */
+  selectedMemberQName?: QName;
   /** Whether the field's declared type is an abstract xs:complexType */
   isAbstractType?: boolean;
   /** Optional description extracted from xs:annotation/xs:documentation for tooltip/help text */
@@ -324,6 +331,7 @@ export class BaseField implements IField {
   predicates: Predicate[] = [];
   wrapperKind?: WrapperKind;
   selectedMemberIndex?: number;
+  selectedMemberQName?: QName;
   isAbstractType?: boolean;
   originalField?: IOriginalFieldState;
   description?: string;
@@ -337,6 +345,7 @@ export class BaseField implements IField {
     }
     if (this.wrapperKind !== undefined) existing.wrapperKind = this.wrapperKind;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
+    if (this.selectedMemberQName !== undefined) existing.selectedMemberQName = this.selectedMemberQName;
     if (this.isAbstractType !== undefined) existing.isAbstractType = this.isAbstractType;
     if (this.description !== undefined) existing.description = this.description;
     for (const child of this.fields) child.adopt(existing);
@@ -364,6 +373,7 @@ export class BaseField implements IField {
     adopted.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     adopted.wrapperKind = this.wrapperKind;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
+    adopted.selectedMemberQName = this.selectedMemberQName;
     adopted.isAbstractType = this.isAbstractType;
     adopted.description = this.description;
     adopted.fields = this.fields.map((child) => child.adopt(adopted));

--- a/packages/ui/src/services/document/choice-selection.service.test.ts
+++ b/packages/ui/src/services/document/choice-selection.service.test.ts
@@ -281,15 +281,15 @@ describe('ChoiceSelectionService', () => {
         const abstractField = findAbstractField(choiceField);
 
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
-        const emailIndex = abstractField.selectedMemberIndex;
-        expect(emailIndex).toBeDefined();
+        const emailQName = abstractField.selectedMemberQName;
+        expect(emailQName).toBeDefined();
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
 
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution stays in both definition and live field — consistent state
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
-        expect(abstractField.selectedMemberIndex).toBe(emailIndex);
+        expect(abstractField.selectedMemberQName).toBe(emailQName);
       });
 
       it('should preserve descendant abstract substitution when clearing choice selection', () => {
@@ -300,15 +300,15 @@ describe('ChoiceSelectionService', () => {
 
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:SMS', nsMap);
-        const smsIndex = abstractField.selectedMemberIndex;
-        expect(smsIndex).toBeDefined();
+        const smsQName = abstractField.selectedMemberQName;
+        expect(smsQName).toBeDefined();
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
 
         ChoiceSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
 
         // Substitution preserved
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
-        expect(abstractField.selectedMemberIndex).toBe(smsIndex);
+        expect(abstractField.selectedMemberQName).toBe(smsQName);
       });
 
       it('should allow reverting abstract substitution after parent choice selection (issue #3234)', () => {
@@ -318,14 +318,14 @@ describe('ChoiceSelectionService', () => {
         const abstractField = findAbstractField(choiceField);
 
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
-        expect(abstractField.selectedMemberIndex).toBeDefined();
+        expect(abstractField.selectedMemberQName).toBeDefined();
 
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution is preserved, so revert should work
         FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
 
-        expect(abstractField.selectedMemberIndex).toBeUndefined();
+        expect(abstractField.selectedMemberQName).toBeUndefined();
         expect(doc.definition.fieldSubstitutions ?? []).toHaveLength(0);
       });
 
@@ -343,8 +343,7 @@ describe('ChoiceSelectionService', () => {
 
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
         expect(doc.definition.fieldSubstitutions![0].name).toBe('ca:SMS');
-        const smsIndex = abstractField.fields.findIndex((f) => f.name === 'SMS');
-        expect(abstractField.selectedMemberIndex).toBe(smsIndex);
+        expect(abstractField.selectedMemberQName?.getLocalPart()).toBe('SMS');
       });
 
       it('should allow revert after switching substitution across choice changes', () => {
@@ -359,7 +358,7 @@ describe('ChoiceSelectionService', () => {
 
         FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
 
-        expect(abstractField.selectedMemberIndex).toBeUndefined();
+        expect(abstractField.selectedMemberQName).toBeUndefined();
         expect(doc.definition.fieldSubstitutions).toHaveLength(0);
       });
     });
@@ -458,14 +457,14 @@ describe('ChoiceSelectionService', () => {
 
         // Select substitution
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
-        const emailIndex = abstractField.selectedMemberIndex;
+        const emailQName = abstractField.selectedMemberQName;
 
         // Switch choice away and back
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution survived
-        expect(abstractField.selectedMemberIndex).toBe(emailIndex);
+        expect(abstractField.selectedMemberQName).toBe(emailQName);
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
         expect(doc.definition.fieldSubstitutions![0].name).toBe('ca:Email');
       });
@@ -477,7 +476,7 @@ describe('ChoiceSelectionService', () => {
         const abstractField = findAbstractField(choiceField);
 
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:SMS', nsMap);
-        const smsIndex = abstractField.selectedMemberIndex;
+        const smsQName = abstractField.selectedMemberQName;
 
         // Multiple choice changes
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
@@ -486,7 +485,7 @@ describe('ChoiceSelectionService', () => {
         ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution survived all transitions
-        expect(abstractField.selectedMemberIndex).toBe(smsIndex);
+        expect(abstractField.selectedMemberQName).toBe(smsQName);
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       });
     });

--- a/packages/ui/src/services/document/document-util.service.test.ts
+++ b/packages/ui/src/services/document/document-util.service.test.ts
@@ -1572,6 +1572,73 @@ describe('DocumentUtilService', () => {
     });
   });
 
+  describe('getSelectedMember()', () => {
+    it('should return selected member by index for choice wrappers', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const choiceField = new XmlSchemaField(doc.fields[0], '__choice__', false);
+      choiceField.wrapperKind = 'choice';
+      const member0 = new XmlSchemaField(choiceField, 'email', false);
+      const member1 = new XmlSchemaField(choiceField, 'phone', false);
+      choiceField.fields = [member0, member1];
+      choiceField.selectedMemberIndex = 1;
+
+      const result = DocumentUtilService.getSelectedMember(choiceField);
+
+      expect(result).toBe(member1);
+    });
+
+    it('should return selected member by QName for abstract wrappers', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const abstractField = new XmlSchemaField(doc.fields[0], 'AbstractAnimal', false);
+      abstractField.wrapperKind = 'abstract';
+      const cat = new XmlSchemaField(abstractField, 'Cat', false);
+      cat.namespaceURI = 'http://example.com/test';
+      const dog = new XmlSchemaField(abstractField, 'Dog', false);
+      dog.namespaceURI = 'http://example.com/test';
+      abstractField.fields = [cat, dog];
+      abstractField.selectedMemberQName = new QName('http://example.com/test', 'Cat');
+
+      const result = DocumentUtilService.getSelectedMember(abstractField);
+
+      expect(result).toBe(cat);
+    });
+
+    it('should return undefined when no selection for abstract wrapper', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const abstractField = new XmlSchemaField(doc.fields[0], 'AbstractAnimal', false);
+      abstractField.wrapperKind = 'abstract';
+      const cat = new XmlSchemaField(abstractField, 'Cat', false);
+      abstractField.fields = [cat];
+
+      const result = DocumentUtilService.getSelectedMember(abstractField);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when QName does not match any child', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const abstractField = new XmlSchemaField(doc.fields[0], 'AbstractAnimal', false);
+      abstractField.wrapperKind = 'abstract';
+      const cat = new XmlSchemaField(abstractField, 'Cat', false);
+      cat.namespaceURI = 'http://example.com/test';
+      abstractField.fields = [cat];
+      abstractField.selectedMemberQName = new QName('http://example.com/test', 'Dog');
+
+      const result = DocumentUtilService.getSelectedMember(abstractField);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for non-wrapper fields', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const normalField = new XmlSchemaField(doc.fields[0], 'normalField', false);
+
+      const result = DocumentUtilService.getSelectedMember(normalField);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('processOverrides() with substitutions', () => {
     const namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test', xs: NS_XML_SCHEMA };
 

--- a/packages/ui/src/services/document/document-util.service.ts
+++ b/packages/ui/src/services/document/document-util.service.ts
@@ -48,6 +48,26 @@ export class DocumentUtilService {
   }
 
   /**
+   * Resolves the currently selected member from a wrapper field.
+   * Choice wrappers use positional selection ({@link IField.selectedMemberIndex}).
+   * Abstract wrappers use name-based selection ({@link IField.selectedMemberQName})
+   * because their candidate set is open-ended and must survive wrapper child rebuilds.
+   */
+  static getSelectedMember(field: IField): IField | undefined {
+    if (field.wrapperKind === 'choice') {
+      return field.selectedMemberIndex === undefined ? undefined : field.fields?.[field.selectedMemberIndex];
+    }
+    if (field.wrapperKind === 'abstract' && field.selectedMemberQName) {
+      return field.fields?.find(
+        (child) =>
+          child.name === field.selectedMemberQName!.getLocalPart() &&
+          child.namespaceURI === field.selectedMemberQName!.getNamespaceURI(),
+      );
+    }
+    return undefined;
+  }
+
+  /**
    * Resolve type fragments from reference and populate into the document tree so that it could be expanded in the UI.
    *
    *  @TODO is it safe to change field type dynamically even on XML field? we might eventually need to readahead field type
@@ -136,7 +156,7 @@ export class DocumentUtilService {
   /**
    * Performs an in-place mutation of a non-abstract field, overwriting its wire name, type,
    * namespace, and fragment refs with the substitute element's metadata.
-   * Only used for non-abstract fields — abstract wrapper fields use `selectedMemberIndex`
+   * Only used for non-abstract fields — abstract wrapper fields use `selectedMemberQName`
    * instead. See {@link processFieldSubstitution} for the branching logic.
    *
    * @param field - The field to apply the substitution to
@@ -166,7 +186,7 @@ export class DocumentUtilService {
    * Two distinct paths exist depending on the target field:
    * - **Abstract wrapper fields** (`wrapperKind='abstract'`): the wrapper already holds all concrete
    *   substitution candidates as children (populated by the parser). Applying a substitution
-   *   finds the matching candidate by name and sets `selectedMemberIndex` on the wrapper —
+   *   finds the matching candidate by name and sets `selectedMemberQName` on the wrapper —
    *   the field tree is not mutated.
    * - **Non-abstract fields**: the field is directly mutated via {@link applySubstitutionToField},
    *   which replaces the field's name, type, namespace, and children with the substitute
@@ -189,12 +209,11 @@ export class DocumentUtilService {
     if (field.wrapperKind === 'abstract') {
       const info = resolveSubstituteFn(document, substitution, namespaceMap);
       if (!info) return;
-      const candidateName = info.qname.getLocalPart();
-      const candidateIndex = field.fields.findIndex(
-        (f) => f.name === candidateName && f.namespaceURI === info.qname.getNamespaceURI(),
+      const candidate = field.fields.some(
+        (f) => f.name === info.qname.getLocalPart() && f.namespaceURI === info.qname.getNamespaceURI(),
       );
-      if (candidateIndex >= 0) {
-        field.selectedMemberIndex = candidateIndex;
+      if (candidate) {
+        field.selectedMemberQName = info.qname;
       }
       return;
     }

--- a/packages/ui/src/services/document/field-override.service.test.ts
+++ b/packages/ui/src/services/document/field-override.service.test.ts
@@ -717,8 +717,8 @@ describe('FieldOverrideService', () => {
       expect(doc.definition.fieldSubstitutions![0].name).toBe('sub:Cat');
       expect(abstractAnimalField.wrapperKind).toBe('abstract');
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
-      const catIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Cat');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(catIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Cat');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe(NS_SUBSTITUTION);
     });
 
     it('should revert substitution and restore original field state', () => {
@@ -728,13 +728,13 @@ describe('FieldOverrideService', () => {
       const originalFieldCount = abstractAnimalField.fields.length;
 
       FieldOverrideService.applyFieldSubstitution(abstractAnimalField, 'sub:Cat', namespaceMap);
-      expect(abstractAnimalField.selectedMemberIndex).toBeDefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeDefined();
 
       FieldOverrideService.revertFieldSubstitution(abstractAnimalField, namespaceMap);
 
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
       expect(abstractAnimalField.wrapperKind).toBe('abstract');
-      expect(abstractAnimalField.selectedMemberIndex).toBeUndefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
       expect(abstractAnimalField.fields).toHaveLength(originalFieldCount);
       expect(doc.definition.fieldSubstitutions).toHaveLength(0);
     });
@@ -761,12 +761,12 @@ describe('FieldOverrideService', () => {
 
       FieldOverrideService.applyFieldSubstitution(abstractAnimalField, 'sub:Cat', namespaceMap);
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
-      expect(abstractAnimalField.selectedMemberIndex).toBeDefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeDefined();
 
       FieldOverrideService.revertFieldSubstitution(abstractAnimalField, namespaceMap);
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(0);
-      expect(abstractAnimalField.selectedMemberIndex).toBeUndefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
     });
 
     it('should do nothing on apply when document is not XmlSchemaDocument', () => {
@@ -823,8 +823,8 @@ describe('FieldOverrideService', () => {
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('sub:Dog');
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
-      const dogIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Dog');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(dogIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Dog');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe(NS_SUBSTITUTION);
     });
 
     it('should register missing namespace and prefix the key when namespace is not in map', () => {
@@ -836,7 +836,7 @@ describe('FieldOverrideService', () => {
 
       expect(namespaceMap['ns0']).toBe(NS_SUBSTITUTION);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('ns0:Cat');
-      expect(abstractAnimalField.selectedMemberIndex).toBeDefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeDefined();
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
     });
 
@@ -849,7 +849,8 @@ describe('FieldOverrideService', () => {
 
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
       const fishIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Fish');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(fishIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Fish');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe(NS_SUBSTITUTION);
       const fishField = abstractAnimalField.fields[fishIndex];
       expect(fishField.fields.some((f) => f.name === 'freshwater')).toBe(true);
     });
@@ -867,13 +868,13 @@ describe('FieldOverrideService', () => {
       FieldOverrideService.applyFieldSubstitution(abstractAnimalField, catKey, namespaceMap);
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
-      const catIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Cat');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(catIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Cat');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe(NS_SUBSTITUTION);
 
       FieldOverrideService.revertFieldSubstitution(abstractAnimalField, namespaceMap);
 
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
-      expect(abstractAnimalField.selectedMemberIndex).toBeUndefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
       expect(abstractAnimalField.fields).toHaveLength(originalFieldCount);
       expect(doc.definition.fieldSubstitutions ?? []).toHaveLength(0);
     });
@@ -919,8 +920,8 @@ describe('FieldOverrideService', () => {
       expect(doc.definition.fieldSubstitutions![0].name).toBe('Cat');
       expect(abstractAnimalField.wrapperKind).toBe('abstract');
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
-      const catIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Cat');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(catIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Cat');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe('');
     });
 
     it('should revert Cat substitution and restore blank-namespace field', () => {
@@ -933,7 +934,7 @@ describe('FieldOverrideService', () => {
 
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
       expect(abstractAnimalField.wrapperKind).toBe('abstract');
-      expect(abstractAnimalField.selectedMemberIndex).toBeUndefined();
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
       expect(abstractAnimalField.fields).toHaveLength(originalFieldCount);
       expect(doc.definition.fieldSubstitutions).toHaveLength(0);
     });
@@ -958,8 +959,8 @@ describe('FieldOverrideService', () => {
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('Dog');
       expect(abstractAnimalField.name).toBe('AbstractAnimal');
-      const dogIndex = abstractAnimalField.fields.findIndex((f) => f.name === 'Dog');
-      expect(abstractAnimalField.selectedMemberIndex).toBe(dogIndex);
+      expect(abstractAnimalField.selectedMemberQName?.getLocalPart()).toBe('Dog');
+      expect(abstractAnimalField.selectedMemberQName?.getNamespaceURI()).toBe('');
     });
   });
 });

--- a/packages/ui/src/services/document/field-override.service.ts
+++ b/packages/ui/src/services/document/field-override.service.ts
@@ -24,7 +24,7 @@ import { XmlSchemaTypesService } from './xml-schema/xml-schema-types.service';
  *
  * **Design constraint:** Field Type Override and Field Substitution are mutually exclusive.
  * A field can have at most one active: either a Field Type Override (`SAFE`/`FORCE`) or a
- * Field Substitution (`SUBSTITUTION` / `selectedMemberIndex`), never both. The {@link FieldOverrideModal}
+ * Field Substitution (`SUBSTITUTION` / `selectedMemberQName`), never both. The {@link FieldOverrideModal}
  * enforces this by disabling the inactive radio when an override exists. Service methods
  * `applyFieldTypeOverride` and `applyFieldSubstitution` also guard against conflicting state.
  * For abstract wrappers, `withFieldContextMenu` redirects UI actions to the wrapper
@@ -260,7 +260,7 @@ export class FieldOverrideService {
 
     if (
       field.typeOverride === FieldOverrideVariant.SUBSTITUTION ||
-      (field.wrapperKind === 'abstract' && field.selectedMemberIndex !== undefined)
+      (field.wrapperKind === 'abstract' && field.selectedMemberQName !== undefined)
     ) {
       return;
     }
@@ -449,13 +449,7 @@ export class FieldOverrideService {
       document.definition.fieldSubstitutions.push(entry);
     }
     if (field.wrapperKind === 'abstract') {
-      const candidateName = candidate.qname.getLocalPart();
-      const candidateIndex = field.fields.findIndex(
-        (f) => f.name === candidateName && f.namespaceURI === candidate.qname.getNamespaceURI(),
-      );
-      if (candidateIndex >= 0) {
-        field.selectedMemberIndex = candidateIndex;
-      }
+      field.selectedMemberQName = candidate.qname;
     } else {
       const livePath = SchemaPathService.build(field, namespaceMap);
       DocumentUtilService.applySubstitutionToField(field, candidate);
@@ -488,7 +482,7 @@ export class FieldOverrideService {
       (s) => s.schemaPath !== originalPath,
     );
     if (field.wrapperKind === 'abstract') {
-      field.selectedMemberIndex = undefined;
+      field.selectedMemberQName = undefined;
     } else if (field.typeOverride === FieldOverrideVariant.SUBSTITUTION) {
       DocumentUtilService.restoreOriginalField(field);
       DocumentUtilService.invalidateDescendants(document, originalPath);

--- a/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.model.ts
@@ -507,6 +507,7 @@ export class JsonSchemaField extends BaseField {
     }
     if (this.wrapperKind !== undefined) existing.wrapperKind = this.wrapperKind;
     if (this.selectedMemberIndex !== undefined) existing.selectedMemberIndex = this.selectedMemberIndex;
+    if (this.selectedMemberQName !== undefined) existing.selectedMemberQName = this.selectedMemberQName;
     if (this.description !== undefined) existing.description = this.description;
     for (const child of this.fields) child.adopt(existing);
     return existing;
@@ -524,6 +525,7 @@ export class JsonSchemaField extends BaseField {
     to.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     to.wrapperKind = this.wrapperKind;
     to.selectedMemberIndex = this.selectedMemberIndex;
+    to.selectedMemberQName = this.selectedMemberQName;
     to.description = this.description;
     to.fields = this.fields.map((child) => child.adopt(to) as JsonSchemaField);
     return to;

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.model.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.model.ts
@@ -95,6 +95,7 @@ export class XmlSchemaField extends BaseField {
     adopted.namedTypeFragmentRefs = this.namedTypeFragmentRefs;
     adopted.wrapperKind = this.wrapperKind;
     adopted.selectedMemberIndex = this.selectedMemberIndex;
+    adopted.selectedMemberQName = this.selectedMemberQName;
     adopted.isAbstractType = this.isAbstractType;
     adopted.description = this.description;
     adopted.fields = this.fields.map((child) => child.adopt(adopted) as XmlSchemaField);

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.schema-files.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.schema-files.test.ts
@@ -623,4 +623,77 @@ describe('XmlSchemaDocumentService / schema file management', () => {
       expect(catField).toBeDefined();
     });
   });
+
+  describe('rebuildAbstractWrapperChildren', () => {
+    const NS_SUBSTITUTION = 'http://www.example.com/SUBSTITUTION';
+
+    const additionalXsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:sub="http://www.example.com/SUBSTITUTION"
+  targetNamespace="http://www.example.com/SUBSTITUTION"
+  elementFormDefault="qualified">
+  <xs:import namespace="http://www.example.com/SUBSTITUTION" schemaLocation="FieldSubstitution.xsd"/>
+  <xs:element name="Bird" substitutionGroup="sub:AbstractAnimal" type="sub:Animal_t"/>
+</xs:schema>`;
+
+    function createAbstractAnimalDocument(): XmlSchemaDocument {
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        { namespaceUri: NS_SUBSTITUTION, name: 'AbstractAnimal' },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      return result.document as XmlSchemaDocument;
+    }
+
+    it('should include new substitution group candidates after addSchemaFiles', () => {
+      const document = createAbstractAnimalDocument();
+      const rootField = document.fields[0];
+      expect(rootField.wrapperKind).toBe('abstract');
+      expect(rootField.name).toBe('AbstractAnimal');
+
+      const initialChildNames = rootField.fields.map((f) => f.name);
+      expect(initialChildNames).not.toContain('Bird');
+
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'additional.xsd': additionalXsd });
+
+      const updatedChildNames = rootField.fields.map((f) => f.name);
+      expect(updatedChildNames).toContain('Bird');
+    });
+
+    it('should reuse existing IField objects when rebuilding abstract wrapper children', () => {
+      const document = createAbstractAnimalDocument();
+      const rootField = document.fields[0];
+      expect(rootField.wrapperKind).toBe('abstract');
+
+      const existingByName = new Map(rootField.fields.map((f) => [f.name, f] as const));
+      expect(existingByName.size).toBeGreaterThan(0);
+
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'additional.xsd': additionalXsd });
+
+      for (const child of rootField.fields) {
+        const previousRef = existingByName.get(child.name);
+        if (previousRef) {
+          expect(child).toBe(previousRef);
+        }
+      }
+    });
+
+    it('should preserve selectedMemberQName after abstract wrapper rebuild', () => {
+      const document = createAbstractAnimalDocument();
+      const rootField = document.fields[0];
+      expect(rootField.wrapperKind).toBe('abstract');
+
+      const catQName = new QName(NS_SUBSTITUTION, 'Cat');
+      rootField.selectedMemberQName = catQName;
+
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'additional.xsd': additionalXsd });
+
+      expect(rootField.selectedMemberQName).toBeDefined();
+      expect(rootField.selectedMemberQName!.getNamespaceURI()).toBe(NS_SUBSTITUTION);
+      expect(rootField.selectedMemberQName!.getLocalPart()).toBe('Cat');
+    });
+  });
 });

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -277,6 +277,53 @@ export class XmlSchemaDocumentService {
     collection.getSchemaResolver().addFiles(additionalFiles);
     XmlSchemaDocumentUtilService.loadXmlSchemaFiles(collection, additionalFiles);
     XmlSchemaDocumentService.populateNamedTypeFragments(document);
+    XmlSchemaDocumentService.rebuildAbstractWrapperChildren(document);
+  }
+
+  /**
+   * Rebuilds the children of abstract wrapper fields after schema attachment.
+   * Abstract wrapper candidates are open-ended — new candidates can appear in
+   * separate schema files. This re-queries {@link XmlSchemaTypesService.getSubstitutionGroupMembers}
+   * and updates `.fields` while reusing existing `IField` objects where possible
+   * to preserve FieldItem references in the visualization layer.
+   * Choice wrapper children are not rebuilt because their members are inline and static.
+   */
+  private static rebuildAbstractWrapperChildren(document: XmlSchemaDocument): void {
+    for (const field of document.fields) {
+      XmlSchemaDocumentService.rebuildAbstractWrapperField(field as XmlSchemaField, document.xmlSchemaCollection);
+    }
+    for (const fragment of Object.values(document.namedTypeFragments)) {
+      for (const field of fragment.fields) {
+        XmlSchemaDocumentService.rebuildAbstractWrapperField(field as XmlSchemaField, document.xmlSchemaCollection);
+      }
+    }
+  }
+
+  private static rebuildAbstractWrapperField(field: XmlSchemaField, collection: XmlSchemaCollection): void {
+    if (field.wrapperKind === 'abstract') {
+      const headQName = new QName(field.namespaceURI, field.name);
+      const headElement = collection.getElementByQName(headQName);
+      if (headElement) {
+        const members = XmlSchemaTypesService.getSubstitutionGroupMembers(headElement, collection);
+        const existingByKey = new Map(field.fields.map((f) => [`${f.namespaceURI}|${f.name}`, f]));
+        const newFields: XmlSchemaField[] = [];
+        for (const member of members) {
+          const memberName = member.getWireName()!.getLocalPart()!;
+          const memberNs = member.getWireName()!.getNamespaceURI();
+          const key = `${memberNs}|${memberName}`;
+          const existing = existingByKey.get(key);
+          if (existing) {
+            newFields.push(existing as XmlSchemaField);
+          } else {
+            XmlSchemaDocumentService.populateElement(field, newFields, member);
+          }
+        }
+        field.fields = newFields;
+      }
+    }
+    for (const child of field.fields) {
+      XmlSchemaDocumentService.rebuildAbstractWrapperField(child as XmlSchemaField, collection);
+    }
   }
 
   /**

--- a/packages/ui/src/services/schema-path.service.test.ts
+++ b/packages/ui/src/services/schema-path.service.test.ts
@@ -1,5 +1,6 @@
 import { Types } from '../models/datamapper';
 import { TestUtil } from '../stubs/datamapper/data-mapper';
+import { QName } from '../xml-schema-ts/QName';
 import { XmlSchemaField } from './document/xml-schema/xml-schema-document.model';
 import { SchemaPathSegment, SchemaPathService } from './schema-path.service';
 
@@ -379,11 +380,11 @@ describe('SchemaPathService', () => {
       expect(path).toBe('/ns0:ShipOrder/ns0:AbstractElement');
     });
 
-    it('should show selected candidate name when terminal abstract has selectedMemberIndex', () => {
+    it('should show selected candidate name when terminal abstract has selectedMemberQName', () => {
       const document = TestUtil.createSourceOrderDoc();
       const root = document.fields[0];
       const abstractField = makeAbstractField(root, ['Cat', 'Dog']);
-      abstractField.selectedMemberIndex = 1;
+      abstractField.selectedMemberQName = new QName('io.kaoto.datamapper.poc.test', 'Dog');
       root.fields.push(abstractField);
 
       const path = SchemaPathService.formatDisplayPath(abstractField, namespaceMap);

--- a/packages/ui/src/services/schema-path.service.ts
+++ b/packages/ui/src/services/schema-path.service.ts
@@ -93,7 +93,7 @@ export class SchemaPathService {
    * for matching against persisted definitions. Choice wrappers emit `{choice:N}` segments.
    * Abstract wrappers are collapsed: when the next field in the stack is a child of the
    * wrapper, the wrapper segment is skipped; otherwise the selected candidate (via
-   * `selectedMemberIndex`) replaces the wrapper segment.
+   * `selectedMemberQName`) replaces the wrapper segment.
    *
    * Note: mutates `namespaceMap` by registering prefixes for encountered namespace URIs.
    */
@@ -113,8 +113,8 @@ export class SchemaPathService {
       } else if (f.wrapperKind === 'abstract' && i < lastIndex) {
         i++;
         segments.push(SchemaPathService.buildElementSegment(fieldStack[i], namespaceMap));
-      } else if (f.wrapperKind === 'abstract' && f.selectedMemberIndex !== undefined) {
-        const selectedMember = f.fields?.[f.selectedMemberIndex];
+      } else if (f.wrapperKind === 'abstract') {
+        const selectedMember = DocumentUtilService.getSelectedMember(f);
         if (selectedMember) {
           ensureNamespaceRegistered(
             selectedMember.namespaceURI,

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -31,6 +31,7 @@ import {
   getX12850ForEachXslt,
   TestUtil,
 } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
 import { DocumentUtilService } from '../document/document-util.service';
 import { JsonSchemaDocumentService } from '../document/json-schema/json-schema-document.service';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
@@ -439,9 +440,8 @@ describe('MappingLinksService', () => {
       const abstractAnimalField = zooField.fields.find(
         (f: IField) => f.wrapperKind === 'abstract' && f.name === 'AbstractAnimal',
       )!;
-      const catIndex = abstractAnimalField.fields.findIndex((f: IField) => f.name === 'Cat');
-      abstractAnimalField.selectedMemberIndex = catIndex;
-      const catField = abstractAnimalField.fields[catIndex];
+      abstractAnimalField.selectedMemberQName = new QName(NS_SUBSTITUTION, 'Cat');
+      const catField = abstractAnimalField.fields.find((f: IField) => f.name === 'Cat')!;
       DocumentUtilService.resolveTypeFragment(catField);
       const indoorField = catField.fields.find((f: IField) => f.name === 'indoor')!;
       return { document, zooField, abstractAnimalField, catField, indoorField };
@@ -516,7 +516,7 @@ describe('MappingLinksService', () => {
         catField,
         indoorField,
       } = createZooDoc(DocumentType.TARGET_BODY);
-      abstractAnimalField.selectedMemberIndex = undefined;
+      abstractAnimalField.selectedMemberQName = undefined;
 
       const zooTree = new MappingTree(
         zooTargetDoc.documentType,

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -254,11 +254,9 @@ export class MappingLinksService {
   }
 
   private static isSelectedWrapperField(node: IParentType): boolean {
-    return (
-      MappingLinksService.isWrapperField(node) &&
-      'selectedMemberIndex' in node &&
-      node.selectedMemberIndex !== undefined
-    );
+    if (!MappingLinksService.isWrapperField(node)) return false;
+    if (node.wrapperKind === 'abstract') return node.selectedMemberQName !== undefined;
+    return node.selectedMemberIndex !== undefined;
   }
 
   private static isSelectedWrapperMember(field: IField): boolean {
@@ -268,7 +266,7 @@ export class MappingLinksService {
   /**
    * Collects the IDs of consecutive `wrapperKind` ancestor wrapper
    * fields, ordered from outermost to innermost. Only includes **unselected**
-   * wrappers (`selectedMemberIndex` is `undefined`) because selected wrappers are
+   * wrappers (no member selected) because selected wrappers are
    * not rendered as visual nodes — the selected member replaces them in the tree.
    * Returns an empty array when the field has no unselected wrapper ancestors.
    */

--- a/packages/ui/src/services/visualization/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.test.ts
@@ -23,6 +23,7 @@ import {
   VariableNodeData,
 } from '../../models/datamapper/visualization';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
 import { JsonSchemaDocument, JsonSchemaField } from '../document/json-schema/json-schema-document.model';
 import { XmlSchemaDocument, XmlSchemaField } from '../document/xml-schema/xml-schema-document.model';
 import { MappingValidationService } from './mapping-validation.service';
@@ -162,7 +163,7 @@ describe('MappingValidationService', () => {
     describe('abstract validation', () => {
       it('should reject any source to unselected abstract target', () => {
         const source = createMockField({ type: Types.String });
-        const target = createMockField({ wrapperKind: 'abstract', selectedMemberIndex: undefined });
+        const target = createMockField({ wrapperKind: 'abstract', selectedMemberQName: undefined });
         const result = MappingValidationService.validateFieldPair(source, target);
         expect(result.isValid).toBe(false);
         expect(result.errorMessage).toContain('unselected abstract element');
@@ -170,7 +171,7 @@ describe('MappingValidationService', () => {
 
       it('should allow source to target with selected abstract member', () => {
         const source = createMockField({ type: Types.String });
-        const target = createMockField({ wrapperKind: 'abstract', selectedMemberIndex: 0 });
+        const target = createMockField({ wrapperKind: 'abstract', selectedMemberQName: new QName(null, 'MockMember') });
         const result = MappingValidationService.validateFieldPair(source, target);
         expect(result.isValid).toBe(true);
       });
@@ -424,7 +425,7 @@ describe('MappingValidationService', () => {
 
     it('should reject cross-side drop to unselected abstract target with errorMessage', () => {
       const sourceField = createMockField({ type: Types.String });
-      const targetField = createMockField({ wrapperKind: 'abstract', selectedMemberIndex: undefined });
+      const targetField = createMockField({ wrapperKind: 'abstract', selectedMemberQName: undefined });
       const fromNode = new FieldNodeData(sourceDocNode, sourceField);
       const toNode = new TargetFieldNodeData(targetDocNode, targetField);
       const result = MappingValidationService.validateMappingPair(fromNode, toNode);

--- a/packages/ui/src/services/visualization/mapping-validation.service.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.ts
@@ -242,7 +242,7 @@ export class MappingValidationService {
   }
 
   private static validateAbstractRules(_source: IField, target: IField): ValidationResult {
-    if (target.wrapperKind === 'abstract' && target.selectedMemberIndex === undefined) {
+    if (target.wrapperKind === 'abstract' && target.selectedMemberQName === undefined) {
       return {
         isValid: false,
         errorMessage: 'Cannot map to an unselected abstract element. Please select a concrete candidate first.',

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -16,6 +16,7 @@ import {
   TargetFieldNodeData,
 } from '../../models/datamapper/visualization';
 import { getFieldSubstitutionXsd, TestUtil } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
 import { MappingActionService } from './mapping-action.service';
@@ -39,7 +40,7 @@ describe('VisualizationService / abstract fields', () => {
 
   function createMockAbstractField(
     candidates: { name: string; children?: { name: string }[] }[],
-    selectedMemberIndex?: number,
+    selectedMemberQName?: QName,
   ) {
     const baseField = sourceDoc.fields[0];
     const candidateFields = candidates.map((c) => ({
@@ -58,7 +59,7 @@ describe('VisualizationService / abstract fields', () => {
       name: 'AbstractElement',
       displayName: 'AbstractElement',
       wrapperKind: 'abstract' as const,
-      selectedMemberIndex,
+      selectedMemberQName,
       fields: candidateFields,
     } as unknown as typeof baseField;
   }
@@ -110,7 +111,10 @@ describe('VisualizationService / abstract fields', () => {
     });
 
     it('should create AbstractFieldNodeData with selected candidate for source abstract fields', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }], 0);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
       const parentField = {
         ...sourceDoc.fields[0],
         fields: [abstractField],
@@ -123,7 +127,10 @@ describe('VisualizationService / abstract fields', () => {
     });
 
     it('should create TargetAbstractFieldNodeData with selected candidate for target abstract fields', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }], 1);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Dog'),
+      );
       const parentField = {
         ...targetDoc.fields[0],
         fields: [abstractField],
@@ -136,7 +143,10 @@ describe('VisualizationService / abstract fields', () => {
     });
 
     it('should still report isAbstractField for selected abstract candidates', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 0);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
       const parentField = {
         ...sourceDoc.fields[0],
         fields: [abstractField],
@@ -147,7 +157,10 @@ describe('VisualizationService / abstract fields', () => {
     });
 
     it('should set abstractField reference for selected abstract candidates', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 0);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
       const parentField = {
         ...sourceDoc.fields[0],
         fields: [abstractField],
@@ -158,8 +171,8 @@ describe('VisualizationService / abstract fields', () => {
       expect(abstractNode.abstractField).toBe(abstractField);
     });
 
-    it('should use abstract field itself when selectedMemberIndex is out of bounds', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 99);
+    it('should use abstract field itself when selectedMemberQName matches no candidate', () => {
+      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], new QName('', 'nonexistent'));
       const parentField = {
         ...sourceDoc.fields[0],
         fields: [abstractField],
@@ -181,8 +194,8 @@ describe('VisualizationService / abstract fields', () => {
       expect(children[1].title).toBe('Dog');
     });
 
-    it('should fall back to all candidates when selectedMemberIndex is out of bounds', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 99);
+    it('should fall back to all candidates when selectedMemberQName matches no candidate', () => {
+      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], new QName('', 'nonexistent'));
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
       const children = VisualizationService.generateNonDocumentNodeDataChildren(abstractNode);
       expect(children).toHaveLength(2);
@@ -269,7 +282,7 @@ describe('VisualizationService / abstract fields', () => {
         const document = result.document as XmlSchemaDocument;
         const zooField = document.fields[0];
         const abstractAnimalField = zooField.fields.find((f) => f.name === 'AbstractAnimal')!;
-        abstractAnimalField.selectedMemberIndex = 0;
+        abstractAnimalField.selectedMemberQName = new QName('http://www.example.com/SUBSTITUTION', 'Cat');
 
         const docNode = new DocumentNodeData(document);
         const docChildren = VisualizationService.generateStructuredDocumentChildren(docNode);
@@ -294,7 +307,7 @@ describe('VisualizationService / abstract fields', () => {
         const document = result.document as XmlSchemaDocument;
         const zooField = document.fields[0];
         const abstractAnimalField = zooField.fields.find((f) => f.name === 'AbstractAnimal')!;
-        abstractAnimalField.selectedMemberIndex = 0;
+        abstractAnimalField.selectedMemberQName = new QName('http://www.example.com/SUBSTITUTION', 'Cat');
 
         const docNode = new DocumentNodeData(document);
         const docChildren = VisualizationService.generateStructuredDocumentChildren(docNode);
@@ -324,7 +337,7 @@ describe('VisualizationService / abstract fields', () => {
         const document = result.document as XmlSchemaDocument;
         const zooField = document.fields[0];
         const abstractAnimalField = zooField.fields.find((f) => f.name === 'AbstractAnimal')!;
-        abstractAnimalField.selectedMemberIndex = 0;
+        abstractAnimalField.selectedMemberQName = new QName('http://www.example.com/SUBSTITUTION', 'Cat');
 
         const docNode = new DocumentNodeData(document);
         const docChildren = VisualizationService.generateStructuredDocumentChildren(docNode);
@@ -385,7 +398,10 @@ describe('VisualizationService / abstract fields', () => {
     });
 
     it('should return nodeData.title for selected abstract candidate (abstractField set)', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 0);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
       const parentField = { ...sourceDoc.fields[0], fields: [abstractField] };
       const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
       const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
@@ -526,7 +542,10 @@ describe('VisualizationService / abstract fields', () => {
 
   describe('mapping through selected target abstract wrapper', () => {
     it('engageMapping to a selected abstract candidate creates FieldItem for the candidate', () => {
-      const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }], 0);
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
       const parentField = {
         ...targetDoc.fields[0],
         fields: [abstractField],
@@ -554,7 +573,7 @@ describe('VisualizationService / abstract fields', () => {
     it('re-rendered tree generates children for a mapped selected abstract candidate', () => {
       const abstractField = createMockAbstractField(
         [{ name: 'Cat', children: [{ name: 'catName' }] }, { name: 'Dog' }],
-        0,
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
       );
       const parentField = {
         ...targetDoc.fields[0],

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -125,7 +125,7 @@ export class VisualizationService {
   /**
    * Creates a {@link ChoiceFieldNodeData} or {@link TargetChoiceFieldNodeData} for a choice wrapper field.
    *
-   * When no member is selected (`field.selectedMemberIndex === undefined`), the returned node's
+   * When no member is selected ({@link DocumentUtilService.getSelectedMember} returns `undefined`), the returned node's
    * `field` is the choice wrapper itself and `choiceField` is `undefined`. {@link createNodeTitle}
    * recognises this state and returns the member label string (e.g. `"(email | phone)"`), while
    * {@link NodeTitle} renders it alongside a `<Label>choice</Label>` badge.
@@ -140,10 +140,9 @@ export class VisualizationService {
     mappings: MappingItem[] | undefined,
     spec: WrapperSpec,
   ): NodeData {
-    const selectedMember =
-      field.selectedMemberIndex === undefined ? undefined : field.fields?.[field.selectedMemberIndex];
+    const selectedMember = DocumentUtilService.getSelectedMember(field);
 
-    if (selectedMember?.wrapperKind && selectedMember.selectedMemberIndex !== undefined) {
+    if (selectedMember?.wrapperKind && DocumentUtilService.getSelectedMember(selectedMember) !== undefined) {
       const innerSpec = selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
       return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, innerSpec);
     }
@@ -235,8 +234,7 @@ export class VisualizationService {
       DocumentUtilService.resolveTypeFragment(field);
       return field.fields;
     }
-    const selectedMember =
-      field.selectedMemberIndex === undefined ? undefined : field.fields?.[field.selectedMemberIndex];
+    const selectedMember = DocumentUtilService.getSelectedMember(field);
     return selectedMember ? [field] : field.fields;
   }
 


### PR DESCRIPTION
…ty + wrapper rebuild

Fixes: https://github.com/KaotoIO/kaoto/issues/3408

* Introduce `IField.selectedMemberQName` to make abstract substitution consistent over additional schema attachment
* Rebuild abstract substitution candidates on attach schema event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Abstract field selections now use stable qualified names, improving consistency when choosing substitution options and switching between them.

* **Bug Fixes**
  * Fixed selection-related behavior in context menus, override/revert actions, validation, display paths, and visualization so abstract wrapper choices are handled correctly.
  * Preserved selected abstract members when schema files are added or fields are copied/reused, preventing selections from being lost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->