### PR TITLE
refactor: migrate CamelCatalogService catalog maps to async DynamicCatalogRegistry

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -69,6 +69,13 @@ describe('Canvas', () => {
     const vizNode = await entity.toVizNode();
     const controller = ControllerService.createController();
     const fromModelSpy = vi.spyOn(controller, 'fromModel');
+    // Spy on the graph prototype before rendering: the async `getNodeValidationText` effects in the
+    // custom nodes keep the render `act()` open long enough that the scheduled `requestAnimationFrame`
+    // can fire during it. `fromModel` also swaps the graph instance, so we spy on the prototype to
+    // capture the `fit` call regardless of which instance receives it or exactly when the frame fires.
+    const graphPrototype = Object.getPrototypeOf(controller.getGraph());
+    const fitSpy = vi.spyOn(graphPrototype, 'fit');
+    const layoutSpy = vi.spyOn(graphPrototype, 'layout');
 
     await act(async () => {
       render(
@@ -79,11 +86,6 @@ describe('Canvas', () => {
         </Provider>,
       );
     });
-
-    // The graph has been initialized with the .fromModel method, but the requestAnimationFrame
-    // has not been called yet, so the graph.fit(80) is not called yet.
-    const fitSpy = vi.spyOn(controller.getGraph(), 'fit');
-    const layoutSpy = vi.spyOn(controller.getGraph(), 'layout');
 
     await act(async () => {
       await vi.runAllTimersAsync();

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -7,8 +7,11 @@ import {
   SchemaProvider,
 } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CamelLanguageProvider } from '../../../../../../dynamic-catalog/providers/camel-components.provider';
 import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { setHeaderExpressionSchema } from '../../../../../../stubs/expression-definition-schema';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
@@ -19,64 +22,80 @@ describe('ExpressionField', () => {
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
+    DynamicCatalogRegistry.get().setCatalog(
+      CatalogKind.Language,
+      new DynamicCatalog(new CamelLanguageProvider(catalogsMap.languageCatalog)),
+    );
   });
 
-  it('renders empty expression field with schema', () => {
-    const { container } = render(
-      <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
-        <SchemaProvider schema={setHeaderExpressionSchema}>
-          <ExpressionField propName={ROOT_PATH} required />
-        </SchemaProvider>
-      </ModelContextProvider>,
-    );
-
-    expect(container).toMatchSnapshot();
+  afterEach(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
   });
 
-  it('renders expression field with selection', () => {
-    const { container } = render(
-      <FormComponentFactoryProvider>
-        <ModelContextProvider
-          model={{
-            id: 'setHeader-1891',
-            expression: {
-              simple: {},
-            },
-          }}
-          onPropertyChange={vi.fn()}
-        >
-          <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
-            <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required />
-            </SchemaProvider>
-          </SchemaDefinitionsProvider>
-        </ModelContextProvider>
-      </FormComponentFactoryProvider>,
-    );
+  it('renders empty expression field with schema', async () => {
+    let container: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
+          <SchemaProvider schema={setHeaderExpressionSchema}>
+            <ExpressionField propName={ROOT_PATH} required />
+          </SchemaProvider>
+        </ModelContextProvider>,
+      ));
+    });
 
-    expect(container).toMatchSnapshot();
+    expect(container!).toMatchSnapshot();
+  });
+
+  it('renders expression field with selection', async () => {
+    let container: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <FormComponentFactoryProvider>
+          <ModelContextProvider
+            model={{
+              id: 'setHeader-1891',
+              expression: {
+                simple: {},
+              },
+            }}
+            onPropertyChange={vi.fn()}
+          >
+            <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
+              <SchemaProvider schema={setHeaderExpressionSchema}>
+                <ExpressionField propName={ROOT_PATH} required />
+              </SchemaProvider>
+            </SchemaDefinitionsProvider>
+          </ModelContextProvider>
+        </FormComponentFactoryProvider>,
+      ));
+    });
+
+    expect(container!).toMatchSnapshot();
   });
 
   it('should be able to change the selection', async () => {
-    render(
-      <FormComponentFactoryProvider>
-        <ModelContextProvider
-          model={{
-            id: 'setHeader-1891',
-            expression: {
-              simple: {},
-            },
-          }}
-          onPropertyChange={vi.fn()}
-        >
-          <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
-            <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required />
-            </SchemaProvider>
-          </SchemaDefinitionsProvider>
-        </ModelContextProvider>
-      </FormComponentFactoryProvider>,
-    );
+    await act(async () => {
+      render(
+        <FormComponentFactoryProvider>
+          <ModelContextProvider
+            model={{
+              id: 'setHeader-1891',
+              expression: {
+                simple: {},
+              },
+            }}
+            onPropertyChange={vi.fn()}
+          >
+            <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
+              <SchemaProvider schema={setHeaderExpressionSchema}>
+                <ExpressionField propName={ROOT_PATH} required />
+              </SchemaProvider>
+            </SchemaDefinitionsProvider>
+          </ModelContextProvider>
+        </FormComponentFactoryProvider>,
+      );
+    });
 
     const formPageObject = new KaotoFormPageObject(screen, act);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
@@ -113,6 +132,8 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
+    // Wait for the async parseExpressionModel effect to populate the expression field
+    await waitFor(() => formPageObject.getFieldByDisplayName('Expression'));
     await formPageObject.inputText('Expression', '');
 
     expect(onPropertyChangeSpy).toHaveBeenCalled();
@@ -124,27 +145,29 @@ describe('ExpressionField', () => {
     const onPropertyChangeSpy = vi.fn();
     const EXPRESSION_STRING = 'Test';
 
-    render(
-      <FormComponentFactoryProvider>
-        <ModelContextProvider
-          model={{
-            id: 'setHeader-1891',
-            expression: {
-              simple: {
-                expression: EXPRESSION_STRING,
+    await act(async () => {
+      render(
+        <FormComponentFactoryProvider>
+          <ModelContextProvider
+            model={{
+              id: 'setHeader-1891',
+              expression: {
+                simple: {
+                  expression: EXPRESSION_STRING,
+                },
               },
-            },
-          }}
-          onPropertyChange={onPropertyChangeSpy}
-        >
-          <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
-            <SchemaProvider schema={setHeaderExpressionSchema}>
-              <ExpressionField propName={ROOT_PATH} required />
-            </SchemaProvider>
-          </SchemaDefinitionsProvider>
-        </ModelContextProvider>
-      </FormComponentFactoryProvider>,
-    );
+            }}
+            onPropertyChange={onPropertyChangeSpy}
+          >
+            <SchemaDefinitionsProvider schema={setHeaderExpressionSchema} omitFields={[]}>
+              <SchemaProvider schema={setHeaderExpressionSchema}>
+                <ExpressionField propName={ROOT_PATH} required />
+              </SchemaProvider>
+            </SchemaDefinitionsProvider>
+          </ModelContextProvider>
+        </FormComponentFactoryProvider>,
+      );
+    });
 
     const formPageObject = new KaotoFormPageObject(screen, act);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
@@ -174,7 +197,8 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = screen.getByTestId(`#__expression-list__clear`);
+    // Wait for the async parseExpressionModel effect to populate the expression list
+    const clearButton = await screen.findByTestId(`#__expression-list__clear`);
     await act(async () => {
       fireEvent.click(clearButton);
     });
@@ -186,7 +210,7 @@ describe('ExpressionField', () => {
   it('should update the model with `undefined` when the model is empty after clearing the expression', async () => {
     const onPropertyChangeSpy = vi.fn();
 
-    const wrapper = render(
+    const { findByTestId } = render(
       <ModelContextProvider
         model={{
           expression: {
@@ -201,7 +225,8 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = wrapper.getByTestId(`#__expression-list__clear`);
+    // Wait for the async parseExpressionModel effect to populate the expression list
+    const clearButton = await findByTestId(`#__expression-list__clear`);
 
     await act(async () => {
       fireEvent.click(clearButton);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
@@ -1,3 +1,4 @@
+import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import {
   FieldProps,
   FieldWrapper,
@@ -7,7 +8,7 @@ import {
   useFieldValue,
 } from '@kaoto/forms';
 import { isEmpty } from 'lodash';
-import { FunctionComponent, useContext, useMemo } from 'react';
+import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
 
 import { ROOT_PATH, setValue } from '../../../../../../utils';
 import { ExpressionService } from './expression.service';
@@ -34,13 +35,42 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
 
   const isRootExpression = schema.format === 'expression';
-  const parsedModel = ExpressionService.parseExpressionModel(originalModel);
+  const [parsedModel, setParsedModel] = useState<ExpressionDefinition | undefined>(undefined);
+  /**
+   * Whether the first async `parseExpressionModel` has resolved. `ExpressionFieldInner` relies on
+   * `useOneOfField`, which latches its selected schema from the model on its mount render only.
+   * Mounting it before the model is parsed would latch an empty selection that never recovers, so
+   * we hold rendering until the initial parse completes. The flag stays `true` afterwards so later
+   * `originalModel` changes re-parse without remounting (and thus without dropping the selection).
+   */
+  const [isModelParsed, setIsModelParsed] = useState(false);
   const expressionsSchema = useMemo(() => ExpressionService.getExpressionsSchema(schema), [schema]);
 
-  const onExpressionChange = (propName: string, model: unknown) => {
+  useEffect(() => {
+    let cancelled = false;
+    ExpressionService.parseExpressionModel(originalModel)
+      .then((model) => {
+        if (!cancelled) {
+          setParsedModel(model);
+          setIsModelParsed(true);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to parse expression model:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [originalModel]);
+
+  if (!isModelParsed) {
+    return null;
+  }
+
+  const onExpressionChange = async (propName: string, model: unknown) => {
     let localValue = parsedModel ?? {};
 
-    ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
+    await ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
     let updatedValue = model;
     if (typeof model === 'string' && model.trim() === '') {
       updatedValue = undefined;

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
@@ -1,6 +1,8 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ExpressionService } from './expression.service';
@@ -9,7 +11,14 @@ describe('ExpressionService', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     const languageCatalog = catalogsMap.languageCatalog;
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
+
+    // Set up DynamicCatalogRegistry with a catalog backed by the language catalog map
+    const mockProvider = {
+      id: 'language-mock',
+      fetch: async (key: string) => languageCatalog[key],
+      fetchAll: async () => languageCatalog,
+    };
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
   });
 
   describe('getExpressionsSchema', () => {
@@ -189,8 +198,8 @@ describe('ExpressionService', () => {
     ],
   ];
 
-  it.each(expressionsArray)('should parse %s', (parentModel, expected) => {
-    const result = ExpressionService.parseExpressionModel(parentModel);
+  it.each(expressionsArray)('should parse %s', async (parentModel, expected) => {
+    const result = await ExpressionService.parseExpressionModel(parentModel);
 
     expect(result).toEqual(expected);
   });
@@ -201,20 +210,20 @@ describe('ExpressionService', () => {
       CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
     });
 
-    it('should update the target model expression if supported', () => {
+    it('should update the target model expression if supported', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { csimple: { expression: undefined } };
 
-      ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
 
       expect(targetModel.csimple.expression).toBe('sourceExpr');
     });
 
-    it('should not update the target model if language does not support expression', () => {
+    it('should not update the target model if language does not support expression', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { bean: { expression: undefined } };
 
-      ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
 
       expect(targetModel.bean.expression).toBeUndefined();
     });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
@@ -1,6 +1,7 @@
 import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../../../models/kaoto-schema';
 import { CamelCatalogService } from '../../../../../../models/visualization/flows/camel-catalog.service';
@@ -64,7 +65,7 @@ export class ExpressionService {
    * </ul>
    * @param parentModel The parent step model object which has expression as its parameter. For example `setBody` contents.
    * */
-  static parseExpressionModel(parentModel?: Record<string, unknown>): ExpressionDefinition | undefined {
+  static async parseExpressionModel(parentModel?: Record<string, unknown>): Promise<ExpressionDefinition | undefined> {
     if (!isDefined(parentModel)) {
       return undefined;
     }
@@ -78,7 +79,7 @@ export class ExpressionService {
       return { ...model, ...parsedModel };
     }
 
-    const languageNames = this.getLanguageNames();
+    const languageNames = await this.getLanguageNames();
     return Object.entries(parentModel).reduce((acc, [key, value]) => {
       if (languageNames.includes(key)) {
         acc[key] = this.parseLanguageModel({ [key]: value }, key)[key];
@@ -90,12 +91,8 @@ export class ExpressionService {
     }, {} as ExpressionDefinition);
   }
 
-  private static getLanguageNames(): string[] {
-    const languageCatalogMap = CamelCatalogService.getLanguageMap();
-
-    if (Object.keys(languageCatalogMap).length === 0) {
-      throw new Error('Language catalog is not initialized');
-    }
+  private static async getLanguageNames(): Promise<string[]> {
+    const languageCatalogMap = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()) ?? {};
 
     return Object.values(languageCatalogMap).map((lang) => lang.model.name);
   }
@@ -118,14 +115,14 @@ export class ExpressionService {
     }
   }
 
-  static updateExpressionFromModel(
+  static async updateExpressionFromModel(
     sourceModel: Record<string, unknown> | undefined,
     targetModel: Record<string, unknown>,
-  ): void {
+  ): Promise<void> {
     if (!isDefined(sourceModel) || !isDefined(targetModel)) {
       return;
     }
-    const languageNames = this.getLanguageNames();
+    const languageNames = await this.getLanguageNames();
     const sourceKey = Object.keys(sourceModel).find((key) => languageNames.includes(key));
     const sourceExpressionString = sourceKey
       ? (sourceModel[sourceKey] as Record<string, unknown>)?.expression

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -119,7 +119,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -148,7 +148,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -171,7 +171,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue('Some validation warning');
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue('Some validation warning');
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -194,7 +194,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('when-setHeader');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -226,7 +226,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(groupVizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(groupVizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(groupVizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(groupVizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     const draggedVizNode = createVisualizationNode('when-0', {
       name: 'when',

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -26,7 +26,7 @@ import {
   useHover,
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
-import { FunctionComponent, useContext, useMemo, useRef } from 'react';
+import { FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
@@ -73,9 +73,24 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = groupVizNode?.data?.processorIconTooltip ?? '';
     const isDisabled = !!groupVizNode?.getNodeDefinition()?.disabled;
-    const validationText = groupVizNode?.getNodeValidationText();
+    const [validationText, setValidationText] = useState<string | undefined>(undefined);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const { childCount, hasGroupChildren } = getVizNodeChildrenInfo(groupVizNode);
+    useEffect(() => {
+      let cancelled = false;
+      groupVizNode
+        ?.getNodeValidationText()
+        .then((text) => {
+          if (!cancelled) setValidationText(text);
+        })
+        .catch((error) => {
+          console.error('Failed to get node validation text:', error);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [groupVizNode]);
+
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
       CanvasDefaults.HOVER_DELAY_IN,

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -26,7 +26,7 @@ import {
   useHover,
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
-import { FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, useContext, useMemo, useRef } from 'react';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
@@ -46,6 +46,7 @@ import {
   NODE_DRAG_TYPE,
 } from '../customComponentUtils';
 import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
+import { useNodeValidationText } from '../hooks/use-node-validation-text.hook';
 import { CustomNodeContainer } from '../Node/CustomNodeContainer';
 import {
   checkNodeDropCompatibility,
@@ -73,23 +74,9 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = groupVizNode?.data?.processorIconTooltip ?? '';
     const isDisabled = !!groupVizNode?.getNodeDefinition()?.disabled;
-    const [validationText, setValidationText] = useState<string | undefined>(undefined);
+    const validationText = useNodeValidationText(groupVizNode);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const { childCount, hasGroupChildren } = getVizNodeChildrenInfo(groupVizNode);
-    useEffect(() => {
-      let cancelled = false;
-      groupVizNode
-        ?.getNodeValidationText()
-        .then((text) => {
-          if (!cancelled) setValidationText(text);
-        })
-        .catch((error) => {
-          console.error('Failed to get node validation text:', error);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [groupVizNode]);
 
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
@@ -86,7 +86,7 @@ describe('CustomNode', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('log');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
     vi.spyOn(vizNode, 'canDragNode').mockReturnValue(false);
     vi.spyOn(vizNode, 'canDropOnNode').mockReturnValue(false);
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -29,7 +29,7 @@ import {
   withSelection,
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
-import { FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, useContext, useMemo, useRef } from 'react';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
@@ -43,6 +43,7 @@ import { CanvasNode } from '../../Canvas/canvas.models';
 import { StepToolbar } from '../../Canvas/StepToolbar/StepToolbar';
 import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { getDropTargetContainerClassNames, GROUP_DRAG_TYPE, NODE_DRAG_TYPE } from '../customComponentUtils';
+import { useNodeValidationText } from '../hooks/use-node-validation-text.hook';
 import { TargetAnchor } from '../target-anchor';
 import { CustomNodeContainer } from './CustomNodeContainer';
 import {
@@ -133,7 +134,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = vizNode?.data.processorIconTooltip ?? '';
     const isDisabled = !!vizNode?.getNodeDefinition()?.disabled;
-    const [validationText, setValidationText] = useState<string | undefined>(undefined);
+    const validationText = useNodeValidationText(vizNode);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
@@ -147,20 +148,6 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       isToolbarHover,
       selected,
     );
-    useEffect(() => {
-      let cancelled = false;
-      vizNode
-        ?.getNodeValidationText()
-        .then((text) => {
-          if (!cancelled) setValidationText(text);
-        })
-        .catch((error) => {
-          console.error('Failed to get node validation text:', error);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [vizNode]);
 
     const canDragNode = vizNode?.canDragNode() ?? false;
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -29,7 +29,7 @@ import {
   withSelection,
 } from '@patternfly/react-topology';
 import clsx from 'clsx';
-import { FunctionComponent, useContext, useMemo, useRef } from 'react';
+import { FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
@@ -133,7 +133,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = vizNode?.data.processorIconTooltip ?? '';
     const isDisabled = !!vizNode?.getNodeDefinition()?.disabled;
-    const validationText = vizNode?.getNodeValidationText();
+    const [validationText, setValidationText] = useState<string | undefined>(undefined);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(
@@ -147,6 +147,21 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
       isToolbarHover,
       selected,
     );
+    useEffect(() => {
+      let cancelled = false;
+      vizNode
+        ?.getNodeValidationText()
+        .then((text) => {
+          if (!cancelled) setValidationText(text);
+        })
+        .catch((error) => {
+          console.error('Failed to get node validation text:', error);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [vizNode]);
+
     const canDragNode = vizNode?.canDragNode() ?? false;
 
     const hasSomeInteractions = useMemo(

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { IVisualizationNode } from '../../../../models';
+import { useNodeValidationText } from './use-node-validation-text.hook';
+
+interface FakeNode {
+  lastUpdate: number;
+  getNodeValidationText: ReturnType<typeof vi.fn>;
+}
+
+const createNode = (text: string | undefined): FakeNode => ({
+  lastUpdate: 0,
+  getNodeValidationText: vi.fn().mockResolvedValue(text),
+});
+
+describe('useNodeValidationText', () => {
+  it('should return undefined before the async validation resolves', () => {
+    const node = createNode('Some warning');
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return the resolved validation text', async () => {
+    const node = createNode('Some warning');
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(result.current).toBe('Some warning');
+    });
+  });
+
+  it('should re-resolve when the node is edited in place (lastUpdate changes)', async () => {
+    const node = createNode(undefined);
+    const { result, rerender } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(node.getNodeValidationText).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBeUndefined();
+
+    // Simulate an in-place edit: same node reference, new validation result, bumped lastUpdate.
+    node.getNodeValidationText.mockResolvedValue('Now invalid');
+    node.lastUpdate = 1;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current).toBe('Now invalid');
+    });
+    expect(node.getNodeValidationText).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return undefined when no node is provided', () => {
+    const { result } = renderHook(() => useNodeValidationText());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should log and not throw when validation rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const node = createNode(undefined);
+    node.getNodeValidationText.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to get node validation text:', expect.any(Error));
+    });
+    expect(result.current).toBeUndefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { IVisualizationNode } from '../../../../models';
+
+/**
+ * Resolves the validation text for a node via the async `getNodeValidationText` API.
+ *
+ * The node's validation depends on its current definition, which is mutated in place on edits while
+ * bumping `lastUpdate`. Keying the effect on `lastUpdate` (in addition to the node itself) ensures the
+ * validation text is recomputed whenever the node changes, not only when a different node is provided.
+ *
+ * @param vizNode The visualization node to validate.
+ * @returns The validation text, or `undefined` while it resolves or when there is nothing to report.
+ */
+export const useNodeValidationText = (vizNode?: IVisualizationNode): string | undefined => {
+  const [validationText, setValidationText] = useState<string | undefined>(undefined);
+  const lastUpdate = vizNode?.lastUpdate;
+
+  useEffect(() => {
+    let cancelled = false;
+    vizNode
+      ?.getNodeValidationText()
+      .then((text) => {
+        if (!cancelled) setValidationText(text);
+      })
+      .catch((error) => {
+        console.error('Failed to get node validation text:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `lastUpdate` is intentionally included so the text re-resolves when the node is edited in place.
+  }, [vizNode, lastUpdate]);
+
+  return validationText;
+};

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -72,7 +72,7 @@ export interface BaseVisualEntity extends BaseEntity {
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction;
 
   /** Given a path, retrieve the Node validation status */
-  getNodeValidationText(path?: string): string | undefined;
+  getNodeValidationText(path?: string): Promise<string | undefined>;
 
   /** Generates a IVisualizationNode from the underlying Camel entity */
   toVizNode: () => Promise<IVisualizationNode>;
@@ -157,7 +157,7 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
   removeChild(): void;
 
   /** Retrieve the node's validation status, relying into the underlying entity */
-  getNodeValidationText(): string | undefined;
+  getNodeValidationText(): Promise<string | undefined>;
 }
 
 export interface IVisualizationNodeData {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -141,24 +141,24 @@ describe('AbstractCamelVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = abstractVisualEntity.getNodeValidationText(undefined);
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await abstractVisualEntity.getNodeValidationText(undefined);
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = abstractVisualEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await abstractVisualEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const missingParametersModel = cloneDeep(camelRouteJson.route);
       missingParametersModel.from.uri = '';
       abstractVisualEntity = new CamelRouteVisualEntity(missingParametersModel);
 
-      const result = abstractVisualEntity.getNodeValidationText('route.from');
+      const result = await abstractVisualEntity.getNodeValidationText('route.from');
 
       expect(result).toBe('1 required parameter is not yet configured: [ uri ]');
     });

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -223,12 +223,12 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
+  async getNodeValidationText(path?: string | undefined): Promise<string | undefined> {
     const schema = this.getNodeSchema(path);
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   async toVizNode(): Promise<IVisualizationNode> {

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -3,26 +3,17 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { ICamelComponentDefinition } from '../../camel/camel-components-catalog';
-import { ICamelDataformatDefinition } from '../../camel/camel-dataformats-catalog';
-import { ICamelLanguageDefinition } from '../../camel/camel-languages-catalog';
-import { ICamelLoadBalancerDefinition } from '../../camel/camel-loadbalancers-catalog';
 import { IKameletDefinition } from '../../camel/kamelets-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { CamelCatalogService } from './camel-catalog.service';
 
 describe('CamelCatalogService', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
-  let dataformatsCatalogMap: Record<string, ICamelDataformatDefinition>;
-  let languagesCatalogMap: Record<string, ICamelLanguageDefinition>;
-  let loadbalancersMap: Record<string, ICamelLoadBalancerDefinition>;
   let kameletCatalogMap: Record<string, IKameletDefinition>;
 
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     componentCatalogMap = catalogsMap.componentCatalogMap;
-    dataformatsCatalogMap = catalogsMap.dataformatCatalog;
-    languagesCatalogMap = catalogsMap.languageCatalog;
-    loadbalancersMap = catalogsMap.loadbalancerCatalog;
     kameletCatalogMap = catalogsMap.kameletsCatalogMap;
     CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
   });
@@ -43,57 +34,6 @@ describe('CamelCatalogService', () => {
       const component = CamelCatalogService.getComponent(CatalogKind.Component);
 
       expect(component).toBeUndefined();
-    });
-  });
-
-  describe('getLanguageMap', () => {
-    it('should return an empty object if there is no language map', () => {
-      const map = CamelCatalogService.getLanguageMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a language map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Language,
-        languagesCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getLanguageMap();
-      expect(map).toEqual(languagesCatalogMap);
-    });
-  });
-
-  describe('getDataFormatMap', () => {
-    it('should return an empty object if there is no data format map', () => {
-      const map = CamelCatalogService.getDataFormatMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a data format map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Dataformat,
-        dataformatsCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getDataFormatMap();
-      expect(map).toEqual(dataformatsCatalogMap);
-    });
-  });
-
-  describe('getLoadBalancerMap', () => {
-    it('should return an empty object if there is no load balancer map', () => {
-      const map = CamelCatalogService.getLoadBalancerMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a load balancer map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Loadbalancer,
-        loadbalancersMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getLoadBalancerMap();
-      expect(map).toEqual(loadbalancersMap);
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -69,18 +69,6 @@ export class CamelCatalogService {
     return this.catalogs[catalogKey]?.[componentName];
   }
 
-  static getLanguageMap(): Record<string, ICamelLanguageDefinition> {
-    return this.catalogs[CatalogKind.Language] || {};
-  }
-
-  static getDataFormatMap(): Record<string, ICamelDataformatDefinition> {
-    return this.catalogs[CatalogKind.Dataformat] || {};
-  }
-
-  static getLoadBalancerMap(): Record<string, ICamelLoadBalancerDefinition> {
-    return this.catalogs[CatalogKind.Loadbalancer] || {};
-  }
-
   /**
    * Public only as a convenience method for test
    * not meant to be used in production code

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -147,10 +147,10 @@ describe('CamelErrorHandlerVisualEntity', () => {
     });
   });
 
-  it('should return undefined validation text', () => {
+  it('should return undefined validation text', async () => {
     const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
 
-    expect(entity.getNodeValidationText()).toBeUndefined();
+    expect(await entity.getNodeValidationText()).toBeUndefined();
   });
 
   describe('toVizNode', () => {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -142,7 +142,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(): string | undefined {
+  async getNodeValidationText(): Promise<string | undefined> {
     return undefined;
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -90,13 +90,13 @@ describe('CamelInterceptFromVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue(undefined!);
 
     const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
       interceptFrom: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptFromVisualEntity.getNodeValidationText('interceptFrom');
+    await interceptFromVisualEntity.getNodeValidationText('interceptFrom');
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -89,13 +89,13 @@ describe('CamelInterceptSendToEndpointVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue(undefined!);
 
     const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
       interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint');
+    await interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint');
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -83,13 +83,13 @@ describe('CamelInterceptVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue(undefined!);
 
     const interceptVisualEntity = new CamelInterceptVisualEntity({
       intercept: { id: 'id', disabled: false },
     });
-    interceptVisualEntity.getNodeValidationText('intercept');
+    await interceptVisualEntity.getNodeValidationText('intercept');
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -88,13 +88,13 @@ describe('CamelOnCompletionVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue(undefined!);
 
     const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
       onCompletion: { id: 'id', mode: 'AfterConsumer' },
     });
-    onCompletionVisualEntity.getNodeValidationText('onCompletion');
+    await onCompletionVisualEntity.getNodeValidationText('onCompletion');
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -126,7 +126,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRestConfigurationVisualEntity({
         restConfiguration: {
           ...restConfigurationDef.restConfiguration,
@@ -141,19 +141,19 @@ describe('CamelRestConfigurationVisualEntity', () => {
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRestConfigurationDef: RestConfiguration = { ...restConfigurationDef.restConfiguration };
       const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
 
-      entity.getNodeValidationText();
+      await entity.getNodeValidationText();
 
       expect(restConfigurationDef.restConfiguration).toEqual(originalRestConfigurationDef);
     });
 
-    it('should return errors when there is an invalid property', () => {
+    it('should return errors when there is an invalid property', async () => {
       const invalidRestConfigurationDef: RestConfiguration = {
         ...restConfigurationDef.restConfiguration,
         useXForwardHeaders: 'true' as unknown as RestConfiguration['useXForwardHeaders'],
@@ -167,7 +167,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
       };
       const entity = new CamelRestConfigurationVisualEntity({ restConfiguration: invalidRestConfigurationDef });
 
-      expect(entity.getNodeValidationText()).toBe(`'/useXForwardHeaders' must be boolean,
+      expect(await entity.getNodeValidationText()).toBe(`'/useXForwardHeaders' must be boolean,
 '/apiVendorExtension' must be boolean,
 '/skipBindingOnErrorCode' must be boolean,
 '/clientRequestValidation' must be boolean,

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -122,7 +122,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(): string | undefined {
+  async getNodeValidationText(): Promise<string | undefined> {
     const schema = this.getNodeSchema();
     if (!schema) return undefined;
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -419,7 +419,7 @@ describe('CamelRestVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRestVisualEntity({
         rest: {
           ...restDef.rest,
@@ -427,19 +427,19 @@ describe('CamelRestVisualEntity', () => {
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRestDef: Rest = { ...restDef.rest };
       const entity = new CamelRestVisualEntity(restDef);
 
-      entity.getNodeValidationText();
+      await entity.getNodeValidationText();
 
       expect(restDef.rest).toEqual(originalRestDef);
     });
 
-    it('should NOT return errors when there is an invalid property', () => {
+    it('should NOT return errors when there is an invalid property', async () => {
       const invalidRestDef: Rest = {
         ...restDef.rest,
         bindingMode: 'true' as unknown as Rest['bindingMode'],
@@ -447,7 +447,7 @@ describe('CamelRestVisualEntity', () => {
       };
       const entity = new CamelRestVisualEntity({ rest: invalidRestDef });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
@@ -227,23 +227,23 @@ describe('CamelRouteConfigurationVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRouteConfigurationVisualEntity({
         routeConfiguration: {
           ...routeConfigurationDef.routeConfiguration,
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRouteConfigurationDef: RouteConfigurationDefinition = {
         ...routeConfigurationDef.routeConfiguration,
       };
       const entity = new CamelRouteConfigurationVisualEntity(routeConfigurationDef);
 
-      entity.getNodeValidationText();
+      await entity.getNodeValidationText();
 
       expect(routeConfigurationDef.routeConfiguration).toEqual(originalRouteConfigurationDef);
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -884,19 +884,19 @@ describe('CitrusTestVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = citrusTestEntity.getNodeValidationText();
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await citrusTestEntity.getNodeValidationText();
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = citrusTestEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await citrusTestEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const invalidModel = cloneDeep(citrusTestJson);
       setValue(invalidModel, 'actions[0].print.message', undefined);
       const entity = new CitrusTestVisualEntity(invalidModel);
@@ -904,7 +904,7 @@ describe('CitrusTestVisualEntity', () => {
       const spy = vi.spyOn(CitrusTestSchemaService, 'extractTestActionName');
       spy.mockReturnValueOnce('print');
 
-      const result = entity.getNodeValidationText('actions.0.print');
+      const result = await entity.getNodeValidationText('actions.0.print');
 
       expect(spy).toHaveBeenCalledWith('actions.0.print');
       expect(result).toBe('1 required parameter is not yet configured: [ message ]');

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -334,12 +334,12 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
+  async getNodeValidationText(path?: string | undefined): Promise<string | undefined> {
     const schema = this.getNodeSchema(path);
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   getGroupIcons(): { icon: string; title: string }[] {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -509,24 +509,24 @@ describe('Pipe', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = pipeVisualEntity.getNodeValidationText();
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await pipeVisualEntity.getNodeValidationText();
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = pipeVisualEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await pipeVisualEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const missingParametersModel = cloneDeep(pipeJson);
       missingParametersModel.spec!.steps![0].properties = {};
       pipeVisualEntity = new PipeVisualEntity(missingParametersModel);
 
-      const result = pipeVisualEntity.getNodeValidationText('steps.0');
+      const result = await pipeVisualEntity.getNodeValidationText('steps.0');
 
       expect(result).toBe('1 required parameter is not yet configured: [ milliseconds ]');
     });

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -207,12 +207,12 @@ export class PipeVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
+  async getNodeValidationText(path?: string | undefined): Promise<string | undefined> {
     const schema = this.getNodeSchema(path);
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   async toVizNode(): Promise<IVisualizationNode> {

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
@@ -1,6 +1,8 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getFirstCatalogMap } from '../../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../kaoto-schema';
@@ -49,62 +51,71 @@ describe('ModelValidationService', () => {
     CamelCatalogService.setCatalogKey(CatalogKind.Pattern, catalogsMap.patternCatalogMap);
     CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, catalogsMap.kameletsCatalogMap);
     CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
+
+    // Set up DynamicCatalogRegistry so that ExpressionService.parseExpressionModel can resolve language names
+    const languageCatalog = catalogsMap.languageCatalog;
+    const mockProvider = {
+      id: 'language-mock',
+      fetch: async (key: string) => languageCatalog[key],
+      fetchAll: async () => languageCatalog,
+    };
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
   });
 
   describe('validateNodeStatus()', () => {
-    it('should return a validation text pointing to a single missing property', () => {
+    it('should return a validation text pointing to a single missing property', async () => {
       const schema = CamelComponentSchemaService.getSchema({ processorName: 'to', componentName: 'activemq' });
       const model = camelRoute.route.from.steps[0].to;
 
-      const result = ModelValidationService.validateNodeStatus(schema, model);
+      const result = await ModelValidationService.validateNodeStatus(schema, model);
 
       expect(result).toBe('1 required parameter is not yet configured: [ destinationName ]');
     });
 
-    it('should return a validation text pointing to multiple missing properties', () => {
+    it('should return a validation text pointing to multiple missing properties', async () => {
       const schema = CamelComponentSchemaService.getSchema({
         processorName: 'to',
         componentName: 'kamelet:kafka-not-secured-sink',
       });
       const model = camelRoute.route.from.steps[2].to;
 
-      const result = ModelValidationService.validateNodeStatus(schema, model);
+      const result = await ModelValidationService.validateNodeStatus(schema, model);
 
       expect(result).toBe('1 required parameter is not yet configured: [ templateId ]');
     });
 
-    it('should return a validation text for setheader pointing to multiple missing properties', () => {
+    it('should return a validation text for setheader pointing to multiple missing properties', async () => {
       const schema = CamelComponentSchemaService.getSchema({ processorName: 'setHeader' });
       const model = camelRoute.route.from.steps[1].setHeader;
 
-      const result = ModelValidationService.validateNodeStatus(schema, model);
+      const result = await ModelValidationService.validateNodeStatus(schema, model);
 
       expect(result).toBe('2 required parameters are not yet configured: [ expression,name ]');
     });
 
-    it('should return a validation text for setheader with a different model dialect', () => {
+    it('should return a validation text for setheader with a different model dialect', async () => {
       const schema = CamelComponentSchemaService.getSchema({ processorName: 'setHeader' });
       const model = {
         name: 'test',
         constant: 'Hello Camel',
       };
 
-      const result = ModelValidationService.validateNodeStatus(schema, model);
+      const result = await ModelValidationService.validateNodeStatus(schema, model);
 
       expect(result).toBe('');
     });
 
-    it('should return an empty string if there is no missing property', () => {
+    it('should return an empty string if there is no missing property', async () => {
       const schema = CamelComponentSchemaService.getSchema({ processorName: 'to', componentName: 'activemq' });
       const model = { ...camelRoute.route.from.steps[0].to, parameters: { destinationName: 'myQueue' } };
 
-      const result = ModelValidationService.validateNodeStatus(schema, model);
+      const result = await ModelValidationService.validateNodeStatus(schema, model);
 
       expect(result).toBe('');
     });
 
-    it('should return an empty string if the schema is undefined', () => {
-      const result = ModelValidationService.validateNodeStatus(
+    it('should return an empty string if the schema is undefined', async () => {
+      const result = await ModelValidationService.validateNodeStatus(
         undefined as unknown as KaotoSchemaDefinition['schema'],
         {},
       );
@@ -124,21 +135,21 @@ describe('ModelValidationService', () => {
       definitions: {},
     };
 
-    it('should report missing required array property when not present', () => {
+    it('should report missing required array property when not present', async () => {
       const model = {};
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('1 required parameter is not yet configured: [ items ]');
     });
 
-    it('should report missing required array property when empty', () => {
+    it('should report missing required array property when empty', async () => {
       const model = { items: [] };
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('1 required parameter is not yet configured: [ items ]');
     });
 
-    it('should not report missing required array property when array is non-empty', () => {
+    it('should not report missing required array property when array is non-empty', async () => {
       const model = { items: [1, 2, 3] };
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('');
     });
   });

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
@@ -29,11 +29,11 @@ function isEmptyOrNotArray(value: unknown): boolean {
  * property file.
  */
 export class ModelValidationService {
-  static validateNodeStatus(schema: KaotoSchemaDefinition['schema'], definition: unknown): string {
+  static async validateNodeStatus(schema: KaotoSchemaDefinition['schema'], definition: unknown): Promise<string> {
     if (!schema) return '';
     let message = '';
 
-    const validationResult = this.validateRequiredProperties(schema, definition, '', schema.definitions);
+    const validationResult = await this.validateRequiredProperties(schema, definition, '', schema.definitions);
     const missingProperties = validationResult
       .filter((result) => result.type === 'missingRequired')
       .map((result) => result.propertyName);
@@ -48,40 +48,40 @@ export class ModelValidationService {
     return message;
   }
 
-  private static validateRequiredProperties(
+  private static async validateRequiredProperties(
     schema: KaotoSchemaDefinition['schema'],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     model: any,
     parentPath: string,
     definitions?: Record<string, KaotoSchemaDefinition['schema']>,
-  ): IValidationResult[] {
+  ): Promise<IValidationResult[]> {
     const answer = [] as IValidationResult[];
 
     const resolvedSchema = schema;
     if (Array.isArray(resolvedSchema.anyOf)) {
       let parsedModel = model;
-      resolvedSchema.anyOf.forEach((anyOfSchema) => {
+      for (const anyOfSchema of resolvedSchema.anyOf) {
         if (isDefined(anyOfSchema.format) && anyOfSchema.format === 'expression') {
-          parsedModel = ExpressionService.parseExpressionModel(model);
+          parsedModel = await ExpressionService.parseExpressionModel(model);
         }
-        answer.push(...this.validateRequiredProperties(anyOfSchema, parsedModel, parentPath, definitions));
-      });
+        answer.push(...(await this.validateRequiredProperties(anyOfSchema, parsedModel, parentPath, definitions)));
+      }
     }
 
     if (Array.isArray(resolvedSchema.oneOf)) {
-      resolvedSchema.oneOf.forEach((oneOfSchema) =>
-        answer.push(...this.validateRequiredProperties(oneOfSchema, model, parentPath, definitions)),
-      );
+      for (const oneOfSchema of resolvedSchema.oneOf) {
+        answer.push(...(await this.validateRequiredProperties(oneOfSchema, model, parentPath, definitions)));
+      }
     }
 
     if (!schema.properties && schema.$ref) {
       // resolve the ref
       const resolvedSchema = resolveSchemaWithRef(schema, definitions!);
-      answer.push(...this.validateRequiredProperties(resolvedSchema, model, parentPath, definitions));
+      answer.push(...(await this.validateRequiredProperties(resolvedSchema, model, parentPath, definitions)));
     }
 
     if (schema.properties) {
-      Object.entries(schema.properties).forEach(([propertyName, propertyValue]) => {
+      for (const [propertyName, propertyValue] of Object.entries(schema.properties)) {
         const propertySchema = propertyValue as KaotoSchemaDefinition['schema'];
         const path = parentPath ? `${parentPath}.${propertyName}` : propertyName;
 
@@ -99,20 +99,22 @@ export class ModelValidationService {
             propertyName: propertyName,
             message: `Missing required property ${propertyName}`,
           });
-          return;
+          continue;
         }
         if (model?.[propertyName] && propertySchema.$ref) {
           const resolvedPropertySchema = resolveSchemaWithRef(propertySchema, definitions!);
           answer.push(
-            ...this.validateRequiredProperties(resolvedPropertySchema, model[propertyName], path, definitions),
+            ...(await this.validateRequiredProperties(resolvedPropertySchema, model[propertyName], path, definitions)),
           );
         }
         if (propertySchema.type === 'object') {
           if (model) {
-            answer.push(...this.validateRequiredProperties(propertySchema, model[propertyName], path, definitions));
+            answer.push(
+              ...(await this.validateRequiredProperties(propertySchema, model[propertyName], path, definitions)),
+            );
           }
         }
-      });
+      }
     }
 
     return answer;

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -447,7 +447,7 @@ describe('VisualizationNode', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined when the underlying BaseVisualCamelEntity is not defined', () => {
+    it('should return undefined when the underlying BaseVisualCamelEntity is not defined', async () => {
       node = createVisualizationNode('test', {
         name: 'log',
         isGroup: false,
@@ -456,13 +456,13 @@ describe('VisualizationNode', () => {
         description: '',
         iconUrl: '',
       });
-      const validationText = node.getNodeValidationText();
+      const validationText = await node.getNodeValidationText();
 
       expect(validationText).toBeUndefined();
     });
 
-    it('should return the validation text from the underlying BaseVisualCamelEntity', () => {
-      const getNodeValidationTextSpy = vi.fn().mockReturnValue('test-validation-text');
+    it('should return the validation text from the underlying BaseVisualCamelEntity', async () => {
+      const getNodeValidationTextSpy = vi.fn().mockResolvedValue('test-validation-text');
       const visualEntity = {
         getNodeValidationText: getNodeValidationTextSpy,
       } as unknown as BaseVisualEntity;
@@ -477,7 +477,7 @@ describe('VisualizationNode', () => {
         description: '',
         iconUrl: '',
       });
-      const validationText = node.getNodeValidationText();
+      const validationText = await node.getNodeValidationText();
 
       expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path);
       expect(validationText).toBe('test-validation-text');

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -164,7 +164,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     }
   }
 
-  getNodeValidationText(): string | undefined {
+  async getNodeValidationText(): Promise<string | undefined> {
     return this.getBaseEntity()?.getNodeValidationText(this.data.path);
   }
 


### PR DESCRIPTION
### Context
Refactors `CamelCatalogService` per the issue: removes the unused sync catalog-map helpers and migrates the language-map consumers to the async `DynamicCatalogRegistry` API, propagating the resulting async change up to the React render layer.

### Changes

- **`CamelCatalogService`**: delete unused `getDataFormatMap` and `getLoadBalancerMap`, and remove `getLanguageMap`.
- **`ExpressionService`**: `getLanguageNames`, `parseExpressionModel`, and `updateExpressionFromModel` are now `async`, sourcing languages from `DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()`.
- **Validation chain**: `ModelValidationService.validateNodeStatus` / `validateRequiredProperties` and `getNodeValidationText` (interfaces + all visual-entity implementations + `VisualizationNode`) are now `async`.
- **Render layer**:
  - `ExpressionField` parses the model in an effect and gates rendering on an `isModelParsed` flag, so the third-party `useOneOfField` mounts with the resolved model (otherwise it latches an empty selection).
  - Extracted a shared `useNodeValidationText` hook consumed by `CustomNode` and `CustomGroupExpanded`, removing duplicated async boilerplate. The hook keys on `lastUpdate`, fixing a regression where the validation warning would not refresh after in-place node edits.
- **Tests**: updated to `await` the now-async APIs; added a unit test for `useNodeValidationText` (including re-validation on edit).

Closes https://github.com/KaotoIO/kaoto/issues/3442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation messages and expression fields now load and update asynchronously, improving reliability in the canvas and forms.
  * Group and node warning indicators now use a shared validation flow for more consistent results.

* **Bug Fixes**
  * Fixed validation text and expression parsing so they refresh correctly after edits and async updates.
  * Improved handling of loading states to avoid stale or missing validation results.

* **Tests**
  * Updated and expanded test coverage for asynchronous validation, parsing, and UI rendering flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->