### PR TITLE
fix: use metadata.name instead of filename for kamelet indexing

### DIFF
--- a/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.test.ts
+++ b/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.test.ts
@@ -28,7 +28,7 @@ spec:
       const result = await provider.fetchAll();
 
       expect(client).toHaveBeenCalledWith(FileTypes.Kamelets);
-      expect(result['http-source.kamelet.yaml']).toMatchObject({ kind: 'Kamelet', metadata: { name: 'http-source' } });
+      expect(result['http-source']).toMatchObject({ kind: 'Kamelet', metadata: { name: 'http-source' } });
     });
 
     it('should merge embedded kamelets with remote kamelets, remote taking precedence', async () => {
@@ -40,7 +40,7 @@ spec:
       const result = await provider.fetchAll();
 
       expect(result).toHaveProperty('timer-source');
-      expect(result).toHaveProperty('http-source.kamelet.yaml');
+      expect(result).toHaveProperty('http-source');
     });
 
     it('should skip an entry and log an error when YAML parsing fails', async () => {
@@ -67,8 +67,8 @@ spec:
 
       const result = await provider.fetchAll();
 
-      expect(result).toHaveProperty('good.yaml');
-      expect(result).not.toHaveProperty('bad.yaml');
+      expect(result).toHaveProperty('good-kamelet');
+      expect(result).not.toHaveProperty('bad');
       consoleErrorSpy.mockRestore();
     });
 
@@ -79,6 +79,39 @@ spec:
       const result = await provider.fetchAll();
 
       expect(result).toEqual({});
+    });
+
+    it('should skip an entry and log an error when metadata.name is missing', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const yamlWithoutName = 'kind: Kamelet\nmetadata:\n  labels:\n    test: value\n';
+      const client = vi.fn().mockResolvedValue([{ filename: 'no-name.yaml', content: yamlWithoutName }]);
+      const provider = new CamelKameletsProvider({}, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toEqual({});
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error parsing no-name.yaml', expect.any(TypeError));
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should handle null response from client', async () => {
+      const client = vi.fn().mockResolvedValue(null);
+      const embedded = { 'timer-source': { metadata: { name: 'timer-source' } } as IKameletDefinition };
+      const provider = new CamelKameletsProvider(embedded, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toEqual(embedded);
+    });
+
+    it('should handle undefined response from client', async () => {
+      const client = vi.fn().mockResolvedValue(undefined);
+      const embedded = { 'timer-source': { metadata: { name: 'timer-source' } } as IKameletDefinition };
+      const provider = new CamelKameletsProvider(embedded, client);
+
+      const result = await provider.fetchAll();
+
+      expect(result).toEqual(embedded);
     });
   });
 

--- a/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.ts
+++ b/packages/ui/src/dynamic-catalog/providers/camel-kamelets.provider.ts
@@ -24,7 +24,12 @@ export class CamelKameletsProvider implements ICatalogProvider<IKameletDefinitio
       (acc, { filename, content }) => {
         try {
           const remoteKamelet = parse(content) as IKameletDefinition;
-          acc[filename] = remoteKamelet;
+          const name = remoteKamelet.metadata.name;
+          if (!name) {
+            throw new TypeError('Missing `metadata.name` property');
+          }
+
+          acc[name] = remoteKamelet;
         } catch (error) {
           console.error(`Error parsing ${filename}`, error);
         }


### PR DESCRIPTION
## Description

Fixes #3496

The `CamelKameletsProvider` was incorrectly using the filename as the key when indexing remote kamelets, instead of using the kamelet's `metadata.name` property. This could lead to incorrect kamelet lookups and catalog inconsistencies.

## Changes

- ✅ Use `remoteKamelet.metadata.name` as the key for indexing kamelets
- ✅ Add validation to ensure `metadata.name` exists, throwing a TypeError if missing
- ✅ Handle the error gracefully by logging and skipping invalid entries
- ✅ Added comprehensive test coverage to achieve 100% coverage
- ✅ Added tests for edge cases: missing metadata.name, null/undefined client responses

## Test Results

- All 11 tests passing
- Coverage: 100% statements, 100% branches, 100% functions, 100% lines

## Impact

This ensures kamelets are correctly indexed and retrievable by their canonical name, improving reliability of the dynamic catalog system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote kamelet handling by using each kamelet’s defined name for identification.
  * Remote kamelets now correctly replace matching embedded or duplicate entries.
  * Invalid kamelets without a name are skipped safely and logged.
  * Embedded kamelets are preserved when remote data is unavailable or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->