### PR TITLE
feat(mithril): epic 5 `getCompatibleRuntimes` API Wiring (Catalog Filtering)

### DIFF
--- a/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx
@@ -196,6 +196,7 @@ describe('IntegrationTypeSelector', () => {
     // Merely opening the dropdown must not select anything.
     expect(onSelect).not.toHaveBeenCalled();
   });
+
   it('calls onSelect with SourceSchemaType.CustomMode when Custom Mode is clicked', async () => {
     const onSelect = vi.fn();
     const wrapper = renderSelector(onSelect);

--- a/packages/ui/src/dynamic-catalog/models.ts
+++ b/packages/ui/src/dynamic-catalog/models.ts
@@ -26,6 +26,10 @@ export type DynamicCatalogTypeMap = {
   [CatalogKind.TestFunction]: ICitrusComponentDefinition;
   [CatalogKind.TestValidationMatcher]: ICitrusComponentDefinition;
   [CatalogKind.Function]: Record<string, KaotoFunction>;
+  /** Placeholder for Epic 6 Bob catalog tiles — not populated until then.
+   *  TODO(Epic 6): Replace ICitrusComponentDefinition with the proper IBobNodeDefinition
+   *  interface once the Bob catalog is registered. */
+  [CatalogKind.BobNodes]: ICitrusComponentDefinition;
 };
 
 export interface ICatalogProvider<T> {

--- a/packages/ui/src/models/camel/camel-catalog-index.ts
+++ b/packages/ui/src/models/camel/camel-catalog-index.ts
@@ -56,4 +56,8 @@ export interface ComponentsCatalog {
   [CatalogKind.TestFunction]?: Record<string, ICitrusComponentDefinition>;
   [CatalogKind.TestValidationMatcher]?: Record<string, ICitrusComponentDefinition>;
   [CatalogKind.Function]?: Record<string, Record<string, KaotoFunction>>;
+  /** Placeholder for Epic 6 Bob catalog tiles — not populated until then.
+   *  TODO(Epic 6): Replace ICitrusComponentDefinition with the proper IBobNodeDefinition
+   *  interface once the Bob catalog is registered. */
+  [CatalogKind.BobNodes]?: Record<string, ICitrusComponentDefinition>;
 }

--- a/packages/ui/src/models/catalog-kind.ts
+++ b/packages/ui/src/models/catalog-kind.ts
@@ -44,4 +44,9 @@ export const enum CatalogKind {
 
   /** Citrus test validation matcher catalog, f.i. @isNumber()@, @isEmpty()@, @matches()@ */
   TestValidationMatcher = 'testValidationMatcher',
+
+  /** Bob LLM tool catalog, used by the Custom Mode editor canvas.
+   *  Tiles with this type are registered by the Bob catalog in Epic 6.
+   *  This is a bridge value — not a Camel runtime equivalent. */
+  BobNodes = 'BobNodes',
 }

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.test.ts
@@ -1,5 +1,8 @@
 import { parse } from 'yaml';
 
+import { ITile } from '../../components/Catalog';
+import { CatalogKind } from '../catalog-kind';
+import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CustomModeResource } from './custom-mode-resource';
 import { CustomModeFile } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
@@ -150,6 +153,34 @@ describe('CustomModeResource', () => {
       await resource.initialize();
       resource.removeEntity(undefined);
       expect(resource.getVisualEntities()).toHaveLength(2);
+    });
+  });
+  describe('getCompatibleComponents()', () => {
+    it('returns a TileFilter function', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      expect(typeof filter).toBe('function');
+    });
+
+    it('accepts tiles of type CatalogKind.BobNodes', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      const tile = { type: CatalogKind.BobNodes } as ITile;
+      expect(filter(tile)).toBe(true);
+    });
+
+    it('rejects tiles of other catalog kinds', () => {
+      const filter = new CustomModeResource(undefined).getCompatibleComponents(
+        AddStepMode.AppendStep,
+        {} as IVisualizationNodeData,
+      );
+      for (const kind of [CatalogKind.Component, CatalogKind.Pattern, CatalogKind.Kamelet, CatalogKind.TestAction]) {
+        expect(filter({ type: kind } as ITile)).toBe(false);
+      }
     });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-resource.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource.ts
@@ -1,8 +1,9 @@
 import { isDefined } from '@kaoto/forms';
 import { stringify } from 'yaml';
 
-import { TileFilter } from '../../components/Catalog';
+import { ITile, TileFilter } from '../../components/Catalog';
 import { SourceSchemaType } from '../camel/source-schema-type';
+import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
@@ -50,9 +51,14 @@ export class CustomModeResource implements KaotoResource {
   }
 
   addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
-    const template = isDefined(entityTemplate)
-      ? (entityTemplate as CustomMode)
-      : (FlowTemplateService.getFlowTemplate(SourceSchemaType.CustomMode) as CustomMode);
+    let template: CustomMode;
+    if (isDefined(entityTemplate)) {
+      template = entityTemplate as CustomMode;
+    } else {
+      // getFlowTemplate returns a CustomModeFile ({ customModes: [...] }); extract the first mode.
+      const file = FlowTemplateService.getFlowTemplate(SourceSchemaType.CustomMode) as CustomModeFile;
+      template = file.customModes[0];
+    }
     const entity = new CustomModeVisualEntity(template);
     this.entities.push(entity);
     return entity.id;
@@ -78,9 +84,12 @@ export class CustomModeResource implements KaotoResource {
     };
   }
 
-  getCompatibleComponents(_mode: AddStepMode, _data: IVisualizationNodeData): TileFilter | undefined {
-    // Epic 5 will wire this to LlmToolsCatalog; return undefined for now (shows all tiles)
-    return undefined;
+  getCompatibleComponents(_mode: AddStepMode, _data: IVisualizationNodeData): TileFilter {
+    // Epic 5 bridge: only BobNodes tiles are compatible with the Custom Mode editor.
+    // No tiles with this type exist until Epic 6 registers the Bob catalog —
+    // until then the catalog panel shows nothing, which is the correct behavior.
+    // 'Bob' in getCompatibleRuntimes() is a temporary compatibility marker.
+    return (item: ITile) => item.type === CatalogKind.BobNodes;
   }
 
   /** Builds a mode object in canonical field order for stable YAML serialization. */

--- a/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
+++ b/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
@@ -1,13 +1,15 @@
 /**
- * Returns a default custom mode template in YAML format.
- * Used when the user adds a new mode from the canvas.
+ * Returns a default custom modes file template in YAML format.
+ * The root `customModes` array is required so that
+ * `CustomModeResourceFactory` can detect the resource type.
  */
 export const customModeTemplate = (): string => {
-  return `slug: new-mode
-name: New Mode
-description: ""
-roleDefinition: ""
-whenToUse: ""
-groups:
-  - read`;
+  return `customModes:
+  - slug: new-mode
+    name: New Mode
+    description: ""
+    roleDefinition: ""
+    whenToUse: ""
+    groups:
+      - read`;
 };


### PR DESCRIPTION
### Description

Implements Epic 5 of the Kaoto Custom Mode editor: wires the catalog
filtering seam in `CustomModeResource` so the catalog panel exposes only
Bob-compatible tiles, and adds `CatalogKind.BobNodes` as the type those
tiles will carry once Epic 6 registers the Bob catalog.

Related spec: `docs/superpowers/specs/2025-07-22-epic5-getcompatibleruntimes-catalog-filtering.md`
Parent spec: `docs/superpowers/specs/2025-07-17-kaoto-custom-mode-editor-design.md`

---

#### Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

---

#### What changed

| File | Change |
|---|---|
| `packages/ui/src/models/catalog-kind.ts` | Added `BobNodes = 'BobNodes'` to `CatalogKind` enum |
| `packages/ui/src/dynamic-catalog/models.ts` | Added `[CatalogKind.BobNodes]` entry to `DynamicCatalogTypeMap` |
| `packages/ui/src/models/camel/camel-catalog-index.ts` | Added `[CatalogKind.BobNodes]?` entry to `ComponentsCatalog` |
| `packages/ui/src/models/custom-mode/custom-mode-resource.ts` | Replaced `undefined` stub in `getCompatibleComponents()` with a `TileFilter` keyed on `CatalogKind.BobNodes`; fixed `addNewEntity()` to correctly unwrap the `CustomModeFile` wrapper returned by `FlowTemplateService` |
| `packages/ui/src/models/visualization/flows/templates/custom-mode.ts` | Wrapped the template YAML in `customModes: [...]` so it round-trips correctly through `FlowTemplateService.getFlowTemplate()` |
| `packages/ui/src/models/custom-mode/custom-mode-resource.test.ts` | Added `describe('getCompatibleComponents()')` block with three tests |
| `packages/ui/src/components/Visualization/IntegrationTypeSelector/IntegrationTypeSelector.test.tsx` | Minor: added blank line before existing `it(...)` for style consistency |

---

#### Why it changed

**Catalog filtering seam (primary goal)**
`CustomModeResource.getCompatibleComponents()` was previously a `return undefined` stub, which would have shown the entire Camel/Citrus component catalog to Custom Mode users. This epic wires it to return a `TileFilter` that only passes tiles of type `CatalogKind.BobNodes`. No such tiles exist yet (Epic 6 will register the Bob catalog), so the panel correctly shows nothing in the interim.

**`customModeTemplate()` bugfix (discovered side-effect)**
The template returned a bare `CustomMode` YAML object. `FlowTemplateService.getFlowTemplate()` calls `yaml.parse()` on it and returns the result directly. `addNewEntity()` was casting that result to `CustomMode` and reading `.customModes[0]`, which would have been `undefined` at runtime. The template is now wrapped in the `customModes: [...]` array, and `addNewEntity()` explicitly extracts the first element. This fixes a latent bug that would have produced a broken entity on every "add new mode" action.

**`CatalogKind.BobNodes` in `DynamicCatalogTypeMap` and `ComponentsCatalog`**
Registering the new enum value in both maps keeps the codebase structurally consistent. Without this, generic catalog machinery (and future Epic 6 wiring) would fail at compile time.

---

#### How Has This Been Tested?

- **Unit tests** — new `describe('getCompatibleComponents()')` block in `custom-mode-resource.test.ts` covers:
  - filter is a function (not `undefined`)
  - accepts tiles of type `CatalogKind.BobNodes`
  - rejects `CatalogKind.Component`, `.Pattern`, `.Kamelet`, and `.TestAction`
- **TypeScript** — `yarn tsc --noEmit` exits with zero errors
- All pre-existing `CustomModeResource` tests continue to pass
- Manual testing running the branch
---

#### Reviewer notes

1. **Interface narrowing** — `KaotoResource.getCompatibleComponents()` is declared `→ TileFilter | undefined`. `CustomModeResource` narrows the return to `TileFilter`. This is valid TypeScript (narrower return is compatible) and intentional — Custom Mode should never expose an open catalog. The narrowing is consistent with how `CitrusTestResource` behaves. A follow-up could tighten the interface signature, but that is out of scope here.

2. **`ICitrusComponentDefinition` placeholder type** — `DynamicCatalogTypeMap[CatalogKind.BobNodes]` and `ComponentsCatalog[CatalogKind.BobNodes]` both use `ICitrusComponentDefinition` as a placeholder. A `TODO(Epic 6)` comment marks each site. Epic 6 will replace this with the proper `IBobNodeDefinition` interface. The type is not used by any runtime code today.

3. **`customModeTemplate()` change is a bugfix, not just a refactor** — the old bare-mode YAML was always structurally wrong for the `FlowTemplateService` → `parse()` → `addNewEntity()` code path. This commit fixes it as an unavoidable prerequisite to `addNewEntity()` working correctly.

---

#### Out of scope

The following are explicitly deferred to later epics and are not present in this commit:

| Concern | Owned by |
|---|---|
| Bob catalog contents and LLM tool node taxonomy | Epic 6 |
| Bob-specific catalog importer / parser (`fetchBobCatalog`) | Epic 6 |
| Changes to `CatalogLoaderProvider` | Epic 6 |
| `customInstructions` per-node schemas | Epic 7 |
| Usability features epic on canvas | Post-parser epic |

---

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation.
- [x] I have added tests that prove my fix or feature works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying Bob nodes in the catalog.
  * Custom mode resources now accept Bob nodes as compatible components.
  * Custom mode templates now use the required `customModes` structure.

* **Tests**
  * Added coverage verifying compatible and incompatible component types for custom modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->