### PR TITLE
fix(DataMapper): preserve repeated abstract element refs

### DIFF
--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.abstract-repeated-ref.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.abstract-repeated-ref.test.ts
@@ -1,0 +1,47 @@
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+} from '../../../models/datamapper/document';
+import { XmlSchemaDocument } from './xml-schema-document.model';
+import { XmlSchemaDocumentService } from './xml-schema-document.service';
+
+describe('XmlSchemaDocumentService / repeated abstract element refs', () => {
+  it('should create a unique wrapper with its own cardinality for each abstract element ref', () => {
+    const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com/vehicles"
+           targetNamespace="http://example.com/vehicles"
+           elementFormDefault="qualified">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="tns:AbstractVehicle"/>
+        <xs:element ref="tns:AbstractVehicle" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AbstractVehicle" type="xs:string" abstract="true"/>
+  <xs:element name="Car" type="xs:string" substitutionGroup="tns:AbstractVehicle"/>
+</xs:schema>`;
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'vehicles.xsd': xsd },
+      { namespaceUri: 'http://example.com/vehicles', name: 'Root' },
+    );
+
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+
+    expect(result.validationStatus).toBe('success');
+    const document = result.document as XmlSchemaDocument;
+    const abstractFields = document.fields[0].fields.filter((field) => field.wrapperKind === 'abstract');
+    expect(abstractFields).toHaveLength(2);
+    expect(new Set(abstractFields.map((field) => field.name)).size).toBe(2);
+    expect(abstractFields.map((field) => field.displayName)).toEqual(['AbstractVehicle', 'AbstractVehicle']);
+    expect(abstractFields.map((field) => field.minOccurs)).toEqual([1, 1]);
+    expect(abstractFields.map((field) => field.maxOccurs)).toEqual([1, 'unbounded']);
+  });
+});

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -532,8 +532,8 @@ export class XmlSchemaDocumentService {
 
   /**
    * Populates an XML element as an {@link XmlSchemaField} into the given fields array.
-   * Skips elements that already exist in fields (by name, namespace, and isAttribute). Resolves element references
-   * and delegates to schema type handling to populate child fields and type metadata.
+   * Skips concrete elements that already exist in fields (by name, namespace, and isAttribute). Resolves element
+   * references and delegates to schema type handling to populate child fields and type metadata.
    *
    * Per the XSD spec, `abstract` is only valid on global element declarations — element
    * references (`<xs:element ref="..."/>`) cannot carry it. Therefore abstract detection
@@ -552,13 +552,13 @@ export class XmlSchemaDocumentService {
     const namespaceURI = resolvedElement.getWireName()!.getNamespaceURI();
     const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;
 
-    const existing = fields.find((f) => f.name === name && !f.isAttribute && f.namespaceURI === namespaceURI);
-    if (existing) {
+    if (resolvedElement.isAbstract()) {
+      XmlSchemaDocumentService.populateAbstractElement(parent, fields, element, resolvedElement);
       return;
     }
 
-    if (resolvedElement.isAbstract()) {
-      XmlSchemaDocumentService.populateAbstractElement(parent, fields, element, resolvedElement);
+    const existing = fields.find((f) => f.name === name && !f.isAttribute && f.namespaceURI === namespaceURI);
+    if (existing) {
       return;
     }
 
@@ -958,9 +958,9 @@ export class XmlSchemaDocumentService {
    * Creates an abstract element wrapper {@link XmlSchemaField} with {@link XmlSchemaField.wrapperKind}
    * set to `'abstract'`, and populates its children from the concrete substitution group members.
    *
-   * Unlike {@link populateChoice} which uses the synthetic name `__choice__`, the abstract wrapper
-   * uses the actual element name since abstract elements ARE real XML elements — they just cannot
-   * be instantiated directly. The `{abstract:N}` path index is derived at runtime by
+   * Abstract wrappers use the actual element name when it is unique among siblings and add a stable
+   * sibling-position suffix when it is not. The resolved element name remains the display name.
+   * The `{abstract:N}` path index is derived at runtime by
    * {@link SchemaPathService.getAbstractSiblingIndex}, analogous to `{choice:N}`.
    *
    * @param parent - The parent document or field that owns the fields array
@@ -975,16 +975,23 @@ export class XmlSchemaDocumentService {
     resolvedElement: XmlSchemaElement,
   ) {
     const ownerDoc = ('ownerDocument' in parent ? parent.ownerDocument : parent) as XmlSchemaDocument;
-    const name = resolvedElement.getWireName()!.getLocalPart()!;
+    const displayName = resolvedElement.getWireName()!.getLocalPart()!;
+    const namespaceURI = resolvedElement.getWireName()!.getNamespaceURI();
+    let name = displayName;
+    let siblingIndex = fields.length;
+    while (fields.some((field) => field.name === name && !field.isAttribute && field.namespaceURI === namespaceURI)) {
+      name = `${displayName}-${siblingIndex}`;
+      siblingIndex++;
+    }
     const abstractField = new XmlSchemaField(parent, name, false);
     abstractField.wrapperKind = 'abstract';
-    abstractField.namespaceURI = resolvedElement.getWireName()!.getNamespaceURI();
+    abstractField.namespaceURI = namespaceURI;
     abstractField.namespacePrefix = resolvedElement.getWireName()!.getPrefix();
     abstractField.minOccurs = element.getMinOccurs();
     abstractField.maxOccurs = element.getMaxOccurs();
     abstractField.minOccursExplicit = element.isMinOccursExplicit();
     abstractField.maxOccursExplicit = element.isMaxOccursExplicit();
-    abstractField.displayName = name;
+    abstractField.displayName = displayName;
     fields.push(abstractField);
     ownerDoc.totalFieldCount++;
 


### PR DESCRIPTION
### Description

Preserve every repeated abstract-element reference as a distinct wrapper with particle-specific cardinality, while retaining the declaration name for display, and add a focused XSD regression test.

Fixes #3473

#### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?
- `corepack yarn workspace @kaoto/kaoto test src/services/document/xml-schema/xml-schema-document.service.abstract-repeated-ref.test.ts packages/ui/src/services/document/xml-schema/xml-schema-document.service.abstract-repeated-ref.test.ts --configLoader runner` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto lint` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto lint:style` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto test --configLoader runner --maxWorkers 4` — passed in a network-isolated container.

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] I have updated relevant documentation (not applicable: behavior and regression-test change only).
- [x] I have added tests that prove the fix works.

---
AI assistance was used; I reviewed and own this change.

Northset self-run record for commit `ffc3e0524801`: [M-020 receipt](https://northset-oss.github.io/verification-pilot/#M-020).
It records the declared checks and published bundle provenance.
Contributor self-run; not maintainer verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML Schema generation for repeated abstract element references, ensuring abstract wrappers are created consistently and processed in the correct order.
  * Abstract wrapper fields are now named deterministically to avoid collisions, while keeping the same display name, namespace, and independent cardinality settings.
* **Tests**
  * Added coverage for XSD cases where the same abstract element is referenced multiple times with differing `maxOccurs` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->