### PR TITLE
feat(DataMapper): Abstract UX: S4: XSLT-based auto-detection of wrapp…

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, createRef, FunctionComponent, useCallback } from 'react';
 
 import { useDataMapper } from '../../../hooks/useDataMapper';
 import { MappingSerializerService } from '../../../services/mapping/mapping-serializer.service';
+import { WrapperAutoDetectionService } from '../../../services/mapping/wrapper-auto-detection.service';
 import { readFileAsString } from '../../../stubs/read-file-as-string';
 
 type ImportMappingFileDropdownItemProps = {
@@ -31,6 +32,11 @@ export const ImportMappingFileDropdownItem: FunctionComponent<ImportMappingFileD
             targetBodyDocument,
             mappingTree,
             sourceParameterMap,
+          );
+          WrapperAutoDetectionService.autoDetectWrapperSelections(
+            mappingTree,
+            targetBodyDocument,
+            mappingTree.namespaceMap,
           );
           for (const msg of messages) {
             sendAlert(msg);

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -86,9 +86,9 @@ export class FieldItem extends MappingItem {
    * during drag-and-drop mapping.
    *
    * Preserved by {@link doClone} — "Duplicate" inherits the original's value.
-   * Reconstructed during deserialization from document-level field substitution,
-   * choice selection state, and empty terminal detection. Consumed by pruning
-   * and deletability logic.
+   * Auto-detected during deserialization by {@link WrapperAutoDetectionService} from
+   * wrapper selections, substitution state, and empty terminal detection.
+   * Consumed by pruning and deletability logic.
    */
   isUserCreated = false;
 

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -33,6 +33,7 @@ import { CanvasView } from '../models/datamapper/view';
 import { DocumentService } from '../services/document/document.service';
 import { MappingService } from '../services/mapping/mapping.service';
 import { MappingSerializerService } from '../services/mapping/mapping-serializer.service';
+import { WrapperAutoDetectionService } from '../services/mapping/wrapper-auto-detection.service';
 
 export interface IDataMapperContext {
   isLoading: boolean;
@@ -160,6 +161,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
         freshTree,
         latestSourceParameterMap,
       );
+      WrapperAutoDetectionService.autoDetectWrapperSelections(loaded, latestTargetBodyDocument, effectiveNamespaceMap);
       setMappingTree(loaded);
       for (const msg of messages) {
         sendAlert(msg);

--- a/packages/ui/src/services/document/field-override.service.ts
+++ b/packages/ui/src/services/document/field-override.service.ts
@@ -1,4 +1,10 @@
-import { DocumentDefinition, IDocument, IField, PrimitiveDocument } from '../../models/datamapper/document';
+import {
+  DocumentDefinition,
+  IDocument,
+  IField,
+  IParentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
 import { IFieldSubstitution, IFieldTypeOverride } from '../../models/datamapper/metadata';
 import { FieldOverrideVariant, IFieldSubstituteInfo, IFieldTypeInfo, Types } from '../../models/datamapper/types';
 import { ensureNamespaceRegistered, formatQNameWithPrefix, formatWithPrefix } from '../namespace-util';
@@ -394,6 +400,28 @@ export class FieldOverrideService {
       field,
       field.ownerDocument.xmlSchemaCollection,
       namespaceMap,
+    );
+  }
+
+  /**
+   * Reverse-lookup: given an element name and namespace, find the substitution group head
+   * field among the direct children of `parentField`.
+   *
+   * Delegates to {@link XmlSchemaTypesService.findSubstitutionGroupHead} for XML Schema documents.
+   * Returns `undefined` for non-XML documents or when no match is found.
+   */
+  static findSubstitutionGroupHead(
+    parentField: IParentType,
+    elementName: string,
+    elementNamespace: string,
+  ): { headField: IField; info: IFieldSubstituteInfo } | undefined {
+    const document = 'ownerDocument' in parentField ? parentField.ownerDocument : parentField;
+    if (!(document instanceof XmlSchemaDocument) || !document.xmlSchemaCollection) return undefined;
+    return XmlSchemaTypesService.findSubstitutionGroupHead(
+      parentField,
+      elementName,
+      elementNamespace,
+      document.xmlSchemaCollection,
     );
   }
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
@@ -1,4 +1,4 @@
-import { IDocument, IField } from '../../../models/datamapper/document';
+import { IDocument, IField, IParentType } from '../../../models/datamapper/document';
 import { IFieldSubstitution } from '../../../models/datamapper/metadata';
 import { NS_XML_SCHEMA } from '../../../models/datamapper/standard-namespaces';
 import {
@@ -24,6 +24,7 @@ import { QName } from '../../../xml-schema-ts/QName';
 import { XmlSchemaSimpleContent } from '../../../xml-schema-ts/simple/XmlSchemaSimpleContent';
 import { XmlSchemaSimpleTypeRestriction } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction';
 import { ensureNamespaceRegistered, formatQNameWithPrefix, parseQNameString } from '../../namespace-util';
+import { DocumentUtilService } from '../document-util.service';
 import { XmlSchemaDocument } from './xml-schema-document.model';
 import { XmlSchemaDocumentUtilService } from './xml-schema-document-util.service';
 
@@ -849,6 +850,68 @@ export class XmlSchemaTypesService {
       }
     }
     return allElements;
+  }
+
+  /**
+   * Reverse-lookup: given an element name and namespace, find the substitution group head
+   * field among the direct children of `parentField`.
+   *
+   * Walks up the substitution chain from the substitute element via `getSubstitutionGroup()`
+   * instead of enumerating all members of every potential head — O(chainLength × children)
+   * vs the previous O(children × allElements).
+   *
+   * Skips wrapper fields and already-substituted fields. Does NOT enforce `maxOccurs` —
+   * that policy belongs to the caller.
+   *
+   * @returns The matching head field and resolved substitute info, or `undefined`
+   */
+  static findSubstitutionGroupHead(
+    parentField: IParentType,
+    elementName: string,
+    elementNamespace: string,
+    collection: XmlSchemaCollection,
+  ): { headField: IField; info: IFieldSubstituteInfo } | undefined {
+    const substituteElement = collection.getElementByQName(new QName(elementNamespace, elementName));
+    if (!substituteElement) return undefined;
+
+    const wireName = substituteElement.getWireName();
+    if (!wireName?.getLocalPart()) return undefined;
+
+    const resolvedParent = 'parent' in parentField ? DocumentUtilService.resolveTypeFragment(parentField) : parentField;
+
+    const visited = new Set<string>();
+    let current: XmlSchemaElement | null = substituteElement;
+    while (current) {
+      const headQName = current.getSubstitutionGroup();
+      if (!headQName) return undefined;
+
+      const headQNameString = headQName.toString();
+      if (visited.has(headQNameString)) return undefined;
+      visited.add(headQNameString);
+
+      const headField = resolvedParent.fields.find(
+        (f) =>
+          !f.wrapperKind &&
+          f.typeOverride !== FieldOverrideVariant.SUBSTITUTION &&
+          f.name === headQName.getLocalPart() &&
+          f.namespaceURI === headQName.getNamespaceURI(),
+      );
+
+      if (headField) {
+        return {
+          headField,
+          info: {
+            qname: wireName,
+            displayName: wireName.getLocalPart()!,
+            ...XmlSchemaTypesService.resolveElementTypeInfo(substituteElement, collection),
+          },
+        };
+      }
+
+      current = collection.getElementByQName(headQName);
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -26,6 +26,8 @@ import { DeserializeItemResult, DeserializeResult, MappingItemClass } from '../.
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
 import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { SendAlertProps } from '../../models/datamapper/visualization';
+import { DocumentUtilService } from '../document/document-util.service';
+import { FieldOverrideService } from '../document/field-override.service';
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
 import { MappingService } from './mapping.service';
 import { MappingSerializerJsonAddon } from './mapping-serializer-json-addon';
@@ -391,6 +393,13 @@ export class MappingSerializerService {
     const name = item.localName;
     const existing = XmlSchemaDocumentUtilService.getChildField(parentField, name, namespace);
     if (existing) return existing;
+
+    const substitutionMatch = FieldOverrideService.findSubstitutionGroupHead(parentField, name, namespace);
+    if (substitutionMatch?.headField.maxOccurs === 1) {
+      DocumentUtilService.applySubstitutionToField(substitutionMatch.headField, substitutionMatch.info);
+      return substitutionMatch.headField;
+    }
+
     const field = new BaseField(
       parentField,
       'ownerDocument' in parentField ? parentField.ownerDocument : parentField,

--- a/packages/ui/src/services/mapping/wrapper-auto-detection.service.test.ts
+++ b/packages/ui/src/services/mapping/wrapper-auto-detection.service.test.ts
@@ -1,0 +1,656 @@
+import {
+  BaseField,
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  IDocument,
+  RootElementOption,
+} from '../../models/datamapper/document';
+import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
+import { NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../../models/datamapper/types';
+import {
+  getChoiceWithAbstractXsd,
+  getFieldSubstitutionXsd,
+  getNonAbstractSubstitutionXsd,
+  getSchemaTestXsd,
+} from '../../stubs/datamapper/data-mapper';
+import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
+import { MappingSerializerService } from './mapping-serializer.service';
+import { WrapperAutoDetectionService } from './wrapper-auto-detection.service';
+
+const NS_SUBSTITUTION = 'http://www.example.com/SUBSTITUTION';
+const NS_CHOICE_ABSTRACT = 'http://www.example.com/CHOICE_ABSTRACT';
+const NS_SCHEMA_TEST = 'http://www.example.com/test';
+const NS_NONABSTRACT = 'http://www.example.com/NONABSTRACT';
+
+const NOTIFICATION_ROOT: RootElementOption = { namespaceUri: NS_CHOICE_ABSTRACT, name: 'Notification' };
+
+function createTargetDoc(
+  schemaContent: string,
+  schemaFileName: string,
+  options?: {
+    definition?: DocumentDefinition;
+    rootElementChoice?: RootElementOption;
+    namespaceMap?: Record<string, string>;
+  },
+): IDocument {
+  const def =
+    options?.definition ??
+    new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        [schemaFileName]: schemaContent,
+      },
+      options?.rootElementChoice,
+    );
+  const result = XmlSchemaDocumentService.createXmlSchemaDocument(def, options?.namespaceMap);
+  if (result.validationStatus !== 'success' || !result.document) {
+    throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create document');
+  }
+  return result.document;
+}
+
+function deserializeAndAutoDetect(
+  xslt: string,
+  targetDocument: IDocument,
+  namespaceMap?: Record<string, string>,
+): MappingTree {
+  const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+  const sourceParameterMap = new Map<string, IDocument>();
+  MappingSerializerService.deserialize(xslt, targetDocument, mappingTree, sourceParameterMap);
+  const effectiveNsMap = namespaceMap ?? { ...mappingTree.namespaceMap };
+  WrapperAutoDetectionService.autoDetectWrapperSelections(mappingTree, targetDocument, effectiveNsMap);
+  return mappingTree;
+}
+
+function makeXslt(namespaces: Record<string, string>, body: string): string {
+  const nsAttrs = Object.entries(namespaces)
+    .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
+    .join(' ');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" ${nsAttrs}>
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+${body}
+  </xsl:template>
+</xsl:stylesheet>`;
+}
+
+describe('WrapperAutoDetectionService', () => {
+  describe('abstract field auto-detection', () => {
+    it('should set selectedMemberQName when concrete element at abstract position has maxOccurs=1', () => {
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <ns0:Nickname>test</ns0:Nickname>
+    </ns0:Zoo>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractLabel = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractLabel',
+      );
+      expect(abstractLabel).toBeDefined();
+      expect(abstractLabel!.selectedMemberQName).toBeDefined();
+      expect(abstractLabel!.selectedMemberQName!.getLocalPart()).toBe('Nickname');
+
+      const zooFieldItem = mappingTree.children[0] as FieldItem;
+      const nicknameFieldItem = zooFieldItem.children[0] as FieldItem;
+      expect(nicknameFieldItem.isUserCreated).toBe(true);
+
+      const subs = targetDoc.definition.fieldSubstitutions;
+      expect(subs).toBeDefined();
+      expect(subs!.some((s) => s.name.includes('Nickname'))).toBe(true);
+    });
+
+    it('should NOT auto-detect when abstract wrapper has maxOccurs > 1', () => {
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <ns0:Dog><ns0:name>Rex</ns0:name><ns0:breed>Lab</ns0:breed></ns0:Dog>
+    </ns0:Zoo>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractAnimal = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractAnimal',
+      );
+      expect(abstractAnimal).toBeDefined();
+      expect(abstractAnimal!.maxOccurs).not.toBe(1);
+      expect(abstractAnimal!.selectedMemberQName).toBeUndefined();
+    });
+
+    it('should NOT auto-detect when element is inside xsl:if', () => {
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <xsl:if test="true()">
+        <ns0:Nickname>test</ns0:Nickname>
+      </xsl:if>
+    </ns0:Zoo>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractLabel = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractLabel',
+      );
+      expect(abstractLabel!.selectedMemberQName).toBeUndefined();
+    });
+
+    it('should NOT auto-detect when element is inside xsl:choose/xsl:when', () => {
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <xsl:choose>
+        <xsl:when test="true()">
+          <ns0:Nickname>test</ns0:Nickname>
+        </xsl:when>
+      </xsl:choose>
+    </ns0:Zoo>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractLabel = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractLabel',
+      );
+      expect(abstractLabel!.selectedMemberQName).toBeUndefined();
+    });
+
+    it('should skip when existing .kaoto metadata has substitution entry', () => {
+      const nsMap = { ns0: NS_SUBSTITUTION };
+      const def = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            schemaPath: '/ns0:Zoo/{abstract:1}',
+            name: 'ns0:XsStringTag',
+            originalName: 'ns0:AbstractLabel',
+          },
+        ],
+      );
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd', {
+        definition: def,
+        namespaceMap: nsMap,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <ns0:Nickname>test</ns0:Nickname>
+    </ns0:Zoo>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractLabel = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractLabel',
+      );
+      expect(abstractLabel!.selectedMemberQName).toBeDefined();
+      expect(abstractLabel!.selectedMemberQName!.getLocalPart()).toBe('XsStringTag');
+    });
+
+    it('should auto-detect direct substitution (InlineIntCount -> AbstractCount)', () => {
+      const targetDoc = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <ns0:InlineIntCount>5</ns0:InlineIntCount>
+    </ns0:Zoo>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const abstractCount = targetDoc.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractCount',
+      );
+      expect(abstractCount).toBeDefined();
+      expect(abstractCount!.selectedMemberQName).toBeDefined();
+      expect(abstractCount!.selectedMemberQName!.getLocalPart()).toBe('InlineIntCount');
+    });
+  });
+
+  describe('choice field auto-detection', () => {
+    it('should set selectedMemberIndex when element uniquely identifies a choice branch', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id>123</ns0:id>
+      <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+    </ns0:Notification>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      expect(choiceWrapper!.selectedMemberIndex).toBeDefined();
+
+      const webhookMember = choiceWrapper!.fields.find((f) => f.name === 'Webhook');
+      expect(choiceWrapper!.selectedMemberIndex).toBe(choiceWrapper!.fields.indexOf(webhookMember!));
+
+      const notifFieldItem = mappingTree.children[0] as FieldItem;
+      const webhookFieldItem = notifFieldItem.children.find(
+        (c) => c instanceof FieldItem && c.field.name === 'Webhook',
+      ) as FieldItem;
+      expect(webhookFieldItem.isUserCreated).toBe(true);
+
+      const selections = targetDoc.definition.choiceSelections;
+      expect(selections).toBeDefined();
+      expect(selections!.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should NOT auto-detect when element is inside xsl:if', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <xsl:if test="true()">
+        <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+      </xsl:if>
+    </ns0:Notification>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper!.selectedMemberIndex).toBeUndefined();
+    });
+  });
+
+  describe('nested choice + abstract auto-detection', () => {
+    it('should auto-detect both choice and abstract selections for Email inside choice>abstract', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id>123</ns0:id>
+      <ns0:Email><ns0:content>hello</ns0:content><ns0:subject>test</ns0:subject></ns0:Email>
+    </ns0:Notification>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      expect(choiceWrapper!.selectedMemberIndex).toBeDefined();
+
+      const abstractWrapper = choiceWrapper!.fields.find((f) => f.wrapperKind === 'abstract');
+      expect(abstractWrapper).toBeDefined();
+      expect(abstractWrapper!.selectedMemberQName).toBeDefined();
+      expect(abstractWrapper!.selectedMemberQName!.getLocalPart()).toBe('Email');
+
+      expect(choiceWrapper!.selectedMemberIndex).toBe(choiceWrapper!.fields.indexOf(abstractWrapper!));
+    });
+  });
+
+  describe('non-abstract substitution auto-detection (Phase A)', () => {
+    it('should apply substitution when substitute element appears where head is expected', () => {
+      const targetDoc = createTargetDoc(getNonAbstractSubstitutionXsd(), 'NonAbstractSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_NONABSTRACT },
+        `    <ns0:Root>
+      <ns0:SubElement><ns0:base>val</ns0:base><ns0:extra>x</ns0:extra></ns0:SubElement>
+    </ns0:Root>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+
+      const headField = targetDoc.fields[0].fields.find(
+        (f) => f.originalField?.name === 'HeadElement' || f.name === 'SubElement',
+      );
+      expect(headField).toBeDefined();
+      expect(headField!.name).toBe('SubElement');
+
+      const subs = targetDoc.definition.fieldSubstitutions;
+      expect(subs).toBeDefined();
+      expect(subs!.some((s) => s.name.includes('SubElement'))).toBe(true);
+
+      const rootItem = mappingTree.children[0] as FieldItem;
+      const subItem = rootItem.children.find(
+        (c) => c instanceof FieldItem && c.field.name === 'SubElement',
+      ) as FieldItem;
+      expect(subItem).toBeDefined();
+      expect(subItem.isUserCreated).toBe(true);
+    });
+  });
+
+  describe('empty element marking', () => {
+    it('should mark FieldItems with no children as isUserCreated', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id/>
+    </ns0:Notification>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+      const notifItem = mappingTree.children[0] as FieldItem;
+      const idItem = notifItem.children.find((c) => c instanceof FieldItem && c.field.name === 'id') as FieldItem;
+      expect(idItem).toBeDefined();
+      expect(idItem.isUserCreated).toBe(true);
+    });
+
+    it('should NOT mark FieldItems that have children as isUserCreated', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id><xsl:value-of select="'123'"/></ns0:id>
+    </ns0:Notification>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+      const notifItem = mappingTree.children[0] as FieldItem;
+      const idItem = notifItem.children.find((c) => c instanceof FieldItem && c.field.name === 'id') as FieldItem;
+      expect(idItem).toBeDefined();
+      expect(idItem.isUserCreated).toBe(false);
+    });
+  });
+
+  describe('condition checks', () => {
+    it('hasConditionalWrapper should return false for FieldItem not in conditional', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id>123</ns0:id>
+    </ns0:Notification>`,
+      );
+
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const sourceParameterMap = new Map<string, IDocument>();
+      MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap);
+
+      const notifItem = mappingTree.children[0] as FieldItem;
+      const idItem = notifItem.children.find((c) => c instanceof FieldItem && c.field.name === 'id') as FieldItem;
+      expect(WrapperAutoDetectionService.hasConditionalWrapper(idItem)).toBe(false);
+    });
+
+    it('hasConditionalWrapper should return true for FieldItem inside xsl:if', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <xsl:if test="true()">
+        <ns0:id>123</ns0:id>
+      </xsl:if>
+    </ns0:Notification>`,
+      );
+
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const sourceParameterMap = new Map<string, IDocument>();
+      MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap);
+
+      const notifItem = mappingTree.children[0] as FieldItem;
+      const ifItem = notifItem.children[0];
+      const idItem = ifItem.children.find((c) => c instanceof FieldItem && c.field.name === 'id') as FieldItem;
+      expect(idItem).toBeDefined();
+      expect(WrapperAutoDetectionService.hasConditionalWrapper(idItem)).toBe(true);
+    });
+
+    it('isUniqueInWrapper should return true for unique element in wrapper', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      const webhook = choiceWrapper!.fields.find((f) => f.name === 'Webhook');
+      expect(webhook).toBeDefined();
+      expect(WrapperAutoDetectionService.isUniqueInWrapper(webhook!, choiceWrapper!)).toBe(true);
+    });
+  });
+
+  describe('choice auto-detection with SchemaTest.xsd', () => {
+    it('should auto-detect choice selection from SchemaTest.xsd', () => {
+      const targetDoc = createTargetDoc(getSchemaTestXsd(), 'SchemaTest.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SCHEMA_TEST },
+        `    <ns0:Root>
+      <ns0:person>
+        <ns0:fax>123-456</ns0:fax>
+      </ns0:person>
+    </ns0:Root>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+
+      const personField = targetDoc.fields[0].fields.find((f) => f.name === 'person');
+      expect(personField).toBeDefined();
+      const choiceWrapper = personField!.fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      expect(choiceWrapper!.maxOccurs).toBe(1);
+      const faxMember = choiceWrapper!.fields.find((f) => f.name === 'fax');
+      expect(faxMember).toBeDefined();
+      expect(choiceWrapper!.selectedMemberIndex).toBe(choiceWrapper!.fields.indexOf(faxMember!));
+    });
+  });
+
+  describe('choice metadata precedence', () => {
+    it('should skip auto-detection when existing .kaoto metadata has choiceSelections entry', () => {
+      const nsMap = { ns0: NS_CHOICE_ABSTRACT };
+      const def = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'ChoiceWithAbstract.xsd': getChoiceWithAbstractXsd() },
+        NOTIFICATION_ROOT,
+        undefined,
+        [{ schemaPath: '/ns0:Notification/{choice:0}', selectedMemberIndex: 0 }],
+      );
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        definition: def,
+        namespaceMap: nsMap,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <ns0:id>123</ns0:id>
+      <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+    </ns0:Notification>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc, nsMap);
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      expect(choiceWrapper!.selectedMemberIndex).toBe(0);
+    });
+  });
+
+  describe('choice with xsl:choose wrapping', () => {
+    it('should NOT auto-detect when element is inside xsl:choose/xsl:when', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const xslt = makeXslt(
+        { ns0: NS_CHOICE_ABSTRACT },
+        `    <ns0:Notification>
+      <xsl:choose>
+        <xsl:when test="true()">
+          <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+        </xsl:when>
+      </xsl:choose>
+    </ns0:Notification>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      expect(choiceWrapper).toBeDefined();
+      expect(choiceWrapper!.selectedMemberIndex).toBeUndefined();
+    });
+  });
+
+  describe('ambiguous element detection', () => {
+    it('isUniqueInWrapper should return false when element name appears in multiple wrapper children', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice')!;
+      const webhook = choiceWrapper.fields.find((f) => f.name === 'Webhook')!;
+      const duplicate = new BaseField(choiceWrapper, targetDoc, 'Webhook');
+      duplicate.namespaceURI = webhook.namespaceURI;
+      choiceWrapper.fields.push(duplicate);
+
+      expect(WrapperAutoDetectionService.isUniqueInWrapper(webhook, choiceWrapper)).toBe(false);
+
+      choiceWrapper.fields.pop();
+    });
+  });
+
+  describe('non-abstract substitution edge cases', () => {
+    it('should NOT apply substitution when head field has maxOccurs > 1', () => {
+      const schema = getNonAbstractSubstitutionXsd().replace(
+        '<xs:element ref="HeadElement"/>',
+        '<xs:element ref="HeadElement" maxOccurs="unbounded"/>',
+      );
+      const targetDoc = createTargetDoc(schema, 'NonAbstractUnbounded.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_NONABSTRACT },
+        `    <ns0:Root>
+      <ns0:SubElement><ns0:base>val</ns0:base><ns0:extra>x</ns0:extra></ns0:SubElement>
+    </ns0:Root>`,
+      );
+
+      deserializeAndAutoDetect(xslt, targetDoc);
+
+      const headField = targetDoc.fields[0].fields.find((f) => f.name === 'HeadElement');
+      expect(headField).toBeDefined();
+      expect(headField!.typeOverride).not.toBe(FieldOverrideVariant.SUBSTITUTION);
+    });
+
+    it('should substitute field but NOT persist metadata when inside xsl:if', () => {
+      const targetDoc = createTargetDoc(getNonAbstractSubstitutionXsd(), 'NonAbstractConditional.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_NONABSTRACT },
+        `    <ns0:Root>
+      <xsl:if test="true()">
+        <ns0:SubElement><ns0:base>val</ns0:base><ns0:extra>x</ns0:extra></ns0:SubElement>
+      </xsl:if>
+    </ns0:Root>`,
+      );
+
+      const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
+
+      const substitutedField = targetDoc.fields[0].fields.find((f) => f.name === 'SubElement');
+      expect(substitutedField).toBeDefined();
+      expect(substitutedField!.typeOverride).toBe(FieldOverrideVariant.SUBSTITUTION);
+
+      expect(targetDoc.definition.fieldSubstitutions ?? []).toHaveLength(0);
+
+      const rootItem = mappingTree.children[0] as FieldItem;
+      const ifItem = rootItem.children[0];
+      const subItem = ifItem.children.find((c) => c instanceof FieldItem && c.field.name === 'SubElement') as FieldItem;
+      expect(subItem).toBeDefined();
+      expect(subItem.isUserCreated).toBe(true);
+    });
+  });
+
+  describe('persistence round-trip', () => {
+    it('should preserve auto-detected abstract selection through metadata round-trip', () => {
+      const targetDoc1 = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd');
+      const xslt = makeXslt(
+        { ns0: NS_SUBSTITUTION },
+        `    <ns0:Zoo>
+      <ns0:Nickname>test</ns0:Nickname>
+    </ns0:Zoo>`,
+      );
+
+      const nsMap1 = { ns0: NS_SUBSTITUTION };
+      deserializeAndAutoDetect(xslt, targetDoc1, nsMap1);
+
+      const subs1 = targetDoc1.definition.fieldSubstitutions;
+      expect(subs1).toBeDefined();
+      expect(subs1!.length).toBeGreaterThanOrEqual(1);
+
+      const def2 = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        undefined,
+        undefined,
+        undefined,
+        [...subs1!],
+      );
+      const nsMap2 = { ns0: NS_SUBSTITUTION };
+      const targetDoc2 = createTargetDoc(getFieldSubstitutionXsd(), 'FieldSubstitution.xsd', {
+        definition: def2,
+        namespaceMap: nsMap2,
+      });
+
+      deserializeAndAutoDetect(xslt, targetDoc2, nsMap2);
+
+      const abstractLabel2 = targetDoc2.fields[0].fields.find(
+        (f) => f.wrapperKind === 'abstract' && f.name === 'AbstractLabel',
+      );
+      expect(abstractLabel2).toBeDefined();
+      expect(abstractLabel2!.selectedMemberQName).toBeDefined();
+      expect(abstractLabel2!.selectedMemberQName!.getLocalPart()).toBe('Nickname');
+    });
+  });
+
+  describe('FieldItem.clone() preserves isUserCreated', () => {
+    it('should copy isUserCreated=true via clone()', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const field = targetDoc.fields[0].fields.find((f) => f.name === 'id')!;
+      const fi = new FieldItem(mappingTree, field);
+      fi.isUserCreated = true;
+      const cloned = fi.clone();
+      expect((cloned as FieldItem).isUserCreated).toBe(true);
+    });
+
+    it('should copy isUserCreated=false (default) via clone()', () => {
+      const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
+        rootElementChoice: NOTIFICATION_ROOT,
+      });
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const field = targetDoc.fields[0].fields.find((f) => f.name === 'id')!;
+      const fi = new FieldItem(mappingTree, field);
+      const cloned = fi.clone();
+      expect((cloned as FieldItem).isUserCreated).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/services/mapping/wrapper-auto-detection.service.ts
+++ b/packages/ui/src/services/mapping/wrapper-auto-detection.service.ts
@@ -1,0 +1,238 @@
+import { IDocument, IField, IParentType } from '../../models/datamapper/document';
+import {
+  FieldItem,
+  IfItem,
+  MappingItem,
+  MappingParentType,
+  MappingTree,
+  OtherwiseItem,
+  WhenItem,
+} from '../../models/datamapper/mapping';
+import { IChoiceSelection, IFieldSubstitution } from '../../models/datamapper/metadata';
+import { FieldOverrideVariant } from '../../models/datamapper/types';
+import { QName } from '../../xml-schema-ts/QName';
+import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
+import { ensureNamespaceRegistered, formatWithPrefix } from '../namespace-util';
+import { SchemaPathService } from '../schema-path.service';
+
+/**
+ * Infers abstract substitutions, non-abstract substitutions, and xs:choice selections
+ * from XSLT content when loading without `.kaoto` metadata.
+ *
+ * Auto-detection is target-side only and runs after XSLT deserialization, before visualization.
+ * Three conditions must all hold for auto-detection:
+ * 1. `maxOccurs = 1` on the wrapper (or field for non-abstract substitution)
+ * 2. Element uniquely identifies the target (not ambiguous across branches)
+ * 3. No conditional instruction wrapping (`xsl:if`, `xsl:choose`)
+ */
+export class WrapperAutoDetectionService {
+  static autoDetectWrapperSelections(
+    mappingTree: MappingTree,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): void {
+    if (!(targetDocument instanceof XmlSchemaDocument)) return;
+
+    const processedWrappers = new Set<IField>();
+    WrapperAutoDetectionService.walkMappingTree(mappingTree, targetDocument, namespaceMap, processedWrappers);
+    WrapperAutoDetectionService.markEmptyFieldItems(mappingTree);
+  }
+
+  private static walkMappingTree(
+    parent: MappingParentType,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+    processedWrappers: Set<IField>,
+  ): void {
+    for (const child of parent.children) {
+      if (child instanceof FieldItem) {
+        WrapperAutoDetectionService.processFieldItem(child, targetDocument, namespaceMap, processedWrappers);
+        WrapperAutoDetectionService.tryPersistNonAbstractSubstitution(child, targetDocument, namespaceMap);
+      }
+      WrapperAutoDetectionService.walkMappingTree(child, targetDocument, namespaceMap, processedWrappers);
+    }
+  }
+
+  private static processFieldItem(
+    fieldItem: FieldItem,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+    processedWrappers: Set<IField>,
+  ): void {
+    let identifyingField: IField = fieldItem.field;
+    let current: IParentType = identifyingField.parent;
+
+    while ('wrapperKind' in current && current.wrapperKind) {
+      if (!processedWrappers.has(current)) {
+        processedWrappers.add(current);
+        if (current.wrapperKind === 'abstract') {
+          WrapperAutoDetectionService.tryAutoDetectAbstractSelection(
+            current,
+            identifyingField,
+            fieldItem,
+            targetDocument,
+            namespaceMap,
+          );
+        } else if (current.wrapperKind === 'choice') {
+          WrapperAutoDetectionService.tryAutoDetectChoiceSelection(
+            current,
+            identifyingField,
+            fieldItem,
+            targetDocument,
+            namespaceMap,
+          );
+        }
+      }
+      identifyingField = current;
+      current = current.parent;
+    }
+  }
+
+  private static tryAutoDetectAbstractSelection(
+    wrapperField: IField,
+    candidateField: IField,
+    fieldItem: FieldItem,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): void {
+    if (wrapperField.selectedMemberQName) return;
+    if (!WrapperAutoDetectionService.isMaxOccursOne(wrapperField)) return;
+    if (!WrapperAutoDetectionService.isUniqueInWrapper(candidateField, wrapperField)) return;
+    if (WrapperAutoDetectionService.hasConditionalWrapper(fieldItem)) return;
+    if (WrapperAutoDetectionService.hasExistingSubstitutionMetadata(wrapperField, targetDocument, namespaceMap)) return;
+
+    wrapperField.selectedMemberQName = new QName(candidateField.namespaceURI, candidateField.name);
+    fieldItem.isUserCreated = true;
+
+    ensureNamespaceRegistered(candidateField.namespaceURI, namespaceMap, candidateField.namespacePrefix ?? undefined);
+    ensureNamespaceRegistered(wrapperField.namespaceURI, namespaceMap, wrapperField.namespacePrefix ?? undefined);
+
+    const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
+    const entry: IFieldSubstitution = {
+      schemaPath,
+      name: formatWithPrefix(candidateField.namespaceURI, candidateField.name, namespaceMap),
+      originalName: formatWithPrefix(wrapperField.namespaceURI, wrapperField.name, namespaceMap),
+    };
+    targetDocument.definition.fieldSubstitutions ??= [];
+    targetDocument.definition.fieldSubstitutions.push(entry);
+  }
+
+  private static tryAutoDetectChoiceSelection(
+    wrapperField: IField,
+    memberField: IField,
+    fieldItem: FieldItem,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): void {
+    if (wrapperField.selectedMemberIndex !== undefined) return;
+    if (!WrapperAutoDetectionService.isMaxOccursOne(wrapperField)) return;
+    if (!WrapperAutoDetectionService.isUniqueInWrapper(memberField, wrapperField)) return;
+    if (WrapperAutoDetectionService.hasConditionalWrapper(fieldItem)) return;
+    if (WrapperAutoDetectionService.hasExistingChoiceMetadata(wrapperField, targetDocument, namespaceMap)) return;
+
+    const memberIndex = wrapperField.fields.indexOf(memberField);
+    if (memberIndex < 0) return;
+
+    wrapperField.selectedMemberIndex = memberIndex;
+    fieldItem.isUserCreated = true;
+
+    const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
+    const entry: IChoiceSelection = {
+      schemaPath,
+      selectedMemberIndex: memberIndex,
+    };
+    targetDocument.definition.choiceSelections ??= [];
+    targetDocument.definition.choiceSelections.push(entry);
+  }
+
+  /**
+   * Detects non-abstract fields that were auto-substituted during deserialization (Phase A)
+   * but lack a corresponding `IFieldSubstitution` entry in the definition. Persists the entry
+   * if the auto-detection conditions are met.
+   */
+  private static tryPersistNonAbstractSubstitution(
+    fieldItem: FieldItem,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): void {
+    const field = fieldItem.field;
+    if (field.typeOverride !== FieldOverrideVariant.SUBSTITUTION) return;
+    if (!field.originalField) return;
+    if (!WrapperAutoDetectionService.isMaxOccursOne(field)) return;
+    if (WrapperAutoDetectionService.hasConditionalWrapper(fieldItem)) return;
+
+    ensureNamespaceRegistered(field.namespaceURI, namespaceMap, field.namespacePrefix ?? undefined);
+    ensureNamespaceRegistered(
+      field.originalField.namespaceURI,
+      namespaceMap,
+      field.originalField.namespacePrefix ?? undefined,
+    );
+
+    const schemaPath = SchemaPathService.buildOriginal(field, namespaceMap);
+
+    const existing = targetDocument.definition.fieldSubstitutions?.find((s) => s.schemaPath === schemaPath);
+    if (existing) return;
+
+    const entry: IFieldSubstitution = {
+      schemaPath,
+      name: formatWithPrefix(field.namespaceURI, field.name, namespaceMap),
+      originalName: formatWithPrefix(field.originalField.namespaceURI, field.originalField.name, namespaceMap),
+    };
+    targetDocument.definition.fieldSubstitutions ??= [];
+    targetDocument.definition.fieldSubstitutions.push(entry);
+  }
+
+  static hasConditionalWrapper(mappingItem: MappingItem): boolean {
+    let current: MappingParentType = mappingItem.parent;
+    while (current instanceof MappingItem) {
+      if (current instanceof IfItem || current instanceof WhenItem || current instanceof OtherwiseItem) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  private static isMaxOccursOne(field: IField): boolean {
+    return field.maxOccurs === 1;
+  }
+
+  static isUniqueInWrapper(identifyingField: IField, wrapperField: IField): boolean {
+    let count = 0;
+    for (const member of wrapperField.fields) {
+      if (member.name === identifyingField.name && member.namespaceURI === identifyingField.namespaceURI) {
+        count++;
+      }
+    }
+    return count === 1;
+  }
+
+  private static hasExistingSubstitutionMetadata(
+    wrapperField: IField,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): boolean {
+    if (!targetDocument.definition.fieldSubstitutions?.length) return false;
+    const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
+    return targetDocument.definition.fieldSubstitutions.some((s) => s.schemaPath === schemaPath);
+  }
+
+  private static hasExistingChoiceMetadata(
+    wrapperField: IField,
+    targetDocument: IDocument,
+    namespaceMap: Record<string, string>,
+  ): boolean {
+    if (!targetDocument.definition.choiceSelections?.length) return false;
+    const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
+    return targetDocument.definition.choiceSelections.some((s) => s.schemaPath === schemaPath);
+  }
+
+  private static markEmptyFieldItems(parent: MappingParentType): void {
+    for (const child of parent.children) {
+      if (child instanceof FieldItem && child.children.length === 0) {
+        child.isUserCreated = true;
+      }
+      WrapperAutoDetectionService.markEmptyFieldItems(child);
+    }
+  }
+}

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -301,6 +301,9 @@ export function getFieldSubstitutionNoNsXsd(): string {
 export function getChoiceWithAbstractXsd(): string {
   return readStubFile('./xml/ChoiceWithAbstract.xsd');
 }
+export function getNonAbstractSubstitutionXsd(): string {
+  return readStubFile('./xml/NonAbstractSubstitution.xsd');
+}
 export function getAnnotatedFieldsXsd(): string {
   return readStubFile('./xml/AnnotatedFields.xsd');
 }

--- a/packages/ui/src/stubs/datamapper/xml/NonAbstractSubstitution.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/NonAbstractSubstitution.xsd
@@ -1,0 +1,28 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.example.com/NONABSTRACT"
+           xmlns="http://www.example.com/NONABSTRACT"
+           elementFormDefault="qualified">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="HeadElement"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="HeadElement" type="HeadType"/>
+  <xs:element name="SubElement" type="SubType" substitutionGroup="HeadElement"/>
+  <xs:complexType name="HeadType">
+    <xs:sequence>
+      <xs:element name="base" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SubType">
+    <xs:complexContent>
+      <xs:extension base="HeadType">
+        <xs:sequence>
+          <xs:element name="extra" type="xs:string"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
…er field selections and substitutions

Fixes: https://github.com/KaotoIO/kaoto/issues/3410

Add capability to detect choice selection and substitution when deserializing XSLT. Apply them only when it's deterministic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic recognition of wrapper selections after importing/loading mappings, including abstract and choice wrapper cases.
  * Enhanced substitution-group handling during mapping import to better restore the correct target structure.
* **Bug Fixes**
  * Preserved existing selection/substitution metadata to prevent unintended overwrites on reload.
  * More accurately marks wrapper-less empty leaf items as user-created, and avoids auto-detection in conditional mapping paths or ambiguous/maxOccurs scenarios.
* **Tests**
  * Added comprehensive Jest coverage for wrapper auto-detection and related persistence/cloning behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->