### PR TITLE
fix(RestDslEditor): make method badge non-interactive

### DIFF
--- a/packages/ui/src/pages/RestDslEditor/components/MethodBadge.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/MethodBadge.test.tsx
@@ -32,4 +32,10 @@ describe('MethodBadge', () => {
     render(<MethodBadge type="patch" />);
     expect(screen.getByText('PATCH')).toBeInTheDocument();
   });
+
+  it('does not render a focusable element since the badge is decorative', () => {
+    const { container } = render(<MethodBadge type="get" />);
+
+    expect(container.querySelector('button')).toBeNull();
+  });
 });

--- a/packages/ui/src/pages/RestDslEditor/components/MethodBadge.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/MethodBadge.tsx
@@ -1,6 +1,6 @@
 import './MethodBadge.scss';
 
-import { OperationalTag } from '@carbon/react';
+import { Tag } from '@carbon/react';
 import { FunctionComponent } from 'react';
 
 type MethodBadgeProps = {
@@ -11,9 +11,11 @@ type MethodBadgeProps = {
 /**
  * Displays a colored badge for HTTP method types.
  * Each method type is assigned a specific color for visual distinction.
+ * The badge is purely decorative, so it renders a non-interactive Tag that
+ * doesn't receive keyboard focus.
  */
 export const MethodBadge: FunctionComponent<MethodBadgeProps> = ({ type }) => {
-  let badgeType = 'gray';
+  let badgeType: 'blue' | 'cyan' | 'green' | 'red' | 'teal' | 'gray' = 'gray';
 
   switch (type) {
     case 'get':
@@ -37,7 +39,9 @@ export const MethodBadge: FunctionComponent<MethodBadgeProps> = ({ type }) => {
 
   return (
     <div className="method-badge">
-      <OperationalTag size="md" text={type.toUpperCase()} type={badgeType} />
+      <Tag size="md" type={badgeType}>
+        {type.toUpperCase()}
+      </Tag>
     </div>
   );
 };


### PR DESCRIPTION
## What

Renders the REST DSL editor's HTTP method badge with Carbon's non-interactive `Tag` instead of `OperationalTag`.

`OperationalTag` renders a focusable `<button>`, so every operation row in the REST tree added a keyboard tab stop that performs no action: keyboard users had to Tab through one dead stop per operation, and screen readers announced an interactive element with no behavior (WCAG 2.4.3 Focus Order, 4.1.2 Name/Role/Value). The badge is purely decorative — the module README describes it as a "Visual badge component displaying HTTP method types with color coding" — so it shouldn't participate in the tab order at all.

The same color `type` values are supported by `Tag`, so the visual appearance is unchanged; `badgeType` is now typed to the union `Tag` expects.

## Testing

- New unit test asserting the badge renders no focusable element.
- Existing `MethodBadge` tests pass unchanged (7/7).
- `eslint` and `tsc --noEmit` clean.

Fixes #3467

---

Prepared with AI assistance (Claude Code); reviewed and submitted by a human contributor, per CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP method badges to be decorative and non-interactive, preventing them from receiving keyboard focus.

* **Tests**
  * Added coverage verifying that method badges no longer render as focusable buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->