### PR TITLE
fix(DataMapper): Block DnD onto sequence wrapper node

### DIFF
--- a/packages/ui/src/services/visualization/mapping-validation.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.test.ts
@@ -455,6 +455,17 @@ describe('MappingValidationService', () => {
       expect(result.targetNode).toBe(toNode);
     });
 
+    it('should reject variable dropped onto sequence wrapper target', () => {
+      const variable = new VariableItem(tree, 'rootVar');
+      tree.children.push(variable);
+      const sourceNode = new SourceVariableNodeData(variable);
+      const seqField = createMockField({ wrapperKind: 'sequence', type: Types.Container });
+      const toNode = new TargetSequenceFieldNodeData(targetDocNode, seqField);
+      const result = MappingValidationService.validateMappingPair(sourceNode, toNode);
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toContain('sequence group');
+    });
+
     it('should accept root-level variable for any target', () => {
       const variable = new VariableItem(tree, 'rootVar');
       tree.children.push(variable);

--- a/packages/ui/src/services/visualization/mapping-validation.service.ts
+++ b/packages/ui/src/services/visualization/mapping-validation.service.ts
@@ -150,6 +150,7 @@ export class MappingValidationService {
         for (const rule of [
           MappingValidationService.validateChoiceRules,
           MappingValidationService.validateAbstractRules,
+          MappingValidationService.validateSequenceRules,
         ]) {
           const result = rule(targetField, targetField);
           if (!result.isValid) return result;


### PR DESCRIPTION
Addresses: https://github.com/KaotoIO/kaoto/pull/3439#pullrequestreview-4658991337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapping validation in the visualization UI so variable drops targeting sequence-wrapper fields are rejected.
  * Updated the validation output to reference the relevant sequence group for clearer feedback.
* **Tests**
  * Added coverage to ensure dropping a variable onto a sequence-wrapper target is considered invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->