### PR TITLE
fix(sonar): resolve high-priority SonarQube issues in the UI package

### DIFF
--- a/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.test.tsx
+++ b/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { IPropertiesTable, PropertiesHeaders, PropertiesTableType } from '../PropertiesModal.models';
+import { PropertiesTableTree } from './PropertiesTableTree';
+
+describe('PropertiesTableTree', () => {
+  const table: IPropertiesTable = {
+    type: PropertiesTableType.Tree,
+    headers: [PropertiesHeaders.Name, PropertiesHeaders.Description],
+    rows: [
+      {
+        name: 'parent',
+        description: 'parent description',
+        type: 'object',
+        rowAdditionalInfo: {},
+        children: [{ name: 'child', description: 'child description', type: 'string', rowAdditionalInfo: {} }],
+      },
+      { name: 'sibling', description: 'sibling description', type: 'string', rowAdditionalInfo: {} },
+    ],
+  };
+
+  const renderTree = () => render(<PropertiesTableTree rootDataTestId="props" table={table} />);
+
+  it('renders every row of the tree, including nested children', () => {
+    renderTree();
+
+    expect(screen.getByText('parent')).toBeInTheDocument();
+    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.getByText('sibling')).toBeInTheDocument();
+  });
+
+  it('toggles the expanded state of a parent row when its toggle is clicked', () => {
+    renderTree();
+
+    // Only the parent row (the one with children) exposes an expand/collapse toggle.
+    const toggle = screen.getByRole('button');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.tsx
+++ b/packages/ui/src/components/PropertiesModal/Tables/PropertiesTableTree.tsx
@@ -12,6 +12,13 @@ interface IPropertiesTableTreeProps {
 
 export const PropertiesTableTree: FunctionComponent<IPropertiesTableTreeProps> = (props) => {
   const [expandedNodeId, setExpandedNodeId] = useState<number[]>([]);
+
+  const handleCollapse = (rowIndex: number, isExpanded: boolean) => {
+    setExpandedNodeId((prevExpanded) => {
+      const otherExpandedNodeNames = prevExpanded.filter((row_unique_id) => row_unique_id !== rowIndex);
+      return isExpanded ? otherExpandedNodeNames : [...otherExpandedNodeNames, rowIndex];
+    });
+  };
   /** 
     source: https://www.patternfly.org/components/table#tree-table
     Recursive function which flattens the data into an array of flattened TreeRowWrapper components
@@ -36,10 +43,7 @@ export const PropertiesTableTree: FunctionComponent<IPropertiesTableTreeProps> =
 
     const treeRow: TdProps['treeRow'] = {
       onCollapse: () => {
-        setExpandedNodeId((prevExpanded) => {
-          const otherExpandedNodeNames = prevExpanded.filter((row_unique_id) => row_unique_id !== rowIndex);
-          return isExpanded ? otherExpandedNodeNames : [...otherExpandedNodeNames, rowIndex];
-        });
+        handleCollapse(rowIndex, isExpanded);
       },
       rowIndex,
       props: {

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.test.tsx
@@ -137,4 +137,20 @@ describe('useDeleteHotkey', () => {
 
     expect(preventDefault).toHaveBeenCalled();
   });
+
+  it('logs the error and does not clear the selection when deletion fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    onDeleteStep.mockRejectedValue(new Error('delete boom'));
+    const handler = setupHotkey(makeNode({ canRemoveStep: true }));
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      handler({ preventDefault } as unknown as KeyboardEvent);
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to delete node:', expect.any(Error));
+    expect(clearSelected).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/delete-hotkey.hook.tsx
@@ -29,7 +29,9 @@ export default function useDeleteHotkey(selectedVizNode: IVisualizationNode | un
   useEffect(() => {
     hotkeys('Delete, backspace', (event) => {
       event.preventDefault();
-      void handleKeyDown();
+      handleKeyDown().catch((error) => {
+        console.error('Failed to handle delete hotkey:', error);
+      });
     });
 
     return () => {

--- a/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/replace-step.hook.tsx
@@ -69,7 +69,7 @@ export const useReplaceStep = (vizNode: IVisualizationNode) => {
     entitiesContext.updateEntitiesFromCamelResource();
 
     /** Notify VS Code host about the new step */
-    void metadataContext?.onStepUpdated?.(StepUpdateAction.Replace, definedComponent.type, definedComponent.name);
+    await metadataContext?.onStepUpdated?.(StepUpdateAction.Replace, definedComponent.type, definedComponent.name);
   }, [
     catalogModalContext,
     entitiesContext,

--- a/packages/ui/src/components/registers/RegisterNodeInteractionAddons.test.tsx
+++ b/packages/ui/src/components/registers/RegisterNodeInteractionAddons.test.tsx
@@ -1,0 +1,87 @@
+import { render, waitFor } from '@testing-library/react';
+import type { Mock } from 'vitest';
+
+import { IMetadataApi, MetadataContext } from '../../providers';
+import { onDeleteDataMapper } from '../DataMapper/on-delete-datamapper';
+import {
+  IInteractionType,
+  IOnDeleteAddon,
+  IRegisteredInteractionAddon,
+} from './interactions/node-interaction-addon.model';
+import { NodeInteractionAddonContext } from './interactions/node-interaction-addon.provider';
+import { RegisterNodeInteractionAddons } from './RegisterNodeInteractionAddons';
+
+vi.mock('../DataMapper/on-delete-datamapper', async () => {
+  const actual = await vi.importActual('../DataMapper/on-delete-datamapper');
+  return {
+    ...actual,
+    onDeleteDataMapper: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('RegisterNodeInteractionAddons', () => {
+  const renderWithSpy = (metadataApi: IMetadataApi | undefined = undefined) => {
+    const registered: IRegisteredInteractionAddon[] = [];
+    const registerInteractionAddon = vi.fn((addon: IRegisteredInteractionAddon) => {
+      registered.push(addon);
+    });
+
+    const result = render(
+      <MetadataContext.Provider value={metadataApi}>
+        <NodeInteractionAddonContext.Provider
+          value={{ registerInteractionAddon, getRegisteredInteractionAddons: () => [] }}
+        >
+          <RegisterNodeInteractionAddons>
+            <p>child content</p>
+          </RegisterNodeInteractionAddons>
+        </NodeInteractionAddonContext.Provider>
+      </MetadataContext.Provider>,
+    );
+
+    return { registered, result };
+  };
+
+  const getOnDeleteAddon = (registered: IRegisteredInteractionAddon[]) =>
+    registered.find((addon) => addon.type === IInteractionType.ON_DELETE) as IOnDeleteAddon;
+
+  it('registers all four interaction addon types', () => {
+    const { registered } = renderWithSpy();
+
+    expect(registered.map((addon) => addon.type)).toEqual([
+      IInteractionType.ON_DELETE,
+      IInteractionType.ON_COPY,
+      IInteractionType.ON_DUPLICATE,
+      IInteractionType.ON_PASTE,
+    ]);
+  });
+
+  it('renders its children', () => {
+    const { result } = renderWithSpy();
+
+    expect(result.getByText('child content')).toBeInTheDocument();
+  });
+
+  it('does not invoke the DataMapper delete when no metadata API is available', () => {
+    const { registered } = renderWithSpy(undefined);
+
+    getOnDeleteAddon(registered).callback({ vizNode: {} as never, modalAnswer: undefined });
+
+    expect(onDeleteDataMapper).not.toHaveBeenCalled();
+  });
+
+  it('logs an error and does not throw when the DataMapper delete rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (onDeleteDataMapper as Mock).mockRejectedValueOnce(new Error('delete boom'));
+    const { registered } = renderWithSpy({} as IMetadataApi);
+
+    expect(() => {
+      getOnDeleteAddon(registered).callback({ vizNode: {} as never, modalAnswer: undefined });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to delete DataMapper mapping:', expect.any(Error));
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
+++ b/packages/ui/src/components/registers/RegisterNodeInteractionAddons.tsx
@@ -29,7 +29,11 @@ export const RegisterNodeInteractionAddons: FunctionComponent<PropsWithChildren>
       type: IInteractionType.ON_DELETE,
       activationFn: datamapperActivationFn,
       callback: ({ vizNode, modalAnswer }) => {
-        void (metadataApi && onDeleteDataMapper(metadataApi, vizNode, modalAnswer));
+        if (metadataApi) {
+          onDeleteDataMapper(metadataApi, vizNode, modalAnswer).catch((error) => {
+            console.error('Failed to delete DataMapper mapping:', error);
+          });
+        }
       },
       modalCustomization: {
         additionalText: 'Do you also want to delete the associated Kaoto DataMapper mapping file (XSLT)?',

--- a/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-tiles.provider.test.tsx
@@ -297,6 +297,29 @@ describe('CatalogTilesProvider', () => {
     expect(cachedTiles?.length).toBeGreaterThan(0);
   });
 
+  it('logs an error and still renders children when fetching tiles fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const componentCatalog = mockRegistry.getCatalog(CatalogKind.Component);
+    vi.spyOn(componentCatalog!, 'getAll').mockRejectedValue(new Error('catalog boom'));
+
+    await act(async () => {
+      render(
+        <CatalogContext.Provider value={mockRegistry}>
+          <CatalogTilesProvider>
+            <span data-testid="still-here">Loaded</span>
+          </CatalogTilesProvider>
+        </CatalogContext.Provider>,
+      );
+    });
+
+    expect(screen.getByTestId('still-here')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch tiles:', expect.any(Error));
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('should populate tiles upon loading', async () => {
     const componentCatalog = mockRegistry.getCatalog(CatalogKind.Component);
     const patternCatalog = mockRegistry.getCatalog(CatalogKind.Pattern);

--- a/packages/ui/src/dynamic-catalog/catalog-tiles.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog-tiles.provider.tsx
@@ -104,7 +104,9 @@ export const CatalogTilesProvider: FunctionComponent<PropsWithChildren> = (props
   const getTiles = useCallback(() => tilesRef.current, []);
 
   useEffect(() => {
-    void fetchTiles();
+    fetchTiles().catch((error) => {
+      console.error('Failed to fetch tiles:', error);
+    });
   }, [fetchTiles]);
 
   const value = useMemo(

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -159,7 +159,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     const index = parentChildren.findIndex((node) => node.id === this.id);
 
     if (index !== undefined && index > -1) {
-      this.setParentNode(undefined);
+      this.setParentNode();
       parentChildren.splice(index, 1);
     }
   }
@@ -177,13 +177,11 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   }
 
   protected getRootNode(): IVisualizationNode {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let rootNode: IVisualizationNode | undefined = this;
+    return this.findRoot(this);
+  }
 
-    while (rootNode?.getPreviousNode() !== undefined || rootNode?.getParentNode() !== undefined) {
-      rootNode = rootNode.getPreviousNode() ?? rootNode.getParentNode();
-    }
-
-    return rootNode!;
+  private findRoot(node: IVisualizationNode): IVisualizationNode {
+    const nextNode = node.getPreviousNode() ?? node.getParentNode();
+    return nextNode ? this.findRoot(nextNode) : node;
   }
 }

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { FunctionComponent, useRef } from 'react';
 
 import { SourceCodeSync } from '../../providers/source-code-sync';
@@ -27,7 +27,7 @@ describe('SourceCodeBridgeProvider', () => {
   });
 
   it('should call onNewEdit when the entities:updated event is emitted', () => {
-    const mockOnNewEdit = vi.fn();
+    const mockOnNewEdit = vi.fn().mockResolvedValue(undefined);
 
     render(
       <SourceCodeBridgeProvider onNewEdit={mockOnNewEdit}>
@@ -43,7 +43,7 @@ describe('SourceCodeBridgeProvider', () => {
   });
 
   it('should ignore the first code:updated event', () => {
-    const mockOnNewEdit = vi.fn();
+    const mockOnNewEdit = vi.fn().mockResolvedValue(undefined);
 
     render(
       <SourceCodeBridgeProvider onNewEdit={mockOnNewEdit}>
@@ -59,7 +59,7 @@ describe('SourceCodeBridgeProvider', () => {
   });
 
   it('should call onNewEdit when the code:updated event if there is source code available', () => {
-    const mockOnNewEdit = vi.fn();
+    const mockOnNewEdit = vi.fn().mockResolvedValue(undefined);
 
     render(
       <SourceCodeBridgeProvider onNewEdit={mockOnNewEdit}>
@@ -83,6 +83,28 @@ describe('SourceCodeBridgeProvider', () => {
 
     expect(mockOnNewEdit).toHaveBeenCalledWith(mockCamelRoute);
     expect(mockOnNewEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs an error and still updates the source ref when onNewEdit rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockOnNewEdit = vi.fn().mockRejectedValue(new Error('edit boom'));
+
+    render(
+      <SourceCodeBridgeProvider onNewEdit={mockOnNewEdit}>
+        <p>Complaint letter</p>
+      </SourceCodeBridgeProvider>,
+    );
+
+    await act(async () => {
+      EventNotifier.getInstance().next('entities:updated', mockCamelRoute);
+    });
+
+    expect(mockOnNewEdit).toHaveBeenCalledWith(mockCamelRoute);
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to apply edit:', expect.any(Error));
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('should unsubscribe from events on unmount', async () => {
@@ -125,7 +147,7 @@ describe('SourceCodeBridgeProvider', () => {
   });
 
   it('does not call onNewEdit for the empty initial code emitted on mount', () => {
-    const mockOnNewEdit = vi.fn();
+    const mockOnNewEdit = vi.fn().mockResolvedValue(undefined);
 
     render(
       <SourceCodeSync>

--- a/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.tsx
+++ b/packages/ui/src/multiplying-architecture/Bridge/SourceCodeBridgeProvider.tsx
@@ -22,14 +22,18 @@ export const SourceCodeBridgeProvider = forwardRef<SourceCodeBridgeProviderRef, 
      */
     useEffect(() => {
       const unsubscribeFromEntities = eventNotifier.subscribe('entities:updated', (newContent: string) => {
-        void onNewEdit(newContent);
+        onNewEdit(newContent).catch((error) => {
+          console.error('Failed to apply edit:', error);
+        });
         sourceCodeRef.current = newContent;
       });
 
       const unsubscribeFromSourceCode = eventNotifier.subscribe('code:updated', ({ code: newContent }) => {
         /** Ignore the first change, from an empty string to the file content  */
         if (sourceCodeRef.current !== '') {
-          void onNewEdit(newContent);
+          onNewEdit(newContent).catch((error) => {
+            console.error('Failed to apply edit:', error);
+          });
         }
         sourceCodeRef.current = newContent;
       });

--- a/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorFactory.ts
@@ -21,7 +21,7 @@ export class KaotoEditorFactory implements EditorFactory<Editor, KaotoEditorChan
     const settingsAdapter = new DefaultSettingsAdapter(settings);
     this.updateCatalogUrl(settingsAdapter, initArgs);
 
-    return Promise.resolve(new KaotoEditorApp(envelopeContext, initArgs, settingsAdapter));
+    return new KaotoEditorApp(envelopeContext, initArgs, settingsAdapter);
   }
 
   /**

--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.tsx
@@ -8,12 +8,12 @@ import { RestDslImportWizard } from './RestDslImportWizard';
 export const RestDslImportPage: FunctionComponent = () => {
   const navigate = useNavigate();
 
-  const handleClose = useCallback(() => {
-    void navigate(Links.RestEditor);
+  const handleClose = useCallback(async () => {
+    await navigate(Links.RestEditor);
   }, [navigate]);
 
-  const handleGoToDesigner = useCallback(() => {
-    void navigate(Links.Home);
+  const handleGoToDesigner = useCallback(async () => {
+    await navigate(Links.Home);
   }, [navigate]);
 
   return (

--- a/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportWizard.tsx
@@ -81,9 +81,9 @@ const ImportWizardFooter: FunctionComponent<ImportWizardFooterProps> = ({
           <Button
             variant="secondary"
             type="button"
-            onClick={(event) => {
+            onClick={async (event) => {
               event.preventDefault();
-              void onGoToDesigner(event);
+              await onGoToDesigner(event);
             }}
           >
             Go to Designer

--- a/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
+++ b/packages/ui/src/pages/RestDslImport/components/ApicurioImportSource.tsx
@@ -42,7 +42,9 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
 
   useEffect(() => {
     if (registryUrl) {
-      void fetchArtifacts();
+      fetchArtifacts().catch((error) => {
+        console.error('Failed to fetch artifacts:', error);
+      });
     }
   }, [fetchArtifacts, registryUrl]);
 
@@ -100,7 +102,9 @@ export const ApicurioImportSource: FunctionComponent<ApicurioImportSourceProps> 
   const handleSelectArtifact = useCallback(
     (artifactId: string) => {
       setSelectedId(artifactId);
-      void handleLoadArtifact(artifactId);
+      handleLoadArtifact(artifactId).catch((error) => {
+        console.error('Failed to load artifact:', error);
+      });
     },
     [handleLoadArtifact],
   );

--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { readdir, readFile } from 'node:fs/promises';
+import { readdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
@@ -26,11 +27,11 @@ import { beanWithConstructorAandProperties, beanWithConstructorAandPropertiesXML
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { isXML, KaotoXmlParser } from './kaoto-xml-parser';
 
-describe('XmlParser', async () => {
+describe('XmlParser', () => {
   let parser: KaotoXmlParser;
   const xmlDir = path.join(__dirname, '../../stubs/xml');
   const yamlDir = path.join(__dirname, '../../stubs/yaml');
-  const xmlFiles = (await readdir(xmlDir)).filter((file) => file.endsWith('.xml'));
+  const xmlFiles = readdirSync(xmlDir).filter((file) => file.endsWith('.xml'));
 
   beforeAll(async () => {
     parser = new KaotoXmlParser();


### PR DESCRIPTION
## What

Resolves **14 of the 18** HIGH-impact / OPEN SonarQube issues in the `@kaoto/kaoto` UI package, plus a test-quality fix. All changes are behavior-preserving refactors (with the bonus that the former `void` fire-and-forget calls now log the errors they previously discarded).

### Rules fixed

| Rule | Impact | Count | What it flagged | Fix approach |
| ---- | ------ | :---: | --------------- | ------------ |
| `typescript:S3735` | 🟠 High | 11 | Use of the `void` operator | `await` inside `async` callbacks where possible; `.catch(err => console.error(...))` where the enclosing callback must stay synchronous (`useEffect`, event subscribers, `() => void` addon APIs) |
| `typescript:S7746` | 🟠 High | 1 | `return Promise.resolve(value)` in an `async` method | Return the value directly (the `async` wrapper already yields a promise) |
| `typescript:S7740` | 🟠 High | 1 | Assigning `this` to a variable (`no-this-alias`) | Replaced the alias loop with a `private` recursive `findRoot` method |
| `typescript:S2004` | 🟠 High | 1 | Functions nested more than 4 levels deep | Extracted the collapse handler to component scope |

> The `void` → `await`/`.catch()` split matters: `@typescript-eslint/no-floating-promises` (enabled here) *requires* every unawaited promise to be handled, so the naive "remove `void`" would break the build. Each site was converted to whichever form its context allows.

### Not included

The remaining **4** issues are all `typescript:S3776` (cognitive complexity) — genuine logic refactors that deserve their own focused PR with tests around each function.

## Tests

- **New** unit tests for two previously-untested components: `RegisterNodeInteractionAddons` and `PropertiesTableTree`.
- Added coverage for the **reachable** `.catch()` error branches (`fetchTiles`, `onNewEdit`, `onDeleteDataMapper`) and delete-hotkey error resilience.
- Fixed a **latent test-mock bug** in `SourceCodeBridgeProvider.test.tsx`: a `vi.fn()` mock violated the `onNewEdit: (edit) => Promise<void>` contract, which surfaced only once the `void` was replaced with `.catch()`.
- Converted the `XmlParser` test's `async describe` (with a top-level `await readdir`) to synchronous `readdirSync`.

## Verification

```
yarn workspace @kaoto/kaoto lint        # clean
yarn workspace @kaoto/kaoto lint:style  # clean
yarn workspace @kaoto/kaoto test        # 6323 passed, 10 skipped, 2 todo
```

Fixes verified locally against the IDE's SonarQube analyzer (no longer reports the four rules on the touched lines).

---

_AI-assisted: refactors and tests drafted with Claude Code and reviewed by the submitter, per [AGENTS.md](../blob/main/AGENTS.md). A human is responsible for the final review and sign-off._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across delete, replace, tile loading, imports, and navigation by handling failures more consistently and surfacing errors via logs.
  * Tree tables now keep expand/collapse behavior consistent and predictable.
* **Tests**
  * Added/expanded coverage for tree row expansion, failed delete actions, failed tile loading, and failed edit propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->