### PR TITLE
fix(DataMapper): Do not add select if variable has children

### DIFF
--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -384,7 +384,19 @@ export class UnknownMappingItem extends MappingItem {
 
 /**
  * Represents an `xsl:variable` element.
- * {@link name} is the variable name; {@link expression} is the XPath `select` attribute value.
+ *
+ * A variable can be defined in two ways:
+ * 1. With a `select` attribute containing an XPath expression (stored in {@link expression})
+ * 2. With child content (stored in {@link children})
+ *
+ * These are mutually exclusive - a variable should have either select OR children, not both.
+ *
+ * - If {@link children} is empty and {@link expression} is empty: serializes as `<xsl:variable name="x" select=""/>`
+ *   to indicate an unconfigured variable
+ * - If {@link children} is empty and {@link expression} is set: serializes as `<xsl:variable name="x" select="expr"/>`
+ * - If {@link children} is not empty: serializes as `<xsl:variable name="x">...children...</xsl:variable>`
+ *   (no select attribute)
+ *
  * Can be a child of FieldItem, ForEachItem, IfItem, WhenItem, or OtherwiseItem.
  */
 export class VariableItem extends MappingItem implements IExpressionHolder {

--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -10,6 +10,7 @@ import {
   UnknownMappingItem,
   ValueSelector,
   ValueType,
+  VariableItem,
 } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
 import {
@@ -623,5 +624,195 @@ describe('UnknownMappingItemHandler', () => {
     expect(result.mappingItem).toBeInstanceOf(UnknownMappingItem);
     expect((result.mappingItem as UnknownMappingItem).element.localName).toBe('some-unknown');
     expect(result.fieldItem).toBeNull();
+  });
+
+  describe('VariableItemHandler', () => {
+    const handler = new handlerModule.VariableItemHandler();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+
+    describe('serialize', () => {
+      it('should serialize variable with expression (no children)', () => {
+        const variable = new VariableItem(mappingTree, 'myVar');
+        variable.expression = '/Order/Id';
+
+        const xslt = MappingSerializerService.createNew();
+        const el = handler.serialize(xslt.documentElement, variable);
+
+        expect(el.localName).toBe('variable');
+        expect(el.getAttribute('name')).toBe('myVar');
+        expect(el.getAttribute('select')).toBe('/Order/Id');
+        expect(el.childNodes).toHaveLength(0);
+      });
+
+      it('should serialize empty variable with select=""', () => {
+        const variable = new VariableItem(mappingTree, 'emptyVar');
+        // No expression set, no children
+
+        const xslt = MappingSerializerService.createNew();
+        const el = handler.serialize(xslt.documentElement, variable);
+
+        expect(el.localName).toBe('variable');
+        expect(el.getAttribute('name')).toBe('emptyVar');
+        expect(el.getAttribute('select')).toBe('');
+        expect(el.hasAttribute('select')).toBe(true);
+      });
+
+      it('should serialize variable with children (no select attribute)', () => {
+        const variable = new VariableItem(mappingTree, 'complexVar');
+        variable.expression = '/Order/Id'; // This should be ignored when children exist
+
+        // Add a child to simulate variable with content
+        const childIf = new IfItem(variable);
+        childIf.expression = 'true()';
+        variable.children.push(childIf);
+
+        const xslt = MappingSerializerService.createNew();
+        const el = handler.serialize(xslt.documentElement, variable);
+
+        expect(el.localName).toBe('variable');
+        expect(el.getAttribute('name')).toBe('complexVar');
+        expect(el.hasAttribute('select')).toBe(false);
+        // Children would be serialized by the parent serializer
+      });
+    });
+
+    describe('deserialize', () => {
+      it('should deserialize variable with select attribute', () => {
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:variable name="testVar" select="/Order/Total"/></xsl:stylesheet>`,
+          'application/xml',
+        );
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        expect(result!.mappingItem).toBeInstanceOf(VariableItem);
+        const variable = result!.mappingItem as VariableItem;
+        expect(variable.name).toBe('testVar');
+        expect(variable.expression).toBe('/Order/Total');
+        expect(result!.fieldItem).toBeNull();
+        expect(result!.messages).toBeUndefined();
+      });
+
+      it('should deserialize variable with empty select attribute', () => {
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:variable name="unconfigured" select=""/></xsl:stylesheet>`,
+          'application/xml',
+        );
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        const variable = result!.mappingItem as VariableItem;
+        expect(variable.name).toBe('unconfigured');
+        expect(variable.expression).toBe('');
+      });
+
+      it('should deserialize variable with child content (no select)', () => {
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}">
+            <xsl:variable name="complexVar">
+              <value>123</value>
+            </xsl:variable>
+          </xsl:stylesheet>`,
+          'application/xml',
+        );
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        const variable = result!.mappingItem as VariableItem;
+        expect(variable.name).toBe('complexVar');
+        expect(variable.expression).toBe('');
+        expect(result!.messages).toBeUndefined();
+      });
+
+      it('should not treat whitespace-only text nodes as children', () => {
+        // A self-closing element parsed from a formatted document gets whitespace text nodes.
+        // Those must not be treated as "has children", or the select expression would be silently dropped.
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}">
+            <xsl:variable name="wsVar" select="/Order/Total"/>
+          </xsl:stylesheet>`,
+          'application/xml',
+        );
+        // firstElementChild is the xsl:variable — it has surrounding whitespace text nodes
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        const variable = result!.mappingItem as VariableItem;
+        expect(variable.name).toBe('wsVar');
+        expect(variable.expression).toBe('/Order/Total');
+        expect(result!.messages).toBeUndefined();
+      });
+
+      it('should warn when variable has both select and children (invalid XSLT)', () => {
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}">
+          <xsl:variable name="invalidVar" select="/Order/Id">
+            <value>should not be here</value>
+          </xsl:variable>
+        </xsl:stylesheet>`,
+          'application/xml',
+        );
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        const variable = result!.mappingItem as VariableItem;
+        expect(variable.name).toBe('invalidVar');
+        expect(variable.expression).toBe(''); // Expression should be ignored when children exist
+        expect(result!.messages).toBeDefined();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages![0].variant).toBe('warning');
+        expect(result!.messages![0].title).toContain('both select attribute and child content');
+      });
+
+      it('should skip variable without name', () => {
+        const xslt = new DOMParser().parseFromString(
+          `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:variable select="/Order/Id"/></xsl:stylesheet>`,
+          'application/xml',
+        );
+        const element = xslt.documentElement.firstElementChild!;
+        const result = handler.deserialize(element, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(result).toBeTruthy();
+        expect(result!.mappingItem).toBeUndefined();
+        expect(result!.messages).toBeDefined();
+        expect(result!.messages).toHaveLength(1);
+        expect(result!.messages![0].variant).toBe('danger');
+        expect(result!.messages![0].title).toContain('without a name');
+      });
+    });
+
+    describe('round-trip', () => {
+      it('should round-trip variable with expression', () => {
+        const variable = new VariableItem(mappingTree, 'roundTripVar');
+        variable.expression = '/Order/Customer/Name';
+
+        const xslt = MappingSerializerService.createNew();
+        const serialized = handler.serialize(xslt.documentElement, variable);
+        const deserialized = handler.deserialize(serialized, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(deserialized!.mappingItem).toBeInstanceOf(VariableItem);
+        const result = deserialized!.mappingItem as VariableItem;
+        expect(result.name).toBe('roundTripVar');
+        expect(result.expression).toBe('/Order/Customer/Name');
+      });
+
+      it('should round-trip empty variable', () => {
+        const variable = new VariableItem(mappingTree, 'emptyRoundTrip');
+
+        const xslt = MappingSerializerService.createNew();
+        const serialized = handler.serialize(xslt.documentElement, variable);
+        const deserialized = handler.deserialize(serialized, mappingTree as unknown as IParentType, mappingTree);
+
+        expect(deserialized!.mappingItem).toBeInstanceOf(VariableItem);
+        const result = deserialized!.mappingItem as VariableItem;
+        expect(result.name).toBe('emptyRoundTrip');
+        expect(result.expression).toBe('');
+      });
+    });
   });
 });

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -353,16 +353,15 @@ export class ForEachGroupItemHandler implements XsltItemHandler<ForEachGroupItem
 }
 
 /**
- * Handles {@link VariableItem} — maps to `xsl:variable` with a `select` XPath expression.
+ * Handles {@link VariableItem} — maps to `xsl:variable` with a `select` XPath expression or child content.
  *
- * TODO(#2362-content-form): Currently only the `select` attribute form is supported:
- *   `<xsl:variable name="x" select="..."/>`
- * The content form (variable with child elements instead of a select attribute) is not yet
- * supported. When implementing content-form support:
- *   - `serialize`: omit the `select` attribute and serialize `mapping.children` as child elements
- *   - `deserialize`: when no `select` attribute is present, deserialize child elements recursively
- *   - `VariableItem` model: add a flag or union to distinguish scalar vs node-set variables
- *   - `SourceVariableNodeData` in `engageMapping`: handle container drop differently
+ * Both XSLT variable forms are supported:
+ *   - Select form:  `<xsl:variable name="x" select="expr"/>` — used when {@link VariableItem.children} is empty.
+ *   - Empty select: `<xsl:variable name="x" select=""/>` — used when no expression and no children (unconfigured).
+ *   - Content form: `<xsl:variable name="x">…children…</xsl:variable>` — used when {@link VariableItem.children}
+ *     is non-empty; the `select` attribute is omitted and children are serialized by {@link MappingSerializerService}.
+ *
+ * Having both a `select` attribute and child elements is invalid XSLT and triggers a warning on deserialization.
  */
 export class VariableItemHandler implements XsltItemHandler<VariableItem> {
   readonly itemClass = VariableItem;
@@ -371,8 +370,16 @@ export class VariableItemHandler implements XsltItemHandler<VariableItem> {
   serialize(parent: Element, mapping: VariableItem): Element {
     const xslVariable = parent.ownerDocument.createElementNS(NS_XSL, 'variable');
     xslVariable.setAttribute('name', mapping.name);
-    // TODO(#2362-content-form): if mapping has children (content form), serialize them instead
-    xslVariable.setAttribute('select', mapping.expression);
+
+    /*
+     * Select form: only add `select` when there are no children.
+     * Content form: children are serialized by MappingSerializerService.populateMapping after this returns,
+     * so no `select` attribute should be added.
+     */
+    if (mapping.children.length === 0) {
+      xslVariable.setAttribute('select', mapping.expression || '');
+    }
+
     parent.appendChild(xslVariable);
     return xslVariable;
   }
@@ -407,11 +414,34 @@ export class VariableItemHandler implements XsltItemHandler<VariableItem> {
         ],
       };
     }
+
     const variableItem = new VariableItem(parentMapping, varName);
-    // TODO(#2362-content-form): if element has no `select` attribute but has child elements,
-    // deserialize children recursively into variableItem.children instead
-    variableItem.expression = element.getAttribute('select') || '';
-    return { mappingItem: variableItem, fieldItem: null };
+    const hasChildren = Array.from(element.childNodes).some((n) => n.nodeType === Node.ELEMENT_NODE);
+    const selectAttr = element.getAttribute('select');
+
+    // Warn if variable has both select and children (invalid XSLT)
+    let messages: { variant: 'warning'; title: string; description: string }[] | undefined;
+    if (hasChildren && selectAttr) {
+      messages = [
+        {
+          variant: 'warning' as const,
+          title: `Variable "${varName}" has both select attribute and child content`,
+          description:
+            'XSLT variables should have either select attribute OR child content, not both. The select attribute will be ignored.',
+        },
+      ];
+    }
+
+    /*
+     * Select form: restore expression from `select` attribute.
+     * Content form: leave expression empty — child elements are deserialized into
+     * variableItem.children by MappingSerializerService.restoreElementNode.
+     */
+    if (!hasChildren) {
+      variableItem.expression = selectAttr || '';
+    }
+
+    return { mappingItem: variableItem, fieldItem: null, messages };
   }
 }
 


### PR DESCRIPTION
Resolves: [#3330](https://github.com/KaotoIO/kaoto/issues/3330)


<img width="1243" height="811" alt="variable-select" src="https://github.com/user-attachments/assets/70be4d61-3ba2-456d-a3a2-057ed05b0aeb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XSLT `<xsl:variable>` mapping to correctly support both `select`-based variables and child-content variables.
  * Serialization now omits `select` when child content is present, and deserialization warns when both forms are provided.
  * Missing variable names now produce appropriate warnings (and are handled safely).
* **Tests**
  * Added thorough `VariableItemHandler` tests covering serialization/deserialization, empty values, whitespace-only nodes, warnings, and round-trip behavior.
* **Documentation**
  * Clarified the supported variable configuration modes and serialization/deserialization expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->