### PR TITLE
fix(Canvas): preserve state across tab switches

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
@@ -111,4 +111,25 @@ describe('Test toolbar on hover actions', () => {
     cy.checkNodeExist('when', 0);
     cy.checkNodeExist('otherwise', 0);
   });
+
+  it('Keep the selected route collapsed after switching tabs', () => {
+    cy.uploadFixture('flows/camelRoute/multiflow.yaml');
+    cy.openDesignPage();
+
+    cy.toggleExpandGroup('route-1234');
+    cy.checkNodeExist('timer', 1);
+    cy.checkNodeExist('log', 1);
+
+    cy.openSourceCode();
+    cy.openDesignPage();
+
+    cy.get('span[title="route-1234"]').should('be.visible').click();
+    cy.get('[data-testid="route-1234|step-toolbar-button-collapse"]').should('have.attr', 'title', 'Expand step');
+
+    cy.openGroupConfigurationTab('route-4321');
+    cy.get('[data-testid="route-4321|step-toolbar-button-collapse"]').should('have.attr', 'title', 'Collapse step');
+
+    cy.checkNodeExist('timer', 1);
+    cy.checkNodeExist('log', 1);
+  });
 });

--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/hoverToolbarActions.cy.ts
@@ -129,7 +129,17 @@ describe('Test toolbar on hover actions', () => {
     cy.openGroupConfigurationTab('route-4321');
     cy.get('[data-testid="route-4321|step-toolbar-button-collapse"]').should('have.attr', 'title', 'Collapse step');
 
+    cy.selectAppendNode('log');
+    cy.chooseFromCatalog('component', 'activemq');
+
+    cy.get('span[title="route-1234"]').should('be.visible').click();
+    cy.get('[data-testid="route-1234|step-toolbar-button-collapse"]').should('have.attr', 'title', 'Expand step');
+
+    cy.openGroupConfigurationTab('route-4321');
+    cy.get('[data-testid="route-4321|step-toolbar-button-collapse"]').should('have.attr', 'title', 'Collapse step');
+
     cy.checkNodeExist('timer', 1);
     cy.checkNodeExist('log', 1);
+    cy.checkNodeExist('activemq', 1);
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -594,6 +594,53 @@ describe('Canvas', () => {
     );
   });
 
+  it('reinitializes the graph when content resolves after a settled empty state', async () => {
+    const RuntimeProvider = TestRuntimeProviderWrapper().Provider;
+    const { Provider } = await TestProvidersWrapper();
+    const controller = ControllerService.createController();
+    const fromModelSpy = vi.spyOn(controller, 'fromModel');
+    const vizNode = await entity.toVizNode();
+
+    const { rerender } = render(
+      <RuntimeProvider>
+        <Provider>
+          <VisualizationProvider controller={controller}>
+            <Canvas vizNodes={[]} entitiesCount={0} />
+          </VisualizationProvider>
+        </Provider>
+      </RuntimeProvider>,
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    fromModelSpy.mockClear();
+
+    rerender(
+      <RuntimeProvider>
+        <Provider>
+          <VisualizationProvider controller={controller}>
+            <Canvas vizNodes={[]} entitiesCount={1} isVizNodesResolving />
+          </VisualizationProvider>
+        </Provider>
+      </RuntimeProvider>,
+    );
+    rerender(
+      <RuntimeProvider>
+        <Provider>
+          <VisualizationProvider controller={controller}>
+            <Canvas vizNodes={[vizNode]} entitiesCount={1} />
+          </VisualizationProvider>
+        </Provider>
+      </RuntimeProvider>,
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(fromModelSpy).toHaveBeenCalledWith(expect.anything(), false);
+    expect(fromModelSpy).not.toHaveBeenCalledWith(expect.anything(), true);
+  });
+
   it('preserves collapse and viewport state through a resolving remount', async () => {
     const { Provider } = await TestProvidersWrapper();
     const controller = ControllerService.createController();

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -1,4 +1,4 @@
-import { VisualizationProvider } from '@patternfly/react-topology';
+import { action, Point, VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 
@@ -586,5 +586,58 @@ describe('Canvas', () => {
         expect(screen.queryByText('Vertical Layout')).not.toBeInTheDocument();
       },
     );
+  });
+
+  it('preserves collapse and viewport state when remounted', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { Provider } = await TestProvidersWrapper();
+    const controller = ControllerService.createController();
+    const fromModelSpy = vi.spyOn(controller, 'fromModel');
+    const vizNode = await entity.toVizNode();
+
+    let setCanvasVisible: (visible: boolean) => void = () => {};
+    const Inner = () => {
+      const [isCanvasVisible, setIsCanvasVisible] = useState(true);
+      setCanvasVisible = setIsCanvasVisible;
+      return (
+        <VisualizationProvider controller={controller}>
+          {isCanvasVisible && <Canvas vizNodes={[vizNode]} entitiesCount={1} />}
+        </VisualizationProvider>
+      );
+    };
+
+    render(
+      <Provider>
+        <Inner />
+      </Provider>,
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    const graph = controller.getGraph();
+    action(() => {
+      graph.setScale(1.5);
+      graph.setPosition(new Point(120, 80));
+    })();
+    fromModelSpy.mockClear();
+    vi.mocked(applyCollapseState).mockClear();
+
+    await act(async () => {
+      setCanvasVisible(false);
+    });
+    await act(async () => {
+      setCanvasVisible(true);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(fromModelSpy).toHaveBeenCalledWith(expect.anything(), true);
+    expect(fromModelSpy).not.toHaveBeenCalledWith(expect.anything(), false);
+    expect(applyCollapseState).toHaveBeenCalledWith(controller);
+    expect(controller.getGraph()).toBe(graph);
+    expect(graph.getScale()).toBe(1.5);
+    expect(graph.getPosition()).toEqual(new Point(120, 80));
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx
@@ -1,4 +1,4 @@
-import { action, Point, VisualizationProvider } from '@patternfly/react-topology';
+import { action, isNode, Point, VisualizationProvider } from '@patternfly/react-topology';
 import { act, fireEvent, render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 
@@ -17,13 +17,8 @@ import { camelRouteJson } from '../../../stubs/camel-route';
 import { kameletJson } from '../../../stubs/kamelet-route';
 import { Canvas } from './Canvas';
 import { LayoutType } from './canvas.models';
+import { COLLAPSE_STATE } from './collapse-handler-state';
 import { ControllerService } from './controller.service';
-
-vi.mock('./apply-collapse-state', () => ({
-  applyCollapseState: vi.fn(),
-}));
-
-import { applyCollapseState } from './apply-collapse-state';
 
 describe('Canvas', () => {
   const entity = new CamelRouteVisualEntity(camelRouteJson);
@@ -100,12 +95,15 @@ describe('Canvas', () => {
     expect(layoutSpy).not.toHaveBeenCalled();
   });
 
-  it('when initialized is true, runs fromModel(model, true), and applyCollapseState', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('merges a changed visualization model after initialization', async () => {
     const { Provider } = await TestProvidersWrapper();
     const controller = ControllerService.createController();
     const fromModelSpy = vi.spyOn(controller, 'fromModel');
     const vizNode = await entity.toVizNode();
+    const updatedEntity = new CamelRouteVisualEntity({
+      route: { ...camelRouteJson.route, id: 'route-updated' },
+    });
+    const updatedVizNode = await updatedEntity.toVizNode();
 
     // Stateful child so we can update entities without re-rendering Provider
     let setVizNodesState: (next: IVisualizationNode[]) => void = () => {};
@@ -132,14 +130,22 @@ describe('Canvas', () => {
     fromModelSpy.mockClear();
 
     await act(async () => {
-      setVizNodesState([vizNode].slice());
+      setVizNodesState([updatedVizNode]);
     });
     await act(async () => {
       await vi.runAllTimersAsync();
     });
 
     expect(fromModelSpy).toHaveBeenCalledWith(expect.anything(), true);
-    expect(applyCollapseState).toHaveBeenCalledWith(controller);
+    expect(fromModelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodes: expect.arrayContaining([expect.objectContaining({ data: { vizNode: updatedVizNode } })]),
+      }),
+      true,
+    );
+    expect(
+      controller.getElements().some((element) => isNode(element) && element.getData()?.vizNode === updatedVizNode),
+    ).toBe(true);
   });
 
   it('should be able to delete the routes', async () => {
@@ -588,27 +594,17 @@ describe('Canvas', () => {
     );
   });
 
-  it('preserves collapse and viewport state when remounted', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('preserves collapse and viewport state through a resolving remount', async () => {
     const { Provider } = await TestProvidersWrapper();
     const controller = ControllerService.createController();
     const fromModelSpy = vi.spyOn(controller, 'fromModel');
     const vizNode = await entity.toVizNode();
 
-    let setCanvasVisible: (visible: boolean) => void = () => {};
-    const Inner = () => {
-      const [isCanvasVisible, setIsCanvasVisible] = useState(true);
-      setCanvasVisible = setIsCanvasVisible;
-      return (
-        <VisualizationProvider controller={controller}>
-          {isCanvasVisible && <Canvas vizNodes={[vizNode]} entitiesCount={1} />}
-        </VisualizationProvider>
-      );
-    };
-
-    render(
+    const { rerender } = render(
       <Provider>
-        <Inner />
+        <VisualizationProvider controller={controller}>
+          <Canvas vizNodes={[vizNode]} entitiesCount={1} />
+        </VisualizationProvider>
       </Provider>,
     );
     await act(async () => {
@@ -616,28 +612,64 @@ describe('Canvas', () => {
     });
 
     const graph = controller.getGraph();
+    const routeGroup = controller
+      .getElements()
+      .find(
+        (element) =>
+          isNode(element) &&
+          (element.getData()?.vizNode as IVisualizationNode | undefined)?.getNodeDefinition()?.id === 'route-8888',
+      );
+    expect(routeGroup && isNode(routeGroup)).toBe(true);
+    if (!routeGroup || !isNode(routeGroup)) {
+      throw new Error('Expected route group was not found');
+    }
+
     action(() => {
+      routeGroup.setCollapsed(true);
+      controller.setState({ [COLLAPSE_STATE]: ['route-8888'] });
       graph.setScale(1.5);
       graph.setPosition(new Point(120, 80));
     })();
     fromModelSpy.mockClear();
-    vi.mocked(applyCollapseState).mockClear();
 
-    await act(async () => {
-      setCanvasVisible(false);
-    });
-    await act(async () => {
-      setCanvasVisible(true);
-    });
+    rerender(
+      <Provider>
+        <VisualizationProvider controller={controller}>{null}</VisualizationProvider>
+      </Provider>,
+    );
+    rerender(
+      <Provider>
+        <VisualizationProvider controller={controller}>
+          <Canvas vizNodes={[]} entitiesCount={1} isVizNodesResolving />
+        </VisualizationProvider>
+      </Provider>,
+    );
+
+    const refreshedVizNode = await entity.toVizNode();
+    rerender(
+      <Provider>
+        <VisualizationProvider controller={controller}>
+          <Canvas vizNodes={[refreshedVizNode]} entitiesCount={1} />
+        </VisualizationProvider>
+      </Provider>,
+    );
     await act(async () => {
       await vi.runAllTimersAsync();
     });
 
     expect(fromModelSpy).toHaveBeenCalledWith(expect.anything(), true);
     expect(fromModelSpy).not.toHaveBeenCalledWith(expect.anything(), false);
-    expect(applyCollapseState).toHaveBeenCalledWith(controller);
     expect(controller.getGraph()).toBe(graph);
     expect(graph.getScale()).toBe(1.5);
     expect(graph.getPosition()).toEqual(new Point(120, 80));
+
+    const remountedRouteGroup = controller
+      .getElements()
+      .find(
+        (element) =>
+          isNode(element) &&
+          (element.getData()?.vizNode as IVisualizationNode | undefined)?.getNodeDefinition()?.id === 'route-8888',
+      );
+    expect(remountedRouteGroup && isNode(remountedRouteGroup) && remountedRouteGroup.isCollapsed()).toBe(true);
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -66,7 +66,8 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   const activeLayout =
     settingsLayout ?? localStorage.getItem(LocalStorageKeys.CanvasLayout) ?? CanvasDefaults.DEFAULT_LAYOUT;
 
-  const [initialized, setInitialized] = useState(false);
+  const controller = useVisualizationController();
+  const [initialized, setInitialized] = useState(() => controller.getGraph().getLayout() !== undefined);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [selectedNode, setSelectedNode] = useState<CanvasNode | undefined>(undefined);
   const [sidebarWidth, setSidebarWidth] = useLocalStorage(
@@ -77,7 +78,6 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   /** Context to interact with the Canvas catalog */
   const catalogModalContext = useContext(CatalogModalContext);
 
-  const controller = useVisualizationController();
   const shouldShowEmptyState = useMemo(() => {
     const areNoFlows = entitiesCount === 0;
     const areAllFlowsHidden = vizNodes.length === 0 && entitiesCount > 0;

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -29,7 +29,6 @@ import {
 
 import { CatalogModalContext } from '../../../dynamic-catalog/catalog-modal.provider';
 import { useLocalStorage } from '../../../hooks';
-import { usePrevious } from '../../../hooks/previous.hook';
 import { LocalStorageKeys } from '../../../models';
 import { CanvasLayoutDirection } from '../../../models/settings/settings.model';
 import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
@@ -50,6 +49,12 @@ interface CanvasProps {
   entitiesCount: number;
   isVizNodesResolving?: boolean;
   contextToolbar?: ReactNode;
+}
+
+const SETTLED_EMPTY_STATE = 'settledEmptyStateVisible';
+
+interface CanvasState {
+  [SETTLED_EMPTY_STATE]?: boolean;
 }
 
 export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
@@ -86,7 +91,13 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
     return areNoFlows || areAllFlowsHidden;
   }, [entitiesCount, vizNodes.length]);
 
-  const wasEmptyStateVisible = usePrevious(!isVizNodesResolving && shouldShowEmptyState);
+  const wasEmptyStateVisible = controller.getState<CanvasState>()[SETTLED_EMPTY_STATE];
+  useEffect(() => {
+    if (!isVizNodesResolving) {
+      controller.setState({ [SETTLED_EMPTY_STATE]: shouldShowEmptyState });
+    }
+  }, [controller, isVizNodesResolving, shouldShowEmptyState]);
+
   const clearSelection = useCallback(() => {
     setSelectedIds([]);
     setSelectedNode(undefined);

--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -67,7 +67,9 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
     settingsLayout ?? localStorage.getItem(LocalStorageKeys.CanvasLayout) ?? CanvasDefaults.DEFAULT_LAYOUT;
 
   const controller = useVisualizationController();
-  const [initialized, setInitialized] = useState(() => controller.getGraph().getLayout() !== undefined);
+  const [initialized, setInitialized] = useState(
+    () => controller.hasGraph() && controller.getGraph().getLayout() !== undefined,
+  );
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [selectedNode, setSelectedNode] = useState<CanvasNode | undefined>(undefined);
   const [sidebarWidth, setSidebarWidth] = useLocalStorage(
@@ -84,7 +86,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
     return areNoFlows || areAllFlowsHidden;
   }, [entitiesCount, vizNodes.length]);
 
-  const wasEmptyStateVisible = usePrevious(shouldShowEmptyState);
+  const wasEmptyStateVisible = usePrevious(!isVizNodesResolving && shouldShowEmptyState);
   const clearSelection = useCallback(() => {
     setSelectedIds([]);
     setSelectedNode(undefined);


### PR DESCRIPTION
### Description

Preserve collapsed groups and the current canvas viewport when the Design tab remounts with its existing visualization controller, while retaining first-load fit behavior, and add a focused lifecycle regression test.

Fixes #3301

#### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?
- `corepack yarn workspace @kaoto/kaoto test src/components/Visualization/Canvas/Canvas.test.tsx packages/ui/src/components/Visualization/Canvas/Canvas.test.tsx --configLoader runner` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto lint` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto lint:style` — passed in a network-isolated container.
- `corepack yarn workspace @kaoto/kaoto test --configLoader runner --maxWorkers 2` — passed in a network-isolated container.

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] I have updated relevant documentation (not applicable: behavior and regression-test change only).
- [x] I have added tests that prove the fix works.

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-021:start -->
### Verification

[Northset proof-of-pass receipt M-021](https://northset-oss.github.io/verification-pilot/receipts/M-021/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-021:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the visualization’s graph instance, zoom, and position across remounts, keeping targeted route groups collapsed.
  * Improved canvas initialization to correctly handle when a layout already exists.
  * Refined empty-state behavior during node visualization resolving to better reflect settled visibility.
* **Tests**
  * Updated/expanded Canvas tests to validate collapse persistence and reinitialization behavior after content settles.
  * Added Cypress coverage to ensure collapsed route groups stay consistent when switching between design/source views and changing configuration tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->