### PR TITLE
Mithril epic5

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -6,7 +6,7 @@ import { CamelCatalogService, CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel';
 import { configureSourceSchemaTypes, TestProvidersWrapper } from '../../../../stubs';
 import { camelRouteJson } from '../../../../stubs/camel-route';
-import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../stubs/test-load-catalog';
 import { NewEntity } from './NewEntity';
 
 describe('NewEntity', () => {
@@ -17,6 +17,7 @@ describe('NewEntity', () => {
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it('component renders', async () => {

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -196,6 +196,7 @@ describe('IntegrationTypeSelector', () => {
     // Merely opening the dropdown must not select anything.
     expect(onSelect).not.toHaveBeenCalled();
   });
+
   it('calls onSelect with SourceSchemaType.CustomMode when Custom Mode is clicked', async () => {
     const onSelect = vi.fn();
     const wrapper = renderSelector(onSelect);

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -72,7 +72,7 @@ describe('IntegrationTypeSelector', () => {
       fireEvent.click(wrapper.getByTestId('test-toggle'));
     });
 
-    for (const label of ['Camel Route', 'Kamelet', 'Pipe', 'Test']) {
+    for (const label of ['Camel Route', 'Kamelet', 'Pipe', 'Test', 'Custom Mode']) {
       expect(await wrapper.findByText(label)).toBeInTheDocument();
     }
   });
@@ -195,5 +195,22 @@ describe('IntegrationTypeSelector', () => {
 
     // Merely opening the dropdown must not select anything.
     expect(onSelect).not.toHaveBeenCalled();
+  });
+  it('calls onSelect with SourceSchemaType.CustomMode when Custom Mode is clicked', async () => {
+    const onSelect = vi.fn();
+    const wrapper = renderSelector(onSelect);
+
+    act(() => {
+      fireEvent.click(wrapper.getByTestId('test-toggle'));
+    });
+
+    const option = await wrapper.findByText('Custom Mode');
+    act(() => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(SourceSchemaType.CustomMode);
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.tsx
@@ -4,7 +4,13 @@ import { FunctionComponent, MouseEvent, Ref, useCallback, useContext, useState }
 import { sourceSchemaConfig, SourceSchemaType } from '../../../models/camel';
 import { EntitiesContext } from '../../../providers/entities.provider';
 
-const DSL_LIST = [SourceSchemaType.Route, SourceSchemaType.Kamelet, SourceSchemaType.Pipe, SourceSchemaType.Test];
+const DSL_LIST = [
+  SourceSchemaType.Route,
+  SourceSchemaType.Kamelet,
+  SourceSchemaType.Pipe,
+  SourceSchemaType.Test,
+  SourceSchemaType.CustomMode,
+];
 
 interface IntegrationTypeOption {
   description: string;

--- a/packages/ui/src/dynamic-catalog/models.ts
+++ b/packages/ui/src/dynamic-catalog/models.ts
@@ -26,6 +26,10 @@ export type DynamicCatalogTypeMap = {
   [CatalogKind.TestFunction]: ICitrusComponentDefinition;
   [CatalogKind.TestValidationMatcher]: ICitrusComponentDefinition;
   [CatalogKind.Function]: Record<string, KaotoFunction>;
+  /** Placeholder for Epic 6 Bob catalog tiles — not populated until then.
+   *  TODO(Epic 6): Replace ICitrusComponentDefinition with the proper IBobNodeDefinition
+   *  interface once the Bob catalog is registered. */
+  [CatalogKind.BobNodes]: ICitrusComponentDefinition;
 };
 
 export interface ICatalogProvider<T> {

--- a/packages/ui/src/models/camel/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel/camel-catalog-index.ts
@@ -56,4 +56,8 @@ export interface ComponentsCatalog {
   [CatalogKind.TestFunction]?: Record<string, ICitrusComponentDefinition>;
   [CatalogKind.TestValidationMatcher]?: Record<string, ICitrusComponentDefinition>;
   [CatalogKind.Function]?: Record<string, Record<string, KaotoFunction>>;
+  /** Placeholder for Epic 6 Bob catalog tiles — not populated until then.
+   *  TODO(Epic 6): Replace ICitrusComponentDefinition with the proper IBobNodeDefinition
+   *  interface once the Bob catalog is registered. */
+  [CatalogKind.BobNodes]?: Record<string, ICitrusComponentDefinition>;
 }

--- a/packages/ui/src/models/camel/camel-resource-factory.test.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.test.ts
@@ -1,3 +1,4 @@
+import { CustomModeResource } from '../custom-mode/custom-mode-resource';
 import { CamelResourceFactory } from './camel-resource-factory';
 import { CamelRouteResource } from './camel-route-resource';
 import { CamelXMLRouteResource } from './camel-xml-route-resource';
@@ -67,6 +68,22 @@ describe('CamelResourceFactory', () => {
       const resource = CamelResourceFactory.createCamelResource('- from:\n    uri: direct:start\n    steps: []\n');
       expect(resource).toBeInstanceOf(CamelRouteResource);
       expect(resource).not.toBeInstanceOf(CamelXMLRouteResource);
+    });
+    it('returns CustomModeResource for custom_modes.yaml path', () => {
+      const resource = CamelResourceFactory.createCamelResource(undefined, { path: 'custom_modes.yaml' });
+      expect(resource).toBeInstanceOf(CustomModeResource);
+    });
+
+    it('returns CustomModeResource for path-prefixed custom_modes.yaml', () => {
+      const resource = CamelResourceFactory.createCamelResource(undefined, { path: '/configs/custom_modes.yaml' });
+      expect(resource).toBeInstanceOf(CustomModeResource);
+    });
+
+    it('returns CustomModeResource for yaml with customModes array (no path)', () => {
+      const yaml =
+        'customModes:\n  - slug: plan\n    name: Plan\n    description: ""\n    roleDefinition: ""\n    whenToUse: ""\n    groups: []\n';
+      const resource = CamelResourceFactory.createCamelResource(yaml);
+      expect(resource).toBeInstanceOf(CustomModeResource);
     });
   });
 });

--- a/packages/ui/src/models/camel/camel-resource-factory.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.ts
@@ -5,6 +5,7 @@ import { isXML } from '../../serializers/xml/kaoto-xml-parser';
 import { parseYamlComments } from '../../utils/yaml-comments';
 import { CitrusTestResourceFactory } from '../citrus/citrus-test-resource-factory';
 import { Test } from '../citrus/entities/Test';
+import { CustomModeResourceFactory } from '../custom-mode/custom-mode-resource-factory';
 import { KaotoResource } from '../kaoto-resource';
 import { CamelKResourceFactory } from './camel-k-resource-factory';
 import { CamelRouteResource } from './camel-route-resource';
@@ -35,6 +36,11 @@ export class CamelResourceFactory {
     const testResource = CitrusTestResourceFactory.getCitrusTestResource(parsedCode as Test, pathResourceType);
     if (testResource) {
       return testResource;
+    }
+
+    const customModeResource = CustomModeResourceFactory.getCustomModeResource(parsedCode, pathResourceType);
+    if (customModeResource) {
+      return customModeResource;
     }
 
     const resource = CamelKResourceFactory.getCamelKResource(

--- a/packages/ui/src/models/camel/source-schema-config.ts
+++ b/packages/ui/src/models/camel/source-schema-config.ts
@@ -16,6 +16,7 @@ interface IEntitySchemaConfig {
   [SourceSchemaType.Pipe]: ISourceSchema;
   [SourceSchemaType.KameletBinding]: ISourceSchema;
   [SourceSchemaType.Integration]: ISourceSchema;
+  [SourceSchemaType.CustomMode]: ISourceSchema;
 }
 
 class SourceSchemaConfig {
@@ -59,6 +60,12 @@ class SourceSchemaConfig {
       schema: undefined,
       multipleRoute: true,
       description: 'An integration defines a Camel route in a CRD file.',
+    },
+    [SourceSchemaType.CustomMode]: {
+      name: 'Custom Mode',
+      schema: undefined,
+      multipleRoute: true,
+      description: 'Defines a Bob custom mode, including its role, instructions, and tool permissions.',
     },
   };
 

--- a/packages/ui/src/models/camel/source-schema-type.test.ts
+++ b/packages/ui/src/models/camel/source-schema-type.test.ts
@@ -29,6 +29,7 @@ describe('getResourceTypeFromPath', () => {
     ['my-it.citrus.yml', SourceSchemaType.Test],
     ['my.citrus.it.xml', SourceSchemaType.Test],
     ['my-it.citrus.xml', SourceSchemaType.Test],
+    ['custom_modes.yaml', SourceSchemaType.CustomMode],
     ['yaml', undefined],
     ['yml', undefined],
     ['my.json', undefined],

--- a/packages/ui/src/models/camel/source-schema-type.ts
+++ b/packages/ui/src/models/camel/source-schema-type.ts
@@ -5,6 +5,7 @@ export enum SourceSchemaType {
   Kamelet = 'Kamelet',
   Pipe = 'Pipe',
   Test = 'Test',
+  CustomMode = 'CustomMode',
 }
 
 export const getResourceTypeFromPath = (path?: string): SourceSchemaType | undefined => {
@@ -32,6 +33,8 @@ export const getResourceTypeFromPath = (path?: string): SourceSchemaType | undef
     path?.endsWith('citrus.it.yml')
   ) {
     return SourceSchemaType.Test;
+  } else if (path === 'custom_modes.yaml' || path?.endsWith('/custom_modes.yaml')) {
+    return SourceSchemaType.CustomMode;
   } else if (path?.endsWith('.xml') || path?.endsWith('.yaml') || path?.endsWith('.yml')) {
     return SourceSchemaType.Route;
   }

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -44,4 +44,9 @@ export const enum CatalogKind {
 
   /** Citrus test validation matcher catalog, f.i. @isNumber()@, @isEmpty()@, @matches()@ */
   TestValidationMatcher = 'testValidationMatcher',
+
+  /** Bob LLM tool catalog, used by the Custom Mode editor canvas.
+   *  Tiles with this type are registered by the Bob catalog in Epic 6.
+   *  This is a bridge value — not a Camel runtime equivalent. */
+  BobNodes = 'BobNodes',
 }

--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
@@ -1,0 +1,17 @@
+import { CustomInstructionsParser } from './custom-instructions-parser';
+
+describe('CustomInstructionsParser (stub)', () => {
+  describe('parse', () => {
+    it('returns an empty array for any input', () => {
+      expect(CustomInstructionsParser.parse('## Step 1\nsome content')).toEqual([]);
+      expect(CustomInstructionsParser.parse('')).toEqual([]);
+    });
+  });
+
+  describe('serialize', () => {
+    it('returns an empty string for any input', () => {
+      expect(CustomInstructionsParser.serialize([{ nodeType: 'section', rawContent: '## Step 1' }])).toBe('');
+      expect(CustomInstructionsParser.serialize([])).toBe('');
+    });
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
@@ -1,0 +1,24 @@
+/** Represents a single parsed node from a customInstructions string.
+ *  nodeType is the opaque key name (defined in Epic 7). */
+export interface CustomInstructionsNode {
+  nodeType: string;
+  rawContent: string;
+}
+
+/**
+ * Parses and serializes the `customInstructions` field of a CustomMode.
+ * Stub — Epic 7 replaces parse() and serialize() with real implementations.
+ */
+export class CustomInstructionsParser {
+  /** Stub: always returns an empty array. */
+  static parse(_raw: string): CustomInstructionsNode[] {
+    // TODO: Epic 7 — implement real parsing
+    return [];
+  }
+
+  /** Stub: always returns an empty string. */
+  static serialize(_nodes: CustomInstructionsNode[]): string {
+    // TODO: Epic 7 — implement real serialization
+    return '';
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-resource-factory.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource-factory.test.ts
@@ -1,0 +1,42 @@
+// kaoto/packages/ui/src/models/custom-mode/custom-mode-resource-factory.test.ts
+import { SourceSchemaType } from '../camel/source-schema-type';
+import { CustomModeResource } from './custom-mode-resource';
+import { CustomModeResourceFactory } from './custom-mode-resource-factory';
+
+const validFile = {
+  customModes: [{ slug: 'plan', name: 'Plan', description: '', roleDefinition: '', whenToUse: '', groups: [] }],
+};
+
+describe('CustomModeResourceFactory', () => {
+  it('returns CustomModeResource when type is SourceSchemaType.CustomMode', () => {
+    const result = CustomModeResourceFactory.getCustomModeResource(undefined, SourceSchemaType.CustomMode);
+    expect(result).toBeInstanceOf(CustomModeResource);
+  });
+
+  it('returns CustomModeResource when json has a customModes array (no type hint)', () => {
+    const result = CustomModeResourceFactory.getCustomModeResource(validFile);
+    expect(result).toBeInstanceOf(CustomModeResource);
+  });
+
+  it('returns undefined for plain object without customModes', () => {
+    const result = CustomModeResourceFactory.getCustomModeResource({ routes: [] });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = CustomModeResourceFactory.getCustomModeResource(null as any);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for an array at root', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = CustomModeResourceFactory.getCustomModeResource([] as any);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when customModes is not an array', () => {
+    const result = CustomModeResourceFactory.getCustomModeResource({ customModes: 'bad' } as unknown as never);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-mode-resource-factory.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource-factory.ts
@@ -1,0 +1,33 @@
+import { isDefined } from '@kaoto/forms';
+
+import { SourceSchemaType } from '../camel/source-schema-type';
+import { KaotoResource } from '../kaoto-resource';
+import { CustomModeResource } from './custom-mode-resource';
+import { CustomModeFile } from './custom-mode-types';
+
+/**
+ * Factory for creating CustomModeResource instances.
+ *
+ * Detection strategy (mirrors CitrusTestResourceFactory):
+ * 1. Explicit SourceSchemaType.CustomMode path hint → always create (Task 5 wires the enum value)
+ * 2. JSON root has a `customModes` array → create regardless of path
+ */
+export class CustomModeResourceFactory {
+  static getCustomModeResource(json?: unknown, type?: SourceSchemaType): KaotoResource | undefined {
+    if (type === SourceSchemaType.CustomMode) {
+      return new CustomModeResource(json as CustomModeFile);
+    }
+
+    if (
+      isDefined(json) &&
+      !Array.isArray(json) &&
+      typeof json === 'object' &&
+      isDefined((json as Record<string, unknown>).customModes) &&
+      Array.isArray((json as Record<string, unknown>).customModes)
+    ) {
+      return new CustomModeResource(json as CustomModeFile);
+    }
+
+    return undefined;
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
@@ -1,0 +1,155 @@
+import { parse } from 'yaml';
+
+import { CustomModeResource } from './custom-mode-resource';
+import { CustomModeFile } from './custom-mode-types';
+import { CustomModeVisualEntity } from './custom-mode-visual-entity';
+
+const twoModeFile: CustomModeFile = {
+  customModes: [
+    {
+      slug: 'plan',
+      name: 'Plan',
+      description: 'Planning mode',
+      roleDefinition: 'You plan things.',
+      whenToUse: 'When planning.',
+      groups: ['read'],
+    },
+    {
+      slug: 'code',
+      name: 'Code',
+      description: 'Coding mode',
+      roleDefinition: 'You write code.',
+      whenToUse: 'When coding.',
+      groups: ['read', 'edit'],
+    },
+  ],
+};
+
+describe('CustomModeResource', () => {
+  describe('initialize()', () => {
+    it('creates one visual entity per mode', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      expect(resource.getVisualEntities()).toHaveLength(2);
+    });
+
+    it('visual entities are CustomModeVisualEntity instances', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      resource.getVisualEntities().forEach((e) => {
+        expect(e).toBeInstanceOf(CustomModeVisualEntity);
+      });
+    });
+
+    it('handles empty customModes array', async () => {
+      const resource = new CustomModeResource({ customModes: [] });
+      await resource.initialize();
+      expect(resource.getVisualEntities()).toHaveLength(0);
+    });
+
+    it('handles undefined rawFile', async () => {
+      const resource = new CustomModeResource(undefined);
+      await resource.initialize();
+      expect(resource.getVisualEntities()).toHaveLength(0);
+    });
+  });
+
+  describe('getEntities()', () => {
+    it('returns empty array (no non-visual entities)', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      expect(resource.getEntities()).toEqual([]);
+    });
+  });
+
+  describe('supportsMultipleVisualEntities()', () => {
+    it('returns true', () => {
+      expect(new CustomModeResource(undefined).supportsMultipleVisualEntities()).toBe(true);
+    });
+  });
+
+  describe('getCompatibleRuntimes()', () => {
+    it('returns ["Bob"]', () => {
+      expect(new CustomModeResource(undefined).getCompatibleRuntimes()).toEqual(['Bob']);
+    });
+  });
+
+  describe('toJSON()', () => {
+    it('returns a CustomModeFile with all modes', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const json = resource.toJSON() as CustomModeFile;
+      expect(json.customModes).toHaveLength(2);
+      expect(json.customModes[0].slug).toBe('plan');
+      expect(json.customModes[1].slug).toBe('code');
+    });
+  });
+
+  describe('toSourceCode()', () => {
+    it('serializes to YAML with customModes root key', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const yaml = await resource.toSourceCode();
+      expect(yaml).toContain('customModes:');
+      expect(yaml).toContain('slug: plan');
+      expect(yaml).toContain('slug: code');
+    });
+
+    it('produces canonical field order: slug before name before description', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const yaml = await resource.toSourceCode();
+      const slugIdx = yaml.indexOf('slug:');
+      const nameIdx = yaml.indexOf('name:');
+      const descIdx = yaml.indexOf('description:');
+      expect(slugIdx).toBeLessThan(nameIdx);
+      expect(nameIdx).toBeLessThan(descIdx);
+    });
+
+    it('is stable: parse → serialize produces identical output twice', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const first = await resource.toSourceCode();
+      const resource2 = new CustomModeResource(parse(first) as CustomModeFile);
+      await resource2.initialize();
+      const second = await resource2.toSourceCode();
+      expect(second).toBe(first);
+    });
+  });
+
+  describe('addNewEntity()', () => {
+    it('appends a new entity and returns its id', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const id = resource.addNewEntity();
+      expect(id).toBeTruthy();
+      expect(resource.getVisualEntities()).toHaveLength(3);
+    });
+
+    it('new entity has slug "new-mode"', async () => {
+      const resource = new CustomModeResource({ customModes: [] });
+      await resource.initialize();
+      const id = resource.addNewEntity();
+      const entity = resource.getVisualEntities().find((e) => e.id === id);
+      expect((entity!.toJSON() as ReturnType<CustomModeVisualEntity['toJSON']>).slug).toBe('new-mode');
+    });
+  });
+
+  describe('removeEntity()', () => {
+    it('removes the entity with the given id', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      const [first] = resource.getVisualEntities();
+      resource.removeEntity([first.id]);
+      expect(resource.getVisualEntities()).toHaveLength(1);
+      expect(resource.getVisualEntities()[0].id).not.toBe(first.id);
+    });
+
+    it('is a no-op for undefined ids', async () => {
+      const resource = new CustomModeResource(twoModeFile);
+      await resource.initialize();
+      resource.removeEntity(undefined);
+      expect(resource.getVisualEntities()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
@@ -1,5 +1,8 @@
 import { parse } from 'yaml';
 
+import { ITile } from '../../components/Catalog';
+import { CatalogKind } from '../catalog-kind';
+import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CustomModeResource } from './custom-mode-resource';
 import { CustomModeFile } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
@@ -150,6 +153,34 @@ describe('CustomModeResource', () => {
       await resource.initialize();
       resource.removeEntity(undefined);
       expect(resource.getVisualEntities()).toHaveLength(2);
+    });
+  });
+  describe('getCompatibleComponents()', () => {
+    it('returns a TileFilter function', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      expect(typeof filter).toBe('function');
+    });
+
+    it('accepts tiles of type CatalogKind.BobNodes', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      const tile = { type: CatalogKind.BobNodes } as ITile;
+      expect(filter(tile)).toBe(true);
+    });
+
+    it('rejects tiles of other catalog kinds', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      for (const kind of [CatalogKind.Component, CatalogKind.Pattern, CatalogKind.Kamelet, CatalogKind.TestAction]) {
+        expect(filter({ type: kind } as ITile)).toBe(false);
+      }
     });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.ts
@@ -1,8 +1,9 @@
 import { isDefined } from '@kaoto/forms';
 import { stringify } from 'yaml';
 
-import { TileFilter } from '../../components/Catalog';
+import { ITile, TileFilter } from '../../components/Catalog';
 import { SourceSchemaType } from '../camel/source-schema-type';
+import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
@@ -50,9 +51,14 @@ export class CustomModeResource implements KaotoResource {
   }
 
   addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
-    const template = isDefined(entityTemplate)
-      ? (entityTemplate as CustomMode)
-      : (FlowTemplateService.getFlowTemplate(SourceSchemaType.CustomMode) as CustomMode);
+    let template: CustomMode;
+    if (isDefined(entityTemplate)) {
+      template = entityTemplate as CustomMode;
+    } else {
+      // getFlowTemplate returns a CustomModeFile ({ customModes: [...] }); extract the first mode.
+      const file = FlowTemplateService.getFlowTemplate(SourceSchemaType.CustomMode) as CustomModeFile;
+      template = file.customModes[0];
+    }
     const entity = new CustomModeVisualEntity(template);
     this.entities.push(entity);
     return entity.id;
@@ -78,9 +84,12 @@ export class CustomModeResource implements KaotoResource {
     };
   }
 
-  getCompatibleComponents(_mode: AddStepMode, _data: IVisualizationNodeData): TileFilter | undefined {
-    // Epic 5 will wire this to LlmToolsCatalog; return undefined for now (shows all tiles)
-    return undefined;
+  getCompatibleComponents(_mode: AddStepMode, _data: IVisualizationNodeData): TileFilter {
+    // Epic 5 bridge: only BobNodes tiles are compatible with the Custom Mode editor.
+    // No tiles with this type exist until Epic 6 registers the Bob catalog —
+    // until then the catalog panel shows nothing, which is the correct behavior.
+    // 'Bob' in getCompatibleRuntimes() is a temporary compatibility marker.
+    return (item: ITile) => item.type === CatalogKind.BobNodes;
   }
 
   /** Builds a mode object in canonical field order for stable YAML serialization. */

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.ts
@@ -1,0 +1,101 @@
+import { isDefined } from '@kaoto/forms';
+import { stringify } from 'yaml';
+
+import { TileFilter } from '../../components/Catalog';
+import { SourceSchemaType } from '../camel/source-schema-type';
+import { BaseEntity, EntityType } from '../entities';
+import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
+import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
+import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
+import { CustomMode, CustomModeFile } from './custom-mode-types';
+import { CustomModeVisualEntity } from './custom-mode-visual-entity';
+
+export class CustomModeResource implements KaotoResource {
+  static readonly SUPPORTED_ENTITIES: { type: EntityType }[] = [{ type: EntityType.CustomMode }];
+
+  private entities: CustomModeVisualEntity[] = [];
+
+  get supportedEntities() {
+    return CustomModeResource.SUPPORTED_ENTITIES;
+  }
+
+  constructor(private readonly rawFile?: CustomModeFile) {}
+
+  async initialize(): Promise<void> {
+    if (!isDefined(this.rawFile) || !Array.isArray(this.rawFile.customModes)) {
+      this.entities = [];
+      return;
+    }
+    this.entities = this.rawFile.customModes.map((mode) => new CustomModeVisualEntity(mode));
+  }
+
+  getType(): SourceSchemaType {
+    return SourceSchemaType.CustomMode;
+  }
+
+  getCompatibleRuntimes(): string[] {
+    return ['Bob'];
+  }
+
+  supportsMultipleVisualEntities(): boolean {
+    return true;
+  }
+
+  getVisualEntities(): CustomModeVisualEntity[] {
+    return this.entities;
+  }
+
+  getEntities(): BaseEntity[] {
+    return [];
+  }
+
+  addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
+    const template = isDefined(entityTemplate)
+      ? (entityTemplate as CustomMode)
+      : (FlowTemplateService.getFlowTemplate(SourceSchemaType.CustomMode) as CustomMode);
+    const entity = new CustomModeVisualEntity(template);
+    this.entities.push(entity);
+    return entity.id;
+  }
+
+  removeEntity(ids?: string[]): void {
+    if (!isDefined(ids)) return;
+    this.entities = this.entities.filter((e) => !ids.includes(e.id));
+  }
+
+  toJSON(): CustomModeFile {
+    return { customModes: this.entities.map((e) => e.toJSON()) };
+  }
+
+  async toSourceCode(): Promise<string> {
+    return stringify({ customModes: this.entities.map((e) => this.serializeMode(e.toJSON())) });
+  }
+
+  getCanvasEntityList(): BaseVisualEntityDefinition {
+    return {
+      common: [{ name: EntityType.CustomMode, title: 'Custom Mode', description: 'A Bob custom mode definition.' }],
+      groups: {},
+    };
+  }
+
+  getCompatibleComponents(_mode: AddStepMode, _data: IVisualizationNodeData): TileFilter | undefined {
+    // Epic 5 will wire this to LlmToolsCatalog; return undefined for now (shows all tiles)
+    return undefined;
+  }
+
+  /** Builds a mode object in canonical field order for stable YAML serialization. */
+  private serializeMode(mode: CustomMode): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+      slug: mode.slug,
+      name: mode.name,
+      description: mode.description,
+      roleDefinition: mode.roleDefinition,
+      whenToUse: mode.whenToUse,
+    };
+    if (isDefined(mode.customInstructions)) {
+      out.customInstructions = mode.customInstructions;
+    }
+    out.groups = mode.groups;
+    return out;
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-types.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-types.ts
@@ -1,0 +1,21 @@
+// kaoto/packages/ui/src/models/custom-mode/custom-mode-types.ts
+
+/** A single tool permission group entry. Either a plain string (e.g. "read") or
+ *  a tuple of [groupName, constraint] (e.g. ["edit", { fileRegex: "(\\.yaml$)" }]). */
+export type CustomModeGroup = string | [string, { fileRegex: string }];
+
+/** One mode definition — mirrors the YAML schema exactly. */
+export interface CustomMode {
+  slug: string;
+  name: string;
+  description: string;
+  roleDefinition: string;
+  whenToUse: string;
+  customInstructions?: string;
+  groups: CustomModeGroup[];
+}
+
+/** The top-level structure of a custom_modes.yaml file. */
+export interface CustomModeFile {
+  customModes: CustomMode[];
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -1,0 +1,54 @@
+import { EntityType } from '../entities';
+import { CustomMode } from './custom-mode-types';
+import { CustomModeVisualEntity } from './custom-mode-visual-entity';
+
+const sampleMode: CustomMode = {
+  slug: 'plan',
+  name: 'Plan',
+  description: 'Planning mode',
+  roleDefinition: 'You plan things.',
+  whenToUse: 'When planning.',
+  groups: ['read'],
+};
+
+describe('CustomModeVisualEntity', () => {
+  let entity: CustomModeVisualEntity;
+
+  beforeEach(() => {
+    entity = new CustomModeVisualEntity(sampleMode);
+  });
+
+  it('has a non-empty id', () => {
+    expect(entity.id).toBeTruthy();
+  });
+
+  it('has type EntityType.CustomMode', () => {
+    expect(entity.type).toBe(EntityType.CustomMode);
+  });
+
+  it('toJSON returns the raw CustomMode object', () => {
+    expect(entity.toJSON()).toEqual(sampleMode);
+  });
+
+  it('getId returns the same id as the id property', () => {
+    expect(entity.getId()).toBe(entity.id);
+  });
+
+  it('setId updates the id', () => {
+    entity.setId('my-id');
+    expect(entity.id).toBe('my-id');
+    expect(entity.getId()).toBe('my-id');
+  });
+
+  it('getRootPath returns "customMode"', () => {
+    expect(entity.getRootPath()).toBe('customMode');
+  });
+
+  it('getOmitFormFields returns empty array', () => {
+    expect(entity.getOmitFormFields()).toEqual([]);
+  });
+
+  it('getNodeLabel returns slug', () => {
+    expect(entity.getNodeLabel()).toBe('plan');
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -1,54 +1,230 @@
 import { EntityType } from '../entities';
+import { AddStepMode } from '../visualization/base-visual-entity';
 import { CustomMode } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
 
-const sampleMode: CustomMode = {
-  slug: 'plan',
-  name: 'Plan',
-  description: 'Planning mode',
-  roleDefinition: 'You plan things.',
-  whenToUse: 'When planning.',
+const makeMode = (overrides?: Partial<CustomMode>): CustomMode => ({
+  slug: 'test-mode',
+  name: 'Test Mode',
+  description: 'A test mode',
+  roleDefinition: 'You are a test assistant.',
+  whenToUse: 'Use this for testing.',
   groups: ['read'],
-};
+  ...overrides,
+});
 
 describe('CustomModeVisualEntity', () => {
   let entity: CustomModeVisualEntity;
 
   beforeEach(() => {
-    entity = new CustomModeVisualEntity(sampleMode);
+    entity = new CustomModeVisualEntity(makeMode());
   });
 
-  it('has a non-empty id', () => {
-    expect(entity.id).toBeTruthy();
+  describe('constructor', () => {
+    it('sets id from mode slug', () => {
+      expect(entity.id).toBe('test-mode');
+    });
+
+    it('sets type to EntityType.CustomMode', () => {
+      expect(entity.type).toBe(EntityType.CustomMode);
+    });
+
+    it('generates a fallback id when slug is missing and writes it back to mode.slug', () => {
+      const e = new CustomModeVisualEntity(makeMode({ slug: undefined as unknown as string }));
+      expect(e.id).toMatch(/^custom-mode-/);
+      expect(e.toJSON().slug).toBe(e.id);
+    });
   });
 
-  it('has type EntityType.CustomMode', () => {
-    expect(entity.type).toBe(EntityType.CustomMode);
+  describe('getRootPath', () => {
+    it('returns customMode', () => {
+      expect(entity.getRootPath()).toBe('customMode');
+    });
   });
 
-  it('toJSON returns the raw CustomMode object', () => {
-    expect(entity.toJSON()).toEqual(sampleMode);
+  describe('getId / setId', () => {
+    it('getId returns the entity id', () => {
+      expect(entity.getId()).toBe('test-mode');
+    });
+
+    it('setId updates id and mode.slug', () => {
+      entity.setId('new-slug');
+      expect(entity.id).toBe('new-slug');
+      expect(entity.toJSON().slug).toBe('new-slug');
+    });
   });
 
-  it('getId returns the same id as the id property', () => {
-    expect(entity.getId()).toBe(entity.id);
+  describe('getNodeLabel', () => {
+    it('returns mode name for root path', () => {
+      expect(entity.getNodeLabel('customMode')).toBe('Test Mode');
+    });
+
+    it('falls back to id when name is empty', () => {
+      const e = new CustomModeVisualEntity(makeMode({ name: '' }));
+      expect(e.getNodeLabel('customMode')).toBe('test-mode');
+    });
+
+    it('returns last segment for customInstructions paths', () => {
+      expect(entity.getNodeLabel('customMode.customInstructions.0.section')).toBe('section');
+    });
+
+    it('returns empty string for unrecognised paths', () => {
+      expect(entity.getNodeLabel('something.else')).toBe('');
+      expect(entity.getNodeLabel(undefined)).toBe('');
+    });
   });
 
-  it('setId updates the id', () => {
-    entity.setId('my-id');
-    expect(entity.id).toBe('my-id');
-    expect(entity.getId()).toBe('my-id');
+  describe('getNodeSchema', () => {
+    it('returns root schema for customMode path', () => {
+      const schema = entity.getNodeSchema('customMode');
+      expect(schema).toBeDefined();
+      expect(schema!.type).toBe('object');
+      expect(schema!.properties).toHaveProperty('slug');
+      expect(schema!.properties).toHaveProperty('groups');
+    });
+
+    it('returns undefined for customInstructions child paths (stub)', () => {
+      expect(entity.getNodeSchema('customMode.customInstructions.0.section')).toBeUndefined();
+    });
+
+    it('returns undefined for unrecognised paths', () => {
+      expect(entity.getNodeSchema('other')).toBeUndefined();
+      expect(entity.getNodeSchema(undefined)).toBeUndefined();
+    });
   });
 
-  it('getRootPath returns "customMode"', () => {
-    expect(entity.getRootPath()).toBe('customMode');
+  describe('getNodeDefinition', () => {
+    it('returns mode object without customInstructions for root path', () => {
+      const def = entity.getNodeDefinition('customMode') as CustomMode;
+      expect(def.slug).toBe('test-mode');
+      expect((def as unknown as Record<string, unknown>).customInstructions).toBeUndefined();
+    });
+
+    it('returns undefined for unrecognised paths', () => {
+      expect(entity.getNodeDefinition('other')).toBeUndefined();
+      expect(entity.getNodeDefinition(undefined)).toBeUndefined();
+    });
   });
 
-  it('getOmitFormFields returns empty array', () => {
-    expect(entity.getOmitFormFields()).toEqual([]);
+  describe('getOmitFormFields', () => {
+    it('includes customInstructions', () => {
+      expect(entity.getOmitFormFields()).toContain('customInstructions');
+    });
   });
 
-  it('getNodeLabel returns slug', () => {
-    expect(entity.getNodeLabel()).toBe('plan');
+  describe('updateModel', () => {
+    it('updates mode fields and keeps id in sync when slug changes', () => {
+      entity.updateModel('customMode', { slug: 'updated-slug', name: 'Updated' });
+      expect(entity.id).toBe('updated-slug');
+      expect(entity.toJSON().name).toBe('Updated');
+    });
+
+    it('updates name without touching slug', () => {
+      entity.updateModel('customMode', { name: 'Only Name Changed' });
+      expect(entity.id).toBe('test-mode');
+      expect(entity.toJSON().name).toBe('Only Name Changed');
+    });
+
+    it('is a no-op for unrecognised paths', () => {
+      entity.updateModel('other.path', { name: 'Should Not Apply' });
+      expect(entity.toJSON().name).toBe('Test Mode');
+    });
+
+    it('is a no-op when path is undefined', () => {
+      entity.updateModel(undefined, { name: 'Should Not Apply' });
+      expect(entity.toJSON().name).toBe('Test Mode');
+    });
+  });
+
+  describe('toJSON', () => {
+    it('returns the underlying CustomMode object', () => {
+      const json = entity.toJSON();
+      expect(json.slug).toBe('test-mode');
+      expect(json.groups).toEqual(['read']);
+    });
+  });
+
+  describe('getNodeInteraction', () => {
+    it('canRemoveFlow true only for mode node (isGroup false, root path)', () => {
+      const interaction = entity.getNodeInteraction({ path: 'customMode', isGroup: false } as never);
+      expect(interaction.canRemoveFlow).toBe(true);
+      expect(interaction.canRemoveStep).toBe(false);
+      expect(interaction.canHaveChildren).toBe(false);
+      expect(interaction.canBeDisabled).toBe(false);
+    });
+
+    it('canRemoveFlow false for group node (isGroup true, root path)', () => {
+      const interaction = entity.getNodeInteraction({ path: 'customMode', isGroup: true } as never);
+      expect(interaction.canRemoveFlow).toBe(false);
+    });
+
+    it('all false for customInstructions siblings', () => {
+      const interaction = entity.getNodeInteraction({
+        path: 'customMode.customInstructions.0.section',
+        isGroup: false,
+      } as never);
+      expect(interaction.canRemoveFlow).toBe(false);
+      expect(interaction.canRemoveStep).toBe(false);
+    });
+  });
+
+  describe('canDragNode / canDropOnNode / getCopiedContent', () => {
+    it('always returns false / undefined', () => {
+      expect(entity.canDragNode()).toBe(false);
+      expect(entity.canDragNode('customMode')).toBe(false);
+      expect(entity.canDropOnNode()).toBe(false);
+      expect(entity.getCopiedContent('customMode')).toBeUndefined();
+    });
+  });
+
+  describe('addStep / removeStep / pasteStep', () => {
+    it('addStep is a no-op', () => {
+      expect(() => {
+        entity.addStep({ definedComponent: {} as never, mode: AddStepMode.AppendStep, data: {} as never });
+      }).not.toThrow();
+    });
+
+    it('removeStep is a no-op', () => {
+      expect(() => {
+        entity.removeStep('customMode.customInstructions.0.section');
+      }).not.toThrow();
+    });
+
+    it('pasteStep is a no-op', () => {
+      expect(() => {
+        entity.pasteStep({ clipboardContent: {} as never, mode: AddStepMode.AppendStep, data: {} as never });
+      }).not.toThrow();
+    });
+  });
+
+  describe('toVizNode', () => {
+    it('returns a mode group node with isGroup true', async () => {
+      const groupNode = await entity.toVizNode();
+      expect(groupNode.data.isGroup).toBe(true);
+      expect(groupNode.data.path).toBe('customMode');
+    });
+
+    it('mode group node has two children: mode node and placeholder', async () => {
+      const groupNode = await entity.toVizNode();
+      expect(groupNode.getChildren()).toHaveLength(2);
+    });
+
+    it('first child is the mode node (isGroup false, same path)', async () => {
+      const modeNode = (await entity.toVizNode()).getChildren()![0];
+      expect(modeNode.data.isGroup).toBe(false);
+      expect(modeNode.data.path).toBe('customMode');
+    });
+
+    it('last child is the placeholder', async () => {
+      const children = (await entity.toVizNode()).getChildren()!;
+      expect(children[children.length - 1].data.isPlaceholder).toBe(true);
+    });
+
+    it('mode node and placeholder are linked via prev/next', async () => {
+      const children = (await entity.toVizNode()).getChildren()!;
+      const [modeNode, placeholder] = children;
+      expect(modeNode.getNextNode()).toBe(placeholder);
+      expect(placeholder.getPreviousNode()).toBe(modeNode);
+    });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -1,0 +1,112 @@
+import { getCamelRandomId } from '../../camel-utils/camel-random-id';
+import { DefinedComponent } from '../camel/camel-catalog-index';
+import { EntityType } from '../entities';
+import { KaotoSchemaDefinition } from '../kaoto-schema';
+import { NodeLabelType } from '../settings/settings.model';
+import {
+  AddStepMode,
+  BaseVisualEntity,
+  DISABLED_NODE_INTERACTION,
+  IVisualizationNode,
+  IVisualizationNodeData,
+  NodeInteraction,
+} from '../visualization/base-visual-entity';
+import { IClipboardCopyObject } from '../visualization/clipboard';
+import { CustomMode } from './custom-mode-types';
+
+/**
+ * Minimal shell for Epic 1. Methods required by BaseVisualEntity but not yet
+ * implemented return safe no-op values. toVizNode() is implemented in Epic 2.
+ */
+export class CustomModeVisualEntity implements BaseVisualEntity {
+  readonly type = EntityType.CustomMode;
+  id: string;
+
+  constructor(private readonly mode: CustomMode) {
+    this.id = getCamelRandomId('custom-mode');
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  setId(id: string): void {
+    this.id = id;
+  }
+
+  toJSON(): CustomMode {
+    return this.mode;
+  }
+
+  getRootPath(): string {
+    return 'customMode';
+  }
+
+  getNodeLabel(_path?: string, _labelType?: NodeLabelType): string {
+    return this.mode.slug;
+  }
+
+  getNodeSchema(_path?: string): KaotoSchemaDefinition['schema'] | undefined {
+    return undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getNodeDefinition(_path?: string): any {
+    return this.mode;
+  }
+
+  getOmitFormFields(): string[] {
+    return [];
+  }
+
+  updateModel(_path: string | undefined, _value: unknown): void {
+    // no-op — Epic 2
+  }
+
+  addStep(_options: {
+    definedComponent: DefinedComponent;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    targetProperty?: string;
+    insertAtStart?: boolean;
+  }): void {
+    // no-op — Epic 2
+  }
+
+  getCopiedContent(_path?: string): IClipboardCopyObject | undefined {
+    return undefined;
+  }
+
+  pasteStep(_options: {
+    clipboardContent: IClipboardCopyObject;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    insertAtStart?: boolean;
+  }): void {
+    // no-op — Epic 2
+  }
+
+  canDragNode(_path?: string): boolean {
+    return false;
+  }
+
+  canDropOnNode(_path?: string): boolean {
+    return false;
+  }
+
+  removeStep(_path?: string): void {
+    // no-op — Epic 2
+  }
+
+  getNodeInteraction(_data: IVisualizationNodeData): NodeInteraction {
+    return DISABLED_NODE_INTERACTION;
+  }
+
+  getNodeValidationText(_path?: string): string | undefined {
+    return undefined;
+  }
+
+  async toVizNode(): Promise<IVisualizationNode> {
+    throw new Error('CustomModeVisualEntity.toVizNode() — not implemented until Epic 2');
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -1,3 +1,5 @@
+import { isDefined } from '@kaoto/forms';
+
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { DefinedComponent } from '../camel/camel-catalog-index';
 import { EntityType } from '../entities';
@@ -12,78 +14,114 @@ import {
   NodeInteraction,
 } from '../visualization/base-visual-entity';
 import { IClipboardCopyObject } from '../visualization/clipboard';
+import { CustomModeSchemaService } from '../visualization/flows/support/custom-mode-schema.service';
+import { createVisualizationNode } from '../visualization/visualization-node';
+import { CustomInstructionsNode, CustomInstructionsParser } from './custom-instructions-parser';
 import { CustomMode } from './custom-mode-types';
 
-/**
- * Minimal shell for Epic 1. Methods required by BaseVisualEntity but not yet
- * implemented return safe no-op values. toVizNode() is implemented in Epic 2.
- */
 export class CustomModeVisualEntity implements BaseVisualEntity {
-  readonly type = EntityType.CustomMode;
   id: string;
+  readonly type = EntityType.CustomMode;
+  static readonly ROOT_PATH = 'customMode';
+
+  private parsedNodes: CustomInstructionsNode[] = [];
+  private parsedNodesDirty = false;
 
   constructor(private readonly mode: CustomMode) {
-    this.id = getCamelRandomId('custom-mode');
+    if (isDefined(mode?.slug) && mode.slug !== '') {
+      this.id = mode.slug;
+    } else {
+      this.id = getCamelRandomId('custom-mode');
+      this.mode.slug = this.id;
+    }
+    this.parsedNodes = CustomInstructionsParser.parse(mode?.customInstructions ?? '');
+  }
+
+  static isApplicable(entity: unknown): entity is CustomMode {
+    if (!isDefined(entity) || Array.isArray(entity) || typeof entity !== 'object') return false;
+    return 'slug' in entity && 'name' in entity && 'groups' in entity;
+  }
+
+  getRootPath(): string {
+    return CustomModeVisualEntity.ROOT_PATH;
   }
 
   getId(): string {
     return this.id;
   }
 
-  setId(id: string): void {
-    this.id = id;
+  setId(slug: string): void {
+    this.id = slug;
+    this.mode.slug = slug;
   }
 
-  toJSON(): CustomMode {
-    return this.mode;
+  getNodeLabel(path?: string, _labelType?: NodeLabelType): string {
+    if (!path) return '';
+    if (path === this.getRootPath()) return this.mode.name || this.id;
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      return path.split('.').pop() ?? '';
+    }
+    return '';
   }
 
-  getRootPath(): string {
-    return 'customMode';
-  }
-
-  getNodeLabel(_path?: string, _labelType?: NodeLabelType): string {
-    return this.mode.slug;
-  }
-
-  getNodeSchema(_path?: string): KaotoSchemaDefinition['schema'] | undefined {
+  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
+    if (!path) return undefined;
+    if (path === this.getRootPath()) return CustomModeSchemaService.getRootSchema();
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      return CustomModeSchemaService.getNodeSchema(path.split('.').pop() ?? '');
+    }
     return undefined;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getNodeDefinition(_path?: string): any {
-    return this.mode;
-  }
-
-  getOmitFormFields(): string[] {
-    return [];
-  }
-
-  updateModel(_path: string | undefined, _value: unknown): void {
-    // no-op — Epic 2
-  }
-
-  addStep(_options: {
-    definedComponent: DefinedComponent;
-    mode: AddStepMode;
-    data: IVisualizationNodeData;
-    targetProperty?: string;
-    insertAtStart?: boolean;
-  }): void {
-    // no-op — Epic 2
-  }
-
-  getCopiedContent(_path?: string): IClipboardCopyObject | undefined {
+  getNodeDefinition(path?: string): any {
+    if (!path) return undefined;
+    if (path === this.getRootPath()) {
+      const { customInstructions: _ci, ...rest } = this.mode as CustomMode & { customInstructions?: string };
+      return rest;
+    }
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      const index = Number(path.replace(`${this.getRootPath()}.customInstructions.`, '').split('.')[0]);
+      return Number.isInteger(index) ? this.parsedNodes[index] : undefined;
+    }
     return undefined;
   }
 
-  pasteStep(_options: {
-    clipboardContent: IClipboardCopyObject;
-    mode: AddStepMode;
-    data: IVisualizationNodeData;
-    insertAtStart?: boolean;
-  }): void {
-    // no-op — Epic 2
+  getOmitFormFields(): string[] {
+    return ['customInstructions'];
+  }
+
+  updateModel(path: string | undefined, value: unknown): void {
+    if (!path) return;
+    if (path === this.getRootPath()) {
+      Object.assign(this.mode, value);
+      this.id = isDefined(this.mode.slug) && this.mode.slug !== '' ? this.mode.slug : this.id;
+      return;
+    }
+    if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
+      const index = Number(path.replace(`${this.getRootPath()}.customInstructions.`, '').split('.')[0]);
+      if (Number.isInteger(index) && isDefined(this.parsedNodes[index])) {
+        this.parsedNodes[index] = value as CustomInstructionsNode;
+        this.parsedNodesDirty = true;
+      }
+    }
+  }
+
+  toJSON(): CustomMode {
+    if (this.parsedNodesDirty) {
+      this.mode.customInstructions = CustomInstructionsParser.serialize(this.parsedNodes);
+      this.parsedNodesDirty = false;
+    }
+    return this.mode;
+  }
+
+  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
+    const isModeNode = data.path === this.getRootPath() && !data.isGroup;
+    return { ...DISABLED_NODE_INTERACTION, canRemoveFlow: isModeNode };
+  }
+
+  getNodeValidationText(_path?: string): string | undefined {
+    return undefined;
   }
 
   canDragNode(_path?: string): boolean {
@@ -94,19 +132,102 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
     return false;
   }
 
-  removeStep(_path?: string): void {
-    // no-op — Epic 2
-  }
-
-  getNodeInteraction(_data: IVisualizationNodeData): NodeInteraction {
-    return DISABLED_NODE_INTERACTION;
-  }
-
-  getNodeValidationText(_path?: string): string | undefined {
+  getCopiedContent(_path?: string): IClipboardCopyObject | undefined {
     return undefined;
   }
 
+  /** No-op — deferred to drag-and-drop epic. */
+  addStep(_options: {
+    definedComponent: DefinedComponent;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    targetProperty?: string;
+    insertAtStart?: boolean;
+  }): void {
+    // TODO: drag-and-drop epic
+  }
+
+  /** No-op — deferred to drag-and-drop epic. */
+  removeStep(_path?: string): void {
+    // TODO: drag-and-drop epic
+  }
+
+  /** No-op — deferred to drag-and-drop epic. */
+  pasteStep(_options: {
+    clipboardContent: IClipboardCopyObject;
+    mode: AddStepMode;
+    data: IVisualizationNodeData;
+    insertAtStart?: boolean;
+  }): void {
+    // TODO: drag-and-drop epic
+  }
+
   async toVizNode(): Promise<IVisualizationNode> {
-    throw new Error('CustomModeVisualEntity.toVizNode() — not implemented until Epic 2');
+    // 1. Mode group node — visual container
+    const modeGroupNode = createVisualizationNode(this.id, {
+      name: this.type,
+      path: this.getRootPath(),
+      entity: this,
+      isPlaceholder: false,
+      isGroup: true,
+      iconUrl: '',
+      title: '',
+      description: '',
+    });
+
+    // 2. Mode node — first child, opens the metadata form
+    const modeNode = createVisualizationNode(`${this.id}-mode`, {
+      name: this.type,
+      path: this.getRootPath(),
+      entity: this,
+      isPlaceholder: false,
+      isGroup: false,
+      iconUrl: '',
+      title: this.mode.name || this.id,
+      description: this.mode.description || '',
+    });
+    modeGroupNode.addChild(modeNode);
+
+    // 3. customInstructions sibling nodes (stub: parsedNodes is always [] until Epic 7)
+    const siblings: IVisualizationNode[] = [modeNode];
+    for (let i = 0; i < this.parsedNodes.length; i++) {
+      const node = this.parsedNodes[i];
+      const path = `${this.getRootPath()}.customInstructions.${i}.${node.nodeType}`;
+      const vizNode = createVisualizationNode(path, {
+        name: node.nodeType,
+        path,
+        entity: this,
+        isPlaceholder: false,
+        isGroup: false,
+        iconUrl: '',
+        title: node.nodeType,
+        description: '',
+      });
+      modeGroupNode.addChild(vizNode);
+      siblings.push(vizNode);
+    }
+
+    // 4. Placeholder
+    const placeholderPath = `${this.getRootPath()}.customInstructions.${this.parsedNodes.length}.placeholder`;
+    const placeholderNode = createVisualizationNode(placeholderPath, {
+      name: 'placeholder',
+      path: placeholderPath,
+      entity: this,
+      isPlaceholder: true,
+      isGroup: false,
+      iconUrl: '',
+      title: '',
+      description: '',
+    });
+    modeGroupNode.addChild(placeholderNode);
+    siblings.push(placeholderNode);
+
+    // 5. Wire prev/next links across the flat sequence
+    for (let i = 0; i < siblings.length - 1; i++) {
+      siblings[i].setNextNode(siblings[i + 1]);
+      siblings[i + 1].setPreviousNode(siblings[i]);
+    }
+
+    return modeGroupNode;
   }
 }

--- a/packages/ui/src/models/custom-mode/index.ts
+++ b/packages/ui/src/models/custom-mode/index.ts
@@ -1,3 +1,4 @@
+export * from './custom-instructions-parser';
 export * from './custom-mode-resource';
 export * from './custom-mode-resource-factory';
 export * from './custom-mode-types';

--- a/packages/ui/src/models/custom-mode/index.ts
+++ b/packages/ui/src/models/custom-mode/index.ts
@@ -1,0 +1,4 @@
+export * from './custom-mode-resource';
+export * from './custom-mode-resource-factory';
+export * from './custom-mode-types';
+export * from './custom-mode-visual-entity';

--- a/packages/ui/src/models/entities/base-entity.ts
+++ b/packages/ui/src/models/entities/base-entity.ts
@@ -19,6 +19,7 @@ export const enum EntityType {
   Metadata = 'metadata',
   PipeErrorHandler = 'pipeErrorHandler',
   NonVisualEntity = 'nonVisualEntity',
+  CustomMode = 'customMode',
 }
 
 export interface BaseEntity {

--- a/packages/ui/src/models/visualization/flows/index.ts
+++ b/packages/ui/src/models/visualization/flows/index.ts
@@ -1,3 +1,4 @@
+export * from '../../custom-mode/custom-mode-visual-entity';
 export * from './camel-catalog.service';
 export * from './camel-route-visual-entity';
 export * from './citrus-test-visual-entity';

--- a/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
@@ -1,0 +1,44 @@
+import { CustomModeSchemaService } from './custom-mode-schema.service';
+
+describe('CustomModeSchemaService', () => {
+  describe('getRootSchema', () => {
+    it('returns an object schema', () => {
+      expect(CustomModeSchemaService.getRootSchema().type).toBe('object');
+    });
+
+    it('includes all expected top-level properties', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      expect(Object.keys(properties!)).toEqual(
+        expect.arrayContaining(['slug', 'name', 'description', 'roleDefinition', 'whenToUse', 'groups']),
+      );
+    });
+
+    it('marks slug and name as required', () => {
+      expect(CustomModeSchemaService.getRootSchema().required).toEqual(expect.arrayContaining(['slug', 'name']));
+    });
+
+    it('sets x-component textarea on roleDefinition and whenToUse', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      expect((properties!['roleDefinition'] as Record<string, unknown>)['x-component']).toBe('textarea');
+      expect((properties!['whenToUse'] as Record<string, unknown>)['x-component']).toBe('textarea');
+    });
+
+    it('groups is an array with 8-item enum', () => {
+      const { properties } = CustomModeSchemaService.getRootSchema();
+      const groups = properties!['groups'] as Record<string, unknown>;
+      expect(groups.type).toBe('array');
+      const items = groups.items as Record<string, unknown>;
+      expect(items.enum as string[]).toHaveLength(8);
+      expect(items.enum).toEqual(
+        expect.arrayContaining(['read', 'edit', 'command', 'mcp', 'subagent', 'skill', 'execute', 'todo']),
+      );
+    });
+  });
+
+  describe('getNodeSchema', () => {
+    it('returns undefined for any nodeType (stub)', () => {
+      expect(CustomModeSchemaService.getNodeSchema('section')).toBeUndefined();
+      expect(CustomModeSchemaService.getNodeSchema('unknown')).toBeUndefined();
+    });
+  });
+});

--- a/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.ts
@@ -1,0 +1,60 @@
+import { JSONSchema4 } from 'json-schema';
+
+/** Provides JSON schemas for CustomMode canvas nodes. No catalog dependency. */
+export class CustomModeSchemaService {
+  /** Schema for the mode node form (all fields except customInstructions). */
+  static getRootSchema(): JSONSchema4 {
+    return {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          title: 'Slug',
+          description: 'Machine identifier — kebab-case, unique within the file.',
+        },
+        name: {
+          type: 'string',
+          title: 'Name',
+          description: 'Display name shown in the mode selector (may include emoji).',
+        },
+        description: {
+          type: 'string',
+          title: 'Description',
+          description: 'One-liner shown in the orchestrator dropdown.',
+        },
+        roleDefinition: {
+          type: 'string',
+          title: 'Role Definition',
+          description: 'Defines who this mode is — shown to the LLM as a system prompt prefix.',
+          'x-component': 'textarea',
+        } as JSONSchema4,
+        whenToUse: {
+          type: 'string',
+          title: 'When to Use',
+          description: 'Tells the orchestrator when to route to this mode.',
+          'x-component': 'textarea',
+        } as JSONSchema4,
+        groups: {
+          type: 'array',
+          title: 'Tool Groups',
+          description: 'Tool permission groups granted to this mode.',
+          // TODO: tuple-groups epic — tuple form [name, {fileRegex}] not yet supported
+          items: {
+            type: 'string',
+            enum: ['read', 'edit', 'command', 'mcp', 'subagent', 'skill', 'execute', 'todo'],
+          },
+        },
+      },
+      required: ['slug', 'name'],
+    };
+  }
+
+  /**
+   * Schema for a customInstructions child node.
+   * Stub — Epic 7 fills in per-type schemas once node types are finalised.
+   */
+  static getNodeSchema(_nodeType: string): JSONSchema4 | undefined {
+    // TODO: Epic 7 — fill in per-type schemas
+    return undefined;
+  }
+}

--- a/packages/ui/src/models/visualization/flows/support/flow-templates-service.ts
+++ b/packages/ui/src/models/visualization/flows/support/flow-templates-service.ts
@@ -2,6 +2,7 @@ import { parse } from 'yaml';
 
 import { SourceSchemaType } from '../../../camel/source-schema-type';
 import { testTemplate } from '../templates/citrus';
+import { customModeTemplate } from '../templates/custom-mode';
 import { kameletTemplate } from '../templates/kamelet';
 import { pipeTemplate } from '../templates/pipe';
 import { routeTemplate } from '../templates/route';
@@ -24,6 +25,9 @@ export class FlowTemplateService {
 
       case SourceSchemaType.Kamelet:
         return kameletTemplate();
+
+      case SourceSchemaType.CustomMode:
+        return customModeTemplate();
 
       default:
         return '';

--- a/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
+++ b/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
@@ -1,13 +1,15 @@
 /**
- * Returns a default custom mode template in YAML format.
- * Used when the user adds a new mode from the canvas.
+ * Returns a default custom modes file template in YAML format.
+ * The root `customModes` array is required so that
+ * `CustomModeResourceFactory` can detect the resource type.
  */
 export const customModeTemplate = (): string => {
-  return `slug: new-mode
-name: New Mode
-description: ""
-roleDefinition: ""
-whenToUse: ""
-groups:
-  - read`;
+  return `customModes:
+  - slug: new-mode
+    name: New Mode
+    description: ""
+    roleDefinition: ""
+    whenToUse: ""
+    groups:
+      - read`;
 };

--- a/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
+++ b/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a default custom mode template in YAML format.
+ * Used when the user adds a new mode from the canvas.
+ */
+export const customModeTemplate = (): string => {
+  return `slug: new-mode
+name: New Mode
+description: ""
+roleDefinition: ""
+whenToUse: ""
+groups:
+  - read`;
+};

--- a/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.tsx
@@ -32,6 +32,7 @@ const SCHEMA_TABS: Record<SourceSchemaType, TabList[]> = {
   [SourceSchemaType.KameletBinding]: [TabList.Design, TabList.Metadata, TabList.ErrorHandler, TabList.About],
   [SourceSchemaType.Pipe]: [TabList.Design, TabList.Metadata, TabList.ErrorHandler, TabList.About],
   [SourceSchemaType.Test]: [TabList.Design, TabList.About],
+  [SourceSchemaType.CustomMode]: [TabList.Design],
 };
 
 export const KaotoEditor = () => {

--- a/packages/ui/src/stubs/sourceSchemaConfig.ts
+++ b/packages/ui/src/stubs/sourceSchemaConfig.ts
@@ -15,6 +15,7 @@ export const configureSourceSchemaTypes = (): void => {
     { type: SourceSchemaType.Test, name: 'Test', description: 'Test desc' },
     { type: SourceSchemaType.Integration, name: 'Integration', description: 'Integration desc' },
     { type: SourceSchemaType.KameletBinding, name: 'kameletBinding', description: 'KameletBinding desc' },
+    { type: SourceSchemaType.CustomMode, name: 'Custom Mode', description: 'Custom Mode desc' },
   ];
 
   for (const { type, name, description } of types) {


### PR DESCRIPTION
### Description

Implements Epic 5 of the Kaoto Custom Mode editor: wires the catalog
filtering seam in `CustomModeResource` so the catalog panel exposes only
Bob-compatible tiles, and adds `CatalogKind.BobNodes` as the type those
tiles will carry once Epic 6 registers the Bob catalog.

Related spec: `docs/superpowers/specs/2025-07-22-epic5-getcompatibleruntimes-catalog-filtering.md`
Parent spec: `docs/superpowers/specs/2025-07-17-kaoto-custom-mode-editor-design.md`

---

#### Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

---

#### What changed

| File | Change |
|---|---|
| `packages/ui/src/models/catalog-kind.ts` | Added `BobNodes = 'BobNodes'` to `CatalogKind` enum |
| `packages/ui/src/dynamic-catalog/models.ts` | Added `[CatalogKind.BobNodes]` entry to `DynamicCatalogTypeMap` |
| `packages/ui/src/models/camel/camel-catalog-index.ts` | Added `[CatalogKind.BobNodes]?` entry to `ComponentsCatalog` |
| `packages/ui/src/models/custom-mode/custom-mode-resource.ts` | Replaced `undefined` stub in `getCompatibleComponents()` with a `TileFilter` keyed on `CatalogKind.BobNodes`; fixed `addNewEntity()` to correctly unwrap the `CustomModeFile` wrapper returned by `FlowTemplateService` |
| `packages/ui/src/models/visualization/flows/templates/custom-mode.ts` | Wrapped the template YAML in `customModes: [...]` so it round-trips correctly through `FlowTemplateService.getFlowTemplate()` |
| `packages/ui/src/models/custom-mode/custom-mode-resource.test.ts` | Added `describe('getCompatibleComponents()')` block with three tests |
| `packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx` | Minor: added blank line before existing `it(...)` for style consistency |

---

#### Why it changed

**Catalog filtering seam (primary goal)**
`CustomModeResource.getCompatibleComponents()` was previously a `return undefined` stub, which would have shown the entire Camel/Citrus component catalog to Custom Mode users. This epic wires it to return a `TileFilter` that only passes tiles of type `CatalogKind.BobNodes`. No such tiles exist yet (Epic 6 will register the Bob catalog), so the panel correctly shows nothing in the interim.

**`customModeTemplate()` bugfix (discovered side-effect)**
The template returned a bare `CustomMode` YAML object. `FlowTemplateService.getFlowTemplate()` calls `yaml.parse()` on it and returns the result directly. `addNewEntity()` was casting that result to `CustomMode` and reading `.customModes[0]`, which would have been `undefined` at runtime. The template is now wrapped in the `customModes: [...]` array, and `addNewEntity()` explicitly extracts the first element. This fixes a latent bug that would have produced a broken entity on every "add new mode" action.

**`CatalogKind.BobNodes` in `DynamicCatalogTypeMap` and `ComponentsCatalog`**
Registering the new enum value in both maps keeps the codebase structurally consistent. Without this, generic catalog machinery (and future Epic 6 wiring) would fail at compile time.

---

#### How Has This Been Tested?

- **Unit tests** — new `describe('getCompatibleComponents()')` block in `custom-mode-resource.test.ts` covers:
  - filter is a function (not `undefined`)
  - accepts tiles of type `CatalogKind.BobNodes`
  - rejects `CatalogKind.Component`, `.Pattern`, `.Kamelet`, and `.TestAction`
- **TypeScript** — `yarn tsc --noEmit` exits with zero errors
- All pre-existing `CustomModeResource` tests continue to pass
- Manual testing running the branch

---

#### Reviewer notes

1. **Interface narrowing** — `KaotoResource.getCompatibleComponents()` is declared `→ TileFilter | undefined`. `CustomModeResource` narrows the return to `TileFilter`. This is valid TypeScript (narrower return is compatible) and intentional — Custom Mode should never expose an open catalog. The narrowing is consistent with how `CitrusTestResource` behaves. A follow-up could tighten the interface signature, but that is out of scope here.

2. **`ICitrusComponentDefinition` placeholder type** — `DynamicCatalogTypeMap[CatalogKind.BobNodes]` and `ComponentsCatalog[CatalogKind.BobNodes]` both use `ICitrusComponentDefinition` as a placeholder. A `TODO(Epic 6)` comment marks each site. Epic 6 will replace this with the proper `IBobNodeDefinition` interface. The type is not used by any runtime code today.

3. **`customModeTemplate()` change is a bugfix, not just a refactor** — the old bare-mode YAML was always structurally wrong for the `FlowTemplateService` → `parse()` → `addNewEntity()` code path. This commit fixes it as an unavoidable prerequisite to `addNewEntity()` working correctly.

---

#### Out of scope

The following are explicitly deferred to later epics and are not present in this commit:

| Concern | Owned by |
|---|---|
| Bob catalog contents and LLM tool node taxonomy | Epic 6 |
| Bob-specific catalog importer / parser (`fetchBobCatalog`) | Epic 6 |
| Changes to `CatalogLoaderProvider` | Epic 6 |
| `customInstructions` per-node schemas | Epic 7 |
| Adding `SourceSchemaType.CustomMode` to `DSL_LIST` | Epic 4 (parallel, independent) |
| Canvas step drag-and-drop for Custom Mode nodes | Post-parser epic |

---

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation.
- [x] I have added tests that prove my fix or feature works.