### PR TITLE
feat(DataMapper): Use TypeaheadSelect instead of Select in FieldOverrideModal for type field

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/RootElementSelect.tsx
@@ -23,7 +23,7 @@ export const RootElementSelect: FunctionComponent<RootElementSelectProps> = ({
       rootElementOptions.map((opt) => ({
         value: toOptionKey(opt),
         label: opt.name,
-        description: opt.namespaceUri ? `Namespace URI: ${opt.namespaceUri}` : '',
+        ...(opt.namespaceUri && { description: `Namespace URI: ${opt.namespaceUri}` }),
       })),
     [rootElementOptions],
   );

--- a/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.test.tsx
@@ -163,4 +163,69 @@ describe('TypeaheadSelect', () => {
     });
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
+
+  it('should not close when blur target is inside the listbox', () => {
+    render(<TypeaheadSelect value="order-key" onChange={vi.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+
+    // Blur to one of the PF listbox option buttons — handleBlur should detect relatedTarget inside [role="listbox"]
+    const options = screen.getAllByRole('option');
+    act(() => {
+      fireEvent.blur(getInput(), { relatedTarget: options[0] });
+    });
+
+    // Dropdown should stay open because relatedTarget is inside the listbox
+    expect(screen.getAllByRole('listbox').length).toBeGreaterThan(0);
+  });
+
+  it('should fall back to value when option has no label', () => {
+    const noLabelOptions: TypeaheadSelectOption[] = [{ value: 'raw-value', description: 'some description' }];
+    render(
+      <TypeaheadSelect value="raw-value" onChange={vi.fn()} options={noLabelOptions} data-testid="select-input" />,
+    );
+    // selectedLabel should fall back to value when label is undefined
+    expect(getInput().value).toBe('raw-value');
+  });
+
+  it('should display value in dropdown when option has no label', () => {
+    const noLabelOptions: TypeaheadSelectOption[] = [{ value: 'raw-value', description: 'some description' }];
+    render(
+      <TypeaheadSelect value="other-value" onChange={vi.fn()} options={noLabelOptions} data-testid="select-input" />,
+    );
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getByText('raw-value')).toBeInTheDocument();
+  });
+
+  it('should not call onChange when dropdown opens without selecting an option', () => {
+    const onChange = vi.fn();
+    render(<TypeaheadSelect value="order-key" onChange={onChange} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    // Opening the dropdown alone must not trigger onChange
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should keep dropdown open when typing while already open', () => {
+    render(<TypeaheadSelect value="order-key" onChange={vi.fn()} options={OPTIONS} data-testid="select-input" />);
+    act(() => {
+      fireEvent.focus(getInput());
+    });
+    expect(screen.getAllByRole('listbox').length).toBeGreaterThan(0);
+
+    // Type while dropdown is already open — it should remain open
+    act(() => {
+      fireEvent.change(getInput(), { target: { value: 'O' } });
+    });
+    expect(screen.getAllByRole('listbox').length).toBeGreaterThan(0);
+  });
+
+  it('should not render clear button when no value is displayed', () => {
+    render(<TypeaheadSelect value="" onChange={vi.fn()} options={OPTIONS} data-testid="select-input" />);
+    expect(screen.queryByLabelText('Clear expression')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/TypeaheadSelect.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   MenuToggle,
   MenuToggleElement,
+  PopperOptions,
   Select,
   SelectList,
   SelectOption,
@@ -15,7 +16,7 @@ import { FunctionComponent, Ref, useCallback, useMemo, useRef, useState } from '
 export interface TypeaheadSelectOption {
   value: string;
   label?: string;
-  description: string;
+  description?: string;
 }
 
 interface TypeaheadSelectProps {
@@ -27,6 +28,7 @@ interface TypeaheadSelectProps {
   placeholder?: string;
   ariaLabel?: string;
   className?: string;
+  popperProps?: PopperOptions;
 }
 
 /**
@@ -43,6 +45,7 @@ export const TypeaheadSelect: FunctionComponent<TypeaheadSelectProps> = ({
   placeholder,
   ariaLabel,
   className,
+  popperProps,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [filterText, setFilterText] = useState('');
@@ -59,7 +62,7 @@ export const TypeaheadSelect: FunctionComponent<TypeaheadSelectProps> = ({
     if (!filterText) return options;
     const lower = filterText.toLowerCase();
     return options.filter(
-      (opt) => (opt.label ?? opt.value).toLowerCase().includes(lower) || opt.description.toLowerCase().includes(lower),
+      (opt) => (opt.label ?? opt.value).toLowerCase().includes(lower) || opt.description?.toLowerCase().includes(lower),
     );
   }, [options, filterText]);
 
@@ -151,7 +154,7 @@ export const TypeaheadSelect: FunctionComponent<TypeaheadSelectProps> = ({
       onOpenChange={setIsOpen}
       toggle={toggle}
       maxMenuHeight="240px"
-      popperProps={{ preventOverflow: true }}
+      popperProps={{ preventOverflow: true, ...popperProps }}
     >
       <SelectList>
         {filteredOptions.map((opt, idx) => (

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.test.tsx
@@ -185,8 +185,13 @@ describe('useFieldOverrideMenu', () => {
       expect(screen.getByText(/Field Override:/)).toBeInTheDocument();
     });
 
+    // Find the typeahead toggle button for the type selector and open it
+    const typeToggle = screen
+      .getByTestId('type-select')
+      .closest('.pf-v6-c-menu-toggle')!
+      .querySelector('.pf-v6-c-menu-toggle__button') as HTMLButtonElement;
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Select a new type...' }));
+      fireEvent.click(typeToggle);
     });
 
     const intOption = screen.getAllByText('int').find((el) => el.closest('[role="option"]'));

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx
@@ -49,6 +49,16 @@ describe('FieldOverrideModal', () => {
     vi.restoreAllMocks();
   });
 
+  /** Returns the MenuToggle chevron button that opens/closes the typeahead dropdown. */
+  const getMenuToggle = () =>
+    screen
+      .getByTestId('type-select')
+      .closest('.pf-v6-c-menu-toggle')!
+      .querySelector('.pf-v6-c-menu-toggle__button') as HTMLButtonElement;
+
+  /** Returns the typeahead text input. */
+  const getTypeSelectInput = () => screen.getByTestId('type-select').querySelector('input') as HTMLInputElement;
+
   it('should render modal when isOpen is true', () => {
     render(
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
@@ -71,12 +81,11 @@ describe('FieldOverrideModal', () => {
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
     act(() => {
-      fireEvent.click(toggle);
+      fireEvent.click(getMenuToggle());
     });
 
-    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 
   it('should update selected type when a type is selected from dropdown', async () => {
@@ -103,9 +112,8 @@ describe('FieldOverrideModal', () => {
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
     act(() => {
-      fireEvent.click(toggle);
+      fireEvent.click(getMenuToggle());
     });
 
     const stringOptions = screen.getAllByText('string');
@@ -118,13 +126,9 @@ describe('FieldOverrideModal', () => {
     });
 
     await waitFor(() => {
-      // After selection, the toggle should show the selected type name
-      const toggle = screen.getByRole('button', { name: /string/i });
-      expect(toggle).toBeInTheDocument();
+      // After selection, the input should show the selected type label
+      expect(getTypeSelectInput().value).toBe('string');
     });
-
-    // Verify the placeholder text is no longer visible
-    expect(screen.queryByText('Select a new type...')).not.toBeInTheDocument();
   });
 
   it('should enable Save button when a type is selected', async () => {
@@ -144,9 +148,8 @@ describe('FieldOverrideModal', () => {
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
     act(() => {
-      fireEvent.click(toggle);
+      fireEvent.click(getMenuToggle());
     });
 
     const stringOptions = screen.getAllByText('string');
@@ -220,9 +223,8 @@ describe('FieldOverrideModal', () => {
       />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
     act(() => {
-      fireEvent.click(toggle);
+      fireEvent.click(getMenuToggle());
     });
 
     const stringOptions = screen.getAllByText('string');
@@ -315,10 +317,11 @@ describe('FieldOverrideModal', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('should display type description when available', async () => {
+  it('should display namespace URI as description when available', async () => {
+    const NS_XS = 'http://www.w3.org/2001/XMLSchema';
     const mockCandidates: Record<string, IFieldTypeInfo> = {
       'xs:string': {
-        typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'string'),
+        typeQName: new QName(NS_XS, 'string'),
         displayName: 'string',
         description: 'A text string type',
         type: Types.String,
@@ -332,22 +335,13 @@ describe('FieldOverrideModal', () => {
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
     );
 
-    const toggle = screen.getByRole('button', { name: 'Select a new type...' });
     act(() => {
-      fireEvent.click(toggle);
+      fireEvent.click(getMenuToggle());
     });
 
-    const stringOptions = screen.getAllByText('string');
-    const stringOption = stringOptions.find((el) => el.closest('[role="option"]'));
-    if (!stringOption) {
-      throw new Error('String option not found');
-    }
-    act(() => {
-      fireEvent.click(stringOption);
-    });
-
+    // Namespace URI is shown as description in the dropdown; type description is not rendered
     await waitFor(() => {
-      expect(screen.getByText('A text string type')).toBeInTheDocument();
+      expect(screen.getByText(`Namespace URI: ${NS_XS}`)).toBeInTheDocument();
     });
   });
 
@@ -379,7 +373,7 @@ describe('FieldOverrideModal', () => {
       <FieldOverrideModal onClose={vi.fn()} onSave={vi.fn()} onAttach={vi.fn()} onRemove={vi.fn()} field={testField} />,
     );
 
-    expect(screen.getByRole('button', { name: 'xs:int' })).toBeInTheDocument();
+    expect(getTypeSelectInput().value).toBe('xs:int');
   });
 
   describe('Substitution mode', () => {
@@ -410,7 +404,7 @@ describe('FieldOverrideModal', () => {
         />,
       );
 
-      const substitutionRadio = screen.getByLabelText('Substitute Element');
+      const substitutionRadio = screen.getByRole('radio', { name: 'Substitute Element' });
       act(() => {
         fireEvent.click(substitutionRadio);
       });
@@ -435,10 +429,10 @@ describe('FieldOverrideModal', () => {
       );
 
       act(() => {
-        fireEvent.click(screen.getByLabelText('Substitute Element'));
+        fireEvent.click(screen.getByRole('radio', { name: 'Substitute Element' }));
       });
 
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(getTypeSelectInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should call onSave with substitution payload when saving in substitution mode', async () => {
@@ -460,13 +454,12 @@ describe('FieldOverrideModal', () => {
 
       // Switch to substitution mode
       act(() => {
-        fireEvent.click(screen.getByLabelText('Substitute Element'));
+        fireEvent.click(screen.getByRole('radio', { name: 'Substitute Element' }));
       });
 
       // Open dropdown and select Cat
-      const toggle = screen.getByRole('button', { name: 'Select a substitute element...' });
       act(() => {
-        fireEvent.click(toggle);
+        fireEvent.click(getMenuToggle());
       });
 
       const catOption = screen.getAllByText('Cat').find((el) => el.closest('[role="option"]'));
@@ -514,9 +507,8 @@ describe('FieldOverrideModal', () => {
       );
 
       // Select a type in type mode
-      const typeToggle = screen.getByRole('button', { name: 'Select a new type...' });
       act(() => {
-        fireEvent.click(typeToggle);
+        fireEvent.click(getMenuToggle());
       });
       const stringOption = screen.getAllByText('string').find((el) => el.closest('[role="option"]'));
       if (!stringOption) throw new Error('string option not found');
@@ -530,11 +522,11 @@ describe('FieldOverrideModal', () => {
 
       // Switch to substitution mode — selection should reset, Save should be disabled
       act(() => {
-        fireEvent.click(screen.getByLabelText('Substitute Element'));
+        fireEvent.click(screen.getByRole('radio', { name: 'Substitute Element' }));
       });
 
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(getTypeSelectInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should start in substitution mode when field has existing substitution', () => {
@@ -556,8 +548,8 @@ describe('FieldOverrideModal', () => {
       );
 
       // Should auto-select substitution radio and show substitution placeholder
-      expect(screen.getByLabelText('Substitute Element')).toBeChecked();
-      expect(screen.getByRole('button', { name: 'Select a substitute element...' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Substitute Element' })).toBeChecked();
+      expect(getTypeSelectInput()).toHaveAttribute('placeholder', 'Select a substitute element...');
     });
 
     it('should pre-select the active substitute element when field has existing substitution', () => {
@@ -582,8 +574,8 @@ describe('FieldOverrideModal', () => {
         />,
       );
 
-      // The active substitute 'sub:Cat' should be pre-selected in the dropdown toggle
-      expect(screen.getByRole('button', { name: 'Cat' })).toBeInTheDocument();
+      // The active substitute 'sub:Cat' should be pre-selected in the input
+      expect(getTypeSelectInput().value).toBe('Cat');
     });
 
     it('should disable Override Type radio when field has existing substitution', () => {
@@ -605,9 +597,9 @@ describe('FieldOverrideModal', () => {
       );
 
       // Substitution mode is active, so Override Type radio should be disabled
-      expect(screen.getByLabelText('Override Type')).toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Override Type' })).toBeDisabled();
       // The active mode radio should remain enabled
-      expect(screen.getByLabelText('Substitute Element')).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Substitute Element' })).not.toBeDisabled();
     });
 
     it('should disable Substitute Element radio when field has existing type override', () => {
@@ -638,9 +630,9 @@ describe('FieldOverrideModal', () => {
       );
 
       // Type mode is active, so Substitute Element radio should be disabled
-      expect(screen.getByLabelText('Substitute Element')).toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Substitute Element' })).toBeDisabled();
       // The active mode radio should remain enabled
-      expect(screen.getByLabelText('Override Type')).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Override Type' })).not.toBeDisabled();
     });
 
     it('should not disable radios when field has no existing override', () => {
@@ -662,8 +654,8 @@ describe('FieldOverrideModal', () => {
       );
 
       // Both radios should be enabled when there's no override
-      expect(screen.getByLabelText('Override Type')).not.toBeDisabled();
-      expect(screen.getByLabelText('Substitute Element')).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Override Type' })).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Substitute Element' })).not.toBeDisabled();
     });
   });
 
@@ -956,6 +948,258 @@ describe('FieldOverrideModal', () => {
       // Error message should be displayed
       await waitFor(() => {
         expect(screen.getByText(/Invalid schema: Invalid schema structure/)).toBeInTheDocument();
+      });
+    });
+
+    it('should skip reading a file already present in uploadedSchemas', async () => {
+      const getResourceContentMock = mockApi.getResourceContent as Mock;
+
+      // First upload succeeds
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValueOnce(['types.xsd']);
+      getResourceContentMock.mockResolvedValueOnce('<xs:schema/>');
+
+      const onAttachMock = vi.fn();
+      renderWithContext({ onAttach: onAttachMock });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('upload-schema-button'));
+      });
+      await waitFor(() => {
+        expect(onAttachMock).toHaveBeenCalledTimes(1);
+      });
+
+      // Second upload of same file — getResourceContent should NOT be called again
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValueOnce(['types.xsd']);
+      getResourceContentMock.mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('upload-schema-button'));
+      });
+
+      await waitFor(() => {
+        expect(getResourceContentMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should skip reading a file already in existingFiles', async () => {
+      const getResourceContentMock = mockApi.getResourceContent as Mock;
+
+      // 'shipOrder.xsd' is already in existingFiles (from testTargetDoc definition)
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue(['shipOrder.xsd']);
+      getResourceContentMock.mockClear();
+
+      renderWithContext();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('upload-schema-button'));
+      });
+
+      // File is already in existingFiles — getResourceContent should not be called
+      expect(getResourceContentMock).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when file picker returns empty selection', async () => {
+      vi.spyOn(DataMapperMetadataService, 'selectDocumentSchema').mockResolvedValue([]);
+      const onAttachMock = vi.fn();
+      renderWithContext({ onAttach: onAttachMock });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('upload-schema-button'));
+      });
+
+      expect(onAttachMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should not call onSave when Save is clicked with no selection', () => {
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      const onSaveMock = vi.fn();
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={onSaveMock}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={testField}
+        />,
+      );
+
+      // Save button is disabled when no key is selected, but click it anyway to confirm guard
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      expect(saveButton).toBeDisabled();
+      act(() => {
+        fireEvent.click(saveButton);
+      });
+      expect(onSaveMock).not.toHaveBeenCalled();
+    });
+
+    it('should retain the original selection when typing a non-candidate value into the filter input', async () => {
+      const mockCandidates: Record<string, IFieldTypeInfo> = {
+        'xs:string': {
+          typeQName: new QName('http://www.w3.org/2001/XMLSchema', 'string'),
+          displayName: 'string',
+          type: Types.String,
+          isBuiltIn: true,
+        },
+      };
+
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockCandidates);
+      const onSaveMock = vi.fn();
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={onSaveMock}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={testField}
+        />,
+      );
+
+      // Select a valid type first
+      act(() => {
+        fireEvent.click(getMenuToggle());
+      });
+      const stringOption = screen.getAllByText('string').find((el) => el.closest('[role="option"]'));
+      if (!stringOption) throw new Error('string option not found');
+      act(() => {
+        fireEvent.click(stringOption);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+      });
+
+      // Typing into the filter input only updates filterText in TypeaheadSelect;
+      // it never calls onChange, so selectedKey stays 'xs:string'.
+      const input = screen.getByTestId('type-select').querySelector('input') as HTMLInputElement;
+      act(() => {
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: 'unknown-key' } });
+      });
+
+      // Save should still fire with the original valid selection intact
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      });
+      expect(onSaveMock).toHaveBeenCalledWith({
+        mode: 'type',
+        selectedType: mockCandidates['xs:string'],
+        selectedKey: 'xs:string',
+      });
+    });
+
+    it('should start in substitution mode when field wrapperKind is abstract', () => {
+      const abstractField = { ...testField, wrapperKind: 'abstract' as const, typeOverride: FieldOverrideVariant.NONE };
+
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({});
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={abstractField}
+        />,
+      );
+
+      // Abstract wrapper fields always start in substitution mode
+      expect(screen.getByRole('radio', { name: 'Substitute Element' })).toBeChecked();
+    });
+
+    it('should show Remove Override button for abstract wrapper field', () => {
+      const abstractField = { ...testField, wrapperKind: 'abstract' as const, typeOverride: FieldOverrideVariant.NONE };
+
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue({});
+      vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({});
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={abstractField}
+        />,
+      );
+
+      // Abstract wrapper is treated as having an existing override
+      expect(screen.getByRole('button', { name: 'Remove Override' })).toBeInTheDocument();
+    });
+
+    it('should build typeahead options with only namespace URI as description', async () => {
+      const NS_XS = 'http://www.w3.org/2001/XMLSchema';
+      testMappingTree.namespaceMap = { xs: NS_XS };
+
+      const mockCandidates: Record<string, IFieldTypeInfo> = {
+        'xs:int': {
+          typeQName: new QName(NS_XS, 'int'),
+          displayName: 'int',
+          type: Types.Integer,
+          isBuiltIn: true,
+          description: 'Integer scalar type',
+        },
+      };
+
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockCandidates);
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={testField}
+        />,
+      );
+
+      act(() => {
+        fireEvent.click(getMenuToggle());
+      });
+
+      // The description rendered in the SelectOption should show only the namespace URI
+      await waitFor(() => {
+        expect(screen.getByText(`Namespace URI: ${NS_XS}`)).toBeInTheDocument();
+        expect(screen.queryByText(/Integer scalar type/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should build typeahead options with only namespaceURI when description is absent', async () => {
+      const NS_XS = 'http://www.w3.org/2001/XMLSchema';
+      testMappingTree.namespaceMap = { xs: NS_XS };
+
+      const mockCandidates: Record<string, IFieldTypeInfo> = {
+        'xs:int': {
+          typeQName: new QName(NS_XS, 'int'),
+          displayName: 'int',
+          type: Types.Integer,
+          isBuiltIn: true,
+          // no description
+        },
+      };
+
+      vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockCandidates);
+
+      render(
+        <FieldOverrideModal
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+          onAttach={vi.fn()}
+          onRemove={vi.fn()}
+          field={testField}
+        />,
+      );
+
+      act(() => {
+        fireEvent.click(getMenuToggle());
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(`Namespace URI: ${NS_XS}`)).toBeInTheDocument();
       });
     });
   });

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverrideModal.tsx
@@ -6,22 +6,17 @@ import {
   HelperText,
   HelperTextItem,
   Icon,
-  MenuToggle,
-  MenuToggleElement,
   ModalBody,
   ModalFooter,
   ModalHeader,
   ModalVariant,
   Radio,
-  Select,
-  SelectList,
-  SelectOption,
   Spinner,
   Split,
   SplitItem,
 } from '@patternfly/react-core';
 import { FileImportIcon, WrenchIcon } from '@patternfly/react-icons';
-import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField, SCHEMA_FILE_NAME_PATTERN_XML } from '../../../../models/datamapper/document';
@@ -30,6 +25,7 @@ import { MetadataContext } from '../../../../providers';
 import { formatQNameWithPrefix } from '../../../../services/namespace-util';
 import { SchemaPathService } from '../../../../services/schema-path.service';
 import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
+import { TypeaheadSelect, TypeaheadSelectOption } from '../AttachSchema/TypeaheadSelect';
 import { getFileName, pickAndValidateSchemaFiles } from '../utils';
 import { CandidateDisplay, getOverrideCandidates, OverrideMode } from './override-util';
 import { SchemaFileList } from './SchemaFileList';
@@ -62,12 +58,9 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
   const [overrideMode, setOverrideMode] = useState<OverrideMode>(initialMode);
   const [selectedKey, setSelectedKey] = useState<string | null>(initialCandidates.selectedKey);
   const [candidates, setCandidates] = useState<Record<string, CandidateDisplay>>(initialCandidates.candidates);
-  const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [uploadedSchemas, setUploadedSchemas] = useState<Record<string, string>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [isUploadingSchema, setIsUploadingSchema] = useState(false);
-
-  const selectedCandidate = selectedKey ? (candidates[selectedKey] ?? null) : null;
 
   const existingFiles = Object.keys(field?.ownerDocument?.definition?.definitionFiles ?? {});
 
@@ -94,18 +87,15 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
     return () => {
       setUploadError(null);
       setSelectedKey(null);
-      setIsSelectOpen(false);
       setUploadedSchemas({});
     };
   }, []);
 
   const handleTypeSelect = useCallback(
-    (_event: MouseEvent | undefined, value: string | number | undefined) => {
-      const key = value as string;
-      if (key in candidates) {
-        setSelectedKey(key);
+    (value: string) => {
+      if (value in candidates) {
+        setSelectedKey(value);
       }
-      setIsSelectOpen(false);
     },
     [candidates],
   );
@@ -173,34 +163,26 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
     if (overrideMode === 'substitution') {
       onSave({ mode: 'substitution', selectedKey });
     } else {
-      const selectedType = candidates[selectedKey] as IFieldTypeInfo | undefined;
+      const selectedType = candidates[selectedKey]?.rawTypeInfo;
       if (selectedType) {
         onSave({ mode: 'type', selectedType, selectedKey });
       }
     }
   }, [selectedKey, overrideMode, candidates, onSave]);
 
-  const handleToggleSelect = useCallback(() => {
-    setIsSelectOpen((prev) => !prev);
-  }, []);
-
   const isSubstitutionMode = overrideMode === 'substitution';
   const selectLabel = isSubstitutionMode ? 'Substitute Element' : 'New Type';
   const selectPlaceholder = isSubstitutionMode ? 'Select a substitute element...' : 'Select a new type...';
 
-  const renderToggle = useCallback(
-    (toggleRef: Ref<MenuToggleElement>) => (
-      <MenuToggle ref={toggleRef} onClick={handleToggleSelect} isExpanded={isSelectOpen} isFullWidth>
-        {selectedCandidate?.displayName || selectPlaceholder}
-      </MenuToggle>
-    ),
-    [handleToggleSelect, isSelectOpen, selectedCandidate?.displayName, selectPlaceholder],
-  );
-
-  const sortedCandidates = useMemo(
-    () => Object.entries(candidates).sort(([, a], [, b]) => a.displayName.localeCompare(b.displayName)),
-    [candidates],
-  );
+  const typeaheadOptions = useMemo<TypeaheadSelectOption[]>(() => {
+    return Object.entries(candidates)
+      .sort(([, a], [, b]) => a.displayName.localeCompare(b.displayName))
+      .map(([key, candidate]) => ({
+        value: key,
+        label: candidate.displayName,
+        ...(candidate.namespaceURI && { description: `Namespace URI: ${candidate.namespaceURI}` }),
+      }));
+  }, [candidates]);
 
   const hasExistingOverride = field?.typeOverride !== FieldOverrideVariant.NONE || isAbstractWrapper;
 
@@ -273,35 +255,16 @@ export const FieldOverrideModal: FunctionComponent<FieldOverrideModalProps> = ({
           </FormGroup>
 
           <FormGroup label={selectLabel} fieldId="type-select" isRequired>
-            <Select
+            <TypeaheadSelect
               id="type-select"
-              isOpen={isSelectOpen}
-              selected={selectedKey}
-              onSelect={handleTypeSelect}
-              onOpenChange={(isOpen) => {
-                setIsSelectOpen(isOpen);
-              }}
-              toggle={renderToggle}
-              maxMenuHeight="240px"
-              popperProps={{
-                preventOverflow: true,
-              }}
-            >
-              <SelectList>
-                {sortedCandidates.map(([key, candidate]) => (
-                  <SelectOption key={key} value={key}>
-                    {candidate.displayName}
-                  </SelectOption>
-                ))}
-              </SelectList>
-            </Select>
-            {selectedCandidate?.description && (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem>{selectedCandidate.description}</HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            )}
+              data-testid="type-select"
+              value={selectedKey ?? ''}
+              onChange={handleTypeSelect}
+              options={typeaheadOptions}
+              placeholder={selectPlaceholder}
+              ariaLabel={selectLabel}
+              popperProps={{ width: 'trigger' }}
+            />
           </FormGroup>
 
           <FormGroup label="Document Schema Files" fieldId="schema-upload">

--- a/packages/ui/src/components/Document/actions/FieldOverride/override-util.test.ts
+++ b/packages/ui/src/components/Document/actions/FieldOverride/override-util.test.ts
@@ -1,9 +1,11 @@
 import { IField } from '../../../../models/datamapper/document';
-import { FieldOverrideVariant, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldSubstituteInfo, IFieldTypeInfo, Types } from '../../../../models/datamapper/types';
+import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { QName } from '../../../../xml-schema-ts/QName';
-import { getOverrideDisplayInfo } from './override-util';
+import { CandidateDisplay, derivePreselectedKey, getOverrideCandidates, getOverrideDisplayInfo } from './override-util';
 
 const NS = 'http://www.w3.org/2001/XMLSchema';
+const SUB_NS = 'http://example.com/sub';
 
 function createField(overrides: Partial<IField> = {}): IField {
   return {
@@ -12,6 +14,7 @@ function createField(overrides: Partial<IField> = {}): IField {
     type: Types.String,
     typeQName: new QName(NS, 'string'),
     typeOverride: FieldOverrideVariant.NONE,
+    namespaceURI: '',
     ...overrides,
   } as IField;
 }
@@ -80,5 +83,273 @@ describe('getOverrideDisplayInfo', () => {
     const result = getOverrideDisplayInfo(field, namespaceMap);
     expect(result).not.toBeNull();
     expect(result!.original).toBe('?');
+  });
+
+  it('should return type override display info for FORCE variant', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.FORCE,
+      typeQName: new QName(NS, 'anyType'),
+      originalField: {
+        name: 'fieldA',
+        displayName: 'fieldA',
+        namespaceURI: '',
+        namespacePrefix: null,
+        type: Types.String,
+        typeQName: new QName(NS, 'string'),
+        namedTypeFragmentRefs: [],
+      },
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    expect(result!.originalLabel).toBe('Original type');
+    expect(result!.currentLabel).toBe('Overridden type');
+    expect(result!.original).toBe('xs:string');
+    expect(result!.current).toBe('xs:anyType');
+  });
+
+  it('should use field.typeQName for original when originalField.typeQName is null', () => {
+    // Line 36: field.originalField?.typeQName ?? field.typeQName — the ?? branch fires
+    // Line 38: field.originalField?.typeQName?.toString() is undefined → falls to field.originalField?.type
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: new QName(NS, 'int'),
+      originalField: {
+        name: 'fieldA',
+        displayName: 'fieldA',
+        namespaceURI: '',
+        namespacePrefix: null,
+        type: Types.String,
+        typeQName: null,
+        namedTypeFragmentRefs: [],
+      },
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    // original: formatQNameWithPrefix(field.typeQName, namespaceMap, originalField.type) → 'xs:int'
+    // (the QName is non-null so formatQNameWithPrefix uses it, ignoring the fallback)
+    expect(result!.original).toBe('xs:int');
+    expect(result!.current).toBe('xs:int');
+  });
+
+  it('should use field.type as fallback for original when originalField is absent (type override)', () => {
+    // Line 38: field.originalField?.typeQName?.toString() → undefined
+    //          field.originalField?.type → undefined
+    //          → falls through to field.type
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: new QName(NS, 'int'),
+      originalField: undefined,
+      type: Types.String,
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    // original: formatQNameWithPrefix(field.typeQName, namespaceMap, field.type) → 'xs:int'
+    // (QName is non-null so it resolves normally; fallback 'String' is not used)
+    expect(result!.original).toBe('xs:int');
+    expect(result!.current).toBe('xs:int');
+  });
+
+  it('should use field.type as current fallback when field.typeQName is null', () => {
+    // Line 40: field.typeQName?.toString() → undefined → falls to field.type
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: null,
+      type: Types.String,
+      originalField: {
+        name: 'fieldA',
+        displayName: 'fieldA',
+        namespaceURI: '',
+        namespacePrefix: null,
+        type: Types.Integer,
+        typeQName: new QName(NS, 'string'),
+        namedTypeFragmentRefs: [],
+      },
+    });
+
+    const result = getOverrideDisplayInfo(field, namespaceMap);
+    expect(result).not.toBeNull();
+    expect(result!.original).toBe('xs:string');
+    // current: formatQNameWithPrefix(null, namespaceMap, field.type) → field.type fallback
+    expect(result!.current).toBe(Types.String);
+  });
+});
+
+describe('derivePreselectedKey', () => {
+  const namespaceMap = { sub: SUB_NS, xs: NS };
+
+  it('returns key when mode is substitution and key is in candidates', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SUBSTITUTION,
+      name: 'Cat',
+      namespaceURI: SUB_NS,
+    });
+    const candidates: Record<string, CandidateDisplay> = { 'sub:Cat': { displayName: 'Cat', namespaceURI: SUB_NS } };
+    expect(derivePreselectedKey(field, 'substitution', namespaceMap, candidates)).toBe('sub:Cat');
+  });
+
+  it('returns null when mode is substitution but key is not in candidates', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SUBSTITUTION,
+      name: 'Dog',
+      namespaceURI: SUB_NS,
+    });
+    const candidates: Record<string, CandidateDisplay> = { 'sub:Cat': { displayName: 'Cat', namespaceURI: SUB_NS } };
+    expect(derivePreselectedKey(field, 'substitution', namespaceMap, candidates)).toBeNull();
+  });
+
+  it('returns null when mode is substitution but typeOverride is not SUBSTITUTION', () => {
+    const field = createField({ typeOverride: FieldOverrideVariant.NONE });
+    expect(derivePreselectedKey(field, 'substitution', namespaceMap, {})).toBeNull();
+  });
+
+  it('returns key when mode is type and override is SAFE with matching typeQName', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: new QName(NS, 'int'),
+    });
+    const candidates: Record<string, CandidateDisplay> = { 'xs:int': { displayName: 'int', namespaceURI: NS } };
+    expect(derivePreselectedKey(field, 'type', namespaceMap, candidates)).toBe('xs:int');
+  });
+
+  it('returns null when mode is type and key is not in candidates', () => {
+    const field = createField({
+      typeOverride: FieldOverrideVariant.SAFE,
+      typeQName: new QName(NS, 'boolean'),
+    });
+    const candidates: Record<string, CandidateDisplay> = { 'xs:int': { displayName: 'int', namespaceURI: NS } };
+    expect(derivePreselectedKey(field, 'type', namespaceMap, candidates)).toBeNull();
+  });
+
+  it('returns null when mode is type but typeOverride is NONE', () => {
+    const field = createField({ typeOverride: FieldOverrideVariant.NONE, typeQName: new QName(NS, 'int') });
+    expect(derivePreselectedKey(field, 'type', namespaceMap, {})).toBeNull();
+  });
+
+  it('returns null when mode is type but typeOverride is SUBSTITUTION', () => {
+    const field = createField({ typeOverride: FieldOverrideVariant.SUBSTITUTION, typeQName: new QName(NS, 'int') });
+    expect(derivePreselectedKey(field, 'type', namespaceMap, {})).toBeNull();
+  });
+
+  it('returns null when mode is type but typeQName is null', () => {
+    const field = createField({ typeOverride: FieldOverrideVariant.SAFE, typeQName: null });
+    expect(derivePreselectedKey(field, 'type', namespaceMap, {})).toBeNull();
+  });
+});
+
+describe('getOverrideCandidates', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds type candidates from getSafeOverrideCandidates and resolves namespaceURI', () => {
+    const typeQName = new QName(NS, 'int');
+    const mockRaw: Record<string, IFieldTypeInfo> = {
+      'xs:int': {
+        displayName: 'int',
+        typeQName,
+        type: Types.Integer,
+        isBuiltIn: true,
+        description: 'Integer type',
+      },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockRaw);
+
+    const { candidates, selectedKey } = getOverrideCandidates(field, 'type', { xs: NS });
+
+    expect(candidates['xs:int'].displayName).toBe('int');
+    expect(candidates['xs:int'].namespaceURI).toBe(NS);
+    expect(selectedKey).toBeNull();
+  });
+
+  it('populates rawTypeInfo for type-mode candidates', () => {
+    const typeQName = new QName(NS, 'int');
+    const mockRaw: Record<string, IFieldTypeInfo> = {
+      'xs:int': { displayName: 'int', typeQName, type: Types.Integer, isBuiltIn: true },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockRaw);
+
+    const { candidates } = getOverrideCandidates(field, 'type', { xs: NS });
+
+    expect(candidates['xs:int'].rawTypeInfo).toBe(mockRaw['xs:int']);
+  });
+
+  it('builds substitution candidates from getFieldSubstitutionCandidates and resolves namespaceURI', () => {
+    const qname = new QName(SUB_NS, 'Cat');
+    const mockRaw: Record<string, IFieldSubstituteInfo> = {
+      'sub:Cat': {
+        displayName: 'Cat',
+        qname,
+        type: Types.Container,
+        typeQName: null,
+        namedTypeFragmentRefs: [],
+      },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(mockRaw);
+
+    const { candidates, selectedKey } = getOverrideCandidates(field, 'substitution', { sub: SUB_NS });
+
+    expect(candidates['sub:Cat'].displayName).toBe('Cat');
+    expect(candidates['sub:Cat'].namespaceURI).toBe(SUB_NS);
+    expect(selectedKey).toBeNull();
+  });
+
+  it('leaves rawTypeInfo undefined for substitution-mode candidates', () => {
+    const qname = new QName(SUB_NS, 'Cat');
+    const mockRaw: Record<string, IFieldSubstituteInfo> = {
+      'sub:Cat': { displayName: 'Cat', qname, type: Types.Container, typeQName: null, namedTypeFragmentRefs: [] },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(mockRaw);
+
+    const { candidates } = getOverrideCandidates(field, 'substitution', { sub: SUB_NS });
+
+    expect(candidates['sub:Cat'].rawTypeInfo).toBeUndefined();
+  });
+
+  it('uses empty string when typeQName has no namespace URI in type mode', () => {
+    const typeQName = new QName(null, 'myType');
+    const mockRaw: Record<string, IFieldTypeInfo> = {
+      myType: { displayName: 'myType', typeQName, type: Types.String, isBuiltIn: false },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockRaw);
+
+    const { candidates } = getOverrideCandidates(field, 'type', {});
+
+    // QName(null, ...) returns '' from getNamespaceURI(); 'N/A' fallback only for null/undefined
+    expect(candidates['myType'].namespaceURI).toBe('');
+  });
+
+  it('uses empty string when qname has no namespace URI in substitution mode', () => {
+    const qname = new QName(null, 'Dog');
+    const mockRaw: Record<string, IFieldSubstituteInfo> = {
+      Dog: { displayName: 'Dog', qname, type: Types.Container, typeQName: null, namedTypeFragmentRefs: [] },
+    };
+    const field = createField();
+    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue(mockRaw);
+
+    const { candidates } = getOverrideCandidates(field, 'substitution', {});
+
+    // QName(null, ...) returns '' from getNamespaceURI(); 'N/A' fallback only for null/undefined
+    expect(candidates['Dog'].namespaceURI).toBe('');
+  });
+
+  it('derives a pre-selected key for type mode when field has SAFE override with matching typeQName', () => {
+    const typeQName = new QName(NS, 'int');
+    const mockRaw: Record<string, IFieldTypeInfo> = {
+      'xs:int': { displayName: 'int', typeQName, type: Types.Integer, isBuiltIn: true },
+    };
+    const field = createField({ typeOverride: FieldOverrideVariant.SAFE, typeQName });
+    vi.spyOn(FieldOverrideService, 'getSafeOverrideCandidates').mockReturnValue(mockRaw);
+
+    const { selectedKey } = getOverrideCandidates(field, 'type', { xs: NS });
+
+    expect(selectedKey).toBe('xs:int');
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldOverride/override-util.ts
+++ b/packages/ui/src/components/Document/actions/FieldOverride/override-util.ts
@@ -1,5 +1,5 @@
 import { IField } from '../../../../models/datamapper/document';
-import { FieldOverrideVariant } from '../../../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldSubstituteInfo, IFieldTypeInfo } from '../../../../models/datamapper/types';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { formatQNameWithPrefix, formatWithPrefix } from '../../../../services/namespace-util';
 
@@ -44,7 +44,12 @@ export function getOverrideDisplayInfo(
 export type OverrideMode = 'type' | 'substitution';
 
 /** Minimal display shape shared by type and substitution candidates */
-export type CandidateDisplay = { displayName: string; description?: string };
+export type CandidateDisplay = {
+  displayName: string;
+  namespaceURI: string;
+  /** Populated only for type-mode candidates; undefined for substitution candidates */
+  rawTypeInfo?: IFieldTypeInfo;
+};
 
 /** Derive the pre-selected key when opening the modal for a field with an existing override. */
 export function derivePreselectedKey(
@@ -76,11 +81,30 @@ export function getOverrideCandidates(
   field: IField,
   mode: OverrideMode,
   namespaceMap: Record<string, string>,
-): { candidates: Record<string, CandidateDisplay>; selectedKey: string | null } {
-  const candidates =
-    mode === 'substitution'
-      ? FieldOverrideService.getFieldSubstitutionCandidates(field, namespaceMap)
-      : FieldOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+): {
+  candidates: Record<string, CandidateDisplay>;
+  selectedKey: string | null;
+} {
+  const isSubstitution = mode === 'substitution';
+
+  const rawCandidates = isSubstitution
+    ? FieldOverrideService.getFieldSubstitutionCandidates(field, namespaceMap)
+    : FieldOverrideService.getSafeOverrideCandidates(field, namespaceMap);
+
+  const candidates: Record<string, CandidateDisplay> = {};
+
+  for (const [key, value] of Object.entries(rawCandidates)) {
+    const namespaceURI = isSubstitution
+      ? (value as IFieldSubstituteInfo).qname.getNamespaceURI()
+      : (value as IFieldTypeInfo).typeQName.getNamespaceURI();
+
+    candidates[key] = {
+      displayName: value.displayName,
+      namespaceURI,
+      rawTypeInfo: isSubstitution ? undefined : (value as IFieldTypeInfo),
+    };
+  }
+
   const selectedKey = derivePreselectedKey(field, mode, namespaceMap, candidates);
   return { candidates, selectedKey };
 }


### PR DESCRIPTION
Resolves: [#3344](https://github.com/KaotoIO/kaoto/issues/3344)

https://github.com/user-attachments/assets/782f9b3c-2f72-4678-9c43-beb8f46c91f4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded field override type picking to searchable typeahead with improved namespace-based option display.
  * Added support for customizing typeahead dropdown positioning, and improved option rendering when description data is missing.
* **Bug Fixes**
  * Improved typeahead interaction (blur/typing behavior) and prevented unintended `onChange` during open/empty/clear flows.
  * Updated override save behavior to only save type selections when the required type info is available.
  * Schema upload now skips re-reading already-uploaded files and ignores empty selections.
* **Tests**
  * Expanded coverage for typeahead interactions, option formatting, override saving edge cases, and schema upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->