### PR TITLE
chore(eslint): enforce stricter React/JSX rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,18 @@ export default [
       'react/react-in-jsx-scope': 'off',
       'react/display-name': 'off',
       'react/prop-types': 'off',
+      'react/jsx-boolean-value': ['error', 'never'],
+      'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
+      'react/no-unstable-nested-components': 'error',
+      'react/function-component-definition': [
+        'error',
+        {
+          namedComponents: 'arrow-function',
+          unnamedComponents: 'arrow-function',
+        },
+      ],
+      'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
+      'react/self-closing-comp': 'error',
     },
   },
   eslintConfigPrettier,

--- a/packages/ui-tests/stories/canvas/InlineEdit.stories.tsx
+++ b/packages/ui-tests/stories/canvas/InlineEdit.stories.tsx
@@ -25,7 +25,7 @@ const Template: StoryFn<typeof InlineEdit> = (args) => {
       <CardBody>
         <InlineEdit {...args} value={args.value ?? localValue} onChange={args.onChange ?? setLocalValue} />
       </CardBody>
-      <CardFooter></CardFooter>
+      <CardFooter />
     </Card>
   );
 };

--- a/packages/ui-tests/stories/components/ExpansionPanels.stories.tsx
+++ b/packages/ui-tests/stories/components/ExpansionPanels.stories.tsx
@@ -42,7 +42,7 @@ const DataMapperLikeTemplate: StoryFn<typeof ExpansionPanels> = () => {
         <ExpansionPanel
           id="parameters-header"
           summary={<PanelHeader title="Parameters" count={5} />}
-          defaultExpanded={true}
+          defaultExpanded
           defaultHeight={180}
           minHeight={80}
         >
@@ -60,7 +60,7 @@ const DataMapperLikeTemplate: StoryFn<typeof ExpansionPanels> = () => {
         <ExpansionPanel
           id="non-collapsible"
           summary={<PanelHeader title="Non-collapsible-param" count={5} />}
-          defaultExpanded={true}
+          defaultExpanded
           defaultHeight={180}
           minHeight={80}
           collapsible={false}
@@ -79,7 +79,7 @@ const DataMapperLikeTemplate: StoryFn<typeof ExpansionPanels> = () => {
         <ExpansionPanel
           id="source-body"
           summary={<PanelHeader title="Body" count={150} />}
-          defaultExpanded={true}
+          defaultExpanded
           defaultHeight={400}
           minHeight={100}
         >

--- a/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroup.stories.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroup.stories.tsx
@@ -223,7 +223,8 @@ export const Step7_Complete: StoryFn = () => (
       The fully configured structure. <code>for-each-group</code> iterates over the source collection and groups items
       by the configured expression. Inside it, <code>for-each current-group()</code> iterates over each group&apos;s
       items, and the user maps individual fields (Title, Quantity) from the expanded Item node. The generated XSLT uses{' '}
-      <code>xsl:for-each-group</code> with the chosen strategy attribute (e.g. <code>{'group-by="Category"'}</code>).
+      <code>xsl:for-each-group</code> with the chosen strategy attribute (e.g.{' '}
+      <code>group-by=&quot;Category&quot;</code>).
     </p>
     <div style={STORY_COMPONENT_BOX}>
       <ForEachGroupMockup

--- a/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/for-each-group/ForEachGroupMockup.tsx
@@ -32,7 +32,7 @@ import {
   PencilAltIcon,
   TrashIcon,
 } from '@patternfly/react-icons';
-import { CSSProperties, FunctionComponent, MouseEvent, ReactNode, Ref, useEffect, useState } from 'react';
+import { CSSProperties, FunctionComponent, MouseEvent, ReactNode, Ref, useCallback, useEffect, useState } from 'react';
 
 export type GroupingStrategy = 'group-by' | 'group-adjacent' | 'group-starting-with' | 'group-ending-with';
 
@@ -159,6 +159,54 @@ const MockTrashButton: FunctionComponent<{ ariaLabel: string }> = ({ ariaLabel }
   </ActionListItem>
 );
 
+const CollectionMenuToggle: FunctionComponent<{
+  toggleRef: Ref<MenuToggleElement>;
+  isOpen: boolean;
+  onClick: (e: MouseEvent) => void;
+}> = ({ toggleRef, isOpen, onClick }) => (
+  <MenuToggle
+    ref={toggleRef}
+    icon={<EllipsisVIcon />}
+    variant="plain"
+    onClick={onClick}
+    isExpanded={isOpen}
+    aria-label="Transformation Action list"
+    style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+  />
+);
+
+const InnerCollectionMenuToggle: FunctionComponent<{
+  toggleRef: Ref<MenuToggleElement>;
+  isOpen: boolean;
+  onClick: (e: MouseEvent) => void;
+}> = ({ toggleRef, isOpen, onClick }) => (
+  <MenuToggle
+    ref={toggleRef}
+    icon={<EllipsisVIcon />}
+    variant="plain"
+    onClick={onClick}
+    isExpanded={isOpen}
+    aria-label="Transformation Action list"
+    style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+  />
+);
+
+const ForEachGroupMenuToggle: FunctionComponent<{
+  toggleRef: Ref<MenuToggleElement>;
+  isOpen: boolean;
+  onClick: (e: MouseEvent) => void;
+}> = ({ toggleRef, isOpen, onClick }) => (
+  <MenuToggle
+    ref={toggleRef}
+    icon={<EllipsisVIcon />}
+    variant="plain"
+    onClick={onClick}
+    isExpanded={isOpen}
+    aria-label="for-each-group actions"
+    style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
+  />
+);
+
 interface MockGroupingModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -242,6 +290,19 @@ const MockCollectionFieldMenu: FunctionComponent<MockCollectionFieldMenuProps> =
     setIsOpen(false);
   };
 
+  const renderToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <CollectionMenuToggle
+        toggleRef={toggleRef}
+        isOpen={isOpen}
+        onClick={(_e: MouseEvent) => {
+          setIsOpen(!isOpen);
+        }}
+      />
+    ),
+    [isOpen],
+  );
+
   return (
     <ActionListItem>
       <Dropdown
@@ -250,19 +311,7 @@ const MockCollectionFieldMenu: FunctionComponent<MockCollectionFieldMenuProps> =
           setIsOpen(open);
         }}
         onSelect={handleSelect}
-        toggle={(toggleRef: Ref<MenuToggleElement>) => (
-          <MenuToggle
-            ref={toggleRef}
-            icon={<EllipsisVIcon />}
-            variant="plain"
-            onClick={(_e: MouseEvent) => {
-              setIsOpen(!isOpen);
-            }}
-            isExpanded={isOpen}
-            aria-label="Transformation Action list"
-            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
-          />
-        )}
+        toggle={renderToggle}
         popperProps={{ position: 'end', preventOverflow: true }}
         zIndex={100}
       >
@@ -297,6 +346,19 @@ const MockInnerCollectionFieldMenu: FunctionComponent<MockInnerCollectionFieldMe
     if (initialOpen) setIsOpen(true);
   }, [initialOpen]);
 
+  const renderToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <InnerCollectionMenuToggle
+        toggleRef={toggleRef}
+        isOpen={isOpen}
+        onClick={(_e: MouseEvent) => {
+          setIsOpen(!isOpen);
+        }}
+      />
+    ),
+    [isOpen],
+  );
+
   return (
     <ActionListItem>
       <Dropdown
@@ -307,19 +369,7 @@ const MockInnerCollectionFieldMenu: FunctionComponent<MockInnerCollectionFieldMe
         onSelect={() => {
           setIsOpen(false);
         }}
-        toggle={(toggleRef: Ref<MenuToggleElement>) => (
-          <MenuToggle
-            ref={toggleRef}
-            icon={<EllipsisVIcon />}
-            variant="plain"
-            onClick={(_e: MouseEvent) => {
-              setIsOpen(!isOpen);
-            }}
-            isExpanded={isOpen}
-            aria-label="Transformation Action list"
-            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
-          />
-        )}
+        toggle={renderToggle}
         popperProps={{ position: 'end', preventOverflow: true }}
         zIndex={100}
       >
@@ -360,6 +410,19 @@ const MockForEachGroupMenu: FunctionComponent<MockForEachGroupMenuProps> = ({ in
     setIsOpen(false);
   };
 
+  const renderToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => (
+      <ForEachGroupMenuToggle
+        toggleRef={toggleRef}
+        isOpen={isOpen}
+        onClick={(_e: MouseEvent) => {
+          setIsOpen(!isOpen);
+        }}
+      />
+    ),
+    [isOpen],
+  );
+
   return (
     <ActionListItem>
       <Dropdown
@@ -368,19 +431,7 @@ const MockForEachGroupMenu: FunctionComponent<MockForEachGroupMenuProps> = ({ in
           setIsOpen(open);
         }}
         onSelect={handleSelect}
-        toggle={(toggleRef: Ref<MenuToggleElement>) => (
-          <MenuToggle
-            ref={toggleRef}
-            icon={<EllipsisVIcon />}
-            variant="plain"
-            onClick={(_e: MouseEvent) => {
-              setIsOpen(!isOpen);
-            }}
-            isExpanded={isOpen}
-            aria-label="for-each-group actions"
-            style={{ height: INPUT_HEIGHT, padding: '0 0.25rem' }}
-          />
-        )}
+        toggle={renderToggle}
         popperProps={{ position: 'end', preventOverflow: true }}
         zIndex={100}
       >

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.scss
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.scss
@@ -187,7 +187,6 @@
   font-size: 0.875rem;
   padding-left: var(--pf-t--global--spacer--sm);
   gap: 0.375rem;
-
 }
 
 .tgt-variable-row {

--- a/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
+++ b/packages/ui-tests/stories/ui-mockups/datamapper/variable/VariableMockup.tsx
@@ -8,12 +8,106 @@ import { FunctionComponent, MouseEvent, Ref, useCallback, useEffect, useMemo, us
 
 import { VariableInputPlaceholder } from './VariableInputPlaceholder';
 
+const ForEachMenuToggle: FunctionComponent<{
+  toggleRef: Ref<HTMLButtonElement>;
+  isForEachMenuOpen: boolean;
+  onClick: (e: MouseEvent) => void;
+}> = ({ toggleRef, isForEachMenuOpen, onClick }) => (
+  <MenuToggle
+    icon={<EllipsisVIcon />}
+    ref={toggleRef}
+    onClick={onClick}
+    variant="plain"
+    isExpanded={isForEachMenuOpen}
+    aria-label="for-each actions"
+  />
+);
+
+const VariableMenuToggle: FunctionComponent<{
+  toggleRef: Ref<HTMLButtonElement>;
+  isExpanded: boolean;
+  onClick: (e: MouseEvent) => void;
+}> = ({ toggleRef, isExpanded, onClick }) => (
+  <MenuToggle
+    icon={<EllipsisVIcon />}
+    ref={toggleRef}
+    onClick={onClick}
+    variant="plain"
+    isExpanded={isExpanded}
+    aria-label="Variable actions"
+  />
+);
+
 interface MockVariable {
   id: string;
   name: string;
   expression: string;
   nodePath: string;
 }
+
+const TargetVariableRow: FunctionComponent<{
+  variable: MockVariable;
+  showVarExpression: boolean;
+  isMenuOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onToggle: () => void;
+  onStartRename: () => void;
+  onDelete: () => void;
+}> = ({ variable, showVarExpression, isMenuOpen, onOpenChange, onToggle, onStartRename, onDelete }) => {
+  const renderToggle = useCallback(
+    (toggleRef: Ref<HTMLButtonElement>) => (
+      <VariableMenuToggle
+        toggleRef={toggleRef}
+        isExpanded={isMenuOpen}
+        onClick={(e: MouseEvent) => {
+          e.stopPropagation();
+          onToggle();
+        }}
+      />
+    ),
+    [isMenuOpen, onToggle],
+  );
+
+  return (
+    <div className="node__container">
+      <div id={`tgt-${variable.id}`} className="node__header">
+        <div className="tgt-variable-row">
+          <Label isCompact>$</Label>
+          <span style={{ marginLeft: '0.25rem' }}>{variable.name}</span>
+          {showVarExpression && (
+            <input className="tgt-xpath-input" value={variable.expression} readOnly aria-label="XPath expression" />
+          )}
+          <div className="variable-node__actions">
+            <Tooltip content="Edit XPath expression">
+              <Button variant="plain" icon={<PencilAltIcon />} aria-label="Edit XPath" />
+            </Tooltip>
+            <Dropdown isOpen={isMenuOpen} onOpenChange={onOpenChange} toggle={renderToggle}>
+              <DropdownList>
+                <DropdownItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStartRename();
+                  }}
+                >
+                  Rename variable...
+                </DropdownItem>
+              </DropdownList>
+            </Dropdown>
+            <Button
+              variant="plain"
+              icon={<TrashIcon />}
+              aria-label="Delete variable"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 interface MappingLine {
   sourceId: string;
@@ -129,6 +223,20 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
     setVariables((prev) => prev.filter((v) => v.id !== id));
     setTargetVarMenuOpenId(null);
   }, []);
+
+  const renderForEachToggle = useCallback(
+    (toggleRef: Ref<HTMLButtonElement>) => (
+      <ForEachMenuToggle
+        toggleRef={toggleRef}
+        isForEachMenuOpen={isForEachMenuOpen}
+        onClick={(e: MouseEvent) => {
+          e.stopPropagation();
+          setIsForEachMenuOpen(!isForEachMenuOpen);
+        }}
+      />
+    ),
+    [isForEachMenuOpen],
+  );
 
   return (
     <div ref={containerRef} className="variable-mockup-view">
@@ -289,19 +397,7 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                                 onOpenChange={(isOpen) => {
                                   setIsForEachMenuOpen(isOpen);
                                 }}
-                                toggle={(toggleRef: Ref<HTMLButtonElement>) => (
-                                  <MenuToggle
-                                    icon={<EllipsisVIcon />}
-                                    ref={toggleRef}
-                                    onClick={(e: MouseEvent) => {
-                                      e.stopPropagation();
-                                      setIsForEachMenuOpen(!isForEachMenuOpen);
-                                    }}
-                                    variant="plain"
-                                    isExpanded={isForEachMenuOpen}
-                                    aria-label="for-each actions"
-                                  />
-                                )}
+                                toggle={renderForEachToggle}
                               >
                                 <DropdownList>
                                   <DropdownItem
@@ -338,69 +434,25 @@ export const VariableMockup: FunctionComponent<VariableMockupProps> = ({ step })
                                 </div>
                               </div>
                             ) : (
-                              <div key={variable.id} className="node__container">
-                                <div id={`tgt-${variable.id}`} className="node__header">
-                                  <div className="tgt-variable-row">
-                                    <Label isCompact>$</Label>
-                                    <span style={{ marginLeft: '0.25rem' }}>{variable.name}</span>
-                                    {showVarExpression && (
-                                      <input
-                                        className="tgt-xpath-input"
-                                        value={variable.expression}
-                                        readOnly
-                                        aria-label="XPath expression"
-                                      />
-                                    )}
-                                    <div className="variable-node__actions">
-                                      <Tooltip content="Edit XPath expression">
-                                        <Button variant="plain" icon={<PencilAltIcon />} aria-label="Edit XPath" />
-                                      </Tooltip>
-                                      <Dropdown
-                                        isOpen={targetVarMenuOpenId === variable.id}
-                                        onOpenChange={(isOpen) => {
-                                          setTargetVarMenuOpenId(isOpen ? variable.id : null);
-                                        }}
-                                        toggle={(toggleRef: Ref<HTMLButtonElement>) => (
-                                          <MenuToggle
-                                            icon={<EllipsisVIcon />}
-                                            ref={toggleRef}
-                                            onClick={(e: MouseEvent) => {
-                                              e.stopPropagation();
-                                              setTargetVarMenuOpenId(
-                                                targetVarMenuOpenId === variable.id ? null : variable.id,
-                                              );
-                                            }}
-                                            variant="plain"
-                                            isExpanded={targetVarMenuOpenId === variable.id}
-                                            aria-label="Variable actions"
-                                          />
-                                        )}
-                                      >
-                                        <DropdownList>
-                                          <DropdownItem
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              setRenamingVarInTargetId(variable.id);
-                                              setTargetVarMenuOpenId(null);
-                                            }}
-                                          >
-                                            Rename variable...
-                                          </DropdownItem>
-                                        </DropdownList>
-                                      </Dropdown>
-                                      <Button
-                                        variant="plain"
-                                        icon={<TrashIcon />}
-                                        aria-label="Delete variable"
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          handleDeleteVar(variable.id);
-                                        }}
-                                      />
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
+                              <TargetVariableRow
+                                key={variable.id}
+                                variable={variable}
+                                showVarExpression={showVarExpression}
+                                isMenuOpen={targetVarMenuOpenId === variable.id}
+                                onOpenChange={(isOpen) => {
+                                  setTargetVarMenuOpenId(isOpen ? variable.id : null);
+                                }}
+                                onToggle={() => {
+                                  setTargetVarMenuOpenId(targetVarMenuOpenId === variable.id ? null : variable.id);
+                                }}
+                                onStartRename={() => {
+                                  setRenamingVarInTargetId(variable.id);
+                                  setTargetVarMenuOpenId(null);
+                                }}
+                                onDelete={() => {
+                                  handleDeleteVar(variable.id);
+                                }}
+                              />
                             ),
                           )}
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -27,7 +27,7 @@ import {
 import { CatalogSchemaLoader } from './utils/catalog-schema-loader';
 import { setColorScheme } from './utils/color-scheme';
 
-function App() {
+const App = () => {
   const controller = useMemo(() => ControllerService.createController(), []);
   const settingsAdapter = new LocalStorageSettingsAdapter();
   let catalogUrl = CatalogSchemaLoader.DEFAULT_CATALOG_PATH;
@@ -87,6 +87,6 @@ function App() {
       </SourceCodeLocalStorageProvider>
     </SettingsProvider>
   );
-}
+};
 
 export default App;

--- a/packages/ui/src/components/DataMapper/debug/CanvasMonitor.tsx
+++ b/packages/ui/src/components/DataMapper/debug/CanvasMonitor.tsx
@@ -10,5 +10,5 @@ export const CanvasMonitor: FunctionComponent = () => {
     console.debug('Connection Ports: [' + nodePaths.map((p) => p + '\n').toString() + ']');
   }, [nodesConnectionPorts]);
 
-  return <></>;
+  return null;
 };

--- a/packages/ui/src/components/DataMapper/debug/ContextToolbar.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ContextToolbar.tsx
@@ -21,14 +21,12 @@ import { ToggleDebugToolbarItem } from './ToggleDebugToolbarItem';
 
 export const ContextToolbar: FunctionComponent = () => {
   return (
-    <Toolbar id="data-toolbar" role={'complementary'}>
+    <Toolbar id="data-toolbar" role="complementary">
       <ToolbarContent>
-        {
-          <ToolbarGroup variant="action-group" gap={{ default: 'gapMd' }}>
-            <MainMenuToolbarItem />
-            <ToggleDebugToolbarItem />
-          </ToolbarGroup>
-        }
+        <ToolbarGroup variant="action-group" gap={{ default: 'gapMd' }}>
+          <MainMenuToolbarItem />
+          <ToggleDebugToolbarItem />
+        </ToolbarGroup>
       </ToolbarContent>
     </Toolbar>
   );

--- a/packages/ui/src/components/DataMapper/debug/DataMapperMonitor.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DataMapperMonitor.tsx
@@ -21,5 +21,5 @@ export const DataMapperMonitor = () => {
     });
   }, [selectedNodePath, selectedNodeIsSource, mappingTree, sourceBodyDocument, sourceParameterMap]);
 
-  return <></>;
+  return null;
 };

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
@@ -67,7 +67,7 @@ describe('ExportMappingFileModal', () => {
   it('should render when isOpen is true', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -77,7 +77,7 @@ describe('ExportMappingFileModal', () => {
   it('should display modal title', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -87,7 +87,7 @@ describe('ExportMappingFileModal', () => {
   it('should render code editor wrapper', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -99,7 +99,7 @@ describe('ExportMappingFileModal', () => {
   it('should render close button', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -111,7 +111,7 @@ describe('ExportMappingFileModal', () => {
   it('should call onClose when close button is clicked', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -127,7 +127,7 @@ describe('ExportMappingFileModal', () => {
   it('should call onClose when modal is closed via backdrop or escape', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -145,7 +145,7 @@ describe('ExportMappingFileModal', () => {
   it('should serialize and display empty mappings when no mappings exist', async () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -174,7 +174,7 @@ describe('ExportMappingFileModal', () => {
     render(
       <TestProviders>
         <TestLoader>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestLoader>
       </TestProviders>,
     );
@@ -188,7 +188,7 @@ describe('ExportMappingFileModal', () => {
   it('should have code editor with XML language', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -200,7 +200,7 @@ describe('ExportMappingFileModal', () => {
   it('should have code editor with download enabled', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -227,7 +227,7 @@ describe('ExportMappingFileModal', () => {
     const { rerender } = render(
       <TestProviders>
         <TestLoader>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestLoader>
       </TestProviders>,
     );
@@ -240,7 +240,7 @@ describe('ExportMappingFileModal', () => {
     rerender(
       <TestProviders>
         <TestLoader>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestLoader>
       </TestProviders>,
     );
@@ -253,7 +253,7 @@ describe('ExportMappingFileModal', () => {
   it('should have modal with large variant', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -265,7 +265,7 @@ describe('ExportMappingFileModal', () => {
   it('should render code editor with word wrap enabled', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -277,7 +277,7 @@ describe('ExportMappingFileModal', () => {
   it('should render code editor with sizeToFit dimensions', () => {
     render(
       <TestProviders>
-        <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+        <ExportMappingFileModal isOpen onClose={mockOnClose} />
       </TestProviders>,
     );
 
@@ -325,7 +325,7 @@ describe('ExportMappingFileModal', () => {
     it('should call editor.layout() when editor mounts', () => {
       render(
         <TestProviders>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestProviders>,
       );
 
@@ -344,7 +344,7 @@ describe('ExportMappingFileModal', () => {
     it('should call editor.focus() when editor mounts', () => {
       render(
         <TestProviders>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestProviders>,
       );
 
@@ -363,7 +363,7 @@ describe('ExportMappingFileModal', () => {
     it('should call monaco.editor.getModels()[0].updateOptions with tabSize: 2', () => {
       render(
         <TestProviders>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestProviders>,
       );
 
@@ -384,7 +384,7 @@ describe('ExportMappingFileModal', () => {
     it('should call all three operations in sequence when editor mounts', () => {
       render(
         <TestProviders>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestProviders>,
       );
 
@@ -415,7 +415,7 @@ describe('ExportMappingFileModal', () => {
     it('should handle onEditorDidMount callback being called multiple times', () => {
       render(
         <TestProviders>
-          <ExportMappingFileModal isOpen={true} onClose={mockOnClose} />
+          <ExportMappingFileModal isOpen onClose={mockOnClose} />
         </TestProviders>,
       );
 

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.tsx
@@ -51,7 +51,7 @@ export const ExportMappingFileModal: FunctionComponent<ExportMappingFileModalPro
       <ModalBody>
         <CodeEditor
           isReadOnly={false}
-          isDownloadEnabled={true}
+          isDownloadEnabled
           code={serializedMappings}
           language={Language.xml}
           onEditorDidMount={onEditorDidMount}

--- a/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/MainMenuToolbarItem.tsx
@@ -1,11 +1,20 @@
-import { Dropdown, DropdownList, MenuToggle, ToolbarItem } from '@patternfly/react-core';
-import { FunctionComponent, useState } from 'react';
+import { Dropdown, DropdownList, MenuToggle, MenuToggleElement, ToolbarItem } from '@patternfly/react-core';
+import { FunctionComponent, Ref, useCallback, useState } from 'react';
 
 import { useToggle } from '../../../hooks/useToggle';
 import { ExportMappingFileDropdownItem } from './ExportMappingFileDropdownItem';
 import { ExportMappingFileModal } from './ExportMappingFileModal';
 import { ImportMappingFileDropdownItem } from './ImportMappingFileDropdownItem';
 import { ResetMappingsDropdownItem } from './ResetMappingsDropdownItem';
+
+const MainMenuToggle: FunctionComponent<{ toggleRef: Ref<MenuToggleElement>; onClick: () => void }> = ({
+  toggleRef,
+  onClick,
+}) => (
+  <MenuToggle ref={toggleRef} id="main-menu-toggle" data-testid="dm-debug-main-menu-button" onClick={onClick}>
+    DataMapper Debugger
+  </MenuToggle>
+);
 
 export const MainMenuToolbarItem: FunctionComponent = () => {
   const { state: isOpen, toggle: onToggle, toggleOff } = useToggle(false);
@@ -16,21 +25,18 @@ export const MainMenuToolbarItem: FunctionComponent = () => {
     toggleOff();
   };
 
+  const renderToggle = useCallback(
+    (toggleRef: Ref<MenuToggleElement>) => <MainMenuToggle toggleRef={toggleRef} onClick={onToggle} />,
+    [onToggle],
+  );
+
   return (
     <ToolbarItem>
-      <Dropdown
-        toggle={(toggleRef) => (
-          <MenuToggle ref={toggleRef} id="main-menu-toggle" data-testid="dm-debug-main-menu-button" onClick={onToggle}>
-            DataMapper Debugger
-          </MenuToggle>
-        )}
-        isOpen={isOpen}
-        isPlain={true}
-      >
-        <DropdownList data-testid={'dm-debug-main-menu-dropdownlist'}>
-          <ImportMappingFileDropdownItem onComplete={toggleOff} key={'import-mapping'} />
-          <ExportMappingFileDropdownItem onClick={handleOpenExportModal} key={'export-mapping'} />
-          <ResetMappingsDropdownItem onComplete={toggleOff} key={'reset-mappings'} />
+      <Dropdown toggle={renderToggle} isOpen={isOpen} isPlain>
+        <DropdownList data-testid="dm-debug-main-menu-dropdownlist">
+          <ImportMappingFileDropdownItem onComplete={toggleOff} key="import-mapping" />
+          <ExportMappingFileDropdownItem onClick={handleOpenExportModal} key="export-mapping" />
+          <ResetMappingsDropdownItem onComplete={toggleOff} key="reset-mappings" />
         </DropdownList>
       </Dropdown>
       <ExportMappingFileModal

--- a/packages/ui/src/components/DataMapper/debug/ToggleDebugToolbarItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ToggleDebugToolbarItem.tsx
@@ -19,7 +19,7 @@ export const ToggleDebugToolbarItem: FunctionComponent = () => {
           onChange={() => {
             setDebug(!debug);
           }}
-        ></ToggleGroupItem>
+        />
       </ToggleGroup>
     </ToolbarItem>
   );

--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -55,7 +55,7 @@ describe('DocumentHeader', () => {
           document={document}
           documentType={DocumentType.TARGET_BODY}
           isReadOnly={false}
-          enableDnD={true}
+          enableDnD
         />
       </DataMapperProvider>,
     );

--- a/packages/ui/src/components/Document/BaseDocument.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.tsx
@@ -155,7 +155,7 @@ export const DocumentHeader: FunctionComponent<DocumentHeaderProps> = ({
         />
       )}
       {enableDnD ? (
-        <NodeContainer nodeData={nodeData} enableDnD={true}>
+        <NodeContainer nodeData={nodeData} enableDnD>
           {headerContent}
         </NodeContainer>
       ) : (

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
@@ -33,7 +33,7 @@ describe('NodeTitle', () => {
     );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
-    render(<NodeTitle nodeData={documentNodeData} isDocument={true} rank={0} />);
+    render(<NodeTitle nodeData={documentNodeData} isDocument rank={0} />);
 
     const titleElement = screen.getByRole('heading', { level: 5 });
     expect(titleElement).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe('NodeTitle', () => {
     const documentNodeData = new DocumentNodeData(primitiveDoc);
     const customClass = 'custom-test-class';
 
-    render(<NodeTitle nodeData={documentNodeData} isDocument={true} className={customClass} rank={0} />);
+    render(<NodeTitle nodeData={documentNodeData} isDocument className={customClass} rank={0} />);
 
     const titleElement = screen.getByRole('heading', { level: 5 });
     expect(titleElement).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('NodeTitle', () => {
     );
     const primitiveNodeData = new DocumentNodeData(primitiveDoc);
 
-    render(<NodeTitle nodeData={primitiveNodeData} isDocument={true} rank={0} />);
+    render(<NodeTitle nodeData={primitiveNodeData} isDocument rank={0} />);
 
     const titleElement = screen.getByRole('heading', { level: 5 });
     expect(titleElement).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('NodeTitle', () => {
     );
     const documentNodeData = new DocumentNodeData(primitiveDoc);
 
-    render(<NodeTitle nodeData={documentNodeData} isDocument={true} rank={0} />);
+    render(<NodeTitle nodeData={documentNodeData} isDocument rank={0} />);
 
     const titleElement = screen.getByRole('heading', { level: 5 });
     expect(titleElement).toBeInTheDocument();

--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -186,8 +186,8 @@ describe('BaseNode', () => {
           nodeData={createMockNodeData()}
           title="Title"
           data-testid="test-node"
-          isExpandable={true}
-          isExpanded={true}
+          isExpandable
+          isExpanded
           onExpandChange={() => {}}
         />,
       );
@@ -201,7 +201,7 @@ describe('BaseNode', () => {
           nodeData={createMockNodeData()}
           title="Title"
           data-testid="test-node"
-          isExpandable={true}
+          isExpandable
           isExpanded={false}
           onExpandChange={() => {}}
         />,
@@ -217,8 +217,8 @@ describe('BaseNode', () => {
           nodeData={createMockNodeData()}
           title="Title"
           data-testid="test-node"
-          isExpandable={true}
-          isExpanded={true}
+          isExpandable
+          isExpanded
           onExpandChange={onExpandChange}
         />,
       );
@@ -337,8 +337,8 @@ describe('BaseNode', () => {
           nodeData={createMockNodeData({ type: Types.Array, isCollection: true })}
           title="Title"
           data-testid="test-node"
-          isExpandable={true}
-          isExpanded={true}
+          isExpandable
+          isExpanded
           onExpandChange={() => {}}
         />,
       );

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -178,8 +178,8 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
           onClose={handleCloseCommentModal}
           mapping={mapping}
           onUpdate={onUpdate}
-          showDeleteButton={true}
-          withFormGroup={true}
+          showDeleteButton
+          withFormGroup
         />
       )}
     </section>

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -266,7 +266,7 @@ describe('ParametersSection', () => {
         <DataMapperProvider>
           <MappingLinksProvider>
             <ExpansionPanels>
-              <ParametersSection isReadOnly={true} />
+              <ParametersSection isReadOnly />
             </ExpansionPanels>
           </MappingLinksProvider>
         </DataMapperProvider>
@@ -850,7 +850,7 @@ describe('ParametersSection', () => {
           <DataMapperProvider>
             <MappingLinksProvider>
               <ExpansionPanels>
-                <ParametersSection isReadOnly={true} />
+                <ParametersSection isReadOnly />
               </ExpansionPanels>
             </MappingLinksProvider>
           </DataMapperProvider>

--- a/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocumentNode.test.tsx
@@ -669,7 +669,7 @@ describe('SourceDocumentNode', () => {
         });
       });
 
-      render(<SourceDocumentNode treeNode={tree.root} documentId={documentNodeData.id} isReadOnly={true} rank={0} />, {
+      render(<SourceDocumentNode treeNode={tree.root} documentId={documentNodeData.id} isReadOnly rank={0} />, {
         wrapper,
       });
 

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaButton.test.tsx
@@ -44,7 +44,7 @@ describe('AttachSchemaButton', () => {
             <AttachSchemaButton
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
-              hasSchema={true}
+              hasSchema
               documentReferenceId={BODY_DOCUMENT_ID}
             />
           </MappingLinksProvider>
@@ -74,7 +74,7 @@ describe('AttachSchemaButton', () => {
             <AttachSchemaButton
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
-              hasSchema={true}
+              hasSchema
               documentReferenceId={BODY_DOCUMENT_ID}
             />
           </MappingLinksProvider>
@@ -117,7 +117,7 @@ describe('AttachSchemaButton', () => {
             <AttachSchemaButton
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
-              hasSchema={true}
+              hasSchema
               documentReferenceId={BODY_DOCUMENT_ID}
             />
           </MappingLinksProvider>

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.test.tsx
@@ -38,7 +38,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -83,7 +83,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.TARGET_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -129,7 +129,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -165,7 +165,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -203,7 +203,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -244,7 +244,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -287,7 +287,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.TARGET_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -332,7 +332,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={onModalClose}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -362,7 +362,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.TARGET_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -401,7 +401,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.SOURCE_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -424,7 +424,7 @@ describe('AttachSchemaModal', () => {
       <BrowserFilePickerMetadataProvider>
         <DataMapperProvider>
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.TARGET_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -466,7 +466,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -518,7 +518,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -567,7 +567,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.TARGET_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -625,7 +625,7 @@ describe('AttachSchemaModal', () => {
         dataMapperContext = useDataMapper();
         return (
           <AttachSchemaModal
-            isModalOpen={true}
+            isModalOpen
             onModalClose={vi.fn()}
             documentType={DocumentType.TARGET_BODY}
             documentId={BODY_DOCUMENT_ID}
@@ -694,7 +694,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.TARGET_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -733,7 +733,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -805,7 +805,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -855,7 +855,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.TARGET_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -902,7 +902,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.TARGET_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -951,7 +951,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -994,7 +994,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -1043,7 +1043,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -1094,7 +1094,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.SOURCE_BODY}
               documentId={BODY_DOCUMENT_ID}
@@ -1115,7 +1115,7 @@ describe('AttachSchemaModal', () => {
         <BrowserFilePickerMetadataProvider>
           <DataMapperProvider>
             <AttachSchemaModal
-              isModalOpen={true}
+              isModalOpen
               onModalClose={vi.fn()}
               documentType={DocumentType.PARAM}
               documentId="myParam"
@@ -1146,7 +1146,7 @@ describe('AttachSchemaModal', () => {
           <BrowserFilePickerMetadataProvider>
             <DataMapperProvider>
               <AttachSchemaModal
-                isModalOpen={true}
+                isModalOpen
                 onModalClose={vi.fn()}
                 documentType={DocumentType.SOURCE_BODY}
                 documentId={BODY_DOCUMENT_ID}
@@ -1202,7 +1202,7 @@ describe('AttachSchemaModal', () => {
           <BrowserFilePickerMetadataProvider>
             <DataMapperProvider>
               <AttachSchemaModal
-                isModalOpen={true}
+                isModalOpen
                 onModalClose={vi.fn()}
                 documentType={DocumentType.SOURCE_BODY}
                 documentId={BODY_DOCUMENT_ID}
@@ -1233,7 +1233,7 @@ describe('AttachSchemaModal', () => {
           <BrowserFilePickerMetadataProvider>
             <DataMapperProvider>
               <AttachSchemaModal
-                isModalOpen={true}
+                isModalOpen
                 onModalClose={vi.fn()}
                 documentType={DocumentType.SOURCE_BODY}
                 documentId={BODY_DOCUMENT_ID}

--- a/packages/ui/src/components/Document/actions/ChoiceSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/ChoiceSelectionModal.test.tsx
@@ -27,7 +27,7 @@ describe('ChoiceSelectionModal', () => {
 
   it('should render modal with choice field displayName in title', () => {
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByText('Choice: Test Choice')).toBeInTheDocument();
   });
 
@@ -38,7 +38,7 @@ describe('ChoiceSelectionModal', () => {
       wrapperKind: 'choice',
       fields: [{ name: 'optA', displayName: 'optA', fields: [] }],
     } as unknown as IField;
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByText('Choice: rawChoice')).toBeInTheDocument();
   });
 
@@ -49,40 +49,40 @@ describe('ChoiceSelectionModal', () => {
       wrapperKind: 'choice',
       fields: [],
     } as unknown as IField;
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByText('Choice: Choice')).toBeInTheDocument();
   });
 
   it('should show placeholder when no member is pre-selected', () => {
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     const input = getTypeaheadInput();
     expect(input.getAttribute('placeholder')).toBe('Select a member...');
   });
 
   it('should show pre-selected member name in typeahead input', () => {
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 1);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     const input = getTypeaheadInput();
     expect(input.getAttribute('value')).toBe('phone');
   });
 
   it('should disable Save button when no member is selected', () => {
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
   it('should enable Save button when a member is pre-selected', () => {
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 0);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
   });
 
   it('should call onClose when Cancel is clicked', () => {
     const onClose = vi.fn();
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={onClose} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={onClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
@@ -93,7 +93,7 @@ describe('ChoiceSelectionModal', () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 1);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={onSelect} onClose={onClose} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={onSelect} onClose={onClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -108,7 +108,7 @@ describe('ChoiceSelectionModal', () => {
       { name: 'email', displayName: 'Email' },
       { name: 'phone', displayName: 'Phone' },
     ]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={onSelect} onClose={onClose} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={onSelect} onClose={onClose} />);
 
     const input = getTypeaheadInput();
     act(() => {
@@ -134,7 +134,7 @@ describe('ChoiceSelectionModal', () => {
   it('should not call onSelect when Save is clicked without selection', () => {
     const onSelect = vi.fn();
     const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={onSelect} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={onSelect} onClose={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -147,7 +147,7 @@ describe('ChoiceSelectionModal', () => {
       { name: 'phone', displayName: 'Phone' },
       { name: 'fax', displayName: 'Fax' },
     ]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
 
     const input = getTypeaheadInput();
     act(() => {
@@ -172,7 +172,7 @@ describe('ChoiceSelectionModal', () => {
       ],
       selectedMemberIndex: 0,
     } as unknown as IField;
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
 
     const input = getTypeaheadInput();
     expect(input.getAttribute('value')).toBe('email');
@@ -185,7 +185,7 @@ describe('ChoiceSelectionModal', () => {
       wrapperKind: 'choice',
       fields: undefined,
     } as unknown as IField;
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
 
     const input = getTypeaheadInput();
     expect(input.getAttribute('placeholder')).toBe('Select a member...');
@@ -197,7 +197,7 @@ describe('ChoiceSelectionModal', () => {
       { name: 'email', displayName: 'Email' },
       { name: 'phone', displayName: 'Phone' },
     ]);
-    render(<ChoiceSelectionModal isOpen={true} choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
+    render(<ChoiceSelectionModal isOpen choiceField={choiceField} onSelect={vi.fn()} onClose={vi.fn()} />);
 
     const input = getTypeaheadInput();
     act(() => {

--- a/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldOverride/FieldOverride.test.tsx
@@ -76,7 +76,7 @@ describe('FieldOverride', () => {
 
   it('should pass field to FieldOverrideModal when open', () => {
     const field = testTargetDoc.fields[0];
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -93,7 +93,7 @@ describe('FieldOverride', () => {
 
   it('should call applyFieldTypeOverride and updateDocument on save', () => {
     const field = testTargetDoc.fields[0];
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -115,7 +115,7 @@ describe('FieldOverride', () => {
   it('should not call addSchemaFilesForTypeOverride on save', () => {
     const field = testTargetDoc.fields[0];
 
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -131,7 +131,7 @@ describe('FieldOverride', () => {
     const field = testTargetDoc.fields[0];
     const schemas = { 'custom.xsd': '<xs:schema/>' };
 
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -148,7 +148,7 @@ describe('FieldOverride', () => {
 
   it('should call applyFieldSubstitution on save with substitution mode', () => {
     const field = testTargetDoc.fields[0];
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -170,7 +170,7 @@ describe('FieldOverride', () => {
   it('should call revertFieldTypeOverride and updateDocument on remove', () => {
     const field = testTargetDoc.fields[0];
     field.typeOverride = FieldOverrideVariant.SAFE;
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];
@@ -186,7 +186,7 @@ describe('FieldOverride', () => {
 
   it('should pass onClose to FieldOverrideModal', () => {
     const field = testTargetDoc.fields[0];
-    render(<FieldOverride isOpen={true} field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
+    render(<FieldOverride isOpen field={field} onComplete={mockOnComplete} onClose={mockOnClose} />);
 
     const mockFieldOverrideModal = vi.mocked(FieldOverrideModal);
     const lastCall = mockFieldOverrideModal.mock.calls[mockFieldOverrideModal.mock.calls.length - 1];

--- a/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
@@ -20,7 +20,7 @@ describe('CommentModal', () => {
 
   describe('Modal Visibility', () => {
     it('should render modal when isOpen is true', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       expect(screen.getByTestId('comment-modal')).toBeInTheDocument();
     });
 
@@ -32,17 +32,17 @@ describe('CommentModal', () => {
 
   describe('Adding New Comment', () => {
     it('should display "Add Comment" title when mapping has no comment', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       expect(screen.getByText('Add Comment')).toBeInTheDocument();
     });
 
     it('should display Create button when adding new comment', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       expect(screen.getByTestId('create-comment-btn')).toBeInTheDocument();
     });
 
     it('should create comment and call onUpdate when Create is clicked', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const textarea = screen.getByTestId('comment-textarea');
       act(() => {
@@ -66,24 +66,24 @@ describe('CommentModal', () => {
     });
 
     it('should display "Edit Comment" title when mapping has a comment', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       expect(screen.getByText('Edit Comment')).toBeInTheDocument();
     });
 
     it('should populate textarea with existing comment', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       const textarea = screen.getByTestId('comment-textarea') as HTMLTextAreaElement;
       expect(textarea.value).toBe('Existing comment');
     });
 
     it('should display Update and Delete buttons when editing with showDeleteButton=true', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
       expect(screen.getByTestId('update-comment-btn')).toBeInTheDocument();
       expect(screen.getByTestId('delete-comment-btn')).toBeInTheDocument();
     });
 
     it('should update comment and call onUpdate when Update is clicked', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const textarea = screen.getByTestId('comment-textarea');
       act(() => {
@@ -101,7 +101,7 @@ describe('CommentModal', () => {
     });
 
     it('should delete comment and call onUpdate when Delete is clicked', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const deleteBtn = screen.getByTestId('delete-comment-btn');
       act(() => {
@@ -122,7 +122,7 @@ describe('CommentModal', () => {
     it('should show Confirm button instead of Update/Delete when showDeleteButton=false', () => {
       render(
         <CommentModal
-          isOpen={true}
+          isOpen
           onClose={onCloseMock}
           mapping={mapping}
           onUpdate={onUpdateMock}
@@ -138,7 +138,7 @@ describe('CommentModal', () => {
     it('should update comment when Confirm is clicked with showDeleteButton=false', () => {
       render(
         <CommentModal
-          isOpen={true}
+          isOpen
           onClose={onCloseMock}
           mapping={mapping}
           onUpdate={onUpdateMock}
@@ -163,7 +163,7 @@ describe('CommentModal', () => {
 
   describe('Cancel Functionality', () => {
     it('should call onClose when Cancel is clicked', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const cancelBtn = screen.getByTestId('cancel-comment-btn');
       act(() => {
@@ -175,7 +175,7 @@ describe('CommentModal', () => {
     });
 
     it('should not update mapping when Cancel is clicked', () => {
-      render(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      render(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const textarea = screen.getByTestId('comment-textarea');
       act(() => {
@@ -195,7 +195,7 @@ describe('CommentModal', () => {
     it('should update textarea when mapping.comment changes', () => {
       mapping.comment = 'Initial comment';
       const { rerender } = render(
-        <CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />,
+        <CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />,
       );
 
       const textarea = screen.getByTestId('comment-textarea') as HTMLTextAreaElement;
@@ -203,14 +203,14 @@ describe('CommentModal', () => {
 
       // Change mapping comment
       mapping.comment = 'Updated comment';
-      rerender(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      rerender(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       expect(textarea.value).toBe('Updated comment');
     });
 
     it('should update textarea when modal reopens with different mapping', () => {
       const { rerender } = render(
-        <CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />,
+        <CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />,
       );
 
       // Close modal
@@ -218,7 +218,7 @@ describe('CommentModal', () => {
 
       // Change mapping and reopen
       mapping.comment = 'New comment';
-      rerender(<CommentModal isOpen={true} onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
+      rerender(<CommentModal isOpen onClose={onCloseMock} mapping={mapping} onUpdate={onUpdateMock} />);
 
       const textarea = screen.getByTestId('comment-textarea') as HTMLTextAreaElement;
       expect(textarea.value).toBe('New comment');

--- a/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.test.tsx
@@ -110,7 +110,7 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should render when isOpen is true', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('for-each-group-modal')).toBeInTheDocument();
   });
 
@@ -120,34 +120,34 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should display for-each-group expression in description', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByText('for-each-group: /Orders/Order')).toBeInTheDocument();
   });
 
   it('should display current grouping strategy in dropdown', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('for-each-group-strategy-toggle')).toHaveTextContent('Group By');
   });
 
   it('should display current grouping expression in input', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     const input = screen.getByTestId('for-each-group-expression').querySelector('input') as HTMLInputElement;
     expect(input.value).toBe('Category');
   });
 
   it('should disable Save when grouping expression is empty', () => {
     forEachGroupItem.groupingExpression = '';
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('for-each-group-save-btn')).toBeDisabled();
   });
 
   it('should enable Save when grouping expression is non-empty', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('for-each-group-save-btn')).toBeEnabled();
   });
 
   it('should disable Save when grouping expression is cleared', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     const input = screen.getByTestId('for-each-group-expression').querySelector('input') as HTMLInputElement;
     act(() => {
@@ -158,7 +158,7 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should change grouping strategy via dropdown', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('for-each-group-strategy-toggle'));
@@ -172,7 +172,7 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should update grouping expression input', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     const input = screen.getByTestId('for-each-group-expression').querySelector('input') as HTMLInputElement;
     act(() => {
@@ -185,7 +185,7 @@ describe('ForEachGroupModal', () => {
   it('should save grouping strategy and expression to mapping on Save', async () => {
     const onUpdate = vi.fn();
     const onClose = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={onClose} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={onClose} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('for-each-group-strategy-toggle'));
@@ -216,7 +216,7 @@ describe('ForEachGroupModal', () => {
   it('should not modify mapping on Cancel', async () => {
     const onUpdate = vi.fn();
     const onClose = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={onClose} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={onClose} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     const input = screen.getByTestId('for-each-group-expression').querySelector('input') as HTMLInputElement;
     act(() => {
@@ -236,7 +236,7 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should open XPath editor for grouping expression', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.queryByTestId('xpath-editor-modal')).not.toBeInTheDocument();
 
     act(() => {
@@ -249,7 +249,7 @@ describe('ForEachGroupModal', () => {
 
   it('should apply XPath editor expression to grouping expression', async () => {
     const onUpdate = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('for-each-group-edit-expression'));
@@ -272,7 +272,7 @@ describe('ForEachGroupModal', () => {
   });
 
   it('should close XPath editor on close callback', () => {
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('for-each-group-edit-expression'));
@@ -287,7 +287,7 @@ describe('ForEachGroupModal', () => {
 
   it('should start with no sort keys when mapping has none', () => {
     forEachGroupItem.sortItems = [];
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.queryByTestId('sort-expression-0')).not.toBeInTheDocument();
   });
 
@@ -298,7 +298,7 @@ describe('ForEachGroupModal', () => {
     sort2.expression = 'Price';
     forEachGroupItem.sortItems = [sort1, sort2];
 
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     const getInput = (idx: number) =>
       screen.getByTestId(`sort-expression-${idx}`).querySelector('input') as HTMLInputElement;
@@ -308,7 +308,7 @@ describe('ForEachGroupModal', () => {
 
   it('should add a sort key', () => {
     forEachGroupItem.sortItems = [];
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-add-key'));
@@ -321,7 +321,7 @@ describe('ForEachGroupModal', () => {
     sort.expression = 'Title';
     forEachGroupItem.sortItems = [sort];
 
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('sort-expression-0')).toBeInTheDocument();
 
     act(() => {
@@ -333,7 +333,7 @@ describe('ForEachGroupModal', () => {
   it('should save sort items to mapping on Save', async () => {
     forEachGroupItem.sortItems = [];
     const onUpdate = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-add-key'));
@@ -360,7 +360,7 @@ describe('ForEachGroupModal', () => {
   it('should filter out empty sort expressions on Save', async () => {
     forEachGroupItem.sortItems = [];
     const onUpdate = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-add-key'));
@@ -392,7 +392,7 @@ describe('ForEachGroupModal', () => {
     sort.expression = 'Title';
     forEachGroupItem.sortItems = [sort];
     const onClose = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={onClose} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
+    render(<ForEachGroupModal isOpen onClose={onClose} mapping={forEachGroupItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('mock-drag-trigger'));
@@ -412,7 +412,7 @@ describe('ForEachGroupModal', () => {
     forEachGroupItem.sortItems = [sort1, sort2];
 
     const onUpdate = vi.fn();
-    render(<ForEachGroupModal isOpen={true} onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
+    render(<ForEachGroupModal isOpen onClose={vi.fn()} mapping={forEachGroupItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('mock-drop-trigger'));

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortModal.test.tsx
@@ -106,7 +106,7 @@ describe('SortModal', () => {
   });
 
   it('should render when isOpen is true', () => {
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('sort-modal')).toBeInTheDocument();
   });
 
@@ -116,7 +116,7 @@ describe('SortModal', () => {
   });
 
   it('should display for-each expression in subtitle', () => {
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.getByText('for-each: /items/item')).toBeInTheDocument();
   });
 
@@ -129,7 +129,7 @@ describe('SortModal', () => {
     sort2.order = 'descending';
     forEachItem.sortItems = [sort1, sort2];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     expect(getExpressionInput(0).value).toBe('Title');
     expect(getExpressionInput(1).value).toBe('Price');
@@ -139,13 +139,13 @@ describe('SortModal', () => {
   });
 
   it('should start with one empty sort key when no existing sort items', () => {
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('sort-expression-0')).toBeInTheDocument();
     expect(screen.queryByTestId('sort-expression-1')).not.toBeInTheDocument();
   });
 
   it('should add a new sort key', () => {
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     act(() => {
       fireEvent.click(screen.getByTestId('sort-add-key'));
     });
@@ -157,7 +157,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.getByTestId('sort-expression-0')).toBeInTheDocument();
 
     act(() => {
@@ -169,7 +169,7 @@ describe('SortModal', () => {
   it('should save sort items to mapping on Save', async () => {
     const onUpdate = vi.fn();
     const onClose = vi.fn();
-    render(<SortModal isOpen={true} onClose={onClose} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={onClose} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.change(getExpressionInput(0), { target: { value: 'Title' } });
@@ -193,7 +193,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [];
     const onUpdate = vi.fn();
     const onClose = vi.fn();
-    render(<SortModal isOpen={true} onClose={onClose} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={onClose} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.change(getExpressionInput(0), { target: { value: 'something' } });
@@ -212,7 +212,7 @@ describe('SortModal', () => {
 
   it('should filter out empty expressions on Save', async () => {
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-add-key'));
@@ -238,7 +238,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     const orderBtn = screen.getByTestId('sort-order-0');
     expect(orderBtn).toHaveAttribute('aria-label', 'Sort order 1: ascending');
@@ -252,7 +252,7 @@ describe('SortModal', () => {
 
   it('should not call onClose when drag just ended', () => {
     const onClose = vi.fn();
-    render(<SortModal isOpen={true} onClose={onClose} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={onClose} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('mock-drag-trigger'));
@@ -272,7 +272,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort1, sort2];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     expect(getExpressionInput(0).value).toBe('Title');
     expect(getExpressionInput(1).value).toBe('Price');
@@ -297,7 +297,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.queryByTestId('xpath-editor-modal')).not.toBeInTheDocument();
 
     act(() => {
@@ -313,7 +313,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-edit-xpath-0'));
@@ -332,7 +332,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-edit-xpath-0'));
@@ -360,7 +360,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
     expect(screen.queryByTestId('sort-advanced-panel-0')).not.toBeInTheDocument();
 
     act(() => {
@@ -382,7 +382,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-save-btn'));
@@ -403,7 +403,7 @@ describe('SortModal', () => {
     sort.caseOrder = 'upper-first';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.change(getExpressionInput(0), { target: { value: 'Price' } });
@@ -423,7 +423,7 @@ describe('SortModal', () => {
     sort.stable = 'yes';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-order-0'));
@@ -443,7 +443,7 @@ describe('SortModal', () => {
     sort.lang = 'en';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     const advancedBtn = screen.getByTestId('sort-advanced-0');
     expect(advancedBtn).toHaveClass('sort-modal__settings-configured');
@@ -455,7 +455,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-advanced-0'));
@@ -482,7 +482,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-advanced-0'));
@@ -509,7 +509,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-advanced-0'));
@@ -539,7 +539,7 @@ describe('SortModal', () => {
     forEachItem.sortItems = [sort];
 
     const onUpdate = vi.fn();
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={onUpdate} />);
 
     act(() => {
       fireEvent.click(screen.getByTestId('sort-advanced-0'));
@@ -568,7 +568,7 @@ describe('SortModal', () => {
     sort.expression = 'Title';
     forEachItem.sortItems = [sort];
 
-    render(<SortModal isOpen={true} onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
+    render(<SortModal isOpen onClose={vi.fn()} mapping={forEachItem} onUpdate={vi.fn()} />);
 
     const advancedBtn = screen.getByTestId('sort-advanced-0');
     expect(advancedBtn).not.toHaveClass('sort-modal__settings-configured');

--- a/packages/ui/src/components/Document/actions/MemberSelectionModal.tsx
+++ b/packages/ui/src/components/Document/actions/MemberSelectionModal.tsx
@@ -15,7 +15,7 @@ export interface MemberSelectionModalProps<T> {
   onClose: () => void;
 }
 
-export function MemberSelectionModal<T>({
+export const MemberSelectionModal = <T,>({
   isOpen,
   title,
   placeholder,
@@ -24,7 +24,7 @@ export function MemberSelectionModal<T>({
   selectedValue,
   onSelect,
   onClose,
-}: Readonly<MemberSelectionModalProps<T>>) {
+}: Readonly<MemberSelectionModalProps<T>>) => {
   const [value, setValue] = useState<T | null>(selectedValue);
 
   useEffect(() => {
@@ -72,4 +72,4 @@ export function MemberSelectionModal<T>({
       </ModalFooter>
     </DataMapperModal>
   );
-}
+};

--- a/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/SubstitutionSelectionModal.test.tsx
@@ -53,7 +53,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -73,7 +73,7 @@ describe('SubstitutionSelectionModal', () => {
     } as unknown as IField;
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -93,7 +93,7 @@ describe('SubstitutionSelectionModal', () => {
     } as unknown as IField;
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -110,7 +110,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -131,7 +131,7 @@ describe('SubstitutionSelectionModal', () => {
     );
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -149,7 +149,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -169,7 +169,7 @@ describe('SubstitutionSelectionModal', () => {
     );
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -187,7 +187,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -212,7 +212,7 @@ describe('SubstitutionSelectionModal', () => {
     );
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={onSelect}
@@ -235,7 +235,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={onSelect}
@@ -272,7 +272,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={onSelect}
@@ -293,7 +293,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -320,7 +320,7 @@ describe('SubstitutionSelectionModal', () => {
     ]);
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}
@@ -353,7 +353,7 @@ describe('SubstitutionSelectionModal', () => {
     } as unknown as IField;
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={{}}
         onSelect={vi.fn()}
@@ -374,7 +374,7 @@ describe('SubstitutionSelectionModal', () => {
 
     render(
       <SubstitutionSelectionModal
-        isOpen={true}
+        isOpen
         abstractField={abstractField}
         candidates={candidatesMap}
         onSelect={vi.fn()}

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -116,7 +116,7 @@ export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ nodeData,
                       </Icon>
                     )
                   }
-                ></Button>
+                />
               </Popover>
             </InputGroupItem>
           )}

--- a/packages/ui/src/components/Document/actions/withFieldContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/withFieldContextMenu.test.tsx
@@ -48,12 +48,7 @@ describe('withFieldContextMenu', () => {
     const { documentNodeData, fieldNode } = createFieldNode();
 
     render(
-      <SourceDocumentNodeWithContextMenu
-        treeNode={fieldNode}
-        documentId={documentNodeData.id}
-        isReadOnly={true}
-        rank={1}
-      />,
+      <SourceDocumentNodeWithContextMenu treeNode={fieldNode} documentId={documentNodeData.id} isReadOnly rank={1} />,
       { wrapper },
     );
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -220,7 +220,7 @@ describe('ExpansionPanel', () => {
             unregisterLayoutCallback: mockUnregisterLayoutCallback,
           }}
         >
-          <ExpansionPanel id="test-panel" summary={<div>Test Summary</div>} defaultExpanded={true}>
+          <ExpansionPanel id="test-panel" summary={<div>Test Summary</div>} defaultExpanded>
             <div>Test Content</div>
           </ExpansionPanel>
         </ExpansionContext.Provider>,

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -162,7 +162,7 @@ const createTestPanelWithCallback = (callbackRef: { current: boolean }) => {
     }, [context, id]);
 
     return (
-      <ExpansionPanel id={id} summary={<div>Test Panel</div>} defaultExpanded={true}>
+      <ExpansionPanel id={id} summary={<div>Test Panel</div>} defaultExpanded>
         Content
       </ExpansionPanel>
     );

--- a/packages/ui/src/components/MetadataEditor/TopmostArrayTable.tsx
+++ b/packages/ui/src/components/MetadataEditor/TopmostArrayTable.tsx
@@ -31,7 +31,7 @@ type TopmostArrayTableProps = {
  * @param props
  * @constructor
  */
-export function TopmostArrayTable(props: TopmostArrayTableProps) {
+export const TopmostArrayTable = (props: TopmostArrayTableProps) => {
   function handleTrashClick(index: number) {
     const newMetadata = props.model ? props.model.slice() : [];
     newMetadata.length !== 0 && newMetadata.splice(index, 1);
@@ -53,7 +53,7 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
           <Thead>
             <Tr>
               {props.itemSchema.required?.map((name: string) => (
-                <Th modifier={'nowrap'} key={name}>
+                <Th modifier="nowrap" key={name}>
                   {name.toUpperCase()}
                 </Th>
               ))}
@@ -124,4 +124,4 @@ export function TopmostArrayTable(props: TopmostArrayTableProps) {
       </InnerScrollContainer>
     </OuterScrollContainer>
   );
-}
+};

--- a/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
+++ b/packages/ui/src/components/PropertiesModal/PropertiesModal.tsx
@@ -97,7 +97,7 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
   const title: ReactElement = (
     <div className="properties-modal__title-div">
       {props.tile.iconUrl && (
-        <img src={props.tile.iconUrl} alt={`${props.tile.type} icon`} className={'properties-modal__title-image'} />
+        <img src={props.tile.iconUrl} alt={`${props.tile.type} icon`} className="properties-modal__title-image" />
       )}
       <h1 className="properties-modal__title">{props.tile.title}</h1>
     </div>
@@ -109,7 +109,7 @@ export const PropertiesModal: FunctionComponent<IPropertiesModalProps> = (props)
       <br />
       <Tabs activeKey={activeTabKey} onSelect={handleTabClick} aria-label="Properties tabs" isBox role="region">
         {tabs.map((tab, tab_index) => (
-          <Tab data-testid={'tab-' + tab_index} key={tab.rootName} eventKey={tab_index} title={tab.rootName}></Tab>
+          <Tab data-testid={'tab-' + tab_index} key={tab.rootName} eventKey={tab_index} title={tab.rootName} />
         ))}
       </Tabs>
     </div>

--- a/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableCommon.tsx
+++ b/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableCommon.tsx
@@ -44,7 +44,7 @@ export const renderRowData = (
           ''
         )
       }
-      {<span>{row[header]?.toString()}</span>}
+      <span>{row[header]?.toString()}</span>
       {
         //prefix with group for name cell if needed
         header == PropertiesHeaders.Name && row.rowAdditionalInfo.group ? (

--- a/packages/ui/src/components/RenderingAnchor/rendering.provider.test.tsx
+++ b/packages/ui/src/components/RenderingAnchor/rendering.provider.test.tsx
@@ -108,7 +108,7 @@ describe('RenderingProvider', () => {
     expect(anotherComponent).toBeNull();
   });
 
-  function ProviderConsumer(props: { anchorTag: string; registerComponents: IRegisteredComponent[] }) {
+  const ProviderConsumer = (props: { anchorTag: string; registerComponents: IRegisteredComponent[] }) => {
     const { registerComponent, getRegisteredComponents } = useContext(RenderingAnchorContext);
 
     props.registerComponents.forEach((regComponent) => {
@@ -124,5 +124,5 @@ describe('RenderingProvider', () => {
         ))}
       </div>
     );
-  }
+  };
 });

--- a/packages/ui/src/components/View/MappingLink.test.tsx
+++ b/packages/ui/src/components/View/MappingLink.test.tsx
@@ -58,7 +58,7 @@ describe('MappingLink', () => {
   it('applies selected class when isSelected is true', () => {
     const { getByTestId } = render(
       <svg>
-        <MappingLink {...defaultProps} isSelected={true} />
+        <MappingLink {...defaultProps} isSelected />
       </svg>,
     );
     expect(getByTestId('mapping-link-selected-10-20-100-200').classList).toContain('mapping-link--selected');

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
@@ -106,13 +106,13 @@ export const EndpointField: FunctionComponent<FieldProps> = ({ propName, require
           onCleanInput={onCleanInput}
           onCreate={onSelect}
           disabled={disabled}
-          allowCustomInput={true}
+          allowCustomInput
         />
       </FieldWrapper>
 
       {isOpen && (
         <NewEndpointModal
-          mode={'Create'}
+          mode="Create"
           endpointsSchema={endpointsSchema}
           onConfirm={handleCreate}
           onCancel={handleCancel}

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
@@ -105,8 +105,8 @@ export const EndpointListField: FunctionComponent<FieldProps> = ({ propName, req
 
   return (
     <>
-      <FieldWrapper propName={propName} required={required} title={''} type="string">
-        <Table aria-label={'endpoint-table'} variant={TableVariant.compact} borders>
+      <FieldWrapper propName={propName} required={required} title="" type="string">
+        <Table aria-label="endpoint-table" variant={TableVariant.compact} borders>
           <Thead>
             <Tr>
               <Th>Name</Th>

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -25,7 +25,7 @@ describe('ExpressionField', () => {
     const { container } = render(
       <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
         <SchemaProvider schema={setHeaderExpressionSchema}>
-          <ExpressionField propName={ROOT_PATH} required={true} />
+          <ExpressionField propName={ROOT_PATH} required />
         </SchemaProvider>
       </ModelContextProvider>,
     );
@@ -47,7 +47,7 @@ describe('ExpressionField', () => {
         >
           <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
             <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required={true} />
+              <ExpressionField propName={ROOT_PATH} required />
             </SchemaProvider>
           </SchemaDefinitionsProvider>
         </ModelContextProvider>
@@ -71,7 +71,7 @@ describe('ExpressionField', () => {
         >
           <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
             <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required={true} />
+              <ExpressionField propName={ROOT_PATH} required />
             </SchemaProvider>
           </SchemaDefinitionsProvider>
         </ModelContextProvider>
@@ -105,7 +105,7 @@ describe('ExpressionField', () => {
         >
           <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
             <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required={true} />
+              <ExpressionField propName={ROOT_PATH} required />
             </SchemaProvider>
           </SchemaDefinitionsProvider>
         </ModelContextProvider>
@@ -139,7 +139,7 @@ describe('ExpressionField', () => {
         >
           <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
             <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required={true} />
+              <ExpressionField propName={ROOT_PATH} required />
             </SchemaProvider>
           </SchemaDefinitionsProvider>
         </ModelContextProvider>
@@ -169,7 +169,7 @@ describe('ExpressionField', () => {
         onPropertyChange={onPropertyChangeSpy}
       >
         <SchemaProvider schema={setHeaderExpressionSchema}>
-          <ExpressionField propName={ROOT_PATH} required={true} />
+          <ExpressionField propName={ROOT_PATH} required />
         </SchemaProvider>
       </ModelContextProvider>,
     );
@@ -196,7 +196,7 @@ describe('ExpressionField', () => {
         onPropertyChange={onPropertyChangeSpy}
       >
         <SchemaProvider schema={setHeaderExpressionSchema}>
-          <ExpressionField propName={ROOT_PATH} required={true} />
+          <ExpressionField propName={ROOT_PATH} required />
         </SchemaProvider>
       </ModelContextProvider>,
     );

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.test.tsx
@@ -284,7 +284,7 @@ describe('StepToolbar', () => {
       const mockOnCollapseToggle = vi.fn();
 
       await act(async () => {
-        render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} isCollapsed={true} />);
+        render(<StepToolbar vizNode={mockVizNode} onCollapseToggle={mockOnCollapseToggle} isCollapsed />);
       });
 
       const collapseButton = screen.getByTestId('Test Node|step-toolbar-button-collapse');

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/EntitiesList.tsx
@@ -78,7 +78,7 @@ export const EntitiesList: FunctionComponent<IEntitiesList> = ({
   return (
     <>
       <EntityOption
-        key={`entity-option-all`}
+        key="entity-option-all"
         entityLabel="all"
         isVisible={allEntitiesVisible}
         onToggleVisibility={() => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowClipboard/FlowClipboard.tsx
@@ -10,7 +10,7 @@ export const successTooltipText = 'Content added to clipboard';
 
 export const defaultTooltipText = 'Copy to clipboard';
 
-export function FlowClipboard() {
+export const FlowClipboard = () => {
   const [isCopied, setIsCopied] = useState(false);
   const status = isCopied ? 'success' : undefined;
   const tooltipText = isCopied ? successTooltipText : defaultTooltipText;
@@ -39,4 +39,4 @@ export function FlowClipboard() {
       data-copied={isCopied}
     />
   );
-}
+};

--- a/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/FlowExportImage/FlowExportImage.tsx
@@ -8,7 +8,7 @@ import { VisibleFlowsContext } from '../../../../providers/visible-flows.provide
 import { useGraphLayout } from '../../Custom/hooks/use-graph-layout.hook';
 import { HiddenCanvas } from './HiddenCanvas';
 
-export function FlowExportImage() {
+export const FlowExportImage = () => {
   const [isExporting, setIsExporting] = useState(false);
   const { visualEntities } = useEntityContext();
   const { visibleFlows } = useContext(VisibleFlowsContext)!;
@@ -40,4 +40,4 @@ export function FlowExportImage() {
       )}
     </>
   );
-}
+};

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/ItemReplaceStep.test.tsx
@@ -63,7 +63,7 @@ describe('ItemReplaceStep', () => {
     const wrapper = render(
       <EntitiesContext.Provider value={mockEntitiesContext}>
         <ActionConfirmationModalContext.Provider value={mockReplaceModalContext}>
-          <ItemReplaceStep vizNode={vizNode} loadActionConfirmationModal={true} />
+          <ItemReplaceStep vizNode={vizNode} loadActionConfirmationModal />
         </ActionConfirmationModalContext.Provider>
       </EntitiesContext.Provider>,
     );

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -207,7 +207,7 @@ describe('CustomGroupExpanded', () => {
 
     await renderInContext(
       <SettingsProvider adapter={onSelectionAdapter}>
-        <CustomGroupExpanded element={element} selected={true} />
+        <CustomGroupExpanded element={element} selected />
       </SettingsProvider>,
     );
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeContainer.test.tsx
@@ -35,8 +35,8 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={1}
         ProcessorIcon={null}
-        processorDescription={''}
-        isDisabled={true}
+        processorDescription=""
+        isDisabled
       />,
     );
 
@@ -50,10 +50,10 @@ describe('CustomNodeContainer', () => {
       <CustomNodeContainer
         {...defaultContainerProps}
         vizNode={vizNode}
-        isCollapsed={true}
+        isCollapsed
         childCount={5}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -90,7 +90,7 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -107,7 +107,7 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -144,7 +144,7 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -161,8 +161,8 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
-        isDisabled={true}
+        processorDescription=""
+        isDisabled
       />,
     );
 
@@ -178,7 +178,7 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -195,7 +195,7 @@ describe('CustomNodeContainer', () => {
         vizNode={vizNode}
         childCount={0}
         ProcessorIcon={null}
-        processorDescription={''}
+        processorDescription=""
         isDisabled={false}
       />,
     );
@@ -214,7 +214,7 @@ describe('CustomNodeContainer', () => {
         childCount={3}
         ProcessorIcon={MockProcessorIcon}
         processorDescription="Processor desc"
-        isDisabled={true}
+        isDisabled
       />,
     );
 
@@ -231,9 +231,9 @@ describe('CustomNodeContainer', () => {
       <CustomNodeContainer
         {...defaultContainerProps}
         vizNode={vizNode}
-        isCollapsed={true}
+        isCollapsed
         childCount={1}
-        hasGroupChildren={true}
+        hasGroupChildren
         ProcessorIcon={null}
         processorDescription={undefined}
         isDisabled={false}

--- a/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/VisualizationEmptyState.tsx
@@ -45,7 +45,7 @@ export const VisualizationEmptyState: FunctionComponent<IVisualizationEmptyState
                 onClick={() => {
                   visibleFlowsContext.visualFlowsApi?.showFlows();
                 }}
-                data-testid={'show-all-routes-button'}
+                data-testid="show-all-routes-button"
                 variant="control"
                 icon={<EyeIcon />}
               >

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -71,5 +71,5 @@ export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onCh
     xpathLanguage.tokensProvider,
   ]);
 
-  return <div className="xpath-editor" data-testid="xpath-editor" ref={monacoEl}></div>;
+  return <div className="xpath-editor" data-testid="xpath-editor" ref={monacoEl} />;
 };

--- a/packages/ui/src/components/XPath/XPathEditorLayout.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.tsx
@@ -105,7 +105,7 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({
               data-testid="xpath-editor-tab-field"
             >
               <TabContent id="fields" className="xpath-editor--full-height xpath-editor__tab">
-                <SourcePanel isReadOnly={true} />
+                <SourcePanel isReadOnly />
               </TabContent>
             </Tab>
 

--- a/packages/ui/src/layout/Shell.test.tsx
+++ b/packages/ui/src/layout/Shell.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../hooks/local-storage.hook', () => ({
 }));
 
 vi.mock('./Navigation', () => ({
-  Navigation: ({ isNavOpen }: { isNavOpen: boolean }) => <div data-testid="navigation" data-is-open={isNavOpen}></div>,
+  Navigation: ({ isNavOpen }: { isNavOpen: boolean }) => <div data-testid="navigation" data-is-open={isNavOpen} />,
 }));
 
 vi.mock('./TopBar', () => ({

--- a/packages/ui/src/layout/TopBar.tsx
+++ b/packages/ui/src/layout/TopBar.tsx
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { EllipsisVIcon, ExternalLinkAltIcon, FireIcon, GithubIcon } from '@patternfly/react-icons';
 import { BarsIcon } from '@patternfly/react-icons/dist/js/icons/bars-icon';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import camelLogo from '../assets/camel-logo.svg';
@@ -37,14 +37,24 @@ const displayObject: MastheadProps['display'] = {
   default: 'inline',
 };
 
+const TopBarMenuToggle: FunctionComponent<{
+  toggleRef: React.Ref<MenuToggleElement>;
+  onClick: () => void;
+  isOpen: boolean;
+}> = ({ toggleRef, onClick, isOpen }) => (
+  <MenuToggle ref={toggleRef} onClick={onClick} variant="plain" isExpanded={isOpen}>
+    <EllipsisVIcon />
+  </MenuToggle>
+);
+
 export const TopBar: FunctionComponent<ITopBar> = (props) => {
   const logoLink = useComponentLink(Links.Home);
   const [isOpen, setIsOpen] = React.useState(false);
   const [isAboutModalOpen, setIsAboutModalOpen] = React.useState(false);
 
-  const onToggle = () => {
-    setIsOpen(!isOpen);
-  };
+  const onToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent> | undefined) => {
     event?.stopPropagation();
@@ -54,6 +64,13 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
   const toggleAboutModal = () => {
     setIsAboutModalOpen(!isAboutModalOpen);
   };
+
+  const renderToggle = useCallback(
+    (toggleRef: React.Ref<MenuToggleElement>) => (
+      <TopBarMenuToggle toggleRef={toggleRef} onClick={onToggle} isOpen={isOpen} />
+    ),
+    [onToggle, isOpen],
+  );
 
   return (
     <>
@@ -73,11 +90,7 @@ export const TopBar: FunctionComponent<ITopBar> = (props) => {
           <ToolbarItem className="shell__link">
             <Dropdown
               onSelect={onSelect}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle ref={toggleRef} onClick={onToggle} variant="plain" isExpanded={isOpen}>
-                  <EllipsisVIcon />
-                </MenuToggle>
-              )}
+              toggle={renderToggle}
               isOpen={isOpen}
               onOpenChange={(isOpen: boolean) => {
                 setIsOpen(isOpen);

--- a/packages/ui/src/pages/Catalog/CatalogPage.tsx
+++ b/packages/ui/src/pages/Catalog/CatalogPage.tsx
@@ -55,9 +55,7 @@ export const CatalogPage: FunctionComponent = () => {
   return (
     <>
       <Catalog tiles={tiles} onTileClick={onTileClick} />
-      {modalTile && (
-        <PropertiesModal tile={modalTile} isModalOpen={isModalOpen} onClose={handleOnClose}></PropertiesModal>
-      )}
+      {modalTile && <PropertiesModal tile={modalTile} isModalOpen={isModalOpen} onClose={handleOnClose} />}
     </>
   );
 };

--- a/packages/ui/src/pages/DataMapperNotYetInBrowser/DataMapperNotYetInBrowser.tsx
+++ b/packages/ui/src/pages/DataMapperNotYetInBrowser/DataMapperNotYetInBrowser.tsx
@@ -22,7 +22,7 @@ export const DataMapperNotYetInBrowserPage: FunctionComponent = () => {
   return (
     <Panel>
       <PanelHeader>
-        <Brand src={icon_component_datamapper} alt="Kaoto DataMapper icon"></Brand>
+        <Brand src={icon_component_datamapper} alt="Kaoto DataMapper icon" />
         <Title headingLevel="h1">The Kaoto DataMapper cannot be configured</Title>
       </PanelHeader>
       <PanelMain>

--- a/packages/ui/src/providers/action-confirmation-modal.provider.tsx
+++ b/packages/ui/src/providers/action-confirmation-modal.provider.tsx
@@ -129,7 +129,7 @@ export const ActionConfirmationModalContextProvider: FunctionComponent<PropsWith
 
       {isModalOpen && (
         <Modal isOpen variant={ModalVariant.small} onClose={handleCloseModal} ouiaId="ActionConfirmationModal">
-          <ModalHeader title={title} titleIconVariant={'warning'} />
+          <ModalHeader title={title} titleIconVariant="warning" />
           <ModalBody>
             {textParagraphs.length === 1
               ? textParagraphs[0]

--- a/packages/ui/src/providers/data-mapping-links.provider.test.tsx
+++ b/packages/ui/src/providers/data-mapping-links.provider.test.tsx
@@ -20,7 +20,7 @@ describe('DataMappingLinksProvider', () => {
   it('should fail if not within DataMapperProvider', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const thrower = () => {
-      render(<MappingLinksProvider></MappingLinksProvider>);
+      render(<MappingLinksProvider />);
     };
     expect(thrower).toThrow();
     consoleSpy.mockRestore();

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -49,11 +49,11 @@ describe('DataMapperProvider', () => {
           done = true;
         }
       }, [mappingTree, refreshMappingTree]);
-      return <div data-testid="testdiv"></div>;
+      return <div data-testid="testdiv" />;
     };
     render(
       <DataMapperProvider>
-        <TestRefreshMappingTree></TestRefreshMappingTree>
+        <TestRefreshMappingTree />
       </DataMapperProvider>,
     );
     await screen.findByTestId('testdiv');
@@ -81,11 +81,11 @@ describe('DataMapperProvider', () => {
           tree = mappingTree;
         }
       }, [mappingTree, refreshMappingTree, resetMappingTree]);
-      return <div data-testid="testdiv"></div>;
+      return <div data-testid="testdiv" />;
     };
     render(
       <DataMapperProvider>
-        <TestRefreshMappingTree></TestRefreshMappingTree>
+        <TestRefreshMappingTree />
       </DataMapperProvider>,
     );
     await waitFor(() => tree);
@@ -108,7 +108,7 @@ describe('DataMapperProvider', () => {
           done = true;
         }
       }, [refreshSourceParameters, sourceParameterMap]);
-      return <div data-testid="testdiv"></div>;
+      return <div data-testid="testdiv" />;
     };
     render(
       <DataMapperProvider>

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -376,7 +376,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
                 key={option.key ?? `alert-key-${index}`}
                 variant={option.variant}
                 title={option.title}
-                timeout={true}
+                timeout
                 onTimeout={() => {
                   closeAlert(option);
                 }}

--- a/packages/ui/src/providers/dnd/DataMapperDndMonitor.tsx
+++ b/packages/ui/src/providers/dnd/DataMapperDndMonitor.tsx
@@ -37,5 +37,5 @@ export const DataMapperDnDMonitor: FunctionComponent = () => {
     },
   });
 
-  return <></>;
+  return null;
 };

--- a/packages/ui/src/providers/settings.provider.test.tsx
+++ b/packages/ui/src/providers/settings.provider.test.tsx
@@ -20,7 +20,7 @@ describe('SettingsProvider', () => {
   });
 });
 
-function TestProvider() {
+const TestProvider = () => {
   const settingsContext = useContext(SettingsContext);
   const [settings, setSettings] = useState<SettingsModel | null>(null);
 
@@ -29,4 +29,4 @@ function TestProvider() {
   }, [settingsContext]);
 
   return <p data-testid="settings">{JSON.stringify(settings)}</p>;
-}
+};

--- a/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.tsx
+++ b/packages/ui/src/stubs/BrowserFilePickerMetadataProvider.tsx
@@ -85,7 +85,7 @@ export const BrowserFilePickerMetadataProvider: FunctionComponent<PropsWithChild
       <input
         type="file"
         style={{ display: 'none' }}
-        data-testid={`attach-schema-file-input`}
+        data-testid="attach-schema-file-input"
         onChange={onImport}
         ref={fileInputRef}
       />


### PR DESCRIPTION
## What

Enables six additional [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react) rules to tighten our React/JSX conventions, and applies their autofixes across the codebase. The bulk of the 66-file diff is mechanical autofix churn rather than hand edits.

## Rules enabled

| Rule | Config | What it enforces |
|------|--------|------------------|
| [`react/jsx-boolean-value`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) | `['error', 'never']` | Omit the explicit `={true}` on boolean props — write `<Foo bar />` instead of `<Foo bar={true} />`. |
| [`react/jsx-curly-brace-presence`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md) | `['error', { props: 'never', children: 'never' }]` | Disallow unnecessary curly braces around string literals in props and children — `title="x"` instead of `title={'x'}`. |
| [`react/no-unstable-nested-components`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) | `'error'` | Forbid defining components inside the render body of another component, which creates a new component identity on every render and forces React to remount the subtree (losing state and hurting performance). |
| [`react/function-component-definition`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md) | `['error', { namedComponents: 'arrow-function', unnamedComponents: 'arrow-function' }]` | Require function components to be declared as arrow functions for a consistent definition style. |
| [`react/jsx-no-useless-fragment`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md) | `['error', { allowExpressions: true }]` | Remove redundant `<>...</>` fragments that wrap a single child or add no value. `allowExpressions` keeps fragments that wrap a single expression where they are still needed. |
| [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) | `'error'` | Use self-closing tags for elements with no children — `<div />` instead of `<div></div>`. |

## Why

These rules catch a real correctness footgun (`no-unstable-nested-components`) and otherwise reduce visual noise and keep JSX style consistent across the project. All six are autofixable, so enforcement carries little ongoing maintenance cost.

## Notes

Most of the changed files are the result of `eslint --fix`; no runtime behavior changes are intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized React component syntax and JSX formatting across the UI for clearer, more consistent code.
  * Simplified several elements and props to use self-closing tags, boolean shorthand, and direct string literals where appropriate.
* **Refactor**
  * Updated multiple toolbar, modal, and data-mapper components to use extracted toggle/row helpers, improving consistency in rendering patterns.
* **Tests**
  * Aligned test setup throughout the UI to match the updated JSX conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->