### PR TITLE
fix(Citrus): add description field support to `CitrusTestVisualEntity`

### DIFF
--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -113,9 +113,55 @@ describe('CitrusTestVisualEntity', () => {
       expect(label).toBe('sample-test');
     });
 
+    it('should return the description as a node label', () => {
+      const testDefinition = cloneDeep(citrusTestJson);
+      testDefinition.description = 'Test description';
+      citrusTestEntity = new CitrusTestVisualEntity(testDefinition);
+
+      const result = citrusTestEntity.getNodeLabel('test', NodeLabelType.Description);
+
+      expect(result).toBe('Test description');
+    });
+
+    it('should return the ID as a node label if description is empty', () => {
+      const testDefinition = cloneDeep(citrusTestJson);
+      testDefinition.description = '';
+      citrusTestEntity = new CitrusTestVisualEntity(testDefinition);
+
+      const result = citrusTestEntity.getNodeLabel('test', NodeLabelType.Description);
+
+      expect(result).toBe('sample-test');
+    });
+
     it('should get the label from given node path', () => {
       const label = citrusTestEntity.getNodeLabel('actions.0.print');
       expect(label).toBe('print');
+    });
+
+    it('should return the description for a child action when available', () => {
+      const testDefinition = cloneDeep(citrusTestJson);
+      setValue(testDefinition, 'actions.0.print.description', 'Print greeting message');
+      citrusTestEntity = new CitrusTestVisualEntity(testDefinition);
+
+      const result = citrusTestEntity.getNodeLabel('actions.0.print', NodeLabelType.Description);
+
+      expect(result).toBe('Print greeting message');
+    });
+
+    it('should return the default label for a child action when description is not available', () => {
+      const result = citrusTestEntity.getNodeLabel('actions.0.print', NodeLabelType.Description);
+
+      expect(result).toBe('print');
+    });
+
+    it('should return the default label for a child action when labelType is not Description', () => {
+      const testDefinition = cloneDeep(citrusTestJson);
+      setValue(testDefinition, 'actions.0.print.description', 'Print greeting message');
+      citrusTestEntity = new CitrusTestVisualEntity(testDefinition);
+
+      const result = citrusTestEntity.getNodeLabel('actions.0.print');
+
+      expect(result).toBe('print');
     });
   });
 
@@ -924,7 +970,7 @@ describe('CitrusTestVisualEntity', () => {
       citrusTestEntity.test.description = 'This is a test description';
       const vizNode = await citrusTestEntity.toVizNode();
 
-      expect(vizNode.getNodeLabel(NodeLabelType.Description)).toBe('sample-test');
+      expect(vizNode.getNodeLabel(NodeLabelType.Description)).toBe('This is a test description');
     });
 
     it('should use the path name as the node label', async () => {

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -10,6 +10,7 @@ import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../citrus/citrus-catalog-index'
 import { Test, TestAction, TestActions } from '../../citrus/entities/Test';
 import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import { NodeLabelType } from '../../settings';
 import {
   AddStepMode,
   BaseVisualEntity,
@@ -135,11 +136,25 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
    * @param path - The path to the node in the visualization tree
    * @returns The display label for the node
    */
-  getNodeLabel(path?: string): string {
+  getNodeLabel(path?: string, labelType?: NodeLabelType): string {
     if (!path) return '';
 
     if (path === this.getRootPath()) {
+      const description: string | undefined = this.test.description;
+      if (labelType === NodeLabelType.Description && description) {
+        return description;
+      }
+
       return this.id;
+    }
+
+    // Check if we should return description for child actions
+    if (labelType === NodeLabelType.Description) {
+      const actionModel: TestAction = getValue(this.test, this.toModelPath(path));
+      const description = actionModel?.description;
+      if (description) {
+        return description;
+      }
     }
 
     const name = path.split('.').pop() || '';


### PR DESCRIPTION
Implements description field support for CitrusTestVisualEntity to match the functionality in AbstractCamelVisualEntity. The getNodeLabel method now accepts an optional NodeLabelType parameter and returns the description when NodeLabelType.Description is specified.

Fixes https://github.com/KaotoIO/kaoto/issues/3365

## Changes
- Updated `CitrusTestVisualEntity.getNodeLabel()` to accept optional `NodeLabelType` parameter
- Added logic to return description when `NodeLabelType.Description` is used
- Added comprehensive tests for the new functionality
- All 90 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Visual test nodes now show the test description when a description-based label is requested.
  * Child action nodes display the related action description when available.
  * If descriptions are missing—or a non-description label type is requested—labels revert to the previous default formatting.
* **Tests**
  * Updated visualization node label tests to cover description-present/empty cases and validate the updated description label behavior for both root and child paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->