### PR TITLE
fix(mithril): remove redundant modeNode child from toVizNode()

### DIFF
--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -1,5 +1,6 @@
 import { EntityType } from '../entities';
 import { AddStepMode } from '../visualization/base-visual-entity';
+import { NodeEnrichmentService } from '../visualization/flows/nodes/node-enrichment.service';
 import { CustomMode } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
 
@@ -17,6 +18,7 @@ describe('CustomModeVisualEntity', () => {
   let entity: CustomModeVisualEntity;
 
   beforeEach(() => {
+    vi.spyOn(NodeEnrichmentService, 'enrichNodeFromCatalog').mockResolvedValue(undefined);
     entity = new CustomModeVisualEntity(makeMode());
   });
 
@@ -204,15 +206,15 @@ describe('CustomModeVisualEntity', () => {
       expect(groupNode.data.path).toBe('customMode');
     });
 
-    it('mode group node has two children: mode node and placeholder', async () => {
+    it('group node carries the mode name as title when catalog absent', async () => {
       const groupNode = await entity.toVizNode();
-      expect(groupNode.getChildren()).toHaveLength(2);
+      expect(groupNode.data.title).toBe('Test Mode');
     });
 
-    it('first child is the mode node (isGroup false, same path)', async () => {
-      const modeNode = (await entity.toVizNode()).getChildren()![0];
-      expect(modeNode.data.isGroup).toBe(false);
-      expect(modeNode.data.path).toBe('customMode');
+    it('group node has one child when there are no parsed steps: the placeholder', async () => {
+      const groupNode = await entity.toVizNode();
+      expect(groupNode.getChildren()).toHaveLength(1);
+      expect(groupNode.getChildren()![0].data.isPlaceholder).toBe(true);
     });
 
     it('last child is the placeholder', async () => {
@@ -220,11 +222,15 @@ describe('CustomModeVisualEntity', () => {
       expect(children[children.length - 1].data.isPlaceholder).toBe(true);
     });
 
-    it('mode node and placeholder are linked via prev/next', async () => {
+    it('placeholder has no previous node when there are no parsed steps', async () => {
       const children = (await entity.toVizNode()).getChildren()!;
-      const [modeNode, placeholder] = children;
-      expect(modeNode.getNextNode()).toBe(placeholder);
-      expect(placeholder.getPreviousNode()).toBe(modeNode);
+      const [placeholder] = children;
+      expect(placeholder.getPreviousNode()).toBeUndefined();
+    });
+
+    it('calls enrichNodeFromCatalog with BobNodes catalog kind', async () => {
+      await entity.toVizNode();
+      expect(NodeEnrichmentService.enrichNodeFromCatalog).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -2,6 +2,7 @@ import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { DefinedComponent } from '../camel/camel-catalog-index';
+import { CatalogKind } from '../catalog-kind';
 import { EntityType } from '../entities';
 import { KaotoSchemaDefinition } from '../kaoto-schema';
 import { NodeLabelType } from '../settings/settings.model';
@@ -14,6 +15,7 @@ import {
   NodeInteraction,
 } from '../visualization/base-visual-entity';
 import { IClipboardCopyObject } from '../visualization/clipboard';
+import { NodeEnrichmentService } from '../visualization/flows/nodes/node-enrichment.service';
 import { CustomModeSchemaService } from '../visualization/flows/support/custom-mode-schema.service';
 import { createVisualizationNode } from '../visualization/visualization-node';
 import { CustomInstructionsNode, CustomInstructionsParser } from './custom-instructions-parser';
@@ -163,7 +165,9 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
   }
 
   async toVizNode(): Promise<IVisualizationNode> {
-    // 1. Mode group node — visual container
+    // 1. Mode group node — carries the title; clicking it opens the metadata form.
+    //    Title is left empty here so enrichNodeFromCatalog can populate it from the catalog (Epic 6).
+    //    A post-enrichment fallback sets mode.name when the catalog has no entry.
     const modeGroupNode = createVisualizationNode(this.id, {
       name: this.type,
       path: this.getRootPath(),
@@ -172,24 +176,18 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
       isGroup: true,
       iconUrl: '',
       title: '',
-      description: '',
-    });
-
-    // 2. Mode node — first child, opens the metadata form
-    const modeNode = createVisualizationNode(`${this.id}-mode`, {
-      name: this.type,
-      path: this.getRootPath(),
-      entity: this,
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: this.mode.name || this.id,
       description: this.mode.description || '',
     });
-    modeGroupNode.addChild(modeNode);
 
-    // 3. customInstructions sibling nodes (stub: parsedNodes is always [] until Epic 7)
-    const siblings: IVisualizationNode[] = [modeNode];
+    await NodeEnrichmentService.enrichNodeFromCatalog(modeGroupNode, CatalogKind.BobNodes);
+
+    // Catalog title takes priority; fall back to mode.name when BobNodes catalog is absent (pre-Epic 6).
+    if (!modeGroupNode.data.title) {
+      modeGroupNode.data.title = this.mode.name || this.id;
+    }
+
+    // 2. customInstructions sibling nodes (stub: parsedNodes is always [] until Epic 7)
+    const siblings: IVisualizationNode[] = [];
     for (let i = 0; i < this.parsedNodes.length; i++) {
       const node = this.parsedNodes[i];
       const path = `${this.getRootPath()}.customInstructions.${i}.${node.nodeType}`;


### PR DESCRIPTION
## Summary
toVizNode() emitted a ${slug}-mode child node that shared the same path, entity, and form as the group node, causing the mode name to appear twice on the canvas. This removes that child, moves the title/description onto the group node directly, and wires enrichNodeFromCatalog(CatalogKind.BobNodes) for Epic 6 readiness — matching the pattern used by Camel and Citrus visual entities.

## What changed
custom-mode-visual-entity.ts: Removed modeNode child; moved title/description onto modeGroupNode; added enrichNodeFromCatalog(CatalogKind.BobNodes) call with a post-enrichment mode.name fallback; changed siblings init from [modeNode] to [].
custom-mode-visual-entity.test.ts: Mocked enrichNodeFromCatalog in beforeEach; replaced old two-child structure tests with new single-child (placeholder-only) assertions.

## How it was verified
unit test pass
manual testing

## Reviewer notes
No changes outside the two files in scope — FlowService, resolver maps, and CustomModeResource are untouched.
The TITLE_RESOLVER_MAP BobNodes entry and removal of the mode.name fallback guard are deferred to Epic 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom mode visualization when catalog information is unavailable by displaying the mode name or identifier.
  * Corrected empty custom mode displays to show a single placeholder with appropriate navigation behavior.
  * Improved navigation between custom instruction steps by removing redundant entries.
* **Tests**
  * Expanded coverage for catalog enrichment, fallback titles, placeholder behavior, and instruction navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->