### PR TITLE
feat(DataMapper): Abstract UX: S11: Support maxOccurs>1 for abstract/choice wrapper fields

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -75,6 +75,8 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
   const choiceDepth = VisualizationUtilService.getSelectedChoiceDepth(nodeData);
   const isAbstractField = VisualizationUtilService.isAbstractField(nodeData);
   const isSelectedAbstract = VisualizationUtilService.isSelectedAbstractField(nodeData);
+  const isAbstractWrapperMember = VisualizationUtilService.isAbstractWrapperMember(nodeData);
+  const isChoiceWrapperMember = VisualizationUtilService.isChoiceWrapperMember(nodeData);
   const isAttributeField = VisualizationUtilService.isAttributeField(nodeData);
   const isDraggable = MappingValidationService.isDraggable(nodeData);
   const isSource = nodeData.isSource;
@@ -146,6 +148,15 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
           className="node__spacer"
           status={isSelectedAbstract ? 'success' : undefined}
           data-testid="abstract-field-icon"
+        >
+          <Choices />
+        </Icon>
+      )}
+      {(isAbstractWrapperMember || isChoiceWrapperMember) && (
+        <Icon
+          className="node__spacer"
+          status={field?.wrapperKind ? undefined : 'success'}
+          data-testid={field?.wrapperKind ? 'abstract-field-icon' : 'wrapper-member-icon'}
         >
           <Choices />
         </Icon>

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -24,6 +24,7 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { MappingService } from '../../services/mapping/mapping.service';
 import { MappingActionService } from '../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../services/visualization/mapping-action-registry.service';
 import { TreeParsingService } from '../../services/visualization/tree-parsing.service';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { VisualizationService } from '../../services/visualization/visualization.service';
@@ -774,7 +775,7 @@ describe('TargetDocumentNode', () => {
       const tree = new DocumentTree(documentNodeData);
 
       const getAllowedActionsSpy = vi
-        .spyOn(MappingActionService, 'getAllowedActions')
+        .spyOn(MappingActionRegistryService, 'getAllowedActions')
         .mockReturnValue([MappingActionKind.ValueSelector]);
       const applyValueSelectorSpy = vi.spyOn(MappingActionService, 'applyValueSelector');
 
@@ -804,7 +805,7 @@ describe('TargetDocumentNode', () => {
       const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
 
-      const getAllowedActionsSpy = vi.spyOn(MappingActionService, 'getAllowedActions').mockReturnValue([]);
+      const getAllowedActionsSpy = vi.spyOn(MappingActionRegistryService, 'getAllowedActions').mockReturnValue([]);
       const applyValueSelectorSpy = vi.spyOn(MappingActionService, 'applyValueSelector');
 
       act(() => {

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../models/datamapper/visualization';
 import { MappingService } from '../../services/mapping/mapping.service';
 import { MappingActionService } from '../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../services/visualization/mapping-action-registry.service';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { VisualizationService } from '../../services/visualization/visualization.service';
 import { VisualizationUtilService } from '../../services/visualization/visualization-util.service';
@@ -110,7 +111,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
     );
 
     const handleDoubleClickField = useCallback(() => {
-      const allowValueSelector = MappingActionService.getAllowedActions(nodeData).includes(
+      const allowValueSelector = MappingActionRegistryService.getAllowedActions(nodeData).includes(
         MappingActionKind.ValueSelector,
       );
 

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.ts
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.ts
@@ -1,6 +1,6 @@
 import { IField } from '../../../../models/datamapper/document';
 import { IFieldSubstituteInfo } from '../../../../models/datamapper/types';
-import { NodeData } from '../../../../models/datamapper/visualization';
+import { FieldItemNodeData, NodeData, TargetAbstractFieldNodeData } from '../../../../models/datamapper/visualization';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { VisualizationService } from '../../../../services/visualization/visualization.service';
 import { VisualizationUtilService } from '../../../../services/visualization/visualization-util.service';
@@ -32,8 +32,33 @@ export function findCandidateQName(
   return entry?.[0];
 }
 
+/**
+ * Resolves the concrete IField from the wrapper's children by QName. Returns the actual
+ * document-tree field instance (not schema metadata) so callers can pass it directly to
+ * {@link MappingService.updateFieldItemField}. Uses `cachedCandidates` when the wrapper
+ * matches `knownWrapper` to avoid re-querying the schema collection on each call.
+ */
+export function resolveCandidateField(
+  wrapperField: IField,
+  qname: string,
+  cachedCandidates: Record<string, IFieldSubstituteInfo>,
+  knownWrapper: IField | undefined,
+  namespaceMap: Record<string, string>,
+): IField | undefined {
+  const resolvedCandidates =
+    wrapperField === knownWrapper
+      ? cachedCandidates
+      : FieldOverrideService.getFieldSubstitutionCandidates(wrapperField, namespaceMap);
+  const candidate = resolvedCandidates[qname];
+  if (!candidate) return undefined;
+  return wrapperField.fields?.find(
+    (f) => f.name === candidate.qname.getLocalPart() && f.namespaceURI === candidate.qname.getNamespaceURI(),
+  );
+}
+
 export interface AbstractFieldInfo {
   isAbstractWrapper: boolean;
+  isAbstractWrapperMember: boolean;
   isSelectedSubstitution: boolean;
   isSubstitutionCandidate: boolean;
   abstractWrapperField: IField | undefined;
@@ -45,6 +70,7 @@ export interface AbstractFieldInfo {
 export function resolveAbstractFieldInfo(nodeData: NodeData, namespaceMap: Record<string, string>): AbstractFieldInfo {
   const field = VisualizationUtilService.getField(nodeData);
   const isAbstractWrapper = field?.wrapperKind === 'abstract';
+  const isAbstractWrapperMember = VisualizationUtilService.isAbstractWrapperMember(nodeData);
   const isSelectedSubstitution = VisualizationUtilService.isAbstractField(nodeData);
 
   const candidateParent = field?.parent && 'wrapperKind' in field.parent ? field.parent : undefined;
@@ -62,10 +88,13 @@ export function resolveAbstractFieldInfo(nodeData: NodeData, namespaceMap: Recor
     abstractWrapperField = field;
   } else if (isSelectedSubstitution) {
     abstractWrapperField = nodeData.abstractField;
+  } else if (isAbstractWrapperMember && nodeData instanceof FieldItemNodeData) {
+    abstractWrapperField = nodeData.wrapperField ?? (nodeData.parent as TargetAbstractFieldNodeData).field;
   }
 
   return {
     isAbstractWrapper,
+    isAbstractWrapperMember,
     isSelectedSubstitution,
     isSubstitutionCandidate,
     abstractWrapperField,

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
@@ -1,11 +1,18 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
-import { DocumentDefinition, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper';
+import {
+  BODY_DOCUMENT_ID,
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+} from '../../../../models/datamapper';
 import { DocumentTree } from '../../../../models/datamapper/document-tree';
+import { DocumentTreeNode } from '../../../../models/datamapper/document-tree-node';
 import { FieldItem, MappingTree } from '../../../../models/datamapper/mapping';
 import {
   DocumentNodeData,
+  FieldItemNodeData,
   TargetAbstractFieldNodeData,
   TargetDocumentNodeData,
 } from '../../../../models/datamapper/visualization';
@@ -13,6 +20,8 @@ import { MappingLinksProvider } from '../../../../providers/data-mapping-links.p
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
 import { XmlSchemaDocumentService } from '../../../../services/document/xml-schema/xml-schema-document.service';
+import { MappingService } from '../../../../services/mapping/mapping.service';
+import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
 import { TreeParsingService } from '../../../../services/visualization/tree-parsing.service';
 import { VisualizationService } from '../../../../services/visualization/visualization.service';
 import { getFieldSubstitutionXsd } from '../../../../stubs/datamapper/data-mapper';
@@ -305,6 +314,314 @@ describe('useAbstractFieldSubstitutionMenu', () => {
       const abstractTargetNode = abstractNode.nodeData as TargetAbstractFieldNodeData;
       abstractTargetNode.mapping = new FieldItem(mappingTree, abstractAnimalField);
       expect(VisualizationService.hasChildren(abstractTargetNode)).toBe(true);
+    });
+
+    it('should return to unconfigured state after select then clear (no orphan FieldItem)', () => {
+      const { documentNodeData, abstractNode, abstractAnimalField, mappingTree } = createTargetAbstractFieldNode();
+      const candidates = FieldOverrideService.getFieldSubstitutionCandidates(
+        abstractAnimalField,
+        mappingTree.namespaceMap,
+      );
+      const catQName = Object.keys(candidates).find((k) => k.includes('Cat'))!;
+      FieldOverrideService.applyFieldSubstitution(abstractAnimalField, catQName, mappingTree.namespaceMap);
+      const abstractTargetNode = abstractNode.nodeData as TargetAbstractFieldNodeData;
+      const fieldItem = new FieldItem(mappingTree, abstractAnimalField);
+      mappingTree.children.push(fieldItem);
+      abstractTargetNode.mapping = fieldItem;
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={abstractNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${abstractNode.nodeData.id}`));
+      });
+      act(() => {
+        fireEvent.click(screen.getByText('Clear substitution'));
+      });
+
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(0);
+    });
+  });
+
+  describe('target-side abstract wrapper with maxOccurs>1', () => {
+    function createTargetZooDoc() {
+      const definition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        { namespaceUri: NS_SUBSTITUTION, name: 'Zoo' },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      if (result.validationStatus !== 'success' || !result.document) {
+        throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create Zoo test document');
+      }
+      return result.document;
+    }
+
+    const createTargetZooAbstractNode = () => {
+      const document = createTargetZooDoc();
+      const mappingTree = new MappingTree(
+        document.documentType,
+        document.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const documentNodeData = new TargetDocumentNodeData(document, mappingTree);
+      const zooField = document.fields[0];
+      const abstractAnimalField = zooField.fields.find((f) => f.name === 'AbstractAnimal')!;
+      expect(abstractAnimalField.maxOccurs).not.toBe(1);
+
+      const tree = new DocumentTree(documentNodeData);
+      TreeParsingService.parseTree(tree);
+      const zooNode = tree.root.children[0];
+      const abstractNode = zooNode.children.find((c) => c.nodeData instanceof TargetAbstractFieldNodeData)!;
+      return { document, documentNodeData, abstractNode, abstractAnimalField, mappingTree };
+    };
+
+    it('should call applyTargetSelection when selecting candidate on maxOccurs>1 wrapper', () => {
+      const { documentNodeData, abstractNode, mappingTree } = createTargetZooAbstractNode();
+      const applySpy = vi.spyOn(MappingActionService, 'applyTargetSelection');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={abstractNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${abstractNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Cat'));
+      });
+
+      expect(applySpy).toHaveBeenCalledWith(abstractNode.nodeData, expect.objectContaining({}));
+      const createdFieldItem = mappingTree.children
+        .flatMap((c) => (c instanceof FieldItem ? c.children : []))
+        .find((c) => c instanceof FieldItem && c.field.name === 'Cat') as FieldItem | undefined;
+      expect(createdFieldItem?.isUserCreated).toBe(true);
+      applySpy.mockRestore();
+    });
+
+    it('should not set selectedMemberQName on wrapper after selection on maxOccurs>1 (per-instance)', () => {
+      const { documentNodeData, abstractNode, abstractAnimalField } = createTargetZooAbstractNode();
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={abstractNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${abstractNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Dog'));
+      });
+
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
+    });
+
+    it('should still call applyFieldSubstitution for maxOccurs=1 wrapper (regression)', () => {
+      const { documentNodeData, abstractNode, abstractAnimalField } = createTargetZooAbstractNode();
+      abstractAnimalField.maxOccurs = 1;
+      const applySpy = vi.spyOn(FieldOverrideService, 'applyFieldSubstitution');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={abstractNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${abstractNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Cat'));
+      });
+
+      expect(applySpy).toHaveBeenCalledWith(abstractAnimalField, expect.stringContaining('Cat'), expect.any(Object));
+      applySpy.mockRestore();
+    });
+
+    it('should remove FieldItem when clearing per-instance selection on maxOccurs>1', () => {
+      const { abstractAnimalField, mappingTree } = createTargetZooAbstractNode();
+      const catField = abstractAnimalField.fields.find((f) => f.name === 'Cat')!;
+      const fieldItem = new FieldItem(mappingTree, catField);
+      fieldItem.isUserCreated = true;
+      mappingTree.children.push(fieldItem);
+
+      fieldItem.children = [];
+      MappingService.updateFieldItemField(fieldItem, abstractAnimalField);
+
+      expect(abstractAnimalField.selectedMemberQName).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(1);
+      expect((mappingTree.children[0] as FieldItem).field).toBe(abstractAnimalField);
+    });
+  });
+
+  describe('FieldItemNodeData under abstract wrapper (member context menu)', () => {
+    function createTargetZooDoc() {
+      const definition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        { namespaceUri: NS_SUBSTITUTION, name: 'Zoo' },
+      );
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      if (result.validationStatus !== 'success' || !result.document) {
+        throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create Zoo test document');
+      }
+      return result.document;
+    }
+
+    const createMemberNode = () => {
+      const document = createTargetZooDoc();
+      const mappingTree = new MappingTree(
+        document.documentType,
+        document.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const documentNodeData = new TargetDocumentNodeData(document, mappingTree);
+      const zooField = document.fields[0];
+      const abstractAnimalField = zooField.fields.find((f) => f.name === 'AbstractAnimal')!;
+      const catField = abstractAnimalField.fields.find((f) => f.name === 'Cat')!;
+
+      const tree = new DocumentTree(documentNodeData);
+      TreeParsingService.parseTree(tree);
+      const zooNode = tree.root.children[0];
+      const abstractNode = zooNode.children.find((c) => c.nodeData instanceof TargetAbstractFieldNodeData)!;
+
+      const abstractNodeData = abstractNode.nodeData as TargetAbstractFieldNodeData;
+      const parentItem = MappingActionService.getOrCreateFieldItem(abstractNodeData.parent);
+      const fieldItem = MappingService.createFieldItem(parentItem, catField);
+      fieldItem.isUserCreated = true;
+      abstractNodeData.mapping = new FieldItem(parentItem, abstractAnimalField);
+
+      const fieldItemNodeData = new FieldItemNodeData(abstractNodeData, fieldItem, abstractAnimalField);
+      const memberTreeNode = new DocumentTreeNode(fieldItemNodeData, abstractNode);
+
+      return { document, documentNodeData, memberTreeNode, fieldItem, abstractAnimalField, mappingTree };
+    };
+
+    it('should show substitution candidates in context menu for member node', () => {
+      const { documentNodeData, memberTreeNode } = createMemberNode();
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={memberTreeNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${memberTreeNode.nodeData.id}`));
+      });
+
+      const menuItems = screen.getAllByText('Cat');
+      expect(menuItems.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText('Dog')).toBeInTheDocument();
+      expect(screen.getByText('Fish')).toBeInTheDocument();
+      expect(screen.getByText('Kitten')).toBeInTheDocument();
+    });
+
+    it('should show "Clear substitution" for member node', () => {
+      const { documentNodeData, memberTreeNode } = createMemberNode();
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={memberTreeNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${memberTreeNode.nodeData.id}`));
+      });
+
+      expect(screen.getByText('Clear substitution')).toBeInTheDocument();
+    });
+
+    it('should call updateFieldItemField when changing substitution on member node', () => {
+      const { documentNodeData, memberTreeNode } = createMemberNode();
+      const updateSpy = vi.spyOn(MappingService, 'updateFieldItemField');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={memberTreeNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${memberTreeNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Dog'));
+      });
+
+      expect(updateSpy).toHaveBeenCalled();
+      updateSpy.mockRestore();
+    });
+
+    it('should revert FieldItem to wrapper field when clearing substitution on member node', () => {
+      const { documentNodeData, memberTreeNode, abstractAnimalField } = createMemberNode();
+      const updateSpy = vi.spyOn(MappingService, 'updateFieldItemField');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={memberTreeNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${memberTreeNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Clear substitution'));
+      });
+
+      expect(updateSpy).toHaveBeenCalledWith(expect.any(FieldItem), abstractAnimalField);
+      updateSpy.mockRestore();
     });
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
@@ -12,10 +12,147 @@ import { SchemaPathService } from '../../../../services/schema-path.service';
 import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
 import { MenuAction, MenuGroup } from '../FieldContextMenu';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
-import { buildSelectSelfAction, findCandidateQName, resolveAbstractFieldInfo } from './menu-utils';
+import {
+  buildSelectSelfAction,
+  findCandidateQName,
+  resolveAbstractFieldInfo,
+  resolveCandidateField,
+} from './menu-utils';
 import { MemberSelection, MenuContributor } from './types';
 
 const INLINE_SUBSTITUTION_LIMIT = 10;
+
+function applyPerInstanceAbstractSubstitution(
+  nodeData: NodeData,
+  wrapperField: IField,
+  qname: string,
+  candidates: Record<string, IFieldSubstituteInfo>,
+  abstractWrapperField: IField | undefined,
+  namespaceMap: { [prefix: string]: string },
+): void {
+  const candidateField = resolveCandidateField(wrapperField, qname, candidates, abstractWrapperField, namespaceMap);
+  if (candidateField) {
+    MappingActionService.applyTargetSelection(nodeData as TargetNodeData, candidateField);
+  }
+}
+
+function applyDocumentLevelAbstractSubstitution(
+  nodeData: NodeData,
+  wrapperField: IField,
+  qname: string,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  FieldOverrideService.applyFieldSubstitution(wrapperField, qname, namespaceMap);
+  if (!isTargetSide) return;
+  const selectedMember = DocumentUtilService.getSelectedMember(wrapperField);
+  if (selectedMember) MappingActionService.applyTargetSelection(nodeData as TargetNodeData, selectedMember);
+}
+
+function clearDocumentLevelAbstractSubstitution(
+  nodeData: NodeData,
+  wrapperField: IField,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  if (isTargetSide) MappingActionService.clearTargetSelection(nodeData as TargetNodeData, wrapperField);
+  const doc = wrapperField.ownerDocument;
+  const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
+  DocumentUtilService.invalidateDescendants(doc, schemaPath);
+  FieldOverrideService.revertFieldSubstitution(wrapperField, namespaceMap);
+}
+
+function resolveSelectedQName(
+  abstractWrapperField: IField | undefined,
+  candidates: Record<string, IFieldSubstituteInfo>,
+): string | undefined {
+  if (!abstractWrapperField) return undefined;
+  const selectedField = DocumentUtilService.getSelectedMember(abstractWrapperField);
+  return selectedField ? findCandidateQName(candidates, selectedField) : undefined;
+}
+
+function applyAbstractSubstitution(
+  nodeData: NodeData,
+  wrapperField: IField,
+  qname: string,
+  candidates: Record<string, IFieldSubstituteInfo>,
+  abstractWrapperField: IField | undefined,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  if (isTargetSide && wrapperField.maxOccurs !== 1) {
+    applyPerInstanceAbstractSubstitution(nodeData, wrapperField, qname, candidates, abstractWrapperField, namespaceMap);
+    return;
+  }
+  applyDocumentLevelAbstractSubstitution(nodeData, wrapperField, qname, namespaceMap, isTargetSide);
+}
+
+function clearAbstractSubstitution(
+  nodeData: NodeData,
+  wrapperField: IField,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  if (isTargetSide && wrapperField.maxOccurs !== 1) {
+    MappingActionService.clearPerInstanceWrapperSelection(nodeData as TargetNodeData, wrapperField);
+    return;
+  }
+  clearDocumentLevelAbstractSubstitution(nodeData, wrapperField, namespaceMap, isTargetSide);
+}
+
+function resolveSubstitutionCandidates(
+  abstractWrapperField: IField | undefined,
+  namespaceMap: { [prefix: string]: string },
+): Record<string, IFieldSubstituteInfo> {
+  if (!abstractWrapperField) return {};
+  return FieldOverrideService.getFieldSubstitutionCandidates(abstractWrapperField, namespaceMap);
+}
+
+function resolveMemberSelectedQName(
+  isAbstractWrapperMember: boolean,
+  field: IField | undefined,
+  abstractWrapperField: IField | undefined,
+  candidates: Record<string, IFieldSubstituteInfo>,
+): string | undefined {
+  if (!isAbstractWrapperMember || !field || !abstractWrapperField) return undefined;
+  return findCandidateQName(candidates, field);
+}
+
+interface AbstractMenuGroupsConfig {
+  isAbstractWrapper: boolean;
+  isAbstractWrapperMember: boolean;
+  isSelectedSubstitution: boolean;
+  candidates: Record<string, IFieldSubstituteInfo>;
+  selectedQName: string | undefined;
+  memberSelectedQName: string | undefined;
+  selectSelfAction: MenuAction | undefined;
+  clearSubstitutionAction: MenuAction;
+  changeSubstituteAction: MenuAction;
+  onSelectSubstitution: (qname: string) => void;
+  onOpenSubstitutionModal: () => void;
+}
+
+function buildMenuGroupsForAbstractNode(config: AbstractMenuGroupsConfig): MenuGroup[] {
+  if (config.isAbstractWrapper || config.isAbstractWrapperMember) {
+    return buildAbstractWrapperMenuGroups(
+      config.candidates,
+      config.isAbstractWrapperMember ? config.memberSelectedQName : config.selectedQName,
+      config.isAbstractWrapperMember ? undefined : config.selectSelfAction,
+      config.clearSubstitutionAction,
+      config.onSelectSubstitution,
+      config.onOpenSubstitutionModal,
+    );
+  }
+  const substitutionActions: MenuAction[] = [];
+  if (config.isSelectedSubstitution)
+    substitutionActions.push(config.clearSubstitutionAction, config.changeSubstituteAction);
+  if (config.selectSelfAction) substitutionActions.push(config.selectSelfAction);
+  return [{ actions: substitutionActions }];
+}
+
+function handleAbstractModalSelect(selection: MemberSelection, onSelectSubstitution: (qname: string) => void): void {
+  if (selection.substituteQName) onSelectSubstitution(selection.substituteQName);
+}
 
 function buildInlineSubstitutionActions(
   candidates: Record<string, IFieldSubstituteInfo>,
@@ -68,6 +205,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
 
   const {
     isAbstractWrapper,
+    isAbstractWrapperMember,
     isSelectedSubstitution,
     isSubstitutionCandidate,
     abstractWrapperField,
@@ -78,44 +216,40 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
 
   const [isSubstitutionModalOpen, setIsSubstitutionModalOpen] = useState(false);
 
-  const candidates = useMemo(() => {
-    if (!abstractWrapperField) return {};
-    return FieldOverrideService.getFieldSubstitutionCandidates(abstractWrapperField, mappingTree.namespaceMap);
-  }, [abstractWrapperField, mappingTree.namespaceMap]);
+  const candidates = useMemo(
+    () => resolveSubstitutionCandidates(abstractWrapperField, mappingTree.namespaceMap),
+    [abstractWrapperField, mappingTree.namespaceMap],
+  );
 
-  const selectedQName = useMemo(() => {
-    if (!abstractWrapperField) return undefined;
-    const selectedField = DocumentUtilService.getSelectedMember(abstractWrapperField);
-    if (!selectedField) return undefined;
-    return findCandidateQName(candidates, selectedField);
-  }, [abstractWrapperField, candidates]);
+  const selectedQName = useMemo(
+    () => resolveSelectedQName(abstractWrapperField, candidates),
+    [abstractWrapperField, candidates],
+  );
 
   const isTargetSide = !nodeData.isSource;
 
   const applySubstitution = useCallback(
-    (field: IField, qname: string) => {
-      FieldOverrideService.applyFieldSubstitution(field, qname, mappingTree.namespaceMap);
-
-      if (isTargetSide) {
-        const selectedMember = DocumentUtilService.getSelectedMember(field);
-        if (selectedMember) MappingActionService.applyTargetSelection(nodeData as TargetNodeData, selectedMember);
-      }
-
-      const doc = field.ownerDocument;
+    (wrapperField: IField, qname: string) => {
+      applyAbstractSubstitution(
+        nodeData,
+        wrapperField,
+        qname,
+        candidates,
+        abstractWrapperField,
+        mappingTree.namespaceMap,
+        isTargetSide,
+      );
+      const doc = wrapperField.ownerDocument;
       const previousRefId = doc.getReferenceId(mappingTree.namespaceMap);
       updateDocument(doc, doc.definition, previousRefId);
     },
-    [isTargetSide, mappingTree.namespaceMap, nodeData, updateDocument],
+    [isTargetSide, candidates, abstractWrapperField, mappingTree.namespaceMap, nodeData, updateDocument],
   );
 
   const applyClearSubstitution = useCallback(
-    (field: IField) => {
-      if (isTargetSide) MappingActionService.clearTargetSelection(nodeData as TargetNodeData, field);
-
-      const doc = field.ownerDocument;
-      const schemaPath = SchemaPathService.build(field, mappingTree.namespaceMap);
-      DocumentUtilService.invalidateDescendants(doc, schemaPath);
-      FieldOverrideService.revertFieldSubstitution(field, mappingTree.namespaceMap);
+    (wrapperField: IField) => {
+      clearAbstractSubstitution(nodeData, wrapperField, mappingTree.namespaceMap, isTargetSide);
+      const doc = wrapperField.ownerDocument;
       const previousRefId = doc.getReferenceId(mappingTree.namespaceMap);
       updateDocument(doc, doc.definition, previousRefId);
     },
@@ -164,22 +298,24 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
     testId: 'change-substitution',
   };
 
-  let menuGroups: MenuGroup[];
-  if (isAbstractWrapper) {
-    menuGroups = buildAbstractWrapperMenuGroups(
-      candidates,
-      selectedQName,
-      selectSelfAction,
-      clearSubstitutionAction,
-      handleSelectSubstitution,
-      handleOpenSubstitutionModal,
-    );
-  } else {
-    const substitutionActions: MenuAction[] = [];
-    if (isSelectedSubstitution) substitutionActions.push(clearSubstitutionAction, changeSubstituteAction);
-    if (selectSelfAction) substitutionActions.push(selectSelfAction);
-    menuGroups = [{ actions: substitutionActions }];
-  }
+  const memberSelectedQName = useMemo(
+    () => resolveMemberSelectedQName(isAbstractWrapperMember, field, abstractWrapperField, candidates),
+    [isAbstractWrapperMember, field, abstractWrapperField, candidates],
+  );
+
+  const menuGroups = buildMenuGroupsForAbstractNode({
+    isAbstractWrapper,
+    isAbstractWrapperMember,
+    isSelectedSubstitution,
+    candidates,
+    selectedQName,
+    memberSelectedQName,
+    selectSelfAction,
+    clearSubstitutionAction,
+    changeSubstituteAction,
+    onSelectSubstitution: handleSelectSubstitution,
+    onOpenSubstitutionModal: handleOpenSubstitutionModal,
+  });
 
   const closeSubstitutionModal = useCallback(() => {
     setIsSubstitutionModalOpen(false);
@@ -198,9 +334,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
 
   const handleModalSelect = useCallback(
     (selection: MemberSelection) => {
-      if (selection.substituteQName) {
-        handleSelectSubstitution(selection.substituteQName);
-      }
+      handleAbstractModalSelect(selection, handleSelectSubstitution);
     },
     [handleSelectSubstitution],
   );
@@ -217,7 +351,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
           description={`Choose a concrete element for ${fieldName}`}
           testId="substitution-selection-modal"
           candidates={modalCandidates}
-          selectedKey={selectedQName ?? null}
+          selectedKey={(isAbstractWrapperMember ? memberSelectedQName : selectedQName) ?? null}
           onSelect={handleModalSelect}
           onClose={closeSubstitutionModal}
         />

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -13,13 +13,15 @@ import {
 } from '../../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
-import { ChoiceSelectionService } from '../../../../services/document/choice-selection.service';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
+import { WrapperSelectionService } from '../../../../services/document/wrapper-selection.service';
 import { XmlSchemaField } from '../../../../services/document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../../../../services/document/xml-schema/xml-schema-document.service';
+import { MappingService } from '../../../../services/mapping/mapping.service';
+import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
 import { TreeParsingService } from '../../../../services/visualization/tree-parsing.service';
 import { VisualizationService } from '../../../../services/visualization/visualization.service';
-import { getChoiceWithAbstractXsd, TestUtil } from '../../../../stubs/datamapper/data-mapper';
+import { getChoiceWithAbstractXsd, getTestDocumentXsd, TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { SourceDocumentNodeWithContextMenu } from '../../SourceDocumentNode';
 import { TargetDocumentNodeWithContextMenu } from '../../TargetDocumentNode';
 
@@ -63,31 +65,32 @@ describe('useChoiceContextMenu', () => {
     return { document, documentNodeData, choiceNode, choiceField };
   };
 
-  const createLargeChoiceFieldNode = (size = 11) => {
-    const document = TestUtil.createSourceOrderDoc();
-    const parentField = document.fields[0];
-    const choiceField = new XmlSchemaField(parentField, 'largeChoice', false);
-    choiceField.displayName = 'Large Choice';
-    choiceField.type = Types.Container;
-    choiceField.wrapperKind = 'choice';
-    choiceField.selectedMemberIndex = undefined;
+  const NS_TEST = 'io.kaoto.datamapper.poc.test';
 
-    const members = Array.from({ length: size }, (_, i) => {
-      const member = new XmlSchemaField(choiceField, `member${i}`, false);
-      member.displayName = `Member ${i}`;
-      member.type = Types.String;
-      return member;
+  const createLargeChoiceFieldNode = () => {
+    const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test-doc', {
+      'TestDocument.xsd': getTestDocumentXsd(),
     });
-    choiceField.fields = members;
-    parentField.fields.push(choiceField);
-
+    definition.rootElementChoice = { namespaceUri: NS_TEST, name: 'TestDocument' };
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    if (result.validationStatus !== 'success' || !result.document) {
+      throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create TestDocument');
+    }
+    const document = result.document;
     const documentNodeData = new DocumentNodeData(document);
     const tree = new DocumentTree(documentNodeData);
     TreeParsingService.parseTree(tree);
-    const orderNode = tree.root.children[0];
-    const lastChild = orderNode.children.length - 1;
-    const choiceNode = orderNode.children[lastChild];
-    return { documentNodeData, choiceNode };
+    const rootNode = tree.root.children[0];
+    const choiceNode = rootNode.children.find(
+      (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.name === 'LargeChoiceElement',
+    );
+    if (!choiceNode) throw new Error('LargeChoiceElement not found');
+    const largeChoiceField = (choiceNode.nodeData as FieldNodeData).field;
+    const innerChoiceNode = choiceNode.children.find(
+      (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.wrapperKind === 'choice',
+    );
+    if (!innerChoiceNode) throw new Error('Choice wrapper not found under LargeChoiceElement');
+    return { documentNodeData, choiceNode: innerChoiceNode, choiceField: largeChoiceField };
   };
 
   it('should show choice members inline for unselected choice wrapper (Case A)', () => {
@@ -162,7 +165,7 @@ describe('useChoiceContextMenu', () => {
   it('should call setChoiceSelection when clicking a choice member', () => {
     const { documentNodeData, choiceNode, choiceField } = createChoiceFieldNode(false);
 
-    const setSpy = vi.spyOn(ChoiceSelectionService, 'setChoiceSelection');
+    const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection');
 
     render(
       <SourceDocumentNodeWithContextMenu
@@ -190,7 +193,7 @@ describe('useChoiceContextMenu', () => {
     const { documentNodeData, choiceNode, choiceField } = createChoiceFieldNode(false);
     choiceField.selectedMemberIndex = 1;
 
-    const clearSpy = vi.spyOn(ChoiceSelectionService, 'clearChoiceSelection');
+    const clearSpy = vi.spyOn(WrapperSelectionService, 'clearChoiceSelection');
 
     render(
       <SourceDocumentNodeWithContextMenu
@@ -232,7 +235,7 @@ describe('useChoiceContextMenu', () => {
     });
 
     expect(screen.getByText('Select Member...')).toBeInTheDocument();
-    expect(screen.queryByText('Member 0')).not.toBeInTheDocument();
+    expect(screen.queryByText('OptionA')).not.toBeInTheDocument();
     expect(screen.queryByText('Clear selection')).not.toBeInTheDocument();
   });
 
@@ -257,7 +260,7 @@ describe('useChoiceContextMenu', () => {
       fireEvent.click(screen.getByText('Select Member...'));
     });
 
-    expect(screen.getByText('Select member for Large Choice')).toBeInTheDocument();
+    expect(screen.getByText('Select member for choice')).toBeInTheDocument();
   });
 
   it('should show empty menu for choice wrapper with no members and no selection', () => {
@@ -316,13 +319,13 @@ describe('useChoiceContextMenu', () => {
       fireEvent.click(screen.getByText('Select Member...'));
     });
 
-    expect(screen.getByText('Select member for Large Choice')).toBeInTheDocument();
+    expect(screen.getByText('Select member for choice')).toBeInTheDocument();
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     });
 
-    expect(screen.queryByText('Select member for Large Choice')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select member for choice')).not.toBeInTheDocument();
   });
 
   it('should show Select action for choice member child (Case C)', () => {
@@ -351,7 +354,7 @@ describe('useChoiceContextMenu', () => {
     const { documentNodeData, choiceNode, choiceField } = createChoiceFieldNode(false);
     const memberNode = choiceNode.children[1];
 
-    const setSpy = vi.spyOn(ChoiceSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
+    const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
 
     render(
       <SourceDocumentNodeWithContextMenu
@@ -447,7 +450,7 @@ describe('useChoiceContextMenu', () => {
     it('should call setChoiceSelection on inner wrapper when clicking an inner member', () => {
       const { documentNodeData, choiceNode, innerChoiceField } = createNestedChoiceFieldNode();
 
-      const setSpy = vi.spyOn(ChoiceSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
+      const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
 
       render(
         <SourceDocumentNodeWithContextMenu
@@ -474,7 +477,7 @@ describe('useChoiceContextMenu', () => {
     it('should call clearChoiceSelection on outer wrapper when clicking Clear selection', () => {
       const { documentNodeData, choiceNode, outerChoiceField } = createNestedChoiceFieldNode();
 
-      const clearSpy = vi.spyOn(ChoiceSelectionService, 'clearChoiceSelection').mockImplementation(vi.fn());
+      const clearSpy = vi.spyOn(WrapperSelectionService, 'clearChoiceSelection').mockImplementation(vi.fn());
 
       render(
         <SourceDocumentNodeWithContextMenu
@@ -517,44 +520,109 @@ describe('useChoiceContextMenu', () => {
 
       expect(screen.queryByText(/Select '.*' in '.*'/)).not.toBeInTheDocument();
     });
-  });
 
-  describe('target-side choice wrapper', () => {
-    const createTargetChoiceFieldNode = () => {
-      const document = TestUtil.createTargetOrderDoc();
-      const mappingTree = new MappingTree(
-        document.documentType,
-        document.documentId,
-        DocumentDefinitionType.XML_SCHEMA,
-      );
-      const documentNodeData = new TargetDocumentNodeData(document, mappingTree);
+    it('should clear parent (middle) wrapper, not outermost, in 3-level nesting', () => {
+      const document = TestUtil.createSourceOrderDoc();
       const parentField = document.fields[0];
 
-      const choiceField = new XmlSchemaField(parentField, 'contactChoice', false);
-      choiceField.displayName = 'Contact Choice';
-      choiceField.type = Types.Container;
-      choiceField.wrapperKind = 'choice';
-      choiceField.selectedMemberIndex = undefined;
+      const outerChoiceField = new XmlSchemaField(parentField, 'outerChoice', false);
+      outerChoiceField.displayName = 'Outer';
+      outerChoiceField.type = Types.Container;
+      outerChoiceField.wrapperKind = 'choice';
+      outerChoiceField.selectedMemberIndex = 0;
 
-      const emailField = new XmlSchemaField(choiceField, 'email', false);
-      emailField.displayName = 'Email';
-      emailField.type = Types.String;
+      const middleChoiceField = new XmlSchemaField(outerChoiceField, 'middleChoice', false);
+      middleChoiceField.displayName = 'Middle';
+      middleChoiceField.type = Types.Container;
+      middleChoiceField.wrapperKind = 'choice';
+      middleChoiceField.selectedMemberIndex = 0;
 
-      const phoneField = new XmlSchemaField(choiceField, 'phone', false);
-      phoneField.displayName = 'Phone';
-      phoneField.type = Types.String;
+      const innerChoiceField = new XmlSchemaField(middleChoiceField, 'innerChoice', false);
+      innerChoiceField.displayName = 'Inner';
+      innerChoiceField.type = Types.Container;
+      innerChoiceField.wrapperKind = 'choice';
 
-      choiceField.fields = [emailField, phoneField];
-      parentField.fields.push(choiceField);
+      const leafA = new XmlSchemaField(innerChoiceField, 'leafA', false);
+      leafA.displayName = 'LeafA';
+      leafA.type = Types.String;
+      const leafB = new XmlSchemaField(innerChoiceField, 'leafB', false);
+      leafB.displayName = 'LeafB';
+      leafB.type = Types.String;
+      innerChoiceField.fields = [leafA, leafB];
 
+      middleChoiceField.fields = [innerChoiceField];
+
+      const plainOuter = new XmlSchemaField(outerChoiceField, 'plainOuter', false);
+      plainOuter.displayName = 'PlainOuter';
+      plainOuter.type = Types.String;
+      outerChoiceField.fields = [middleChoiceField, plainOuter];
+
+      parentField.fields.push(outerChoiceField);
+
+      const documentNodeData = new DocumentNodeData(document);
       const tree = new DocumentTree(documentNodeData);
       TreeParsingService.parseTree(tree);
       const orderNode = tree.root.children[0];
-      const lastChild = orderNode.children.length - 1;
-      const choiceNode = orderNode.children[lastChild];
-      return { documentNodeData, choiceNode, choiceField, mappingTree };
-    };
+      const choiceNode = orderNode.children[orderNode.children.length - 1];
 
+      const clearSpy = vi.spyOn(WrapperSelectionService, 'clearChoiceSelection').mockImplementation(vi.fn());
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Clear selection'));
+      });
+
+      expect(clearSpy).toHaveBeenCalledWith(expect.any(Object), middleChoiceField, expect.any(Object));
+      clearSpy.mockRestore();
+    });
+  });
+
+  const createTargetChoiceFieldNode = (maxOccurs?: number | 'unbounded') => {
+    const document = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(document.documentType, document.documentId, DocumentDefinitionType.XML_SCHEMA);
+    const documentNodeData = new TargetDocumentNodeData(document, mappingTree);
+    const parentField = document.fields[0];
+
+    const choiceField = new XmlSchemaField(parentField, 'contactChoice', false);
+    choiceField.displayName = 'Contact Choice';
+    choiceField.type = Types.Container;
+    choiceField.wrapperKind = 'choice';
+    choiceField.selectedMemberIndex = undefined;
+    if (maxOccurs !== undefined) choiceField.maxOccurs = maxOccurs;
+
+    const emailField = new XmlSchemaField(choiceField, 'email', false);
+    emailField.displayName = 'Email';
+    emailField.type = Types.String;
+
+    const phoneField = new XmlSchemaField(choiceField, 'phone', false);
+    phoneField.displayName = 'Phone';
+    phoneField.type = Types.String;
+
+    choiceField.fields = [emailField, phoneField];
+    parentField.fields.push(choiceField);
+
+    const tree = new DocumentTree(documentNodeData);
+    TreeParsingService.parseTree(tree);
+    const orderNode = tree.root.children[0];
+    const lastChild = orderNode.children.length - 1;
+    const choiceNode = orderNode.children[lastChild];
+    return { documentNodeData, choiceNode, choiceField, mappingTree };
+  };
+
+  describe('target-side choice wrapper', () => {
     it('should hide children for unconfigured target choice wrapper', () => {
       const { choiceNode } = createTargetChoiceFieldNode();
       expect(VisualizationService.hasChildren(choiceNode.nodeData)).toBe(false);
@@ -586,7 +654,7 @@ describe('useChoiceContextMenu', () => {
     it('should create FieldItem on target-side when selecting a choice member', () => {
       const { documentNodeData, choiceNode, choiceField } = createTargetChoiceFieldNode();
 
-      const setSpy = vi.spyOn(ChoiceSelectionService, 'setChoiceSelection');
+      const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection');
 
       render(
         <TargetDocumentNodeWithContextMenu
@@ -616,7 +684,7 @@ describe('useChoiceContextMenu', () => {
       const choiceTargetNode = choiceNode.nodeData as TargetChoiceFieldNodeData;
       choiceTargetNode.mapping = new FieldItem(mappingTree, choiceField.fields[0]);
 
-      const clearSpy = vi.spyOn(ChoiceSelectionService, 'clearChoiceSelection');
+      const clearSpy = vi.spyOn(WrapperSelectionService, 'clearChoiceSelection');
 
       render(
         <TargetDocumentNodeWithContextMenu
@@ -640,12 +708,139 @@ describe('useChoiceContextMenu', () => {
       clearSpy.mockRestore();
     });
 
+    it('should return to unconfigured state after select then clear (no orphan FieldItem)', () => {
+      const { documentNodeData, choiceNode, choiceField, mappingTree } = createTargetChoiceFieldNode();
+      const doc = choiceField.ownerDocument;
+      WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, mappingTree.namespaceMap);
+      const choiceTargetNode = choiceNode.nodeData as TargetChoiceFieldNodeData;
+      const fieldItem = new FieldItem(mappingTree, choiceField.fields[0]);
+      mappingTree.children.push(fieldItem);
+      choiceTargetNode.mapping = fieldItem;
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+      act(() => {
+        fireEvent.click(screen.getByText('Clear selection'));
+      });
+
+      expect(choiceField.selectedMemberIndex).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(0);
+    });
+
     it('should show children after member is selected on target choice wrapper', () => {
       const { choiceNode, choiceField, mappingTree } = createTargetChoiceFieldNode();
       choiceField.selectedMemberIndex = 0;
       const choiceTargetNode = choiceNode.nodeData as TargetChoiceFieldNodeData;
       choiceTargetNode.mapping = new FieldItem(mappingTree, choiceField.fields[0]);
       expect(VisualizationService.hasChildren(choiceTargetNode)).toBe(true);
+    });
+  });
+
+  describe('target-side choice wrapper with maxOccurs>1', () => {
+    it('should call applyTargetSelection when selecting member on maxOccurs>1 choice', () => {
+      const { documentNodeData, choiceNode, mappingTree } = createTargetChoiceFieldNode('unbounded');
+      const applySpy = vi.spyOn(MappingActionService, 'applyTargetSelection');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Email'));
+      });
+
+      expect(applySpy).toHaveBeenCalledWith(choiceNode.nodeData, expect.objectContaining({}));
+      const createdFieldItem = mappingTree.children
+        .flatMap((c) => (c instanceof FieldItem ? c.children : []))
+        .find((c) => c instanceof FieldItem && c.field.name === 'email') as FieldItem | undefined;
+      expect(createdFieldItem?.isUserCreated).toBe(true);
+      applySpy.mockRestore();
+    });
+
+    it('should not set selectedMemberIndex on wrapper after selection on maxOccurs>1 choice (per-instance)', () => {
+      const { documentNodeData, choiceNode, choiceField } = createTargetChoiceFieldNode('unbounded');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Phone'));
+      });
+
+      expect(choiceField.selectedMemberIndex).toBeUndefined();
+    });
+
+    it('should still call setChoiceSelection for maxOccurs=1 choice (regression)', () => {
+      const { documentNodeData, choiceNode, choiceField } = createTargetChoiceFieldNode('unbounded');
+      choiceField.maxOccurs = 1;
+      const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Email'));
+      });
+
+      expect(setSpy).toHaveBeenCalledWith(expect.any(Object), choiceField, 0, expect.any(Object));
+      setSpy.mockRestore();
+    });
+
+    it('should revert FieldItem field when clearing per-instance selection on maxOccurs>1', () => {
+      const { choiceField, mappingTree } = createTargetChoiceFieldNode('unbounded');
+      const fieldItem = new FieldItem(mappingTree, choiceField.fields[0]);
+      fieldItem.isUserCreated = true;
+      mappingTree.children.push(fieldItem);
+
+      fieldItem.children = [];
+      MappingService.updateFieldItemField(fieldItem, choiceField);
+
+      expect(choiceField.selectedMemberIndex).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(1);
+      expect((mappingTree.children[0] as FieldItem).field).toBe(choiceField);
     });
   });
 
@@ -686,7 +881,7 @@ describe('useChoiceContextMenu', () => {
       const lastChild = orderNode.children.length - 1;
       const choiceNode = orderNode.children[lastChild];
 
-      const clearSpy = vi.spyOn(ChoiceSelectionService, 'clearChoiceSelection').mockImplementation(vi.fn());
+      const clearSpy = vi.spyOn(WrapperSelectionService, 'clearChoiceSelection').mockImplementation(vi.fn());
 
       render(
         <SourceDocumentNodeWithContextMenu
@@ -728,7 +923,7 @@ describe('useChoiceContextMenu', () => {
       return result.document;
     }
 
-    function findChoiceTreeNode(docType: DocumentType = DocumentType.SOURCE_BODY) {
+    function buildDocumentTree(docType: DocumentType) {
       const document = createChoiceWithAbstractDoc(docType);
       const isTarget = docType === DocumentType.TARGET_BODY;
       let documentNodeData;
@@ -744,13 +939,22 @@ describe('useChoiceContextMenu', () => {
       }
       const tree = new DocumentTree(documentNodeData);
       TreeParsingService.parseTree(tree);
+      return { document, documentNodeData, tree };
+    }
+
+    function findChoiceTreeNode(docType: DocumentType = DocumentType.SOURCE_BODY) {
+      const { document, documentNodeData, tree } = buildDocumentTree(docType);
       const rootNode = tree.root.children[0];
-      const choiceNode = rootNode.children.find(
+      const shortNode = rootNode.children.find(
+        (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.name === 'Short',
+      );
+      if (!shortNode) throw new Error('Short node not found');
+      const choiceNode = shortNode.children.find(
         (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.wrapperKind === 'choice',
       );
       if (!choiceNode) throw new Error('Choice tree node not found');
       const choiceField = (choiceNode.nodeData as FieldNodeData).field;
-      return { document, documentNodeData, choiceNode, choiceField, isTarget };
+      return { document, documentNodeData, choiceNode, choiceField };
     }
 
     it('should dissolve abstract member into substitution candidates in context menu', () => {
@@ -779,7 +983,7 @@ describe('useChoiceContextMenu', () => {
     it('should set both selectedMemberIndex and substituteQName when selecting dissolved abstract candidate', () => {
       const { documentNodeData, choiceNode, choiceField } = findChoiceTreeNode(DocumentType.SOURCE_BODY);
 
-      const setSpy = vi.spyOn(ChoiceSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
+      const setSpy = vi.spyOn(WrapperSelectionService, 'setChoiceSelection').mockImplementation(vi.fn());
       const applySpy = vi.spyOn(FieldOverrideService, 'applyFieldSubstitution').mockImplementation(vi.fn());
 
       render(
@@ -832,6 +1036,118 @@ describe('useChoiceContextMenu', () => {
       expect(screen.getByText('SMS')).toBeInTheDocument();
       expect(screen.getByText('Webhook')).toBeInTheDocument();
       expect(screen.queryByText('AbstractMessage')).not.toBeInTheDocument();
+    });
+
+    it('should return to unconfigured state after select then clear on choice-with-abstract (no orphan FieldItem)', () => {
+      const { documentNodeData, choiceNode, choiceField } = findChoiceTreeNode(DocumentType.TARGET_BODY);
+      const mappingTree = (documentNodeData as TargetDocumentNodeData).mappingTree;
+      const doc = choiceField.ownerDocument;
+      const webhookIndex = choiceField.fields.findIndex((f) => f.name === 'Webhook');
+      WrapperSelectionService.setChoiceSelection(doc, choiceField, webhookIndex, mappingTree.namespaceMap);
+      const choiceTargetNode = choiceNode.nodeData as TargetChoiceFieldNodeData;
+      const fieldItem = new FieldItem(mappingTree, choiceField.fields[webhookIndex]);
+      mappingTree.children.push(fieldItem);
+      choiceTargetNode.mapping = fieldItem;
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+      act(() => {
+        fireEvent.click(screen.getByText('Clear selection'));
+      });
+
+      expect(choiceField.selectedMemberIndex).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(0);
+    });
+
+    it('should revert FieldItem field when clearing per-instance selection on maxOccurs>1 choice-with-abstract', () => {
+      const { tree } = buildDocumentTree(DocumentType.TARGET_BODY);
+      const mappingTree = (tree.root.nodeData as TargetDocumentNodeData).mappingTree;
+      const rootNode = tree.root.children[0];
+      const largeNode = rootNode.children.find(
+        (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.name === 'Large',
+      );
+      if (!largeNode) throw new Error('Large node not found');
+      const unboundedChoiceNode = largeNode.children.find((c) => {
+        if (!(c.nodeData instanceof FieldNodeData)) return false;
+        const f = c.nodeData.field;
+        return f?.wrapperKind === 'choice' && f.maxOccurs !== 1;
+      });
+      if (!unboundedChoiceNode) throw new Error('Unbounded choice node not found in Large');
+      const unboundedChoiceField = (unboundedChoiceNode.nodeData as FieldNodeData).field;
+      const webhookMultiIndex = unboundedChoiceField.fields.findIndex((f) => f.name === 'WebhookMulti');
+      const fieldItem = new FieldItem(mappingTree, unboundedChoiceField.fields[webhookMultiIndex]);
+      fieldItem.isUserCreated = true;
+      mappingTree.children.push(fieldItem);
+
+      fieldItem.children = [];
+      MappingService.updateFieldItemField(fieldItem, unboundedChoiceField);
+
+      expect(unboundedChoiceField.selectedMemberIndex).toBeUndefined();
+      expect(mappingTree.children).toHaveLength(1);
+      expect((mappingTree.children[0] as FieldItem).field).toBe(unboundedChoiceField);
+    });
+
+    function findUnboundedChoiceTreeNode() {
+      const { document, documentNodeData, tree } = buildDocumentTree(DocumentType.TARGET_BODY);
+      const rootNode = tree.root.children[0];
+      const shortNode = rootNode.children.find(
+        (c) => c.nodeData instanceof FieldNodeData && c.nodeData.field?.name === 'Short',
+      );
+      if (!shortNode) throw new Error('Short node not found');
+      const choiceNode = shortNode.children.find((c) => {
+        if (!(c.nodeData instanceof FieldNodeData)) return false;
+        const f = c.nodeData.field;
+        return f?.wrapperKind === 'choice' && f.maxOccurs !== 1;
+      });
+      if (!choiceNode) throw new Error('Unbounded choice node not found in Short');
+      const choiceField = (choiceNode.nodeData as FieldNodeData).field;
+      return { document, documentNodeData, choiceNode, choiceField };
+    }
+
+    it('should not mutate shared abstract field when selecting dissolved abstract candidate on maxOccurs>1 choice (per-instance)', () => {
+      const { document, documentNodeData, choiceNode, choiceField } = findUnboundedChoiceTreeNode();
+      const abstractMember = choiceField.fields.find((f) => f.wrapperKind === 'abstract');
+      if (!abstractMember) throw new Error('Abstract member not found in choice');
+
+      const applySubSpy = vi.spyOn(FieldOverrideService, 'applyFieldSubstitution');
+      const applySpy = vi.spyOn(MappingActionService, 'applyTargetSelection');
+
+      render(
+        <TargetDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      act(() => {
+        fireEvent.contextMenu(screen.getByTestId(`node-target-${choiceNode.nodeData.id}`));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Email'));
+      });
+
+      expect(applySubSpy).not.toHaveBeenCalled();
+      expect(applySpy).toHaveBeenCalled();
+      expect(abstractMember.selectedMemberQName).toBeUndefined();
+      expect(document.definition.fieldSubstitutions ?? []).toHaveLength(0);
+
+      applySubSpy.mockRestore();
+      applySpy.mockRestore();
     });
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
@@ -4,17 +4,17 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
-import { NodeData, TargetNodeData } from '../../../../models/datamapper/visualization';
-import { ChoiceSelectionService } from '../../../../services/document/choice-selection.service';
+import { FieldItemNodeData, NodeData, TargetNodeData } from '../../../../models/datamapper/visualization';
 import { DocumentUtilService } from '../../../../services/document/document-util.service';
 import { FieldOverrideService } from '../../../../services/document/field-override.service';
+import { WrapperSelectionService } from '../../../../services/document/wrapper-selection.service';
 import { SchemaPathService } from '../../../../services/schema-path.service';
 import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
 import { VisualizationService } from '../../../../services/visualization/visualization.service';
 import { VisualizationUtilService } from '../../../../services/visualization/visualization-util.service';
 import { MenuAction, MenuGroup } from '../FieldContextMenu';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
-import { buildSelectSelfAction, dissolveChoiceMembers } from './menu-utils';
+import { buildSelectSelfAction, dissolveChoiceMembers, findCandidateQName, resolveCandidateField } from './menu-utils';
 import { MemberSelection, MenuContributor, WrapperCandidate } from './types';
 
 const INLINE_CHOICE_LIMIT = 10;
@@ -42,51 +42,175 @@ function buildInlineMemberActions(
   }));
 }
 
-interface ChoiceNodeInfo {
-  isChoiceWrapper: boolean;
-  isSelectedChoice: boolean;
-  isChoiceMember: boolean;
-  activeChoiceWrapperForMembers: IField | undefined;
-  choiceWrapperField: IField | undefined;
-  choiceMemberField: IField | undefined;
-  parentChoiceWrapperField: IField | undefined;
-  choiceMemberIndex: number | undefined;
+function applyPerInstanceChoiceSelection(
+  nodeData: NodeData,
+  wrapper: IField,
+  selection: MemberSelection,
+  namespaceMap: { [prefix: string]: string },
+): void {
+  let candidateField: IField | undefined = wrapper.fields[selection.memberIndex];
+  if (selection.substituteQName && candidateField) {
+    candidateField = resolveCandidateField(candidateField, selection.substituteQName, {}, undefined, namespaceMap);
+  }
+  if (candidateField) {
+    MappingActionService.applyTargetSelection(nodeData as TargetNodeData, candidateField);
+  }
 }
 
-function resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
-  const field = VisualizationUtilService.getField(nodeData);
-  const isChoiceWrapper = field?.wrapperKind === 'choice';
-  const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
+function applyDocumentLevelChoiceSelection(
+  nodeData: NodeData,
+  wrapper: IField,
+  selection: MemberSelection,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  const doc = wrapper.ownerDocument;
+  WrapperSelectionService.setChoiceSelection(doc, wrapper, selection.memberIndex, namespaceMap);
 
-  const choiceMemberField =
-    VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
-  const choiceMemberParent =
-    choiceMemberField?.parent && 'wrapperKind' in choiceMemberField.parent ? choiceMemberField.parent : undefined;
-  const isChoiceMember = choiceMemberParent?.wrapperKind === 'choice';
-  const parentChoiceWrapperField = isChoiceMember ? choiceMemberParent : undefined;
-  const choiceMemberIndex =
-    isChoiceMember && parentChoiceWrapperField && choiceMemberField
-      ? parentChoiceWrapperField.fields.indexOf(choiceMemberField)
-      : undefined;
-
-  let choiceWrapperField: IField | undefined;
-  if (isSelectedChoice) {
-    choiceWrapperField = VisualizationUtilService.resolveOutermostSelectedWrapper(nodeData.choiceField).outermost;
-  } else if (isChoiceWrapper) {
-    choiceWrapperField = field;
+  if (selection.substituteQName) {
+    const abstractMember = wrapper.fields[selection.memberIndex];
+    if (abstractMember) {
+      FieldOverrideService.applyFieldSubstitution(abstractMember, selection.substituteQName, namespaceMap);
+    }
   }
-  const activeChoiceWrapperForMembers = isSelectedChoice && isChoiceWrapper ? field : choiceWrapperField;
 
-  return {
-    isChoiceWrapper,
-    isSelectedChoice,
-    isChoiceMember,
-    activeChoiceWrapperForMembers,
-    choiceWrapperField,
-    choiceMemberField,
-    parentChoiceWrapperField,
-    choiceMemberIndex,
-  };
+  if (isTargetSide) {
+    const selectedMember = DocumentUtilService.getSelectedMember(wrapper);
+    if (selectedMember) {
+      const candidateField = selection.substituteQName
+        ? (DocumentUtilService.getSelectedMember(selectedMember) ?? selectedMember)
+        : selectedMember;
+      MappingActionService.applyTargetSelection(nodeData as TargetNodeData, candidateField);
+    }
+  }
+}
+
+function clearDocumentLevelChoiceSelection(
+  nodeData: NodeData,
+  wrapper: IField,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+  clearDescendantSelections: (field: IField) => void,
+): void {
+  if (isTargetSide) MappingActionService.clearTargetSelection(nodeData as TargetNodeData, wrapper);
+  clearDescendantSelections(wrapper);
+  const doc = wrapper.ownerDocument;
+  const schemaPath = SchemaPathService.build(wrapper, namespaceMap);
+  DocumentUtilService.invalidateDescendants(doc, schemaPath);
+  WrapperSelectionService.clearChoiceSelection(doc, wrapper, namespaceMap);
+}
+
+function clearChoiceSelectionOnField(
+  nodeData: NodeData,
+  wrapper: IField,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+  clearDescendantSelections: (field: IField) => void,
+): void {
+  if (isTargetSide && wrapper.maxOccurs !== 1) {
+    MappingActionService.clearPerInstanceWrapperSelection(nodeData as TargetNodeData, wrapper);
+    return;
+  }
+  clearDocumentLevelChoiceSelection(nodeData, wrapper, namespaceMap, isTargetSide, clearDescendantSelections);
+}
+
+function resolveMemberSelectedKey(
+  nodeData: NodeData,
+  choiceWrapperMemberField: IField | undefined,
+  dissolved: WrapperCandidate[],
+  namespaceMap: Record<string, string>,
+): string | null {
+  if (!(nodeData instanceof FieldItemNodeData)) return null;
+  const memberField = nodeData.field;
+  const wrapper = choiceWrapperMemberField;
+  if (!wrapper) return null;
+  const idx = wrapper.fields.indexOf(memberField);
+  if (idx < 0) {
+    const memberParent = memberField.parent && 'wrapperKind' in memberField.parent ? memberField.parent : undefined;
+    if (memberParent) {
+      const parentIdx = wrapper.fields.indexOf(memberParent as IField);
+      const candidates = FieldOverrideService.getFieldSubstitutionCandidates(memberParent as IField, namespaceMap);
+      const substituteQName = findCandidateQName(candidates, memberField);
+      return (
+        dissolved.find((d) => d.selection.memberIndex === parentIdx && d.selection.substituteQName === substituteQName)
+          ?.key ?? null
+      );
+    }
+    return null;
+  }
+  return dissolved.find((d) => d.selection.memberIndex === idx && !d.selection.substituteQName)?.key ?? null;
+}
+
+function dispatchChoiceSelection(
+  nodeData: NodeData,
+  wrapper: IField,
+  selection: MemberSelection,
+  namespaceMap: { [prefix: string]: string },
+  isTargetSide: boolean,
+): void {
+  if (isTargetSide && wrapper.maxOccurs !== 1) {
+    applyPerInstanceChoiceSelection(nodeData, wrapper, selection, namespaceMap);
+    return;
+  }
+  applyDocumentLevelChoiceSelection(nodeData, wrapper, selection, namespaceMap, isTargetSide);
+}
+
+function resolveChoiceWrapper(
+  isChoiceWrapperMember: boolean,
+  choiceWrapperMemberField: IField | undefined,
+  fallback: IField | undefined,
+): IField | undefined {
+  return isChoiceWrapperMember ? choiceWrapperMemberField : fallback;
+}
+
+function resolveSelectedModalKey(
+  isChoiceWrapperMember: boolean,
+  memberSelectedKey: string | null,
+  activeChoiceWrapperForMembers: IField | undefined,
+  dissolved: WrapperCandidate[],
+): string | null {
+  if (isChoiceWrapperMember) return memberSelectedKey;
+  const idx = activeChoiceWrapperForMembers?.selectedMemberIndex;
+  if (idx === undefined) return null;
+  const member = activeChoiceWrapperForMembers?.fields[idx];
+  const substituteQName = member?.selectedMemberQName?.toString();
+  return (
+    dissolved.find((d) => d.selection.memberIndex === idx && d.selection.substituteQName === substituteQName)?.key ??
+    null
+  );
+}
+
+interface ChoiceMenuGroupsConfig {
+  isChoiceWrapper: boolean;
+  isChoiceWrapperMember: boolean;
+  isNestedSelectedChoice: boolean;
+  isSelectedChoice: boolean;
+  dissolved: WrapperCandidate[];
+  selectedModalKey: string | null;
+  selectSelfAction: MenuAction | undefined;
+  clearChoiceAction: MenuAction;
+  changeMemberAction: MenuAction;
+  onSelectChoiceMember: (selection: MemberSelection) => void;
+  onOpenChoiceModal: () => void;
+}
+
+function buildMenuGroupsForChoiceNode(config: ChoiceMenuGroupsConfig): MenuGroup[] {
+  if (config.isChoiceWrapper || config.isChoiceWrapperMember) {
+    const groups = buildChoiceWrapperMenuGroups(
+      config.dissolved,
+      config.selectedModalKey,
+      config.isChoiceWrapperMember ? undefined : config.selectSelfAction,
+      config.clearChoiceAction,
+      config.onSelectChoiceMember,
+      config.onOpenChoiceModal,
+    );
+    if (config.isNestedSelectedChoice) groups.push({ actions: [config.clearChoiceAction, config.changeMemberAction] });
+    return groups;
+  }
+  const choiceActions: MenuAction[] = [];
+  if (config.isSelectedChoice) choiceActions.push(config.clearChoiceAction, config.changeMemberAction);
+  if (config.selectSelfAction) choiceActions.push(config.selectSelfAction);
+  return [{ actions: choiceActions }];
 }
 
 function buildChoiceWrapperMenuGroups(
@@ -121,12 +245,14 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     isChoiceWrapper,
     isSelectedChoice,
     isChoiceMember,
+    isChoiceWrapperMember,
     activeChoiceWrapperForMembers,
-    choiceWrapperField,
+    effectiveChoiceWrapper,
+    choiceWrapperMemberField,
     choiceMemberField,
     parentChoiceWrapperField,
     choiceMemberIndex,
-  } = resolveChoiceNodeInfo(nodeData);
+  } = VisualizationUtilService.resolveChoiceNodeInfo(nodeData);
 
   const isNestedSelectedChoice = isSelectedChoice && isChoiceWrapper;
   const isTargetSide = !nodeData.isSource;
@@ -134,36 +260,14 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   const [isChoiceModalOpen, setIsChoiceModalOpen] = useState(false);
 
   const dissolved = useMemo(() => {
-    const members = activeChoiceWrapperForMembers?.fields ?? [];
+    const members = effectiveChoiceWrapper?.fields ?? [];
     return dissolveChoiceMembers(members, mappingTree.namespaceMap);
-  }, [activeChoiceWrapperForMembers?.fields, mappingTree.namespaceMap]);
+  }, [effectiveChoiceWrapper?.fields, mappingTree.namespaceMap]);
 
   const applyChoiceSelection = useCallback(
     (wrapper: IField, selection: MemberSelection) => {
+      dispatchChoiceSelection(nodeData, wrapper, selection, mappingTree.namespaceMap, isTargetSide);
       const doc = wrapper.ownerDocument;
-      ChoiceSelectionService.setChoiceSelection(doc, wrapper, selection.memberIndex, mappingTree.namespaceMap);
-
-      if (selection.substituteQName) {
-        const abstractMember = wrapper.fields[selection.memberIndex];
-        if (abstractMember) {
-          FieldOverrideService.applyFieldSubstitution(
-            abstractMember,
-            selection.substituteQName,
-            mappingTree.namespaceMap,
-          );
-        }
-      }
-
-      if (isTargetSide) {
-        const selectedMember = DocumentUtilService.getSelectedMember(wrapper);
-        if (selectedMember) {
-          const candidateField = selection.substituteQName
-            ? (DocumentUtilService.getSelectedMember(selectedMember) ?? selectedMember)
-            : selectedMember;
-          MappingActionService.applyTargetSelection(nodeData as TargetNodeData, candidateField);
-        }
-      }
-
       const previousRefId = doc.getReferenceId(mappingTree.namespaceMap);
       updateDocument(doc, doc.definition, previousRefId);
     },
@@ -172,29 +276,15 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
 
   const clearDescendantSelections = useCallback(
     (field: IField) => {
-      const member = DocumentUtilService.getSelectedMember(field);
-      if (!member) return;
-      if (member.wrapperKind === 'choice' && member.selectedMemberIndex !== undefined) {
-        clearDescendantSelections(member);
-        member.selectedMemberIndex = undefined;
-      }
-      if (member.wrapperKind === 'abstract' && member.selectedMemberQName) {
-        FieldOverrideService.revertFieldSubstitution(member, mappingTree.namespaceMap);
-      }
+      WrapperSelectionService.clearDescendantWrapperSelections(field, mappingTree.namespaceMap);
     },
     [mappingTree.namespaceMap],
   );
 
   const applyClearChoice = useCallback(
     (wrapper: IField) => {
-      if (isTargetSide) MappingActionService.clearTargetSelection(nodeData as TargetNodeData, wrapper);
-
-      clearDescendantSelections(wrapper);
-
+      clearChoiceSelectionOnField(nodeData, wrapper, mappingTree.namespaceMap, isTargetSide, clearDescendantSelections);
       const doc = wrapper.ownerDocument;
-      const schemaPath = SchemaPathService.build(wrapper, mappingTree.namespaceMap);
-      DocumentUtilService.invalidateDescendants(doc, schemaPath);
-      ChoiceSelectionService.clearChoiceSelection(doc, wrapper, mappingTree.namespaceMap);
       const previousRefId = doc.getReferenceId(mappingTree.namespaceMap);
       updateDocument(doc, doc.definition, previousRefId);
     },
@@ -204,17 +294,44 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   // Case A: select a member from this node's own wrapper member list
   const handleSelectChoiceMember = useCallback(
     (selection: MemberSelection) => {
-      if (!activeChoiceWrapperForMembers) return;
-      applyChoiceSelection(activeChoiceWrapperForMembers, selection);
+      const wrapper = resolveChoiceWrapper(
+        isChoiceWrapperMember,
+        choiceWrapperMemberField,
+        activeChoiceWrapperForMembers,
+      );
+      if (!wrapper) return;
+      applyChoiceSelection(wrapper, selection);
     },
-    [activeChoiceWrapperForMembers, applyChoiceSelection],
+    [isChoiceWrapperMember, choiceWrapperMemberField, activeChoiceWrapperForMembers, applyChoiceSelection],
   );
 
-  // Case A/B: clear selection on this node's wrapper (or the selected wrapper)
+  // Case A/B: clear selection on this node's active wrapper, cascading to parent when empty
   const handleClearChoice = useCallback(() => {
-    if (!choiceWrapperField) return;
-    applyClearChoice(choiceWrapperField);
-  }, [choiceWrapperField, applyClearChoice]);
+    const wrapper = resolveChoiceWrapper(
+      isChoiceWrapperMember,
+      choiceWrapperMemberField,
+      activeChoiceWrapperForMembers,
+    );
+    if (!wrapper) return;
+
+    if (wrapper.selectedMemberIndex === undefined && isNestedSelectedChoice) {
+      const f = VisualizationUtilService.getField(nodeData);
+      const parent = f?.parent;
+      if (parent && 'wrapperKind' in parent && parent.wrapperKind === 'choice') {
+        applyClearChoice(parent as IField);
+        return;
+      }
+    }
+
+    applyClearChoice(wrapper);
+  }, [
+    isChoiceWrapperMember,
+    choiceWrapperMemberField,
+    activeChoiceWrapperForMembers,
+    isNestedSelectedChoice,
+    nodeData,
+    applyClearChoice,
+  ]);
 
   const handleOpenChoiceModal = useCallback(() => {
     setIsChoiceModalOpen(true);
@@ -249,49 +366,48 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     testId: 'change-choice-member',
   };
 
-  const selectedModalKey = useMemo<string | null>(() => {
-    const idx = activeChoiceWrapperForMembers?.selectedMemberIndex;
-    if (idx === undefined) return null;
-    const member = activeChoiceWrapperForMembers?.fields[idx];
-    const substituteQName = member?.selectedMemberQName?.toString();
-    return (
-      dissolved.find((d) => d.selection.memberIndex === idx && d.selection.substituteQName === substituteQName)?.key ??
-      null
-    );
-  }, [activeChoiceWrapperForMembers, dissolved]);
+  const memberSelectedKey = useMemo<string | null>(
+    () =>
+      isChoiceWrapperMember
+        ? resolveMemberSelectedKey(nodeData, choiceWrapperMemberField, dissolved, mappingTree.namespaceMap)
+        : null,
+    [isChoiceWrapperMember, nodeData, choiceWrapperMemberField, dissolved, mappingTree.namespaceMap],
+  );
 
-  let menuGroups: MenuGroup[];
-  if (isChoiceWrapper) {
-    menuGroups = buildChoiceWrapperMenuGroups(
-      dissolved,
-      selectedModalKey,
-      selectSelfAction,
-      clearChoiceAction,
-      handleSelectChoiceMember,
-      handleOpenChoiceModal,
-    );
-    if (isNestedSelectedChoice) {
-      menuGroups.push({ actions: [clearChoiceAction, changeMemberAction] });
-    }
-  } else {
-    const choiceActions: MenuAction[] = [];
-    if (isSelectedChoice) {
-      choiceActions.push(clearChoiceAction, changeMemberAction);
-    }
-    if (selectSelfAction) choiceActions.push(selectSelfAction);
-    menuGroups = [{ actions: choiceActions }];
-  }
+  const selectedModalKey = useMemo<string | null>(
+    () => resolveSelectedModalKey(isChoiceWrapperMember, memberSelectedKey, activeChoiceWrapperForMembers, dissolved),
+    [isChoiceWrapperMember, memberSelectedKey, activeChoiceWrapperForMembers, dissolved],
+  );
+
+  const menuGroups = buildMenuGroupsForChoiceNode({
+    isChoiceWrapper,
+    isChoiceWrapperMember,
+    isNestedSelectedChoice,
+    isSelectedChoice,
+    dissolved,
+    selectedModalKey,
+    selectSelfAction,
+    clearChoiceAction,
+    changeMemberAction,
+    onSelectChoiceMember: handleSelectChoiceMember,
+    onOpenChoiceModal: handleOpenChoiceModal,
+  });
 
   const closeChoiceModal = useCallback(() => {
     setIsChoiceModalOpen(false);
   }, []);
 
-  const fieldName = activeChoiceWrapperForMembers?.displayName || activeChoiceWrapperForMembers?.name || 'Choice';
+  const effectiveWrapper = resolveChoiceWrapper(
+    isChoiceWrapperMember,
+    choiceWrapperMemberField,
+    activeChoiceWrapperForMembers,
+  );
+  const fieldName = effectiveWrapper?.displayName || effectiveWrapper?.name || 'Choice';
 
   return {
     groups: menuGroups,
     modals:
-      isChoiceModalOpen && activeChoiceWrapperForMembers ? (
+      isChoiceModalOpen && effectiveWrapper ? (
         <WrapperSelectionModal
           isOpen={isChoiceModalOpen}
           title={`Select member for ${fieldName}`}

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
@@ -13,7 +13,7 @@ import { MappingItem } from '../../../../models/datamapper/mapping';
 import { IMappingActionCallbacks } from '../../../../models/datamapper/mapping-action';
 import { TargetNodeData } from '../../../../models/datamapper/visualization';
 import { DEFAULT_POPPER_PROPS } from '../../../../models/popper-default';
-import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../../../services/visualization/mapping-action-registry.service';
 import { useMappingActionModals } from './useMappingActionModals';
 
 type MappingContextMenuProps = {
@@ -28,7 +28,7 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
   onUpdate,
 }) => {
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
-  const menuItems = useMemo(() => MappingActionService.getMappingContextMenuItems(nodeData), [nodeData]);
+  const menuItems = useMemo(() => MappingActionRegistryService.getMappingContextMenuItems(nodeData), [nodeData]);
 
   const mappingItem = nodeData.mapping instanceof MappingItem ? nodeData.mapping : undefined;
 

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, KeyboardEvent, MouseEvent, useCallback } from 'react
 
 import { MappingActionKind } from '../../../models/datamapper/mapping-action';
 import { TargetNodeData } from '../../../models/datamapper/visualization';
-import { MappingActionService } from '../../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../../services/visualization/mapping-action-registry.service';
 import { VisualizationService } from '../../../services/visualization/visualization.service';
 import { DeleteMappingItemAction } from './DeleteMappingItemAction';
 import { MappingContextMenuAction } from './MappingMenu/MappingContextMenuAction';
@@ -20,7 +20,7 @@ type TargetNodeActionsProps = {
 
 export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({ className, nodeData, onUpdate }) => {
   const expressionItem = VisualizationService.getExpressionItemForNode(nodeData);
-  const allowedActions = new Set(MappingActionService.getAllowedActions(nodeData));
+  const allowedActions = new Set(MappingActionRegistryService.getAllowedActions(nodeData));
 
   const handleStopPropagation = useCallback((event: MouseEvent | KeyboardEvent) => {
     if (!(event.currentTarget as HTMLElement).contains(event.target as Node)) return;

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -9,7 +9,7 @@ import { DocumentType } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { MappingActionKind } from '../../models/datamapper/mapping-action';
 import { TargetDocumentNodeData } from '../../models/datamapper/visualization';
-import { MappingActionService } from '../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../services/visualization/mapping-action-registry.service';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { VisualizationService } from '../../services/visualization/visualization.service';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
@@ -111,7 +111,7 @@ export const TargetPanel: FunctionComponent = () => {
   // Actions for target body document
   const documentActions = useMemo(() => {
     const actions = [...edgeMarkers];
-    const allowedActions = new Set(MappingActionService.getAllowedActions(targetBodyNodeData));
+    const allowedActions = new Set(MappingActionRegistryService.getAllowedActions(targetBodyNodeData));
 
     // XPath actions for primitive target body with mapping
     if (expressionItem) {

--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.test.tsx
@@ -6,6 +6,7 @@ import { IDocument } from '../models/datamapper';
 import { MappingActionKind } from '../models/datamapper/mapping-action';
 import { DocumentNodeData, TargetDocumentNodeData } from '../models/datamapper/visualization';
 import { MappingActionService } from '../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../services/visualization/mapping-action-registry.service';
 import { TreeUIService } from '../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../store/document-tree.store';
 import { useDataMapper } from './useDataMapper';
@@ -14,6 +15,7 @@ import { useDataMapperDeleteHotkey } from './useDataMapperDeleteHotkey.hook';
 // Mock dependencies
 vi.mock('hotkeys-js');
 vi.mock('./useDataMapper');
+vi.mock('../services/visualization/mapping-action-registry.service');
 vi.mock('../services/visualization/mapping-action.service');
 vi.mock('../services/visualization/tree-ui.service');
 
@@ -57,7 +59,7 @@ describe('useDataMapperDeleteHotkey', () => {
     } as any);
 
     // Mock MappingActionService
-    (MappingActionService.getAllowedActions as Mock) = mockGetAllowedActions;
+    (MappingActionRegistryService.getAllowedActions as Mock) = mockGetAllowedActions;
     (MappingActionService.deleteMappingItem as Mock) = mockDeleteMappingItem;
 
     // Mock TreeUIService

--- a/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.tsx
+++ b/packages/ui/src/hooks/useDataMapperDeleteHotkey.hook.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from 'react';
 import { MappingActionKind } from '../models/datamapper/mapping-action';
 import { DocumentNodeData, TargetDocumentNodeData } from '../models/datamapper/visualization';
 import { MappingActionService } from '../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../services/visualization/mapping-action-registry.service';
 import { TreeUIService } from '../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../store/document-tree.store';
 import { useDataMapper } from './useDataMapper';
@@ -37,7 +38,7 @@ export function useDataMapperDeleteHotkey(onUpdate: () => void) {
     if (!selectedNode) return;
 
     // Check if deletion is allowed for this node
-    const allowedActions = new Set(MappingActionService.getAllowedActions(selectedNode));
+    const allowedActions = new Set(MappingActionRegistryService.getAllowedActions(selectedNode));
     if (!allowedActions.has(MappingActionKind.Delete)) return;
 
     // Delete the mapping

--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -2,7 +2,7 @@ import type { TargetNodeData } from './visualization';
 
 /**
  * Enumeration of actions that can be performed on a target mapping node.
- * Used as keys returned by {@link MappingActionService.getAllowedActions} to
+ * Used as keys returned by {@link MappingActionRegistryService.getAllowedActions} to
  * drive which UI controls are rendered for a given node.
  */
 export enum MappingActionKind {

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -69,6 +69,9 @@ export type TargetNodeDataType =
   | TargetAbstractFieldNodeData
   | TargetSequenceFieldNodeData;
 
+/** Target node types that support for-each wrapping. */
+export type ForEachCapableNodeData = TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData;
+
 /**
  * Visualization node for a source or target document root.
  * Its `title` is set to the document's `documentId`.
@@ -262,6 +265,7 @@ export class FieldItemNodeData extends MappingNodeData {
   constructor(
     public parent: TargetNodeData,
     public mapping: FieldItem,
+    public wrapperField?: IField,
   ) {
     super(parent, mapping);
     this.title = mapping.field.displayName;

--- a/packages/ui/src/services/document/field-override.service.ts
+++ b/packages/ui/src/services/document/field-override.service.ts
@@ -26,7 +26,7 @@ import { XmlSchemaTypesService } from './xml-schema/xml-schema-types.service';
  * code duplication and improving maintainability by eliminating if-XML/if-JSON patterns
  * scattered across multiple services.
  *
- * Note: Choice selection operations have been moved to {@link ChoiceSelectionService}.
+ * Note: Choice selection operations have been moved to {@link WrapperSelectionService}.
  *
  * **Design constraint:** Field Type Override and Field Substitution are mutually exclusive.
  * A field can have at most one active: either a Field Type Override (`SAFE`/`FORCE`) or a

--- a/packages/ui/src/services/document/wrapper-selection.service.test.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.test.ts
@@ -4,8 +4,8 @@ import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { getChoiceWithAbstractXsd } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaCollection } from '../../xml-schema-ts';
 import { SchemaPathService } from '../schema-path.service';
-import { ChoiceSelectionService } from './choice-selection.service';
 import { FieldOverrideService } from './field-override.service';
+import { WrapperSelectionService } from './wrapper-selection.service';
 import { XmlSchemaDocument, XmlSchemaField } from './xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from './xml-schema/xml-schema-document.service';
 
@@ -27,8 +27,10 @@ function createChoiceWithAbstractDoc() {
 
 function findChoiceField(doc: XmlSchemaDocument): XmlSchemaField {
   const root = doc.fields[0];
-  const choice = root.fields.find((f) => f.wrapperKind === 'choice');
-  if (!choice) throw new Error('Choice field not found in Notification');
+  const short = root.fields.find((f) => f.name === 'Short');
+  if (!short) throw new Error('Short field not found in Notification');
+  const choice = short.fields.find((f) => f.wrapperKind === 'choice');
+  if (!choice) throw new Error('Choice field not found in Short');
   return choice;
 }
 
@@ -46,7 +48,7 @@ function findDescendantLeaf(field: IField): IField {
   return current;
 }
 
-describe('ChoiceSelectionService', () => {
+describe('WrapperSelectionService', () => {
   let document: XmlSchemaDocument;
   let namespaceMap: Record<string, string>;
 
@@ -112,7 +114,7 @@ describe('ChoiceSelectionService', () => {
     it('should set selection on choice field', () => {
       const choice = document.fields[0].fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
 
       expect(choice.selectedMemberIndex).toBe(1);
     });
@@ -120,7 +122,7 @@ describe('ChoiceSelectionService', () => {
     it('should set selection with index 0', () => {
       const choice = document.fields[0].fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, choice, 0, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 0, namespaceMap);
 
       expect(choice.selectedMemberIndex).toBe(0);
       expect(document.definition.choiceSelections?.[0].selectedMemberIndex).toBe(0);
@@ -130,7 +132,7 @@ describe('ChoiceSelectionService', () => {
       const choice = document.fields[0].fields[0];
       const expectedPath = SchemaPathService.build(choice, namespaceMap);
 
-      ChoiceSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
 
       expect(document.definition.choiceSelections).toBeDefined();
       expect(document.definition.choiceSelections?.length).toBe(1);
@@ -143,8 +145,8 @@ describe('ChoiceSelectionService', () => {
     it('should update existing selection in definition', () => {
       const choice = document.fields[0].fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
-      ChoiceSelectionService.setChoiceSelection(document, choice, 2, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 2, namespaceMap);
 
       expect(document.definition.choiceSelections?.length).toBe(1);
       expect(document.definition.choiceSelections?.[0].selectedMemberIndex).toBe(2);
@@ -154,7 +156,7 @@ describe('ChoiceSelectionService', () => {
       const nonChoiceField = document.fields[0].fields[1];
 
       expect(() => {
-        ChoiceSelectionService.setChoiceSelection(document, nonChoiceField, 0, namespaceMap);
+        WrapperSelectionService.setChoiceSelection(document, nonChoiceField, 0, namespaceMap);
       }).toThrow('Field is not a choice compositor');
     });
 
@@ -162,7 +164,7 @@ describe('ChoiceSelectionService', () => {
       const choice = document.fields[0].fields[0];
 
       expect(() => {
-        ChoiceSelectionService.setChoiceSelection(document, choice, 99, namespaceMap);
+        WrapperSelectionService.setChoiceSelection(document, choice, 99, namespaceMap);
       }).toThrow('Invalid member index');
     });
 
@@ -170,7 +172,7 @@ describe('ChoiceSelectionService', () => {
       const choice = document.fields[0].fields[0];
 
       expect(() => {
-        ChoiceSelectionService.setChoiceSelection(document, choice, -1, namespaceMap);
+        WrapperSelectionService.setChoiceSelection(document, choice, -1, namespaceMap);
       }).toThrow('Invalid member index');
     });
 
@@ -179,8 +181,8 @@ describe('ChoiceSelectionService', () => {
       const container = document.fields[0].fields[1];
       const containerChoice = container.fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, containerChoice, 0, namespaceMap);
-      ChoiceSelectionService.setChoiceSelection(document, parentChoice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, containerChoice, 0, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, parentChoice, 1, namespaceMap);
 
       // Container choice is in a sibling subtree — its path does not start with parentChoice's path
       expect(document.definition.choiceSelections?.length).toBe(2);
@@ -191,10 +193,10 @@ describe('ChoiceSelectionService', () => {
       const emailMember = parentChoice.fields[0];
       const nestedChoice = emailMember.fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, nestedChoice, 0, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, nestedChoice, 0, namespaceMap);
       expect(document.definition.choiceSelections?.length).toBe(1);
 
-      ChoiceSelectionService.setChoiceSelection(document, parentChoice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, parentChoice, 1, namespaceMap);
 
       // Both parent and nested selections preserved
       expect(document.definition.choiceSelections?.length).toBe(2);
@@ -205,18 +207,18 @@ describe('ChoiceSelectionService', () => {
   describe('clearChoiceSelection()', () => {
     it('should clear selection from choice field', () => {
       const choice = document.fields[0].fields[0];
-      ChoiceSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
 
-      ChoiceSelectionService.clearChoiceSelection(document, choice, namespaceMap);
+      WrapperSelectionService.clearChoiceSelection(document, choice, namespaceMap);
 
       expect(choice.selectedMemberIndex).toBeUndefined();
     });
 
     it('should remove selection from document definition', () => {
       const choice = document.fields[0].fields[0];
-      ChoiceSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, choice, 1, namespaceMap);
 
-      ChoiceSelectionService.clearChoiceSelection(document, choice, namespaceMap);
+      WrapperSelectionService.clearChoiceSelection(document, choice, namespaceMap);
 
       expect(document.definition.choiceSelections).toEqual([]);
     });
@@ -226,7 +228,7 @@ describe('ChoiceSelectionService', () => {
       choice.selectedMemberIndex = undefined;
 
       expect(() => {
-        ChoiceSelectionService.clearChoiceSelection(document, choice, namespaceMap);
+        WrapperSelectionService.clearChoiceSelection(document, choice, namespaceMap);
       }).not.toThrow();
 
       expect(choice.selectedMemberIndex).toBeUndefined();
@@ -236,7 +238,7 @@ describe('ChoiceSelectionService', () => {
       const nonChoiceField = document.fields[0].fields[1];
 
       expect(() => {
-        ChoiceSelectionService.clearChoiceSelection(document, nonChoiceField, namespaceMap);
+        WrapperSelectionService.clearChoiceSelection(document, nonChoiceField, namespaceMap);
       }).toThrow('Field is not a choice compositor');
     });
 
@@ -245,11 +247,11 @@ describe('ChoiceSelectionService', () => {
       const container = document.fields[0].fields[1];
       const containerChoice = container.fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, parentChoice, 0, namespaceMap);
-      ChoiceSelectionService.setChoiceSelection(document, containerChoice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, parentChoice, 0, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, containerChoice, 1, namespaceMap);
       expect(document.definition.choiceSelections?.length).toBe(2);
 
-      ChoiceSelectionService.clearChoiceSelection(document, parentChoice, namespaceMap);
+      WrapperSelectionService.clearChoiceSelection(document, parentChoice, namespaceMap);
 
       expect(document.definition.choiceSelections?.length).toBe(1);
       expect(document.definition.choiceSelections?.[0].schemaPath).toContain('Container');
@@ -260,11 +262,11 @@ describe('ChoiceSelectionService', () => {
       const emailMember = parentChoice.fields[0];
       const nestedChoice = emailMember.fields[0];
 
-      ChoiceSelectionService.setChoiceSelection(document, parentChoice, 0, namespaceMap);
-      ChoiceSelectionService.setChoiceSelection(document, nestedChoice, 1, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, parentChoice, 0, namespaceMap);
+      WrapperSelectionService.setChoiceSelection(document, nestedChoice, 1, namespaceMap);
       expect(document.definition.choiceSelections?.length).toBe(2);
 
-      ChoiceSelectionService.clearChoiceSelection(document, parentChoice, namespaceMap);
+      WrapperSelectionService.clearChoiceSelection(document, parentChoice, namespaceMap);
 
       // Nested selection preserved
       expect(document.definition.choiceSelections?.length).toBe(1);
@@ -285,7 +287,7 @@ describe('ChoiceSelectionService', () => {
         expect(emailQName).toBeDefined();
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution stays in both definition and live field — consistent state
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
@@ -298,13 +300,13 @@ describe('ChoiceSelectionService', () => {
         const choiceField = findChoiceField(doc);
         const abstractField = findAbstractField(choiceField);
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:SMS', nsMap);
         const smsQName = abstractField.selectedMemberQName;
         expect(smsQName).toBeDefined();
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
 
-        ChoiceSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
+        WrapperSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
 
         // Substitution preserved
         expect(doc.definition.fieldSubstitutions).toHaveLength(1);
@@ -320,7 +322,7 @@ describe('ChoiceSelectionService', () => {
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
         expect(abstractField.selectedMemberQName).toBeDefined();
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution is preserved, so revert should work
         FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
@@ -336,7 +338,7 @@ describe('ChoiceSelectionService', () => {
         const abstractField = findAbstractField(choiceField);
 
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Switch from Email to SMS
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:SMS', nsMap);
@@ -353,7 +355,7 @@ describe('ChoiceSelectionService', () => {
         const abstractField = findAbstractField(choiceField);
 
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
         FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:SMS', nsMap);
 
         FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
@@ -387,7 +389,7 @@ describe('ChoiceSelectionService', () => {
           { schemaPath: leafPath, type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.SAFE },
         ];
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         expect(doc.definition.fieldTypeOverrides).toHaveLength(1);
         expect(leafField.typeOverride).toBe(FieldOverrideVariant.SAFE);
@@ -398,7 +400,7 @@ describe('ChoiceSelectionService', () => {
         const nsMap = { ca: NS_CHOICE_ABSTRACT };
         const choiceField = findChoiceField(doc);
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         const firstMember = choiceField.fields[0];
         const leafField = findDescendantLeaf(firstMember);
@@ -418,7 +420,7 @@ describe('ChoiceSelectionService', () => {
           { schemaPath: leafPath, type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.SAFE },
         ];
 
-        ChoiceSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
+        WrapperSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
 
         expect(doc.definition.fieldTypeOverrides).toHaveLength(1);
         expect(leafField.typeOverride).toBe(FieldOverrideVariant.SAFE);
@@ -434,15 +436,15 @@ describe('ChoiceSelectionService', () => {
         const nestedChoice = emailMember.fields[0]; // [work, personal]
 
         // Select nested choice inside email
-        ChoiceSelectionService.setChoiceSelection(doc, parentChoice, 0, nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, nestedChoice, 1, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, parentChoice, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, nestedChoice, 1, nsMap);
         expect(nestedChoice.selectedMemberIndex).toBe(1);
 
         // Switch parent away from email
-        ChoiceSelectionService.setChoiceSelection(doc, parentChoice, 2, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, parentChoice, 2, nsMap);
 
         // Switch parent back to email
-        ChoiceSelectionService.setChoiceSelection(doc, parentChoice, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, parentChoice, 0, nsMap);
 
         // Nested selection survived the round-trip
         expect(nestedChoice.selectedMemberIndex).toBe(1);
@@ -460,8 +462,8 @@ describe('ChoiceSelectionService', () => {
         const emailQName = abstractField.selectedMemberQName;
 
         // Switch choice away and back
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution survived
         expect(abstractField.selectedMemberQName).toBe(emailQName);
@@ -479,10 +481,10 @@ describe('ChoiceSelectionService', () => {
         const smsQName = abstractField.selectedMemberQName;
 
         // Multiple choice changes
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
-        ChoiceSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
+        WrapperSelectionService.clearChoiceSelection(doc, choiceField, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Substitution survived all transitions
         expect(abstractField.selectedMemberQName).toBe(smsQName);
@@ -508,7 +510,7 @@ describe('ChoiceSelectionService', () => {
         });
         expect(doc.definition.fieldSubstitutions).toHaveLength(2);
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Both substitutions preserved
         expect(doc.definition.fieldSubstitutions).toHaveLength(2);
@@ -519,10 +521,11 @@ describe('ChoiceSelectionService', () => {
         const nsMap = { ca: NS_CHOICE_ABSTRACT };
         const choiceField = findChoiceField(doc);
 
-        // Manually add a type override for a sibling field (id field, outside the choice)
         const root = doc.fields[0];
-        const idField = root.fields.find((f) => f.name === 'id');
-        if (!idField) throw new Error('id field not found');
+        const short = root.fields.find((f) => f.name === 'Short');
+        if (!short) throw new Error('Short field not found in Notification');
+        const idField = short.fields.find((f) => f.name === 'id');
+        if (!idField) throw new Error('id field not found in Short');
         const idPath = SchemaPathService.build(idField, nsMap);
         idField.typeOverride = FieldOverrideVariant.SAFE;
         idField.originalField = {
@@ -538,7 +541,7 @@ describe('ChoiceSelectionService', () => {
           { schemaPath: idPath, type: 'xs:int', originalType: 'xs:string', variant: FieldOverrideVariant.SAFE },
         ];
 
-        ChoiceSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
 
         // Sibling type override should be preserved
         expect(doc.definition.fieldTypeOverrides).toHaveLength(1);

--- a/packages/ui/src/services/document/wrapper-selection.service.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.ts
@@ -2,12 +2,13 @@ import { IDocument, IField } from '../../models/datamapper/document';
 import { IChoiceSelection } from '../../models/datamapper/metadata';
 import { SchemaPathService } from '../schema-path.service';
 import { DocumentUtilService } from './document-util.service';
+import { FieldOverrideService } from './field-override.service';
 
 /**
- * Service for choice selection operations.
- * Provides high-level orchestration for setting and managing choice selections.
+ * Service for wrapper selection operations (choice and abstract).
+ * Provides high-level orchestration for setting and managing wrapper selections.
  *
- * This service consolidates choice selection functionality, similar to
+ * This service consolidates wrapper selection functionality, similar to
  * FieldOverrideService for type overrides.
  *
  * Note: Batch application of saved selections is handled by DocumentUtilService.processOverrides()
@@ -17,13 +18,13 @@ import { DocumentUtilService } from './document-util.service';
  * @example
  * ```typescript
  * // Set a choice selection
- * ChoiceSelectionService.setChoiceSelection(document, choiceField, 1, namespaceMap);
+ * WrapperSelectionService.setChoiceSelection(document, choiceField, 1, namespaceMap);
  *
  * // Clear a choice selection
- * ChoiceSelectionService.clearChoiceSelection(document, choiceField, namespaceMap);
+ * WrapperSelectionService.clearChoiceSelection(document, choiceField, namespaceMap);
  * ```
  */
-export class ChoiceSelectionService {
+export class WrapperSelectionService {
   /**
    * Set a choice selection on a choice field.
    *
@@ -43,15 +44,6 @@ export class ChoiceSelectionService {
    * @param choiceField - The choice field to set selection on (must have wrapperKind === 'choice')
    * @param selectedMemberIndex - 0-based index of the choice member to select
    * @param namespaceMap - Namespace prefix to URI mapping for path generation
-   *
-   * @example
-   * ```typescript
-   * ChoiceSelectionService.setChoiceSelection(document, choiceField, 1, namespaceMap);
-   *
-   * // Persist changes via provider
-   * const previousRefId = document.getReferenceId(namespaceMap);
-   * updateDocument(document, document.definition, previousRefId);
-   * ```
    *
    * @see clearChoiceSelection
    */
@@ -95,15 +87,6 @@ export class ChoiceSelectionService {
    * @param choiceField - The choice field to clear selection from
    * @param namespaceMap - Namespace prefix to URI mapping for path generation
    *
-   * @example
-   * ```typescript
-   * ChoiceSelectionService.clearChoiceSelection(document, choiceField, namespaceMap);
-   *
-   * // Persist changes via provider
-   * const previousRefId = document.getReferenceId(namespaceMap);
-   * updateDocument(document, document.definition, previousRefId);
-   * ```
-   *
    * @see setChoiceSelection
    */
   static clearChoiceSelection(document: IDocument, choiceField: IField, namespaceMap: Record<string, string>): void {
@@ -118,5 +101,27 @@ export class ChoiceSelectionService {
     const schemaPath = SchemaPathService.build(choiceField, namespaceMap);
 
     DocumentUtilService.removeChoiceSelection(document, schemaPath, namespaceMap);
+  }
+
+  /**
+   * Recursively clears nested wrapper selections (both choice and abstract) beneath
+   * the given field's currently selected member. Walks the member chain depth-first:
+   * clears `selectedMemberIndex` for choice wrappers, reverts `selectedMemberQName`
+   * for abstract wrappers.
+   *
+   * This operates on the live field tree only — it does not update the document
+   * definition. Callers should follow up with {@link DocumentUtilService.invalidateDescendants}
+   * to clean up persisted overrides, and then persist via `updateDocument()`.
+   */
+  static clearDescendantWrapperSelections(field: IField, namespaceMap: Record<string, string>): void {
+    const member = DocumentUtilService.getSelectedMember(field);
+    if (!member) return;
+    if (member.wrapperKind === 'choice' && member.selectedMemberIndex !== undefined) {
+      WrapperSelectionService.clearDescendantWrapperSelections(member, namespaceMap);
+      member.selectedMemberIndex = undefined;
+    }
+    if (member.wrapperKind === 'abstract' && member.selectedMemberQName) {
+      FieldOverrideService.revertFieldSubstitution(member, namespaceMap);
+    }
   }
 }

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -616,6 +616,41 @@ describe('MappingService', () => {
     });
   });
 
+  describe('removeStaleMappingsForDocument() with isUserCreated FieldItem', () => {
+    it('should retain isUserCreated FieldItem even when it has no children', () => {
+      const parentItem = tree.children[0] as FieldItem;
+      const targetField = targetDoc.fields[0].fields[0];
+      const userCreatedItem = new FieldItem(parentItem, targetField);
+      userCreatedItem.isUserCreated = true;
+      parentItem.children.push(userCreatedItem);
+
+      const childrenBefore = parentItem.children.length;
+      MappingService.removeStaleMappingsForDocument(tree, targetDoc);
+      expect(parentItem.children).toHaveLength(childrenBefore);
+      const retained = parentItem.children.find(
+        (c) => c instanceof FieldItem && c.field === targetField && c.isUserCreated,
+      );
+      expect(retained).toBeDefined();
+    });
+
+    it('should remove non-isUserCreated FieldItem with no children', () => {
+      const parentItem = tree.children[0] as FieldItem;
+      const targetField = targetDoc.fields[0].fields[0];
+      const regularItem = new FieldItem(parentItem, targetField);
+      regularItem.isUserCreated = false;
+      regularItem.children = [];
+      parentItem.children.push(regularItem);
+
+      const childrenBefore = parentItem.children.length;
+      MappingService.removeStaleMappingsForDocument(tree, targetDoc);
+      const stillPresent = parentItem.children.find(
+        (c) => c instanceof FieldItem && c.field === targetField && !c.isUserCreated && c.children.length === 0,
+      );
+      expect(stillPresent).toBeUndefined();
+      expect(parentItem.children.length).toBeLessThan(childrenBefore);
+    });
+  });
+
   describe('addIf()', () => {
     it('should add if with mapping', () => {
       const parent = tree.children[0];

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -188,6 +188,7 @@ export class MappingService {
       }
       if (
         (compatibleField && child.children.length > 0) ||
+        (compatibleField && child instanceof FieldItem && child.isUserCreated) ||
         child.parent instanceof InstructionItem ||
         child instanceof InstructionItem ||
         child instanceof ValueSelector

--- a/packages/ui/src/services/mapping/wrapper-auto-detection.service.test.ts
+++ b/packages/ui/src/services/mapping/wrapper-auto-detection.service.test.ts
@@ -228,13 +228,16 @@ describe('WrapperAutoDetectionService', () => {
       const xslt = makeXslt(
         { ns0: NS_CHOICE_ABSTRACT },
         `    <ns0:Notification>
-      <ns0:id>123</ns0:id>
-      <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+      <ns0:Short>
+        <ns0:id>123</ns0:id>
+        <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+      </ns0:Short>
     </ns0:Notification>`,
       );
 
       const mappingTree = deserializeAndAutoDetect(xslt, targetDoc);
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper).toBeDefined();
       expect(choiceWrapper!.selectedMemberIndex).toBeDefined();
 
@@ -242,7 +245,10 @@ describe('WrapperAutoDetectionService', () => {
       expect(choiceWrapper!.selectedMemberIndex).toBe(choiceWrapper!.fields.indexOf(webhookMember!));
 
       const notifFieldItem = mappingTree.children[0] as FieldItem;
-      const webhookFieldItem = notifFieldItem.children.find(
+      const shortFieldItem = notifFieldItem.children.find(
+        (c) => c instanceof FieldItem && c.field.name === 'Short',
+      ) as FieldItem;
+      const webhookFieldItem = shortFieldItem.children.find(
         (c) => c instanceof FieldItem && c.field.name === 'Webhook',
       ) as FieldItem;
       expect(webhookFieldItem.isUserCreated).toBe(true);
@@ -259,14 +265,17 @@ describe('WrapperAutoDetectionService', () => {
       const xslt = makeXslt(
         { ns0: NS_CHOICE_ABSTRACT },
         `    <ns0:Notification>
-      <xsl:if test="true()">
-        <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
-      </xsl:if>
+      <ns0:Short>
+        <xsl:if test="true()">
+          <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+        </xsl:if>
+      </ns0:Short>
     </ns0:Notification>`,
       );
 
       deserializeAndAutoDetect(xslt, targetDoc);
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper!.selectedMemberIndex).toBeUndefined();
     });
   });
@@ -279,14 +288,17 @@ describe('WrapperAutoDetectionService', () => {
       const xslt = makeXslt(
         { ns0: NS_CHOICE_ABSTRACT },
         `    <ns0:Notification>
-      <ns0:id>123</ns0:id>
-      <ns0:Email><ns0:content>hello</ns0:content><ns0:subject>test</ns0:subject></ns0:Email>
+      <ns0:Short>
+        <ns0:id>123</ns0:id>
+        <ns0:Email><ns0:content>hello</ns0:content><ns0:subject>test</ns0:subject></ns0:Email>
+      </ns0:Short>
     </ns0:Notification>`,
       );
 
       deserializeAndAutoDetect(xslt, targetDoc);
 
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper).toBeDefined();
       expect(choiceWrapper!.selectedMemberIndex).toBeDefined();
 
@@ -425,7 +437,8 @@ describe('WrapperAutoDetectionService', () => {
       const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
         rootElementChoice: NOTIFICATION_ROOT,
       });
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper).toBeDefined();
       const webhook = choiceWrapper!.fields.find((f) => f.name === 'Webhook');
       expect(webhook).toBeDefined();
@@ -468,7 +481,7 @@ describe('WrapperAutoDetectionService', () => {
         { 'ChoiceWithAbstract.xsd': getChoiceWithAbstractXsd() },
         NOTIFICATION_ROOT,
         undefined,
-        [{ schemaPath: '/ns0:Notification/{choice:0}', selectedMemberIndex: 0 }],
+        [{ schemaPath: '/ns0:Notification/ns0:Short/{choice:0}', selectedMemberIndex: 0 }],
       );
       const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
         definition: def,
@@ -477,13 +490,16 @@ describe('WrapperAutoDetectionService', () => {
       const xslt = makeXslt(
         { ns0: NS_CHOICE_ABSTRACT },
         `    <ns0:Notification>
-      <ns0:id>123</ns0:id>
-      <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+      <ns0:Short>
+        <ns0:id>123</ns0:id>
+        <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+      </ns0:Short>
     </ns0:Notification>`,
       );
 
       deserializeAndAutoDetect(xslt, targetDoc, nsMap);
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper).toBeDefined();
       expect(choiceWrapper!.selectedMemberIndex).toBe(0);
     });
@@ -497,16 +513,19 @@ describe('WrapperAutoDetectionService', () => {
       const xslt = makeXslt(
         { ns0: NS_CHOICE_ABSTRACT },
         `    <ns0:Notification>
-      <xsl:choose>
-        <xsl:when test="true()">
-          <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
-        </xsl:when>
-      </xsl:choose>
+      <ns0:Short>
+        <xsl:choose>
+          <xsl:when test="true()">
+            <ns0:Webhook><ns0:url>http://example.com</ns0:url></ns0:Webhook>
+          </xsl:when>
+        </xsl:choose>
+      </ns0:Short>
     </ns0:Notification>`,
       );
 
       deserializeAndAutoDetect(xslt, targetDoc);
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice');
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short');
+      const choiceWrapper = short!.fields.find((f) => f.wrapperKind === 'choice');
       expect(choiceWrapper).toBeDefined();
       expect(choiceWrapper!.selectedMemberIndex).toBeUndefined();
     });
@@ -517,7 +536,8 @@ describe('WrapperAutoDetectionService', () => {
       const targetDoc = createTargetDoc(getChoiceWithAbstractXsd(), 'ChoiceWithAbstract.xsd', {
         rootElementChoice: NOTIFICATION_ROOT,
       });
-      const choiceWrapper = targetDoc.fields[0].fields.find((f) => f.wrapperKind === 'choice')!;
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short')!;
+      const choiceWrapper = short.fields.find((f) => f.wrapperKind === 'choice')!;
       const webhook = choiceWrapper.fields.find((f) => f.name === 'Webhook')!;
       const duplicate = new BaseField(choiceWrapper, targetDoc, 'Webhook');
       duplicate.namespaceURI = webhook.namespaceURI;
@@ -631,7 +651,8 @@ describe('WrapperAutoDetectionService', () => {
         BODY_DOCUMENT_ID,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      const field = targetDoc.fields[0].fields.find((f) => f.name === 'id')!;
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short')!;
+      const field = short.fields.find((f) => f.name === 'id')!;
       const fi = new FieldItem(mappingTree, field);
       fi.isUserCreated = true;
       const cloned = fi.clone();
@@ -647,7 +668,8 @@ describe('WrapperAutoDetectionService', () => {
         BODY_DOCUMENT_ID,
         DocumentDefinitionType.XML_SCHEMA,
       );
-      const field = targetDoc.fields[0].fields.find((f) => f.name === 'id')!;
+      const short = targetDoc.fields[0].fields.find((f) => f.name === 'Short')!;
+      const field = short.fields.find((f) => f.name === 'id')!;
       const fi = new FieldItem(mappingTree, field);
       const cloned = fi.clone();
       expect((cloned as FieldItem).isUserCreated).toBe(false);

--- a/packages/ui/src/services/visualization/mapping-action-registry.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action-registry.service.ts
@@ -1,0 +1,391 @@
+import {
+  ChooseItem,
+  FieldItem,
+  ForEachGroupItem,
+  ForEachItem,
+  IfItem,
+  MappingItem,
+  OtherwiseItem,
+  UnknownMappingItem,
+  ValueSelector,
+  WhenItem,
+} from '../../models/datamapper/mapping';
+import { IMappingAction, IMappingContextMenuAction, MappingActionKind } from '../../models/datamapper/mapping-action';
+import {
+  AddMappingNodeData,
+  FieldItemNodeData,
+  ForEachCapableNodeData,
+  MappingNodeData,
+  TargetDocumentNodeData,
+  TargetNodeData,
+  VariableNodeData,
+} from '../../models/datamapper/visualization';
+import { useDocumentTreeStore } from '../../store/document-tree.store';
+import { DocumentService } from '../document/document.service';
+import { MappingActionService } from './mapping-action.service';
+import { VisualizationUtilService } from './visualization-util.service';
+
+/**
+ * Static service that owns the action registry for the DataMapper
+ * visualization layer.
+ *
+ * Determines which actions ({@link MappingActionKind}) are available for a
+ * given target node and provides context menu item definitions. Delegates
+ * actual mutations to {@link MappingActionService}.
+ */
+export class MappingActionRegistryService {
+  private static allowForEachCurrentGroup(nodeData: TargetNodeData): boolean {
+    let current: TargetNodeData | undefined = nodeData;
+    while (current) {
+      if (current instanceof MappingNodeData) {
+        if (current.mapping instanceof ForEachGroupItem) return true;
+        if (current.mapping instanceof ForEachItem && current.mapping.expression === 'current-group()') return false;
+      }
+      current = 'parent' in current ? current.parent : undefined;
+    }
+    return false;
+  }
+
+  private static mappingIsOneOf(...types: Array<abstract new (...args: never[]) => MappingItem>) {
+    return (n: TargetNodeData): boolean =>
+      VisualizationUtilService.isMappingNode(n) && types.some((t) => n.mapping instanceof t);
+  }
+
+  private static isContextMenuAction(def: IMappingAction): def is IMappingContextMenuAction {
+    return 'getLabel' in def;
+  }
+
+  private static readonly ACTION_REGISTRY: (IMappingAction | IMappingContextMenuAction)[] = [
+    {
+      key: MappingActionKind.ContextMenu,
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return true;
+        if (n instanceof TargetDocumentNodeData) return n.isPrimitive;
+        if (VisualizationUtilService.isFieldNode(n)) return true;
+        return (
+          VisualizationUtilService.isMappingNode(n) &&
+          !MappingActionRegistryService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, UnknownMappingItem)(n)
+        );
+      },
+    },
+    {
+      key: MappingActionKind.Delete,
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        if (n instanceof FieldItemNodeData)
+          return (
+            (n.mapping instanceof FieldItem &&
+              n.mapping.isUserCreated &&
+              (n.mapping.parent instanceof FieldItem ||
+                VisualizationUtilService.isAbstractWrapperMember(n) ||
+                VisualizationUtilService.isChoiceWrapperMember(n))) ||
+            MappingActionService.hasValueSelector(n)
+          );
+        if (VisualizationUtilService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
+          return MappingActionService.hasValueSelector(n);
+        return VisualizationUtilService.isMappingNode(n);
+      },
+    },
+    {
+      key: MappingActionKind.Sort,
+      testId: 'transformation-actions-sort',
+      getLabel: (n) => {
+        const mapping = n.mapping;
+        if (mapping instanceof ForEachItem && mapping.sortItems?.length > 0) {
+          return 'Edit Sort';
+        }
+        return 'Configure Sort';
+      },
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.Sort);
+      },
+      isAllowed: MappingActionRegistryService.mappingIsOneOf(ForEachItem),
+    },
+    {
+      key: MappingActionKind.ForEachGroupConfig,
+      testId: 'transformation-actions-foreach-group-config',
+      getLabel: () => 'Configure for-each-group',
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.ForEachGroupConfig);
+      },
+      isAllowed: MappingActionRegistryService.mappingIsOneOf(ForEachGroupItem),
+    },
+    {
+      key: MappingActionKind.Comment,
+      testId: 'transformation-actions-comment',
+      getLabel: (n) => (n.mapping instanceof MappingItem && n.mapping.comment ? 'Edit Comment' : 'Add Comment'),
+      apply: (_n, { openModal }) => {
+        openModal(MappingActionKind.Comment);
+      },
+      isAllowed: (n) => n.mapping instanceof MappingItem,
+    },
+    {
+      key: MappingActionKind.ValueSelector,
+      testId: 'transformation-actions-selector',
+      getLabel: () => 'Add value selector (value-of)',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyValueOfSelector(n);
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        if (!VisualizationUtilService.isMappingNode(n)) return true;
+        return !MappingActionRegistryService.mappingIsOneOf(
+          ValueSelector,
+          ForEachItem,
+          ForEachGroupItem,
+          ChooseItem,
+          UnknownMappingItem,
+        )(n);
+      },
+      isDisabled: (n) => MappingActionService.hasValueOfSelector(n),
+    },
+    {
+      key: MappingActionKind.CopyOfSelector,
+      testId: 'transformation-actions-copy-of',
+      getLabel: () => 'Add copy selector (copy-of)',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyCopyOfSelector(n);
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        if (!VisualizationUtilService.isMappingNode(n)) return true;
+        return !MappingActionRegistryService.mappingIsOneOf(
+          ValueSelector,
+          ForEachItem,
+          ForEachGroupItem,
+          ChooseItem,
+          UnknownMappingItem,
+        )(n);
+      },
+    },
+    {
+      key: MappingActionKind.When,
+      testId: 'transformation-actions-when',
+      getLabel: () => 'Add "when"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyWhen(n);
+        onUpdate();
+      },
+      isAllowed: MappingActionRegistryService.mappingIsOneOf(ChooseItem),
+    },
+    {
+      key: MappingActionKind.Otherwise,
+      testId: 'transformation-actions-otherwise',
+      getLabel: () => 'Add "otherwise"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyOtherwise(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        VisualizationUtilService.isMappingNode(n) && n.mapping instanceof ChooseItem && !n.mapping.otherwise,
+    },
+    {
+      key: MappingActionKind.ForEach,
+      testId: 'transformation-actions-foreach',
+      getLabel: () => 'Wrap with "for-each"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyForEach(n as ForEachCapableNodeData);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        n instanceof AddMappingNodeData ||
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
+    },
+    {
+      key: MappingActionKind.ForEachGroup,
+      testId: 'transformation-actions-foreachgroup',
+      getLabel: () => 'Wrap with "for-each-group"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyForEachGroup(n as ForEachCapableNodeData);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        n instanceof AddMappingNodeData ||
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
+    },
+    {
+      key: MappingActionKind.ForEachCurrentGroup,
+      testId: 'transformation-actions-foreach-current-group',
+      getLabel: () => 'Wrap with "for-each current-group()"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyForEachCurrentGroup(n as ForEachCapableNodeData);
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        if (!VisualizationUtilService.isFieldNode(n) || !VisualizationUtilService.isCollectionField(n)) return false;
+        return MappingActionRegistryService.allowForEachCurrentGroup(n);
+      },
+    },
+    {
+      key: MappingActionKind.If,
+      testId: 'transformation-actions-if',
+      getLabel: () => 'Wrap with "if"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyIf(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        !VisualizationUtilService.isMappingNode(n) ||
+        !MappingActionRegistryService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, IfItem, ChooseItem)(n),
+    },
+    {
+      key: MappingActionKind.Choose,
+      testId: 'transformation-actions-choose',
+      getLabel: () => 'Wrap with "choose-when-otherwise"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyChooseWhenOtherwise(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        !VisualizationUtilService.isMappingNode(n) ||
+        !MappingActionRegistryService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, IfItem, ChooseItem)(n),
+    },
+    {
+      key: MappingActionKind.InnerForEach,
+      testId: 'transformation-actions-foreach-inner',
+      getLabel: () => 'Inner "for-each"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyInnerForEach(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        n instanceof AddMappingNodeData ||
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
+        MappingActionRegistryService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
+    },
+    {
+      key: MappingActionKind.InnerForEachGroup,
+      testId: 'transformation-actions-foreachgroup-inner',
+      getLabel: () => 'Inner "for-each-group"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyInnerForEachGroup(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        n instanceof AddMappingNodeData ||
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
+        MappingActionRegistryService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
+    },
+    {
+      key: MappingActionKind.InnerForEachCurrentGroup,
+      testId: 'transformation-actions-foreach-current-group-inner',
+      getLabel: () => 'Inner "for-each current-group()"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyInnerForEachCurrentGroup(n);
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (n instanceof AddMappingNodeData) return false;
+        const nodeTypeAllowed =
+          (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
+          MappingActionRegistryService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n);
+        if (!nodeTypeAllowed) return false;
+        return MappingActionRegistryService.allowForEachCurrentGroup(n);
+      },
+    },
+    {
+      key: MappingActionKind.InnerChoose,
+      testId: 'transformation-actions-choose-inner',
+      getLabel: () => 'Inner "choose-when-otherwise"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyInnerChooseWhenOtherwise(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
+        MappingActionRegistryService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
+    },
+    {
+      key: MappingActionKind.InnerIf,
+      testId: 'transformation-actions-if-inner',
+      getLabel: () => 'Inner "if"',
+      apply: (n, { onUpdate }) => {
+        MappingActionService.applyInnerIf(n);
+        onUpdate();
+      },
+      isAllowed: (n) =>
+        (VisualizationUtilService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
+        MappingActionRegistryService.mappingIsOneOf(ForEachItem, ForEachGroupItem, IfItem)(n),
+    },
+    {
+      key: MappingActionKind.Variable,
+      testId: 'transformation-actions-variable',
+      getLabel: () => 'Add variable',
+      apply: (n) => {
+        useDocumentTreeStore.getState().setAddingVariableTo(n.path.toString());
+      },
+      isAllowed: (n) => {
+        if (n instanceof VariableNodeData) return false;
+        if (n instanceof TargetDocumentNodeData) return false;
+        if (VisualizationUtilService.isFieldNode(n)) return DocumentService.hasChildren(n.field);
+        return (
+          VisualizationUtilService.isMappingNode(n) &&
+          !MappingActionRegistryService.mappingIsOneOf(ValueSelector, ChooseItem, UnknownMappingItem)(n)
+        );
+      },
+    },
+    {
+      key: MappingActionKind.RenameVariable,
+      testId: 'transformation-actions-rename-variable',
+      getLabel: () => 'Rename variable',
+      apply: (n) => {
+        if (n instanceof VariableNodeData) {
+          useDocumentTreeStore.getState().setRenamingVariable(n.mapping.id);
+        }
+      },
+      isAllowed: (n) => n instanceof VariableNodeData,
+    },
+    {
+      key: MappingActionKind.Duplicate,
+      testId: 'transformation-actions-duplicate',
+      getLabel: (n) => {
+        if (VisualizationUtilService.isMappingNode(n) && n.mapping instanceof IfItem) {
+          return 'Duplicate "if"';
+        }
+        return 'Duplicate';
+      },
+      apply: (n, { onUpdate }) => {
+        if (VisualizationUtilService.isMappingNode(n) && n.mapping instanceof IfItem) {
+          MappingActionService.duplicateIf(n);
+        } else if (VisualizationUtilService.isFieldNode(n)) {
+          MappingActionService.duplicateFieldNode(n);
+        }
+        onUpdate();
+      },
+      isAllowed: (n) => {
+        if (VisualizationUtilService.isMappingNode(n) && n.mapping instanceof IfItem) return true;
+        if (VisualizationUtilService.isFieldNode(n)) return VisualizationUtilService.isCollectionField(n);
+        return false;
+      },
+    },
+  ];
+
+  /**
+   * Returns the set of {@link MappingActionKind} values permitted for the given
+   * target node. Callers should convert the result to a `Set` for O(1) membership
+   * tests when rendering multiple action controls.
+   *
+   * @param nodeData - The target node whose capabilities are evaluated.
+   * @returns An array of allowed action identifiers for this node.
+   */
+  static getAllowedActions(nodeData: TargetNodeData): MappingActionKind[] {
+    return MappingActionRegistryService.ACTION_REGISTRY.filter((def) => def.isAllowed(nodeData)).map((def) => def.key);
+  }
+
+  /**
+   * Returns the context menu action definitions that are allowed for the given
+   * target node. Each returned entry carries its label, testId, and apply callback.
+   *
+   * @param nodeData - The target node whose menu items are evaluated.
+   * @returns An array of allowed context menu action definitions.
+   */
+  static getMappingContextMenuItems(nodeData: TargetNodeData): IMappingContextMenuAction[] {
+    return MappingActionRegistryService.ACTION_REGISTRY.filter(
+      (def): def is IMappingContextMenuAction =>
+        MappingActionRegistryService.isContextMenuAction(def) && def.isAllowed(nodeData),
+    );
+  }
+}

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -28,6 +28,7 @@ import {
   FieldNodeData,
   MappingNodeData,
   SourceVariableNodeData,
+  TargetAbstractFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
@@ -52,6 +53,7 @@ import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.mo
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
 import { MappingSerializerService } from '../mapping/mapping-serializer.service';
 import { MappingActionService } from './mapping-action.service';
+import { MappingActionRegistryService } from './mapping-action-registry.service';
 import { VisualizationService } from './visualization.service';
 
 describe('MappingActionService', () => {
@@ -334,6 +336,61 @@ describe('MappingActionService', () => {
       });
     });
 
+    describe('applyForEach() on abstract wrapper field', () => {
+      it('should wrap the abstract wrapper itself, not its parent', () => {
+        const NS_SUBSTITUTION = 'http://www.example.com/SUBSTITUTION';
+        const definition = new DocumentDefinition(
+          DocumentType.TARGET_BODY,
+          DocumentDefinitionType.XML_SCHEMA,
+          'test-doc',
+          { 'FieldSubstitution.xsd': getFieldSubstitutionXsd() },
+        );
+        definition.rootElementChoice = { namespaceUri: NS_SUBSTITUTION, name: 'Zoo' };
+        const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+        if (!result.document) throw new Error('Failed to create test document');
+        const document = result.document;
+
+        const mappingTree = new MappingTree(
+          document.documentType,
+          document.documentId,
+          DocumentDefinitionType.XML_SCHEMA,
+        );
+        const docNode = new TargetDocumentNodeData(document, mappingTree);
+
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(docNode);
+        const zooChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        const equipmentNode = zooChildren.find((c) => c.title === 'Equipment');
+        expect(equipmentNode).toBeDefined();
+        const equipmentChildren = VisualizationService.generateNonDocumentNodeDataChildren(equipmentNode!);
+        const optionsNode = equipmentChildren.find((c) => c.title === 'Options');
+        expect(optionsNode).toBeDefined();
+        const optionsChildren = VisualizationService.generateNonDocumentNodeDataChildren(optionsNode!);
+        expect(optionsChildren).toHaveLength(1);
+        const abstractWrapperNode = optionsChildren[0];
+        expect(abstractWrapperNode).toBeInstanceOf(TargetAbstractFieldNodeData);
+
+        MappingActionService.applyForEach(abstractWrapperNode as TargetAbstractFieldNodeData);
+
+        expect(mappingTree.children).toHaveLength(1);
+        const zooFieldItem = mappingTree.children[0] as FieldItem;
+        expect(zooFieldItem).toBeInstanceOf(FieldItem);
+        expect(zooFieldItem.field.name).toBe('Zoo');
+
+        const equipmentFieldItem = zooFieldItem.children[0] as FieldItem;
+        expect(equipmentFieldItem.field.name).toBe('Equipment');
+        const optionsFieldItem = equipmentFieldItem.children[0] as FieldItem;
+        expect(optionsFieldItem.field.name).toBe('Options');
+
+        const optionsChild = optionsFieldItem.children[0];
+        expect(optionsChild).toBeInstanceOf(ForEachItem);
+        const forEachItem = optionsChild as ForEachItem;
+        expect(forEachItem.children).toHaveLength(1);
+        const wrappedFieldItem = forEachItem.children[0] as FieldItem;
+        expect(wrappedFieldItem).toBeInstanceOf(FieldItem);
+        expect(wrappedFieldItem.field.wrapperKind).toBe('abstract');
+      });
+    });
+
     describe('applyForEachGroup()', () => {
       it('should add for-each-group', () => {
         let docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -556,7 +613,7 @@ describe('MappingActionService', () => {
         );
         const forEachNode = updatedShipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toBe('for-each');
-        expect(MappingActionService.getAllowedActions(forEachNode)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(forEachNode)).not.toContain(
           MappingActionKind.InnerForEachCurrentGroup,
         );
       });
@@ -575,7 +632,7 @@ describe('MappingActionService', () => {
         );
         const forEachGroupNode = updatedShipOrderChildren[3] as MappingNodeData;
         expect(forEachGroupNode.title).toBe('for-each-group');
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(forEachGroupNode)).toContain(
           MappingActionKind.InnerForEachCurrentGroup,
         );
       });
@@ -602,7 +659,7 @@ describe('MappingActionService', () => {
         const forEachCurrentGroupNode = groupChildren.find((child) => child.title === 'for-each') as MappingNodeData;
         expect((forEachCurrentGroupNode.mapping as ForEachItem).expression).toBe('current-group()');
 
-        expect(MappingActionService.getAllowedActions(forEachCurrentGroupNode)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(forEachCurrentGroupNode)).not.toContain(
           MappingActionKind.InnerForEachCurrentGroup,
         );
       });
@@ -1001,7 +1058,9 @@ describe('MappingActionService', () => {
       it('should include CopyOfSelector in context menu items', () => {
         const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
-        const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderChildren[0] as TargetNodeData);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(
+          shipOrderChildren[0] as TargetNodeData,
+        );
         const copyOfAction = menuItems.find((item) => item.key === MappingActionKind.CopyOfSelector);
         expect(copyOfAction).toBeDefined();
         expect(copyOfAction!.getLabel(shipOrderChildren[0] as TargetNodeData)).toBe('Add copy selector (copy-of)');
@@ -1011,7 +1070,9 @@ describe('MappingActionService', () => {
       it('should include renamed ValueSelector label in context menu items', () => {
         const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
-        const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderChildren[0] as TargetNodeData);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(
+          shipOrderChildren[0] as TargetNodeData,
+        );
         const valueSelectorAction = menuItems.find((item) => item.key === MappingActionKind.ValueSelector);
         expect(valueSelectorAction).toBeDefined();
         expect(valueSelectorAction!.getLabel(shipOrderChildren[0] as TargetNodeData)).toBe(
@@ -1028,7 +1089,7 @@ describe('MappingActionService', () => {
         const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
           updatedDocChildren[0],
         );
-        const menuItems = MappingActionService.getMappingContextMenuItems(
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(
           updatedShipOrderChildren[0] as TargetNodeData,
         );
         const valueSelectorAction = menuItems.find((item) => item.key === MappingActionKind.ValueSelector);
@@ -1594,18 +1655,18 @@ describe('MappingActionService', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
-        expect(MappingActionService.getAllowedActions(targetDocNode)).toContain(MappingActionKind.If);
-        expect(MappingActionService.getAllowedActions(targetDocNode)).toContain(MappingActionKind.Choose);
-        expect(MappingActionService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(targetDocNode)).toContain(MappingActionKind.If);
+        expect(MappingActionRegistryService.getAllowedActions(targetDocNode)).toContain(MappingActionKind.Choose);
+        expect(MappingActionRegistryService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
           MappingActionKind.If,
         );
-        expect(MappingActionService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
           MappingActionKind.Choose,
         );
-        expect(MappingActionService.getAllowedActions(shipOrderChildren[1] as TargetNodeData)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(shipOrderChildren[1] as TargetNodeData)).not.toContain(
           MappingActionKind.If,
         );
-        expect(MappingActionService.getAllowedActions(shipOrderChildren[1] as TargetNodeData)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(shipOrderChildren[1] as TargetNodeData)).not.toContain(
           MappingActionKind.Choose,
         );
       });
@@ -1627,40 +1688,48 @@ describe('MappingActionService', () => {
       it('should include ContextMenu for appropriate nodes', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
-        expect(MappingActionService.getAllowedActions(targetDocNode)).not.toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(targetDocNode)).not.toContain(
+          MappingActionKind.ContextMenu,
+        );
+        expect(MappingActionRegistryService.getAllowedActions(targetDocChildren[0] as TargetNodeData)).toContain(
           MappingActionKind.ContextMenu,
         );
 
         expect(shipOrderChildren).toHaveLength(5);
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
         expect(orderIdNode.title).toBe('OrderId');
-        expect(MappingActionService.getAllowedActions(orderIdNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).toContain(MappingActionKind.ContextMenu);
 
         const ifNode = shipOrderChildren[1] as MappingNodeData;
         expect(ifNode.title).toBe('if');
-        expect(MappingActionService.getAllowedActions(ifNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(ifNode)).toContain(MappingActionKind.ContextMenu);
 
         const shipToNode = shipOrderChildren[2] as TargetFieldNodeData;
         expect(shipToNode.title).toBe('ShipTo');
-        expect(MappingActionService.getAllowedActions(shipToNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(shipToNode)).toContain(MappingActionKind.ContextMenu);
 
         const forEachNode = shipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toBe('for-each');
-        expect(MappingActionService.getAllowedActions(forEachNode)).toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(forEachNode)).toContain(MappingActionKind.Sort);
+        expect(MappingActionRegistryService.getAllowedActions(forEachNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(forEachNode)).toContain(MappingActionKind.Sort);
 
         expect(shipOrderChildren[4] instanceof AddMappingNodeData).toBeTruthy();
         const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
         expect(addMappingNode.title).toBe('Item');
         expect(addMappingNode.id).toContain('add-mapping-fx-Item');
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEach);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEachGroup);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.If);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.Choose);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.ValueSelector);
-        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.CopyOfSelector);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ForEach);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).toContain(
+          MappingActionKind.ForEachGroup,
+        );
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.If);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.Choose);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).not.toContain(
+          MappingActionKind.ValueSelector,
+        );
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).not.toContain(
+          MappingActionKind.CopyOfSelector,
+        );
       });
 
       it('should allow Delete for a field node added via Add Mapping', () => {
@@ -1668,7 +1737,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
         const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
         expect(addMappingNode instanceof AddMappingNodeData).toBeTruthy();
-        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.Delete);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.Delete);
         MappingActionService.addMapping(addMappingNode);
         targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
         const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -1680,7 +1749,7 @@ describe('MappingActionService', () => {
           (n) => n instanceof FieldItemNodeData && n.title === 'Item',
         ) as FieldItemNodeData;
         expect(addedNode).toBeDefined();
-        expect(MappingActionService.getAllowedActions(addedNode)).toContain(MappingActionKind.Delete);
+        expect(MappingActionRegistryService.getAllowedActions(addedNode)).toContain(MappingActionKind.Delete);
       });
 
       it('should keep Delete for an existing value-mapped field node', () => {
@@ -1688,7 +1757,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
         expect(orderIdNode.title).toBe('OrderId');
-        expect(MappingActionService.getAllowedActions(orderIdNode)).toContain(MappingActionKind.Delete);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).toContain(MappingActionKind.Delete);
       });
 
       it('should include ContextMenu for primitive TargetDocumentNodeData', () => {
@@ -1701,7 +1770,9 @@ describe('MappingActionService', () => {
           DocumentDefinitionType.Primitive,
         );
         const primitiveDocNode = new TargetDocumentNodeData(primitiveTargetDoc, primitiveTree);
-        expect(MappingActionService.getAllowedActions(primitiveDocNode)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(primitiveDocNode)).toContain(
+          MappingActionKind.ContextMenu,
+        );
       });
 
       it('should allow ContextMenu and ForEachGroupConfig but exclude Sort and ValueSelector for for-each-group nodes', () => {
@@ -1713,7 +1784,9 @@ describe('MappingActionService', () => {
         const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(itemNode);
         const fieldInsideForEach = forEachChildren[0] as FieldItemNodeData;
         expect(fieldInsideForEach.title).toBe('Item');
-        expect(MappingActionService.getAllowedActions(fieldInsideForEach)).toContain(MappingActionKind.ContextMenu);
+        expect(MappingActionRegistryService.getAllowedActions(fieldInsideForEach)).toContain(
+          MappingActionKind.ContextMenu,
+        );
 
         MappingActionService.applyForEachGroup(shipOrderChildren[4] as AddMappingNodeData);
 
@@ -1726,17 +1799,21 @@ describe('MappingActionService', () => {
         const forEachGroupNode = updatedShipOrderChildren[4] as MappingNodeData;
         expect(forEachGroupNode.title).toBe('for-each-group');
         expect(forEachGroupNode.mapping instanceof ForEachGroupItem).toBeTruthy();
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(MappingActionKind.ContextMenu);
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(forEachGroupNode)).toContain(
+          MappingActionKind.ContextMenu,
+        );
+        expect(MappingActionRegistryService.getAllowedActions(forEachGroupNode)).toContain(
           MappingActionKind.ForEachGroupConfig,
         );
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.Sort);
-        expect(MappingActionService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.ValueSelector);
+        expect(MappingActionRegistryService.getAllowedActions(forEachGroupNode)).not.toContain(MappingActionKind.Sort);
+        expect(MappingActionRegistryService.getAllowedActions(forEachGroupNode)).not.toContain(
+          MappingActionKind.ValueSelector,
+        );
 
         const forEachGroupChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachGroupNode);
         const fieldInsideForEachGroup = forEachGroupChildren[0] as FieldItemNodeData;
         expect(fieldInsideForEachGroup.title).toBe('Item');
-        expect(MappingActionService.getAllowedActions(fieldInsideForEachGroup)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(fieldInsideForEachGroup)).toContain(
           MappingActionKind.ContextMenu,
         );
       });
@@ -1758,7 +1835,7 @@ describe('MappingActionService', () => {
         const forEachGroupChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachGroupNode);
         const fieldInsideForEachGroup = forEachGroupChildren[0] as FieldItemNodeData;
         expect(fieldInsideForEachGroup.title).toBe('Item');
-        expect(MappingActionService.getAllowedActions(fieldInsideForEachGroup)).toContain(
+        expect(MappingActionRegistryService.getAllowedActions(fieldInsideForEachGroup)).toContain(
           MappingActionKind.ForEachCurrentGroup,
         );
       });
@@ -1771,7 +1848,7 @@ describe('MappingActionService', () => {
         const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(itemNode);
         const fieldInsideForEach = forEachChildren[0] as FieldItemNodeData;
         expect(fieldInsideForEach.title).toBe('Item');
-        expect(MappingActionService.getAllowedActions(fieldInsideForEach)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(fieldInsideForEach)).not.toContain(
           MappingActionKind.ForEachCurrentGroup,
         );
       });
@@ -1803,7 +1880,7 @@ describe('MappingActionService', () => {
         const innerChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachCurrentGroupNode);
         const fieldInsideCurrentGroup = innerChildren[0] as FieldItemNodeData;
         expect(fieldInsideCurrentGroup.title).toBe('Item');
-        expect(MappingActionService.getAllowedActions(fieldInsideCurrentGroup)).not.toContain(
+        expect(MappingActionRegistryService.getAllowedActions(fieldInsideCurrentGroup)).not.toContain(
           MappingActionKind.ForEachCurrentGroup,
         );
       });
@@ -1815,10 +1892,10 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
-        expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Sort);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Sort);
 
         const ifNode = shipOrderChildren[1] as MappingNodeData;
-        expect(MappingActionService.getAllowedActions(ifNode)).not.toContain(MappingActionKind.Sort);
+        expect(MappingActionRegistryService.getAllowedActions(ifNode)).not.toContain(MappingActionKind.Sort);
       });
     });
 
@@ -1828,14 +1905,14 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
         const shipOrderNode = targetDocChildren[0] as FieldItemNodeData;
-        expect(MappingActionService.getAllowedActions(shipOrderNode)).toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(shipOrderNode)).toContain(MappingActionKind.Variable);
 
         const shipToNode = shipOrderChildren[2] as TargetFieldNodeData;
-        expect(MappingActionService.getAllowedActions(shipToNode)).toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(shipToNode)).toContain(MappingActionKind.Variable);
       });
 
       it('should not include Variable for TargetDocumentNodeData', () => {
-        expect(MappingActionService.getAllowedActions(targetDocNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(targetDocNode)).not.toContain(MappingActionKind.Variable);
       });
 
       it('should not include Variable for AddMappingNodeData', () => {
@@ -1843,7 +1920,9 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
         const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
-        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).not.toContain(
+          MappingActionKind.Variable,
+        );
       });
 
       it('should not include Variable for terminal field nodes', () => {
@@ -1852,7 +1931,7 @@ describe('MappingActionService', () => {
 
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
         expect(orderIdNode.title).toBe('OrderId');
-        expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Variable);
       });
 
       it('should include Variable for ForEachItem and IfItem MappingNodeData', () => {
@@ -1861,18 +1940,18 @@ describe('MappingActionService', () => {
 
         const ifNode = shipOrderChildren[1] as MappingNodeData;
         expect(ifNode.title).toBe('if');
-        expect(MappingActionService.getAllowedActions(ifNode)).toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(ifNode)).toContain(MappingActionKind.Variable);
 
         const forEachNode = shipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toBe('for-each');
-        expect(MappingActionService.getAllowedActions(forEachNode)).toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(forEachNode)).toContain(MappingActionKind.Variable);
       });
 
       it('should not include Variable for VariableNodeData', () => {
         const variable = new VariableItem(tree, 'testVar');
         tree.children.push(variable);
         const variableNode = new VariableNodeData(targetDocNode, variable);
-        expect(MappingActionService.getAllowedActions(variableNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(variableNode)).not.toContain(MappingActionKind.Variable);
       });
 
       it('should not include Variable for ValueSelector, ChooseItem, or UnknownMappingItem MappingNodeData', () => {
@@ -1881,17 +1960,19 @@ describe('MappingActionService', () => {
         const valueSelector = new ValueSelector(fieldItem);
         fieldItem.children.push(valueSelector);
         const valueSelectorNode = new MappingNodeData(targetDocNode, valueSelector);
-        expect(MappingActionService.getAllowedActions(valueSelectorNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(valueSelectorNode)).not.toContain(
+          MappingActionKind.Variable,
+        );
 
         const chooseItem = new ChooseItem(fieldItem, targetDoc.fields[0]);
         const chooseNode = new MappingNodeData(targetDocNode, chooseItem);
-        expect(MappingActionService.getAllowedActions(chooseNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(chooseNode)).not.toContain(MappingActionKind.Variable);
 
         const unknownElement = document.createElementNS('http://www.w3.org/1999/XSL/Transform', 'apply-templates');
         const unknownItem = new UnknownMappingItem(fieldItem, unknownElement);
         fieldItem.children.push(unknownItem);
         const unknownNode = new MappingNodeData(targetDocNode, unknownItem);
-        expect(MappingActionService.getAllowedActions(unknownNode)).not.toContain(MappingActionKind.Variable);
+        expect(MappingActionRegistryService.getAllowedActions(unknownNode)).not.toContain(MappingActionKind.Variable);
       });
     });
 
@@ -1900,23 +1981,31 @@ describe('MappingActionService', () => {
         const variable = new VariableItem(tree, 'testVar');
         tree.children.push(variable);
         const variableNode = new VariableNodeData(targetDocNode, variable);
-        expect(MappingActionService.getAllowedActions(variableNode)).toContain(MappingActionKind.RenameVariable);
+        expect(MappingActionRegistryService.getAllowedActions(variableNode)).toContain(
+          MappingActionKind.RenameVariable,
+        );
       });
 
       it('should not include RenameVariable for non-variable nodes', () => {
-        expect(MappingActionService.getAllowedActions(targetDocNode)).not.toContain(MappingActionKind.RenameVariable);
+        expect(MappingActionRegistryService.getAllowedActions(targetDocNode)).not.toContain(
+          MappingActionKind.RenameVariable,
+        );
 
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
-        expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.RenameVariable);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).not.toContain(
+          MappingActionKind.RenameVariable,
+        );
 
         const ifNode = shipOrderChildren[1] as MappingNodeData;
-        expect(MappingActionService.getAllowedActions(ifNode)).not.toContain(MappingActionKind.RenameVariable);
+        expect(MappingActionRegistryService.getAllowedActions(ifNode)).not.toContain(MappingActionKind.RenameVariable);
 
         const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
-        expect(MappingActionService.getAllowedActions(addMappingNode)).not.toContain(MappingActionKind.RenameVariable);
+        expect(MappingActionRegistryService.getAllowedActions(addMappingNode)).not.toContain(
+          MappingActionKind.RenameVariable,
+        );
       });
     });
 
@@ -2050,7 +2139,7 @@ describe('MappingActionService', () => {
       it('Variable apply should call setAddingVariableTo with node path', () => {
         const targetDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
         const shipOrderNode = targetDocChildren[0] as FieldItemNodeData;
-        const menuItems = MappingActionService.getMappingContextMenuItems(shipOrderNode);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(shipOrderNode);
         const variableAction = menuItems.find((item) => item.key === MappingActionKind.Variable);
         expect(variableAction).toBeDefined();
         expect(variableAction!.getLabel(shipOrderNode)).toBe('Add variable');
@@ -2066,7 +2155,7 @@ describe('MappingActionService', () => {
         tree.children.push(variable);
         const variableNode = new VariableNodeData(targetDocNode, variable);
 
-        const menuItems = MappingActionService.getMappingContextMenuItems(variableNode);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(variableNode);
         const renameAction = menuItems.find((item) => item.key === MappingActionKind.RenameVariable);
         expect(renameAction).toBeDefined();
         expect(renameAction!.getLabel(variableNode)).toBe('Rename variable');
@@ -2084,7 +2173,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
         const ifNode = shipOrderChildren[1] as MappingNodeData;
         expect(ifNode.title).toBe('if');
-        expect(MappingActionService.getAllowedActions(ifNode)).toContain(MappingActionKind.Duplicate);
+        expect(MappingActionRegistryService.getAllowedActions(ifNode)).toContain(MappingActionKind.Duplicate);
       });
 
       it('should include Duplicate for collection FieldItemNodeData', () => {
@@ -2102,7 +2191,7 @@ describe('MappingActionService', () => {
           (n) => n instanceof FieldItemNodeData && n.title === 'Item',
         ) as FieldItemNodeData;
         expect(addedNode).toBeDefined();
-        expect(MappingActionService.getAllowedActions(addedNode)).toContain(MappingActionKind.Duplicate);
+        expect(MappingActionRegistryService.getAllowedActions(addedNode)).toContain(MappingActionKind.Duplicate);
       });
 
       it('should not include Duplicate for non-collection FieldItemNodeData', () => {
@@ -2110,7 +2199,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
         const orderIdNode = shipOrderChildren[0] as FieldItemNodeData;
         expect(orderIdNode.title).toBe('OrderId');
-        expect(MappingActionService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Duplicate);
+        expect(MappingActionRegistryService.getAllowedActions(orderIdNode)).not.toContain(MappingActionKind.Duplicate);
       });
 
       it('should not include Duplicate for non-IfItem MappingNodeData', () => {
@@ -2118,7 +2207,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
         const forEachNode = shipOrderChildren[3] as MappingNodeData;
         expect(forEachNode.title).toBe('for-each');
-        expect(MappingActionService.getAllowedActions(forEachNode)).not.toContain(MappingActionKind.Duplicate);
+        expect(MappingActionRegistryService.getAllowedActions(forEachNode)).not.toContain(MappingActionKind.Duplicate);
       });
 
       it('should create a new FieldItem with isUserCreated when duplicating a collection field', () => {
@@ -2140,7 +2229,7 @@ describe('MappingActionService', () => {
         const shipOrderMappingItem = targetDocNode.mappingTree.children[0];
         const childCountBefore = shipOrderMappingItem.children.length;
 
-        const menuItems = MappingActionService.getMappingContextMenuItems(addedNode);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(addedNode);
         const duplicateAction = menuItems.find((item) => item.key === MappingActionKind.Duplicate);
         expect(duplicateAction).toBeDefined();
         duplicateAction!.apply(addedNode, { onUpdate: vi.fn(), openModal: vi.fn() });
@@ -2163,7 +2252,7 @@ describe('MappingActionService', () => {
         const parent = originalIf.parent;
         const indexBefore = parent.children.indexOf(originalIf);
 
-        const menuItems = MappingActionService.getMappingContextMenuItems(ifNode);
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(ifNode);
         const duplicateAction = menuItems.find((item) => item.key === MappingActionKind.Duplicate);
         expect(duplicateAction).toBeDefined();
         duplicateAction!.apply(ifNode, { onUpdate: vi.fn(), openModal: vi.fn() });
@@ -2182,7 +2271,7 @@ describe('MappingActionService', () => {
         const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
 
         const ifNode = shipOrderChildren[1] as MappingNodeData;
-        const ifMenuItems = MappingActionService.getMappingContextMenuItems(ifNode);
+        const ifMenuItems = MappingActionRegistryService.getMappingContextMenuItems(ifNode);
         const ifDuplicateAction = ifMenuItems.find((item) => item.key === MappingActionKind.Duplicate);
         expect(ifDuplicateAction).toBeDefined();
         expect(ifDuplicateAction!.getLabel(ifNode)).toBe('Duplicate "if"');
@@ -2197,10 +2286,58 @@ describe('MappingActionService', () => {
         const addedNode = updatedShipOrderChildren.find(
           (n) => n instanceof FieldItemNodeData && n.title === 'Item',
         ) as FieldItemNodeData;
-        const fieldMenuItems = MappingActionService.getMappingContextMenuItems(addedNode);
+        const fieldMenuItems = MappingActionRegistryService.getMappingContextMenuItems(addedNode);
         const fieldDuplicateAction = fieldMenuItems.find((item) => item.key === MappingActionKind.Duplicate);
         expect(fieldDuplicateAction).toBeDefined();
         expect(fieldDuplicateAction!.getLabel(addedNode)).toBe('Duplicate');
+      });
+
+      it('should preserve document-level selection after duplicating a wrapper member', () => {
+        const baseField = sourceDoc.fields[0];
+        const catField = { ...baseField, name: 'Cat', displayName: 'Cat', fields: [] };
+        const dogField = { ...baseField, name: 'Dog', displayName: 'Dog', fields: [] };
+        const abstractField = {
+          ...baseField,
+          name: 'AbstractElement',
+          displayName: 'AbstractElement',
+          wrapperKind: 'abstract' as const,
+          selectedMemberQName: {
+            getNamespaceURI: () => baseField.namespaceURI ?? '',
+            getLocalPart: () => 'Cat',
+          },
+          maxOccurs: 'unbounded' as const,
+          fields: [catField, dogField],
+          ownerDocument: targetDoc,
+        } as unknown as typeof baseField;
+        const parentField = { ...targetDoc.fields[0], fields: [abstractField] };
+
+        const localTree = new MappingTree(
+          targetDoc.documentType,
+          targetDoc.documentId,
+          DocumentDefinitionType.XML_SCHEMA,
+        );
+        localTree.namespaceMap = {};
+        const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+        const catFieldItem = new FieldItem(parentFieldItem, catField as unknown as typeof baseField);
+        parentFieldItem.children.push(catFieldItem);
+        localTree.children.push(parentFieldItem);
+
+        const localTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+        const parentNode = new TargetFieldNodeData(localTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+        parentNode.mapping = parentFieldItem;
+
+        const catNode = new TargetAbstractFieldNodeData(parentNode, catField as unknown as typeof baseField);
+        catNode.abstractField = abstractField;
+        catNode.mapping = catFieldItem;
+
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(catNode);
+        const duplicateAction = menuItems.find((item) => item.key === MappingActionKind.Duplicate);
+        expect(duplicateAction).toBeDefined();
+        duplicateAction!.apply(catNode, { onUpdate: vi.fn(), openModal: vi.fn() });
+
+        expect(abstractField.selectedMemberQName).toBeDefined();
+        expect(parentFieldItem.children).toHaveLength(2);
+        expect(parentFieldItem.children.every((c) => c instanceof FieldItem && c.field.name === 'Cat')).toBe(true);
       });
     });
   });
@@ -2211,16 +2348,16 @@ describe('MappingActionService', () => {
       const docData = new TargetDocumentNodeData(targetDoc, tree);
 
       const fieldNodeData = new FieldItemNodeData(docData, tree.children[0] as FieldItem);
-      expect(MappingActionService.getAllowedActions(fieldNodeData)).not.toContain(MappingActionKind.Delete);
+      expect(MappingActionRegistryService.getAllowedActions(fieldNodeData)).not.toContain(MappingActionKind.Delete);
 
       const forEachNodeData = new MappingNodeData(docData, tree.children[0].children[0] as ForEachItem);
-      expect(MappingActionService.getAllowedActions(forEachNodeData)).toContain(MappingActionKind.Delete);
+      expect(MappingActionRegistryService.getAllowedActions(forEachNodeData)).toContain(MappingActionKind.Delete);
 
       const valueSelectorNodeData = new MappingNodeData(
         docData,
         tree.children[0].children[0].children[0] as ValueSelector,
       );
-      expect(MappingActionService.getAllowedActions(valueSelectorNodeData)).toContain(MappingActionKind.Delete);
+      expect(MappingActionRegistryService.getAllowedActions(valueSelectorNodeData)).toContain(MappingActionKind.Delete);
     });
   });
 
@@ -2253,9 +2390,11 @@ describe('MappingActionService', () => {
 
       const unknownNode = shipOrderChildren.find((n) => n instanceof UnknownMappingNodeData) as UnknownMappingNodeData;
       expect(unknownNode).toBeDefined();
-      expect(MappingActionService.getAllowedActions(unknownNode)).toContain(MappingActionKind.Delete);
-      expect(MappingActionService.getAllowedActions(unknownNode)).not.toContain(MappingActionKind.ContextMenu);
-      expect(MappingActionService.getAllowedActions(unknownNode)).not.toContain(MappingActionKind.ValueSelector);
+      expect(MappingActionRegistryService.getAllowedActions(unknownNode)).toContain(MappingActionKind.Delete);
+      expect(MappingActionRegistryService.getAllowedActions(unknownNode)).not.toContain(MappingActionKind.ContextMenu);
+      expect(MappingActionRegistryService.getAllowedActions(unknownNode)).not.toContain(
+        MappingActionKind.ValueSelector,
+      );
     });
 
     it('should include UnknownMappingNodeData in children of a primitive target document', () => {
@@ -2289,7 +2428,7 @@ describe('MappingActionService', () => {
       const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(targetDocChildren[0]);
       const addMappingNode = shipOrderChildren[4] as AddMappingNodeData;
 
-      const menuItems = MappingActionService.getMappingContextMenuItems(addMappingNode);
+      const menuItems = MappingActionRegistryService.getMappingContextMenuItems(addMappingNode);
       expect(menuItems.length).toBeGreaterThan(0);
 
       for (const item of menuItems) {
@@ -2392,7 +2531,7 @@ describe('MappingActionService', () => {
     });
 
     describe('clearTargetSelection', () => {
-      it('should remove children and replace field on existing FieldItem', () => {
+      it('should remove FieldItem from parent on existing mapping', () => {
         const { mappingTree, fieldNode, zooField } = createTargetSetup();
         const candidateField = zooField.fields[0];
         const existingItem = new FieldItem(mappingTree, candidateField);
@@ -2404,11 +2543,8 @@ describe('MappingActionService', () => {
 
         MappingActionService.clearTargetSelection(fieldNode, zooField);
 
-        expect(mappingTree.children).toHaveLength(1);
-        const replaced = mappingTree.children[0] as FieldItem;
-        expect(replaced.field).toBe(zooField);
-        expect(replaced.isUserCreated).toBe(true);
-        expect(replaced.children).toHaveLength(0);
+        expect(mappingTree.children).toHaveLength(0);
+        expect(existingItem.children).toHaveLength(0);
       });
 
       it('should be no-op when no existing mapping', () => {
@@ -2417,6 +2553,28 @@ describe('MappingActionService', () => {
         MappingActionService.clearTargetSelection(fieldNode, zooField);
 
         expect(mappingTree.children).toHaveLength(0);
+      });
+
+      it('should revert FieldItem to wrapper field when inside InstructionItem', () => {
+        const { mappingTree, fieldNode, zooField } = createTargetSetup();
+        const ifItem = new IfItem(mappingTree);
+        ifItem.expression = 'some-condition';
+        mappingTree.children.push(ifItem);
+
+        const candidateField = zooField.fields[0];
+        const existingItem = new FieldItem(ifItem, candidateField);
+        existingItem.isUserCreated = true;
+        ifItem.children.push(existingItem);
+        fieldNode.mapping = existingItem;
+
+        MappingActionService.clearTargetSelection(fieldNode, zooField);
+
+        expect(ifItem.children).toHaveLength(1);
+        const reverted = ifItem.children[0] as FieldItem;
+        expect(reverted).toBeInstanceOf(FieldItem);
+        expect(reverted.field).toBe(zooField);
+        expect(reverted.isUserCreated).toBe(true);
+        expect(ifItem.expression).toBe('some-condition');
       });
     });
   });

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -5,21 +5,19 @@ import {
   ForEachGroupItem,
   ForEachItem,
   IfItem,
+  InstructionItem,
   MappingItem,
   MappingParentType,
   MappingTree,
-  OtherwiseItem,
-  UnknownMappingItem,
   ValueSelector,
   ValueType,
-  WhenItem,
 } from '../../models/datamapper/mapping';
-import { IMappingAction, IMappingContextMenuAction, MappingActionKind } from '../../models/datamapper/mapping-action';
 import { Types } from '../../models/datamapper/types';
 import {
   AddMappingNodeData,
   ChoiceFieldNodeData,
   FieldItemNodeData,
+  ForEachCapableNodeData,
   MappingNodeData,
   SourceNodeDataType,
   SourceVariableNodeData,
@@ -29,7 +27,6 @@ import {
   TargetFieldNodeData,
   TargetNodeData,
   TargetSequenceFieldNodeData,
-  VariableNodeData,
 } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
 import { DocumentService } from '../document/document.service';
@@ -37,21 +34,19 @@ import { FieldMatchingService } from '../mapping/field-matching.service';
 import { MappingService } from '../mapping/mapping.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
-type ForEachCapableNodeData = TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData;
-
 /**
- * Static service for mapping mutations and the action registry in the
- * DataMapper visualization layer.
+ * Static service for mapping mutations in the DataMapper visualization layer.
  *
  * Owns every operation that modifies the {@link MappingTree} — applying
  * conditions (`if`, `choose/when/otherwise`, `for-each`), engaging and
- * deleting mappings, and adding value selectors — as well as the
- * registry-based capability checks that determine which actions are
- * available for a given target node.
+ * deleting mappings, and adding value selectors.
  *
  * Depends on {@link MappingService} for low-level mapping tree manipulation
  * and on {@link VisualizationUtilService} for node-type inspection,
  * but has no dependency on {@link VisualizationService}.
+ *
+ * The action registry that determines which actions are available for a
+ * given target node lives in {@link MappingActionRegistryService}.
  */
 export class MappingActionService {
   /**
@@ -221,7 +216,7 @@ export class MappingActionService {
    */
   static applyInnerForEach(nodeData: ForEachCapableNodeData | TargetNodeData) {
     // If applying to a ForEachItem or ForEachGroupItem node, use the mapping directly
-    if (MappingActionService.isMappingNode(nodeData)) {
+    if (VisualizationUtilService.isMappingNode(nodeData)) {
       const mapping = (nodeData as MappingNodeData).mapping;
       if (mapping instanceof ForEachItem || mapping instanceof ForEachGroupItem) {
         MappingService.addInnerForEach(mapping);
@@ -240,7 +235,7 @@ export class MappingActionService {
    * @param nodeData - The target field node or for-each node to add the inner for-each-group to.
    */
   static applyInnerForEachGroup(nodeData: ForEachCapableNodeData | TargetNodeData) {
-    if (MappingActionService.isMappingNode(nodeData)) {
+    if (VisualizationUtilService.isMappingNode(nodeData)) {
       const mapping = (nodeData as MappingNodeData).mapping;
       if (mapping instanceof ForEachItem || mapping instanceof ForEachGroupItem) {
         MappingService.addInnerForEachGroup(mapping);
@@ -258,7 +253,7 @@ export class MappingActionService {
    * @param nodeData - The target node to add the inner for-each current-group() to.
    */
   static applyInnerForEachCurrentGroup(nodeData: ForEachCapableNodeData | TargetNodeData) {
-    if (MappingActionService.isMappingNode(nodeData)) {
+    if (VisualizationUtilService.isMappingNode(nodeData)) {
       const mapping = (nodeData as MappingNodeData).mapping;
       if (mapping instanceof ForEachItem || mapping instanceof ForEachGroupItem) {
         MappingService.addInnerForEach(mapping).expression = 'current-group()';
@@ -285,7 +280,7 @@ export class MappingActionService {
    */
   static applyInnerIf(nodeData: TargetNodeData) {
     // If applying to an IfItem node, use the mapping directly
-    if (MappingActionService.isMappingNode(nodeData)) {
+    if (VisualizationUtilService.isMappingNode(nodeData)) {
       const mapping = nodeData.mapping;
       if (mapping instanceof IfItem) {
         MappingService.addInnerIf(mapping);
@@ -361,14 +356,14 @@ export class MappingActionService {
 
     const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
 
-    if (sourceNode instanceof ChoiceFieldNodeData && MappingActionService.isFieldNode(targetNode)) {
+    if (sourceNode instanceof ChoiceFieldNodeData && VisualizationUtilService.isFieldNode(targetNode)) {
       MappingActionService.engageChoiceMapping(sourceNode, targetNode, sourceField);
       return;
     }
 
     if (MappingActionService.tryEngageContainerMapping(sourceNode, targetNode)) return;
 
-    if (MappingActionService.isFieldNode(targetNode)) {
+    if (VisualizationUtilService.isFieldNode(targetNode)) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
       MappingActionService.removeParentContainerCopyOf(item);
       MappingService.mapToField(sourceField, item);
@@ -415,9 +410,7 @@ export class MappingActionService {
    * @param nodeData - The placeholder node representing the "add mapping" action.
    */
   static addMapping(nodeData: AddMappingNodeData) {
-    const parentItem = MappingActionService.getOrCreateFieldItem(nodeData.parent);
-    const fieldItem = MappingService.createFieldItem(parentItem, nodeData.field);
-    fieldItem.isUserCreated = true;
+    MappingActionService.createUserFieldItem(nodeData.parent, nodeData.field);
   }
 
   /**
@@ -436,6 +429,23 @@ export class MappingActionService {
     parent.children.splice(index + 1, 0, cloned);
   }
 
+  static duplicateFieldNode(nodeData: FieldItemNodeData | TargetFieldNodeData): void {
+    MappingActionService.createUserFieldItem(nodeData.parent, nodeData.field);
+  }
+
+  private static createUserFieldItem(parent: TargetNodeData, field: IField): FieldItem {
+    const parentItem = MappingActionService.getOrCreateFieldItem(parent);
+    const fieldItem = MappingService.createFieldItem(parentItem, field);
+    fieldItem.isUserCreated = true;
+    return fieldItem;
+  }
+
+  /**
+   * Creates or updates a per-instance member selection for a wrapper field. Unlike the
+   * document-level selection (`selectedMemberQName`/`selectedMemberIndex`), this operates
+   * on individual FieldItems. New FieldItems are marked `isUserCreated` so they survive
+   * stale-mapping cleanup even before child mappings are created.
+   */
   static applyTargetSelection(nodeData: TargetNodeData, selectedField: IField): void {
     const existingMapping = nodeData.mapping;
     if (existingMapping instanceof FieldItem) {
@@ -447,12 +457,44 @@ export class MappingActionService {
     }
   }
 
+  /**
+   * When the FieldItem lives inside an InstructionItem (xsl:if, xsl:when, etc.), it is
+   * reverted to the wrapper field rather than removed. This preserves the instruction
+   * structure while still producing the correct "unconfigured" visual state — because
+   * {@link VisualizationService.isUnconfiguredTargetWrapper} only inspects direct children
+   * of the nearest non-wrapper ancestor mapping, a FieldItem nested inside an instruction
+   * is invisible to that check. Without an instruction, the FieldItem must be removed so
+   * `isUnconfiguredTargetWrapper` returns true; keeping it would bypass that gate and
+   * render all candidates below a wrapper that has no expand arrow.
+   */
   static clearTargetSelection(nodeData: TargetNodeData, wrapperField: IField): void {
     const existingMapping = nodeData.mapping;
     if (existingMapping instanceof FieldItem) {
       existingMapping.children = [];
-      MappingService.updateFieldItemField(existingMapping, wrapperField);
+      if (existingMapping.parent instanceof InstructionItem) {
+        MappingService.updateFieldItemField(existingMapping, wrapperField);
+      } else {
+        existingMapping.parent.children = existingMapping.parent.children.filter((child) => child !== existingMapping);
+      }
     }
+  }
+
+  /**
+   * Reverts a per-instance wrapper selection without removing the FieldItem.
+   * Unlike {@link clearTargetSelection}, which may remove the FieldItem entirely
+   * (when not inside an InstructionItem), this method always keeps the slot and
+   * reverts its field back to `wrapperField`. Used by collection (maxOccurs>1)
+   * abstract and choice wrappers where each FieldItem represents an independent
+   * instance that should be preserved.
+   */
+  static clearPerInstanceWrapperSelection(nodeData: TargetNodeData, wrapperField: IField): void {
+    const existingMapping = nodeData.mapping;
+    if (existingMapping instanceof FieldItem) {
+      existingMapping.children = [];
+      MappingService.updateFieldItemField(existingMapping, wrapperField);
+      return;
+    }
+    MappingActionService.clearTargetSelection(nodeData, wrapperField);
   }
 
   static getOrCreateParentMapping(nodeData: TargetNodeData): MappingParentType | undefined {
@@ -599,19 +641,48 @@ export class MappingActionService {
     return undefined;
   }
 
+  /**
+   * Ensures a {@link FieldItem} exists in the {@link MappingTree} for the given
+   * visualization node, creating the full ancestor chain as needed.
+   *
+   * The visualization tree includes schema-structural nodes (xs:sequence,
+   * unselected xs:choice/abstract wrappers) that have no XSLT element
+   * counterpart. This method and {@link getOrCreateParentFieldItem} skip
+   * those nodes so the mapping tree reflects only the actual XML output
+   * structure. The split between the two methods exists because wrapper
+   * skipping must only happen during ancestor resolution — the entry-point
+   * node itself is always materialized (except xs:sequence, which is purely
+   * structural at every level).
+   */
   static getOrCreateFieldItem(nodeData: TargetNodeData): MappingItem {
     if (nodeData.mapping) return nodeData.mapping as MappingItem;
     const fieldNodeData = nodeData as TargetFieldNodeData;
+    if (fieldNodeData instanceof TargetSequenceFieldNodeData) {
+      return MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
+    }
+    const parentItem = MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
+    return MappingService.createFieldItem(parentItem, fieldNodeData.field);
+  }
+
+  /**
+   * Recursively resolves or creates ancestor {@link FieldItem}s for a node's
+   * parent chain, skipping schema-structural nodes that produce no XML element:
+   * unselected xs:choice wrappers, unselected abstract wrappers, and
+   * xs:sequence containers.
+   */
+  private static getOrCreateParentFieldItem(nodeData: TargetNodeData): MappingItem {
+    if (nodeData.mapping) return nodeData.mapping as MappingItem;
+    const fieldNodeData = nodeData as TargetFieldNodeData;
     if (fieldNodeData instanceof TargetChoiceFieldNodeData && !fieldNodeData.choiceField) {
-      return MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
+      return MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
     }
     if (fieldNodeData instanceof TargetAbstractFieldNodeData && !fieldNodeData.abstractField) {
-      return MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
+      return MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
     }
     if (fieldNodeData instanceof TargetSequenceFieldNodeData) {
-      return MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
+      return MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
     }
-    const parentItem = MappingActionService.getOrCreateFieldItem(fieldNodeData.parent);
+    const parentItem = MappingActionService.getOrCreateParentFieldItem(fieldNodeData.parent);
     return MappingService.createFieldItem(parentItem, fieldNodeData.field);
   }
 
@@ -620,368 +691,6 @@ export class MappingActionService {
     if (!(parent instanceof MappingItem)) return;
     parent.children = parent.children.filter(
       (c) => !(c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
-    );
-  }
-
-  private static allowForEachCurrentGroup(nodeData: TargetNodeData): boolean {
-    let current: TargetNodeData | undefined = nodeData;
-    while (current) {
-      if (current instanceof MappingNodeData) {
-        if (current.mapping instanceof ForEachGroupItem) return true;
-        if (current.mapping instanceof ForEachItem && current.mapping.expression === 'current-group()') return false;
-      }
-      current = 'parent' in current ? current.parent : undefined;
-    }
-    return false;
-  }
-
-  private static isFieldNode(n: TargetNodeData): n is FieldItemNodeData | TargetFieldNodeData {
-    return n instanceof FieldItemNodeData || n instanceof TargetFieldNodeData;
-  }
-
-  private static isMappingNode(n: TargetNodeData): n is MappingNodeData {
-    return n instanceof MappingNodeData;
-  }
-
-  private static mappingIsOneOf(...types: Array<abstract new (...args: never[]) => MappingItem>) {
-    return (n: TargetNodeData): boolean =>
-      MappingActionService.isMappingNode(n) && types.some((t) => n.mapping instanceof t);
-  }
-
-  private static isContextMenuAction(def: IMappingAction): def is IMappingContextMenuAction {
-    return 'getLabel' in def;
-  }
-
-  private static readonly ACTION_REGISTRY: (IMappingAction | IMappingContextMenuAction)[] = [
-    {
-      key: MappingActionKind.ContextMenu,
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return true;
-        if (n instanceof TargetDocumentNodeData) return n.isPrimitive;
-        if (MappingActionService.isFieldNode(n)) return true;
-        return (
-          MappingActionService.isMappingNode(n) &&
-          !MappingActionService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, UnknownMappingItem)(n)
-        );
-      },
-    },
-    {
-      key: MappingActionKind.Delete,
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return false;
-        if (n instanceof FieldItemNodeData)
-          // A workaround until https://github.com/KaotoIO/kaoto/issues/3242 is solved
-          return (
-            (n.mapping instanceof FieldItem && n.mapping.isUserCreated && n.mapping.parent instanceof FieldItem) ||
-            MappingActionService.hasValueSelector(n)
-          );
-        if (MappingActionService.isFieldNode(n) || n instanceof TargetDocumentNodeData)
-          return MappingActionService.hasValueSelector(n);
-        return MappingActionService.isMappingNode(n);
-      },
-    },
-    {
-      key: MappingActionKind.Sort,
-      testId: 'transformation-actions-sort',
-      getLabel: (n) => {
-        const mapping = n.mapping;
-        if (mapping instanceof ForEachItem && mapping.sortItems?.length > 0) {
-          return 'Edit Sort';
-        }
-        return 'Configure Sort';
-      },
-      apply: (_n, { openModal }) => {
-        openModal(MappingActionKind.Sort);
-      },
-      isAllowed: MappingActionService.mappingIsOneOf(ForEachItem),
-    },
-    {
-      key: MappingActionKind.ForEachGroupConfig,
-      testId: 'transformation-actions-foreach-group-config',
-      getLabel: () => 'Configure for-each-group',
-      apply: (_n, { openModal }) => {
-        openModal(MappingActionKind.ForEachGroupConfig);
-      },
-      isAllowed: MappingActionService.mappingIsOneOf(ForEachGroupItem),
-    },
-    {
-      key: MappingActionKind.Comment,
-      testId: 'transformation-actions-comment',
-      getLabel: (n) => (n.mapping instanceof MappingItem && n.mapping.comment ? 'Edit Comment' : 'Add Comment'),
-      apply: (_n, { openModal }) => {
-        openModal(MappingActionKind.Comment);
-      },
-      isAllowed: (n) => n.mapping instanceof MappingItem,
-    },
-    {
-      key: MappingActionKind.ValueSelector,
-      testId: 'transformation-actions-selector',
-      getLabel: () => 'Add value selector (value-of)',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyValueOfSelector(n);
-        onUpdate();
-      },
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return false;
-        if (!MappingActionService.isMappingNode(n)) return true;
-        return !MappingActionService.mappingIsOneOf(
-          ValueSelector,
-          ForEachItem,
-          ForEachGroupItem,
-          ChooseItem,
-          UnknownMappingItem,
-        )(n);
-      },
-      isDisabled: (n) => MappingActionService.hasValueOfSelector(n),
-    },
-    {
-      key: MappingActionKind.CopyOfSelector,
-      testId: 'transformation-actions-copy-of',
-      getLabel: () => 'Add copy selector (copy-of)',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyCopyOfSelector(n);
-        onUpdate();
-      },
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return false;
-        if (!MappingActionService.isMappingNode(n)) return true;
-        return !MappingActionService.mappingIsOneOf(
-          ValueSelector,
-          ForEachItem,
-          ForEachGroupItem,
-          ChooseItem,
-          UnknownMappingItem,
-        )(n);
-      },
-    },
-    {
-      key: MappingActionKind.When,
-      testId: 'transformation-actions-when',
-      getLabel: () => 'Add "when"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyWhen(n);
-        onUpdate();
-      },
-      isAllowed: MappingActionService.mappingIsOneOf(ChooseItem),
-    },
-    {
-      key: MappingActionKind.Otherwise,
-      testId: 'transformation-actions-otherwise',
-      getLabel: () => 'Add "otherwise"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyOtherwise(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        MappingActionService.isMappingNode(n) && n.mapping instanceof ChooseItem && !n.mapping.otherwise,
-    },
-    {
-      key: MappingActionKind.ForEach,
-      testId: 'transformation-actions-foreach',
-      getLabel: () => 'Wrap with "for-each"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyForEach(n as TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        n instanceof AddMappingNodeData ||
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
-    },
-    {
-      key: MappingActionKind.ForEachGroup,
-      testId: 'transformation-actions-foreachgroup',
-      getLabel: () => 'Wrap with "for-each-group"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyForEachGroup(n as TargetFieldNodeData | FieldItemNodeData | AddMappingNodeData);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        n instanceof AddMappingNodeData ||
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isCollectionField(n)),
-    },
-    {
-      key: MappingActionKind.ForEachCurrentGroup,
-      testId: 'transformation-actions-foreach-current-group',
-      getLabel: () => 'Wrap with "for-each current-group()"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyForEachCurrentGroup(n as ForEachCapableNodeData);
-        onUpdate();
-      },
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return false;
-        if (!MappingActionService.isFieldNode(n) || !VisualizationUtilService.isCollectionField(n)) return false;
-        return MappingActionService.allowForEachCurrentGroup(n);
-      },
-    },
-    {
-      key: MappingActionKind.If,
-      testId: 'transformation-actions-if',
-      getLabel: () => 'Wrap with "if"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyIf(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        !MappingActionService.isMappingNode(n) ||
-        !MappingActionService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, IfItem, ChooseItem)(n),
-    },
-    {
-      key: MappingActionKind.Choose,
-      testId: 'transformation-actions-choose',
-      getLabel: () => 'Wrap with "choose-when-otherwise"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyChooseWhenOtherwise(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        !MappingActionService.isMappingNode(n) ||
-        !MappingActionService.mappingIsOneOf(ValueSelector, WhenItem, OtherwiseItem, IfItem, ChooseItem)(n),
-    },
-    {
-      key: MappingActionKind.InnerForEach,
-      testId: 'transformation-actions-foreach-inner',
-      getLabel: () => 'Inner "for-each"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyInnerForEach(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        n instanceof AddMappingNodeData ||
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
-        MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
-    },
-    {
-      key: MappingActionKind.InnerForEachGroup,
-      testId: 'transformation-actions-foreachgroup-inner',
-      getLabel: () => 'Inner "for-each-group"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyInnerForEachGroup(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        n instanceof AddMappingNodeData ||
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
-        MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
-    },
-    {
-      key: MappingActionKind.InnerForEachCurrentGroup,
-      testId: 'transformation-actions-foreach-current-group-inner',
-      getLabel: () => 'Inner "for-each current-group()"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyInnerForEachCurrentGroup(n);
-        onUpdate();
-      },
-      isAllowed: (n) => {
-        if (n instanceof AddMappingNodeData) return false;
-        const nodeTypeAllowed =
-          (MappingActionService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
-          MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n);
-        if (!nodeTypeAllowed) return false;
-        return MappingActionService.allowForEachCurrentGroup(n);
-      },
-    },
-    {
-      key: MappingActionKind.InnerChoose,
-      testId: 'transformation-actions-choose-inner',
-      getLabel: () => 'Inner "choose-when-otherwise"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyInnerChooseWhenOtherwise(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
-        MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem)(n),
-    },
-    {
-      key: MappingActionKind.InnerIf,
-      testId: 'transformation-actions-if-inner',
-      getLabel: () => 'Inner "if"',
-      apply: (n, { onUpdate }) => {
-        MappingActionService.applyInnerIf(n);
-        onUpdate();
-      },
-      isAllowed: (n) =>
-        (MappingActionService.isFieldNode(n) && VisualizationUtilService.isTerminalField(n)) ||
-        MappingActionService.mappingIsOneOf(ForEachItem, ForEachGroupItem, IfItem)(n),
-    },
-    {
-      key: MappingActionKind.Variable,
-      testId: 'transformation-actions-variable',
-      getLabel: () => 'Add variable',
-      apply: (n) => {
-        useDocumentTreeStore.getState().setAddingVariableTo(n.path.toString());
-      },
-      isAllowed: (n) => {
-        if (n instanceof VariableNodeData) return false;
-        if (n instanceof TargetDocumentNodeData) return false;
-        if (MappingActionService.isFieldNode(n)) return DocumentService.hasChildren(n.field);
-        return (
-          MappingActionService.isMappingNode(n) &&
-          !MappingActionService.mappingIsOneOf(ValueSelector, ChooseItem, UnknownMappingItem)(n)
-        );
-      },
-    },
-    {
-      key: MappingActionKind.RenameVariable,
-      testId: 'transformation-actions-rename-variable',
-      getLabel: () => 'Rename variable',
-      apply: (n) => {
-        if (n instanceof VariableNodeData) {
-          useDocumentTreeStore.getState().setRenamingVariable(n.mapping.id);
-        }
-      },
-      isAllowed: (n) => n instanceof VariableNodeData,
-    },
-    {
-      key: MappingActionKind.Duplicate,
-      testId: 'transformation-actions-duplicate',
-      getLabel: (n) => {
-        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) {
-          return 'Duplicate "if"';
-        }
-        return 'Duplicate';
-      },
-      apply: (n, { onUpdate }) => {
-        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) {
-          MappingActionService.duplicateIf(n);
-        } else if (MappingActionService.isFieldNode(n)) {
-          const parentItem = MappingActionService.getOrCreateFieldItem(n.parent);
-          const fieldItem = MappingService.createFieldItem(parentItem, n.field);
-          fieldItem.isUserCreated = true;
-        }
-        onUpdate();
-      },
-      isAllowed: (n) => {
-        if (MappingActionService.isMappingNode(n) && n.mapping instanceof IfItem) return true;
-        if (MappingActionService.isFieldNode(n)) return VisualizationUtilService.isCollectionField(n);
-        return false;
-      },
-    },
-  ];
-
-  /**
-   * Returns the set of {@link MappingActionKind} values permitted for the given
-   * target node. Callers should convert the result to a `Set` for O(1) membership
-   * tests when rendering multiple action controls.
-   *
-   * @param nodeData - The target node whose capabilities are evaluated.
-   * @returns An array of allowed action identifiers for this node.
-   */
-  static getAllowedActions(nodeData: TargetNodeData): MappingActionKind[] {
-    return MappingActionService.ACTION_REGISTRY.filter((def) => def.isAllowed(nodeData)).map((def) => def.key);
-  }
-
-  /**
-   * Returns the context menu action definitions that are allowed for the given
-   * target node. Each returned entry carries its label, testId, and apply callback.
-   *
-   * @param nodeData - The target node whose menu items are evaluated.
-   * @returns An array of allowed context menu action definitions.
-   */
-  static getMappingContextMenuItems(nodeData: TargetNodeData): IMappingContextMenuAction[] {
-    return MappingActionService.ACTION_REGISTRY.filter(
-      (def): def is IMappingContextMenuAction =>
-        MappingActionService.isContextMenuAction(def) && def.isAllowed(nodeData),
     );
   }
 }

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -12,6 +12,7 @@ import { MappingLineStyle, variableNodePath, VARIABLES_DOCUMENT_ID } from '../..
 import { useDocumentTreeStore } from '../../store';
 import { mockRandomValues } from '../../stubs';
 import {
+  getChoiceWithAbstractXsd,
   getContactsXsd,
   getFieldSubstitutionXsd,
   getInvoice850Xsd,
@@ -424,6 +425,59 @@ describe('MappingLinksService', () => {
         `targetBody:Body://${rootItem.id}/${personItem.id}/inner-choice/${emailItem.id}`,
       );
     });
+
+    it('should not include inner wrapper segments for fields inside per-instance unbounded choice-with-abstract', () => {
+      const targetDefinition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'ChoiceWithAbstract.xsd': getChoiceWithAbstractXsd() },
+      );
+      targetDefinition.rootElementChoice = {
+        namespaceUri: 'http://www.example.com/CHOICE_ABSTRACT',
+        name: 'Notification',
+      };
+      const choiceAbsDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
+
+      const rootField = choiceAbsDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(rootField);
+      const largeField = rootField.fields.find((f: IField) => f.name === 'Large')!;
+      DocumentUtilService.resolveTypeFragment(largeField);
+      const unboundedChoiceField = largeField.fields.find(
+        (f: IField) => f.wrapperKind === 'choice' && f.maxOccurs !== 1,
+      )!;
+      const abstractField = unboundedChoiceField.fields.find((f: IField) => f.wrapperKind === 'abstract')!;
+      const emailField = abstractField.fields.find((f: IField) => f.name === 'Email')!;
+      DocumentUtilService.resolveTypeFragment(emailField);
+      const subjectField = emailField.fields.find((f: IField) => f.name === 'subject')!;
+
+      const choiceAbsTree = new MappingTree(
+        choiceAbsDoc.documentType,
+        choiceAbsDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      choiceAbsTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const rootItem = new FieldItem(choiceAbsTree, rootField);
+      choiceAbsTree.children.push(rootItem);
+      const largeItem = new FieldItem(rootItem, largeField);
+      rootItem.children.push(largeItem);
+      const emailItem = new FieldItem(largeItem, emailField);
+      largeItem.children.push(emailItem);
+      const subjectItem = new FieldItem(emailItem, subjectField);
+      emailItem.children.push(subjectItem);
+      const valueSelector = new ValueSelector(subjectItem);
+      valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      subjectItem.children.push(valueSelector);
+
+      const links = MappingLinksService.extractMappingLinks(choiceAbsTree, paramsMap, sourceDoc);
+      expect(links).toHaveLength(1);
+      expect(links[0].targetNodePath).toBe(
+        `targetBody:Body://${rootItem.id}/${largeItem.id}/${emailItem.id}/${subjectItem.id}`,
+      );
+      expect(links[0].targetNodePath).not.toContain(abstractField.id);
+      expect(links[0].targetNodePath).not.toContain(unboundedChoiceField.id);
+    });
   });
 
   describe('abstract field mapping paths', () => {
@@ -508,7 +562,7 @@ describe('MappingLinksService', () => {
       expect(links[0].targetNodePath).not.toContain(abstractAnimalField.id);
     });
 
-    it('should include unselected abstract wrapper segments in target paths', () => {
+    it('should skip maxOccurs>1 unselected abstract wrapper segments from target paths', () => {
       const {
         document: zooTargetDoc,
         zooField,
@@ -537,7 +591,8 @@ describe('MappingLinksService', () => {
 
       const links = MappingLinksService.extractMappingLinks(zooTree, paramsMap, sourceDoc);
       expect(links).toHaveLength(1);
-      expect(links[0].targetNodePath).toContain(abstractAnimalField.id);
+      expect(links[0].targetNodePath).not.toContain(abstractAnimalField.id);
+      expect(links[0].targetNodePath).toContain(catField.id);
     });
   });
 

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -343,6 +343,9 @@ export class MappingLinksService {
     const segments: string[] = [];
     let current = field.parent;
     while (MappingLinksService.isWrapperField(current)) {
+      if ((current as IField).maxOccurs !== 1) {
+        return [];
+      }
       if (!MappingLinksService.isSelectedWrapperField(current)) {
         segments.push(current.id);
       }

--- a/packages/ui/src/services/visualization/visualization-util.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.test.ts
@@ -316,6 +316,80 @@ describe('VisualizationUtilService', () => {
     });
   });
 
+  describe('isAbstractWrapperMember', () => {
+    it('should return true for FieldItemNodeData under TargetAbstractFieldNodeData', () => {
+      const abstractField = createMockField(sourceDoc.fields[0], {
+        name: 'AbstractAnimal',
+        wrapperKind: 'abstract',
+      });
+      const candidateField = createMockField(sourceDoc.fields[0], {
+        name: 'Cat',
+        parent: abstractField,
+      });
+      const abstractNode = new TargetAbstractFieldNodeData(targetDocNode, abstractField);
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, candidateField);
+      const fieldItemNode = new FieldItemNodeData(abstractNode, fieldItem);
+      expect(VisualizationUtilService.isAbstractWrapperMember(fieldItemNode)).toBe(true);
+    });
+
+    it('should return false for FieldItemNodeData under TargetDocumentNodeData', () => {
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, sourceDoc.fields[0]);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isAbstractWrapperMember(fieldItemNode)).toBe(false);
+    });
+
+    it('should return false for regular FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isAbstractWrapperMember(fieldNode)).toBe(false);
+    });
+
+    it('should return false for AbstractFieldNodeData itself', () => {
+      const abstractField = createMockField(sourceDoc.fields[0], {
+        name: 'AbstractAnimal',
+        wrapperKind: 'abstract',
+      });
+      const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
+      expect(VisualizationUtilService.isAbstractWrapperMember(abstractNode)).toBe(false);
+    });
+  });
+
+  describe('isChoiceWrapperMember', () => {
+    it('should return true for FieldItemNodeData under TargetChoiceFieldNodeData', () => {
+      const choiceField = createMockField(sourceDoc.fields[0], {
+        name: '__choice__',
+        wrapperKind: 'choice',
+      });
+      const memberField = createMockField(sourceDoc.fields[0], {
+        name: 'Email',
+        parent: choiceField,
+      });
+      const choiceNode = new TargetChoiceFieldNodeData(targetDocNode, choiceField);
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, memberField);
+      const fieldItemNode = new FieldItemNodeData(choiceNode, fieldItem);
+      expect(VisualizationUtilService.isChoiceWrapperMember(fieldItemNode)).toBe(true);
+    });
+
+    it('should return false for FieldItemNodeData under TargetDocumentNodeData', () => {
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, sourceDoc.fields[0]);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isChoiceWrapperMember(fieldItemNode)).toBe(false);
+    });
+
+    it('should return false for regular FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isChoiceWrapperMember(fieldNode)).toBe(false);
+    });
+
+    it('should return false for ChoiceFieldNodeData itself', () => {
+      const choiceField = createMockField(sourceDoc.fields[0], {
+        name: '__choice__',
+        wrapperKind: 'choice',
+      });
+      const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
+      expect(VisualizationUtilService.isChoiceWrapperMember(choiceNode)).toBe(false);
+    });
+  });
+
   describe('isTerminalField', () => {
     it('should return true for FieldNodeData with no children (terminal/primitive field)', () => {
       // Create a field with no children - a primitive/terminal field

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -1,13 +1,16 @@
 import { IField } from '../../models/datamapper/document';
 import {
   AbstractFieldNodeData,
+  AddMappingNodeData,
   ChoiceFieldNodeData,
   FieldItemNodeData,
   FieldNodeData,
+  MappingNodeData,
   NodeData,
   SequenceFieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
+  TargetFieldNodeData,
   TargetSequenceFieldNodeData,
 } from '../../models/datamapper/visualization';
 import { DocumentService } from '../document/document.service';
@@ -17,9 +20,10 @@ import { DocumentService } from '../document/document.service';
  * DataMapper visualization layer.
  *
  * Provides node-type checks (`is*Field`) and field extraction helpers that
- * both {@link VisualizationService} (node data generation) and
- * {@link MappingActionService} (mapping mutations) depend on, without either
- * service needing to know about the other.
+ * both {@link VisualizationService} (node data generation),
+ * {@link MappingActionService} (mapping mutations), and
+ * {@link MappingActionRegistryService} (action registry) depend on,
+ * without any of those services needing to know about each other.
  */
 export class VisualizationUtilService {
   /**
@@ -31,6 +35,9 @@ export class VisualizationUtilService {
    */
   static isCollectionField(nodeData: NodeData) {
     if (!(nodeData instanceof FieldNodeData || nodeData instanceof FieldItemNodeData)) return false;
+    if (nodeData instanceof FieldItemNodeData && nodeData.wrapperField) {
+      return DocumentService.isCollectionField(nodeData.wrapperField);
+    }
     if (DocumentService.isCollectionField(nodeData.field)) return true;
     if (VisualizationUtilService.isChoiceField(nodeData)) {
       return !!nodeData.choiceField && DocumentService.isCollectionField(nodeData.choiceField);
@@ -73,11 +80,21 @@ export class VisualizationUtilService {
 
   /**
    * Returns `true` if the node is a choice field without a selected member — i.e. the wrapper
-   * is showing all choice options. Used by the context menu to decide which actions to offer.
+   * is showing all choice options. Also matches target-only unselected wrapper instances:
+   * a {@link FieldItemNodeData} whose field still points at the wrapper itself, or an
+   * {@link AddMappingNodeData} for a choice wrapper field.
    * @param nodeData - The node to test.
    */
-  static isUnselectedChoiceField(nodeData: NodeData): nodeData is ChoiceFieldNodeData | TargetChoiceFieldNodeData {
-    return VisualizationUtilService.isChoiceField(nodeData) && !nodeData.choiceField;
+  static isUnselectedChoiceField(nodeData: NodeData): boolean {
+    if (VisualizationUtilService.isChoiceField(nodeData) && !nodeData.choiceField) return true;
+    if (
+      nodeData instanceof FieldItemNodeData &&
+      nodeData.wrapperField?.wrapperKind === 'choice' &&
+      nodeData.field === nodeData.wrapperField
+    )
+      return true;
+    if (nodeData instanceof AddMappingNodeData && nodeData.field.wrapperKind === 'choice') return true;
+    return false;
   }
 
   /**
@@ -144,13 +161,39 @@ export class VisualizationUtilService {
   }
 
   /**
-   * Returns `true` if the node is an abstract field without a selected substitution member
+   * Returns `true` if the node is an abstract field without a selected substitution member.
+   * Also matches target-only unsubstituted wrapper instances: a {@link FieldItemNodeData}
+   * whose field still points at the wrapper itself, or an {@link AddMappingNodeData} for
+   * an abstract wrapper field.
    * @param nodeData - The node to test.
    */
-  static isUnselectedAbstractField(
-    nodeData: NodeData,
-  ): nodeData is AbstractFieldNodeData | TargetAbstractFieldNodeData {
-    return VisualizationUtilService.isAbstractField(nodeData) && !nodeData.abstractField;
+  static isUnselectedAbstractField(nodeData: NodeData): boolean {
+    if (VisualizationUtilService.isAbstractField(nodeData) && !nodeData.abstractField) return true;
+    if (
+      nodeData instanceof FieldItemNodeData &&
+      nodeData.wrapperField?.wrapperKind === 'abstract' &&
+      nodeData.field === nodeData.wrapperField
+    )
+      return true;
+    if (nodeData instanceof AddMappingNodeData && nodeData.field.wrapperKind === 'abstract') return true;
+    return false;
+  }
+
+  /**
+   * Identifies a per-instance member of a maxOccurs>1 abstract wrapper — a FieldItem
+   * that holds an independent substitution selection, as opposed to the document-level
+   * `selectedMemberQName` model used for maxOccurs=1. Target-side only by construction:
+   * both `FieldItemNodeData` and `TargetAbstractFieldNodeData` are target-only types.
+   */
+  static isAbstractWrapperMember(nodeData: NodeData): boolean {
+    if (!(nodeData instanceof FieldItemNodeData)) return false;
+    return nodeData.parent instanceof TargetAbstractFieldNodeData || nodeData.wrapperField?.wrapperKind === 'abstract';
+  }
+
+  /** Choice-wrapper counterpart of {@link isAbstractWrapperMember}. */
+  static isChoiceWrapperMember(nodeData: NodeData): boolean {
+    if (!(nodeData instanceof FieldItemNodeData)) return false;
+    return nodeData.parent instanceof TargetChoiceFieldNodeData || nodeData.wrapperField?.wrapperKind === 'choice';
   }
 
   /**
@@ -192,4 +235,78 @@ export class VisualizationUtilService {
     }
     return undefined;
   }
+
+  static isFieldNode(nodeData: NodeData): nodeData is FieldItemNodeData | TargetFieldNodeData {
+    return nodeData instanceof FieldItemNodeData || nodeData instanceof TargetFieldNodeData;
+  }
+
+  static isMappingNode(nodeData: NodeData): nodeData is MappingNodeData {
+    return nodeData instanceof MappingNodeData;
+  }
+
+  /**
+   * Resolves the full choice context for a given node — which wrapper it belongs to,
+   * whether it's a selected member, a per-instance wrapper member, etc. Pure read,
+   * no side effects. Used by {@link useChoiceContextMenu} to determine what menu
+   * actions to offer.
+   */
+  static resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
+    const field = VisualizationUtilService.getField(nodeData);
+    const isChoiceWrapper = field?.wrapperKind === 'choice';
+    const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
+
+    const choiceMemberField =
+      VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
+    const choiceMemberParent =
+      choiceMemberField?.parent && 'wrapperKind' in choiceMemberField.parent ? choiceMemberField.parent : undefined;
+    const isChoiceMember = choiceMemberParent?.wrapperKind === 'choice';
+    const parentChoiceWrapperField = isChoiceMember ? choiceMemberParent : undefined;
+    const choiceMemberIndex =
+      isChoiceMember && parentChoiceWrapperField && choiceMemberField
+        ? parentChoiceWrapperField.fields.indexOf(choiceMemberField)
+        : undefined;
+
+    let choiceWrapperField: IField | undefined;
+    if (isSelectedChoice) {
+      choiceWrapperField = VisualizationUtilService.resolveOutermostSelectedWrapper(nodeData.choiceField).outermost;
+    } else if (isChoiceWrapper) {
+      choiceWrapperField = field;
+    }
+    const activeChoiceWrapperForMembers = isSelectedChoice && isChoiceWrapper ? field : choiceWrapperField;
+
+    const isChoiceWrapperMember = VisualizationUtilService.isChoiceWrapperMember(nodeData);
+    const choiceWrapperMemberField =
+      isChoiceWrapperMember && nodeData instanceof FieldItemNodeData
+        ? (nodeData.wrapperField ?? ((nodeData.parent as TargetChoiceFieldNodeData).field as IField))
+        : undefined;
+    const effectiveChoiceWrapper = isChoiceWrapperMember ? choiceWrapperMemberField : activeChoiceWrapperForMembers;
+
+    return {
+      isChoiceWrapper,
+      isSelectedChoice,
+      isChoiceMember,
+      isChoiceWrapperMember,
+      activeChoiceWrapperForMembers,
+      effectiveChoiceWrapper,
+      choiceWrapperField,
+      choiceWrapperMemberField,
+      choiceMemberField,
+      parentChoiceWrapperField,
+      choiceMemberIndex,
+    };
+  }
+}
+
+export interface ChoiceNodeInfo {
+  isChoiceWrapper: boolean;
+  isSelectedChoice: boolean;
+  isChoiceMember: boolean;
+  isChoiceWrapperMember: boolean;
+  activeChoiceWrapperForMembers: IField | undefined;
+  effectiveChoiceWrapper: IField | undefined;
+  choiceWrapperField: IField | undefined;
+  choiceWrapperMemberField: IField | undefined;
+  choiceMemberField: IField | undefined;
+  parentChoiceWrapperField: IField | undefined;
+  choiceMemberIndex: number | undefined;
 }

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -4,12 +4,14 @@ import {
   DocumentDefinitionType,
   DocumentType,
 } from '../../models/datamapper/document';
-import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
+import { FieldItem, ForEachItem, IfItem, MappingTree } from '../../models/datamapper/mapping';
 import {
   AbstractFieldNodeData,
+  AddMappingNodeData,
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
+  MappingNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
@@ -19,6 +21,7 @@ import { getFieldSubstitutionXsd, TestUtil } from '../../stubs/datamapper/data-m
 import { QName } from '../../xml-schema-ts/QName';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
+import { MappingService } from '../mapping/mapping.service';
 import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 import { VisualizationUtilService } from './visualization-util.service';
@@ -562,6 +565,102 @@ describe('VisualizationService / abstract fields', () => {
     });
   });
 
+  describe('S11: maxOccurs>1 collection rendering at parent level', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField([
+        { name: 'Cat', children: [{ name: 'catName' }] },
+        { name: 'Dog' },
+        { name: 'Fish' },
+        { name: 'Kitten' },
+      ]);
+      abstractField.maxOccurs = 'unbounded';
+    });
+
+    function generateFreshParentChildren(localTree: MappingTree) {
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+      if (localTree.children.length > 0) {
+        freshParentNode.mapping = localTree.children[0] as FieldItem;
+      }
+      return VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+    }
+
+    it('maxOccurs>1 with one mapped member renders FieldItemNodeData + AddMappingNodeData at parent level', () => {
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      const parentFieldItem = new FieldItem(tree, parentField as (typeof targetDoc.fields)[0]);
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      parentFieldItem.children.push(catFieldItem);
+      tree.children.push(parentFieldItem);
+
+      const children = generateFreshParentChildren(tree);
+      expect(children).toHaveLength(2);
+      expect(children[0]).toBeInstanceOf(FieldItemNodeData);
+      expect(children[0].title).toBe('Cat');
+      expect((children[0] as FieldItemNodeData).wrapperField).toBe(abstractField);
+      expect(children[1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('maxOccurs>1 with multiple mapped members renders only those + AddMappingNodeData', () => {
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      const parentFieldItem = new FieldItem(tree, parentField as (typeof targetDoc.fields)[0]);
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      const fishFieldItem = new FieldItem(parentFieldItem, abstractField.fields[2]);
+      parentFieldItem.children.push(catFieldItem, fishFieldItem);
+      tree.children.push(parentFieldItem);
+
+      const children = generateFreshParentChildren(tree);
+      const childNames = children.filter((c) => c instanceof FieldItemNodeData).map((c) => c.title);
+      expect(childNames).toContain('Cat');
+      expect(childNames).toContain('Fish');
+      expect(childNames).not.toContain('Dog');
+      expect(childNames).not.toContain('Kitten');
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('maxOccurs>1 with no mapped members renders bare wrapper (initial state)', () => {
+      const children = generateFreshParentChildren(tree);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(TargetAbstractFieldNodeData);
+    });
+
+    it('maxOccurs=1 without mapping should return wrapper node with no children (unconfigured target)', () => {
+      abstractField.maxOccurs = 1;
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      const localTargetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const parentFieldNode = new TargetFieldNodeData(localTargetDocNode, parentField as (typeof targetDoc.fields)[0]);
+      const parentChildren = VisualizationService.generateNonDocumentNodeDataChildren(parentFieldNode);
+      expect(parentChildren).toHaveLength(1);
+      expect(parentChildren[0]).toBeInstanceOf(TargetAbstractFieldNodeData);
+      const abstractNode = parentChildren[0] as TargetAbstractFieldNodeData;
+      const abstractChildren = VisualizationService.generateNonDocumentNodeDataChildren(abstractNode);
+      expect(abstractChildren).toHaveLength(0);
+    });
+
+    it('source-side maxOccurs>1 should still return all candidates', () => {
+      const sourceAbstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }]);
+      sourceAbstractField.maxOccurs = 'unbounded';
+      const abstractNode = new AbstractFieldNodeData(sourceDocNode, sourceAbstractField);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(abstractNode);
+      expect(children).toHaveLength(3);
+      expect(children.map((c) => c.title)).toEqual(['Cat', 'Dog', 'Fish']);
+    });
+  });
+
   describe('mapping through selected target abstract wrapper', () => {
     it('engageMapping to a selected abstract candidate creates FieldItem for the candidate', () => {
       const abstractField = createMockAbstractField(
@@ -626,6 +725,311 @@ describe('VisualizationService / abstract fields', () => {
 
       const candidateChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshAbstractNode);
       expect(candidateChildren.map((c) => c.title)).toEqual(['catName']);
+    });
+  });
+
+  describe('maxOccurs>1 per-instance from the start', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField(
+        [{ name: 'Cat', children: [{ name: 'catName' }] }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
+      abstractField.maxOccurs = 'unbounded';
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      parentFieldItem.children.push(catFieldItem);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should show per-instance FieldItems with wrapperField at parent level', () => {
+      const duplicateFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      duplicateFieldItem.isUserCreated = true;
+      parentFieldItem.children.push(duplicateFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const catChildren = children.filter((c) => c.title === 'Cat');
+      expect(catChildren).toHaveLength(2);
+      for (const child of catChildren) {
+        expect(child).toBeInstanceOf(FieldItemNodeData);
+        expect((child as FieldItemNodeData).wrapperField).toBe(abstractField);
+      }
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+  });
+
+  describe('wrapper-pointing FieldItem shown as unsubstituted instance', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField([{ name: 'Cat', children: [{ name: 'catName' }] }, { name: 'Dog' }]);
+      abstractField.maxOccurs = 'unbounded';
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should show both substituted FieldItem and unsubstituted wrapper instance at parent level', () => {
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      parentFieldItem.children.push(catFieldItem);
+
+      const wrapperFieldItem = new FieldItem(parentFieldItem, abstractField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const fieldItemChildren = children.filter((c) => c instanceof FieldItemNodeData);
+      expect(fieldItemChildren).toHaveLength(2);
+
+      const catChild = fieldItemChildren.find((c) => c.title === 'Cat');
+      expect(catChild).toBeInstanceOf(FieldItemNodeData);
+      expect((catChild as FieldItemNodeData).mapping.field.name).toBe('Cat');
+      expect((catChild as FieldItemNodeData).wrapperField).toBe(abstractField);
+
+      const wrapperChild = fieldItemChildren.find((c) => c.title === 'AbstractElement');
+      expect(wrapperChild).toBeInstanceOf(FieldItemNodeData);
+      expect((wrapperChild as FieldItemNodeData).mapping.field).toBe(abstractField);
+      expect((wrapperChild as FieldItemNodeData).wrapperField).toBe(abstractField);
+
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('unsubstituted instance should have parent field node as parent', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, abstractField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const wrapperChild = children.find((c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'abstract');
+      expect(wrapperChild).toBeDefined();
+      expect((wrapperChild as FieldItemNodeData).parent).toBe(freshParentNode);
+    });
+
+    it('wrapper-pointing FieldItem appears alongside substituted members', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, abstractField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const fieldItemChildren = children.filter((c) => c instanceof FieldItemNodeData);
+      expect(fieldItemChildren).toHaveLength(1);
+      expect((fieldItemChildren[0] as FieldItemNodeData).field).toBe(abstractField);
+    });
+  });
+
+  describe('Bug regression: wrap-with-if on substituted abstract member', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField(
+        [{ name: 'Cat', children: [{ name: 'catName' }] }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      parentFieldItem.children.push(catFieldItem);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should not produce ghost TargetAbstractFieldNodeData after wrapping a substituted member with if', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithIf(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const ghostNodes = children.filter((c) => c instanceof TargetAbstractFieldNodeData);
+      expect(ghostNodes).toHaveLength(0);
+    });
+
+    it('FieldItemNodeData inside IfItem should have wrapperField set', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithIf(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const ifNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof IfItem);
+      expect(ifNode).toBeDefined();
+
+      const ifChildren = VisualizationService.generateNonDocumentNodeDataChildren(ifNode!);
+      const catNode = ifChildren.find((c) => c instanceof FieldItemNodeData && c.title === 'Cat') as FieldItemNodeData;
+      expect(catNode).toBeDefined();
+      expect(catNode.wrapperField).toBe(abstractField);
+      expect(VisualizationUtilService.isAbstractWrapperMember(catNode)).toBe(true);
+    });
+  });
+
+  describe('Bug regression: duplicate on unsubstituted abstract wrapper', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField([
+        { name: 'Cat', children: [{ name: 'catName' }] },
+        { name: 'Dog' },
+        { name: 'Fish' },
+        { name: 'Kitten' },
+      ]);
+      abstractField.maxOccurs = 'unbounded';
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('createNodeTitle should return candidate list label for unsubstituted FieldItemNodeData', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, abstractField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const wrapperNode = children.find(
+        (c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'abstract',
+      ) as FieldItemNodeData;
+      expect(wrapperNode).toBeDefined();
+      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('(Cat | Dog | Fish | +1 more)');
+    });
+
+    it('createNodeTitle should return candidate list label for AddMappingNodeData with abstract wrapper field', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, abstractField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const addNode = children.find((c) => c instanceof AddMappingNodeData) as AddMappingNodeData;
+      expect(addNode).toBeDefined();
+      expect(VisualizationService.createNodeTitle(addNode)).toBe('(Cat | Dog | Fish | +1 more)');
+    });
+  });
+
+  describe('Bug regression: wrap-with-for-each on substituted abstract member (maxOccurs>1)', () => {
+    let abstractField: ReturnType<typeof createMockAbstractField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      abstractField = createMockAbstractField(
+        [{ name: 'Cat', children: [{ name: 'catName' }] }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
+      abstractField.maxOccurs = 'unbounded';
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [abstractField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const catFieldItem = new FieldItem(parentFieldItem, abstractField.fields[0]);
+      parentFieldItem.children.push(catFieldItem);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should not produce ghost TargetAbstractFieldNodeData after wrapping with for-each', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const ghostNodes = children.filter((c) => c instanceof TargetAbstractFieldNodeData);
+      expect(ghostNodes).toHaveLength(0);
+    });
+
+    it('should show MappingNodeData for ForEachItem', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const forEachNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof ForEachItem);
+      expect(forEachNode).toBeDefined();
+    });
+
+    it('should show AddMappingNodeData as last child', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('FieldItemNodeData inside ForEachItem should have wrapperField set', () => {
+      const catFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(catFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const forEachNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof ForEachItem);
+      expect(forEachNode).toBeDefined();
+
+      const forEachChildren = VisualizationService.generateNonDocumentNodeDataChildren(forEachNode!);
+      const catNode = forEachChildren.find(
+        (c) => c instanceof FieldItemNodeData && c.title === 'Cat',
+      ) as FieldItemNodeData;
+      expect(catNode).toBeDefined();
+      expect(catNode.wrapperField).toBe(abstractField);
+      expect(VisualizationUtilService.isAbstractWrapperMember(catNode)).toBe(true);
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.choice.test.ts
@@ -8,25 +8,32 @@ import {
   ChooseItem,
   FieldItem,
   ForEachItem,
+  IfItem,
   MappingTree,
   OtherwiseItem,
   ValueSelector,
 } from '../../models/datamapper/mapping';
 import {
+  AbstractFieldNodeData,
+  AddMappingNodeData,
   ChoiceFieldNodeData,
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
+  MappingNodeData,
+  TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
   TargetNodeData,
 } from '../../models/datamapper/visualization';
 import { getTestDocumentXsd, TestUtil } from '../../stubs/datamapper/data-mapper';
-import { ChoiceSelectionService } from '../document/choice-selection.service';
+import { QName } from '../../xml-schema-ts/QName';
 import { DocumentService } from '../document/document.service';
+import { WrapperSelectionService } from '../document/wrapper-selection.service';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
+import { MappingService } from '../mapping/mapping.service';
 import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 import { VisualizationUtilService } from './visualization-util.service';
@@ -504,6 +511,100 @@ describe('VisualizationService / choice fields', () => {
       expect(outerMembers).toHaveLength(2);
       expect(outerMembers[0]).toBeInstanceOf(ChoiceFieldNodeData);
       expect(outerMembers[1].title).toBe('regularField');
+    });
+  });
+
+  describe('choice with abstract member', () => {
+    function createChoiceWithAbstractMember(outerSelectedIndex?: number, innerSelectedQName?: QName) {
+      const baseField = sourceDoc.fields[0];
+      const abstractCandidates = [
+        { ...baseField, name: 'Email', displayName: 'Email', fields: [] },
+        { ...baseField, name: 'SMS', displayName: 'SMS', fields: [] },
+      ];
+      const abstractMember = {
+        ...baseField,
+        name: 'AbstractMessage',
+        displayName: 'AbstractMessage',
+        wrapperKind: 'abstract' as const,
+        selectedMemberQName: innerSelectedQName,
+        fields: abstractCandidates,
+      };
+      const regularMember = {
+        ...baseField,
+        name: 'Webhook',
+        displayName: 'Webhook',
+        fields: [],
+      };
+      const outerChoice = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        selectedMemberIndex: outerSelectedIndex,
+        fields: [abstractMember, regularMember],
+      } as unknown as typeof baseField;
+      return { outerChoice, abstractMember, regularMember, abstractCandidates };
+    }
+
+    it('selecting abstract member without substitution should create AbstractFieldNodeData', () => {
+      const { outerChoice } = createChoiceWithAbstractMember(0);
+      const parentField = { ...sourceDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(children[0]).not.toBeInstanceOf(ChoiceFieldNodeData);
+      const abstractNode = children[0] as AbstractFieldNodeData;
+      expect(abstractNode.abstractField).toBeUndefined();
+      expect(abstractNode.title).toBe('AbstractMessage');
+    });
+
+    it('target side: selecting abstract member without substitution should create TargetAbstractFieldNodeData', () => {
+      const { outerChoice } = createChoiceWithAbstractMember(0);
+      const parentField = { ...targetDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new TargetFieldNodeData(targetDocNode, parentField as (typeof targetDoc.fields)[0]);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(TargetAbstractFieldNodeData);
+      expect(children[0]).not.toBeInstanceOf(TargetChoiceFieldNodeData);
+      const abstractNode = children[0] as TargetAbstractFieldNodeData;
+      expect(abstractNode.abstractField).toBeUndefined();
+    });
+
+    it('selecting abstract member with substitution should create AbstractFieldNodeData with abstractField set', () => {
+      const { outerChoice, abstractMember } = createChoiceWithAbstractMember(
+        0,
+        new QName('io.kaoto.datamapper.poc.test', 'Email'),
+      );
+      const parentField = { ...sourceDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(children[0].title).toBe('Email');
+      expect((children[0] as AbstractFieldNodeData).abstractField).toBe(abstractMember);
+    });
+
+    it('clearing substitution should revert to AbstractFieldNodeData without abstractField', () => {
+      const { outerChoice, abstractMember } = createChoiceWithAbstractMember(
+        0,
+        new QName('io.kaoto.datamapper.poc.test', 'Email'),
+      );
+      const parentField = { ...sourceDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+
+      const before = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(before[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(before[0].title).toBe('Email');
+
+      abstractMember.selectedMemberQName = undefined;
+
+      const after = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(after).toHaveLength(1);
+      expect(after[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(after[0]).not.toBeInstanceOf(ChoiceFieldNodeData);
+      expect((after[0] as AbstractFieldNodeData).abstractField).toBeUndefined();
+      expect(after[0].title).toBe('AbstractMessage');
     });
   });
 
@@ -1173,7 +1274,7 @@ describe('VisualizationService / choice fields', () => {
       // Simulate user selecting inner choice A (index 0) via context menu
       const outerChoiceField = outerChoiceNode.field;
       const nsMap = testTree.namespaceMap;
-      ChoiceSelectionService.setChoiceSelection(testTargetDoc, outerChoiceField, 0, nsMap);
+      WrapperSelectionService.setChoiceSelection(testTargetDoc, outerChoiceField, 0, nsMap);
 
       // Re-render from scratch
       const freshDocNode = new TargetDocumentNodeData(testTargetDoc, testTree);
@@ -1198,6 +1299,262 @@ describe('VisualizationService / choice fields', () => {
       // Inner choice children should be hidden (unconfigured target wrapper)
       const innerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
       expect(innerChoiceChildren).toHaveLength(0);
+    });
+  });
+
+  describe('maxOccurs>1 per-instance from the start', () => {
+    let choiceField: ReturnType<typeof createMockChoiceField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], undefined, 'unbounded');
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [choiceField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      parentFieldItem.children.push(emailFieldItem);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should show per-instance FieldItems with wrapperField at parent level', () => {
+      const duplicateFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      duplicateFieldItem.isUserCreated = true;
+      parentFieldItem.children.push(duplicateFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const emailChildren = children.filter((c) => c.title === 'email');
+      expect(emailChildren).toHaveLength(2);
+      for (const child of emailChildren) {
+        expect(child).toBeInstanceOf(FieldItemNodeData);
+        expect((child as FieldItemNodeData).wrapperField).toBe(choiceField);
+      }
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+  });
+
+  describe('wrapper-pointing FieldItem shown as unsubstituted choice instance', () => {
+    let choiceField: ReturnType<typeof createMockChoiceField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], undefined, 'unbounded');
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [choiceField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should show both selected member FieldItem and unsubstituted wrapper instance at parent level', () => {
+      const emailFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      parentFieldItem.children.push(emailFieldItem);
+
+      const wrapperFieldItem = new FieldItem(parentFieldItem, choiceField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const fieldItemChildren = children.filter((c) => c instanceof FieldItemNodeData);
+      expect(fieldItemChildren).toHaveLength(2);
+
+      const emailChild = fieldItemChildren.find((c) => c.title === 'email');
+      expect(emailChild).toBeInstanceOf(FieldItemNodeData);
+      expect((emailChild as FieldItemNodeData).mapping.field.name).toBe('email');
+      expect((emailChild as FieldItemNodeData).wrapperField).toBe(choiceField);
+
+      const wrapperChild = fieldItemChildren.find((c) => c.title === 'choice');
+      expect(wrapperChild).toBeInstanceOf(FieldItemNodeData);
+      expect((wrapperChild as FieldItemNodeData).mapping.field).toBe(choiceField);
+      expect((wrapperChild as FieldItemNodeData).wrapperField).toBe(choiceField);
+
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('unsubstituted instance should have parent field node as parent', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, choiceField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const wrapperChild = children.find((c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'choice');
+      expect(wrapperChild).toBeDefined();
+      expect((wrapperChild as FieldItemNodeData).parent).toBe(freshParentNode);
+    });
+
+    it('createNodeTitle should return pipe-connected label for unselected FieldItemNodeData on choice wrapper', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, choiceField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const wrapperNode = children.find(
+        (c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'choice',
+      ) as FieldItemNodeData;
+      expect(wrapperNode).toBeDefined();
+      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('(email | phone)');
+    });
+
+    it('createNodeTitle should return pipe-connected label for AddMappingNodeData on choice wrapper', () => {
+      const wrapperFieldItem = new FieldItem(parentFieldItem, choiceField);
+      parentFieldItem.children.push(wrapperFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const addNode = children.find((c) => c instanceof AddMappingNodeData) as AddMappingNodeData;
+      expect(addNode).toBeDefined();
+      expect(VisualizationService.createNodeTitle(addNode)).toBe('(email | phone)');
+    });
+  });
+
+  describe('Bug regression: wrap-with-for-each on choice member (maxOccurs>1)', () => {
+    let choiceField: ReturnType<typeof createMockChoiceField>;
+    let parentFieldItem: FieldItem;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], undefined, 'unbounded');
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [choiceField],
+      };
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      parentFieldItem.children.push(emailFieldItem);
+      localTree.children.push(parentFieldItem);
+    });
+
+    it('should not produce ghost TargetChoiceFieldNodeData after wrapping with for-each', () => {
+      const emailFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(emailFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const ghostNodes = children.filter((c) => c instanceof TargetChoiceFieldNodeData);
+      expect(ghostNodes).toHaveLength(0);
+    });
+
+    it('should show MappingNodeData for ForEachItem', () => {
+      const emailFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(emailFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const forEachNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof ForEachItem);
+      expect(forEachNode).toBeDefined();
+    });
+
+    it('should show AddMappingNodeData as last child', () => {
+      const emailFieldItem = parentFieldItem.children[0] as FieldItem;
+      MappingService.wrapWithForEach(emailFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+  });
+
+  describe('Bug regression: root-level IfItem wrapping choice member', () => {
+    let choiceField: ReturnType<typeof createMockChoiceField>;
+    let localTree: MappingTree;
+
+    beforeEach(() => {
+      choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], undefined, 'unbounded');
+      const ownerDoc = choiceField.ownerDocument;
+      ownerDoc.fields.push(choiceField);
+      localTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+    });
+
+    afterEach(() => {
+      const ownerDoc = choiceField.ownerDocument;
+      ownerDoc.fields.pop();
+    });
+
+    it('FieldItemNodeData inside root-level IfItem should have wrapperField set', () => {
+      const emailFieldItem = new FieldItem(localTree, choiceField.fields[0]);
+      localTree.children.push(emailFieldItem);
+      MappingService.wrapWithIf(emailFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const children = VisualizationService.generateStructuredDocumentChildren(freshTargetDocNode);
+      const ifNode = children.find((c) => c instanceof MappingNodeData && c.mapping instanceof IfItem);
+      expect(ifNode).toBeDefined();
+
+      const ifChildren = VisualizationService.generateNonDocumentNodeDataChildren(ifNode!);
+      const emailNode = ifChildren.find(
+        (c) => c instanceof FieldItemNodeData && c.title === 'email',
+      ) as FieldItemNodeData;
+      expect(emailNode).toBeDefined();
+      expect(emailNode.wrapperField).toBe(choiceField);
+    });
+  });
+
+  describe('Bug regression: shared InstructionItem across sibling collection wrappers', () => {
+    it('should render InstructionItem only once when it spans two sibling wrappers', () => {
+      const choiceA = createMockChoiceField([{ name: 'emailA' }], undefined, 'unbounded');
+      const choiceB = createMockChoiceField([{ name: 'emailB' }], undefined, 'unbounded');
+      (choiceB as unknown as Record<string, unknown>).name = '__choice__B';
+      const parentField = {
+        ...targetDoc.fields[0],
+        fields: [choiceA, choiceB],
+      };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      localTree.children.push(parentFieldItem);
+
+      const fieldItemA = new FieldItem(parentFieldItem, choiceA.fields[0]);
+      const fieldItemB = new FieldItem(parentFieldItem, choiceB.fields[0]);
+      parentFieldItem.children.push(fieldItemA);
+      parentFieldItem.children.push(fieldItemB);
+      MappingService.wrapWithIf(fieldItemA);
+      const ifItem = parentFieldItem.children.find((c) => c instanceof IfItem) as IfItem;
+      ifItem.children.push(fieldItemB);
+      fieldItemB.parent = ifItem;
+      parentFieldItem.children = parentFieldItem.children.filter((c) => c !== fieldItemB);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const ifNodes = children.filter((c) => c instanceof MappingNodeData && c.mapping instanceof IfItem);
+      expect(ifNodes).toHaveLength(1);
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -5,6 +5,7 @@ import { IDocument, IField } from '../../models/datamapper/document';
 import {
   FieldItem,
   IExpressionHolder,
+  InstructionItem,
   isExpressionHolder,
   MappingItem,
   MappingParentType,
@@ -44,8 +45,9 @@ interface WrapperSpec {
   createSourceNode: (parent: NodeData, field: IField) => FieldNodeData;
   createTargetNode: (parent: TargetNodeData, field: IField, mapping?: FieldItem) => TargetFieldNodeData;
   setWrapperRef: (node: FieldNodeData, wrapperField: IField) => void;
-  isTargetWrapper: (node: NodeData) => boolean;
+  isTargetInstance: (node: NodeData) => boolean;
   hasWrapperRef: (node: NodeData) => boolean;
+  isUnconfiguredTarget: (node: NodeData, mappings: MappingItem[] | undefined) => boolean;
 }
 
 const CHOICE_WRAPPER: WrapperSpec = {
@@ -54,8 +56,23 @@ const CHOICE_WRAPPER: WrapperSpec = {
   setWrapperRef: (node, wrapperField) => {
     (node as ChoiceFieldNodeData | TargetChoiceFieldNodeData).choiceField = wrapperField;
   },
-  isTargetWrapper: (node) => node instanceof TargetChoiceFieldNodeData,
+  isTargetInstance: (node) => node instanceof TargetChoiceFieldNodeData,
   hasWrapperRef: (node) => !!(node as TargetChoiceFieldNodeData).choiceField,
+  isUnconfiguredTarget: (node, mappings) => {
+    if (node.isSource) return false;
+    if (!(node instanceof TargetChoiceFieldNodeData)) return false;
+    if (node.choiceField && node.mapping instanceof FieldItem) return false;
+    if (!mappings) return true;
+    const wrapperField = node.field;
+    return !mappings.some(
+      (m) =>
+        (m instanceof FieldItem && (m.field === wrapperField || DocumentService.isDescendant(wrapperField, m.field))) ||
+        (m instanceof InstructionItem &&
+          MappingService.getInstructionFields(m).some(
+            (f) => f === wrapperField || DocumentService.isDescendant(wrapperField, f),
+          )),
+    );
+  },
 };
 
 const ABSTRACT_WRAPPER: WrapperSpec = {
@@ -64,16 +81,32 @@ const ABSTRACT_WRAPPER: WrapperSpec = {
   setWrapperRef: (node, wrapperField) => {
     (node as AbstractFieldNodeData | TargetAbstractFieldNodeData).abstractField = wrapperField;
   },
-  isTargetWrapper: (node) => node instanceof TargetAbstractFieldNodeData,
+  isTargetInstance: (node) => node instanceof TargetAbstractFieldNodeData,
   hasWrapperRef: (node) => !!(node as TargetAbstractFieldNodeData).abstractField,
+  isUnconfiguredTarget: (node, mappings) => {
+    if (node.isSource) return false;
+    if (!(node instanceof TargetAbstractFieldNodeData)) return false;
+    if (node.abstractField && node.mapping instanceof FieldItem) return false;
+    if (!mappings) return true;
+    const wrapperField = node.field;
+    return !mappings.some(
+      (m) =>
+        (m instanceof FieldItem && (m.field === wrapperField || DocumentService.isDescendant(wrapperField, m.field))) ||
+        (m instanceof InstructionItem &&
+          MappingService.getInstructionFields(m).some(
+            (f) => f === wrapperField || DocumentService.isDescendant(wrapperField, f),
+          )),
+    );
+  },
 };
 
 const SEQUENCE_WRAPPER: WrapperSpec = {
   createSourceNode: (parent, field) => new SequenceFieldNodeData(parent, field),
   createTargetNode: (parent, field, mapping) => new TargetSequenceFieldNodeData(parent, field, mapping),
   setWrapperRef: () => {},
-  isTargetWrapper: (node) => node instanceof TargetSequenceFieldNodeData,
+  isTargetInstance: (node) => node instanceof TargetSequenceFieldNodeData,
   hasWrapperRef: () => false,
+  isUnconfiguredTarget: () => false,
 };
 
 // Regex patterns for DnD ID generation
@@ -150,12 +183,14 @@ export class VisualizationService {
     field: IField,
     mappings: MappingItem[] | undefined,
     spec: WrapperSpec,
-  ): NodeData {
+  ): NodeData | null {
     const selectedMember = DocumentUtilService.getSelectedMember(field);
 
-    if (selectedMember?.wrapperKind && DocumentUtilService.getSelectedMember(selectedMember) !== undefined) {
+    if (selectedMember?.wrapperKind) {
       const innerSpec = selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
-      return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, innerSpec);
+      if (innerSpec !== spec || DocumentUtilService.getSelectedMember(selectedMember) !== undefined) {
+        return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, innerSpec);
+      }
     }
 
     const nodeField = selectedMember ?? field;
@@ -168,9 +203,44 @@ export class VisualizationService {
     const mappingsForMember =
       selectedMember && mappings ? MappingService.filterMappingsForField(mappings, selectedMember) : [];
     const mapping = mappingsForMember.find((m) => m instanceof FieldItem) as FieldItem;
+    if (mappingsForMember.length > 0 && !mapping) return null;
     const node = spec.createTargetNode(parent as TargetNodeData, nodeField, mapping);
     if (selectedMember) spec.setWrapperRef(node, field);
     return node;
+  }
+
+  private static generateCollectionWrapperNodes(
+    parent: NodeData,
+    field: IField,
+    mappings: MappingItem[],
+    renderedNodes: NodeData[],
+  ): NodeData[] {
+    const wrapperSpec = field.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
+    const wrapperFieldItems = mappings.filter(
+      (m): m is FieldItem =>
+        m instanceof FieldItem && (m.field === field || DocumentService.isDescendant(field, m.field)),
+    );
+    const wrapperInstructionItems = mappings.filter(
+      (m): m is InstructionItem =>
+        m instanceof InstructionItem &&
+        !VisualizationService.isExistingMapping(renderedNodes as TargetNodeData[], m) &&
+        MappingService.getInstructionFields(m).some((f) => f === field || DocumentService.isDescendant(field, f)),
+    );
+    if (wrapperFieldItems.length === 0 && wrapperInstructionItems.length === 0) {
+      const node = VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, wrapperSpec);
+      return node ? [node] : [];
+    }
+    const nodes: NodeData[] = [];
+    const allItems: MappingItem[] = [...wrapperFieldItems, ...wrapperInstructionItems];
+    for (const item of allItems.sort((left, right) => MappingService.sortMappingItem(left, right))) {
+      if (item instanceof FieldItem) {
+        nodes.push(new FieldItemNodeData(parent as TargetNodeData, item, field));
+      } else {
+        nodes.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, item));
+      }
+    }
+    nodes.push(new AddMappingNodeData(parent as TargetNodeData, field));
+    return nodes;
   }
 
   private static doGenerateNodeDataFromFields(
@@ -179,70 +249,112 @@ export class VisualizationService {
     mappings?: MappingItem[],
   ): NodeData[] {
     const answer: NodeData[] = [];
-    if (mappings) {
-      let filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof VariableItem;
-      if (parent.isPrimitive) {
-        filterPriorityMappingItem = (m: MappingItem) =>
-          m instanceof UnknownMappingItem || VisualizationService.isInlineValueSelector(m);
-      }
-      for (const m of mappings.filter(filterPriorityMappingItem)) {
+    VisualizationService.collectPriorityMappings(answer, parent, mappings);
+
+    for (const field of fields) {
+      if (VisualizationService.processWrapperField(answer, parent, field, mappings)) continue;
+      VisualizationService.processRegularField(answer, parent, field, mappings);
+    }
+
+    VisualizationService.collectUnrenderedMappings(answer, parent, mappings);
+    return answer;
+  }
+
+  private static collectPriorityMappings(
+    answer: NodeData[],
+    parent: NodeData,
+    mappings: MappingItem[] | undefined,
+  ): void {
+    if (!mappings) return;
+    let filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof VariableItem;
+    if (parent.isPrimitive) {
+      filterPriorityMappingItem = (m: MappingItem) =>
+        m instanceof UnknownMappingItem || VisualizationService.isInlineValueSelector(m);
+    }
+    for (const m of mappings.filter(filterPriorityMappingItem)) {
+      answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m));
+    }
+  }
+
+  private static processRegularField(
+    answer: NodeData[],
+    parent: NodeData,
+    field: IField,
+    mappings: MappingItem[] | undefined,
+  ): void {
+    const mappingsForField = mappings ? MappingService.filterMappingsForField(mappings, field) : [];
+    if (mappingsForField.length === 0) {
+      const fieldNodeData = parent.isSource
+        ? new FieldNodeData(parent, field)
+        : new TargetFieldNodeData(parent as TargetNodeData, field);
+      answer.push(fieldNodeData);
+      return;
+    }
+    for (const mapping of mappingsForField
+      .filter((mapping) => !VisualizationService.isExistingMapping(answer as TargetNodeData[], mapping))
+      .sort((left, right) => MappingService.sortMappingItem(left, right))) {
+      answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, mapping));
+    }
+    if (DocumentService.isCollectionField(field)) {
+      answer.push(new AddMappingNodeData(parent as TargetNodeData, field));
+    }
+  }
+
+  private static collectUnrenderedMappings(
+    answer: NodeData[],
+    parent: NodeData,
+    mappings: MappingItem[] | undefined,
+  ): void {
+    if (!mappings || VisualizationService.isUnconfiguredTargetWrapper(parent, mappings)) return;
+    const rendered = new Set(answer.filter((n): n is TargetNodeData => 'mapping' in n).map((n) => n.mapping));
+    for (const m of mappings) {
+      if (
+        !rendered.has(m) &&
+        !(m instanceof FieldItem) &&
+        !VisualizationService.isInlineValueSelector(m) &&
+        !(m instanceof VariableItem) &&
+        !(m instanceof UnknownMappingItem)
+      ) {
         answer.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m));
       }
     }
-
-    const result = fields.reduce((acc, field) => {
-      if (field.wrapperKind === 'choice') {
-        acc.push(VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, CHOICE_WRAPPER));
-        return acc;
-      }
-      if (field.wrapperKind === 'abstract') {
-        acc.push(VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, ABSTRACT_WRAPPER));
-        return acc;
-      }
-      if (field.wrapperKind === 'sequence') {
-        acc.push(VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, SEQUENCE_WRAPPER));
-        return acc;
-      }
-
-      const mappingsForField = mappings ? MappingService.filterMappingsForField(mappings, field) : [];
-      if (mappingsForField.length === 0) {
-        const fieldNodeData = parent.isSource
-          ? new FieldNodeData(parent, field)
-          : new TargetFieldNodeData(parent as TargetNodeData, field);
-        acc.push(fieldNodeData);
-      } else {
-        for (const mapping of mappingsForField
-          .filter((mapping) => !VisualizationService.isExistingMapping(acc as TargetNodeData[], mapping))
-          .sort((left, right) => MappingService.sortMappingItem(left, right))) {
-          acc.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, mapping));
-        }
-        if (DocumentService.isCollectionField(field)) {
-          acc.push(new AddMappingNodeData(parent as TargetNodeData, field));
-        }
-      }
-      return acc;
-    }, answer);
-
-    if (mappings && !VisualizationService.isUnconfiguredTargetWrapper(parent, mappings)) {
-      const rendered = new Set(result.filter((n): n is TargetNodeData => 'mapping' in n).map((n) => n.mapping));
-      for (const m of mappings) {
-        if (
-          !rendered.has(m) &&
-          !(m instanceof FieldItem) &&
-          !VisualizationService.isInlineValueSelector(m) &&
-          !(m instanceof VariableItem) &&
-          !(m instanceof UnknownMappingItem)
-        ) {
-          result.push(VisualizationService.createNodeDataFromMappingItem(parent as TargetNodeData, m));
-        }
-      }
-    }
-
-    return result;
   }
 
   private static isExistingMapping(nodes: TargetNodeData[], mapping: MappingItem) {
     return nodes.some((node) => 'mapping' in node && node.mapping === mapping);
+  }
+
+  private static processWrapperField(
+    answer: NodeData[],
+    parent: NodeData,
+    field: IField,
+    mappings: MappingItem[] | undefined,
+  ): boolean {
+    if (
+      (field.wrapperKind === 'choice' || field.wrapperKind === 'abstract') &&
+      field.maxOccurs !== 1 &&
+      !parent.isSource &&
+      mappings
+    ) {
+      answer.push(...VisualizationService.generateCollectionWrapperNodes(parent, field, mappings, answer));
+      return true;
+    }
+    if (field.wrapperKind === 'choice') {
+      const node = VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, CHOICE_WRAPPER);
+      if (node) answer.push(node);
+      return true;
+    }
+    if (field.wrapperKind === 'abstract') {
+      const node = VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, ABSTRACT_WRAPPER);
+      if (node) answer.push(node);
+      return true;
+    }
+    if (field.wrapperKind === 'sequence') {
+      const node = VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, SEQUENCE_WRAPPER);
+      if (node) answer.push(node);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -270,32 +382,8 @@ export class VisualizationService {
     return selectedMember ? [field] : field.fields;
   }
 
-  /**
-   * Returns `true` when a target-side wrapper has no FieldItem anywhere in
-   * the resolved mappings. The gate hides wrapper children until the user
-   * picks a substitute/member via the context menu or a mapping is created
-   * through the wrapper.
-   *
-   * Checks for ANY FieldItem (not just direct-child references) because
-   * `getOrCreateFieldItem` skips unselected wrappers — a FieldItem for a
-   * nested descendant (e.g. choice→choice→field) appears as a sibling in
-   * the mapping parent, not under the wrapper itself.
-   */
   private static isUnconfiguredTargetWrapper(parent: NodeData, mappings: MappingItem[] | undefined): boolean {
-    if (parent.isSource) return false;
-    if (!VisualizationService.isTargetWrapper(parent)) return false;
-    if (!mappings) return true;
-    const wrapperField = (parent as TargetFieldNodeData).field;
-    return !mappings.some(
-      (m) =>
-        m instanceof FieldItem && (m.field === wrapperField || DocumentService.isDescendant(wrapperField, m.field)),
-    );
-  }
-
-  private static isTargetWrapper(node: NodeData): boolean {
-    if (node instanceof TargetChoiceFieldNodeData) return node.field.wrapperKind === 'choice';
-    if (node instanceof TargetAbstractFieldNodeData) return node.field.wrapperKind === 'abstract';
-    return false;
+    return VisualizationService.resolveWrapperSpec(parent)?.spec.isUnconfiguredTarget(parent, mappings) ?? false;
   }
 
   private static resolveWrapperSpec(node: NodeData): { node: FieldNodeData; spec: WrapperSpec } | null {
@@ -312,11 +400,11 @@ export class VisualizationService {
    * wrappers to find the nearest real ancestor that carries mapping children.
    */
   private static resolveWrapperNodeMappings(parent: NodeData, spec: WrapperSpec): MappingItem[] | undefined {
-    if (!spec.isTargetWrapper(parent) || spec.hasWrapperRef(parent)) {
+    if (!spec.isTargetInstance(parent) || spec.hasWrapperRef(parent)) {
       return 'mapping' in parent ? (parent as TargetNodeData).mapping?.children : undefined;
     }
     let ancestor: TargetNodeData = (parent as TargetFieldNodeData).parent;
-    while (VisualizationService.isTargetWrapper(ancestor)) {
+    while (VisualizationService.resolveWrapperSpec(ancestor)?.spec.isTargetInstance(ancestor)) {
       ancestor = (ancestor as TargetFieldNodeData).parent;
     }
     return ancestor.mapping?.children;
@@ -329,16 +417,14 @@ export class VisualizationService {
    * @returns An array of child {@link NodeData} instances.
    */
   static generateNonDocumentNodeDataChildren(parent: NodeData): NodeData[] {
+    if (parent instanceof FieldItemNodeData && parent.wrapperField && parent.field === parent.wrapperField) return [];
     const wrapperMatch = VisualizationService.resolveWrapperSpec(parent);
     if (wrapperMatch) {
       const { node, spec } = wrapperMatch;
       const mappings = VisualizationService.resolveWrapperNodeMappings(node, spec);
       if (VisualizationService.isUnconfiguredTargetWrapper(node, mappings)) return [];
-      return VisualizationService.doGenerateNodeDataFromFields(
-        node,
-        VisualizationService.resolveWrapperNodeFields(node.field),
-        mappings,
-      );
+      const fields = VisualizationService.resolveWrapperNodeFields(node.field);
+      return VisualizationService.doGenerateNodeDataFromFields(node, fields, mappings);
     }
     if (parent instanceof SequenceFieldNodeData || parent instanceof TargetSequenceFieldNodeData) {
       return VisualizationService.doGenerateNodeDataFromFields(
@@ -363,8 +449,35 @@ export class VisualizationService {
     return [];
   }
 
+  private static findWrapperFieldForFieldItem(fieldItem: FieldItem): IField | undefined {
+    let current: MappingParentType = fieldItem.parent;
+    while (current instanceof InstructionItem) {
+      current = current.parent;
+    }
+    let fieldsToSearch: IField[];
+    if (current instanceof FieldItem) {
+      fieldsToSearch = current.field.fields;
+    } else if (current instanceof MappingTree) {
+      fieldsToSearch = fieldItem.field.ownerDocument.fields;
+    } else {
+      return undefined;
+    }
+    for (const child of fieldsToSearch) {
+      if (
+        (child.wrapperKind === 'abstract' || child.wrapperKind === 'choice') &&
+        (child === fieldItem.field || DocumentService.isDescendant(child, fieldItem.field))
+      ) {
+        return child;
+      }
+    }
+    return undefined;
+  }
+
   private static createNodeDataFromMappingItem(parent: TargetNodeData, mapping: MappingItem): MappingNodeData {
-    if (mapping instanceof FieldItem) return new FieldItemNodeData(parent, mapping);
+    if (mapping instanceof FieldItem) {
+      const wrapperField = VisualizationService.findWrapperFieldForFieldItem(mapping);
+      return new FieldItemNodeData(parent, mapping, wrapperField);
+    }
     if (mapping instanceof UnknownMappingItem) return new UnknownMappingNodeData(parent, mapping);
     if (mapping instanceof VariableItem) return new VariableNodeData(parent, mapping);
     return new MappingNodeData(parent, mapping);
@@ -383,16 +496,18 @@ export class VisualizationService {
       if (isPrimitiveDocumentWithConditionItem) return true;
     }
     if (nodeData instanceof FieldNodeData) {
-      if (VisualizationService.isTargetWrapper(nodeData)) {
+      if (VisualizationService.resolveWrapperSpec(nodeData)?.spec.isTargetInstance(nodeData)) {
         return (nodeData as TargetFieldNodeData).mapping instanceof FieldItem;
       }
       return DocumentService.hasChildren(nodeData.field);
     }
-    if (nodeData instanceof FieldItemNodeData)
+    if (nodeData instanceof FieldItemNodeData) {
+      if (nodeData.wrapperField && nodeData.field === nodeData.wrapperField) return false;
       return (
         DocumentService.hasChildren(nodeData.field) ||
         nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
       );
+    }
     if (nodeData instanceof MappingNodeData) return nodeData.mapping.children.length > 0;
     return false;
   }
@@ -477,7 +592,11 @@ export class VisualizationService {
    * @param node - The abstract wrapper node whose candidates should be described.
    */
   static getAbstractMemberLabel(node: AbstractFieldNodeData | TargetAbstractFieldNodeData): string {
-    const members = node.field.fields ?? [];
+    return VisualizationService.getAbstractMemberLabelFromField(node.field);
+  }
+
+  private static getAbstractMemberLabelFromField(field: IField): string {
+    const members = field.fields ?? [];
     const labels = members.map((m) => m.displayName ?? m.name);
     if (labels.length === 0) return '(no candidates)';
     const maxVisible = 3;
@@ -509,6 +628,26 @@ export class VisualizationService {
       !nodeData.abstractField
     ) {
       return VisualizationService.getAbstractMemberLabel(nodeData);
+    }
+    if (
+      nodeData instanceof FieldItemNodeData &&
+      nodeData.wrapperField?.wrapperKind === 'abstract' &&
+      nodeData.field === nodeData.wrapperField
+    ) {
+      return VisualizationService.getAbstractMemberLabelFromField(nodeData.wrapperField);
+    }
+    if (nodeData instanceof AddMappingNodeData && nodeData.field.wrapperKind === 'abstract') {
+      return VisualizationService.getAbstractMemberLabelFromField(nodeData.field);
+    }
+    if (
+      nodeData instanceof FieldItemNodeData &&
+      nodeData.wrapperField?.wrapperKind === 'choice' &&
+      nodeData.field === nodeData.wrapperField
+    ) {
+      return VisualizationService.getChoiceMemberLabel(nodeData.wrapperField);
+    }
+    if (nodeData instanceof AddMappingNodeData && nodeData.field.wrapperKind === 'choice') {
+      return VisualizationService.getChoiceMemberLabel(nodeData.field);
     }
     return nodeData.title;
   }

--- a/packages/ui/src/stubs/datamapper/xml/ChoiceWithAbstract.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/ChoiceWithAbstract.xsd
@@ -34,21 +34,71 @@
     </xs:complexContent>
   </xs:complexType>
 
-  <!-- Root element with a choice that includes the abstract element -->
   <xs:element name="Notification">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="id" type="xs:string"/>
-        <xs:choice>
-          <xs:element ref="AbstractMessage"/>
-          <xs:element name="Webhook">
-            <xs:complexType>
-              <xs:sequence>
-                <xs:element name="url" type="xs:string"/>
-              </xs:sequence>
-            </xs:complexType>
-          </xs:element>
-        </xs:choice>
+        <xs:element name="Short">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+              <xs:choice>
+                <xs:element ref="AbstractMessage"/>
+                <xs:element name="Webhook">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="url" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:choice maxOccurs="unbounded">
+                <xs:element ref="AbstractMessage"/>
+                <xs:element name="WebhookMulti">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="url" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Large">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+              <xs:choice>
+                <xs:element ref="AbstractMessage"/>
+                <xs:element name="Webhook" type="xs:string"/>
+                <xs:element name="Push" type="xs:string"/>
+                <xs:element name="Slack" type="xs:string"/>
+                <xs:element name="Teams" type="xs:string"/>
+                <xs:element name="Discord" type="xs:string"/>
+                <xs:element name="Pager" type="xs:string"/>
+                <xs:element name="Fax" type="xs:string"/>
+                <xs:element name="Voice" type="xs:string"/>
+                <xs:element name="Signal" type="xs:string"/>
+                <xs:element name="Telegram" type="xs:string"/>
+                <xs:element name="Matrix" type="xs:string"/>
+              </xs:choice>
+              <xs:choice maxOccurs="unbounded">
+                <xs:element ref="AbstractMessage"/>
+                <xs:element name="WebhookMulti" type="xs:string"/>
+                <xs:element name="PushMulti" type="xs:string"/>
+                <xs:element name="SlackMulti" type="xs:string"/>
+                <xs:element name="TeamsMulti" type="xs:string"/>
+                <xs:element name="DiscordMulti" type="xs:string"/>
+                <xs:element name="PagerMulti" type="xs:string"/>
+                <xs:element name="FaxMulti" type="xs:string"/>
+                <xs:element name="VoiceMulti" type="xs:string"/>
+                <xs:element name="SignalMulti" type="xs:string"/>
+                <xs:element name="TelegramMulti" type="xs:string"/>
+                <xs:element name="MatrixMulti" type="xs:string"/>
+              </xs:choice>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/packages/ui/src/stubs/datamapper/xml/FieldSubstitution.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/FieldSubstitution.xsd
@@ -10,6 +10,26 @@
         <xs:element ref="AbstractLabel"/>
         <xs:element ref="AbstractCount"/>
         <xs:element name="capacity" type="xs:int"/>
+        <xs:element name="Equipment">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Primary">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element ref="AbstractVehicle"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="Options">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element ref="AbstractVehicle" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -108,4 +128,35 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:element name="SmallIntCount" type="SmallInt_t" substitutionGroup="AbstractCount"/>
+
+  <xs:element name="AbstractVehicle" type="Vehicle_t" abstract="true"/>
+  <xs:element name="Car" type="Car_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Truck" type="Truck_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Bus" type="Bus_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Van" type="Van_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Motorcycle" type="Motorcycle_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Bicycle" type="Bicycle_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Scooter" type="Scooter_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Tram" type="Tram_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Ferry" type="Ferry_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Helicopter" type="Helicopter_t" substitutionGroup="AbstractVehicle"/>
+  <xs:element name="Airplane" type="Airplane_t" substitutionGroup="AbstractVehicle"/>
+
+  <xs:complexType name="Vehicle_t">
+    <xs:sequence>
+      <xs:element name="model" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Car_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="doors" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Truck_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="payload" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Bus_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="seats" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Van_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="cargo" type="xs:boolean"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Motorcycle_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="cc" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Bicycle_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="gears" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Scooter_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="electric" type="xs:boolean"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Tram_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="route" type="xs:string"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Ferry_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="capacity" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Helicopter_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="rotors" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+  <xs:complexType name="Airplane_t"><xs:complexContent><xs:extension base="Vehicle_t"><xs:sequence><xs:element name="wingspan" type="xs:int"/></xs:sequence></xs:extension></xs:complexContent></xs:complexType>
+
 </xs:schema>

--- a/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
@@ -158,6 +158,40 @@
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="LargeChoiceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="OptionA" type="xs:string"/>
+                            <xs:element name="OptionB" type="xs:string"/>
+                            <xs:element name="OptionC" type="xs:string"/>
+                            <xs:element name="OptionD" type="xs:string"/>
+                            <xs:element name="OptionE" type="xs:string"/>
+                            <xs:element name="OptionF" type="xs:string"/>
+                            <xs:element name="OptionG" type="xs:string"/>
+                            <xs:element name="OptionH" type="xs:string"/>
+                            <xs:element name="OptionI" type="xs:string"/>
+                            <xs:element name="OptionJ" type="xs:string"/>
+                            <xs:element name="OptionK" type="xs:string"/>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="LargeCollectionChoiceElement">
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="MultiA" type="xs:string"/>
+                            <xs:element name="MultiB" type="xs:string"/>
+                            <xs:element name="MultiC" type="xs:string"/>
+                            <xs:element name="MultiD" type="xs:string"/>
+                            <xs:element name="MultiE" type="xs:string"/>
+                            <xs:element name="MultiF" type="xs:string"/>
+                            <xs:element name="MultiG" type="xs:string"/>
+                            <xs:element name="MultiH" type="xs:string"/>
+                            <xs:element name="MultiI" type="xs:string"/>
+                            <xs:element name="MultiJ" type="xs:string"/>
+                            <xs:element name="MultiK" type="xs:string"/>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="AllElement">
                     <xs:complexType>
                         <xs:all>


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3464

When a wrapper field (abstract or choice) allows multiple instances (maxOccurs>1), the UX now transitions to per-instance mode:

  - Each FieldItem holds an independent member selection, so users can pick different concrete types for each instance (e.g. Car for the first, Truck for the second)
  - Duplicate creates a new instance with its own unsubstituted state rather than cloning the document-level selection
  - Clear-substitution reverts an instance to unsubstituted state within its instruction context, instead of removing the FieldItem entirely
  - Delete is now available for individual wrapper member instances
  - Wrapper member instances display a choice/abstract icon to distinguish them from regular field items

Also refactored MappingActionService by extracting the action registry (which actions are allowed) into MappingActionRegistryService, and promoted shared node-type checks to VisualizationUtilService.

### Abstract

https://github.com/user-attachments/assets/a8caf5c9-6fcd-494e-b911-9fa708e7bf30


### Choice

https://github.com/user-attachments/assets/0d4feb60-d1f2-4000-a460-47d41cfb69f7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary (updated)

* **New Features**
  * Improved per-instance handling for repeating abstract/choice wrapper members, including member-aware selection and modal behavior.
  * Made action availability and context menus more consistent by using a centralized action registry for allowed actions and menu items.

* **Bug Fixes**
  * Prevented orphaned or inconsistent mapping items when clearing substitutions and wrapper-member selections.
  * Preserved user-created mappings during stale-mapping cleanup.
  * Refined visualization and target-path/mapping behavior for nested/repeating abstract/choice wrappers, including proper state restoration when clearing selections in instruction contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->