### PR TITLE
feat(Catalog): wire KaotoEditorChannelApi resource operations to CamelKameletsProvider

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -13,302 +13,345 @@ import {
   kameletToTile,
 } from './camel-to-tile.adapter';
 
-describe('camelComponentToTile', () => {
-  it('should return a tile with the correct type', async () => {
-    const componentDef = {
-      component: {
-        name: 'my-component',
-        title: 'My Component',
-        description: 'My Component Description',
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.name).toBe('my-component');
-    expect(tile.description).toBe('My Component Description');
-  });
-
-  it('should populate the headerTags', async () => {
-    const componentDef = {
-      component: {
-        supportLevel: 'Preview',
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.headerTags).toEqual(['Component', 'Preview']);
-  });
-
-  it('should populate the tags and version', async () => {
-    const componentDef = {
-      component: {
-        label: 'label1,label2',
-        version: '4.0.0',
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.tags).toEqual(['label1', 'label2']);
-    expect(tile.version).toBe('4.0.0');
-  });
-
-  it('should populate the provider', async () => {
-    const componentDef = {
-      component: {
-        provider: 'my-provider',
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.provider).toBe('my-provider');
-  });
-
-  it('should populate tags with `consumerOnly` and `producerOnly` when applicable', async () => {
-    const componentDef = {
-      component: {
-        consumerOnly: true,
-        producerOnly: true,
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.tags).toEqual(['consumerOnly', 'producerOnly']);
-  });
-
-  it('should replace the supportLevel header tag if the component is deprecated', async () => {
-    const componentDef = {
-      component: {
-        supportLevel: 'Stable',
-        deprecated: true,
-      },
-    } as ICamelComponentDefinition;
-
-    const tile = await camelComponentToTile(componentDef);
-
-    expect(tile.headerTags).toEqual(['Component', 'Deprecated']);
-  });
-});
-
-describe('camelProcessorToTile', () => {
-  it('should return a tile with the correct type', async () => {
-    const processorDef = {
-      model: {
-        name: 'my-processor',
-        title: 'My Processor',
-        description: 'My Processor Description',
-        label: 'label1,label2',
-      },
-    } as ICamelProcessorDefinition;
-
-    const tile = await camelProcessorToTile(processorDef);
-
-    expect(tile.name).toBe('my-processor');
-    expect(tile.description).toBe('My Processor Description');
-  });
-
-  it('should populate the headerTags', async () => {
-    const processorDef = {
-      model: {
-        supportLevel: 'Preview',
-        label: 'label1,label2',
-      },
-    } as ICamelProcessorDefinition;
-
-    const tile = await camelProcessorToTile(processorDef);
-
-    expect(tile.headerTags).toEqual(['Processor', 'Preview']);
-  });
-
-  it('should populate the tags', async () => {
-    const processorDef = {
-      model: {
-        label: 'label1,label2',
-      },
-    } as ICamelProcessorDefinition;
-
-    const tile = await camelProcessorToTile(processorDef);
-
-    expect(tile.tags).toEqual(['label1', 'label2']);
-  });
-
-  it('should populate the provider', async () => {
-    const processorDef = {
-      model: {
-        name: 'my-processor',
-        title: 'My Processor',
-        description: 'My Processor Description',
-        label: 'label1,label2',
-        provider: 'my-provider',
-      },
-    } as ICamelProcessorDefinition;
-
-    const tile = await camelProcessorToTile(processorDef);
-
-    expect(tile.provider).toBe('my-provider');
-  });
-});
-
-describe('camelEntityToTile', () => {
-  it('should return a tile with the correct type', async () => {
-    const processorDef = {
-      model: {
-        name: 'my-entity',
-        title: 'My Entity',
-        description: 'My Entity Description',
-        label: 'label1,label2',
-      },
-    } as ICamelProcessorDefinition;
-
-    const tile = await camelEntityToTile(processorDef);
-
-    expect(tile.name).toBe('my-entity');
-    expect(tile.description).toBe('My Entity Description');
-  });
-});
-
-describe('citrusComponentToTile', () => {
-  it('should return a tile with the correct type', async () => {
-    const componentDef = {
-      kind: CatalogKind.TestAction,
-      name: 'my-action',
-      group: 'my-group',
-      title: 'My Action',
-      description: 'This is the description',
-    } as ICitrusComponentDefinition;
-
-    const tile = await citrusComponentToTile(componentDef);
-
-    expect(tile.name).toBe('my-action');
-    expect(tile.title).toBe('My Action');
-    expect(tile.description).toBe('This is the description');
-  });
-
-  it('should return a tile with defaults', async () => {
-    const componentDef = {
-      kind: CatalogKind.TestContainer,
-      name: 'my-container',
-    } as ICitrusComponentDefinition;
-
-    const tile = await citrusComponentToTile(componentDef);
-
-    expect(tile.name).toBe('my-container');
-    expect(tile.title).toBe('my-container');
-    expect(tile.description).toBeUndefined();
-  });
-});
-
-describe('kameletToTile', () => {
-  it('should return a tile with the correct type', async () => {
-    const kameletDef = {
-      metadata: {
-        name: 'my-kamelet',
-        labels: {
-          'camel.apache.org/kamelet.type': 'source',
+describe('camel-to-tile.adapter', () => {
+  describe('camelComponentToTile', () => {
+    it('should return a tile with the correct type', async () => {
+      const componentDef = {
+        component: {
+          name: 'my-component',
+          title: 'My Component',
+          description: 'My Component Description',
         },
-        annotations: {
-          'camel.apache.org/catalog.version': '1.0.0',
-        },
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
-        },
-      },
-    } as IKameletDefinition;
+      } as ICamelComponentDefinition;
 
-    const tile = await kameletToTile(kameletDef);
+      const tile = await camelComponentToTile(componentDef);
 
-    expect(tile.name).toBe('my-kamelet');
-    expect(tile.description).toBe('My Kamelet Description');
+      expect(tile.name).toBe('my-component');
+      expect(tile.description).toBe('My Component Description');
+    });
+
+    it('should populate the headerTags', async () => {
+      const componentDef = {
+        component: {
+          supportLevel: 'Preview',
+        },
+      } as ICamelComponentDefinition;
+
+      const tile = await camelComponentToTile(componentDef);
+
+      expect(tile.headerTags).toEqual(['Component', 'Preview']);
+    });
+
+    it('should populate the tags and version', async () => {
+      const componentDef = {
+        component: {
+          label: 'label1,label2',
+          version: '4.0.0',
+        },
+      } as ICamelComponentDefinition;
+
+      const tile = await camelComponentToTile(componentDef);
+
+      expect(tile.tags).toEqual(['label1', 'label2']);
+      expect(tile.version).toBe('4.0.0');
+    });
+
+    it('should populate the provider', async () => {
+      const componentDef = {
+        component: {
+          provider: 'my-provider',
+        },
+      } as ICamelComponentDefinition;
+
+      const tile = await camelComponentToTile(componentDef);
+
+      expect(tile.provider).toBe('my-provider');
+    });
+
+    it('should populate tags with `consumerOnly` and `producerOnly` when applicable', async () => {
+      const componentDef = {
+        component: {
+          consumerOnly: true,
+          producerOnly: true,
+        },
+      } as ICamelComponentDefinition;
+
+      const tile = await camelComponentToTile(componentDef);
+
+      expect(tile.tags).toEqual(['consumerOnly', 'producerOnly']);
+    });
+
+    it('should replace the supportLevel header tag if the component is deprecated', async () => {
+      const componentDef = {
+        component: {
+          supportLevel: 'Stable',
+          deprecated: true,
+        },
+      } as ICamelComponentDefinition;
+
+      const tile = await camelComponentToTile(componentDef);
+
+      expect(tile.headerTags).toEqual(['Component', 'Deprecated']);
+    });
   });
 
-  it('should populate the tags for type', async () => {
-    const kameletDef = {
-      metadata: {
-        labels: {
-          'camel.apache.org/kamelet.type': 'source',
+  describe('camelProcessorToTile', () => {
+    it('should return a tile with the correct type', async () => {
+      const processorDef = {
+        model: {
+          name: 'my-processor',
+          title: 'My Processor',
+          description: 'My Processor Description',
+          label: 'label1,label2',
         },
-        annotations: {},
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
+      } as ICamelProcessorDefinition;
+
+      const tile = await camelProcessorToTile(processorDef);
+
+      expect(tile.name).toBe('my-processor');
+      expect(tile.description).toBe('My Processor Description');
+    });
+
+    it('should populate the headerTags', async () => {
+      const processorDef = {
+        model: {
+          supportLevel: 'Preview',
+          label: 'label1,label2',
         },
-      },
-    } as IKameletDefinition;
+      } as ICamelProcessorDefinition;
 
-    const tile = await kameletToTile(kameletDef);
+      const tile = await camelProcessorToTile(processorDef);
 
-    expect(tile.tags).toEqual(['source']);
+      expect(tile.headerTags).toEqual(['Processor', 'Preview']);
+    });
+
+    it('should populate the tags', async () => {
+      const processorDef = {
+        model: {
+          label: 'label1,label2',
+        },
+      } as ICamelProcessorDefinition;
+
+      const tile = await camelProcessorToTile(processorDef);
+
+      expect(tile.tags).toEqual(['label1', 'label2']);
+    });
+
+    it('should populate the provider', async () => {
+      const processorDef = {
+        model: {
+          name: 'my-processor',
+          title: 'My Processor',
+          description: 'My Processor Description',
+          label: 'label1,label2',
+          provider: 'my-provider',
+        },
+      } as ICamelProcessorDefinition;
+
+      const tile = await camelProcessorToTile(processorDef);
+
+      expect(tile.provider).toBe('my-provider');
+    });
   });
 
-  it('should use the selected CatalogKind.Kamelet by default', async () => {
-    const kameletDef = {
-      metadata: {
-        labels: {
-          'camel.apache.org/kamelet.type': 'source',
+  describe('camelEntityToTile', () => {
+    it('should return a tile with the correct type', async () => {
+      const processorDef = {
+        model: {
+          name: 'my-entity',
+          title: 'My Entity',
+          description: 'My Entity Description',
+          label: 'label1,label2',
         },
-        annotations: {},
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
-        },
-      },
-    } as IKameletDefinition;
+      } as ICamelProcessorDefinition;
 
-    const tile = await kameletToTile(kameletDef);
+      const tile = await camelEntityToTile(processorDef);
 
-    expect(tile.type).toEqual(CatalogKind.Kamelet);
+      expect(tile.name).toBe('my-entity');
+      expect(tile.description).toBe('My Entity Description');
+    });
   });
 
-  it('should populate the version for annotations', async () => {
-    const kameletDef = {
-      metadata: {
-        labels: {},
-        annotations: {
-          'camel.apache.org/catalog.version': '1.0.0',
-        },
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
-        },
-      },
-    } as IKameletDefinition;
+  describe('citrusComponentToTile', () => {
+    it('should return a tile with the correct type', async () => {
+      const componentDef = {
+        kind: CatalogKind.TestAction,
+        name: 'my-action',
+        group: 'my-group',
+        title: 'My Action',
+        description: 'This is the description',
+      } as ICitrusComponentDefinition;
 
-    const tile = await kameletToTile(kameletDef);
+      const tile = await citrusComponentToTile(componentDef);
 
-    expect(tile.version).toBe('1.0.0');
+      expect(tile.name).toBe('my-action');
+      expect(tile.title).toBe('My Action');
+      expect(tile.description).toBe('This is the description');
+    });
+
+    it('should return a tile with defaults', async () => {
+      const componentDef = {
+        kind: CatalogKind.TestContainer,
+        name: 'my-container',
+      } as ICitrusComponentDefinition;
+
+      const tile = await citrusComponentToTile(componentDef);
+
+      expect(tile.name).toBe('my-container');
+      expect(tile.title).toBe('my-container');
+      expect(tile.description).toBeUndefined();
+    });
   });
 
-  it('should populate the headerTags', async () => {
-    const kameletDef = {
-      metadata: {
-        annotations: {
-          'camel.apache.org/kamelet.support.level': 'Preview',
+  describe('kameletToTile', () => {
+    it('should return a tile with the correct type', async () => {
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          labels: {
+            'camel.apache.org/kamelet.type': 'source',
+          },
+          annotations: {
+            'camel.apache.org/catalog.version': '1.0.0',
+          },
         },
-        labels: {},
-      },
-      spec: {
-        definition: {
-          title: 'My Kamelet',
-          description: 'My Kamelet Description',
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
         },
-      },
-    } as IKameletDefinition;
+      } as IKameletDefinition;
 
-    const tile = await kameletToTile(kameletDef);
+      const tile = await kameletToTile(kameletDef);
 
-    expect(tile.headerTags).toEqual(['Kamelet', 'Preview']);
+      expect(tile.name).toBe('my-kamelet');
+      expect(tile.description).toBe('My Kamelet Description');
+    });
+
+    it('should populate the tags for type', async () => {
+      const kameletDef = {
+        metadata: {
+          labels: {
+            'camel.apache.org/kamelet.type': 'source',
+          },
+          annotations: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.tags).toEqual(['source']);
+    });
+
+    it('should use the selected CatalogKind.Kamelet by default', async () => {
+      const kameletDef = {
+        metadata: {
+          labels: {
+            'camel.apache.org/kamelet.type': 'source',
+          },
+          annotations: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.type).toEqual(CatalogKind.Kamelet);
+    });
+
+    it('should populate the version for annotations', async () => {
+      const kameletDef = {
+        metadata: {
+          labels: {},
+          annotations: {
+            'camel.apache.org/catalog.version': '1.0.0',
+          },
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.version).toBe('1.0.0');
+    });
+
+    it('should populate the headerTags', async () => {
+      const kameletDef = {
+        metadata: {
+          annotations: {
+            'camel.apache.org/kamelet.support.level': 'Preview',
+          },
+          labels: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.headerTags).toEqual(['Kamelet', 'Preview']);
+    });
+
+    it('should not include support level or version when annotations are absent', async () => {
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          annotations: undefined,
+          labels: { 'camel.apache.org/kamelet.type': 'source' },
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as unknown as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.headerTags).toEqual(['Kamelet']);
+      expect(tile.version).toBeUndefined();
+    });
+
+    it('should not include type tag when labels are absent', async () => {
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          annotations: { 'camel.apache.org/kamelet.support.level': 'Stable' },
+          labels: undefined,
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as unknown as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.tags).toEqual([]);
+    });
   });
 });

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -79,17 +79,17 @@ export const camelEntityToTile = async (processorDef: ICamelProcessorDefinition)
 
 export const kameletToTile = async (kameletDef: IKameletDefinition): Promise<ITile> => {
   const headerTags: string[] = ['Kamelet'];
-  if (kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']) {
+  if (kameletDef.metadata.annotations?.['camel.apache.org/kamelet.support.level']) {
     headerTags.push(kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']);
   }
 
   const tags: string[] = [];
-  if (kameletDef.metadata.labels['camel.apache.org/kamelet.type']) {
+  if (kameletDef.metadata.labels?.['camel.apache.org/kamelet.type']) {
     tags.push(kameletDef.metadata.labels['camel.apache.org/kamelet.type']);
   }
 
   let version = undefined;
-  if (kameletDef.metadata.annotations['camel.apache.org/catalog.version']) {
+  if (kameletDef.metadata.annotations?.['camel.apache.org/catalog.version']) {
     version = kameletDef.metadata.annotations['camel.apache.org/catalog.version'];
   }
 

--- a/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.test.ts
+++ b/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.test.ts
@@ -1,0 +1,103 @@
+import { IKameletDefinition } from '../../models/camel/kamelets-catalog';
+import { FileTypes } from '../../models/file-types';
+import { CamelKameletsProvider } from './camel-kamelets.provider';
+
+describe('CamelKameletsProvider', () => {
+  describe('fetchAll', () => {
+    it('should return only embedded kamelets when no client is provided', async () => {
+      const embedded = { 'timer-source': { metadata: { name: 'timer-source' } } as IKameletDefinition };
+      const provider = new CamelKameletsProvider(embedded);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toEqual(embedded);
+    });
+
+    it('should parse YAML content from remote resources', async () => {
+      const yamlContent = `
+kind: Kamelet
+metadata:
+  name: http-source
+spec:
+  definition:
+    title: HTTP Source
+`;
+      const client = vi.fn().mockResolvedValue([{ filename: 'http-source.kamelet.yaml', content: yamlContent }]);
+      const provider = new CamelKameletsProvider({}, client);
+
+      const result = await provider.fetchAll();
+
+      expect(client).toHaveBeenCalledWith(FileTypes.Kamelets);
+      expect(result['http-source.kamelet.yaml']).toMatchObject({ kind: 'Kamelet', metadata: { name: 'http-source' } });
+    });
+
+    it('should merge embedded kamelets with remote kamelets, remote taking precedence', async () => {
+      const embedded = { 'timer-source': { metadata: { name: 'timer-source' } } as IKameletDefinition };
+      const remoteYaml = 'kind: Kamelet\nmetadata:\n  name: http-source\n';
+      const client = vi.fn().mockResolvedValue([{ filename: 'http-source.kamelet.yaml', content: remoteYaml }]);
+      const provider = new CamelKameletsProvider(embedded, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toHaveProperty('timer-source');
+      expect(result).toHaveProperty('http-source.kamelet.yaml');
+    });
+
+    it('should skip an entry and log an error when YAML parsing fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const badContent = ': invalid: yaml: {[';
+      const client = vi.fn().mockResolvedValue([{ filename: 'bad-kamelet.yaml', content: badContent }]);
+      const provider = new CamelKameletsProvider({}, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).not.toHaveProperty('bad-kamelet.yaml');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error parsing bad-kamelet.yaml', expect.anything());
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should continue processing valid entries after a failed parse', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const validYaml = 'kind: Kamelet\nmetadata:\n  name: good-kamelet\n';
+      const client = vi.fn().mockResolvedValue([
+        { filename: 'bad.yaml', content: ': {[' },
+        { filename: 'good.yaml', content: validYaml },
+      ]);
+      const provider = new CamelKameletsProvider({}, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toHaveProperty('good.yaml');
+      expect(result).not.toHaveProperty('bad.yaml');
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should return an empty object when client returns an empty list', async () => {
+      const client = vi.fn().mockResolvedValue([]);
+      const provider = new CamelKameletsProvider({}, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('fetch', () => {
+    it('should return the kamelet for a given key', async () => {
+      const embedded = { 'timer-source': { metadata: { name: 'timer-source' } } as IKameletDefinition };
+      const provider = new CamelKameletsProvider(embedded);
+
+      const result = await provider.fetch('timer-source');
+
+      expect(result).toEqual(embedded['timer-source']);
+    });
+
+    it('should return undefined when the key does not exist', async () => {
+      const provider = new CamelKameletsProvider({});
+
+      const result = await provider.fetch('non-existent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.ts
+++ b/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.ts
@@ -1,3 +1,5 @@
+import { parse } from 'yaml';
+
 import { IKameletDefinition } from '../../models/camel/kamelets-catalog';
 import { FileTypes, FileTypesResponse } from '../../models/file-types';
 import { ICatalogProvider } from '../models';
@@ -20,7 +22,13 @@ export class CamelKameletsProvider implements ICatalogProvider<IKameletDefinitio
     const remoteResources = (await this.client(FileTypes.Kamelets)) ?? [];
     const remoteKamelets = remoteResources.reduce(
       (acc, { filename, content }) => {
-        acc[filename] = JSON.parse(content) as IKameletDefinition;
+        try {
+          const remoteKamelet = parse(content) as IKameletDefinition;
+          acc[filename] = remoteKamelet;
+        } catch (error) {
+          console.error(`Error parsing ${filename}`, error);
+        }
+
         return acc;
       },
       {} as Record<string, IKameletDefinition>,

--- a/packages/ui/src/models-api.ts
+++ b/packages/ui/src/models-api.ts
@@ -3,4 +3,9 @@
  *
  * This file shouldn't export anything other than models, for instance, no components, no hooks, etc.
  */
+export * from './models/catalog-kind';
+export * from './models/file-types';
+export * from './models/runtime-maven-information';
 export * from './models/settings';
+export * from './models/step-update-action';
+export * from './multiplying-architecture';

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.test.tsx
@@ -15,7 +15,7 @@ import { OperatingSystem } from '@kie-tools-core/operating-system/dist/Operating
 import { RefObject } from 'react';
 import type { Mock } from 'vitest';
 
-import { CatalogKind, StepUpdateAction } from '../models';
+import { CatalogKind, FileTypes, StepUpdateAction } from '../models';
 import { AbstractSettingsAdapter, ColorScheme, DefaultSettingsAdapter } from '../models/settings';
 import { setColorScheme } from '../utils/color-scheme';
 import { EditService } from './EditService';
@@ -63,6 +63,7 @@ describe('KaotoEditorApp', () => {
         requests: {
           getMetadata: vi.fn(),
           setMetadata: vi.fn(),
+          getResourcesContentByType: vi.fn(),
           getResourceContent: vi.fn(),
           saveResourceContent: vi.fn(),
           isResourceExist: vi.fn(),
@@ -224,6 +225,16 @@ describe('KaotoEditorApp', () => {
     await kaotoEditorApp.setMetadata('key', 'value');
 
     expect(envelopeContext.channelApi.requests.setMetadata).toHaveBeenCalledWith('key', 'value');
+  });
+
+  it('should delegate to the channelApi getting resources content by type', async () => {
+    const mockResponse = [{ filename: 'my-kamelet.kamelet.yaml', content: 'kind: Kamelet' }];
+    (envelopeContext.channelApi.requests.getResourcesContentByType as Mock).mockResolvedValue(mockResponse);
+
+    const result = await kaotoEditorApp.getResourcesContentByType(FileTypes.Kamelets);
+
+    expect(envelopeContext.channelApi.requests.getResourcesContentByType).toHaveBeenCalledWith(FileTypes.Kamelets);
+    expect(result).toEqual(mockResponse);
   });
 
   it('should delegate to the channelApi getting a file resource content', async () => {

--- a/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditorApp.tsx
@@ -14,7 +14,7 @@ import { createRef, RefObject } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
 import { CatalogLoaderProvider } from '../dynamic-catalog/catalog.provider';
-import { CatalogKind, StepUpdateAction } from '../models';
+import { CatalogKind, FileTypes, FileTypesResponse, StepUpdateAction } from '../models';
 import { AbstractSettingsAdapter, SettingsModel } from '../models/settings';
 import { KaotoResourceProvider } from '../providers';
 import { EntitiesProvider } from '../providers/entities.provider';
@@ -51,6 +51,7 @@ export class KaotoEditorApp implements Editor {
     this.sendStateControlCommand = this.sendStateControlCommand.bind(this);
     this.getMetadata = this.getMetadata.bind(this);
     this.setMetadata = this.setMetadata.bind(this);
+    this.getResourcesContentByType = this.getResourcesContentByType.bind(this);
     this.getResourceContent = this.getResourceContent.bind(this);
     this.isResourceExist = this.isResourceExist.bind(this);
     this.saveResourceContent = this.saveResourceContent.bind(this);
@@ -125,6 +126,10 @@ export class KaotoEditorApp implements Editor {
     return this.envelopeContext.channelApi.requests.setMetadata(key, preferences);
   }
 
+  async getResourcesContentByType(fileType: FileTypes): Promise<FileTypesResponse[]> {
+    return this.envelopeContext.channelApi.requests.getResourcesContentByType(fileType);
+  }
+
   async getResourceContent(path: string): Promise<string | undefined> {
     return this.envelopeContext.channelApi.requests.getResourceContent(path);
   }
@@ -181,7 +186,7 @@ export class KaotoEditorApp implements Editor {
                   runtimeCatalogName={this.settings.runtimeCatalogName}
                   testingCatalogName={this.settings.testingCatalogName}
                 >
-                  <CatalogLoaderProvider>
+                  <CatalogLoaderProvider getResourcesContentByType={this.getResourcesContentByType}>
                     <EntitiesProvider>
                       <KaotoBridge
                         channelType={this.initArgs.channel}


### PR DESCRIPTION
### Context
Expose the resource-file API from the host application (e.g. VS Code Kaoto) through the existing channel API and plumb it into the dynamic catalog pipeline.

### Changes
- Add `FileTypes` enum and `FileTypesResponse` interface to models
- Add `getResourcesContentByType`, `getResourceContent`, `saveResourceContent`, `isResourceExist`, `deleteResource`, and `askUserForFileSelection` to `KaotoEditorChannelApi`
- Wire `KaotoEditorApp` to delegate those operations to `envelopeContext.channelApi`
- Accept a `client` callback in `CamelKameletsProvider` that calls `getResourcesContentByType(FileTypes.Kamelets)` to fetch and merge workspace-local kamelets at catalog load time
- Pass the client through `fetch-camel-catalog` options so the provider receives it during catalog initialisation

fix: https://github.com/KaotoIO/kaoto/issues/3481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving catalog resource content by file type.
  - Expanded the available model exports for application integrations.

- **Bug Fixes**
  - Improved handling of Kamelets with missing metadata without causing errors.
  - Added support for loading remote Kamelets from YAML content.
  - Invalid remote Kamelet definitions are skipped while valid entries continue loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->