### PR TITLE
feat(DataMapper): Add Duplicate mapping context menu

### DIFF
--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -27,6 +27,7 @@ export enum MappingActionKind {
   ForEachCurrentGroup = 'forEachCurrentGroup',
   InnerForEachGroup = 'innerForEachGroup',
   InnerForEachCurrentGroup = 'innerForEachCurrentGroup',
+  Duplicate = 'duplicate',
 }
 
 /**

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -2077,6 +2077,132 @@ describe('MappingActionService', () => {
         useDocumentTreeStore.getState().setRenamingVariable(null);
       });
     });
+
+    describe('Duplicate', () => {
+      it('should include Duplicate for IfItem MappingNodeData', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const ifNode = shipOrderChildren[1] as MappingNodeData;
+        expect(ifNode.title).toBe('if');
+        expect(MappingActionService.getAllowedActions(ifNode)).toContain(MappingActionKind.Duplicate);
+      });
+
+      it('should include Duplicate for collection FieldItemNodeData', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        MappingActionService.addMapping(addMappingNode);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const addedNode = updatedShipOrderChildren.find(
+          (n) => n instanceof FieldItemNodeData && n.title === 'Item',
+        ) as FieldItemNodeData;
+        expect(addedNode).toBeDefined();
+        expect(MappingActionService.getAllowedActions(addedNode)).toContain(MappingActionKind.Duplicate);
+      });
+
+      it('should not include Duplicate for non-collection FieldItemNodeData', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
+        expect(orderIdNode.title).toBe('OrderId');
+        expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Duplicate);
+      });
+
+      it('should not include Duplicate for non-IfItem MappingNodeData', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const forEachNode = shipOrderChildren[3] as MappingNodeData;
+        expect(forEachNode.title).toBe('for-each');
+        expect(MappingActionService.getAllowedActions(forEachNode)).not.toContain(MappingActionKind.Duplicate);
+      });
+
+      it('should create a new FieldItem with isUserCreated when duplicating a collection field', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        MappingActionService.addMapping(addMappingNode);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const addedNode = updatedShipOrderChildren.find(
+          (n) => n instanceof FieldItemNodeData && n.title === 'Item',
+        ) as FieldItemNodeData;
+        expect(addedNode).toBeDefined();
+
+        const shipOrderMappingItem = targetDocNode.mappingTree.children[0];
+        const childCountBefore = shipOrderMappingItem.children.length;
+
+        const menuItems = MappingActionService.getMappingContextMenuItems(addedNode);
+        const duplicateAction = menuItems.find((item) => item.key === MappingActionKind.Duplicate);
+        expect(duplicateAction).toBeDefined();
+        duplicateAction!.apply(addedNode, { onUpdate: vi.fn(), openModal: vi.fn() });
+
+        expect(shipOrderMappingItem.children).toHaveLength(childCountBefore + 1);
+        const newChild = shipOrderMappingItem.children[childCountBefore] as FieldItem;
+        expect(newChild instanceof FieldItem).toBeTruthy();
+        expect(newChild.field.name).toBe('Item');
+        expect(newChild.isUserCreated).toBe(true);
+      });
+
+      it('should clone IfItem with empty expression when duplicating "if"', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+        const ifNode = shipOrderChildren[1] as MappingNodeData;
+        expect(ifNode.title).toBe('if');
+        const originalIf = ifNode.mapping as IfItem;
+        const originalExpression = originalIf.expression;
+        const originalChildCount = originalIf.children.length;
+        const parent = originalIf.parent;
+        const indexBefore = parent.children.indexOf(originalIf);
+
+        const menuItems = MappingActionService.getMappingContextMenuItems(ifNode);
+        const duplicateAction = menuItems.find((item) => item.key === MappingActionKind.Duplicate);
+        expect(duplicateAction).toBeDefined();
+        duplicateAction!.apply(ifNode, { onUpdate: vi.fn(), openModal: vi.fn() });
+
+        const clonedIf = parent.children[indexBefore + 1] as IfItem;
+        expect(clonedIf instanceof IfItem).toBeTruthy();
+        expect(clonedIf).not.toBe(originalIf);
+        expect(clonedIf.expression).toBe('');
+        expect(originalIf.expression).toBe(originalExpression);
+        expect(clonedIf.children).toHaveLength(originalChildCount);
+        expect(clonedIf.parent).toBe(parent);
+      });
+
+      it('should return dynamic label based on node type', () => {
+        const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
+
+        const ifNode = shipOrderChildren[1] as MappingNodeData;
+        const ifMenuItems = MappingActionService.getMappingContextMenuItems(ifNode);
+        const ifDuplicateAction = ifMenuItems.find((item) => item.key === MappingActionKind.Duplicate);
+        expect(ifDuplicateAction).toBeDefined();
+        expect(ifDuplicateAction!.getLabel(ifNode)).toBe('Duplicate "if"');
+
+        const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
+        MappingActionService.addMapping(addMappingNode);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const addedNode = updatedShipOrderChildren.find(
+          (n) => n instanceof FieldItemNodeData && n.title === 'Item',
+        ) as FieldItemNodeData;
+        const fieldMenuItems = MappingActionService.getMappingContextMenuItems(addedNode);
+        const fieldDuplicateAction = fieldMenuItems.find((item) => item.key === MappingActionKind.Duplicate);
+        expect(fieldDuplicateAction).toBeDefined();
+        expect(fieldDuplicateAction!.getLabel(addedNode)).toBe('Duplicate');
+      });
+    });
   });
 
   describe('getAllowedActions() delete', () => {

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -420,6 +420,22 @@ export class MappingActionService {
     fieldItem.isUserCreated = true;
   }
 
+  /**
+   * Duplicates an {@link IfItem}, preserving child field mappings and value selectors
+   * but clearing the condition expression. Sibling conditionals must have different
+   * conditions — forcing the user to enter a new one prevents copy-paste errors and
+   * matches XSLT best practices for conditional branching.
+   */
+  static duplicateIf(nodeData: TargetNodeData): void {
+    const ifItem = nodeData.mapping as IfItem;
+    const parent = ifItem.parent;
+    const cloned = ifItem.clone() as IfItem;
+    cloned.parent = parent;
+    cloned.expression = '';
+    const index = parent.children.indexOf(ifItem);
+    parent.children.splice(index + 1, 0, cloned);
+  }
+
   static applyTargetSelection(nodeData: TargetNodeData, selectedField: IField): void {
     const existingMapping = nodeData.mapping;
     if (existingMapping instanceof FieldItem) {
@@ -915,6 +931,31 @@ export class MappingActionService {
         }
       },
       isAllowed: (n) => n instanceof VariableNodeData,
+    },
+    {
+      key: MappingActionKind.Duplicate,
+      testId: 'transformation-actions-duplicate',
+      getLabel: (n) => {
+        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) {
+          return 'Duplicate "if"';
+        }
+        return 'Duplicate';
+      },
+      apply: (n, { onUpdate }) => {
+        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) {
+          MappingActionService.duplicateIf(n);
+        } else if (MappingActionService.isFieldNode(n)) {
+          const parentItem = MappingActionService.getOrCreateFieldItem(n.parent);
+          const fieldItem = MappingService.createFieldItem(parentItem, n.field);
+          fieldItem.isUserCreated = true;
+        }
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) return true;
+        if (MappingActionService.isFieldNode(n)) return VisualizationUtilService.isCollectionField(n);
+        return false;
+      },
     },
   ];
 


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Duplicate** context-menu action for mapping nodes.
  * Supports duplicating **conditional (if)** mappings and **collection fields**, creating a new user-editable mapping.
  * Duplicated **if** mappings keep existing mapped content, while the duplicate starts with an **empty expression**.
  * Action labels now reflect the target type (e.g., **Duplicate "if"**).

* **Tests**
  * Added test coverage to confirm the Duplicate action appears for supported node types and is excluded for others, including verification of duplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->