### PR TITLE
fix(exports): stop leaking UI components + scss through the `@kaoto/kaoto/models` barrel

### DIFF
--- a/packages/ui/src/models-api.ts
+++ b/packages/ui/src/models-api.ts
@@ -8,4 +8,12 @@ export * from './models/file-types';
 export * from './models/runtime-maven-information';
 export * from './models/settings';
 export * from './models/step-update-action';
-export * from './multiplying-architecture';
+/**
+ * Only re-export the type-safe surface of `./multiplying-architecture` here.
+ * A bare `export * from './multiplying-architecture'` pulls in `KaotoEditorFactory`,
+ * which transitively imports `KaotoEditorApp` (and its `.scss`). Because this barrel is
+ * consumed by non-webview bundles (e.g. the vscode-kaoto extension host / webworker targets
+ * that have no sass-loader), that breaks their build. Keep component/runtime exports out.
+ */
+export type { KaotoEditorChannelApi } from './multiplying-architecture/KaotoEditorChannelApi';
+export type { Suggestion, SuggestionRequestContext } from '@kaoto/forms';


### PR DESCRIPTION
## Motivation

`packages/ui/src/models-api.ts` (the `@kaoto/kaoto/models` subpath) re-exported the entire `multiplying-architecture` barrel via `export * from './multiplying-architecture'`. That barrel exposes `KaotoEditorFactory`, a runtime class that transitively imports `KaotoEditorApp` → `KaotoEditorRouter` → `DataMapperPage`/`KaotoEditor`, which import `.scss`.

This breaks downstream consumers that bundle the `/models` subpath **without** a `sass-loader`. The [vscode-kaoto](https://github.com/KaotoIO/vscode-kaoto) extension's `node` and `webworker` webpack targets now fail with:

```
Module parse failed: Unexpected character '@'
> @use '@carbon/react' with (...)
webpack compiled with 564 errors
```

Because `packages/ui/package.json` declares `sideEffects: ["**/*.css","**/*.scss"]`, these imports cannot be tree-shaken out — any transitive reference forces them into the bundle.

Introduced in `88ccb1bf`.

## Changes

Replace the wildcard re-export with explicit **type-only** re-exports of the surface consumers actually need:

- `KaotoEditorChannelApi` (a pure `interface`)
- `Suggestion`, `SuggestionRequestContext` (type-only, from `@kaoto/forms`)

`export type` is fully erased at compile time, so the emitted `models-api.js` carries no runtime reference to the factory, router, or scss. Component/runtime exports such as `KaotoEditorFactory` remain available on the main `@kaoto/kaoto` entry (`public-api.ts`).

## Verification

- `yarn workspace @kaoto/kaoto run build:lib` — passes; emitted `lib/models-api.js` no longer references `multiplying-architecture`.
- Linked `@kaoto/kaoto` locally into vscode-kaoto and ran `yarn build:prod`: previously **564 errors**, now **compiled successfully, 0 errors**.

Fixes https://github.com/KaotoIO/kaoto/issues/3494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for non-webview builds by preventing unintended runtime and styling dependencies from being included.
  * Preserved access to the supported editor communication and suggestion types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->