### PR TITLE
fix(mithril): custom mode schema - roleDefinition in a template needs to have some default value

### DIFF
--- a/packages/ui/src/models/camel/camel-resource-factory.test.ts
+++ b/packages/ui/src/models/camel/camel-resource-factory.test.ts
@@ -81,7 +81,7 @@ describe('CamelResourceFactory', () => {
 
     it('returns CustomModeResource for yaml with customModes array (no path)', () => {
       const yaml =
-        'customModes:\n  - slug: plan\n    name: Plan\n    description: ""\n    roleDefinition: ""\n    whenToUse: ""\n    groups: []\n';
+        'customModes:\n  - slug: plan\n    name: Plan\n    description: ""\n    roleDefinition: "You plan things."\n    whenToUse: ""\n    groups: []\n';
       const resource = CamelResourceFactory.createCamelResource(yaml);
       expect(resource).toBeInstanceOf(CustomModeResource);
     });

--- a/packages/ui/src/models/custom-mode/custom-mode-resource-factory.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-resource-factory.test.ts
@@ -4,7 +4,9 @@ import { CustomModeResource } from './custom-mode-resource';
 import { CustomModeResourceFactory } from './custom-mode-resource-factory';
 
 const validFile = {
-  customModes: [{ slug: 'plan', name: 'Plan', description: '', roleDefinition: '', whenToUse: '', groups: [] }],
+  customModes: [
+    { slug: 'plan', name: 'Plan', description: '', roleDefinition: 'You plan things.', whenToUse: '', groups: [] },
+  ],
 };
 
 describe('CustomModeResourceFactory', () => {

--- a/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/custom-mode-schema.service.test.ts
@@ -32,8 +32,10 @@ describe('CustomModeSchemaService', () => {
       );
     });
 
-    it('marks slug and name as required', () => {
-      expect(CustomModeSchemaService.getRootSchema().required).toEqual(expect.arrayContaining(['slug', 'name']));
+    it('marks slug, name and roleDefinition as required', () => {
+      expect(CustomModeSchemaService.getRootSchema().required).toEqual(
+        expect.arrayContaining(['slug', 'name', 'roleDefinition']),
+      );
     });
 
     it('sets x-component textarea on roleDefinition and whenToUse', () => {

--- a/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
+++ b/packages/ui/src/models/visualization/flows/templates/custom-mode.ts
@@ -10,7 +10,7 @@ export const customModeTemplate = (): string => {
   - slug: ${getCamelRandomId('new-mode')}
     name: New Mode
     description: ""
-    roleDefinition: ""
+    roleDefinition: "Defines who this New Mode is"
     whenToUse: ""
     groups:
       - read`;

--- a/packages/ui/src/stubs/bob-catalog/custom-mode-schema.json
+++ b/packages/ui/src/stubs/bob-catalog/custom-mode-schema.json
@@ -38,5 +38,5 @@
       }
     }
   },
-  "required": ["slug", "name"]
+  "required": ["slug", "name", "roleDefinition"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom mode templates now include a descriptive role definition by default.
* **Bug Fixes**
  * Custom mode validation now requires a role definition, helping prevent incomplete mode configurations.
* **Tests**
  * Updated validation and resource tests to reflect the required role definition field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**BEFORE:**

https://github.com/user-attachments/assets/8f365716-b981-40da-9168-f0d341ad465d


**AFTER:**

https://github.com/user-attachments/assets/d6c1416b-497b-4c7d-baad-29364126e7f2


