### PR TITLE
fix(DataMapper): wrap xs:sequence inside xs:choice as a grouped option 

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
@@ -21,6 +21,7 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({ classNa
   const isChoiceWrapper = VisualizationUtilService.isUnselectedChoiceField(nodeData);
   const isSelectedChoiceWrapper = VisualizationUtilService.isSelectedNestedChoice(nodeData);
   const isAbstractWrapper = VisualizationUtilService.isUnselectedAbstractField(nodeData);
+  const isSequenceWrapper = VisualizationUtilService.isSequenceField(nodeData);
   const hasNoCandidates = isAbstractWrapper && (nodeData.field.fields ?? []).length === 0;
   const optionalField = nodeData.field.minOccurs === 0;
   const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
@@ -39,17 +40,20 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({ classNa
           {hasNoCandidates ? 'abstract (no candidates)' : 'abstract'}
         </Label>
       )}
-      <span
-        className={clsx(
-          'node-title__text',
-          isChoiceWrapper && 'node-title__text__choice',
-          isAbstractWrapper && 'node-title__text__abstract',
-          className,
-        )}
-        data-rank={rank}
-      >
-        {title}
-      </span>
+      {isSequenceWrapper && <Label>sequence</Label>}
+      {!isSequenceWrapper && (
+        <span
+          className={clsx(
+            'node-title__text',
+            isChoiceWrapper && 'node-title__text__choice',
+            isAbstractWrapper && 'node-title__text__abstract',
+            className,
+          )}
+          data-rank={rank}
+        >
+          {title}
+        </span>
+      )}
       {optionalField && !repeatingField0 && (
         <OptIcon className="node__spacer datamapper-marker-field" aria-label="Optional" />
       )}

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
@@ -41,7 +41,7 @@ export function useFieldOverrideMenu(nodeData: NodeData): MenuContributor {
   }, [abstractWrapperField, field, mappingTree.namespaceMap, updateDocument]);
 
   const groups = useMemo((): MenuGroup[] => {
-    if (field?.wrapperKind === 'choice') return [];
+    if (field?.wrapperKind === 'choice' || field?.wrapperKind === 'sequence') return [];
     return [
       { actions: [{ label: 'Override Field...', onClick: handleOverrideType, testId: 'field-override' }] },
       hasFieldOverride

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -17,8 +17,9 @@ export type IParentType = IDocument | IField;
  * Discriminator for synthetic wrapper fields that group selectable candidates.
  * - `'choice'` — xs:choice compositor wrapping mutually exclusive element alternatives
  * - `'abstract'` — abstract element wrapper holding concrete substitution group members
+ * - `'sequence'` — xs:sequence compositor inside xs:choice, grouping elements that must appear together as one choice option
  */
-export type WrapperKind = 'choice' | 'abstract';
+export type WrapperKind = 'choice' | 'abstract' | 'sequence';
 
 /**
  * Immutable snapshot of a field's identity and structure taken lazily on first expansion

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -59,13 +59,15 @@ export type SourceNodeDataType =
   | FieldNodeData
   | ChoiceFieldNodeData
   | AbstractFieldNodeData
+  | SequenceFieldNodeData
   | SourceVariableNodeData;
 /** Union of all valid target-side node types. */
 export type TargetNodeDataType =
   | TargetDocumentNodeData
   | TargetFieldNodeData
   | TargetChoiceFieldNodeData
-  | TargetAbstractFieldNodeData;
+  | TargetAbstractFieldNodeData
+  | TargetSequenceFieldNodeData;
 
 /**
  * Visualization node for a source or target document root.
@@ -214,6 +216,17 @@ export class TargetAbstractFieldNodeData extends TargetFieldNodeData {
   /** The abstract wrapper field when a member is selected; `undefined` for the unselected wrapper itself. */
   abstractField?: IField;
 }
+
+/**
+ * Visualization node for a source xs:sequence wrapper field inside an xs:choice.
+ * Sequence wrappers have no selection mechanism — they always render all children.
+ */
+export class SequenceFieldNodeData extends FieldNodeData {}
+
+/**
+ * Target-side counterpart of {@link SequenceFieldNodeData}.
+ */
+export class TargetSequenceFieldNodeData extends TargetFieldNodeData {}
 
 /**
  * Visualization node for a mapping item (e.g. `if`, `choose`, `forEach`, `valueSelector`).

--- a/packages/ui/src/services/document/document.service.test.ts
+++ b/packages/ui/src/services/document/document.service.test.ts
@@ -281,6 +281,70 @@ describe('DocumentService', () => {
       expect(result?.name).toBe('email');
     });
 
+    it('should find a compatible field inside a sequence wrapper nested in a choice compositor', () => {
+      const srcDoc = TestUtil.createSourceOrderDoc();
+      const tgtDoc = TestUtil.createTargetOrderDoc();
+
+      const srcShipOrderField = srcDoc.fields[0];
+      const srcChoice = new XmlSchemaField(srcShipOrderField, 'choice', false);
+      srcChoice.wrapperKind = 'choice';
+      const srcSeq = new XmlSchemaField(srcChoice, '__sequence__', false);
+      srcSeq.wrapperKind = 'sequence';
+      const srcKeyField = new XmlSchemaField(srcSeq, 'key', false);
+      srcSeq.fields = [srcKeyField];
+      srcChoice.fields = [srcSeq];
+      srcShipOrderField.fields.push(srcChoice);
+
+      const tgtShipOrderField = tgtDoc.fields[0];
+      const tgtChoice = new XmlSchemaField(tgtShipOrderField, 'choice', false);
+      tgtChoice.wrapperKind = 'choice';
+      const tgtSeq = new XmlSchemaField(tgtChoice, '__sequence__', false);
+      tgtSeq.wrapperKind = 'sequence';
+      const tgtKeyField = new XmlSchemaField(tgtSeq, 'key', false);
+      tgtSeq.fields = [tgtKeyField];
+      tgtChoice.fields = [tgtSeq];
+      tgtShipOrderField.fields.push(tgtChoice);
+
+      const result = DocumentService.getCompatibleField(tgtDoc, srcKeyField);
+
+      expect(result?.name).toBe('key');
+    });
+
+    it('should match sequence wrappers by positional index', () => {
+      const srcDoc = TestUtil.createSourceOrderDoc();
+      const tgtDoc = TestUtil.createTargetOrderDoc();
+
+      const srcShipOrderField = srcDoc.fields[0];
+      const srcChoice = new XmlSchemaField(srcShipOrderField, 'choice', false);
+      srcChoice.wrapperKind = 'choice';
+      const srcSeq0 = new XmlSchemaField(srcChoice, '__sequence__', false);
+      srcSeq0.wrapperKind = 'sequence';
+      srcSeq0.fields = [new XmlSchemaField(srcSeq0, 'alpha', false)];
+      const srcSeq1 = new XmlSchemaField(srcChoice, '__sequence__', false);
+      srcSeq1.wrapperKind = 'sequence';
+      const srcBetaField = new XmlSchemaField(srcSeq1, 'beta', false);
+      srcSeq1.fields = [srcBetaField];
+      srcChoice.fields = [srcSeq0, srcSeq1];
+      srcShipOrderField.fields.push(srcChoice);
+
+      const tgtShipOrderField = tgtDoc.fields[0];
+      const tgtChoice = new XmlSchemaField(tgtShipOrderField, 'choice', false);
+      tgtChoice.wrapperKind = 'choice';
+      const tgtSeq0 = new XmlSchemaField(tgtChoice, '__sequence__', false);
+      tgtSeq0.wrapperKind = 'sequence';
+      tgtSeq0.fields = [new XmlSchemaField(tgtSeq0, 'alpha', false)];
+      const tgtSeq1 = new XmlSchemaField(tgtChoice, '__sequence__', false);
+      tgtSeq1.wrapperKind = 'sequence';
+      const tgtBetaField = new XmlSchemaField(tgtSeq1, 'beta', false);
+      tgtSeq1.fields = [tgtBetaField];
+      tgtChoice.fields = [tgtSeq0, tgtSeq1];
+      tgtShipOrderField.fields.push(tgtChoice);
+
+      const result = DocumentService.getCompatibleField(tgtDoc, srcBetaField);
+
+      expect(result?.name).toBe('beta');
+    });
+
     it('should return undefined when the source choice index has no corresponding choice in the target', () => {
       const srcDoc = TestUtil.createSourceOrderDoc();
       const tgtDoc = TestUtil.createTargetOrderDoc();

--- a/packages/ui/src/services/document/document.service.ts
+++ b/packages/ui/src/services/document/document.service.ts
@@ -324,13 +324,14 @@ export class DocumentService {
     const fieldStack = DocumentUtilService.getFieldStack(field, true);
     for (const right of fieldStack.slice().reverse()) {
       const parent: IParentType = left ?? document;
-      if (right.wrapperKind === 'choice') {
-        const rightChoices: IField[] = right.parent.fields.filter((f) => f.wrapperKind === 'choice');
-        const leftChoices: IField[] = parent.fields.filter((f) => f.wrapperKind === 'choice');
-        const choiceIndex: number = rightChoices.indexOf(right);
-        const choiceFound: IField | undefined = choiceIndex >= 0 ? leftChoices[choiceIndex] : undefined;
-        if (!choiceFound) return undefined;
-        left = choiceFound;
+      if (right.wrapperKind === 'choice' || right.wrapperKind === 'sequence') {
+        const kind = right.wrapperKind;
+        const rightWrappers: IField[] = right.parent.fields.filter((f) => f.wrapperKind === kind);
+        const leftWrappers: IField[] = parent.fields.filter((f) => f.wrapperKind === kind);
+        const wrapperIndex: number = rightWrappers.indexOf(right);
+        const wrapperFound: IField | undefined = wrapperIndex >= 0 ? leftWrappers[wrapperIndex] : undefined;
+        if (!wrapperFound) return undefined;
+        left = wrapperFound;
         continue;
       }
       const found = DocumentService.findCompatibleFieldInParent(parent, right);

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
@@ -116,6 +116,43 @@ describe('XmlSchemaDocumentService', () => {
     expect(choiceWrapper.fields.find((f) => f.name === 'Group1Element2')).toBeDefined();
   });
 
+  it('should wrap xs:sequence inside xs:choice as a sequence wrapper field', () => {
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'testDocument.xsd': getTestDocumentXsd(),
+      },
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const testDoc = XmlSchemaDocumentUtilService.getFirstElement(document.xmlSchemaCollection)!;
+    const fields: XmlSchemaField[] = [];
+    XmlSchemaDocumentService.populateElement(document, fields, testDoc);
+
+    const testDocument = fields[0];
+    const seqInChoiceElement = testDocument.fields.find((f) => f.name === 'SequenceInChoiceElement')!;
+    expect(seqInChoiceElement).toBeDefined();
+
+    const choiceWrapper = seqInChoiceElement.fields[0];
+    expect(choiceWrapper.wrapperKind).toBe('choice');
+
+    // dataValue, numericValue, and a sequence wrapper (not flattened)
+    expect(choiceWrapper.fields).toHaveLength(3);
+    expect(choiceWrapper.fields.find((f) => f.name === 'dataValue')).toBeDefined();
+    expect(choiceWrapper.fields.find((f) => f.name === 'numericValue')).toBeDefined();
+
+    const seqWrapper = choiceWrapper.fields.find((f) => f.wrapperKind === 'sequence')!;
+    expect(seqWrapper).toBeDefined();
+    expect(seqWrapper.name).toBe('__sequence__');
+    expect(seqWrapper.displayName).toBe('sequence');
+    expect(seqWrapper.fields).toHaveLength(2);
+    expect(seqWrapper.fields.find((f) => f.name === 'key')).toBeDefined();
+    expect(seqWrapper.fields.find((f) => f.name === 'value')).toBeDefined();
+  });
+
   it('should preserve maxOccurs from xs:choice on the choice wrapper', () => {
     const xsdContent = `<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -924,9 +924,34 @@ export class XmlSchemaDocumentService {
     fields.push(choiceField);
     ownerDoc.totalFieldCount++;
     for (const member of choice.getItems()) {
-      XmlSchemaDocumentService.populateSequenceMember(choiceField, choiceField.fields, member, visitedGroupRefs);
+      if (member instanceof XmlSchemaSequence) {
+        XmlSchemaDocumentService.populateSequenceInChoice(choiceField, choiceField.fields, member, visitedGroupRefs);
+      } else {
+        XmlSchemaDocumentService.populateSequenceMember(choiceField, choiceField.fields, member, visitedGroupRefs);
+      }
     }
     choiceField.displayName = 'choice';
+  }
+
+  private static populateSequenceInChoice(
+    parent: XmlSchemaParentType,
+    fields: XmlSchemaField[],
+    sequence: XmlSchemaSequence,
+    visitedGroupRefs?: Set<string>,
+  ) {
+    const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;
+    const seqField = new XmlSchemaField(parent, '__sequence__', false);
+    seqField.wrapperKind = 'sequence';
+    seqField.minOccurs = sequence.getMinOccurs();
+    seqField.maxOccurs = sequence.getMaxOccurs();
+    seqField.minOccursExplicit = sequence.isMinOccursExplicit();
+    seqField.maxOccursExplicit = sequence.isMaxOccursExplicit();
+    seqField.displayName = 'sequence';
+    fields.push(seqField);
+    ownerDoc.totalFieldCount++;
+    for (const item of sequence.getItems()) {
+      XmlSchemaDocumentService.populateSequenceMember(seqField, seqField.fields, item, visitedGroupRefs);
+    }
   }
 
   /**

--- a/packages/ui/src/services/schema-path.service.test.ts
+++ b/packages/ui/src/services/schema-path.service.test.ts
@@ -14,6 +14,13 @@ describe('SchemaPathService', () => {
     return choiceField;
   }
 
+  function makeSequenceField(parent: XmlSchemaField, childNames: string[]) {
+    const seqField = new XmlSchemaField(parent, '__sequence__', false);
+    seqField.wrapperKind = 'sequence';
+    seqField.fields = childNames.map((n) => new XmlSchemaField(seqField, n, false));
+    return seqField;
+  }
+
   function makeAbstractField(parent: XmlSchemaField, candidateNames: string[]) {
     const abstractField = new XmlSchemaField(parent, 'AbstractElement', false);
     abstractField.wrapperKind = 'abstract';
@@ -76,6 +83,16 @@ describe('SchemaPathService', () => {
 
     it('should return empty array for root-only path', () => {
       expect(SchemaPathService.parse('/')).toEqual([]);
+    });
+
+    it('should parse a path with a sequence segment', () => {
+      const result = SchemaPathService.parse('/ns0:Root/{choice:0}/{sequence:1}/ns0:Child');
+      expect(result).toEqual<SchemaPathSegment[]>([
+        { kind: 'element', segment: 'ns0:Root' },
+        { kind: 'choice', index: 0 },
+        { kind: 'sequence', index: 1 },
+        { kind: 'element', segment: 'ns0:Child' },
+      ]);
     });
   });
 
@@ -408,6 +425,19 @@ describe('SchemaPathService', () => {
 
       const path = SchemaPathService.formatDisplayPath(choiceField, namespaceMap);
       expect(path).toBe('/ns0:ShipOrder/{choice:0}');
+    });
+
+    it('should omit sequence wrapper from display path', () => {
+      const document = TestUtil.createSourceOrderDoc();
+      const root = document.fields[0];
+      const choiceField = makeChoiceField(root, []);
+      const seqField = makeSequenceField(choiceField, ['key', 'value']);
+      choiceField.fields.push(seqField);
+      root.fields.push(choiceField);
+
+      const keyField = seqField.fields[0];
+      const path = SchemaPathService.formatDisplayPath(keyField, namespaceMap);
+      expect(path).toBe('/ns0:ShipOrder/{choice:0}/key');
     });
   });
 });

--- a/packages/ui/src/services/schema-path.service.ts
+++ b/packages/ui/src/services/schema-path.service.ts
@@ -7,7 +7,8 @@ import { XPathService } from './xpath/xpath.service';
 export type SchemaPathSegment =
   | { kind: 'element'; segment: string }
   | { kind: 'choice'; index: number }
-  | { kind: 'abstract'; index: number };
+  | { kind: 'abstract'; index: number }
+  | { kind: 'sequence'; index: number };
 
 /**
  * Service for schema path string operations: parsing, building, and navigation.
@@ -37,6 +38,7 @@ export type SchemaPathSegment =
 export class SchemaPathService {
   private static readonly CHOICE_SEGMENT_REGEX = /^\{choice:(\d+)}$/;
   private static readonly ABSTRACT_SEGMENT_REGEX = /^\{abstract:(\d+)}$/;
+  private static readonly SEQUENCE_SEGMENT_REGEX = /^\{sequence:(\d+)}$/;
   /**
    * Parses a schema path string into an array of typed segments.
    *
@@ -55,6 +57,11 @@ export class SchemaPathService {
       const abstractMatch = SchemaPathService.ABSTRACT_SEGMENT_REGEX.exec(part);
       if (abstractMatch) {
         segments.push({ kind: 'abstract', index: Number.parseInt(abstractMatch[1], 10) });
+        continue;
+      }
+      const sequenceMatch = SchemaPathService.SEQUENCE_SEGMENT_REGEX.exec(part);
+      if (sequenceMatch) {
+        segments.push({ kind: 'sequence', index: Number.parseInt(sequenceMatch[1], 10) });
         continue;
       }
       segments.push({ kind: 'element', segment: part });
@@ -106,7 +113,9 @@ export class SchemaPathService {
     const lastIndex = fieldStack.length - 1;
     for (let i = 0; i <= lastIndex; i++) {
       const f = fieldStack[i];
-      if (f.wrapperKind === 'choice') {
+      if (f.wrapperKind === 'sequence') {
+        continue;
+      } else if (f.wrapperKind === 'choice') {
         segments.push(
           `{choice:${SchemaPathService.getSiblingIndex(f, (sibling) => sibling.wrapperKind === 'choice')}}`,
         );

--- a/packages/ui/src/services/visualization/mapping-action.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.choice.test.ts
@@ -21,6 +21,7 @@ import {
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
+  TargetSequenceFieldNodeData,
 } from '../../models/datamapper/visualization';
 import { getTestDocumentXsd, TestUtil } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
@@ -396,6 +397,47 @@ describe('MappingActionService / choice field mappings', () => {
 
       expect((freshEmailAddressNode as FieldItemNodeData).path.pathSegments).toContain(nestedChoiceField.id);
       expect(emailAddressItem.nodePath.pathSegments).not.toContain(nestedChoiceField.id);
+    });
+  });
+
+  describe('mapping through sequence wrapper inside choice', () => {
+    it('getOrCreateFieldItem should skip sequence wrapper and create FieldItem under grandparent', () => {
+      const localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const seqField = {
+        ...targetDoc.fields[0],
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [] as unknown[],
+      } as unknown as (typeof targetDoc.fields)[0];
+      const childField = {
+        ...targetDoc.fields[0],
+        name: 'seqChild',
+        displayName: 'seqChild',
+        fields: [],
+        parent: seqField,
+      } as unknown as (typeof targetDoc.fields)[0];
+      seqField.fields = [childField];
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [seqField],
+      };
+      const parentFieldNode = new TargetFieldNodeData(localTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+
+      const seqNode = new TargetSequenceFieldNodeData(parentFieldNode, seqField);
+      const childNode = new TargetFieldNodeData(seqNode, childField);
+
+      const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+      const sourceFieldNode = sourceDocChildren[0] as FieldNodeData;
+      const sourceChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceFieldNode);
+
+      MappingActionService.engageMapping(tree, sourceChildren[0] as FieldNodeData, childNode);
+
+      const parentItem = tree.children[0];
+      expect(parentItem).toBeInstanceOf(FieldItem);
+      const childItem = parentItem.children.find((c) => c instanceof FieldItem && c.field === childField) as FieldItem;
+      expect(childItem).toBeDefined();
+      expect(childItem.field.name).toBe('seqChild');
     });
   });
 

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -28,6 +28,7 @@ import {
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
+  TargetSequenceFieldNodeData,
   VariableNodeData,
 } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
@@ -277,7 +278,7 @@ export class MappingActionService {
   static applyInnerIf(nodeData: TargetNodeData) {
     // If applying to an IfItem node, use the mapping directly
     if (MappingActionService.isMappingNode(nodeData)) {
-      const mapping = (nodeData as MappingNodeData).mapping;
+      const mapping = nodeData.mapping;
       if (mapping instanceof IfItem) {
         MappingService.addInnerIf(mapping);
         return;
@@ -535,6 +536,9 @@ export class MappingActionService {
     if (fieldNodeData instanceof TargetAbstractFieldNodeData && !fieldNodeData.abstractField) {
       return MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
     }
+    if (fieldNodeData instanceof TargetSequenceFieldNodeData) {
+      return MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
+    }
     const parentItem = MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
     return MappingService.createFieldItem(parentItem, fieldNodeData.field);
   }
@@ -546,7 +550,7 @@ export class MappingActionService {
         if (current.mapping instanceof ForEachGroupItem) return true;
         if (current.mapping instanceof ForEachItem && current.mapping.expression === 'current-group()') return false;
       }
-      current = 'parent' in current ? (current.parent as TargetNodeData) : undefined;
+      current = 'parent' in current ? current.parent : undefined;
     }
     return false;
   }

--- a/packages/ui/src/services/visualization/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.test.ts
@@ -16,10 +16,12 @@ import {
   FieldItemNodeData,
   FieldNodeData,
   NodeData,
+  SequenceFieldNodeData,
   SourceVariableNodeData,
   TargetAbstractFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
+  TargetSequenceFieldNodeData,
   UnknownMappingNodeData,
   VariableNodeData,
 } from '../../models/datamapper/visualization';
@@ -180,6 +182,23 @@ describe('MappingValidationService', () => {
       it('should allow source to non-abstract target', () => {
         const source = createMockField({ type: Types.String });
         const target = createMockField({});
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe('sequence validation', () => {
+      it('should reject any source to sequence wrapper target', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ wrapperKind: 'sequence' });
+        const result = MappingValidationService.validateFieldPair(source, target);
+        expect(result.isValid).toBe(false);
+        expect(result.errorMessage).toContain('sequence group');
+      });
+
+      it('should allow source to non-sequence target', () => {
+        const source = createMockField({ type: Types.String });
+        const target = createMockField({ type: Types.String });
         const result = MappingValidationService.validateFieldPair(source, target);
         expect(result.isValid).toBe(true);
       });
@@ -598,6 +617,18 @@ describe('MappingValidationService', () => {
 
     it('should return false for non-primitive DocumentNodeData', () => {
       expect(MappingValidationService.isDraggable(sourceDocNode)).toBe(false);
+    });
+
+    it('should return false for SequenceFieldNodeData', () => {
+      const field = createMockField({ wrapperKind: 'sequence' });
+      const node = new SequenceFieldNodeData(sourceDocNode, field);
+      expect(MappingValidationService.isDraggable(node)).toBe(false);
+    });
+
+    it('should return false for TargetSequenceFieldNodeData', () => {
+      const field = createMockField({ wrapperKind: 'sequence' });
+      const node = new TargetSequenceFieldNodeData(targetDocNode, field);
+      expect(MappingValidationService.isDraggable(node)).toBe(false);
     });
 
     it('should return true for VariableNodeData', () => {

--- a/packages/ui/src/services/visualization/mapping-validation.service.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.ts
@@ -9,12 +9,14 @@ import {
   FieldItemNodeData,
   MappingNodeData,
   NodeData,
+  SequenceFieldNodeData,
   SourceNodeDataType,
   SourceVariableNodeData,
   TargetAbstractFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
+  TargetSequenceFieldNodeData,
   UnknownMappingNodeData,
 } from '../../models/datamapper/visualization';
 import { DocumentService } from '../document/document.service';
@@ -77,6 +79,7 @@ export class MappingValidationService {
     if (node instanceof AddMappingNodeData) return false;
     if ((node instanceof AbstractFieldNodeData || node instanceof TargetAbstractFieldNodeData) && !node.abstractField)
       return false;
+    if (node instanceof SequenceFieldNodeData || node instanceof TargetSequenceFieldNodeData) return false;
     if (node instanceof DocumentNodeData && !node.isPrimitive) return false;
     return true;
   }
@@ -168,6 +171,7 @@ export class MappingValidationService {
   private static readonly pairValidationRules: ReadonlyArray<(source: IField, target: IField) => ValidationResult> = [
     MappingValidationService.validateChoiceRules,
     MappingValidationService.validateAbstractRules,
+    MappingValidationService.validateSequenceRules,
     MappingValidationService.validateContainerRules,
   ];
 
@@ -348,6 +352,16 @@ export class MappingValidationService {
       return {
         isValid: false,
         errorMessage: 'Cannot map to an unselected abstract element. Please select a concrete candidate first.',
+      };
+    }
+    return { isValid: true };
+  }
+
+  private static validateSequenceRules(_source: IField, target: IField): ValidationResult {
+    if (target.wrapperKind === 'sequence') {
+      return {
+        isValid: false,
+        errorMessage: 'Cannot map to a sequence group. Map its individual children instead.',
       };
     }
     return { isValid: true };

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -5,8 +5,10 @@ import {
   FieldItemNodeData,
   FieldNodeData,
   NodeData,
+  SequenceFieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
+  TargetSequenceFieldNodeData,
 } from '../../models/datamapper/visualization';
 import { DocumentService } from '../document/document.service';
 
@@ -146,6 +148,14 @@ export class VisualizationUtilService {
     nodeData: NodeData,
   ): nodeData is AbstractFieldNodeData | TargetAbstractFieldNodeData {
     return VisualizationUtilService.isAbstractField(nodeData) && !nodeData.abstractField;
+  }
+
+  /**
+   * Returns `true` if the node is a sequence wrapper field, on either source or target side.
+   * @param nodeData - The node to test.
+   */
+  static isSequenceField(nodeData: NodeData): nodeData is SequenceFieldNodeData | TargetSequenceFieldNodeData {
+    return nodeData instanceof SequenceFieldNodeData || nodeData instanceof TargetSequenceFieldNodeData;
   }
 
   /**

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -24,11 +24,13 @@ import {
   NameValidation,
   NameValidationStatus,
   NodeData,
+  SequenceFieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
+  TargetSequenceFieldNodeData,
   UnknownMappingNodeData,
   VariableNodeData,
 } from '../../models/datamapper/visualization';
@@ -63,6 +65,14 @@ const ABSTRACT_WRAPPER: WrapperSpec = {
   },
   isTargetWrapper: (node) => node instanceof TargetAbstractFieldNodeData,
   hasWrapperRef: (node) => !!(node as TargetAbstractFieldNodeData).abstractField,
+};
+
+const SEQUENCE_WRAPPER: WrapperSpec = {
+  createSourceNode: (parent, field) => new SequenceFieldNodeData(parent, field),
+  createTargetNode: (parent, field, mapping) => new TargetSequenceFieldNodeData(parent, field, mapping),
+  setWrapperRef: () => {},
+  isTargetWrapper: (node) => node instanceof TargetSequenceFieldNodeData,
+  hasWrapperRef: () => false,
 };
 
 // Regex patterns for DnD ID generation
@@ -187,6 +197,10 @@ export class VisualizationService {
         acc.push(VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, ABSTRACT_WRAPPER));
         return acc;
       }
+      if (field.wrapperKind === 'sequence') {
+        acc.push(VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, SEQUENCE_WRAPPER));
+        return acc;
+      }
 
       const mappingsForField = mappings ? MappingService.filterMappingsForField(mappings, field) : [];
       if (mappingsForField.length === 0) {
@@ -239,10 +253,10 @@ export class VisualizationService {
   }
 
   private static isUnselectedTargetWrapper(node: NodeData): boolean {
-    return (
-      (node instanceof TargetChoiceFieldNodeData && !node.choiceField) ||
-      (node instanceof TargetAbstractFieldNodeData && !node.abstractField)
-    );
+    if (node instanceof TargetChoiceFieldNodeData && !node.choiceField) return true;
+    if (node instanceof TargetAbstractFieldNodeData && !node.abstractField) return true;
+    if (node instanceof TargetSequenceFieldNodeData) return true;
+    return false;
   }
 
   /**
@@ -280,6 +294,13 @@ export class VisualizationService {
         parent,
         VisualizationService.resolveWrapperNodeFields(parent.field),
         VisualizationService.resolveWrapperNodeMappings(parent, ABSTRACT_WRAPPER),
+      );
+    }
+    if (parent instanceof SequenceFieldNodeData || parent instanceof TargetSequenceFieldNodeData) {
+      return VisualizationService.doGenerateNodeDataFromFields(
+        parent,
+        VisualizationService.resolveWrapperNodeFields(parent.field),
+        VisualizationService.resolveWrapperNodeMappings(parent, SEQUENCE_WRAPPER),
       );
     }
     if (parent instanceof FieldNodeData || parent instanceof FieldItemNodeData) {

--- a/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
@@ -130,6 +130,19 @@
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
+                <!-- xs:sequence directly inside xs:choice — elements grouped as one option -->
+                <xs:element name="SequenceInChoiceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="dataValue" type="xs:string"/>
+                            <xs:element name="numericValue" type="xs:decimal"/>
+                            <xs:sequence>
+                                <xs:element name="key" type="xs:string"/>
+                                <xs:element name="value" type="xs:string"/>
+                            </xs:sequence>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="ContainerChoiceElement">
                     <xs:complexType>
                         <xs:choice>


### PR DESCRIPTION
- Add 'sequence' to WrapperKind type for xs:sequence inside xs:choice
- Intercept XmlSchemaSequence in populateChoice and create __sequence__ wrapper field instead of flattening children into the choice
- Extend SchemaPathSegment with {sequence:N} parsing and make sequence transparent in display paths
- Generalize getCompatibleField to navigate sequence wrappers by index
- Add SequenceInChoiceElement to TestDocument.xsd and corresponding test

#Fixes #3345
<img width="614" height="199" alt="Screenshot 2026-07-07 at 11 34 50" src="https://github.com/user-attachments/assets/7285972f-190f-4dda-8bc5-220a8e357dee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added support for **sequence wrappers inside choice structures**, including a dedicated **“sequence”** label in the UI.
  * Updated schema path parsing to handle **`{sequence:N}`** segments while **omitting sequence wrappers** from display paths.

* **Bug Fixes**
  * Improved compatibility resolution and visualization/mapping behavior for nested sequence wrappers.
  * Prevented drag-and-drop and mapping of **sequence wrapper nodes** as containers (map their children instead).

* **Tests**
  * Added unit tests covering sequence-in-choice wrapping, indexing, schema paths, and validation/mapping outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->