### PR TITLE
feat(mithril): epic2 CustomModeVisualEntity Implementation

### DIFF
--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
@@ -1,0 +1,17 @@
+import { CustomInstructionsParser } from './custom-instructions-parser';
+
+describe('CustomInstructionsParser (stub)', () => {
+  describe('parse', () => {
+    it('returns an empty array for any input', () => {
+      expect(CustomInstructionsParser.parse('## Step 1\nsome content')).toEqual([]);
+      expect(CustomInstructionsParser.parse('')).toEqual([]);
+    });
+  });
+
+  describe('serialize', () => {
+    it('returns an empty string for any input', () => {
+      expect(CustomInstructionsParser.serialize([{ nodeType: 'section', rawContent: '## Step 1' }])).toBe('');
+      expect(CustomInstructionsParser.serialize([])).toBe('');
+    });
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
@@ -1,0 +1,24 @@
+/** Represents a single parsed node from a customInstructions string.
+ *  nodeType is the opaque key name (defined in Epic 7). */
+export interface CustomInstructionsNode {
+  nodeType: string;
+  rawContent: string;
+}
+
+/**
+ * Parses and serializes the `customInstructions` field of a CustomMode.
+ * Stub — Epic 7 replaces parse() and serialize() with real implementations.
+ */
+export class CustomInstructionsParser {
+  /** Stub: always returns an empty array. */
+  static parse(_raw: string): CustomInstructionsNode[] {
+    // TODO: Epic 7 — implement real parsing
+    return [];
+  }
+
+  /** Stub: always returns an empty string. */
+  static serialize(_nodes: CustomInstructionsNode[]): string {
+    // TODO: Epic 7 — implement real serialization
+    return '';
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -1,54 +1,230 @@
 import { EntityType } from '../entities';
+import { AddStepMode } from '../visualization/base-visual-entity';
 import { CustomMode } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
 
-const sampleMode: CustomMode = {
-  slug: 'plan',
-  name: 'Plan',
-  description: 'Planning mode',
-  roleDefinition: 'You plan things.',
-  whenToUse: 'When planning.',
+const makeMode = (overrides?: Partial<CustomMode>): CustomMode => ({
+  slug: 'test-mode',
+  name: 'Test Mode',
+  description: 'A test mode',
+  roleDefinition: 'You are a test assistant.',
+  whenToUse: 'Use this for testing.',
   groups: ['read'],
-};
+  ...overrides,
+});
 
 describe('CustomModeVisualEntity', () => {
   let entity: CustomModeVisualEntity;
 
   beforeEach(() => {
-    entity = new CustomModeVisualEntity(sampleMode);
+    entity = new CustomModeVisualEntity(makeMode());
   });
 
-  it('has a non-empty id', () => {
-    expect(entity.id).toBeTruthy();
+  describe('constructor', () => {
+    it('sets id from mode slug', () => {
+      expect(entity.id).toBe('test-mode');
+    });
+
+    it('sets type to EntityType.CustomMode', () => {
+      expect(entity.type).toBe(EntityType.CustomMode);
+    });
+
+    it('generates a fallback id when slug is missing and writes it back to mode.slug', () => {
+      const e = new CustomModeVisualEntity(makeMode({ slug: undefined as unknown as string }));
+      expect(e.id).toMatch(/^custom-mode-/);
+      expect(e.toJSON().slug).toBe(e.id);
+    });
   });
 
-  it('has type EntityType.CustomMode', () => {
-    expect(entity.type).toBe(EntityType.CustomMode);
+  describe('getRootPath', () => {
+    it('returns customMode', () => {
+      expect(entity.getRootPath()).toBe('customMode');
+    });
   });
 
-  it('toJSON returns the raw CustomMode object', () => {
-    expect(entity.toJSON()).toEqual(sampleMode);
+  describe('getId / setId', () => {
+    it('getId returns the entity id', () => {
+      expect(entity.getId()).toBe('test-mode');
+    });
+
+    it('setId updates id and mode.slug', () => {
+      entity.setId('new-slug');
+      expect(entity.id).toBe('new-slug');
+      expect(entity.toJSON().slug).toBe('new-slug');
+    });
   });
 
-  it('getId returns the same id as the id property', () => {
-    expect(entity.getId()).toBe(entity.id);
+  describe('getNodeLabel', () => {
+    it('returns mode name for root path', () => {
+      expect(entity.getNodeLabel('customMode')).toBe('Test Mode');
+    });
+
+    it('falls back to id when name is empty', () => {
+      const e = new CustomModeVisualEntity(makeMode({ name: '' }));
+      expect(e.getNodeLabel('customMode')).toBe('test-mode');
+    });
+
+    it('returns last segment for customInstructions paths', () => {
+      expect(entity.getNodeLabel('customMode.customInstructions.0.section')).toBe('section');
+    });
+
+    it('returns empty string for unrecognised paths', () => {
+      expect(entity.getNodeLabel('something.else')).toBe('');
+      expect(entity.getNodeLabel(undefined)).toBe('');
+    });
   });
 
-  it('setId updates the id', () => {
-    entity.setId('my-id');
-    expect(entity.id).toBe('my-id');
-    expect(entity.getId()).toBe('my-id');
+  describe('getNodeSchema', () => {
+    it('returns root schema for customMode path', () => {
+      const schema = entity.getNodeSchema('customMode');
+      expect(schema).toBeDefined();
+      expect(schema!.type).toBe('object');
+      expect(schema!.properties).toHaveProperty('slug');
+      expect(schema!.properties).toHaveProperty('groups');
+    });
+
+    it('returns undefined for customInstructions child paths (stub)', () => {
+      expect(entity.getNodeSchema('customMode.customInstructions.0.section')).toBeUndefined();
+    });
+
+    it('returns undefined for unrecognised paths', () => {
+      expect(entity.getNodeSchema('other')).toBeUndefined();
+      expect(entity.getNodeSchema(undefined)).toBeUndefined();
+    });
   });
 
-  it('getRootPath returns "customMode"', () => {
-    expect(entity.getRootPath()).toBe('customMode');
+  describe('getNodeDefinition', () => {
+    it('returns mode object without customInstructions for root path', () => {
+      const def = entity.getNodeDefinition('customMode') as CustomMode;
+      expect(def.slug).toBe('test-mode');
+      expect((def as unknown as Record<string, unknown>).customInstructions).toBeUndefined();
+    });
+
+    it('returns undefined for unrecognised paths', () => {
+      expect(entity.getNodeDefinition('other')).toBeUndefined();
+      expect(entity.getNodeDefinition(undefined)).toBeUndefined();
+    });
   });
 
-  it('getOmitFormFields returns empty array', () => {
-    expect(entity.getOmitFormFields()).toEqual([]);
+  describe('getOmitFormFields', () => {
+    it('includes customInstructions', () => {
+      expect(entity.getOmitFormFields()).toContain('customInstructions');
+    });
   });
 
-  it('getNodeLabel returns slug', () => {
-    expect(entity.getNodeLabel()).toBe('plan');
+  describe('updateModel', () => {
+    it('updates mode fields and keeps id in sync when slug changes', () => {
+      entity.updateModel('customMode', { slug: 'updated-slug', name: 'Updated' });
+      expect(entity.id).toBe('updated-slug');
+      expect(entity.toJSON().name).toBe('Updated');
+    });
+
+    it('updates name without touching slug', () => {
+      entity.updateModel('customMode', { name: 'Only Name Changed' });
+      expect(entity.id).toBe('test-mode');
+      expect(entity.toJSON().name).toBe('Only Name Changed');
+    });
+
+    it('is a no-op for unrecognised paths', () => {
+      entity.updateModel('other.path', { name: 'Should Not Apply' });
+      expect(entity.toJSON().name).toBe('Test Mode');
+    });
+
+    it('is a no-op when path is undefined', () => {
+      entity.updateModel(undefined, { name: 'Should Not Apply' });
+      expect(entity.toJSON().name).toBe('Test Mode');
+    });
+  });
+
+  describe('toJSON', () => {
+    it('returns the underlying CustomMode object', () => {
+      const json = entity.toJSON();
+      expect(json.slug).toBe('test-mode');
+      expect(json.groups).toEqual(['read']);
+    });
+  });
+
+  describe('getNodeInteraction', () => {
+    it('canRemoveFlow true only for mode node (isGroup false, root path)', () => {
+      const interaction = entity.getNodeInteraction({ path: 'customMode', isGroup: false } as never);
+      expect(interaction.canRemoveFlow).toBe(true);
+      expect(interaction.canRemoveStep).toBe(false);
+      expect(interaction.canHaveChildren).toBe(false);
+      expect(interaction.canBeDisabled).toBe(false);
+    });
+
+    it('canRemoveFlow false for group node (isGroup true, root path)', () => {
+      const interaction = entity.getNodeInteraction({ path: 'customMode', isGroup: true } as never);
+      expect(interaction.canRemoveFlow).toBe(false);
+    });
+
+    it('all false for customInstructions siblings', () => {
+      const interaction = entity.getNodeInteraction({
+        path: 'customMode.customInstructions.0.section',
+        isGroup: false,
+      } as never);
+      expect(interaction.canRemoveFlow).toBe(false);
+      expect(interaction.canRemoveStep).toBe(false);
+    });
+  });
+
+  describe('canDragNode / canDropOnNode / getCopiedContent', () => {
+    it('always returns false / undefined', () => {
+      expect(entity.canDragNode()).toBe(false);
+      expect(entity.canDragNode('customMode')).toBe(false);
+      expect(entity.canDropOnNode()).toBe(false);
+      expect(entity.getCopiedContent('customMode')).toBeUndefined();
+    });
+  });
+
+  describe('addStep / removeStep / pasteStep', () => {
+    it('addStep is a no-op', () => {
+      expect(() => {
+        entity.addStep({ definedComponent: {} as never, mode: AddStepMode.AppendStep, data: {} as never });
+      }).not.toThrow();
+    });
+
+    it('removeStep is a no-op', () => {
+      expect(() => {
+        entity.removeStep('customMode.customInstructions.0.section');
+      }).not.toThrow();
+    });
+
+    it('pasteStep is a no-op', () => {
+      expect(() => {
+        entity.pasteStep({ clipboardContent: {} as never, mode: AddStepMode.AppendStep, data: {} as never });
+      }).not.toThrow();
+    });
+  });
+
+  describe('toVizNode', () => {
+    it('returns a mode group node with isGroup true', async () => {
+      const groupNode = await entity.toVizNode();
+      expect(groupNode.data.isGroup).toBe(true);
+      expect(groupNode.data.path).toBe('customMode');
+    });
+
+    it('mode group node has two children: mode node and placeholder', async () => {
+      const groupNode = await entity.toVizNode();
+      expect(groupNode.getChildren()).toHaveLength(2);
+    });
+
+    it('first child is the mode node (isGroup false, same path)', async () => {
+      const modeNode = (await entity.toVizNode()).getChildren()![0];
+      expect(modeNode.data.isGroup).toBe(false);
+      expect(modeNode.data.path).toBe('customMode');
+    });
+
+    it('last child is the placeholder', async () => {
+      const children = (await entity.toVizNode()).getChildren()!;
+      expect(children[children.length - 1].data.isPlaceholder).toBe(true);
+    });
+
+    it('mode node and placeholder are linked via prev/next', async () => {
+      const children = (await entity.toVizNode()).getChildren()!;
+      const [modeNode, placeholder] = children;
+      expect(modeNode.getNextNode()).toBe(placeholder);
+      expect(placeholder.getPreviousNode()).toBe(modeNode);
+    });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -1,3 +1,5 @@
+import { isDefined } from '@kaoto/forms';
+
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { DefinedComponent } from '../camel/camel-catalog-index';
 import { EntityType } from '../entities';
@@ -12,78 +14,114 @@ import {
   NodeInteraction,
 } from '../visualization/base-visual-entity';
 import { IClipboardCopyObject } from '../visualization/clipboard';
+import { CustomModeSchemaService } from '../visualization/flows/support/custom-mode-schema.service';
+import { createVisualizationNode } from '../visualization/visualization-node';
+import { CustomInstructionsNode, CustomInstructionsParser } from './custom-instructions-parser';
 import { CustomMode } from './custom-mode-types';
 
-/**
- * Minimal shell for Epic 1. Methods required by BaseVisualEntity but not yet
- * implemented return safe no-op values. toVizNode() is implemented in Epic 2.
- */
 export class CustomModeVisualEntity implements BaseVisualEntity {
-  readonly type = EntityType.CustomMode;
   id: string;
+  readonly type = EntityType.CustomMode;
+  static readonly ROOT_PATH = 'customMode';
+
+  private parsedNodes: CustomInstructionsNode[] = [];
+  private parsedNodesDirty = false;
 
   constructor(private readonly mode: CustomMode) {
-    this.id = getCamelRandomId('custom-mode');
+    if (isDefined(mode?.slug) && mode.slug !== '') {
+      this.id = mode.slug;
+    } else {
+      this.id = getCamelRandomId('custom-mode');
+      this.mode.slug = this.id;
+    }
+    this.parsedNodes = CustomInstructionsParser.parse(mode?.customInstructions ?? '');
+  }
+
+  static isApplicable(entity: unknown): entity is CustomMode {
+    if (!isDefined(entity) || Array.isArray(entity) || typeof entity !== 'object') return false;
+    return 'slug' in entity && 'name' in entity && 'groups' in entity;
+  }
+
+  getRootPath(): string {
+    return CustomModeVisualEntity.ROOT_PATH;
   }
 
   getId(): string {
     return this.id;
   }
 
-  setId(id: string): void {
-    this.id = id;
+  setId(slug: string): void {
+    this.id = slug;
+    this.mode.slug = slug;
   }
 
-  toJSON(): CustomMode {
-    return this.mode;
+  getNodeLabel(path?: string, _labelType?: NodeLabelType): string {
+    if (!path) return '';
+    if (path === this.getRootPath()) return this.mode.name || this.id;
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      return path.split('.').pop() ?? '';
+    }
+    return '';
   }
 
-  getRootPath(): string {
-    return 'customMode';
-  }
-
-  getNodeLabel(_path?: string, _labelType?: NodeLabelType): string {
-    return this.mode.slug;
-  }
-
-  getNodeSchema(_path?: string): KaotoSchemaDefinition['schema'] | undefined {
+  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
+    if (!path) return undefined;
+    if (path === this.getRootPath()) return CustomModeSchemaService.getRootSchema();
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      return CustomModeSchemaService.getNodeSchema(path.split('.').pop() ?? '');
+    }
     return undefined;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getNodeDefinition(_path?: string): any {
-    return this.mode;
-  }
-
-  getOmitFormFields(): string[] {
-    return [];
-  }
-
-  updateModel(_path: string | undefined, _value: unknown): void {
-    // no-op — Epic 2
-  }
-
-  addStep(_options: {
-    definedComponent: DefinedComponent;
-    mode: AddStepMode;
-    data: IVisualizationNodeData;
-    targetProperty?: string;
-    insertAtStart?: boolean;
-  }): void {
-    // no-op — Epic 2
-  }
-
-  getCopiedContent(_path?: string): IClipboardCopyObject | undefined {
+  getNodeDefinition(path?: string): any {
+    if (!path) return undefined;
+    if (path === this.getRootPath()) {
+      const { customInstructions: _ci, ...rest } = this.mode as CustomMode & { customInstructions?: string };
+      return rest;
+    }
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      const index = Number(path.replace(`${this.getRootPath()}.customInstructions.`, '').split('.')[0]);
+      return Number.isInteger(index) ? this.parsedNodes[index] : undefined;
+    }
     return undefined;
   }
 
-  pasteStep(_options: {
-    clipboardContent: IClipboardCopyObject;
-    mode: AddStepMode;
-    data: IVisualizationNodeData;
-    insertAtStart?: boolean;
-  }): void {
-    // no-op — Epic 2
+  getOmitFormFields(): string[] {
+    return ['customInstructions'];
+  }
+
+  updateModel(path: string | undefined, value: unknown): void {
+    if (!path) return;
+    if (path === this.getRootPath()) {
+      Object.assign(this.mode, value);
+      this.id = isDefined(this.mode.slug) && this.mode.slug !== '' ? this.mode.slug : this.id;
+      return;
+    }
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      const index = Number(path.replace(`${this.getRootPath()}.customInstructions.`, '').split('.')[0]);
+      if (Number.isInteger(index) && isDefined(this.parsedNodes[index])) {
+        this.parsedNodes[index] = value as CustomInstructionsNode;
+        this.parsedNodesDirty = true;
+      }
+    }
+  }
+
+  toJSON(): CustomMode {
+    if (this.parsedNodesDirty) {
+      this.mode.customInstructions = CustomInstructionsParser.serialize(this.parsedNodes);
+      this.parsedNodesDirty = false;
+    }
+    return this.mode;
+  }
+
+  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
+    const isModeNode = data.path === this.getRootPath() && !data.isGroup;
+    return { ...DISABLED_NODE_INTERACTION, canRemoveFlow: isModeNode };
+  }
+
+  getNodeValidationText(_path?: string): string | undefined {
+    return undefined;
   }
 
   canDragNode(_path?: string): boolean {
@@ -94,19 +132,102 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
     return false;
   }
 
-  removeStep(_path?: string): void {
-    // no-op — Epic 2
-  }
-
-  getNodeInteraction(_data: IVisualizationNodeData): NodeInteraction {
-    return DISABLED_NODE_INTERACTION;
-  }
-
-  getNodeValidationText(_path?: string): string | undefined {
+  getCopiedContent(_path?: string): IClipboardCopyObject | undefined {
     return undefined;
   }
 
+  /** No-op — deferred to drag-and-drop epic. */
+  addStep(_options: {
+    definedComponent: DefinedComponent;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    targetProperty?: string;
+    insertAtStart?: boolean;
+  }): void {
+    // TODO: drag-and-drop epic
+  }
+
+  /** No-op — deferred to drag-and-drop epic. */
+  removeStep(_path?: string): void {
+    // TODO: drag-and-drop epic
+  }
+
+  /** No-op — deferred to drag-and-drop epic. */
+  pasteStep(_options: {
+    clipboardContent: IClipboardCopyObject;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    insertAtStart?: boolean;
+  }): void {
+    // TODO: drag-and-drop epic
+  }
+
   async toVizNode(): Promise<IVisualizationNode> {
-    throw new Error('CustomModeVisualEntity.toVizNode() — not implemented until Epic 2');
+    // 1. Mode group node — visual container
+    const modeGroupNode = createVisualizationNode(this.id, {
+      name: this.type,
+      path: this.getRootPath(),
+      entity: this,
+      isPlaceholder: false,
+      isGroup: true,
+      iconUrl: '',
+      title: '',
+      description: '',
+    });
+
+    // 2. Mode node — first child, opens the metadata form
+    const modeNode = createVisualizationNode(`${this.id}-mode`, {
+      name: this.type,
+      path: this.getRootPath(),
+      entity: this,
+      isPlaceholder: false,
+      isGroup: false,
+      iconUrl: '',
+      title: this.mode.name || this.id,
+      description: this.mode.description || '',
+    });
+    modeGroupNode.addChild(modeNode);
+
+    // 3. customInstructions sibling nodes (stub: parsedNodes is always [] until Epic 7)
+    const siblings: IVisualizationNode[] = [modeNode];
+    for (let i = 0; i < this.parsedNodes.length; i++) {
+      const node = this.parsedNodes[i];
+      const path = `${this.getRootPath()}.customInstructions.${i}.${node.nodeType}`;
+      const vizNode = createVisualizationNode(path, {
+        name: node.nodeType,
+        path,
+        entity: this,
+        isPlaceholder: false,
+        isGroup: false,
+        iconUrl: '',
+        title: node.nodeType,
+        description: '',
+      });
+      modeGroupNode.addChild(vizNode);
+      siblings.push(vizNode);
+    }
+
+    // 4. Placeholder
+    const placeholderPath = `${this.getRootPath()}.customInstructions.${this.parsedNodes.length}.placeholder`;
+    const placeholderNode = createVisualizationNode(placeholderPath, {
+      name: 'placeholder',
+      path: placeholderPath,
+      entity: this,
+      isPlaceholder: true,
+      isGroup: false,
+      iconUrl: '',
+      title: '',
+      description: '',
+    });
+    modeGroupNode.addChild(placeholderNode);
+    siblings.push(placeholderNode);
+
+    // 5. Wire prev/next links across the flat sequence
+    for (let i = 0; i < siblings.length - 1; i++) {
+      siblings[i].setNextNode(siblings[i + 1]);
+      siblings[i + 1].setPreviousNode(siblings[i]);
+    }
+
+    return modeGroupNode;
   }
 }

--- a/packages/ui/src/models/custom-mode/index.ts
+++ b/packages/ui/src/models/custom-mode/index.ts
@@ -1,3 +1,4 @@
+export * from './custom-instructions-parser';
 export * from './custom-mode-resource';
 export * from './custom-mode-resource-factory';
 export * from './custom-mode-types';

--- a/packages/ui/src/models/visualization/flows/index.ts
+++ b/packages/ui/src/models/visualization/flows/index.ts
@@ -1,3 +1,4 @@
+export * from '../../custom-mode/custom-mode-visual-entity';
 export * from './camel-catalog.service';
 export * from './camel-route-visual-entity';
 export * from './citrus-test-visual-entity';

--- a/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
@@ -1,0 +1,44 @@
+import { CustomModeSchemaService } from './custom-mode-schema.service';
+
+describe('CustomModeSchemaService', () => {
+  describe('getRootSchema', () => {
+    it('returns an object schema', () => {
+      expect(CustomModeSchemaService.getRootSchema().type).toBe('object');
+    });
+
+    it('includes all expected top-level properties', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      expect(Object.keys(properties!)).toEqual(
+        expect.arrayContaining(['slug', 'name', 'description', 'roleDefinition', 'whenToUse', 'groups']),
+      );
+    });
+
+    it('marks slug and name as required', () => {
+      expect(CustomModeSchemaService.getRootSchema().required).toEqual(expect.arrayContaining(['slug', 'name']));
+    });
+
+    it('sets x-component textarea on roleDefinition and whenToUse', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      expect((properties!['roleDefinition'] as Record<string, unknown>)['x-component']).toBe('textarea');
+      expect((properties!['whenToUse'] as Record<string, unknown>)['x-component']).toBe('textarea');
+    });
+
+    it('groups is an array with 8-item enum', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      const groups = properties!['groups'] as Record<string, unknown>;
+      expect(groups.type).toBe('array');
+      const items = groups.items as Record<string, unknown>;
+      expect(items.enum as string[]).toHaveLength(8);
+      expect(items.enum).toEqual(
+        expect.arrayContaining(['read', 'edit', 'command', 'mcp', 'subagent', 'skill', 'execute', 'todo']),
+      );
+    });
+  });
+
+  describe('getNodeSchema', () => {
+    it('returns undefined for any nodeType (stub)', () => {
+      expect(CustomModeSchemaService.getNodeSchema('section')).toBeUndefined();
+      expect(CustomModeSchemaService.getNodeSchema('unknown')).toBeUndefined();
+    });
+  });
+});

--- a/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.ts
@@ -1,0 +1,60 @@
+import { JSONSchema4 } from 'json-schema';
+
+/** Provides JSON schemas for CustomMode canvas nodes. No catalog dependency. */
+export class CustomModeSchemaService {
+  /** Schema for the mode node form (all fields except customInstructions). */
+  static getRootSchema(): JSONSchema4 {
+    return {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          title: 'Slug',
+          description: 'Machine identifier — kebab-case, unique within the file.',
+        },
+        name: {
+          type: 'string',
+          title: 'Name',
+          description: 'Display name shown in the mode selector (may include emoji).',
+        },
+        description: {
+          type: 'string',
+          title: 'Description',
+          description: 'One-liner shown in the orchestrator dropdown.',
+        },
+        roleDefinition: {
+          type: 'string',
+          title: 'Role Definition',
+          description: 'Defines who this mode is — shown to the LLM as a system prompt prefix.',
+          'x-component': 'textarea',
+        } as JSONSchema4,
+        whenToUse: {
+          type: 'string',
+          title: 'When to Use',
+          description: 'Tells the orchestrator when to route to this mode.',
+          'x-component': 'textarea',
+        } as JSONSchema4,
+        groups: {
+          type: 'array',
+          title: 'Tool Groups',
+          description: 'Tool permission groups granted to this mode.',
+          // TODO: tuple-groups epic — tuple form [name, {fileRegex}] not yet supported
+          items: {
+            type: 'string',
+            enum: ['read', 'edit', 'command', 'mcp', 'subagent', 'skill', 'execute', 'todo'],
+          },
+        },
+      },
+      required: ['slug', 'name'],
+    };
+  }
+
+  /**
+   * Schema for a customInstructions child node.
+   * Stub — Epic 7 fills in per-type schemas once node types are finalised.
+   */
+  static getNodeSchema(_nodeType: string): JSONSchema4 | undefined {
+    // TODO: Epic 7 — fill in per-type schemas
+    return undefined;
+  }
+}


### PR DESCRIPTION
Implements the visual entity layer that renders a single CustomMode as a Kaoto canvas flow, following the same pattern as CamelRouteVisualEntity.

- Add CustomInstructionsParser stub (parse/serialize deferred to Epic 7)
- Add CustomModeSchemaService with hardcoded JSON Schema for the mode form (slug, name, description, roleDefinition, whenToUse, groups with 8-value enum; x-component: textarea on long-text fields; tuple groups deferred)
- Replace CustomModeVisualEntity Epic 1 shell with full implementation:
  - id derived from mode.slug (getCamelRandomId fallback)
  - toVizNode() produces mode group node (isGroup: true) -> mode node (metadata form) + placeholder; prev/next linked as flat sequence
  - getNodeSchema/getNodeLabel/getNodeDefinition/updateModel path-aware
  - getOmitFormFields returns ['customInstructions'] (rendered as canvas nodes, not a form field)
  - getNodeInteraction: canRemoveFlow true only on mode node (isGroup false), all drag-and-drop methods deferred to dedicated epic
- Export CustomModeVisualEntity from flows/index.ts and custom-mode/index.ts
- Full unit test coverage: 33 entity tests + 6 schema tests + 2 parser tests


https://github.com/user-attachments/assets/f28d1d32-e424-4608-b4d6-5e28825e152e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visual editing support for custom modes, including metadata and instruction nodes.
  * Added schema definitions for custom mode fields, including validation for required fields and tool-group selections.
  * Added support for synchronizing custom mode edits and visual representations.

* **Tests**
  * Expanded coverage for custom mode visualization, schemas, parsing, serialization, and node interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->