### PR TITLE
feat(mithril): epic4 (custom-mode): add Custom Mode to IntegrationTypeSelector DSL list

### DIFF
--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -72,7 +72,7 @@ describe('IntegrationTypeSelector', () => {
       fireEvent.click(wrapper.getByTestId('test-toggle'));
     });
 
-    for (const label of ['Camel Route', 'Kamelet', 'Pipe', 'Test']) {
+    for (const label of ['Camel Route', 'Kamelet', 'Pipe', 'Test', 'Custom Mode']) {
       expect(await wrapper.findByText(label)).toBeInTheDocument();
     }
   });
@@ -195,5 +195,22 @@ describe('IntegrationTypeSelector', () => {
 
     // Merely opening the dropdown must not select anything.
     expect(onSelect).not.toHaveBeenCalled();
+  });
+  it('calls onSelect with SourceSchemaType.CustomMode when Custom Mode is clicked', async () => {
+    const onSelect = vi.fn();
+    const wrapper = renderSelector(onSelect);
+
+    act(() => {
+      fireEvent.click(wrapper.getByTestId('test-toggle'));
+    });
+
+    const option = await wrapper.findByText('Custom Mode');
+    act(() => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(SourceSchemaType.CustomMode);
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.tsx
@@ -4,7 +4,13 @@ import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useState }
 import { sourceSchemaConfig, SourceSchemaType } from '../../../models/camel';
 import { EntitiesContext } from '../../../providers/entities.provider';
 
-const DSL_LIST = [SourceSchemaType.Route, SourceSchemaType.Kamelet, SourceSchemaType.Pipe, SourceSchemaType.Test];
+const DSL_LIST = [
+  SourceSchemaType.Route,
+  SourceSchemaType.Kamelet,
+  SourceSchemaType.Pipe,
+  SourceSchemaType.Test,
+  SourceSchemaType.CustomMode,
+];
 
 interface IntegrationTypeOption {
   description: string;

--- a/packages/ui/src/stubs/sourceSchemaConfig.ts
+++ b/packages/ui/src/stubs/sourceSchemaConfig.ts
@@ -15,6 +15,7 @@ export const configureSourceSchemaTypes = (): void => {
     { type: SourceSchemaType.Test, name: 'Test', description: 'Test desc' },
     { type: SourceSchemaType.Integration, name: 'Integration', description: 'Integration desc' },
     { type: SourceSchemaType.KameletBinding, name: 'kameletBinding', description: 'KameletBinding desc' },
+    { type: SourceSchemaType.CustomMode, name: 'Custom Mode', description: 'Custom Mode desc' },
   ];
 
   for (const { type, name, description } of types) {


### PR DESCRIPTION
Adds SourceSchemaType.CustomMode to the shared DSL_LIST in [IntegrationTypeSelector.tsx] so that "Custom Mode" appears in every DSL entry point in the Kaoto web UI — both the empty-state "New" button and the context-toolbar type-switcher.

Changes:
- [IntegrationTypeSelector.tsx] — appended SourceSchemaType.CustomMode to DSL_LIST
- [IntegrationTypeSelector.test.tsx] — updated the label-list assertion to include 'Custom Mode'; added a new test verifying onSelect is called with SourceSchemaType.CustomMode when the option is clicked
- [stubs/sourceSchemaConfig.ts]— added a CustomMode stub entry to configureSourceSchemaTypes() so all existing tests continue to compile and pass

https://github.com/user-attachments/assets/8270d6fb-88ff-489b-b232-cfce9b3d7e88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated integration type selector coverage to include the **Custom Mode** option.
  - Added verification that selecting **Custom Mode** triggers the expected selection behavior.
- **Bug Fixes**
  - Added test configuration support for the Custom Mode schema, ensuring it is handled correctly in relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->