### PR TITLE
fix(data-mapper): associate warning with attached file

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/SchemaFileDataList.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/SchemaFileDataList.tsx
@@ -20,10 +20,15 @@ import { FunctionComponent, useCallback, useMemo, useState } from 'react';
 
 import { getFileName } from '../utils';
 
+export interface SchemaFileMessage {
+  text: string;
+  severity: 'error' | 'warning';
+}
+
 export interface SchemaFileItem {
   filePath?: string;
   status: 'success' | 'warning' | 'error';
-  messages: string[];
+  messages: SchemaFileMessage[];
 }
 
 type SchemaFileDataListProps = {
@@ -119,7 +124,7 @@ export const SchemaFileDataList: FunctionComponent<SchemaFileDataListProps> = ({
       >
         {filteredItems.map((item, idx) => {
           const key = item.filePath ?? `global-${item.status}-${idx}`;
-          const displayName = item.filePath ? getFileName(item.filePath) : item.messages[0];
+          const displayName = item.filePath ? getFileName(item.filePath) : (item.messages[0]?.text ?? '');
           const labelId = item.filePath ? `file-${displayName}` : `global-${item.status}-msg-${idx}`;
 
           return (
@@ -144,8 +149,8 @@ export const SchemaFileDataList: FunctionComponent<SchemaFileDataListProps> = ({
                       {item.filePath && item.messages.length > 0 && (
                         <HelperText>
                           {item.messages.map((msg, msgIdx) => (
-                            <HelperTextItem key={`${item.filePath}-msg-${msgIdx}`} variant={item.status}>
-                              {msg}
+                            <HelperTextItem key={`${item.filePath}-msg-${msgIdx}`} variant={msg.severity}>
+                              {msg.text}
                             </HelperTextItem>
                           ))}
                         </HelperText>

--- a/packages/ui/src/components/Document/actions/utils.test.ts
+++ b/packages/ui/src/components/Document/actions/utils.test.ts
@@ -137,7 +137,7 @@ describe('utils', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].status).toBe('error');
-      expect(result[0].messages).toContain('Parse error');
+      expect(result[0].messages).toEqual([{ text: 'Parse error', severity: 'error' }]);
     });
 
     it('should create warning items for files with warnings only', () => {
@@ -150,7 +150,7 @@ describe('utils', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].status).toBe('warning');
-      expect(result[0].messages).toContain('Missing import');
+      expect(result[0].messages).toEqual([{ text: 'Missing import', severity: 'warning' }]);
     });
 
     it('should include global errors without filePath', () => {
@@ -165,7 +165,7 @@ describe('utils', () => {
       const globalItem = result.find((item) => !item.filePath);
       expect(globalItem).toBeDefined();
       expect(globalItem!.status).toBe('error');
-      expect(globalItem!.messages).toContain('Global error');
+      expect(globalItem!.messages).toEqual([{ text: 'Global error', severity: 'error' }]);
     });
 
     it('should include global warnings without filePath', () => {
@@ -179,7 +179,7 @@ describe('utils', () => {
       const globalItem = result.find((item) => !item.filePath);
       expect(globalItem).toBeDefined();
       expect(globalItem!.status).toBe('warning');
-      expect(globalItem!.messages).toContain('Global warning');
+      expect(globalItem!.messages).toEqual([{ text: 'Global warning', severity: 'warning' }]);
     });
 
     it('should sort items by status: error first, then warning, then success', () => {
@@ -207,8 +207,10 @@ describe('utils', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].status).toBe('error');
-      expect(result[0].messages).toContain('Error msg');
-      expect(result[0].messages).toContain('Warning msg');
+      expect(result[0].messages).toEqual([
+        { text: 'Error msg', severity: 'error' },
+        { text: 'Warning msg', severity: 'warning' },
+      ]);
     });
 
     it('should match files by filename when filePath in report uses filename only', () => {

--- a/packages/ui/src/components/Document/actions/utils.ts
+++ b/packages/ui/src/components/Document/actions/utils.ts
@@ -2,7 +2,7 @@ import { CreateDocumentResult, DocumentType } from '../../../models/datamapper/d
 import { IMetadataApi } from '../../../providers/metadata.provider';
 import { DataMapperMetadataService } from '../../../services/datamapper-metadata.service';
 import { DataMapperStepService } from '../../../services/datamapper-step.service';
-import { SchemaFileItem } from './AttachSchema/SchemaFileDataList';
+import { SchemaFileItem, SchemaFileMessage } from './AttachSchema/SchemaFileDataList';
 
 const VALID_XML_EXTENSIONS = ['.xml', '.xsd'];
 const VALID_JSON_EXTENSIONS = ['.json'];
@@ -70,16 +70,16 @@ export function createSchemaFileItems(
     const fileWarnings = createDocumentResult.warnings?.filter((w) => matches(w.filePath)) ?? [];
 
     if (fileErrors.length > 0) {
-      items.push({
-        filePath: fp,
-        status: 'error',
-        messages: [...fileErrors.map((e) => e.message), ...fileWarnings.map((w) => w.message)],
-      });
+      const messages: SchemaFileMessage[] = [
+        ...fileErrors.map((e) => ({ text: e.message, severity: 'error' as const })),
+        ...fileWarnings.map((w) => ({ text: w.message, severity: 'warning' as const })),
+      ];
+      items.push({ filePath: fp, status: 'error', messages });
     } else if (fileWarnings.length > 0) {
       items.push({
         filePath: fp,
         status: 'warning',
-        messages: fileWarnings.map((w) => w.message),
+        messages: fileWarnings.map((w) => ({ text: w.message, severity: 'warning' as const })),
       });
     } else {
       items.push({ filePath: fp, status: 'success', messages: [] });
@@ -87,10 +87,10 @@ export function createSchemaFileItems(
   }
 
   for (const e of createDocumentResult.errors?.filter((e) => !e.filePath) ?? []) {
-    items.push({ status: 'error', messages: [e.message] });
+    items.push({ status: 'error', messages: [{ text: e.message, severity: 'error' }] });
   }
   for (const w of createDocumentResult.warnings?.filter((w) => !w.filePath) ?? []) {
-    items.push({ status: 'warning', messages: [w.message] });
+    items.push({ status: 'warning', messages: [{ text: w.message, severity: 'warning' }] });
   }
 
   items.sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);

--- a/packages/ui/src/services/document/xml-schema/xml-schema-analysis.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-analysis.service.test.ts
@@ -84,9 +84,16 @@ ${elements}
     const circularErrors = result.errors.filter((e) => e.message.includes('Circular'));
     expect(circularErrors).toHaveLength(0);
     const circularWarnings = result.warnings.filter((w) => w.message.includes('Circular xs:include'));
-    expect(circularWarnings.length).toBeGreaterThan(0);
-    expect(circularWarnings[0].message).toContain('A.xsd');
-    expect(circularWarnings[0].message).toContain('B.xsd');
+    expect(circularWarnings).toEqual([
+      {
+        filePath: 'A.xsd',
+        message: 'Circular xs:include detected: A.xsd->B.xsd->A.xsd',
+      },
+      {
+        filePath: 'B.xsd',
+        message: 'Circular xs:include detected: B.xsd->A.xsd->B.xsd',
+      },
+    ]);
   });
 
   it('should allow circular imports (different namespaces)', () => {
@@ -374,10 +381,15 @@ ${elements}
         const result = XmlSchemaAnalysisService.analyze(files);
         expect(result.errors).toHaveLength(0);
         const nsWarnings = result.warnings.filter((w) => w.message.includes('Multiple schemas'));
-        expect(nsWarnings).toHaveLength(1);
-        expect(nsWarnings[0].message).toContain('http://example.com/types');
-        expect(nsWarnings[0].message).toContain('types1.xsd');
-        expect(nsWarnings[0].message).toContain('types2.xsd');
+        expect(nsWarnings).toHaveLength(2);
+        expect(nsWarnings[0]).toEqual({
+          filePath: 'types1.xsd',
+          message: 'Multiple schemas share targetNamespace "http://example.com/types": "types2.xsd"',
+        });
+        expect(nsWarnings[1]).toEqual({
+          filePath: 'types2.xsd',
+          message: 'Multiple schemas share targetNamespace "http://example.com/types": "types1.xsd"',
+        });
       });
 
       it('should not warn when schemas have no targetNamespace', () => {

--- a/packages/ui/src/services/document/xml-schema/xml-schema-analysis.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-analysis.service.ts
@@ -176,6 +176,25 @@ export class XmlSchemaAnalysisService {
     return null;
   }
 
+  private static formatIncludeCycleFrom(start: string, cycleBody: string[]): string {
+    const startIndex = cycleBody.indexOf(start);
+    const rotated = [...cycleBody.slice(startIndex), ...cycleBody.slice(0, startIndex), start];
+    return rotated.join('->');
+  }
+
+  private static getIncludeCycleKey(cycleBody: string[]): string {
+    if (cycleBody.length === 0) {
+      return '';
+    }
+
+    const rotations = cycleBody.map((_node, index) => {
+      const rotated = [...cycleBody.slice(index), ...cycleBody.slice(0, index)];
+      return rotated.join('->');
+    });
+
+    return rotations.slice().sort((a, b) => a.localeCompare(b))[0];
+  }
+
   private static detectCircularIncludes(
     fileInfos: Map<string, SchemaFileInfo>,
     edges: DependencyEdge[],
@@ -189,10 +208,26 @@ export class XmlSchemaAnalysisService {
       }
     }
 
-    const errors: ReportMessage[] = [];
+    const warnings: ReportMessage[] = [];
+    const reportedCycles = new Set<string>();
     const visited = new Set<string>();
     const inStack = new Set<string>();
     const stack: string[] = [];
+
+    const reportCycle = (cycleBody: string[]) => {
+      const cycleKey = XmlSchemaAnalysisService.getIncludeCycleKey(cycleBody);
+      if (!cycleKey || reportedCycles.has(cycleKey)) {
+        return;
+      }
+
+      reportedCycles.add(cycleKey);
+      for (const filePath of cycleBody) {
+        warnings.push({
+          filePath,
+          message: `Circular xs:include detected: ${XmlSchemaAnalysisService.formatIncludeCycleFrom(filePath, cycleBody)}`,
+        });
+      }
+    };
 
     const dfs = (node: string) => {
       visited.add(node);
@@ -202,10 +237,8 @@ export class XmlSchemaAnalysisService {
       for (const neighbor of includeAdj.get(node) ?? []) {
         if (inStack.has(neighbor)) {
           const cycleStart = stack.indexOf(neighbor);
-          const cycle = stack.slice(cycleStart);
-          cycle.push(neighbor);
-          const circularInclude = cycle.map((p) => `"${p}"`).join(' -> ');
-          errors.push({ message: `Circular xs:include detected: ${circularInclude}` });
+          const cycleBody = stack.slice(cycleStart);
+          reportCycle(cycleBody);
         } else if (!visited.has(neighbor)) {
           dfs(neighbor);
         }
@@ -221,7 +254,7 @@ export class XmlSchemaAnalysisService {
       }
     }
 
-    return errors;
+    return warnings;
   }
 
   private static detectCircularImports(
@@ -353,7 +386,21 @@ export class XmlSchemaAnalysisService {
       files.push(filePath);
       nsByNamespace.set(info.targetNamespace, files);
     }
+
     const warnings: ReportMessage[] = [];
+    const reportDuplicate = (ns: string, files: string[]) => {
+      for (const file of files) {
+        const fileList = files
+          .filter((f) => f !== file)
+          .map((f) => `"${f}"`)
+          .join(', ');
+        warnings.push({
+          message: `Multiple schemas share targetNamespace "${ns}": ${fileList}`,
+          filePath: file,
+        });
+      }
+    };
+
     for (const [ns, files] of nsByNamespace) {
       if (files.length <= 1) continue;
 
@@ -364,8 +411,7 @@ export class XmlSchemaAnalysisService {
       const connectedViaIncludes = includeEdges.some((e) => allFilesWithNs.has(e.from) && allFilesWithNs.has(e.to));
       if (connectedViaIncludes) continue;
 
-      const fileList = files.map((f) => `"${f}"`).join(', ');
-      warnings.push({ message: `Multiple schemas share targetNamespace "${ns}": ${fileList}` });
+      reportDuplicate(ns, files);
     }
     return warnings;
   }


### PR DESCRIPTION
Fixes #3307
 
<img width="848" height="615" alt="Screenshot From 2026-07-24 00-28-43" src="https://github.com/user-attachments/assets/26270a69-cd42-4bab-abe5-dac014493848" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML schema validation results for circular `xs:include` relationships by deduplicating and standardizing warning output.
  * Enhanced duplicate `targetNamespace` warnings to better match each file with its related schemas.
  * Updated validation helper text so each message shows the correct content and visual severity.

* **Tests**
  * Strengthened test coverage to assert warning details and structured message output exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->