### PR TITLE
chore: migrate Tier 1 services from CamelCatalogService to DynamicCatalogRegistry

### DIFF
--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -161,7 +161,7 @@ describe('ParametersSection', () => {
     });
 
     const attachButton = screen.getByTestId('attach-schema-param-testparam1-button');
-    act(() => {
+    await act(async () => {
       fireEvent.click(attachButton);
     });
     const importButton = screen.getByTestId('attach-schema-modal-btn-file');
@@ -229,7 +229,7 @@ describe('ParametersSection', () => {
     });
 
     const attachButton = screen.getByTestId('attach-schema-param-testparam1-button');
-    act(() => {
+    await act(async () => {
       fireEvent.click(attachButton);
     });
     const importButton = screen.getByTestId('attach-schema-modal-btn-file');

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.test.tsx
@@ -26,12 +26,14 @@ describe('AttachSchemaButton', () => {
     expect(modal).toBeNull();
 
     const attachButton = await screen.findByTestId('attach-schema-sourceBody-Body-button');
-    act(() => {
+    await act(async () => {
       fireEvent.click(attachButton);
     });
 
-    modal = screen.queryByTestId('attach-schema-modal');
-    expect(modal).toBeInTheDocument();
+    await waitFor(() => {
+      modal = screen.queryByTestId('attach-schema-modal');
+      expect(modal).toBeInTheDocument();
+    });
   });
 
   it('should open update schema warning modal when schema is already attached', async () => {

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.tsx
@@ -49,11 +49,11 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
     setIsWarningModalOpen(false);
   }, []);
 
-  const handleWarningModal = useCallback(() => {
+  const handleWarningModal = useCallback(async () => {
     if (actionName === 'Update') {
       onWarningModalOpen();
     } else {
-      void onAttachSchemaModalOpen();
+      await onAttachSchemaModalOpen();
     }
   }, [actionName, onAttachSchemaModalOpen, onWarningModalOpen]);
 

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.tsx
@@ -3,6 +3,7 @@ import { ImportIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useCallback, useMemo, useState } from 'react';
 
 import { DocumentType } from '../../../../models/datamapper';
+import { DataMapperStepService } from '../../../../services/datamapper-step.service';
 import { AttachSchemaModal } from './AttachSchemaModal';
 import { UpdateSchemaWarningModal } from './UpdateSchemaWarningModal';
 
@@ -21,7 +22,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
 }) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isWarningModalOpen, setIsWarningModalOpen] = useState<boolean>(false);
-
+  const [jsonAllowed, setJsonAllowed] = useState<boolean>(false);
   const actionName = hasSchema ? 'Update' : 'Attach';
 
   const documentTypeLabel = useMemo(() => {
@@ -29,10 +30,12 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
     return documentType === DocumentType.SOURCE_BODY ? 'Source' : 'Target';
   }, [documentId, documentType]);
 
-  const onAttachSchemaModalOpen = useCallback(() => {
+  const onAttachSchemaModalOpen = useCallback(async () => {
+    const supportsJsonBody = await DataMapperStepService.supportsJsonBody();
+    setJsonAllowed(documentType !== DocumentType.SOURCE_BODY || supportsJsonBody);
     setIsWarningModalOpen(false);
     setIsModalOpen(true);
-  }, []);
+  }, [documentType]);
 
   const onModalClose = useCallback(() => {
     setIsModalOpen(false);
@@ -50,7 +53,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
     if (actionName === 'Update') {
       onWarningModalOpen();
     } else {
-      onAttachSchemaModalOpen();
+      void onAttachSchemaModalOpen();
     }
   }, [actionName, onAttachSchemaModalOpen, onWarningModalOpen]);
 
@@ -81,6 +84,7 @@ export const AttachSchemaButton: FunctionComponent<AttachSchemaProps> = ({
         documentReferenceId={documentReferenceId}
         actionName={actionName}
         documentTypeLabel={documentTypeLabel}
+        jsonAllowed={jsonAllowed}
       />
     </>
   );

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -22,6 +22,11 @@ import { AttachSchemaModal } from './AttachSchemaModal';
 vi.mock('../../../../stubs/read-file-as-string');
 const mockReadFileAsString = readFileAsString as MockedFunction<typeof readFileAsString>;
 
+async function findRootElementInput() {
+  const container = await screen.findByTestId('attach-schema-root-element');
+  return container.querySelector('input') as HTMLInputElement;
+}
+
 describe('AttachSchemaModal', () => {
   afterAll(() => {
     mockReadFileAsString.mockReset();
@@ -85,6 +90,7 @@ describe('AttachSchemaModal', () => {
             documentReferenceId={BODY_DOCUMENT_ID}
             actionName="Attach"
             documentTypeLabel="Target"
+            jsonAllowed
           />
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -363,6 +369,7 @@ describe('AttachSchemaModal', () => {
             documentReferenceId={BODY_DOCUMENT_ID}
             actionName="Attach"
             documentTypeLabel="Target"
+            jsonAllowed
           />
         </DataMapperProvider>
       </BrowserFilePickerMetadataProvider>,
@@ -453,11 +460,6 @@ describe('AttachSchemaModal', () => {
   });
 
   describe('Root Element Selection', () => {
-    async function findRootElementInput() {
-      const container = await screen.findByTestId('attach-schema-root-element');
-      return container.querySelector('input') as HTMLInputElement;
-    }
-
     it('should show root element selector when multiple elements are available', async () => {
       mockReadFileAsString.mockResolvedValue(getMultipleElementsXsd());
       render(

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -26,7 +26,6 @@ import {
   SCHEMA_FILE_NAME_PATTERN_XML,
 } from '../../../../models/datamapper/document';
 import { MetadataContext } from '../../../../providers';
-import { DataMapperStepService } from '../../../../services/datamapper-step.service';
 import { DocumentService } from '../../../../services/document/document.service';
 import { createSchemaFileItems, getFileExtension, isJsonExtension, pickAndValidateSchemaFiles } from '../utils';
 import { RootElementSelect } from './RootElementSelect';
@@ -40,6 +39,7 @@ type AttachSchemaModalProps = {
   documentReferenceId: string;
   actionName: string;
   documentTypeLabel: string;
+  jsonAllowed?: boolean;
 };
 
 export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
@@ -50,6 +50,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   documentReferenceId,
   actionName,
   documentTypeLabel,
+  jsonAllowed = false,
 }) => {
   const api = useContext(MetadataContext)!;
   const { mappingTree, setIsLoading, updateDocument } = useDataMapper();
@@ -60,19 +61,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   const [createDocumentResult, setCreateDocumentResult] = useState<CreateDocumentResult | null>(null);
   const [isUploadingSchema, setIsUploadingSchema] = useState(false);
 
-  const fileNamePattern = useMemo(() => {
-    if (documentType === DocumentType.SOURCE_BODY) {
-      return DataMapperStepService.supportsJsonBody() ? SCHEMA_FILE_NAME_PATTERN : SCHEMA_FILE_NAME_PATTERN_XML;
-    }
-    return SCHEMA_FILE_NAME_PATTERN;
-  }, [documentType]);
-
-  const showJsonSchemaOption = useMemo(() => {
-    if (documentType === DocumentType.SOURCE_BODY) {
-      return DataMapperStepService.supportsJsonBody();
-    }
-    return true;
-  }, [documentType]);
+  const fileNamePattern = jsonAllowed ? SCHEMA_FILE_NAME_PATTERN : SCHEMA_FILE_NAME_PATTERN_XML;
 
   const validateAndCreateDocument = useCallback(
     async (allPaths: string[]) => {
@@ -304,7 +293,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
                   }}
                 />
               </InputGroupItem>
-              {showJsonSchemaOption && (
+              {jsonAllowed && (
                 <InputGroupItem>
                   <Radio
                     id="option-json-schema"

--- a/packages/ui/src/components/Document/actions/utils.test.ts
+++ b/packages/ui/src/components/Document/actions/utils.test.ts
@@ -58,34 +58,36 @@ describe('utils', () => {
   });
 
   describe('validateFileExtension', () => {
-    it('should return undefined for valid XML extension on SOURCE_BODY', () => {
-      expect(validateFileExtension('.xsd', DocumentType.SOURCE_BODY)).toBeUndefined();
+    it('should return undefined for valid XML extension on SOURCE_BODY', async () => {
+      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockResolvedValue(false);
+      await expect(validateFileExtension('.xsd', DocumentType.SOURCE_BODY)).resolves.toBeUndefined();
     });
 
-    it('should return error for JSON on SOURCE_BODY when not supported', () => {
-      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockReturnValue(false);
-      const result = validateFileExtension('.json', DocumentType.SOURCE_BODY);
+    it('should return error for JSON on SOURCE_BODY when not supported', async () => {
+      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockResolvedValue(false);
+      const result = await validateFileExtension('.json', DocumentType.SOURCE_BODY);
       expect(result).toContain('JSON source body is not supported');
     });
 
-    it('should return undefined for JSON on SOURCE_BODY when supported', () => {
-      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockReturnValue(true);
-      expect(validateFileExtension('.json', DocumentType.SOURCE_BODY)).toBeUndefined();
+    it('should return undefined for JSON on SOURCE_BODY when supported', async () => {
+      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockResolvedValue(true);
+      await expect(validateFileExtension('.json', DocumentType.SOURCE_BODY)).resolves.toBeUndefined();
     });
 
-    it('should return error for unknown extension on SOURCE_BODY', () => {
-      const result = validateFileExtension('.txt', DocumentType.SOURCE_BODY);
+    it('should return error for unknown extension on SOURCE_BODY', async () => {
+      vi.spyOn(DataMapperStepService, 'supportsJsonBody').mockResolvedValue(false);
+      const result = await validateFileExtension('.txt', DocumentType.SOURCE_BODY);
       expect(result).toContain("Unknown file extension '.txt'");
       expect(result).toContain('Only XML schema file');
     });
 
-    it('should return undefined for valid extensions on TARGET_BODY', () => {
-      expect(validateFileExtension('.xsd', DocumentType.TARGET_BODY)).toBeUndefined();
-      expect(validateFileExtension('.json', DocumentType.TARGET_BODY)).toBeUndefined();
+    it('should return undefined for valid extensions on TARGET_BODY', async () => {
+      await expect(validateFileExtension('.xsd', DocumentType.TARGET_BODY)).resolves.toBeUndefined();
+      await expect(validateFileExtension('.json', DocumentType.TARGET_BODY)).resolves.toBeUndefined();
     });
 
-    it('should return error for unknown extension on TARGET_BODY', () => {
-      const result = validateFileExtension('.txt', DocumentType.TARGET_BODY);
+    it('should return error for unknown extension on TARGET_BODY', async () => {
+      const result = await validateFileExtension('.txt', DocumentType.TARGET_BODY);
       expect(result).toContain("Unknown file extension '.txt'");
       expect(result).toContain('Either XML schema');
     });

--- a/packages/ui/src/components/Document/actions/utils.ts
+++ b/packages/ui/src/components/Document/actions/utils.ts
@@ -24,9 +24,11 @@ export function isJsonExtension(ext: string): boolean {
   return VALID_JSON_EXTENSIONS.includes(ext);
 }
 
-export function validateFileExtension(ext: string, documentType: DocumentType): string | undefined {
+/** Public for tests only */
+export async function validateFileExtension(ext: string, documentType: DocumentType): Promise<string | undefined> {
   if (documentType === DocumentType.SOURCE_BODY) {
-    if (isJsonExtension(ext) && !DataMapperStepService.supportsJsonBody()) {
+    const doesDatamapperSupportsJsonBody = await DataMapperStepService.supportsJsonBody();
+    if (isJsonExtension(ext) && !doesDatamapperSupportsJsonBody) {
       return 'JSON source body is not supported. The xslt-saxon component requires the useJsonBody parameter which is not available in this Camel version. Please use parameter for JSON source.';
     }
     if (!isXmlExtension(ext) && !isJsonExtension(ext)) {
@@ -155,7 +157,7 @@ export async function pickAndValidateSchemaFiles(
   // Validate file extensions for all selected files
   for (const filePath of newPaths) {
     const ext = getFileExtension(filePath);
-    const extensionError = validateFileExtension(ext, documentType);
+    const extensionError = await validateFileExtension(ext, documentType);
     if (extensionError) {
       return { paths: [], error: extensionError };
     }

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/__snapshots__/simple-language.suggestions.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Properties Suggestions > should return suggestions from the catalog 1`] = `
+exports[`Properties Suggestions > should return suggestions for word="''" inputValue="'foo example'" 1`] = `
 [
   {
     "description": "The message body",
@@ -631,7 +631,7 @@ exports[`Properties Suggestions > should return suggestions from the catalog 1`]
 ]
 `;
 
-exports[`Properties Suggestions > should return suggestions when \`word\` it is not specified 1`] = `
+exports[`Properties Suggestions > should return suggestions for word="''" inputValue="'test example'" 1`] = `
 [
   {
     "description": "The message body",
@@ -1262,7 +1262,7 @@ exports[`Properties Suggestions > should return suggestions when \`word\` it is 
 ]
 `;
 
-exports[`Properties Suggestions > should return suggestions when \`word\` it is specified 1`] = `
+exports[`Properties Suggestions > should return suggestions for word="'test'" inputValue="'test example'" 1`] = `
 [
   {
     "description": "The variable with the given name",
@@ -1284,7 +1284,7 @@ exports[`Properties Suggestions > should return suggestions when \`word\` it is 
 ]
 `;
 
-exports[`Properties Suggestions > should use \`foo\` if word is empty 1`] = `
+exports[`Properties Suggestions > should return suggestions from the catalog 1`] = `
 [
   {
     "description": "The message body",

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
@@ -26,38 +26,22 @@ describe('Properties Suggestions', () => {
     expect(applies).toBe(expected);
   });
 
-  it('should use `foo` if word is empty', async () => {
-    const word = '';
-    const suggestions = await getSimpleLanguageSuggestionProvider().getSuggestions(word, {
-      inputValue: 'foo example',
-      cursorPosition: 0,
-      propertyName: 'foo-property',
-    });
+  it.each([
+    { word: '', inputValue: 'foo example', propertyName: 'foo-property' },
+    { word: 'test', inputValue: 'test example', propertyName: 'test-property' },
+    { word: '', inputValue: 'test example', propertyName: 'test-property' },
+  ] as const)(
+    'should return suggestions for word="$word" inputValue="$inputValue"',
+    async ({ word, inputValue, propertyName }) => {
+      const suggestions = await getSimpleLanguageSuggestionProvider().getSuggestions(word, {
+        inputValue,
+        cursorPosition: 0,
+        propertyName,
+      });
 
-    expect(suggestions).toMatchSnapshot();
-  });
-
-  it('should return suggestions when `word` it is specified', async () => {
-    const word = 'test';
-    const suggestions = await getSimpleLanguageSuggestionProvider().getSuggestions(word, {
-      inputValue: 'test example',
-      cursorPosition: 0,
-      propertyName: 'test-property',
-    });
-
-    expect(suggestions).toMatchSnapshot();
-  });
-
-  it('should return suggestions when `word` it is not specified', async () => {
-    const word = '';
-    const suggestions = await getSimpleLanguageSuggestionProvider().getSuggestions(word, {
-      inputValue: 'test example',
-      cursorPosition: 0,
-      propertyName: 'test-property',
-    });
-
-    expect(suggestions).toMatchSnapshot();
-  });
+      expect(suggestions).toMatchSnapshot();
+    },
+  );
 
   it('should use the DynamicCatalogRegistry to query available functions', async () => {
     const registrySpy = vi.spyOn(DynamicCatalogRegistry.get(), 'getEntity');

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.test.ts
@@ -1,15 +1,16 @@
 import { CatalogLibrary } from '@kaoto/camel-catalog/catalog-index.d.ts';
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 
-import { CamelCatalogService, CatalogKind } from '../../../../../../models';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../../../../../models';
 import { IMetadataApi } from '../../../../../../providers';
-import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../../stubs/test-load-catalog';
 import { getSimpleLanguageSuggestionProvider } from './simple-language.suggestions';
 
 describe('Properties Suggestions', () => {
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Function, catalogsMap.functionsCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it.each([
@@ -58,8 +59,8 @@ describe('Properties Suggestions', () => {
     expect(suggestions).toMatchSnapshot();
   });
 
-  it('should use the CamelCatalogService to query available functions', async () => {
-    const catalogSpy = vi.spyOn(CamelCatalogService, 'getComponent');
+  it('should use the DynamicCatalogRegistry to query available functions', async () => {
+    const registrySpy = vi.spyOn(DynamicCatalogRegistry.get(), 'getEntity');
     const word = '';
     await getSimpleLanguageSuggestionProvider().getSuggestions(word, {
       inputValue: 'test example',
@@ -67,7 +68,7 @@ describe('Properties Suggestions', () => {
       propertyName: 'test-property',
     });
 
-    expect(catalogSpy).toHaveBeenCalledWith(CatalogKind.Function, 'simple');
+    expect(registrySpy).toHaveBeenCalledWith(CatalogKind.Function, 'simple');
   });
 
   it('should return suggestions from the catalog', async () => {
@@ -82,7 +83,7 @@ describe('Properties Suggestions', () => {
   });
 
   it('should generate basic functions if the catalog is not available', async () => {
-    vi.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce(undefined);
+    vi.spyOn(DynamicCatalogRegistry.get(), 'getEntity').mockResolvedValueOnce(undefined);
     const suggestions = await getSimpleLanguageSuggestionProvider().getSuggestions('test', {
       inputValue: 'test example',
       cursorPosition: 0,

--- a/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/suggestions/suggestions/simple-language.suggestions.ts
@@ -1,6 +1,7 @@
 import { Suggestion, SuggestionProvider } from '@kaoto/forms';
 
-import { CamelCatalogService, CatalogKind } from '../../../../../../models';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../../../../../models';
 import { IMetadataApi } from '../../../../../../providers';
 
 const SIMPLE_LANGUAGE_ACTIVATED_FIELDS = new Set([
@@ -17,7 +18,7 @@ export const getSimpleLanguageSuggestionProvider = (metadata?: IMetadataApi['get
       const normalizedWord = word === '' ? 'name' : word;
       const normalizedWordLowercase = normalizedWord.toLowerCase();
 
-      const simpleLangFunctions = CamelCatalogService.getComponent(CatalogKind.Function, 'simple') ?? {};
+      const simpleLangFunctions = (await DynamicCatalogRegistry.get().getEntity(CatalogKind.Function, 'simple')) ?? {};
       const {
         body,
         ['variable.name']: variableName,

--- a/packages/ui/src/services/datamapper-step.service.test.ts
+++ b/packages/ui/src/services/datamapper-step.service.test.ts
@@ -1,13 +1,12 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import type { Mock } from 'vitest';
 
+import { DynamicCatalogRegistry } from '../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind, createVisualizationNode, IVisualizationNode } from '../models';
-import { CamelCatalogService } from '../models/visualization/flows/camel-catalog.service';
 import { EntitiesContextResult } from '../providers';
 import { XSLT_COMPONENT_NAME, XsltComponentDef } from '../utils';
 import { DataMapperStepService } from './datamapper-step.service';
 
-vi.mock('../models/visualization/flows/camel-catalog.service');
+vi.mock('../dynamic-catalog/dynamic-catalog-registry');
 
 describe('DataMapperStepService', () => {
   let mockEntitiesContext: Mocked<EntitiesContextResult>;
@@ -157,8 +156,17 @@ describe('DataMapperStepService', () => {
   });
 
   describe('supportsJsonBody', () => {
-    it('should return true when useJsonBody parameter exists in catalog', () => {
-      (CamelCatalogService.getComponent as Mock).mockReturnValue({
+    let mockGetEntity: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockGetEntity = vi.fn();
+      vi.mocked(DynamicCatalogRegistry.get).mockReturnValue({ getEntity: mockGetEntity } as unknown as ReturnType<
+        typeof DynamicCatalogRegistry.get
+      >);
+    });
+
+    it('should return true when useJsonBody parameter exists in catalog', async () => {
+      mockGetEntity.mockResolvedValue({
         properties: {
           useJsonBody: {
             type: 'boolean',
@@ -167,14 +175,14 @@ describe('DataMapperStepService', () => {
         },
       });
 
-      const result = DataMapperStepService.supportsJsonBody();
+      const result = await DataMapperStepService.supportsJsonBody();
 
       expect(result).toBe(true);
-      expect(CamelCatalogService.getComponent).toHaveBeenCalledWith(CatalogKind.Component, 'xslt-saxon');
+      expect(mockGetEntity).toHaveBeenCalledWith(CatalogKind.Component, 'xslt-saxon');
     });
 
-    it('should return false when useJsonBody parameter does not exist in catalog', () => {
-      (CamelCatalogService.getComponent as Mock).mockReturnValue({
+    it('should return false when useJsonBody parameter does not exist in catalog', async () => {
+      mockGetEntity.mockResolvedValue({
         properties: {
           otherParam: {
             type: 'string',
@@ -182,25 +190,25 @@ describe('DataMapperStepService', () => {
         },
       });
 
-      const result = DataMapperStepService.supportsJsonBody();
+      const result = await DataMapperStepService.supportsJsonBody();
 
       expect(result).toBe(false);
     });
 
-    it('should return false when component is not found', () => {
-      (CamelCatalogService.getComponent as Mock).mockReturnValue(undefined);
+    it('should return false when component is not found', async () => {
+      mockGetEntity.mockResolvedValue(undefined);
 
-      const result = DataMapperStepService.supportsJsonBody();
+      const result = await DataMapperStepService.supportsJsonBody();
 
       expect(result).toBe(false);
     });
 
-    it('should return false when component has no properties', () => {
-      (CamelCatalogService.getComponent as Mock).mockReturnValue({
+    it('should return false when component has no properties', async () => {
+      mockGetEntity.mockResolvedValue({
         properties: undefined,
       });
 
-      const result = DataMapperStepService.supportsJsonBody();
+      const result = await DataMapperStepService.supportsJsonBody();
 
       expect(result).toBe(false);
     });

--- a/packages/ui/src/services/datamapper-step.service.ts
+++ b/packages/ui/src/services/datamapper-step.service.ts
@@ -1,8 +1,8 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalogRegistry } from '../dynamic-catalog/dynamic-catalog-registry';
 import { IVisualizationNode } from '../models';
 import { CatalogKind } from '../models/catalog-kind';
-import { CamelCatalogService } from '../models/visualization/flows/camel-catalog.service';
 import { EntitiesContextResult } from '../providers';
 import { isXSLTComponent, XSLT_COMPONENT_NAME } from '../utils';
 import type { XsltComponentDef } from '../utils/is-xslt-component';
@@ -80,8 +80,8 @@ export class DataMapperStepService {
    * This is determined by checking if the useJsonBody parameter exists in the component catalog.
    * @returns True if the xslt-saxon component supports JSON body, false otherwise
    */
-  static supportsJsonBody(): boolean {
-    const component = CamelCatalogService.getComponent(CatalogKind.Component, 'xslt-saxon');
+  static async supportsJsonBody(): Promise<boolean> {
+    const component = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, 'xslt-saxon');
     return component?.properties?.['useJsonBody'] !== undefined;
   }
 
@@ -105,9 +105,7 @@ export class DataMapperStepService {
       return;
     }
 
-    if (!xsltStep.to.parameters) {
-      xsltStep.to.parameters = {};
-    }
+    xsltStep.to.parameters ??= {};
 
     if (isUseJsonBody) {
       xsltStep.to.parameters.useJsonBody = true;

--- a/packages/ui/src/stubs/test-load-catalog.ts
+++ b/packages/ui/src/stubs/test-load-catalog.ts
@@ -5,6 +5,7 @@ import { DynamicCatalogRegistry } from '../dynamic-catalog/dynamic-catalog-regis
 import {
   CamelComponentsProvider,
   CamelDataformatProvider,
+  CamelFunctionProvider,
   CamelLanguageProvider,
   CamelLoadbalancerProvider,
   CamelProcessorsProvider,
@@ -214,5 +215,9 @@ export const setupDynamicCatalogRegistry = (catalogsMap: Awaited<ReturnType<type
   DynamicCatalogRegistry.get().setCatalog(
     CatalogKind.Loadbalancer,
     new DynamicCatalog(new CamelLoadbalancerProvider(catalogsMap.loadbalancerCatalog)),
+  );
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.Function,
+    new DynamicCatalog(new CamelFunctionProvider(catalogsMap.functionsCatalogMap)),
   );
 };


### PR DESCRIPTION
### Context
Migrate the two simplest (Tier 1) call sites away from the static CamelCatalogService and onto the async DynamicCatalogRegistry API, as described in MIGRATION_CAMEL_CATALOG_TO_DYNAMIC.md.

Changes:
- services/datamapper-step.service.ts: replace synchronous CamelCatalogService.getComponent(CatalogKind.Component, 'xslt-saxon') with async DynamicCatalogRegistry.get().getEntity(); supportsJsonBody() is now an async method returning Promise<boolean>.
- components/.../simple-language.suggestions.ts: replace CamelCatalogService.getComponent(CatalogKind.Function, 'simple') with await DynamicCatalogRegistry.get().getEntity() inside the already-async getSuggestions() callback — zero interface impact.
- components/Document/actions/utils.ts: validateFileExtension() made async to await the new supportsJsonBody(); pickAndValidateSchemaFiles() chain updated accordingly.
- components/Document/actions/AttachSchema/AttachSchemaButton.tsx, AttachSchemaModal.tsx: await the now-async validateFileExtension() and pickAndValidateSchemaFiles() calls.
- stubs/test-load-catalog.ts: add setupDynamicCatalogRegistry() helper and functions catalog loading so tests can populate DynamicCatalogRegistry without repeating boilerplate.
- All related test files updated to use the new async signatures.
- Add MIGRATION_CAMEL_CATALOG_TO_DYNAMIC.md: tracks migration status, strategy and a tiered ranking of all remaining call sites.

fixes https://github.com/KaotoIO/kaoto/issues/3431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON schema support is now shown only when it’s available for the current document type.
  * Schema upload validation now checks file types more accurately before allowing you to continue.

* **Bug Fixes**
  * Improved the attach-schema flow so the modal opens reliably after clicking attach.
  * Updated suggestion behavior to use the latest catalog data, helping keep language hints accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->