### PR TITLE
fix(DataMapper): show inherited choice cardinality in field details

### DIFF
--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { IField } from '../../../models/datamapper/document';
-import { DocumentNodeData, FieldNodeData } from '../../../models/datamapper/visualization';
+import { ChoiceFieldNodeData, DocumentNodeData, FieldNodeData } from '../../../models/datamapper/visualization';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
@@ -78,6 +78,32 @@ describe('FieldNodePopover', () => {
       expect(screen.getByText('Min Occurs:')).toBeInTheDocument();
     });
     expect(screen.getByText('Max Occurs:')).toBeInTheDocument();
+  });
+
+  it('should display inherited choice wrapper cardinality for selected choice fields', async () => {
+    const user = userEvent.setup();
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const selectedChoiceMember = { ...baseField, minOccurs: 1, maxOccurs: 1 } as unknown as IField;
+    const choiceWrapper = {
+      ...baseField,
+      minOccurs: 0,
+      maxOccurs: 'unbounded',
+      wrapperKind: 'choice',
+    } as unknown as IField;
+    const choiceNodeData = new ChoiceFieldNodeData(documentNodeData, selectedChoiceMember);
+    choiceNodeData.choiceField = choiceWrapper;
+
+    render(<FieldNodePopover nodeData={choiceNodeData} />, { wrapper });
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Max Occurs:')).toBeInTheDocument();
+    });
+    expect(screen.getByText('unbounded')).toBeInTheDocument();
   });
 
   it('should not display popover when enabled is false', () => {

--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
@@ -37,7 +37,9 @@ export const FieldNodePopover: FunctionComponent<FieldNodePopoverProps> = ({
     return null;
   }
 
-  const detailItems = prepareFieldDetails(field, namespaceMap);
+  const cardinalityField =
+    VisualizationUtilService.isSelectedChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
+  const detailItems = prepareFieldDetails(field, namespaceMap, cardinalityField);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
@@ -222,6 +222,22 @@ describe('field-details-utils', () => {
       expect(result).toContainEqual({ label: 'Max Occurs', value: 'unbounded' });
     });
 
+    it('should use the cardinality field for occurrence details', () => {
+      const field = createMockField({
+        minOccurs: 1,
+        maxOccurs: 1,
+      });
+      const choiceWrapper = createMockField({
+        minOccurs: 0,
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      });
+      const result = prepareFieldDetails(field, {}, choiceWrapper);
+
+      expect(result).toContainEqual({ label: 'Min Occurs', value: '0' });
+      expect(result).toContainEqual({ label: 'Max Occurs', value: 'unbounded' });
+    });
+
     it('should call getOverrideDisplayInfo with field and namespaceMap', () => {
       const field = createMockField();
       const namespaceMap = { 'http://example.com': 'ex' };

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
@@ -28,7 +28,11 @@ export const formatTypeQName = (typeQName: QName | null): string => {
   return namespaceURI ? `${localPart} (${namespaceURI})` : localPart;
 };
 
-export const prepareFieldDetails = (field: IField, namespaceMap: Record<string, string> = {}): LabelValuePair[] => {
+export const prepareFieldDetails = (
+  field: IField,
+  namespaceMap: Record<string, string> = {},
+  cardinalityField: IField = field,
+): LabelValuePair[] => {
   const overrideDisplay = getOverrideDisplayInfo(field, namespaceMap);
 
   const rows = [
@@ -36,11 +40,17 @@ export const prepareFieldDetails = (field: IField, namespaceMap: Record<string, 
     { label: 'Type', value: formatTypeQName(field.typeQName) },
     {
       label: 'Min Occurs',
-      value: field.minOccurs !== null && field.minOccurs !== undefined ? String(field.minOccurs) : null,
+      value:
+        cardinalityField.minOccurs !== null && cardinalityField.minOccurs !== undefined
+          ? String(cardinalityField.minOccurs)
+          : null,
     },
     {
       label: 'Max Occurs',
-      value: field.maxOccurs !== null && field.maxOccurs !== undefined ? String(field.maxOccurs) : null,
+      value:
+        cardinalityField.maxOccurs !== null && cardinalityField.maxOccurs !== undefined
+          ? String(cardinalityField.maxOccurs)
+          : null,
     },
     { label: 'Namespace', value: field.namespaceURI },
     { label: 'Attribute', value: field.isAttribute ? 'yes' : null },


### PR DESCRIPTION
## What changed

Field details now use the choice wrapper as the source for Min/Max Occurs when rendering a selected choice member. This keeps the popover consistent with the existing collection indicator for choice members that inherit cardinality from their parent choice wrapper.

## Why

For collection choice nodes, the visual node can show the layer/collection indicator through `VisualizationUtilService.isCollectionField()`, while the field details popover still read `maxOccurs` from the selected member itself. That made the popover show `Max Occurs: 1` even when the selected member was effectively repeating through an unbounded choice wrapper.

Fixes #3454.

## Validation

- `corepack yarn workspace @kaoto/kaoto test src/components/Document/FieldNodePopover/field-details-utils.test.ts src/components/Document/FieldNodePopover/FieldNodePopover.test.tsx`
- `corepack yarn workspace @kaoto/kaoto lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected occurrence counts in field popovers so selected choice fields now show the inherited wrapper values for **Min Occurs** and **Max Occurs**.
  * Improved field details display to use the appropriate source for cardinality information, preventing incorrect values like `1`/`1` when a wrapper specifies different limits.

* **Tests**
  * Added coverage for choice-field popover behavior and cardinality-based field details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->