### PR TITLE
fix(Kamelets): allow clearing Kamelet configuration values

### DIFF
--- a/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
+++ b/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
@@ -230,4 +230,45 @@ describe('updateKameletFromCustomSchema', () => {
     updateKameletFromCustomSchema(inputKameletStruct as unknown as IKameletDefinition, value);
     expect(inputKameletStruct).toMatchSnapshot();
   });
+
+  it('should clear fields when empty string or undefined is provided', () => {
+    const kameletWithValues = cloneDeep(inputKameletStruct);
+
+    // First, verify the kamelet has values
+    expect(kameletWithValues.metadata.annotations['camel.apache.org/kamelet.icon']).toBeDefined();
+    expect(kameletWithValues.metadata.annotations['camel.apache.org/kamelet.namespace']).toBe('default');
+    expect(kameletWithValues.spec.definition.description).toBe('Produces periodic events about random users!');
+
+    // Now update with empty/undefined values
+    const value = {
+      name: 'kamelet',
+      title: 'kamelet-35256',
+      description: '', // Clear description
+      type: 'Source',
+      icon: '', // Clear icon
+      supportLevel: 'Stable',
+      catalogVersion: 'main-SNAPSHOT',
+      provider: 'Apache Software Foundation',
+      group: 'Users',
+      namespace: undefined, // Clear namespace
+      labels: {},
+      annotations: {},
+      kameletProperties: [
+        {
+          name: 'period',
+          default: 5000,
+          description: 'The time interval between two events',
+          title: 'Period',
+          type: 'integer',
+        },
+      ],
+    };
+
+    updateKameletFromCustomSchema(kameletWithValues, value);
+
+    // Verify that empty values are actually set (not kept as previous values)
+    expect(kameletWithValues.spec.definition.description).toBe('');
+    expect(kameletWithValues.metadata.annotations['camel.apache.org/kamelet.icon']).toBe('');
+    expect(kameletWithValues.metadata.annotations['camel.apache.org/kamelet.namespace']).toBeUndefined();
+  });
 });

--- a/packages/ui/src/utils/update-kamelet-from-custom-schema.ts
+++ b/packages/ui/src/utils/update-kamelet-from-custom-schema.ts
@@ -11,6 +11,10 @@ import { getValue } from './get-value';
 import { setValue } from './set-value';
 
 export const updateKameletFromCustomSchema = (kamelet: IKameletDefinition, value: Record<string, unknown>): void => {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
   const previousName = getValue(kamelet, 'metadata.name');
   const previousTitle = getValue(kamelet, 'spec.definition.title');
   const previousDescription = getValue(kamelet, 'spec.definition.description');
@@ -19,9 +23,9 @@ export const updateKameletFromCustomSchema = (kamelet: IKameletDefinition, value
   const newTitle: string = getValue(value, 'title');
   const newDescription: string = getValue(value, 'description');
 
-  setValue(kamelet, 'metadata.name', newName ?? previousName);
-  setValue(kamelet, 'spec.definition.title', newTitle ?? previousTitle);
-  setValue(kamelet, 'spec.definition.description', newDescription ?? previousDescription);
+  setValue(kamelet, 'metadata.name', 'name' in value ? newName : previousName);
+  setValue(kamelet, 'spec.definition.title', 'title' in value ? newTitle : previousTitle);
+  setValue(kamelet, 'spec.definition.description', 'description' in value ? newDescription : previousDescription);
 
   const previousAnnotations = getValue(kamelet, 'metadata.annotations', {} as IKameletMetadataAnnotations);
   const previousIcon = previousAnnotations[KameletKnownAnnotations.Icon];
@@ -39,20 +43,21 @@ export const updateKameletFromCustomSchema = (kamelet: IKameletDefinition, value
   const newNamespace = getValue(value, 'namespace');
 
   const customAnnotations = {
-    [KameletKnownAnnotations.Icon]: newIcon ?? previousIcon,
-    [KameletKnownAnnotations.SupportLevel]: newSupportLevel ?? previousSupportLevel,
-    [KameletKnownAnnotations.CatalogVersion]: newCatalogVersion ?? previousCatalogVersion,
-    [KameletKnownAnnotations.Provider]: newProvider ?? previousProvider,
-    [KameletKnownAnnotations.Group]: newGroup ?? previousGroup,
-    [KameletKnownAnnotations.Namespace]: newNamespace ?? previousNamespace,
+    [KameletKnownAnnotations.Icon]: 'icon' in value ? newIcon : previousIcon,
+    [KameletKnownAnnotations.SupportLevel]: 'supportLevel' in value ? newSupportLevel : previousSupportLevel,
+    [KameletKnownAnnotations.CatalogVersion]: 'catalogVersion' in value ? newCatalogVersion : previousCatalogVersion,
+    [KameletKnownAnnotations.Provider]: 'provider' in value ? newProvider : previousProvider,
+    [KameletKnownAnnotations.Group]: 'group' in value ? newGroup : previousGroup,
+    [KameletKnownAnnotations.Namespace]: 'namespace' in value ? newNamespace : previousNamespace,
   };
 
   const previousType = getValue(kamelet, 'metadata.labels', {} as IKameletMetadataLabels)[KameletKnownLabels.Type];
   const incomingLabels = getValue(value, 'labels', {});
-  const newLabels = Object.assign({}, incomingLabels, {
-    [KameletKnownLabels.Type]: getValue(value, 'type', previousType),
-  });
-  const newAnnotations = Object.assign({}, getValue(value, 'annotations', {}), customAnnotations);
+  const newLabels = {
+    ...incomingLabels,
+    [KameletKnownLabels.Type]: 'type' in value ? getValue(value, 'type') : previousType,
+  };
+  const newAnnotations = { ...getValue(value, 'annotations', {}), ...customAnnotations };
 
   setValue(kamelet, 'metadata.labels', newLabels);
   setValue(kamelet, 'metadata.annotations', newAnnotations);


### PR DESCRIPTION
## Description

Fixes https://github.com/KaotoIO/kaoto/issues/3492

When configuring a Kamelet's root schema, clearing form fields (e.g., icon, namespace, description) was not properly removing the values. The old values were retained instead of being cleared.

## Changes

- Replace nullish coalescing operator (`??`) with `in` operator checks in `updateKameletFromCustomSchema`
- Add guard to validate value object before processing
- Add test coverage for clearing form fields with empty strings and undefined values

## Root Cause

The `??` operator only checks for `null` or `undefined`, not empty strings. When users cleared form fields (setting them to empty strings), the function would fall back to previous values instead of accepting the empty string.

## Solution

Using `'field' in value` checks if the property exists in the value object, allowing empty strings and undefined values to be properly set.

## Testing

- Added new test: "should clear fields when empty string or undefined is provided"
- All 8 tests passing ✓
- Verified that all fields (name, title, description, icon, supportLevel, catalogVersion, provider, group, namespace, type) now properly accept empty strings and undefined values

## Impact

Users can now successfully clear Kamelet configuration fields like icon, namespace, and description by emptying the form fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updates to custom schemas now correctly clear existing Kamelet metadata and descriptive fields when values are explicitly empty or undefined.
  * Custom schema updates no longer preserve outdated names, titles, descriptions, labels, or annotations when replacement values are provided.
  * Invalid or missing schema values are handled safely without applying unintended updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->