### PR TITLE
feat(DataMapper): Add "Add copy-of" option in 3-dots mapping context …

### DIFF
--- a/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentA.xsd
+++ b/packages/ui-tests/cypress/fixtures/datamapper/xsd/MultiIncludeComponentA.xsd
@@ -6,7 +6,7 @@
   <xs:complexType name="TypeA">
     <xs:sequence>
       <xs:element name="fieldA1" type="xs:string"/>
-      <xs:element name="fieldA2" type="xs:int"/>
+      <xs:element name="fieldA2" type="xs:integer"/>
     </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -55,7 +55,7 @@ describe('MappingContextMenuAction', () => {
       new FieldItem(mappingTree, targetDoc.fields[0]),
     );
     const onUpdateMock = vi.fn();
-    const spyOnApply = vi.spyOn(MappingActionService, 'applyValueSelector');
+    const spyOnApply = vi.spyOn(MappingActionService, 'applyValueOfSelector');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
     act(() => {

--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -8,6 +8,7 @@ import type { TargetNodeData } from './visualization';
 export enum MappingActionKind {
   ContextMenu = 'conditionMenu',
   ValueSelector = 'valueSelector',
+  CopyOfSelector = 'copyOfSelector',
   If = 'if',
   Choose = 'choose',
   ForEach = 'forEach',

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -316,15 +316,27 @@ export class SortItem {
   }
 }
 
-/** Distinguishes how a {@link ValueSelector} produces its output in the generated XSLT. */
+/**
+ * Distinguishes how a {@link ValueSelector} produces its output in the generated XSLT
+ * and how it is rendered in the visualization tree.
+ *
+ * Rendering rules:
+ * - `VALUE` / `ATTRIBUTE` — always rendered **inline** (XPath input on the field row).
+ * - `CONTAINER` — always rendered **inline**. Used for 1-to-1 container copy-of
+ *   from DnD. `FieldItemHandler` skips target element creation so `xsl:copy-of`
+ *   appears directly under the parent XSLT element.
+ * - `CONTAINER_NODE` — always rendered as a dedicated **tree node**. Used for
+ *   explicit copy-of added from the context menu or xs:anyType mappings. Target
+ *   element is always created, with `xsl:copy-of` nested inside it.
+ */
 export enum ValueType {
-  /** Emits a text value via `xsl:value-of`. */
+  /** Emits a text value via `xsl:value-of`. Always rendered inline. */
   VALUE = 'value',
-  /** Emits a structured element container via `xsl:copy-of`. */
+  /** Emits `xsl:copy-of`. Always inline — `FieldItemHandler` skips target element creation. */
   CONTAINER = 'container',
-  /** Emits container children only via `xsl:copy-of select="path/node()"` (for xs:anyType scenarios). */
+  /** Emits `xsl:copy-of` inside a target element. Always rendered as a tree node. */
   CONTAINER_NODE = 'container_node',
-  /** Emits an XML attribute. */
+  /** Emits an XML attribute. Always rendered inline. */
   ATTRIBUTE = 'attribute',
 }
 
@@ -332,6 +344,10 @@ export enum ValueType {
  * Leaf node that supplies the value for a target {@link FieldItem}.
  * Serializes as `xsl:value-of` for scalar values and attributes,
  * or `xsl:copy-of` for container nodes, depending on {@link valueType}.
+ *
+ * A ValueSelector may render either inline on its parent field row or as a
+ * dedicated tree node in the target visualization. The rendering mode is
+ * determined solely by {@link valueType} — see {@link ValueType}.
  */
 export class ValueSelector extends MappingItem implements IExpressionHolder {
   constructor(

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -431,7 +431,7 @@ describe('MappingSerializerService', () => {
       expect(orderPersonSelect?.nodeValue).toBe('/ns0:ShipOrder/ns0:OrderPerson');
       const shipToSelect = xsltDocument
         .evaluate(
-          '/xsl:stylesheet/xsl:template/ShipOrder/xsl:copy-of/@select',
+          '/xsl:stylesheet/xsl:template/ShipOrder/ShipTo/xsl:copy-of/@select',
           xsltDocument,
           xslNsResolver,
           XPathResult.ORDERED_NODE_ITERATOR_TYPE,
@@ -723,8 +723,8 @@ describe('MappingSerializerService', () => {
       const xslIf = shipOrderSelect.iterateNext() as Element;
       expect(xslIf.nodeName).toBe('xsl:if');
       expect(xslIf.getAttribute('test')).toBe("/ns0:ShipOrder/ns0:OrderPerson != ''");
-      const copyOf = shipOrderSelect.iterateNext() as Element;
-      expect(copyOf.nodeName).toBe('xsl:copy-of');
+      const shipTo = shipOrderSelect.iterateNext() as Element;
+      expect(shipTo.nodeName).toBe('ShipTo');
       const xslForEach = shipOrderSelect.iterateNext() as Element;
       expect(xslForEach.nodeName).toBe('xsl:for-each');
       expect(xslForEach.getAttribute('select')).toBe('/ns0:ShipOrder/Item');

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -679,6 +679,9 @@ export class MappingService {
     const valueSelector = MappingService.ensureValueSelector(targetFieldItem, valueType);
     valueSelector.valueType = valueType;
     MappingService.applySourceExpression(source, targetFieldItem, valueSelector);
+    if (valueType === ValueType.CONTAINER_NODE && !valueSelector.expression.endsWith('/node()')) {
+      valueSelector.expression = `${valueSelector.expression}/node()`;
+    }
   }
 
   private static ensureValueSelector(targetFieldItem: MappingItem, valueType?: ValueType): ValueSelector {

--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -1,5 +1,6 @@
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IParentType } from '../../models/datamapper/document';
 import {
+  FieldItem,
   ForEachGroupItem,
   ForEachItem,
   GroupingStrategy,
@@ -7,6 +8,8 @@ import {
   MappingTree,
   SortItem,
   UnknownMappingItem,
+  ValueSelector,
+  ValueType,
 } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
 import {
@@ -26,6 +29,7 @@ import {
   serializeHandlers,
   SortItemHandler,
   UnknownMappingItemHandler,
+  ValueSelectorHandler,
 } from './xslt-item-handlers';
 
 describe('xslt-item-handlers registry', () => {
@@ -80,6 +84,101 @@ describe('FieldItemHandler', () => {
     expect('name' in field && field.name).toBe('newAttr');
     expect('isAttribute' in field && field.isAttribute).toBe(true);
     expect('namespaceURI' in field && field.namespaceURI).toBe('urn:test');
+  });
+});
+
+describe('FieldItemHandler copy-of with value-of', () => {
+  const handler = new FieldItemHandler();
+  const targetDoc = TestUtil.createTargetOrderDoc();
+
+  it('should create target element when both value-of and copy-of coexist', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+
+    const copyOf = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    copyOf.expression = '.';
+    fieldItem.children.push(copyOf);
+
+    const valueOf = new ValueSelector(fieldItem, ValueType.VALUE);
+    valueOf.expression = '/ns0:ShipOrder/ns0:OrderId';
+    fieldItem.children.push(valueOf);
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const result = handler.serialize(parent, fieldItem);
+
+    expect(result).not.toBe(parent);
+    expect(result.localName).toBe(targetDoc.fields[0].name);
+  });
+
+  it('should return parent element when only copy-of exists without child FieldItems or value-of', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+
+    const copyOf = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    copyOf.expression = '.';
+    fieldItem.children.push(copyOf);
+
+    const xslt = MappingSerializerService.createNew();
+    const parent = xslt.documentElement;
+    const result = handler.serialize(parent, fieldItem);
+
+    expect(result).toBe(parent);
+  });
+});
+
+describe('ValueSelectorHandler copy-of', () => {
+  const handler = new ValueSelectorHandler();
+  const targetDoc = TestUtil.createTargetOrderDoc();
+
+  it('should serialize CONTAINER_NODE without appending /node()', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+    vs.expression = '/ns0:Envelope/Payload/node()';
+
+    const xslt = MappingSerializerService.createNew();
+    const result = handler.serialize(xslt.documentElement, vs);
+    expect(result.getAttribute('select')).toBe('/ns0:Envelope/Payload/node()');
+  });
+
+  it('should serialize CONTAINER expression as-is', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    const vs = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    vs.expression = '/ns0:ShipOrder/Item';
+
+    const xslt = MappingSerializerService.createNew();
+    const result = handler.serialize(xslt.documentElement, vs);
+    expect(result.getAttribute('select')).toBe('/ns0:ShipOrder/Item');
+  });
+
+  it('should deserialize copy-of inside FieldItem as CONTAINER_NODE', () => {
+    const xslt = new DOMParser().parseFromString(
+      `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:copy-of select="/ns0:Envelope/Payload/node()"/></xsl:stylesheet>`,
+      'application/xml',
+    );
+    const element = xslt.getElementsByTagNameNS(NS_XSL, 'copy-of')[0];
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    const result = handler.deserialize(element, targetDoc.fields[0], fieldItem);
+    const mappingItem = result.mappingItem as ValueSelector;
+    expect(mappingItem.valueType).toBe(ValueType.CONTAINER_NODE);
+    expect(mappingItem.expression).toBe('/ns0:Envelope/Payload/node()');
+  });
+
+  it('should deserialize copy-of at parent level as CONTAINER', () => {
+    const xslt = new DOMParser().parseFromString(
+      `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:copy-of select="/ns0:ShipOrder/Item"/></xsl:stylesheet>`,
+      'application/xml',
+    );
+    const element = xslt.getElementsByTagNameNS(NS_XSL, 'copy-of')[0];
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const forEachItem = new ForEachItem(mappingTree);
+    const result = handler.deserialize(element, targetDoc.fields[0], forEachItem);
+    const mappingItem = result.mappingItem as ValueSelector;
+    expect(mappingItem.valueType).toBe(ValueType.CONTAINER);
+    expect(mappingItem.expression).toBe('/ns0:ShipOrder/Item');
   });
 });
 

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -31,10 +31,7 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
     const doc = parent.ownerDocument;
     if (mapping.valueType === ValueType.CONTAINER || mapping.valueType === ValueType.CONTAINER_NODE) {
       const copyOf = doc.createElementNS(NS_XSL, 'copy-of');
-      // For CONTAINER_NODE, append /node() to select only children (xs:anyType scenarios)
-      const selectExpression =
-        mapping.valueType === ValueType.CONTAINER_NODE ? `${mapping.expression}/node()` : mapping.expression;
-      copyOf.setAttribute('select', selectExpression);
+      copyOf.setAttribute('select', mapping.expression);
       parent.appendChild(copyOf);
       return copyOf;
     }
@@ -51,11 +48,9 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
   ): DeserializeItemResult<ValueSelector> {
     switch (element.localName) {
       case 'copy-of': {
-        const rawSelect = element.getAttribute('select') || '';
-        const isNodeCopy = rawSelect.endsWith('/node()');
-        const valueType = isNodeCopy ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
+        const valueType = parentMapping instanceof FieldItem ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
         const selector = new ValueSelector(parentMapping, valueType);
-        selector.expression = isNodeCopy ? rawSelect.slice(0, -7) : rawSelect;
+        selector.expression = element.getAttribute('select') || '';
         return { mappingItem: selector, fieldItem: null };
       }
       case 'text': {
@@ -94,7 +89,10 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
       (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER,
     );
     const hasChildFieldItems = mapping.children.some((c) => c instanceof FieldItem);
-    if (hasContainerCopyOf && !hasChildFieldItems) return parent;
+    const hasValueOf = mapping.children.some(
+      (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
+    );
+    if (hasContainerCopyOf && !hasChildFieldItems && !hasValueOf) return parent;
 
     const jsonElement = MappingSerializerJsonAddon.populateFieldItem(parent, mapping);
     if (jsonElement) return jsonElement;

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -802,6 +802,242 @@ describe('MappingActionService', () => {
       });
     });
 
+    describe('applyValueOfSelector()', () => {
+      it('should create VALUE ValueSelector for element field', () => {
+        expect(tree.children).toHaveLength(0);
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        expect(shipOrderChildren[1].title).toBe('OrderPerson');
+        MappingActionService.applyValueOfSelector(shipOrderChildren[1] as TargetNodeData);
+
+        const shipOrderFI = tree.children[0] as FieldItem;
+        const orderPersonFI = shipOrderFI.children[0] as FieldItem;
+        expect(orderPersonFI.children).toHaveLength(1);
+        const vs = orderPersonFI.children[0] as ValueSelector;
+        expect(vs).toBeInstanceOf(ValueSelector);
+        expect(vs.valueType).toBe(ValueType.VALUE);
+      });
+
+      it('should create ATTRIBUTE ValueSelector for attribute field', () => {
+        expect(tree.children).toHaveLength(0);
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        expect(shipOrderChildren[0].title).toBe('OrderId');
+        MappingActionService.applyValueOfSelector(shipOrderChildren[0] as TargetNodeData);
+
+        const shipOrderFI = tree.children[0] as FieldItem;
+        const orderIdFI = shipOrderFI.children[0] as FieldItem;
+        expect(orderIdFI.children).toHaveLength(1);
+        const vs = orderIdFI.children[0] as ValueSelector;
+        expect(vs).toBeInstanceOf(ValueSelector);
+        expect(vs.valueType).toBe(ValueType.ATTRIBUTE);
+      });
+
+      it('should prevent duplicate VALUE ValueSelector', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyValueOfSelector(shipOrderChildren[1] as TargetNodeData);
+        MappingActionService.applyValueOfSelector(shipOrderChildren[1] as TargetNodeData);
+
+        const shipOrderFI = tree.children[0] as FieldItem;
+        const orderPersonFI = shipOrderFI.children[0] as FieldItem;
+        const valueSelectors = orderPersonFI.children.filter(
+          (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
+        );
+        expect(valueSelectors).toHaveLength(1);
+      });
+    });
+
+    describe('applyCopyOfSelector()', () => {
+      it('should create CONTAINER_NODE ValueSelector', () => {
+        expect(tree.children).toHaveLength(0);
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyCopyOfSelector(shipOrderChildren[0] as TargetNodeData);
+
+        const shipOrderFI = tree.children[0] as FieldItem;
+        const orderIdFI = shipOrderFI.children[0] as FieldItem;
+        expect(orderIdFI.children).toHaveLength(1);
+        const vs = orderIdFI.children[0] as ValueSelector;
+        expect(vs).toBeInstanceOf(ValueSelector);
+        expect(vs.valueType).toBe(ValueType.CONTAINER_NODE);
+      });
+
+      it('should allow multiple CONTAINER_NODE ValueSelectors', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyCopyOfSelector(shipOrderChildren[1] as TargetNodeData);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const orderPersonNodeData = updatedShipOrderChildren.find(
+          (c) => c.title === 'OrderPerson',
+        ) as FieldItemNodeData;
+        MappingActionService.applyCopyOfSelector(orderPersonNodeData);
+
+        const shipOrderFI = tree.children[0] as FieldItem;
+        const orderPersonFI = shipOrderFI.children[0] as FieldItem;
+        const containerSelectors = orderPersonFI.children.filter(
+          (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE,
+        );
+        expect(containerSelectors).toHaveLength(2);
+      });
+    });
+
+    describe('hasValueOfSelector()', () => {
+      it('should return false when no ValueSelector exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        expect(MappingActionService.hasValueOfSelector(docChildren[0] as TargetNodeData)).toBe(false);
+      });
+
+      it('should return true when VALUE ValueSelector exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyValueOfSelector(shipOrderChildren[0] as TargetNodeData);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        expect(MappingActionService.hasValueOfSelector(updatedShipOrderChildren[0] as TargetNodeData)).toBe(true);
+      });
+
+      it('should return false when only CONTAINER ValueSelector exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyCopyOfSelector(shipOrderChildren[0] as TargetNodeData);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        expect(MappingActionService.hasValueOfSelector(updatedShipOrderChildren[0] as TargetNodeData)).toBe(false);
+      });
+    });
+
+    describe('removeParentContainerCopyOf via engageMapping', () => {
+      it('should remove copy-of when child field is mapped via DnD', () => {
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceDocChildren[0]);
+        const sourceItem = sourceShipOrderChildren[3] as FieldNodeData;
+
+        let targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        let targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetItem = targetShipOrderChildren[3] as TargetFieldNodeData;
+        MappingActionService.engageMapping(tree, sourceItem, targetItem);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const forEachNode = targetShipOrderChildren[3] as MappingNodeData;
+        const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachNode);
+        const itemNode = forEachChildren[0] as FieldItemNodeData;
+        const itemMapping = itemNode.mapping;
+        expect(
+          itemMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+        ).toBe(true);
+
+        const sourceItemChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceShipOrderChildren[3]);
+        const sourceTitleField = sourceItemChildren[0] as FieldNodeData;
+        const targetItemChildren = VisualizationService.generateNonDocumentNodeDataChildren(itemNode);
+        const targetTitleField = targetItemChildren[0] as TargetFieldNodeData;
+        MappingActionService.engageMapping(tree, sourceTitleField, targetTitleField);
+
+        expect(
+          itemMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+        ).toBe(false);
+        expect(itemMapping.children.some((c) => c instanceof FieldItem && c.field.name === 'Title')).toBe(true);
+      });
+
+      it('should preserve explicit CONTAINER_NODE copy-of when child field is mapped via DnD', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const targetShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const targetShipTo = targetShipOrderChildren.find(
+          (c) => c instanceof TargetFieldNodeData && c.field.name === 'ShipTo',
+        ) as TargetFieldNodeData;
+        MappingActionService.applyCopyOfSelector(targetShipTo);
+
+        const shipOrderMapping = tree.children[0] as FieldItem;
+        const shipToMapping = shipOrderMapping.children.find(
+          (c) => c instanceof FieldItem && c.field.name === 'ShipTo',
+        ) as FieldItem;
+        expect(
+          shipToMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE),
+        ).toBe(true);
+
+        const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
+        const sourceShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceDocChildren[0]);
+        const sourceShipTo = sourceShipOrderChildren.find(
+          (c) => c instanceof FieldNodeData && c.field.name === 'ShipTo',
+        ) as FieldNodeData;
+        const sourceShipToChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceShipTo);
+        const sourceNameField = sourceShipToChildren[0] as FieldNodeData;
+
+        const updatedTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(updatedTargetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const updatedShipToNode = updatedShipOrderChildren.find(
+          (c) => c instanceof FieldItemNodeData && c.field.name === 'ShipTo',
+        ) as FieldItemNodeData;
+        const shipToNodeChildren = VisualizationService.generateNonDocumentNodeDataChildren(updatedShipToNode);
+        const targetNameField = shipToNodeChildren.find(
+          (c) => c instanceof TargetFieldNodeData && c.field.name === 'Name',
+        ) as TargetFieldNodeData;
+        MappingActionService.engageMapping(tree, sourceNameField, targetNameField);
+
+        expect(
+          shipToMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE),
+        ).toBe(true);
+        expect(shipToMapping.children.some((c) => c instanceof FieldItem && c.field.name === 'Name')).toBe(true);
+      });
+    });
+
+    describe('getMappingContextMenuItems() copy-of', () => {
+      it('should include CopyOfSelector in context menu items', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderChildren[0] as TargetNodeData);
+        const copyOfAction = menuItems.find((item) => item.key === MappingActionKind.CopyOfSelector);
+        expect(copyOfAction).toBeDefined();
+        expect(copyOfAction!.getLabel(shipOrderChildren[0] as TargetNodeData)).toBe('Add copy selector (copy-of)');
+        expect(copyOfAction!.testId).toBe('transformation-actions-copy-of');
+      });
+
+      it('should include renamed ValueSelector label in context menu items', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderChildren[0] as TargetNodeData);
+        const valueSelectorAction = menuItems.find((item) => item.key === MappingActionKind.ValueSelector);
+        expect(valueSelectorAction).toBeDefined();
+        expect(valueSelectorAction!.getLabel(shipOrderChildren[0] as TargetNodeData)).toBe(
+          'Add value selector (value-of)',
+        );
+      });
+
+      it('should disable ValueSelector when value-of already exists but not CopyOfSelector', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyValueOfSelector(shipOrderChildren[0] as TargetNodeData);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const menuItems = MappingActionService.getMappingContextMenuItems(
+          updatedShipOrderChildren[0] as TargetNodeData,
+        );
+        const valueSelectorAction = menuItems.find((item) => item.key === MappingActionKind.ValueSelector);
+        expect(valueSelectorAction!.isDisabled!(updatedShipOrderChildren[0] as TargetNodeData)).toBe(true);
+        const copyOfAction = menuItems.find((item) => item.key === MappingActionKind.CopyOfSelector);
+        expect(copyOfAction!.isDisabled).toBeUndefined();
+      });
+    });
+
     describe('getExpressionItemForNode()', () => {
       it('should return ValueSelector for primitive target body', () => {
         const primitiveTargetDoc = new PrimitiveDocument(
@@ -1072,9 +1308,11 @@ describe('MappingActionService', () => {
         expect(forEachItem).toBeDefined();
         expect(forEachItem.expression).toBe('/ns0:ShipOrder/Item');
 
-        expect(forEachItem.children.some((c) => c instanceof FieldItem)).toBeFalsy();
+        const innerFieldItem = forEachItem.children.find((c) => c instanceof FieldItem) as FieldItem;
+        expect(innerFieldItem).toBeDefined();
+        expect(innerFieldItem.field.name).toBe('Item');
 
-        const copyOf = forEachItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        const copyOf = innerFieldItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
         expect(copyOf).toBeDefined();
         expect(copyOf.expression).toBe('.');
       });
@@ -1248,6 +1486,7 @@ describe('MappingActionService', () => {
         const copyOf = itemFieldItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
         expect(copyOf).toBeDefined();
         expect(copyOf.valueType).toEqual(ValueType.CONTAINER_NODE);
+        expect(copyOf.expression).toMatch(/\/node\(\)$/);
       });
     });
 
@@ -1421,6 +1660,7 @@ describe('MappingActionService', () => {
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.Choose);
         expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ContextMenu);
         expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.ValueSelector);
+        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.CopyOfSelector);
       });
 
       it('should allow Delete for a field node added via Add Mapping', () => {

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -62,6 +62,14 @@ export class MappingActionService {
     return nodeData.mapping?.children.some((c) => c instanceof ValueSelector) ?? false;
   }
 
+  static hasValueOfSelector(nodeData: TargetNodeData) {
+    return (
+      nodeData.mapping?.children.some(
+        (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
+      ) ?? false
+    );
+  }
+
   /**
    * Removes the mapping item associated with the node from the mapping tree.
    * No-op if the node has no mapping.
@@ -309,6 +317,34 @@ export class MappingActionService {
     }
   }
 
+  static applyValueOfSelector(nodeData: TargetNodeData) {
+    const mapping =
+      nodeData instanceof TargetFieldNodeData && !nodeData.mapping
+        ? MappingActionService.getOrCreateFieldItem(nodeData)
+        : nodeData.mapping;
+    if (!mapping) return;
+    const hasExisting = mapping.children.some(
+      (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
+    );
+    if (hasExisting) return;
+    const valueType =
+      nodeData instanceof TargetFieldNodeData && nodeData.field.isAttribute ? ValueType.ATTRIBUTE : ValueType.VALUE;
+    const valueSelector = new ValueSelector(mapping, valueType);
+    mapping.children.push(valueSelector);
+    useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
+  }
+
+  static applyCopyOfSelector(nodeData: TargetNodeData) {
+    const mapping =
+      nodeData instanceof TargetFieldNodeData && !nodeData.mapping
+        ? MappingActionService.getOrCreateFieldItem(nodeData)
+        : nodeData.mapping;
+    if (!mapping) return;
+    const copyOfSelector = new ValueSelector(mapping, ValueType.CONTAINER_NODE);
+    mapping.children.push(copyOfSelector);
+    useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
+  }
+
   /**
    * Creates a mapping connection from a source node to a target node in the mapping tree.
    * Handles choice-to-field mappings (auto-generating choose/when/otherwise) as well as
@@ -334,6 +370,7 @@ export class MappingActionService {
 
     if (MappingActionService.isFieldNode(targetNode)) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
+      MappingActionService.removeParentContainerCopyOf(item);
       MappingService.mapToField(sourceField, item);
     } else if (targetNode instanceof MappingNodeData) {
       MappingService.mapToCondition(targetNode.mapping, sourceField);
@@ -481,11 +518,11 @@ export class MappingActionService {
     const forEachItem = new ForEachItem(parentOfItem);
     MappingService.mapToCondition(forEachItem, sourceField);
 
+    const innerFieldItem = MappingService.createFieldItem(forEachItem, targetField);
     if (FieldMatchingService.canUseCopyOf(sourceField, targetField)) {
       const valueType = MappingService.getContainerValueType(sourceField, targetField);
-      MappingService.mapToFieldWithValueType(sourceField, forEachItem, valueType);
+      MappingService.mapToFieldWithValueType(sourceField, innerFieldItem, valueType);
     } else {
-      const innerFieldItem = MappingService.createFieldItem(forEachItem, targetField);
       MappingService.generateAutoChildMappings(sourceField, targetField, innerFieldItem);
     }
 
@@ -560,6 +597,14 @@ export class MappingActionService {
     }
     const parentItem = MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
     return MappingService.createFieldItem(parentItem, fieldNodeData.field);
+  }
+
+  private static removeParentContainerCopyOf(item: MappingItem): void {
+    const parent = item.parent;
+    if (!(parent instanceof MappingItem)) return;
+    parent.children = parent.children.filter(
+      (c) => !(c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+    );
   }
 
   private static allowForEachCurrentGroup(nodeData: TargetNodeData): boolean {
@@ -655,9 +700,9 @@ export class MappingActionService {
     {
       key: MappingActionKind.ValueSelector,
       testId: 'transformation-actions-selector',
-      getLabel: () => 'Add selector expression',
+      getLabel: () => 'Add value selector (value-of)',
       apply: (n, { onUpdate }) => {
-        MappingActionService.applyValueSelector(n);
+        MappingActionService.applyValueOfSelector(n);
         onUpdate();
       },
       isAllowed: (n) => {
@@ -671,7 +716,27 @@ export class MappingActionService {
           UnknownMappingItem,
         )(n);
       },
-      isDisabled: (n) => MappingActionService.hasValueSelector(n),
+      isDisabled: (n) => MappingActionService.hasValueOfSelector(n),
+    },
+    {
+      key: MappingActionKind.CopyOfSelector,
+      testId: 'transformation-actions-copy-of',
+      getLabel: () => 'Add copy selector (copy-of)',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyCopyOfSelector(n);
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        if (!MappingActionService.isMappingNode(n)) return true;
+        return !MappingActionService.mappingIsOneOf(
+          ValueSelector,
+          ForEachItem,
+          ForEachGroupItem,
+          ChooseItem,
+          UnknownMappingItem,
+        )(n);
+      },
     },
     {
       key: MappingActionKind.When,

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -764,7 +764,7 @@ describe('MappingLinksService', () => {
       }
     });
 
-    it('should classify copy-of with CONTAINER_NODE as PARTIAL (inherits from parent)', () => {
+    it('should classify copy-of with CONTAINER_NODE as COPY_OF', () => {
       const manualTree = new MappingTree(
         targetDoc.documentType,
         targetDoc.documentId,
@@ -784,7 +784,8 @@ describe('MappingLinksService', () => {
 
       const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
       expect(links).toHaveLength(1);
-      expect(links[0].lineStyle).toBe(MappingLineStyle.PARTIAL);
+      expect(links[0].lineStyle).toBe(MappingLineStyle.COPY_OF);
+      expect(links[0].targetNodePath).toContain(vs.id);
     });
   });
 

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -66,7 +66,8 @@ export class MappingLinksService {
         if (
           item instanceof FieldItem &&
           !(item.field.ownerDocument instanceof PrimitiveDocument) &&
-          child instanceof ValueSelector
+          child instanceof ValueSelector &&
+          child.valueType !== ValueType.CONTAINER_NODE
         ) {
           const links = MappingLinksService.doExtractMappingLinks(
             child,
@@ -222,7 +223,11 @@ export class MappingLinksService {
     const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
 
     const vs = item.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
-    if (childFieldItems.length === 0 && vs?.valueType === ValueType.CONTAINER) {
+    if (
+      childFieldItems.length === 0 &&
+      vs &&
+      (vs.valueType === ValueType.CONTAINER || vs.valueType === ValueType.CONTAINER_NODE)
+    ) {
       return MappingLineStyle.COPY_OF;
     }
 

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -4,6 +4,7 @@ import {
   DocumentDefinitionType,
   DocumentType,
   IDocument,
+  PrimitiveDocument,
 } from '../../models/datamapper/document';
 import {
   ChooseItem,
@@ -12,6 +13,7 @@ import {
   IfItem,
   MappingTree,
   ValueSelector,
+  ValueType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import {
@@ -612,6 +614,81 @@ describe('VisualizationService', () => {
       const result = VisualizationService.validateParameterName('my param', new Map());
       expect(result.status).toEqual(NameValidationStatus.ERROR);
       expect(result.error).toContain('valid QName');
+    });
+  });
+
+  describe('isInlineValueSelector()', () => {
+    it('should return true for VALUE ValueSelector', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueSelector(fieldItem, ValueType.VALUE);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
+    });
+
+    it('should return true for ATTRIBUTE ValueSelector', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueSelector(fieldItem, ValueType.ATTRIBUTE);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
+    });
+
+    it('should return true for CONTAINER ValueSelector', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
+    });
+
+    it('should return false for CONTAINER_NODE ValueSelector', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(false);
+    });
+
+    it('should return false for non-ValueSelector MappingItem', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      expect(VisualizationService.isInlineValueSelector(fieldItem)).toBe(false);
+    });
+  });
+
+  describe('copy-of tree-node rendering', () => {
+    it('should show CONTAINER_NODE copy-of as tree node in hasChildren', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(fieldItem);
+      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+      fieldItem.children.push(vs);
+      targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+      expect(VisualizationService.hasChildren(docChildren[0])).toBe(true);
+    });
+
+    it('should not show inline VALUE ValueSelector as tree node child', () => {
+      const shipOrderFI = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(shipOrderFI);
+      const orderPersonField = targetDoc.fields[0].fields[0];
+      const orderPersonFI = new FieldItem(shipOrderFI, orderPersonField);
+      shipOrderFI.children.push(orderPersonFI);
+      const vs = new ValueSelector(orderPersonFI, ValueType.VALUE);
+      orderPersonFI.children.push(vs);
+      targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+      const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+      const orderPersonNode = shipOrderChildren.find((c) => c.title === orderPersonField.name) as FieldItemNodeData;
+      expect(VisualizationService.hasChildren(orderPersonNode)).toBe(false);
+    });
+
+    it('should show CONTAINER_NODE copy-of as tree node in primitive document children', () => {
+      const primitiveTargetDoc = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+      const primitiveTree = new MappingTree(
+        primitiveTargetDoc.documentType,
+        primitiveTargetDoc.documentId,
+        DocumentDefinitionType.Primitive,
+      );
+      const vs = new ValueSelector(primitiveTree, ValueType.CONTAINER_NODE);
+      primitiveTree.children.push(vs);
+      const primitiveDocNode = new TargetDocumentNodeData(primitiveTargetDoc, primitiveTree);
+      const children = VisualizationService.generatePrimitiveDocumentChildren(primitiveDocNode);
+      const copyOfNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof ValueSelector);
+      expect(copyOfNode).toBeDefined();
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -11,6 +11,7 @@ import {
   MappingTree,
   UnknownMappingItem,
   ValueSelector,
+  ValueType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import {
@@ -114,7 +115,7 @@ export class VisualizationService {
   static generatePrimitiveDocumentChildren(document: DocumentNodeData): NodeData[] {
     if (!(document instanceof TargetDocumentNodeData) || !document.mapping?.children) return [];
     return document.mapping.children
-      .filter((child) => !(child instanceof ValueSelector))
+      .filter((child) => !VisualizationService.isInlineValueSelector(child))
       .map((child) => VisualizationService.createNodeDataFromMappingItem(document, child));
   }
 
@@ -181,7 +182,8 @@ export class VisualizationService {
     if (mappings) {
       let filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof VariableItem;
       if (parent.isPrimitive) {
-        filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof ValueSelector;
+        filterPriorityMappingItem = (m: MappingItem) =>
+          m instanceof UnknownMappingItem || VisualizationService.isInlineValueSelector(m);
       }
       for (const m of mappings.filter(filterPriorityMappingItem)) {
         answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m));
@@ -227,7 +229,7 @@ export class VisualizationService {
         if (
           !rendered.has(m) &&
           !(m instanceof FieldItem) &&
-          !(m instanceof ValueSelector) &&
+          !VisualizationService.isInlineValueSelector(m) &&
           !(m instanceof VariableItem) &&
           !(m instanceof UnknownMappingItem)
         ) {
@@ -377,7 +379,7 @@ export class VisualizationService {
       if (DocumentService.hasFields(nodeData.document)) return true;
       const isPrimitiveDocument = nodeData instanceof TargetDocumentNodeData && nodeData.isPrimitive;
       const isPrimitiveDocumentWithConditionItem =
-        isPrimitiveDocument && nodeData.mapping.children.some((m) => !(m instanceof ValueSelector));
+        isPrimitiveDocument && nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m));
       if (isPrimitiveDocumentWithConditionItem) return true;
     }
     if (nodeData instanceof FieldNodeData) {
@@ -389,7 +391,7 @@ export class VisualizationService {
     if (nodeData instanceof FieldItemNodeData)
       return (
         DocumentService.hasChildren(nodeData.field) ||
-        nodeData.mapping.children.some((m) => !(m instanceof ValueSelector))
+        nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
       );
     if (nodeData instanceof MappingNodeData) return nodeData.mapping.children.length > 0;
     return false;
@@ -419,9 +421,16 @@ export class VisualizationService {
     return VisualizationService.getFieldValueSelector(nodeData);
   }
 
+  static isInlineValueSelector(item: MappingItem): item is ValueSelector {
+    if (!(item instanceof ValueSelector)) return false;
+    return item.valueType !== ValueType.CONTAINER_NODE;
+  }
+
   private static getFieldValueSelector(nodeData: TargetNodeData) {
     if (nodeData.mapping instanceof FieldItem || nodeData.mapping instanceof MappingTree) {
-      return nodeData.mapping.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      return nodeData.mapping.children.find((c) => VisualizationService.isInlineValueSelector(c)) as
+        | ValueSelector
+        | undefined;
     }
   }
 


### PR DESCRIPTION
…menu

Fixes: https://github.com/KaotoIO/kaoto/issues/3347

- Add "Add copy selector (copy-of)" mapping context menu
- Rename "Add selector expression" to "Add value selector (value-of)"
- Repurpose CONTAINER/CONTAINER_NODE semantics: CONTAINER is always inline (1-to-1 DnD copy-of), CONTAINER_NODE is always a tree node (explicit menu copy-of and xs:anyType mappings)
- Make copy-of expression WYSIWYG — stop silently appending/stripping `/node()` during XSLT serialization/deserialization so the UI matches the generated XSLT
- Remove inline copy-of from parent when child field mapping is added via DnD, since they are mutually exclusive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **copy-of** action (new selector action kind) alongside **value-of**; **value-of**/ **copy-of** behavior is now clearly separated in UI actions and context menus.
  * Improved “copy-of” visualization for container-node selectors, including enhanced mapping links.
  * Collection mappings better support copy-of by mapping into an inner field item when applicable.
* **Bug Fixes**
  * Corrected XSLT serialization/deserialization and XPath handling for container/container-node selectors.
  * Prevented duplicate value-of selectors and improved selector cleanup during remapping.
* **Documentation**
  * Expanded comments clarifying `ValueType` and `ValueSelector` rendering rules.
* **Tests**
  * Updated and extended coverage for copy-of/value-of serialization, deserialization, and visualization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->