### PR TITLE
fix(DataMapper): Always put newly added variable after existing ones

### DIFF
--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -859,12 +859,22 @@ describe('MappingService', () => {
       expect(otherwiseItem.children).toContain(variable);
     });
 
-    it('should insert variable at the beginning of children', () => {
+    it('should insert variable before non-variable children', () => {
       const parent = tree.children[0];
       const firstChildBefore = parent.children[0];
       MappingService.addVariable(parent, 'myVar');
       expect(parent.children[0]).toBeInstanceOf(VariableItem);
       expect(parent.children[1]).toBe(firstChildBefore);
+    });
+
+    it('should insert second variable after the first variable', () => {
+      const parent = tree.children[0];
+      const firstChildBefore = parent.children[0];
+      MappingService.addVariable(parent, 'var1');
+      MappingService.addVariable(parent, 'var2');
+      expect((parent.children[0] as VariableItem).name).toBe('var1');
+      expect((parent.children[1] as VariableItem).name).toBe('var2');
+      expect(parent.children[2]).toBe(firstChildBefore);
     });
   });
 

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -843,8 +843,9 @@ export class MappingService {
   }
 
   /**
-   * Variables are prepended (unshift) to children, matching the XSLT requirement
-   * that `xsl:variable` declarations precede other instructions.
+   * Inserts the new variable after any existing {@link VariableItem} children, keeping all
+   * variable declarations grouped at the front ahead of other instructions — consistent with
+   * the XSLT requirement that `xsl:variable` declarations precede other instructions.
    * @param parent - the parent container
    * @param name - the variable name
    * @param expression - optional initial XPath expression
@@ -855,7 +856,8 @@ export class MappingService {
     if (expression) {
       variable.expression = expression;
     }
-    parent.children.unshift(variable);
+    const lastVariableIndex = parent.children.reduce((idx, child, i) => (child instanceof VariableItem ? i : idx), -1);
+    parent.children.splice(lastVariableIndex + 1, 0, variable);
     return variable;
   }
 


### PR DESCRIPTION
Resolves: [#3434](https://github.com/KaotoIO/kaoto/issues/3434)

https://github.com/user-attachments/assets/71a5202b-521a-474e-878b-ea707277fcf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how newly added variables are placed: variables remain grouped at the top of a parent item while preserving the existing order of already-defined variables.
  * Adding multiple variables now inserts them in sequence rather than always placing each new variable at the very beginning.
* **Tests**
  * Updated variable-ordering coverage to validate correct placement for single and multiple added variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->