### PR TITLE
feat(rest-dsl): add REST tree node context menu

### DIFF
--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
@@ -319,6 +319,39 @@ describe('RestDslEditorPage', () => {
         expect(screen.getByText('Select an entity from the list to edit its configuration')).toBeTruthy();
       });
     });
+
+    it('should update tree and form when deleting a right-clicked method', async () => {
+      const { updateEntitiesFromCamelResourceSpy } = await renderPage(`
+- rest:
+    id: rest-1
+    get:
+      - id: get-1
+        path: /users
+        to:
+          uri: direct:getUsers
+      - id: get-2
+        path: /orders
+        to:
+          uri: direct:getOrders
+      `);
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByText('/users'), { clientX: 120, clientY: 80 });
+      });
+
+      const deleteAction = await screen.findByRole('menuitem', { name: /Delete/ });
+      act(() => {
+        fireEvent.click(deleteAction);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('/users')).toBeNull();
+      });
+
+      expect(screen.getByText('/orders')).toBeTruthy();
+      expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
+      expect(screen.getByText('Select an entity from the list to edit its configuration')).toBeTruthy();
+    });
   });
 
   describe('Add Operation modal focus management', () => {

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -140,6 +140,7 @@ export const RestDslEditorPage: FunctionComponent = () => {
             entities={restRelatedEntities}
             selected={selectedElement}
             onSelect={setSelectedElement}
+            onDelete={handleDelete}
             key={treeVersion}
           >
             <RestTreeToolbar

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
@@ -7,6 +7,7 @@ import { RestTree } from './RestTree';
 
 describe('RestTree', () => {
   const mockOnSelect = vi.fn();
+  const mockOnDelete = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,7 +41,7 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    render(<RestTree entities={entities} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expect(screen.getByRole('tree', { name: 'Rest DSL Configuration' })).toBeInTheDocument();
 
@@ -70,7 +71,7 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    render(<RestTree entities={entities} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     const restNode = screen.getByText('rest-1234');
     fireEvent.click(restNode);
@@ -91,14 +92,186 @@ describe('RestTree', () => {
     });
   });
 
+  it('should select a right-clicked node and open its delete menu', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1234
+    get:
+      - id: get-method-1
+        path: /test
+        to:
+          uri: direct:test
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    fireEvent.contextMenu(screen.getByText('/test'), { clientX: 120, clientY: 80 });
+
+    expect(mockOnSelect).toHaveBeenCalledWith({
+      entityId: 'rest-1234',
+      modelPath: 'rest.get.0',
+    });
+    expect(await screen.findByRole('menu', { name: 'REST tree node actions' })).toBeInTheDocument();
+    const deleteAction = screen.getByRole('menuitem', { name: /Delete/ });
+    expect(deleteAction).toHaveClass('cds--menu-item');
+    expect(deleteAction).toHaveClass('cds--menu-item--danger');
+    expect(deleteAction.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should move the open menu when another node is right-clicked', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1
+- rest:
+    id: rest-2
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    fireEvent.contextMenu(screen.getByText('rest-1'), { clientX: 20, clientY: 30 });
+    await waitFor(() => {
+      expect(screen.getByRole('menu', { name: 'REST tree node actions' })).toHaveStyle({
+        insetInlineStart: '20px',
+        insetBlockStart: '30px',
+      });
+    });
+
+    fireEvent.contextMenu(screen.getByText('rest-2'), { clientX: 220, clientY: 230 });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('menu', { name: 'REST tree node actions' })).toHaveLength(1);
+      expect(screen.getByRole('menu', { name: 'REST tree node actions' })).toHaveStyle({
+        insetInlineStart: '220px',
+        insetBlockStart: '230px',
+      });
+    });
+    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-2', modelPath: 'rest' });
+  });
+
+  it('should open the same menu for configuration, service, and method badge targets', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- restConfiguration:
+    host: localhost
+- rest:
+    id: rest-1
+    get:
+      - id: get-1
+        path: /users
+        to:
+          uri: direct:getUsers
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    const configuration = entities.find((entity) => entity.getRootPath() === 'restConfiguration');
+    if (!configuration) fail('REST configuration not found');
+
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    fireEvent.contextMenu(screen.getByText(configuration.id));
+    expect(mockOnSelect).toHaveBeenLastCalledWith({
+      entityId: configuration.id,
+      modelPath: 'restConfiguration',
+    });
+
+    fireEvent.contextMenu(screen.getByText('rest-1'));
+    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-1', modelPath: 'rest' });
+
+    fireEvent.contextMenu(screen.getByText('GET'));
+    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-1', modelPath: 'rest.get.0' });
+    expect(screen.getAllByRole('menu', { name: 'REST tree node actions' })).toHaveLength(1);
+  });
+
+  it('should not select an already selected node again', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(
+      <RestTree
+        entities={entities}
+        selected={{ entityId: 'rest-1', modelPath: 'rest' }}
+        onSelect={mockOnSelect}
+        onDelete={mockOnDelete}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('rest-1'));
+
+    expect(await screen.findByRole('menu', { name: 'REST tree node actions' })).toBeInTheDocument();
+    expect(mockOnSelect).not.toHaveBeenCalled();
+  });
+
+  it('should delete through the context menu and close it', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    fireEvent.contextMenu(screen.getByText('rest-1'));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Delete/ }));
+
+    expect(mockOnDelete).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(screen.queryByRole('menu', { name: 'REST tree node actions' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close the context menu with Escape or an outside click', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    const treeItem = screen.getByText('rest-1').closest('[role="treeitem"]');
+    if (!(treeItem instanceof HTMLElement)) fail('REST tree item not found');
+
+    fireEvent.contextMenu(treeItem);
+    const deleteAction = await screen.findByRole('menuitem', { name: /Delete/ });
+    await waitFor(() => {
+      expect(deleteAction).toHaveFocus();
+    });
+    fireEvent.keyDown(deleteAction, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByRole('menu', { name: 'REST tree node actions' })).not.toBeInTheDocument();
+    });
+    expect(treeItem).toHaveFocus();
+
+    fireEvent.contextMenu(screen.getByText('rest-1'));
+    expect(await screen.findByRole('menu', { name: 'REST tree node actions' })).toBeInTheDocument();
+    fireEvent.pointerDown(globalThis.document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu', { name: 'REST tree node actions' })).not.toBeInTheDocument();
+    });
+  });
+
   it('should handle empty entities array gracefully', async () => {
     const entities: BaseVisualEntity[] = [];
 
-    render(<RestTree entities={entities} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expect(screen.getByRole('tree', { name: 'Rest DSL Configuration' })).toBeInTheDocument();
 
     expect(screen.queryAllByRole('treeitem')).toHaveLength(0);
+
+    fireEvent.contextMenu(screen.getByRole('tree', { name: 'Rest DSL Configuration' }));
+    expect(screen.queryByRole('menu', { name: 'REST tree node actions' })).not.toBeInTheDocument();
   });
 
   it('should render children prop (toolbar area)', async () => {
@@ -111,7 +284,7 @@ describe('RestTree', () => {
     const entities = getRestEntities(camelResource.getEntities());
 
     render(
-      <RestTree entities={entities} onSelect={mockOnSelect}>
+      <RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete}>
         <div>Toolbar Content</div>
       </RestTree>,
     );
@@ -134,7 +307,9 @@ describe('RestTree', () => {
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest' };
 
-    const { container } = render(<RestTree entities={entities} selected={selected} onSelect={mockOnSelect} />);
+    const { container } = render(
+      <RestTree entities={entities} selected={selected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
+    );
 
     expect(screen.getByRole('tree', { name: 'Rest DSL Configuration' })).toBeInTheDocument();
 
@@ -166,7 +341,9 @@ describe('RestTree', () => {
     const entities = getRestEntities(camelResource.getEntities());
     const selected = { entityId: 'rest-1234', modelPath: 'rest.post.0' };
 
-    const { container } = render(<RestTree entities={entities} selected={selected} onSelect={mockOnSelect} />);
+    const { container } = render(
+      <RestTree entities={entities} selected={selected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
+    );
 
     const expectedActiveId = 'rest-1234::rest.post.0';
 
@@ -183,7 +360,7 @@ describe('RestTree', () => {
 
     const entities = getRestEntities(camelResource.getEntities());
 
-    render(<RestTree entities={entities} selected={undefined} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} selected={undefined} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expect(screen.getByRole('tree', { name: 'Rest DSL Configuration' })).toBeInTheDocument();
     expect(screen.getByText('rest-1234')).toBeInTheDocument();
@@ -205,7 +382,7 @@ describe('RestTree', () => {
     const initialSelected = { entityId: 'rest-1234', modelPath: 'rest' };
 
     const { container, rerender } = render(
-      <RestTree entities={entities} selected={initialSelected} onSelect={mockOnSelect} />,
+      <RestTree entities={entities} selected={initialSelected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
     );
 
     let expectedActiveId = 'rest-1234::rest';
@@ -213,7 +390,7 @@ describe('RestTree', () => {
     expect(activeNode).toBeInTheDocument();
 
     const newSelected = { entityId: 'rest-1234', modelPath: 'rest.get.0' };
-    rerender(<RestTree entities={entities} selected={newSelected} onSelect={mockOnSelect} />);
+    rerender(<RestTree entities={entities} selected={newSelected} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expectedActiveId = 'rest-1234::rest.get.0';
     activeNode = container.querySelector(`[id="${expectedActiveId}"]`);
@@ -232,7 +409,7 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    render(<RestTree entities={entities} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expect(screen.getByText('not specified')).toBeInTheDocument();
   });
@@ -250,7 +427,7 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    render(<RestTree entities={entities} onSelect={mockOnSelect} />);
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expect(screen.getByText('not specified')).toBeInTheDocument();
   });

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -209,6 +209,22 @@ describe('RestTree', () => {
     expect(mockOnSelect).not.toHaveBeenCalled();
   });
 
+  it('should ignore right-clicks outside a tree node', async () => {
+    const camelResource = CamelResourceFactory.createCamelResource(`
+- rest:
+    id: rest-1
+    `);
+    await camelResource.initialize();
+
+    const entities = getRestEntities(camelResource.getEntities());
+    render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
+
+    fireEvent.contextMenu(screen.getByRole('tree', { name: 'Rest DSL Configuration' }));
+
+    expect(screen.queryByRole('menu', { name: 'REST tree node actions' })).not.toBeInTheDocument();
+    expect(mockOnSelect).not.toHaveBeenCalled();
+  });
+
   it('should delete through the context menu and close it', async () => {
     const camelResource = CamelResourceFactory.createCamelResource(`
 - rest:

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
@@ -1,8 +1,8 @@
 import './RestTree.scss';
 
 import { TrashCan } from '@carbon/icons-react';
-import { Menu, MenuItem, TreeNode, TreeView } from '@carbon/react';
-import { FunctionComponent, PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import { Menu, MenuItem, TreeNode, TreeView, useContextMenu } from '@carbon/react';
+import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
 import { restToTree } from '../rest-to-tree';
@@ -27,19 +27,18 @@ export interface IRestTree extends PropsWithChildren {
  */
 export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onSelect, onDelete, children }) => {
   const restTreeNodes = restToTree(entities);
-  const [contextMenuState, setContextMenuState] = useState<{ nodeId: string; x: number; y: number }>();
+  const contextMenuTriggerRef = useRef<HTMLDivElement>(null);
   const contextMenuRef = useRef<HTMLUListElement>(null);
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenuState(undefined);
-  }, []);
+  const contextMenuProps = useContextMenu(contextMenuTriggerRef);
+  const [contextMenuNodeId, setContextMenuNodeId] = useState<string>();
 
   useEffect(() => {
-    if (!contextMenuState) return;
+    if (!contextMenuProps.open) return;
 
+    // Menu closes on blur, but pointer events on non-focusable areas do not always move focus.
     const handlePointerDown = (event: PointerEvent) => {
       if (event.target instanceof Node && !contextMenuRef.current?.contains(event.target)) {
-        closeContextMenu();
+        contextMenuProps.onClose();
       }
     };
 
@@ -47,7 +46,7 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
     return () => {
       document.removeEventListener('pointerdown', handlePointerDown);
     };
-  }, [closeContextMenu, contextMenuState]);
+  }, [contextMenuProps]);
 
   /** Generates a unique node ID from entity ID and model path */
   const getNodeId = (entityId: string, modelPath: string) => `${entityId}::${modelPath}`;
@@ -72,22 +71,31 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
       <div>{children}</div>
 
       <div
+        ref={contextMenuTriggerRef}
         className="rest-tree"
-        onContextMenu={(event) => {
-          if (!(event.target instanceof Element)) return;
+        onContextMenuCapture={(event) => {
+          if (!(event.target instanceof Element)) {
+            event.stopPropagation();
+            return;
+          }
 
           const treeItem = event.target.closest('[role="treeitem"]');
-          if (!(treeItem instanceof HTMLElement) || !event.currentTarget.contains(treeItem)) return;
+          if (!(treeItem instanceof HTMLElement) || !event.currentTarget.contains(treeItem)) {
+            event.stopPropagation();
+            return;
+          }
 
           const selection = selectionsByNodeId.get(treeItem.id);
-          if (!selection) return;
+          if (!selection) {
+            event.stopPropagation();
+            return;
+          }
 
-          event.preventDefault();
           if (selection.entityId !== selected?.entityId || selection.modelPath !== selected.modelPath) {
             onSelect(selection);
           }
           treeItem.focus();
-          setContextMenuState({ nodeId: treeItem.id, x: event.clientX, y: event.clientY });
+          setContextMenuNodeId(treeItem.id);
         }}
       >
         <TreeView label="Rest DSL Configuration" active={activeNodeId}>
@@ -130,15 +138,12 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
         </TreeView>
       </div>
 
-      {contextMenuState && (
+      {contextMenuNodeId && (
         <Menu
-          key={`${contextMenuState.nodeId}:${contextMenuState.x}:${contextMenuState.y}`}
+          key={`${contextMenuNodeId}:${contextMenuProps.x}:${contextMenuProps.y}`}
+          {...contextMenuProps}
           ref={contextMenuRef}
           label="REST tree node actions"
-          open
-          x={contextMenuState.x}
-          y={contextMenuState.y}
-          onClose={closeContextMenu}
         >
           <MenuItem kind="danger" label="Delete" renderIcon={TrashCan} onClick={onDelete} />
         </Menu>

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
@@ -1,7 +1,8 @@
 import './RestTree.scss';
 
-import { TreeNode, TreeView } from '@carbon/react';
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { TrashCan } from '@carbon/icons-react';
+import { Menu, MenuItem, TreeNode, TreeView } from '@carbon/react';
+import { FunctionComponent, PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
 import { restToTree } from '../rest-to-tree';
@@ -17,24 +18,78 @@ export interface IRestTree extends PropsWithChildren {
   entities: BaseVisualEntity[];
   selected?: IRestTreeSelection;
   onSelect: (selection: IRestTreeSelection) => void;
+  onDelete: () => void;
 }
 
 /**
  * Tree view component for displaying REST DSL configurations and services.
  * Shows REST configurations and REST services with their methods in a hierarchical structure.
  */
-export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onSelect, children }) => {
+export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onSelect, onDelete, children }) => {
   const restTreeNodes = restToTree(entities);
+  const [contextMenuState, setContextMenuState] = useState<{ nodeId: string; x: number; y: number }>();
+  const contextMenuRef = useRef<HTMLUListElement>(null);
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenuState(undefined);
+  }, []);
+
+  useEffect(() => {
+    if (!contextMenuState) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !contextMenuRef.current?.contains(event.target)) {
+        closeContextMenu();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [closeContextMenu, contextMenuState]);
 
   /** Generates a unique node ID from entity ID and model path */
   const getNodeId = (entityId: string, modelPath: string) => `${entityId}::${modelPath}`;
   const activeNodeId = selected ? getNodeId(selected.entityId, selected.modelPath) : undefined;
+  const selectionsByNodeId = new Map<string, IRestTreeSelection>();
+
+  restTreeNodes.forEach((node) => {
+    selectionsByNodeId.set(getNodeId(node.entityId, node.modelPath), {
+      entityId: node.entityId,
+      modelPath: node.modelPath,
+    });
+    node.children?.forEach((child) => {
+      selectionsByNodeId.set(getNodeId(child.entityId, child.modelPath), {
+        entityId: child.entityId,
+        modelPath: child.modelPath,
+      });
+    });
+  });
 
   return (
     <>
       <div>{children}</div>
 
-      <div className="rest-tree">
+      <div
+        className="rest-tree"
+        onContextMenu={(event) => {
+          if (!(event.target instanceof Element)) return;
+
+          const treeItem = event.target.closest('[role="treeitem"]');
+          if (!(treeItem instanceof HTMLElement) || !event.currentTarget.contains(treeItem)) return;
+
+          const selection = selectionsByNodeId.get(treeItem.id);
+          if (!selection) return;
+
+          event.preventDefault();
+          if (selection.entityId !== selected?.entityId || selection.modelPath !== selected.modelPath) {
+            onSelect(selection);
+          }
+          treeItem.focus();
+          setContextMenuState({ nodeId: treeItem.id, x: event.clientX, y: event.clientY });
+        }}
+      >
         <TreeView label="Rest DSL Configuration" active={activeNodeId}>
           {restTreeNodes.map((node) => {
             const nodeId = getNodeId(node.entityId, node.modelPath);
@@ -74,6 +129,20 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
           })}
         </TreeView>
       </div>
+
+      {contextMenuState && (
+        <Menu
+          key={`${contextMenuState.nodeId}:${contextMenuState.x}:${contextMenuState.y}`}
+          ref={contextMenuRef}
+          label="REST tree node actions"
+          open
+          x={contextMenuState.x}
+          y={contextMenuState.y}
+          onClose={closeContextMenu}
+        >
+          <MenuItem kind="danger" label="Delete" renderIcon={TrashCan} onClick={onDelete} />
+        </Menu>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Description

Adds a right-click context menu with a Delete action for REST configuration, service, and method tree nodes.

The clicked node is selected before deletion, and the existing REST delete handler is reused. The menu supports repositioning, outside click, blur, and Escape dismissal. Carbon Menu and MenuItem keep the REST editor on Carbon and provide native focus, keyboard navigation, and viewport alignment without PatternFly or Popper.

Closes #3115

#### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?

- REST tree and editor page tests: 29 passed
- Full UI suite: 6526 passed, 5 skipped, 2 todo; one unrelated FieldOverrideModal test failed in the full run and passed in isolation (43/43)
- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`
- `yarn workspace @kaoto/kaoto build:lib`
- Manually checked all three node types, cursor placement, viewport-edge alignment, label/icon/badge targets, repeated right-click, outside click, Escape, and deletion

#### Confirmation behavior

Deletion intentionally matches the existing toolbar action and does not add a confirmation step. Would you prefer a shared confirmation for both toolbar and context-menu deletion in a follow-up?

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation, or no documentation update was needed.
- [x] I have added tests that prove my feature works.

Developed with AI assistance and reviewed/tested by the contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a right-click context menu for REST tree nodes, including consistent action availability across related targets.
  - Added a Delete action to remove a selected REST method from the editor, closing the menu afterward.
  - Context menus can be dismissed with Escape or clicking outside.
- **Bug Fixes**
  - Deleting a REST method now reliably updates the UI and returns the editor to the entity selection state.
- **Tests**
  - Added/expanded UI test coverage for right-click selection, menu behavior, dismissal, and delete flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->