### PR TITLE
fix: replace CamelCatalogService.getCatalogByKey with DynamicCatalog API

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/FormTest.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/FormTest.tsx
@@ -3,8 +3,9 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { KaotoForm } from '@kaoto/forms';
 import { render } from '@testing-library/react';
 
-import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../models';
-import { getFirstCatalogMap } from '../../../../../stubs/test-load-catalog';
+import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind, KaotoSchemaDefinition } from '../../../../../models';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../stubs/test-load-catalog';
 import { getSchemasSlice } from './get-schemas-slices';
 
 export const FormTest = (target: {
@@ -15,17 +16,19 @@ export const FormTest = (target: {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    setupDynamicCatalogRegistry(catalogsMap);
 
-    CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
-    CamelCatalogService.setCatalogKey(CatalogKind.Pattern, catalogsMap.patternCatalogMap);
-    CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, catalogsMap.kameletsCatalogMap);
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
-
-    schemas = getSchemasSlice(CamelCatalogService.getCatalogByKey(target.kind), target.range);
+    const catalogMap = {
+      [CatalogKind.Component]: catalogsMap.componentCatalogMap,
+      [CatalogKind.Pattern]: catalogsMap.patternCatalogMap,
+      [CatalogKind.Kamelet]: catalogsMap.kameletsCatalogMap,
+    }[target.kind];
+    schemas = getSchemasSlice(catalogMap, target.range);
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
     vi.clearAllMocks();
   });
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -8,16 +8,12 @@ import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';
-import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { IDynamicCatalogRegistry } from '../../../../../../dynamic-catalog/models';
-import { CitrusTestEndpointsProvider } from '../../../../../../dynamic-catalog/providers/citrus-components.provider';
-import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { Test } from '../../../../../../models/citrus/entities/Test';
-import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { TestProvidersWrapper } from '../../../../../../stubs';
-import { getFirstCitrusCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { getFirstCitrusCatalogMap, setupCitrusDynamicCatalogRegistry } from '../../../../../../stubs/test-load-catalog';
 import { ITile } from '../../../../../Catalog';
 import { EndpointField } from './EndpointField';
 
@@ -54,10 +50,7 @@ describe('EndpointField', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestEndpoint,
-      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
-    );
+    setupCitrusDynamicCatalogRegistry(catalogsMap);
   });
 
   afterAll(() => {
@@ -212,72 +205,70 @@ describe('EndpointField', () => {
     });
   });
 
-  describe('create endpoint', () => {
-    it('should create new endpoint', async () => {
-      const onPropertyChange = vi.fn();
-      const testModel: Test = {
-        name: 'test',
-        actions: [],
-      };
+  it('should create new endpoint', async () => {
+    const onPropertyChange = vi.fn();
+    const testModel: Test = {
+      name: 'test',
+      actions: [],
+    };
 
-      await renderField({ endpoint: undefined }, testModel, onPropertyChange);
+    await renderField({ endpoint: undefined }, testModel, onPropertyChange);
 
-      // Open the dropdown
-      await waitFor(() => {
-        expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
-      });
-      const toggle = screen.getByLabelText('Endpoint toggle');
+    // Open the dropdown
+    await waitFor(() => {
+      expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
+    });
+    const toggle = screen.getByLabelText('Endpoint toggle');
 
-      await act(async () => {
-        fireEvent.click(toggle);
-      });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
 
-      // Create new endpoint
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: 'option create-new-with-name' })).toBeInTheDocument();
-      });
+    // Create new endpoint
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'option create-new-with-name' })).toBeInTheDocument();
+    });
 
-      await act(async () => {
-        const createNew = screen.getByRole('option', { name: 'option create-new-with-name' });
-        fireEvent.click(createNew);
-      });
+    await act(async () => {
+      const createNew = screen.getByRole('option', { name: 'option create-new-with-name' });
+      fireEvent.click(createNew);
+    });
 
-      // Modal should appear
-      await waitFor(() => {
-        expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
-        // Modal should be in Create mode
-        expect(screen.getByText('Create endpoint')).toBeInTheDocument();
-      });
+    // Modal should appear
+    await waitFor(() => {
+      expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
+      // Modal should be in Create mode
+      expect(screen.getByText('Create endpoint')).toBeInTheDocument();
+    });
 
-      // Select endpoint from catalog
-      await waitFor(() => {
-        expect(screen.getByTestId('tile-header-http-client')).toBeInTheDocument();
-      });
+    // Select endpoint from catalog
+    await waitFor(() => {
+      expect(screen.getByTestId('tile-header-http-client')).toBeInTheDocument();
+    });
 
-      // Click on a tile
-      const httpClientTile = screen.getByTestId('tile-header-http-client');
-      await act(async () => {
-        fireEvent.click(httpClientTile);
-      });
+    // Click on a tile
+    const httpClientTile = screen.getByTestId('tile-header-http-client');
+    await act(async () => {
+      fireEvent.click(httpClientTile);
+    });
 
-      const nameInput = screen.getByLabelText('Name');
-      await act(async () => {
-        fireEvent.change(nameInput, { target: { value: 'httpClient' } });
-      });
+    const nameInput = screen.getByLabelText('Name');
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'httpClient' } });
+    });
 
-      const url = screen.getByLabelText('RequestUrl');
-      await act(async () => {
-        fireEvent.change(url, { target: { value: 'http://localhost:8080' } });
-      });
+    const url = screen.getByLabelText('RequestUrl');
+    await act(async () => {
+      fireEvent.change(url, { target: { value: 'http://localhost:8080' } });
+    });
 
-      const confirmButton = screen.getByTestId('endpoint-modal-confirm-btn');
-      await act(async () => {
-        fireEvent.click(confirmButton);
-      });
+    const confirmButton = screen.getByTestId('endpoint-modal-confirm-btn');
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
 
-      await waitFor(() => {
-        expect(onPropertyChange).toHaveBeenCalledWith(PROP_NAME, 'httpClient');
-      });
+    await waitFor(() => {
+      expect(onPropertyChange).toHaveBeenCalledWith(PROP_NAME, 'httpClient');
     });
   });
 
@@ -523,35 +514,88 @@ describe('EndpointField', () => {
     });
   });
 
-  describe('error handling', () => {
-    it('should log error when getEndpointsSchema rejects', async () => {
-      const schemaError = new Error('schema fetch failed');
-      vi.spyOn(EndpointsEntityHandler.prototype, 'getEndpointsSchema').mockRejectedValueOnce(schemaError);
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('should handle object values by stringifying them', async () => {
+    const testModel: Test = {
+      name: 'test',
+      actions: [],
+    };
 
-      const testModel: Test = { name: 'test', actions: [] };
-      await renderField({ endpoint: undefined }, testModel);
+    const objectValue = { uri: 'http://localhost:8080' };
+    const { getInput } = await renderField({ endpoint: objectValue }, testModel);
 
-      await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch endpoints schema:', schemaError);
-      });
-
-      consoleErrorSpy.mockRestore();
-    });
+    const input = getInput();
+    expect(input).toHaveValue(JSON.stringify(objectValue));
   });
 
-  describe('object values', () => {
-    it('should handle object values by stringifying them', async () => {
-      const testModel: Test = {
-        name: 'test',
-        actions: [],
-      };
+  it('should throw TypeError when camelResource is not a CitrusTestResource', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { Provider } = await TestProvidersWrapper(); // uses CamelRouteResource by default
 
-      const objectValue = { uri: 'http://localhost:8080' };
-      const { getInput } = await renderField({ endpoint: objectValue }, testModel);
+    expect(() => {
+      act(() => {
+        render(
+          <Provider>
+            <SchemaProvider schema={schema}>
+              <ModelContextProvider model={{}} onPropertyChange={vi.fn()}>
+                <EndpointField propName={PROP_NAME} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
+    }).toThrow('EndpointField must be used only with CitrusTestResource');
+  });
 
-      const input = getInput();
-      expect(input).toHaveValue(JSON.stringify(objectValue));
+  it('should restore the previous endpoint reference when cancel is clicked', async () => {
+    const onPropertyChange = vi.fn();
+    const testModel: Test = {
+      name: 'test',
+      actions: [],
+      endpoints: [
+        {
+          http: {
+            client: {
+              name: 'httpClient',
+              requestUrl: 'http://localhost:8080',
+            },
+          },
+        },
+      ],
+    };
+
+    await renderField({ endpoint: 'httpClient' }, testModel, onPropertyChange);
+
+    // Open dropdown and select "create new" option to open the modal
+    await waitFor(() => {
+      expect(screen.getByLabelText('Endpoint toggle')).toBeInTheDocument();
     });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Endpoint toggle'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'option create-new-with-name' })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('option', { name: 'option create-new-with-name' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
+    });
+
+    // Cancel the modal
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('endpoint-modal-cancel-btn'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('NewEndpointModal')).not.toBeInTheDocument();
+    });
+
+    // onChange should be called with the original endpoint reference to restore it
+    expect(onPropertyChange).toHaveBeenCalledWith(PROP_NAME, 'httpClient');
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.test.tsx
@@ -8,11 +8,14 @@ import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { IDynamicCatalogRegistry } from '../../../../../../dynamic-catalog/models';
+import { CitrusTestEndpointsProvider } from '../../../../../../dynamic-catalog/providers/citrus-components.provider';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { Test } from '../../../../../../models/citrus/entities/Test';
-import { CamelCatalogService } from '../../../../../../models/visualization/flows';
+import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { TestProvidersWrapper } from '../../../../../../stubs';
 import { getFirstCitrusCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ITile } from '../../../../../Catalog';
@@ -51,7 +54,14 @@ describe('EndpointField', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, catalogsMap.endpointsCatalogMap);
+    DynamicCatalogRegistry.get().setCatalog(
+      CatalogKind.TestEndpoint,
+      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
+    );
+  });
+
+  afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
   });
 
   const PROP_NAME = 'endpoint';
@@ -510,6 +520,23 @@ describe('EndpointField', () => {
       await waitFor(() => {
         expect(screen.getByText('dynamicJmsEndpoint')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should log error when getEndpointsSchema rejects', async () => {
+      const schemaError = new Error('schema fetch failed');
+      vi.spyOn(EndpointsEntityHandler.prototype, 'getEndpointsSchema').mockRejectedValueOnce(schemaError);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const testModel: Test = { name: 'test', actions: [] };
+      await renderField({ endpoint: undefined }, testModel);
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch endpoints schema:', schemaError);
+      });
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
@@ -1,6 +1,7 @@
 import { FieldProps, FieldWrapper, SchemaContext, Typeahead, TypeaheadItem, useFieldValue } from '@kaoto/forms';
-import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { KaotoSchemaDefinition } from '../../../../../../models';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { EntitiesContext } from '../../../../../../providers';
@@ -13,7 +14,15 @@ export const EndpointField: FunctionComponent<FieldProps> = ({ propName, require
   const testResource = entitiesContext?.camelResource as CitrusTestResource | undefined;
   const endpointReference = value;
   const endpointsHandler = useMemo(() => new EndpointsEntityHandler(testResource), [testResource]);
-  const endpointsSchema = useMemo(() => endpointsHandler.getEndpointsSchema(), [endpointsHandler]);
+  const [endpointsSchema, setEndpointsSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>(undefined);
+  useEffect(() => {
+    endpointsHandler
+      .getEndpointsSchema()
+      .then(setEndpointsSchema)
+      .catch((error) => {
+        console.error('Failed to fetch endpoints schema:', error);
+      });
+  }, [endpointsHandler]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointField.tsx
@@ -1,28 +1,22 @@
 import { FieldProps, FieldWrapper, SchemaContext, Typeahead, TypeaheadItem, useFieldValue } from '@kaoto/forms';
-import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
 
-import { KaotoSchemaDefinition } from '../../../../../../models';
+import { useEntityContext } from '../../../../../../hooks/useEntityContext/useEntityContext';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
-import { EntitiesContext } from '../../../../../../providers';
 import { NewEndpointModal } from './NewEndpointModal';
 
 export const EndpointField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
   const { value = '', onChange, disabled } = useFieldValue<string | undefined>(propName);
-  const entitiesContext = useContext(EntitiesContext);
-  const testResource = entitiesContext?.camelResource as CitrusTestResource | undefined;
   const endpointReference = value;
+  const { camelResource: testResource } = useEntityContext();
+  if (!(testResource instanceof CitrusTestResource)) {
+    throw new TypeError('EndpointField must be used only with CitrusTestResource');
+  }
+
   const endpointsHandler = useMemo(() => new EndpointsEntityHandler(testResource), [testResource]);
-  const [endpointsSchema, setEndpointsSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>(undefined);
-  useEffect(() => {
-    endpointsHandler
-      .getEndpointsSchema()
-      .then(setEndpointsSchema)
-      .catch((error) => {
-        console.error('Failed to fetch endpoints schema:', error);
-      });
-  }, [endpointsHandler]);
+  const endpointsSchema = testResource?.getEndpointsSchema();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -8,11 +8,14 @@ import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { IDynamicCatalogRegistry } from '../../../../../../dynamic-catalog/models';
+import { CitrusTestEndpointsProvider } from '../../../../../../dynamic-catalog/providers/citrus-components.provider';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { Test } from '../../../../../../models/citrus/entities/Test';
-import { CamelCatalogService } from '../../../../../../models/visualization/flows';
+import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../../../providers';
 import { TestProvidersWrapper } from '../../../../../../stubs';
 import { getFirstCitrusCatalogMap } from '../../../../../../stubs/test-load-catalog';
@@ -52,7 +55,14 @@ describe('EndpointListField', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, catalogsMap.endpointsCatalogMap);
+    DynamicCatalogRegistry.get().setCatalog(
+      CatalogKind.TestEndpoint,
+      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
+    );
+  });
+
+  afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
   });
 
   const PROP_NAME = 'endpoints';
@@ -855,6 +865,23 @@ describe('EndpointListField', () => {
           expect(screen.queryByTestId('NewEndpointModal')).not.toBeInTheDocument();
         });
       });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should log error when getEndpointsSchema rejects', async () => {
+      const schemaError = new Error('schema fetch failed');
+      vi.spyOn(EndpointsEntityHandler.prototype, 'getEndpointsSchema').mockRejectedValueOnce(schemaError);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const testModel: Test = { name: 'test', actions: [] };
+      await renderField({ endpoints: [] }, testModel);
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch endpoints schema:', schemaError);
+      });
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.test.tsx
@@ -8,17 +8,13 @@ import type { Mock } from 'vitest';
 
 import { CatalogContext, CatalogTilesContext } from '../../../../../../dynamic-catalog';
 import { CatalogModalProvider } from '../../../../../../dynamic-catalog/catalog-modal.provider';
-import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { IDynamicCatalogRegistry } from '../../../../../../dynamic-catalog/models';
-import { CitrusTestEndpointsProvider } from '../../../../../../dynamic-catalog/providers/citrus-components.provider';
-import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { Test } from '../../../../../../models/citrus/entities/Test';
-import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { ACTION_ID_CANCEL, ACTION_ID_CONFIRM, ActionConfirmationModalContext } from '../../../../../../providers';
 import { TestProvidersWrapper } from '../../../../../../stubs';
-import { getFirstCitrusCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { getFirstCitrusCatalogMap, setupCitrusDynamicCatalogRegistry } from '../../../../../../stubs/test-load-catalog';
 import { ITile } from '../../../../../Catalog';
 import { EndpointListField } from './EndpointListField';
 
@@ -55,10 +51,7 @@ describe('EndpointListField', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestEndpoint,
-      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
-    );
+    setupCitrusDynamicCatalogRegistry(catalogsMap);
   });
 
   afterAll(() => {
@@ -695,55 +688,53 @@ describe('EndpointListField', () => {
     });
   });
 
-  describe('multiple endpoints', () => {
-    it('should render multiple endpoints with correct indices', async () => {
-      const testModel: Test = {
-        name: 'test',
-        actions: [],
-        endpoints: [
-          {
-            http: {
-              client: {
-                name: 'endpoint1',
-                requestUrl: 'http://localhost:8080',
-              },
+  it('should render multiple endpoints with correct indices', async () => {
+    const testModel: Test = {
+      name: 'test',
+      actions: [],
+      endpoints: [
+        {
+          http: {
+            client: {
+              name: 'endpoint1',
+              requestUrl: 'http://localhost:8080',
             },
           },
-          {
-            jms: {
-              asynchronous: {
-                name: 'endpoint2',
-                connectionFactory: 'jmsConnectionFactory',
-                destination: 'queue1',
-              },
+        },
+        {
+          jms: {
+            asynchronous: {
+              name: 'endpoint2',
+              connectionFactory: 'jmsConnectionFactory',
+              destination: 'queue1',
             },
           },
-          {
-            direct: {
-              asynchronous: {
-                name: 'endpoint3',
-                queue: 'queue3',
-              },
+        },
+        {
+          direct: {
+            asynchronous: {
+              name: 'endpoint3',
+              queue: 'queue3',
             },
           },
-        ],
-      };
+        },
+      ],
+    };
 
-      await renderField({ endpoints: testModel.endpoints }, testModel);
+    await renderField({ endpoints: testModel.endpoints }, testModel);
 
-      // All endpoints should be visible
-      expect(screen.getByText('endpoint1')).toBeInTheDocument();
-      expect(screen.getByText('endpoint2')).toBeInTheDocument();
-      expect(screen.getByText('endpoint3')).toBeInTheDocument();
+    // All endpoints should be visible
+    expect(screen.getByText('endpoint1')).toBeInTheDocument();
+    expect(screen.getByText('endpoint2')).toBeInTheDocument();
+    expect(screen.getByText('endpoint3')).toBeInTheDocument();
 
-      // Each should have edit and delete buttons
-      expect(screen.getByTestId('endpoint-edit-0-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('endpoint-edit-1-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('endpoint-edit-2-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('endpoint-delete-0-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('endpoint-delete-1-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('endpoint-delete-2-btn')).toBeInTheDocument();
-    });
+    // Each should have edit and delete buttons
+    expect(screen.getByTestId('endpoint-edit-0-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-edit-1-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-edit-2-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-delete-0-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-delete-1-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-delete-2-btn')).toBeInTheDocument();
   });
 
   describe('handle create or edit', () => {
@@ -805,83 +796,124 @@ describe('EndpointListField', () => {
       });
     });
 
-    describe('create operation', () => {
-      it('should open modal in Create mode when Add button is clicked', async () => {
-        const testModel: Test = {
-          name: 'test',
-          actions: [],
-          endpoints: [],
-        };
+    it('should open modal in Create mode when Add button is clicked', async () => {
+      const testModel: Test = {
+        name: 'test',
+        actions: [],
+        endpoints: [],
+      };
 
-        await renderField({ endpoints: [] }, testModel);
+      await renderField({ endpoints: [] }, testModel);
 
-        const addButton = screen.getByTestId('create-new-endpoint-btn');
-        await act(async () => {
-          fireEvent.click(addButton);
-        });
+      const addButton = screen.getByTestId('create-new-endpoint-btn');
+      await act(async () => {
+        fireEvent.click(addButton);
+      });
 
-        await waitFor(() => {
-          expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
-          expect(screen.getByText('Create endpoint')).toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
+        expect(screen.getByText('Create endpoint')).toBeInTheDocument();
       });
     });
 
-    describe('update operation', () => {
-      it('should close modal on cancel', async () => {
-        const testModel: Test = {
-          name: 'test',
-          actions: [],
-          endpoints: [
-            {
-              http: {
-                client: {
-                  name: 'httpClient',
-                  requestUrl: 'http://localhost:8080',
-                },
+    it('should close modal on cancel', async () => {
+      const testModel: Test = {
+        name: 'test',
+        actions: [],
+        endpoints: [
+          {
+            http: {
+              client: {
+                name: 'httpClient',
+                requestUrl: 'http://localhost:8080',
               },
             },
-          ],
-        };
+          },
+        ],
+      };
 
-        await renderField({ endpoints: testModel.endpoints }, testModel);
+      await renderField({ endpoints: testModel.endpoints }, testModel);
 
-        const editButton = screen.getByTestId('endpoint-edit-0-btn');
-        await act(async () => {
-          fireEvent.click(editButton);
-        });
-
-        await waitFor(() => {
-          expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
-        });
-
-        // Cancel to close modal
-        const cancelButton = screen.getByTestId('endpoint-modal-cancel-btn');
-        await act(async () => {
-          fireEvent.click(cancelButton);
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('NewEndpointModal')).not.toBeInTheDocument();
-        });
+      const editButton = screen.getByTestId('endpoint-edit-0-btn');
+      await act(async () => {
+        fireEvent.click(editButton);
       });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
+      });
+
+      // Cancel to close modal
+      const cancelButton = screen.getByTestId('endpoint-modal-cancel-btn');
+      await act(async () => {
+        fireEvent.click(cancelButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('NewEndpointModal')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not call onChange when the confirmed model has no name property', async () => {
+      const onPropertyChange = vi.fn();
+      const testModel: Test = {
+        name: 'test',
+        actions: [],
+        endpoints: [],
+      };
+
+      await renderField({ endpoints: [] }, testModel, onPropertyChange);
+
+      // Open create modal
+      const addButton = screen.getByTestId('create-new-endpoint-btn');
+      await act(async () => {
+        fireEvent.click(addButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
+      });
+
+      // Select a tile type but do not fill the Name field, leaving it empty
+      await waitFor(() => {
+        expect(screen.getByTestId('tile-header-http-client')).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('tile-header-http-client'));
+      });
+
+      // Confirm without filling in a name — the guard in handleCreateOrEdit returns early
+      const confirmButton = screen.getByTestId('endpoint-modal-confirm-btn');
+      await act(async () => {
+        fireEvent.click(confirmButton);
+      });
+
+      // onChange must not have been called because name was absent
+      expect(onPropertyChange).not.toHaveBeenCalled();
+      // Modal should still be open (not closed) since the guard returned early
+      expect(screen.getByTestId('NewEndpointModal')).toBeInTheDocument();
     });
   });
 
-  describe('error handling', () => {
-    it('should log error when getEndpointsSchema rejects', async () => {
-      const schemaError = new Error('schema fetch failed');
-      vi.spyOn(EndpointsEntityHandler.prototype, 'getEndpointsSchema').mockRejectedValueOnce(schemaError);
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('should throw TypeError when camelResource is not a CitrusTestResource', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { Provider } = await TestProvidersWrapper(); // uses CamelRouteResource by default
 
-      const testModel: Test = { name: 'test', actions: [] };
-      await renderField({ endpoints: [] }, testModel);
-
-      await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch endpoints schema:', schemaError);
+    expect(() => {
+      act(() => {
+        render(
+          <Provider>
+            <ActionConfirmationModalContext.Provider value={mockActionConfirmationModalContext}>
+              <SchemaProvider schema={schema}>
+                <ModelContextProvider model={{}} onPropertyChange={vi.fn()}>
+                  <EndpointListField propName={PROP_NAME} />
+                </ModelContextProvider>
+              </SchemaProvider>
+            </ActionConfirmationModalContext.Provider>
+          </Provider>,
+        );
       });
-
-      consoleErrorSpy.mockRestore();
-    });
+    }).toThrow('EndpointListField must be used only with CitrusTestResource');
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
@@ -2,29 +2,24 @@ import { FieldProps, FieldWrapper, useFieldValue } from '@kaoto/forms';
 import { Button } from '@patternfly/react-core';
 import { EditIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
 
-import { KaotoSchemaDefinition } from '../../../../../../models';
+import { useEntityContext } from '../../../../../../hooks/useEntityContext/useEntityContext';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
-import { ACTION_ID_CANCEL, ActionConfirmationModalContext, EntitiesContext } from '../../../../../../providers';
+import { ACTION_ID_CANCEL, ActionConfirmationModalContext } from '../../../../../../providers';
 import { getValue } from '../../../../../../utils';
 import { NewEndpointModal } from './NewEndpointModal';
 
 export const EndpointListField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { onChange } = useFieldValue<Record<string, unknown>[]>(propName);
-  const entitiesContext = useContext(EntitiesContext);
-  const testResource = entitiesContext?.camelResource as CitrusTestResource | undefined;
+  const { camelResource: testResource } = useEntityContext();
+  if (!(testResource instanceof CitrusTestResource)) {
+    throw new TypeError('EndpointListField must be used only with CitrusTestResource');
+  }
+
   const endpointsHandler = useMemo(() => new EndpointsEntityHandler(testResource), [testResource]);
-  const [endpointsSchema, setEndpointsSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>(undefined);
-  useEffect(() => {
-    endpointsHandler
-      .getEndpointsSchema()
-      .then(setEndpointsSchema)
-      .catch((error) => {
-        console.error('Failed to fetch endpoints schema:', error);
-      });
-  }, [endpointsHandler]);
+  const endpointsSchema = testResource.getEndpointsSchema();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [operation, setOperation] = useState<string>('Create');
   const [editModel, setEditModel] = useState<Record<string, unknown> | undefined>(undefined);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointField/EndpointListField.tsx
@@ -2,8 +2,9 @@ import { FieldProps, FieldWrapper, useFieldValue } from '@kaoto/forms';
 import { Button } from '@patternfly/react-core';
 import { EditIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { KaotoSchemaDefinition } from '../../../../../../models';
 import { CitrusTestResource } from '../../../../../../models/citrus/citrus-test-resource';
 import { EndpointsEntityHandler } from '../../../../../../models/visualization/metadata/citrus/endpoints-entity-handler';
 import { ACTION_ID_CANCEL, ActionConfirmationModalContext, EntitiesContext } from '../../../../../../providers';
@@ -15,7 +16,15 @@ export const EndpointListField: FunctionComponent<FieldProps> = ({ propName, req
   const entitiesContext = useContext(EntitiesContext);
   const testResource = entitiesContext?.camelResource as CitrusTestResource | undefined;
   const endpointsHandler = useMemo(() => new EndpointsEntityHandler(testResource), [testResource]);
-  const endpointsSchema = useMemo(() => endpointsHandler.getEndpointsSchema(), [endpointsHandler]);
+  const [endpointsSchema, setEndpointsSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>(undefined);
+  useEffect(() => {
+    endpointsHandler
+      .getEndpointsSchema()
+      .then(setEndpointsSchema)
+      .catch((error) => {
+        console.error('Failed to fetch endpoints schema:', error);
+      });
+  }, [endpointsHandler]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [operation, setOperation] = useState<string>('Create');
   const [editModel, setEditModel] = useState<Record<string, unknown> | undefined>(undefined);

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -1,5 +1,10 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+
 import { ITile } from '../../components/Catalog';
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
 import { citrusTestJson } from '../../stubs/citrus-test';
+import { getFirstCitrusCatalogMap, setupCitrusDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { SourceSchemaType } from '../camel';
 import { CatalogKind } from '../catalog-kind';
 import { EntityType } from '../entities';
@@ -361,6 +366,119 @@ describe('CitrusTestResource', () => {
       expect(id).not.toBe('');
       expect(resource.getVisualEntities()).toHaveLength(1);
       expect(resource.getVisualEntities()[0]).toBeInstanceOf(CitrusTestVisualEntity);
+    });
+  });
+
+  describe('getEndpointsSchema', () => {
+    describe('with catalog registered', () => {
+      beforeAll(async () => {
+        const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
+        setupCitrusDynamicCatalogRegistry(catalogsMap);
+      });
+
+      afterAll(() => {
+        DynamicCatalogRegistry.get().clearRegistry();
+      });
+
+      it('should return undefined before initialize() is called', () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        // Do NOT call initialize()
+        expect(resource.getEndpointsSchema()).toBeUndefined();
+      });
+
+      it('should return a defined schema with oneOf after initialize()', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        const schema = resource.getEndpointsSchema();
+        expect(schema).toBeDefined();
+        expect(schema!.oneOf).toBeDefined();
+        expect(Array.isArray(schema!.oneOf)).toBeTruthy();
+        expect((schema!.oneOf as unknown[]).length).toBeGreaterThan(0);
+      });
+
+      it('should populate each entry with name and title', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        const schema = resource.getEndpointsSchema();
+        const entries = schema!.oneOf as { name: string; title: string }[];
+        for (const entry of entries) {
+          expect(typeof entry.name).toBe('string');
+          expect(entry.name.length).toBeGreaterThan(0);
+        }
+      });
+
+      it('should return entries sorted alphabetically by name', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        const schema = resource.getEndpointsSchema();
+        const names = (schema!.oneOf as { name: string }[]).map((e) => e.name);
+        const sorted = [...names].sort((a, b) => a.localeCompare(b));
+        expect(names).toEqual(sorted);
+      });
+
+      it('should return the same schema when called multiple times without re-initializing', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        const first = resource.getEndpointsSchema();
+        const second = resource.getEndpointsSchema();
+        expect(first).toBe(second);
+      });
+
+      it('should refresh the schema on re-initialize()', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+        const first = resource.getEndpointsSchema();
+
+        await resource.initialize();
+        const second = resource.getEndpointsSchema();
+
+        // Both should be defined and structurally equal (re-fetched from catalog)
+        expect(second).toBeDefined();
+        expect(second!.oneOf).toEqual(first!.oneOf);
+      });
+    });
+
+    describe('without catalog registered', () => {
+      beforeAll(() => {
+        DynamicCatalogRegistry.get().clearRegistry();
+      });
+
+      it('should return an empty oneOf schema when no TestEndpoint catalog is registered', async () => {
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        const schema = resource.getEndpointsSchema();
+        expect(schema).toBeDefined();
+        expect(schema!.oneOf).toEqual([]);
+      });
+    });
+
+    describe('when catalog throws', () => {
+      beforeAll(() => {
+        DynamicCatalogRegistry.get().setCatalog(CatalogKind.TestEndpoint, {
+          getAll: vi.fn().mockRejectedValue(new Error('catalog error')),
+          get: vi.fn(),
+          clearCache: vi.fn(),
+        });
+      });
+
+      afterAll(() => {
+        DynamicCatalogRegistry.get().clearRegistry();
+      });
+
+      it('should set endpointsSchema to undefined on error', async () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const resource = new CitrusTestResource(citrusTestJson);
+        await resource.initialize();
+
+        expect(resource.getEndpointsSchema()).toBeUndefined();
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch endpoints schema:', expect.any(Error));
+        consoleSpy.mockRestore();
+      });
     });
   });
 });

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -2,11 +2,13 @@ import { isDefined } from '@kaoto/forms';
 import { stringify } from 'yaml';
 
 import { ITile, TileFilter } from '../../components/Catalog';
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
 import { EntityOrderingService } from '../camel/entity-ordering.service';
 import { SourceSchemaType } from '../camel/source-schema-type';
 import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
+import { KaotoSchemaDefinition } from '../kaoto-schema';
 import {
   AddStepMode,
   BaseVisualCamelEntityConstructor,
@@ -41,9 +43,14 @@ export class CitrusTestResource implements KaotoResource {
   }[] = [{ type: EntityType.Test, group: '', Entity: CitrusTestVisualEntity }];
   private entities: BaseEntity[] = [];
   private resolvedEntities: BaseVisualEntityDefinition | undefined;
+  private endpointsSchema: KaotoSchemaDefinition['schema'] | undefined;
 
   get supportedEntities() {
     return CitrusTestResource.SUPPORTED_ENTITIES;
+  }
+
+  getEndpointsSchema(): KaotoSchemaDefinition['schema'] | undefined {
+    return this.endpointsSchema;
   }
 
   /**
@@ -69,6 +76,9 @@ export class CitrusTestResource implements KaotoResource {
     }, [] as BaseEntity[]);
 
     this.entities = EntityOrderingService.sortEntitiesForSerialization(parsedEntities);
+
+    // Fetch and cache endpoints schema
+    await this.fetchEndpointsSchema();
   }
 
   /**
@@ -218,6 +228,34 @@ export class CitrusTestResource implements KaotoResource {
    * @param rawItem - The raw item to convert
    * @returns A BaseCamelEntity instance or undefined if the item is invalid
    */
+  private async fetchEndpointsSchema(): Promise<void> {
+    try {
+      const endpointsCatalog =
+        (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.TestEndpoint)?.getAll()) ?? {};
+      const endpoints: KaotoSchemaDefinition['schema'][] = [];
+
+      for (const endpointKey in endpointsCatalog) {
+        const endpointDefinition = endpointsCatalog[endpointKey];
+        const schema = endpointsCatalog[endpointKey].propertiesSchema as KaotoSchemaDefinition['schema'];
+        if (schema) {
+          schema.name = endpointKey;
+          schema.title = endpointDefinition.title;
+          endpoints.push(schema);
+        }
+      }
+
+      const sortedEndpoints = [...endpoints];
+      sortedEndpoints.sort((a, b) => a.name?.localeCompare(b.name ?? '') ?? 0);
+
+      this.endpointsSchema = {
+        oneOf: sortedEndpoints,
+      };
+    } catch (error) {
+      console.error('Failed to fetch endpoints schema:', error);
+      this.endpointsSchema = undefined;
+    }
+  }
+
   private getEntity(rawItem: unknown): BaseEntity | undefined {
     if (!isDefined(rawItem) || Array.isArray(rawItem)) {
       return undefined;

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -31,14 +31,6 @@ describe('CamelCatalogService', () => {
     CamelCatalogService.clearCatalogs();
   });
 
-  describe('getCatalogByKey', () => {
-    it('should return the catalog', () => {
-      const result = CamelCatalogService.getCatalogByKey(CatalogKind.Component);
-
-      expect(result).toEqual(componentCatalogMap);
-    });
-  });
-
   describe('getComponent', () => {
     it('should return the component', () => {
       const component = CamelCatalogService.getComponent(CatalogKind.Component, 'timer');

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -13,10 +13,6 @@ import { ICitrusComponentDefinition } from '../../citrus/citrus-catalog';
 export class CamelCatalogService {
   private static catalogs: ComponentsCatalog = {};
 
-  static getCatalogByKey<CATALOG_KEY extends CatalogKind>(catalogKey: CATALOG_KEY): ComponentsCatalog[CATALOG_KEY] {
-    return this.catalogs[catalogKey];
-  }
-
   static setCatalogKey<CATALOG_KEY extends CatalogKind>(
     catalogKey: CATALOG_KEY,
     catalog?: ComponentsCatalog[CATALOG_KEY],

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
@@ -1,11 +1,8 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { DynamicCatalog } from '../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
-import { CitrusTestEndpointsProvider } from '../../../../dynamic-catalog/providers/citrus-components.provider';
-import { getFirstCitrusCatalogMap } from '../../../../stubs/test-load-catalog';
-import { CatalogKind } from '../../../catalog-kind';
+import { getFirstCitrusCatalogMap, setupCitrusDynamicCatalogRegistry } from '../../../../stubs/test-load-catalog';
 import { CitrusTestResource } from '../../../citrus/citrus-test-resource';
 import { Test } from '../../../citrus/entities/Test.d';
 import { EndpointsEntityHandler } from './endpoints-entity-handler';
@@ -13,10 +10,7 @@ import { EndpointsEntityHandler } from './endpoints-entity-handler';
 describe('EndpointsEntityHandler', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    DynamicCatalogRegistry.get().setCatalog(
-      CatalogKind.TestEndpoint,
-      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
-    );
+    setupCitrusDynamicCatalogRegistry(catalogsMap);
   });
 
   afterAll(() => {
@@ -36,13 +30,6 @@ describe('EndpointsEntityHandler', () => {
       testResource = new CitrusTestResource(testModel);
       await testResource.initialize();
       endpointsHandler = new EndpointsEntityHandler(testResource);
-    });
-
-    it('should get endpoints schema', async () => {
-      const schema = await endpointsHandler.getEndpointsSchema();
-      expect(schema).toBeDefined();
-      expect(schema!.oneOf).toBeDefined();
-      expect(Array.isArray(schema!.oneOf)).toBeTruthy();
     });
 
     it('should return empty array when no endpoints are defined', () => {
@@ -306,16 +293,6 @@ describe('EndpointsEntityHandler', () => {
 
       const definedEndpoints = endpointsHandler.getDefinedEndpointsNameAndType();
       expect(definedEndpoints[0]).toEqual({ name: 'emptyTypeEndpoint', type: '' });
-    });
-  });
-
-  describe('without CitrusTestResource', () => {
-    it('should get endpoints schema even without resource', async () => {
-      const endpointsHandler = new EndpointsEntityHandler(undefined);
-
-      const schema = await endpointsHandler.getEndpointsSchema();
-      expect(schema).toBeDefined();
-      expect(schema!.oneOf).toBeDefined();
     });
   });
 });

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.test.ts
@@ -1,17 +1,26 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CitrusTestEndpointsProvider } from '../../../../dynamic-catalog/providers/citrus-components.provider';
 import { getFirstCitrusCatalogMap } from '../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { CitrusTestResource } from '../../../citrus/citrus-test-resource';
 import { Test } from '../../../citrus/entities/Test.d';
-import { CamelCatalogService } from '../../flows';
 import { EndpointsEntityHandler } from './endpoints-entity-handler';
 
 describe('EndpointsEntityHandler', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.TestEndpoint, catalogsMap.endpointsCatalogMap);
+    DynamicCatalogRegistry.get().setCatalog(
+      CatalogKind.TestEndpoint,
+      new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
+    );
+  });
+
+  afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
   });
 
   describe('with valid CitrusTestResource', () => {
@@ -29,8 +38,8 @@ describe('EndpointsEntityHandler', () => {
       endpointsHandler = new EndpointsEntityHandler(testResource);
     });
 
-    it('should get endpoints schema', () => {
-      const schema = endpointsHandler.getEndpointsSchema();
+    it('should get endpoints schema', async () => {
+      const schema = await endpointsHandler.getEndpointsSchema();
       expect(schema).toBeDefined();
       expect(schema!.oneOf).toBeDefined();
       expect(Array.isArray(schema!.oneOf)).toBeTruthy();
@@ -301,10 +310,10 @@ describe('EndpointsEntityHandler', () => {
   });
 
   describe('without CitrusTestResource', () => {
-    it('should get endpoints schema even without resource', () => {
+    it('should get endpoints schema even without resource', async () => {
       const endpointsHandler = new EndpointsEntityHandler(undefined);
 
-      const schema = endpointsHandler.getEndpointsSchema();
+      const schema = await endpointsHandler.getEndpointsSchema();
       expect(schema).toBeDefined();
       expect(schema!.oneOf).toBeDefined();
     });

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.ts
@@ -1,19 +1,19 @@
 import { isDefined } from '@kaoto/forms';
 
+import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getValue } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { CitrusTestResource } from '../../../citrus/citrus-test-resource';
 import { Test } from '../../../citrus/entities/Test';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
-import { CamelCatalogService } from '../../flows/camel-catalog.service';
 
 export class EndpointsEntityHandler {
   constructor(readonly testResource?: CitrusTestResource | undefined) {
     if (!this.testResource) return;
   }
 
-  getEndpointsSchema(): KaotoSchemaDefinition['schema'] | undefined {
-    const endpointsCatalog = CamelCatalogService.getCatalogByKey(CatalogKind.TestEndpoint) ?? {};
+  async getEndpointsSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    const endpointsCatalog = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.TestEndpoint)?.getAll()) ?? {};
     const endpoints: KaotoSchemaDefinition['schema'][] = [];
     for (const endpointKey in endpointsCatalog) {
       const endpointDefinition = endpointsCatalog[endpointKey];

--- a/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/citrus/endpoints-entity-handler.ts
@@ -1,40 +1,14 @@
 import { isDefined } from '@kaoto/forms';
 
-import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getValue } from '../../../../utils';
-import { CatalogKind } from '../../../catalog-kind';
 import { CitrusTestResource } from '../../../citrus/citrus-test-resource';
 import { Test } from '../../../citrus/entities/Test';
-import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 
 export class EndpointsEntityHandler {
-  constructor(readonly testResource?: CitrusTestResource | undefined) {
-    if (!this.testResource) return;
-  }
+  constructor(private readonly testResource: CitrusTestResource) {}
 
-  async getEndpointsSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    const endpointsCatalog = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.TestEndpoint)?.getAll()) ?? {};
-    const endpoints: KaotoSchemaDefinition['schema'][] = [];
-    for (const endpointKey in endpointsCatalog) {
-      const endpointDefinition = endpointsCatalog[endpointKey];
-      const schema = endpointsCatalog[endpointKey].propertiesSchema as KaotoSchemaDefinition['schema'];
-      if (schema) {
-        schema.name = endpointKey;
-        schema.title = endpointDefinition.title;
-        endpoints.push(schema);
-      }
-    }
-
-    const sortedEndpoints = [...endpoints];
-    sortedEndpoints.sort((a, b) => a.name?.localeCompare(b.name));
-
-    return {
-      oneOf: sortedEndpoints,
-    };
-  }
-
-  getTestEntity(): Test | undefined {
-    return this.testResource?.toJSON() as Test | undefined;
+  getTestEntity(): Test {
+    return this.testResource.toJSON() as Test;
   }
 
   getEndpoints(): Record<string, unknown>[] {

--- a/packages/ui/src/stubs/test-load-catalog.ts
+++ b/packages/ui/src/stubs/test-load-catalog.ts
@@ -11,6 +11,7 @@ import {
   CamelProcessorsProvider,
 } from '../dynamic-catalog/providers/camel-components.provider';
 import { CamelKameletsProvider } from '../dynamic-catalog/providers/camel-kamelets.provider';
+import { CitrusTestEndpointsProvider } from '../dynamic-catalog/providers/citrus-components.provider';
 import {
   CamelCatalogIndex,
   CitrusCatalogIndex,
@@ -219,5 +220,22 @@ export const setupDynamicCatalogRegistry = (catalogsMap: Awaited<ReturnType<type
   DynamicCatalogRegistry.get().setCatalog(
     CatalogKind.Function,
     new DynamicCatalog(new CamelFunctionProvider(catalogsMap.functionsCatalogMap)),
+  );
+};
+
+/**
+ * Helper to populate DynamicCatalogRegistry with the Citrus TestEndpoint catalog for testing.
+ * Use this in beforeAll/beforeEach to avoid duplicating catalog setup across tests.
+ *
+ * @example
+ * beforeAll(async () => {
+ *   const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary);
+ *   setupCitrusDynamicCatalogRegistry(catalogsMap);
+ * });
+ */
+export const setupCitrusDynamicCatalogRegistry = (catalogsMap: Awaited<ReturnType<typeof testLoadCitrusCatalog>>) => {
+  DynamicCatalogRegistry.get().setCatalog(
+    CatalogKind.TestEndpoint,
+    new DynamicCatalog(new CitrusTestEndpointsProvider(catalogsMap.endpointsCatalogMap)),
   );
 };


### PR DESCRIPTION
### Context
Remove the synchronous getCatalogByKey method from CamelCatalogService and migrate all call sites to the async DynamicCatalog API.

- Remove CamelCatalogService.getCatalogByKey
- endpoints-entity-handler: getEndpointsSchema() now async, reads from DynamicCatalogRegistry.get().getCatalog(CatalogKind.TestEndpoint)?.getAll()
- EndpointField / EndpointListField: replace useMemo with useEffect+useState to resolve the async schema before rendering NewEndpointModal
- FormTest: replace four setCatalogKey calls with setupDynamicCatalogRegistry and add clearRegistry() in afterAll
- Update affected tests to use DynamicCatalogRegistry setup and await the now-async getEndpointsSchema()

Fix https://github.com/KaotoIO/kaoto/issues/3441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint schema loading now uses a dedicated, cached schema source for test endpoints, improving how endpoint-related dialogs populate available options.

* **Bug Fixes**
  * Added clearer handling and logging when endpoint schema retrieval fails.
  * Strengthened runtime validation for endpoint components to ensure they’re used with the correct test resource.

* **Tests**
  * Expanded and reorganized endpoint/form test coverage to reflect the new catalog and schema loading flow, including modal cancel/guard and error-path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->