### PR TITLE
fix(DataMapper): map XSD aliases for field overrides

### DIFF
--- a/packages/ui/src/services/document/field-override.service.test.ts
+++ b/packages/ui/src/services/document/field-override.service.test.ts
@@ -26,6 +26,7 @@ import { XmlSchemaDocument, XmlSchemaField } from './xml-schema/xml-schema-docum
 import { XmlSchemaDocumentService } from './xml-schema/xml-schema-document.service';
 
 const NS_SUBSTITUTION = 'http://www.example.com/SUBSTITUTION';
+const NS_TYPE_MAPPING = 'http://www.example.com/TYPE-MAPPING';
 
 function createSubstitutionDoc() {
   const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test-doc', {
@@ -35,6 +36,46 @@ function createSubstitutionDoc() {
   const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
   if (result.validationStatus !== 'success' || !result.document) {
     throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create substitution test document');
+  }
+  return result.document;
+}
+
+function createSubstitutionZooDoc() {
+  const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test-doc', {
+    'FieldSubstitution.xsd': getFieldSubstitutionXsd(),
+  });
+  definition.rootElementChoice = { namespaceUri: NS_SUBSTITUTION, name: 'Zoo' };
+  const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+  if (result.validationStatus !== 'success' || !result.document) {
+    throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create Zoo test document');
+  }
+  return result.document;
+}
+
+function findFieldByName(fields: IField[], name: string): IField | undefined {
+  for (const field of fields) {
+    if (field.name === name) return field;
+    const nested = findFieldByName(field.fields, name);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+function createTypeMappingDoc(schemaBody: string, rootName: string) {
+  const xsd = `
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+      xmlns:types="${NS_TYPE_MAPPING}"
+      targetNamespace="${NS_TYPE_MAPPING}"
+      elementFormDefault="qualified">
+      ${schemaBody}
+    </xs:schema>`;
+  const definition = new DocumentDefinition(DocumentType.SOURCE_BODY, DocumentDefinitionType.XML_SCHEMA, 'test-doc', {
+    'TypeMapping.xsd': xsd,
+  });
+  definition.rootElementChoice = { namespaceUri: NS_TYPE_MAPPING, name: rootName };
+  const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+  if (result.validationStatus !== 'success' || !result.document) {
+    throw new Error(result.errors?.map((e) => e.message).join('; ') || 'Failed to create type mapping document');
   }
   return result.document;
 }
@@ -61,6 +102,106 @@ function createNoNsSubstitutionDoc() {
 
 describe('FieldOverrideService', () => {
   describe('getSafeOverrideCandidates()', () => {
+    it('should return only xs:int restrictions for the capacity field', () => {
+      const doc = createSubstitutionZooDoc();
+      const capacityField = findFieldByName(doc.fields, 'capacity');
+      if (!capacityField) throw new Error('capacity field not found');
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, sub: NS_SUBSTITUTION };
+      const candidates = FieldOverrideService.getSafeOverrideCandidates(capacityField, namespaceMap);
+
+      expect(capacityField.typeQName?.getLocalPart()).toBe('int');
+      expect(capacityField.type).toBe(Types.Integer);
+      expect(Object.keys(candidates).sort()).toEqual(['sub:PositiveInt_t', 'sub:SmallInt_t']);
+    });
+
+    it('should return only xs:int restrictions for an xs:int attribute', () => {
+      const doc = createTypeMappingDoc(
+        `
+          <xs:simpleType name="PositiveIntAttribute_t">
+            <xs:restriction base="xs:int"><xs:minInclusive value="1"/></xs:restriction>
+          </xs:simpleType>
+          <xs:simpleType name="SmallIntAttribute_t">
+            <xs:restriction base="xs:int"><xs:maxInclusive value="10"/></xs:restriction>
+          </xs:simpleType>
+          <xs:element name="Root">
+            <xs:complexType><xs:attribute name="capacity" type="xs:int"/></xs:complexType>
+          </xs:element>`,
+        'Root',
+      );
+      const capacityField = findFieldByName(doc.fields, 'capacity');
+      if (!capacityField) throw new Error('capacity attribute not found');
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, types: NS_TYPE_MAPPING };
+      const candidates = FieldOverrideService.getSafeOverrideCandidates(capacityField, namespaceMap);
+
+      expect(capacityField.isAttribute).toBe(true);
+      expect(capacityField.type).toBe(Types.Integer);
+      expect(Object.keys(candidates).sort()).toEqual(['types:PositiveIntAttribute_t', 'types:SmallIntAttribute_t']);
+    });
+
+    it('should resolve a named attribute simple type through its xs:int restriction', () => {
+      const doc = createTypeMappingDoc(
+        `
+          <xs:simpleType name="PositiveIntAttribute_t">
+            <xs:restriction base="xs:int"><xs:minInclusive value="1"/></xs:restriction>
+          </xs:simpleType>
+          <xs:element name="Root">
+            <xs:complexType><xs:attribute name="capacity" type="types:PositiveIntAttribute_t"/></xs:complexType>
+          </xs:element>`,
+        'Root',
+      );
+      const capacityField = findFieldByName(doc.fields, 'capacity');
+      if (!capacityField) throw new Error('capacity attribute not found');
+
+      expect(capacityField.isAttribute).toBe(true);
+      expect(capacityField.typeQName?.getLocalPart()).toBe('PositiveIntAttribute_t');
+      expect(capacityField.type).toBe(Types.Integer);
+    });
+
+    it('should keep named list and union fields as AnyType', () => {
+      const doc = createTypeMappingDoc(
+        `
+          <xs:simpleType name="CodeList"><xs:list itemType="xs:string"/></xs:simpleType>
+          <xs:simpleType name="StringOrInt"><xs:union memberTypes="xs:string xs:int"/></xs:simpleType>
+          <xs:element name="Root">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="codes" type="types:CodeList"/>
+                <xs:element name="choice" type="types:StringOrInt"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>`,
+        'Root',
+      );
+      const codesField = findFieldByName(doc.fields, 'codes');
+      const choiceField = findFieldByName(doc.fields, 'choice');
+      if (!codesField || !choiceField) throw new Error('list or union field not found');
+
+      expect(codesField.type).toBe(Types.AnyType);
+      expect(choiceField.type).toBe(Types.AnyType);
+    });
+
+    it('should resolve a user-defined simple type named int through its xs:string restriction', () => {
+      const doc = createTypeMappingDoc(
+        `
+          <xs:simpleType name="int"><xs:restriction base="xs:string"/></xs:simpleType>
+          <xs:complexType name="Unrelated_t"><xs:sequence/></xs:complexType>
+          <xs:element name="Value" type="types:int"/>`,
+        'Value',
+      );
+      const valueField = findFieldByName(doc.fields, 'Value');
+      if (!valueField) throw new Error('Value field not found');
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, types: NS_TYPE_MAPPING };
+      const candidates = FieldOverrideService.getSafeOverrideCandidates(valueField, namespaceMap);
+
+      expect(valueField.typeQName?.getNamespaceURI()).toBe(NS_TYPE_MAPPING);
+      expect(valueField.typeQName?.getLocalPart()).toBe('int');
+      expect(valueField.type).toBe(Types.String);
+      expect(Object.keys(candidates)).toEqual([]);
+    });
+
     it('should return all types for xs:anyType fields', () => {
       const doc = TestUtil.createSourceOrderDoc();
       const anyTypeField = doc.fields[0].fields[0];
@@ -434,6 +575,33 @@ describe('FieldOverrideService', () => {
       expect(stringField.typeOverride).toBe(FieldOverrideVariant.FORCE);
       expect(doc.definition.fieldTypeOverrides).toBeDefined();
       expect(doc.definition.fieldTypeOverrides![0].schemaPath).toBe('/ns0:ShipOrder/ns0:OrderPerson');
+    });
+
+    it('should apply and reload a returned simple restriction as a safe primitive override', () => {
+      const doc = createSubstitutionZooDoc();
+      const capacityField = findFieldByName(doc.fields, 'capacity');
+      if (!capacityField) throw new Error('capacity field not found');
+
+      const namespaceMap = { xs: NS_XML_SCHEMA, sub: NS_SUBSTITUTION };
+      const candidate = FieldOverrideService.getSafeOverrideCandidates(capacityField, namespaceMap)[
+        'sub:PositiveInt_t'
+      ];
+      if (!candidate) throw new Error('PositiveInt_t candidate not found');
+
+      FieldOverrideService.applyFieldTypeOverride(capacityField, candidate, namespaceMap, FieldOverrideVariant.SAFE);
+
+      expect(capacityField.type).toBe(Types.Integer);
+      expect(capacityField.typeOverride).toBe(FieldOverrideVariant.SAFE);
+      expect(capacityField.typeQName?.getLocalPart()).toBe('PositiveInt_t');
+      expect(doc.definition.fieldTypeOverrides).toEqual([
+        expect.objectContaining({ type: 'sub:PositiveInt_t', variant: FieldOverrideVariant.SAFE }),
+      ]);
+
+      const reloaded = XmlSchemaDocumentService.createXmlSchemaDocument(doc.definition, namespaceMap);
+      expect(reloaded.validationStatus).toBe('success');
+      const reloadedCapacity = findFieldByName(reloaded.document!.fields, 'capacity');
+      expect(reloadedCapacity?.type).toBe(Types.Integer);
+      expect(reloadedCapacity?.typeOverride).toBe(FieldOverrideVariant.SAFE);
     });
 
     it('should invalidate descendant overrides and selections after applying type override', () => {

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document-util.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document-util.service.test.ts
@@ -781,27 +781,67 @@ describe('XmlSchemaDocumentUtilService', () => {
     it('should fallback to AnyType for unknown xs type', () => {
       expect(XmlSchemaTypesService.mapTypeStringToEnum(NS_XML_SCHEMA, 'unknownType')).toBe(Types.AnyType);
     });
+
+    it.each([
+      ['gYear', Types.Date],
+      ['gYearMonth', Types.Date],
+      ['gMonth', Types.Date],
+      ['gMonthDay', Types.Date],
+      ['gDay', Types.Date],
+      ['anySimpleType', Types.AnyAtomicType],
+    ])('should map supported xs:%s without falling back to AnyType', (name, expected) => {
+      expect(XmlSchemaTypesService.mapTypeStringToEnum(NS_XML_SCHEMA, name)).toBe(expected);
+    });
   });
 
   describe('getFieldTypeFromName()', () => {
+    it.each([
+      ['int', Types.Integer],
+      ['long', Types.Integer],
+      ['short', Types.Integer],
+      ['byte', Types.Integer],
+      ['unsignedInt', Types.Integer],
+      ['unsignedLong', Types.Integer],
+      ['unsignedShort', Types.Integer],
+      ['unsignedByte', Types.Integer],
+      ['nonPositiveInteger', Types.Integer],
+      ['negativeInteger', Types.Integer],
+      ['nonNegativeInteger', Types.Integer],
+      ['normalizedString', Types.String],
+      ['token', Types.String],
+      ['language', Types.String],
+      ['NMTOKEN', Types.String],
+      ['NMTOKENS', Types.String],
+      ['Name', Types.String],
+      ['ID', Types.String],
+      ['IDREF', Types.String],
+      ['IDREFS', Types.String],
+      ['ENTITY', Types.String],
+      ['ENTITIES', Types.String],
+      ['hexBinary', Types.String],
+      ['base64Binary', Types.String],
+    ])('should use the canonical XSD mapping for %s', (name, expected) => {
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName(name, NS_XML_SCHEMA)).toBe(expected);
+    });
+
     it('should return String type for "string"', () => {
-      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('string')).toBe(Types.String);
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('string', NS_XML_SCHEMA)).toBe(Types.String);
     });
 
     it('should return Integer type for "integer"', () => {
-      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('integer')).toBe(Types.Integer);
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('integer', NS_XML_SCHEMA)).toBe(Types.Integer);
     });
 
     it('should return Boolean type for "boolean"', () => {
-      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('boolean')).toBe(Types.Boolean);
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('boolean', NS_XML_SCHEMA)).toBe(Types.Boolean);
     });
 
     it('should return AnyType for null', () => {
-      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName(null)).toBe(Types.AnyType);
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName(null, NS_XML_SCHEMA)).toBe(Types.AnyType);
     });
 
     it('should return AnyType for unknown type name', () => {
-      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('unknownType')).toBe(Types.AnyType);
+      expect(XmlSchemaDocumentUtilService.getFieldTypeFromName('unknownType', NS_XML_SCHEMA)).toBe(Types.AnyType);
     });
   });
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document-util.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document-util.service.ts
@@ -1,11 +1,11 @@
 import { IField, IParentType, RootElementOption } from '../../../models/datamapper/document';
 import { NS_XML, NS_XML_SCHEMA } from '../../../models/datamapper/standard-namespaces';
 import { Types } from '../../../models/datamapper/types';
-import { capitalize } from '../../../serializers/xml/utils/xml-utils';
 import { XmlSchemaCollection, XmlSchemaElement, XmlSchemaType } from '../../../xml-schema-ts';
 import { QName } from '../../../xml-schema-ts/QName';
 import { QNameMap } from '../../../xml-schema-ts/utils/ObjectMap';
 import { DocumentUtilService } from '../document-util.service';
+import { mapXmlSchemaTypeToEnum } from './xml-schema-type-mapping';
 
 /**
  * Utility service for XML Schema document operations.
@@ -77,10 +77,11 @@ export class XmlSchemaDocumentUtilService {
   /**
    * Gets the field type from a simple type name.
    * @param name - The type name to look up
+   * @param namespaceURI - Namespace that owns the type name
    * @returns The corresponding Types enum value, or Types.AnyType if not found
    */
-  static getFieldTypeFromName(name: string | null): Types {
-    return (name && Types[capitalize(name) as keyof typeof Types]) || Types.AnyType;
+  static getFieldTypeFromName(name: string | null, namespaceURI: string | null): Types {
+    return name ? mapXmlSchemaTypeToEnum(namespaceURI || '', name) : Types.AnyType;
   }
 
   /**

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -1,7 +1,6 @@
 import { DocumentDefinition, RootElementOption } from '../../../models/datamapper/document';
 import { NS_XML_SCHEMA_INSTANCE } from '../../../models/datamapper/standard-namespaces';
 import { Types } from '../../../models/datamapper/types';
-import { capitalize } from '../../../serializers/xml/utils/xml-utils';
 import {
   XmlSchema,
   XmlSchemaAll,
@@ -645,7 +644,7 @@ export class XmlSchemaDocumentService {
   ) {
     if (!schemaType) return;
     if (schemaType instanceof XmlSchemaSimpleType) {
-      const newType = XmlSchemaDocumentUtilService.getFieldTypeFromName(schemaType.getName());
+      const newType = XmlSchemaTypesService.resolveSimpleTypeToEnum(schemaType, ownerDocument.xmlSchemaCollection);
       if (!field.type || field.type === Types.AnyType) {
         field.type = newType;
       }
@@ -774,21 +773,26 @@ export class XmlSchemaDocumentService {
     field.namespaceURI = namespaceURI;
     field.namespacePrefix = attr.getWireName()!.getPrefix();
     field.defaultValue = attr.getDefaultValue() || attr.getFixedValue();
-    const attrTypeName = attr.getSchemaTypeName()?.getLocalPart();
-    field.type = (attrTypeName ? Types[capitalize(attrTypeName) as keyof typeof Types] : null) || Types.AnyType;
+    const attrSchemaTypeQName = attr.getSchemaTypeName();
+    const attrSchemaType =
+      attrSchemaTypeQName &&
+      XmlSchemaDocumentUtilService.lookupSchemaType(ownerDoc.xmlSchemaCollection, attrSchemaTypeQName);
+    field.type =
+      attrSchemaType instanceof XmlSchemaSimpleType
+        ? XmlSchemaTypesService.resolveSimpleTypeToEnum(attrSchemaType, ownerDoc.xmlSchemaCollection)
+        : XmlSchemaDocumentUtilService.getFieldTypeFromName(
+            attrSchemaTypeQName?.getLocalPart() || null,
+            attrSchemaTypeQName?.getNamespaceURI() || null,
+          );
     field.description = XmlSchemaDocumentService.extractDocumentationFromAnnotated(attr);
     fields.push(field);
 
     ownerDoc.totalFieldCount++;
 
-    const attrSchemaTypeQName = attr.getSchemaTypeName();
     if (attrSchemaTypeQName) {
       field.typeQName = attrSchemaTypeQName;
     }
-    const userDefinedAttrType =
-      attrSchemaTypeQName &&
-      XmlSchemaDocumentUtilService.lookupSchemaType(ownerDoc.xmlSchemaCollection, attrSchemaTypeQName);
-    if (userDefinedAttrType) {
+    if (attrSchemaType) {
       field.namedTypeFragmentRefs.push(attrSchemaTypeQName.toString());
     }
 
@@ -1118,11 +1122,19 @@ export class XmlSchemaDocumentService {
   ): XmlSchemaType | null {
     if (!baseTypeQName) return null;
 
+    const baseType = XmlSchemaDocumentUtilService.lookupSchemaType(document.xmlSchemaCollection, baseTypeQName);
+
     if (!parent.type) {
-      parent.type = XmlSchemaDocumentUtilService.getFieldTypeFromName(baseTypeQName.getLocalPart());
+      parent.type =
+        baseType instanceof XmlSchemaSimpleType
+          ? XmlSchemaTypesService.resolveSimpleTypeToEnum(baseType, document.xmlSchemaCollection)
+          : XmlSchemaDocumentUtilService.getFieldTypeFromName(
+              baseTypeQName.getLocalPart(),
+              baseTypeQName.getNamespaceURI(),
+            );
     }
 
-    return XmlSchemaDocumentUtilService.lookupSchemaType(document.xmlSchemaCollection, baseTypeQName);
+    return baseType;
   }
 
   private static populateSimpleExtensionBaseAttributes(
@@ -1136,7 +1148,7 @@ export class XmlSchemaDocumentService {
       XmlSchemaDocumentService.populateSimpleTypeContent(document, parent, simpleContent);
     }
     if (!parent.type) {
-      parent.type = XmlSchemaDocumentUtilService.getFieldTypeFromName(simpleBase.getName());
+      parent.type = XmlSchemaTypesService.resolveSimpleTypeToEnum(simpleBase, document.xmlSchemaCollection);
     }
   }
 
@@ -1221,7 +1233,7 @@ export class XmlSchemaDocumentService {
         XmlSchemaDocumentService.populateSimpleTypeContent(document, parent, simpleContent);
       }
       if (!parent.type) {
-        parent.type = XmlSchemaDocumentUtilService.getFieldTypeFromName(simpleBase.getName());
+        parent.type = XmlSchemaTypesService.resolveSimpleTypeToEnum(simpleBase, document.xmlSchemaCollection);
       }
     }
   }

--- a/packages/ui/src/services/document/xml-schema/xml-schema-type-mapping.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-type-mapping.ts
@@ -1,0 +1,79 @@
+import { NS_XML_SCHEMA } from '../../../models/datamapper/standard-namespaces';
+import { Types } from '../../../models/datamapper/types';
+import { capitalize } from '../../../serializers/xml/utils/xml-utils';
+
+/**
+ * Map an XML Schema QName to the DataMapper type used for compatibility checks.
+ * User-defined types remain containers; known built-in aliases collapse to the
+ * primitive type families understood by the DataMapper.
+ */
+export function mapXmlSchemaTypeToEnum(namespaceURI: string, localPart: string): Types {
+  if (namespaceURI !== NS_XML_SCHEMA) return Types.Container;
+
+  const directType = Types[capitalize(localPart) as keyof typeof Types];
+  if (directType) return directType;
+
+  switch (localPart.toLowerCase()) {
+    case 'string':
+    case 'normalizedstring':
+    case 'token':
+    case 'language':
+    case 'nmtoken':
+    case 'nmtokens':
+    case 'name':
+    case 'id':
+    case 'idref':
+    case 'idrefs':
+    case 'entity':
+    case 'entities':
+      return Types.String;
+
+    case 'int':
+    case 'integer':
+    case 'long':
+    case 'short':
+    case 'byte':
+    case 'unsignedint':
+    case 'unsignedlong':
+    case 'unsignedshort':
+    case 'unsignedbyte':
+    case 'nonpositiveinteger':
+    case 'negativeinteger':
+    case 'nonnegativeinteger':
+      return Types.Integer;
+
+    case 'datetime':
+      return Types.DateTime;
+
+    case 'gyear':
+    case 'gyearmonth':
+    case 'gmonth':
+    case 'gmonthday':
+    case 'gday':
+      return Types.Date;
+
+    case 'duration':
+    case 'daytimeduration':
+    case 'yearmonthduration':
+      return Types.Duration;
+
+    case 'hexbinary':
+    case 'base64binary':
+      return Types.String;
+
+    case 'anyuri':
+      return Types.AnyURI;
+
+    case 'qname':
+      return Types.QName;
+
+    case 'notation':
+      return Types.String;
+
+    case 'anysimpletype':
+      return Types.AnyAtomicType;
+
+    default:
+      return Types.AnyType;
+  }
+}

--- a/packages/ui/src/services/document/xml-schema/xml-schema-type-mapping.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-type-mapping.ts
@@ -1,6 +1,72 @@
 import { NS_XML_SCHEMA } from '../../../models/datamapper/standard-namespaces';
 import { Types } from '../../../models/datamapper/types';
-import { capitalize } from '../../../serializers/xml/utils/xml-utils';
+
+interface XmlSchemaBuiltInType {
+  localName: string;
+  type: Types;
+  caseInsensitiveType?: Types;
+}
+
+export const XML_SCHEMA_BUILT_IN_TYPES: ReadonlyArray<XmlSchemaBuiltInType> = [
+  { localName: 'anyType', type: Types.AnyType },
+  { localName: 'anySimpleType', type: Types.AnyAtomicType },
+  { localName: 'anyAtomicType', type: Types.AnyAtomicType },
+  { localName: 'string', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'boolean', type: Types.Boolean },
+  { localName: 'decimal', type: Types.Decimal },
+  { localName: 'float', type: Types.Float },
+  { localName: 'double', type: Types.Double },
+  { localName: 'duration', type: Types.Duration, caseInsensitiveType: Types.Duration },
+  { localName: 'dateTime', type: Types.DateTime, caseInsensitiveType: Types.DateTime },
+  { localName: 'time', type: Types.Time },
+  { localName: 'date', type: Types.Date },
+  { localName: 'gYearMonth', type: Types.Date, caseInsensitiveType: Types.Date },
+  { localName: 'gYear', type: Types.Date, caseInsensitiveType: Types.Date },
+  { localName: 'gMonthDay', type: Types.Date, caseInsensitiveType: Types.Date },
+  { localName: 'gDay', type: Types.Date, caseInsensitiveType: Types.Date },
+  { localName: 'gMonth', type: Types.Date, caseInsensitiveType: Types.Date },
+  { localName: 'hexBinary', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'base64Binary', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'anyURI', type: Types.AnyURI, caseInsensitiveType: Types.AnyURI },
+  { localName: 'QName', type: Types.QName, caseInsensitiveType: Types.QName },
+  { localName: 'NOTATION', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'normalizedString', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'token', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'language', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'NMTOKEN', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'NMTOKENS', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'Name', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'NCName', type: Types.NCName },
+  { localName: 'ID', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'IDREF', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'IDREFS', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'ENTITY', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'ENTITIES', type: Types.String, caseInsensitiveType: Types.String },
+  { localName: 'integer', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'nonPositiveInteger', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'negativeInteger', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'long', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'int', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'short', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'byte', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'nonNegativeInteger', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'unsignedLong', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'unsignedInt', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'unsignedShort', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'unsignedByte', type: Types.Integer, caseInsensitiveType: Types.Integer },
+  { localName: 'positiveInteger', type: Types.PositiveInteger },
+  { localName: 'yearMonthDuration', type: Types.Duration, caseInsensitiveType: Types.Duration },
+  { localName: 'dayTimeDuration', type: Types.DayTimeDuration, caseInsensitiveType: Types.Duration },
+];
+
+const XML_SCHEMA_TYPE_BY_LOCAL_NAME = new Map(
+  XML_SCHEMA_BUILT_IN_TYPES.map(({ localName, type }) => [localName, type]),
+);
+const XML_SCHEMA_TYPE_BY_CASE_INSENSITIVE_ALIAS = new Map(
+  XML_SCHEMA_BUILT_IN_TYPES.filter(({ caseInsensitiveType }) => caseInsensitiveType !== undefined).map(
+    ({ localName, caseInsensitiveType }) => [localName.toLowerCase(), caseInsensitiveType!],
+  ),
+);
 
 /**
  * Map an XML Schema QName to the DataMapper type used for compatibility checks.
@@ -9,71 +75,9 @@ import { capitalize } from '../../../serializers/xml/utils/xml-utils';
  */
 export function mapXmlSchemaTypeToEnum(namespaceURI: string, localPart: string): Types {
   if (namespaceURI !== NS_XML_SCHEMA) return Types.Container;
-
-  const directType = Types[capitalize(localPart) as keyof typeof Types];
-  if (directType) return directType;
-
-  switch (localPart.toLowerCase()) {
-    case 'string':
-    case 'normalizedstring':
-    case 'token':
-    case 'language':
-    case 'nmtoken':
-    case 'nmtokens':
-    case 'name':
-    case 'id':
-    case 'idref':
-    case 'idrefs':
-    case 'entity':
-    case 'entities':
-      return Types.String;
-
-    case 'int':
-    case 'integer':
-    case 'long':
-    case 'short':
-    case 'byte':
-    case 'unsignedint':
-    case 'unsignedlong':
-    case 'unsignedshort':
-    case 'unsignedbyte':
-    case 'nonpositiveinteger':
-    case 'negativeinteger':
-    case 'nonnegativeinteger':
-      return Types.Integer;
-
-    case 'datetime':
-      return Types.DateTime;
-
-    case 'gyear':
-    case 'gyearmonth':
-    case 'gmonth':
-    case 'gmonthday':
-    case 'gday':
-      return Types.Date;
-
-    case 'duration':
-    case 'daytimeduration':
-    case 'yearmonthduration':
-      return Types.Duration;
-
-    case 'hexbinary':
-    case 'base64binary':
-      return Types.String;
-
-    case 'anyuri':
-      return Types.AnyURI;
-
-    case 'qname':
-      return Types.QName;
-
-    case 'notation':
-      return Types.String;
-
-    case 'anysimpletype':
-      return Types.AnyAtomicType;
-
-    default:
-      return Types.AnyType;
-  }
+  return (
+    XML_SCHEMA_TYPE_BY_LOCAL_NAME.get(localPart) ??
+    XML_SCHEMA_TYPE_BY_CASE_INSENSITIVE_ALIAS.get(localPart.toLowerCase()) ??
+    Types.AnyType
+  );
 }

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
@@ -9,13 +9,45 @@ import {
   getSimpleTypeInheritanceXsd,
   TestUtil,
 } from '../../../stubs/datamapper/data-mapper';
+import { XmlSchema, XmlSchemaCollection, XmlSchemaSimpleType } from '../../../xml-schema-ts';
 import { QName } from '../../../xml-schema-ts/QName';
+import { XmlSchemaSimpleTypeRestriction } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction';
 import { JsonSchemaDocument, JsonSchemaField } from '../json-schema/json-schema-document.model';
 import { XmlSchemaDocument, XmlSchemaField } from './xml-schema-document.model';
 import { XmlSchemaDocumentService } from './xml-schema-document.service';
 import { XmlSchemaTypesService } from './xml-schema-types.service';
 
 describe('XmlSchemaTypesService', () => {
+  describe('resolveSimpleTypeToEnum()', () => {
+    it('should stop safely when simple type restrictions form a cycle', () => {
+      const namespaceURI = 'http://www.example.com/CYCLIC-TYPES';
+      const schema = new XmlSchema(namespaceURI);
+      const typeA = new XmlSchemaSimpleType(schema, true);
+      typeA.setName('TypeA');
+      const typeB = new XmlSchemaSimpleType(schema, true);
+      typeB.setName('TypeB');
+
+      const restrictionA = new XmlSchemaSimpleTypeRestriction();
+      restrictionA.setBaseTypeName(typeB.getQName()!);
+      typeA.setContent(restrictionA);
+      const restrictionB = new XmlSchemaSimpleTypeRestriction();
+      restrictionB.setBaseTypeName(typeA.getQName()!);
+      typeB.setContent(restrictionB);
+
+      let lookups = 0;
+      const collection = {
+        getTypeByQName(qName: QName) {
+          lookups++;
+          if (lookups > 2) throw new Error('restriction cycle was followed more than once');
+          return qName.getLocalPart() === 'TypeA' ? typeA : typeB;
+        },
+      } as XmlSchemaCollection;
+
+      expect(XmlSchemaTypesService.resolveSimpleTypeToEnum(typeA, collection)).toBe(Types.AnyType);
+      expect(lookups).toBe(2);
+    });
+  });
+
   describe('parseTypeOverride()', () => {
     it('should parse qualified type name with namespace', () => {
       const doc = TestUtil.createSourceOrderDoc();

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
@@ -34,17 +34,14 @@ describe('XmlSchemaTypesService', () => {
       restrictionB.setBaseTypeName(typeA.getQName()!);
       typeB.setContent(restrictionB);
 
-      let lookups = 0;
-      const collection = {
-        getTypeByQName(qName: QName) {
-          lookups++;
-          if (lookups > 2) throw new Error('restriction cycle was followed more than once');
-          return qName.getLocalPart() === 'TypeA' ? typeA : typeB;
-        },
-      } as XmlSchemaCollection;
+      const collection = new XmlSchemaCollection();
+      const getTypeByQName = vi.spyOn(collection, 'getTypeByQName').mockImplementation((qName: QName) => {
+        if (getTypeByQName.mock.calls.length > 2) throw new Error('restriction cycle was followed more than once');
+        return qName.getLocalPart() === 'TypeA' ? typeA : typeB;
+      });
 
       expect(XmlSchemaTypesService.resolveSimpleTypeToEnum(typeA, collection)).toBe(Types.AnyType);
-      expect(lookups).toBe(2);
+      expect(getTypeByQName).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.test.ts
@@ -414,6 +414,25 @@ describe('XmlSchemaTypesService', () => {
       expect(Object.values(builtInTypes).some((t) => t.displayName === 'xs:dateTime')).toBe(true);
     });
 
+    it('should expose every supported XSD alias through the canonical type mapping', () => {
+      const builtInTypes = XmlSchemaTypesService.getAllBuiltInTypes({ xs: NS_XML_SCHEMA });
+      const aliases = [
+        'normalizedString',
+        'unsignedInt',
+        'nonPositiveInteger',
+        'base64Binary',
+        'gYearMonth',
+        'NOTATION',
+        'anySimpleType',
+      ];
+
+      for (const localName of aliases) {
+        expect(builtInTypes[`xs:${localName}`]?.type).toBe(
+          XmlSchemaTypesService.mapTypeStringToEnum(NS_XML_SCHEMA, localName),
+        );
+      }
+    });
+
     it('should use custom namespace prefix', () => {
       const namespaceMap = { xsd: NS_XML_SCHEMA };
 

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
@@ -8,7 +8,6 @@ import {
   TypeDerivation,
   Types,
 } from '../../../models/datamapper/types';
-import { capitalize } from '../../../serializers/xml/utils/xml-utils';
 import {
   XmlSchemaCollection,
   XmlSchemaComplexContentExtension,
@@ -27,6 +26,7 @@ import { ensureNamespaceRegistered, formatQNameWithPrefix, parseQNameString } fr
 import { DocumentUtilService } from '../document-util.service';
 import { XmlSchemaDocument } from './xml-schema-document.model';
 import { XmlSchemaDocumentUtilService } from './xml-schema-document-util.service';
+import { mapXmlSchemaTypeToEnum } from './xml-schema-type-mapping';
 
 /**
  * Service for XML Schema type-related operations.
@@ -109,6 +109,10 @@ export class XmlSchemaTypesService {
       return FieldOverrideVariant.SAFE;
     }
 
+    if (XmlSchemaTypesService.isCompatibleSimpleTypeOverride(field, newTypeQName, newNamespaceURI)) {
+      return FieldOverrideVariant.SAFE;
+    }
+
     return FieldOverrideVariant.FORCE;
   }
 
@@ -156,6 +160,23 @@ export class XmlSchemaTypesService {
       originalSchemaType,
       xmlDoc.xmlSchemaCollection,
     );
+  }
+
+  private static isCompatibleSimpleTypeOverride(field: IField, newTypeQName: QName, newNamespaceURI: string): boolean {
+    if (newNamespaceURI === NS_XML_SCHEMA || !(field.ownerDocument instanceof XmlSchemaDocument)) {
+      return false;
+    }
+
+    const collection = field.ownerDocument.xmlSchemaCollection;
+    const newSchemaType = collection.getTypeByQName(newTypeQName);
+    const originalTypeQName = field.originalField?.typeQName ?? field.typeQName;
+    const originalSchemaType = originalTypeQName && collection.getTypeByQName(originalTypeQName);
+
+    if (!(newSchemaType instanceof XmlSchemaSimpleType) || !(originalSchemaType instanceof XmlSchemaSimpleType)) {
+      return false;
+    }
+
+    return XmlSchemaTypesService.isExtensionOrRestriction(newSchemaType, originalSchemaType, collection);
   }
 
   /**
@@ -259,24 +280,27 @@ export class XmlSchemaTypesService {
     return undefined;
   }
 
-  private static resolveSimpleTypeToEnum(schemaType: XmlSchemaSimpleType, collection?: XmlSchemaCollection): Types {
+  static resolveSimpleTypeToEnum(schemaType: XmlSchemaSimpleType, collection?: XmlSchemaCollection): Types {
     const typeQName = schemaType.getQName();
     if (!typeQName?.getLocalPart()) {
       const resolved = XmlSchemaTypesService.followRestrictionChain(schemaType, collection);
-      if (resolved !== Types.Container) return resolved;
-      return XmlSchemaDocumentUtilService.getFieldTypeFromName(schemaType.getName());
+      return resolved === Types.Container ? Types.AnyType : resolved;
     }
-    const type = XmlSchemaTypesService.mapTypeStringToEnum(
-      typeQName.getNamespaceURI() || '',
+    const type = XmlSchemaDocumentUtilService.getFieldTypeFromName(
       typeQName.getLocalPart()!,
+      typeQName.getNamespaceURI(),
     );
     if (type !== Types.Container) return type;
-    return XmlSchemaTypesService.followRestrictionChain(schemaType, collection);
+    const resolved = XmlSchemaTypesService.followRestrictionChain(schemaType, collection);
+    return resolved === Types.Container ? Types.AnyType : resolved;
   }
 
   private static followRestrictionChain(schemaType: XmlSchemaSimpleType, collection?: XmlSchemaCollection): Types {
     let current: XmlSchemaSimpleType = schemaType;
+    const visited = new Set<XmlSchemaSimpleType>();
     while (true) {
+      if (visited.has(current)) return Types.Container;
+      visited.add(current);
       const baseInfo = XmlSchemaTypesService.doGetBaseTypeAndDerivationFromSimpleType(current);
       if (!baseInfo) return Types.Container;
       const baseType = XmlSchemaTypesService.mapTypeStringToEnum(
@@ -455,69 +479,7 @@ export class XmlSchemaTypesService {
    * ```
    */
   static mapTypeStringToEnum(namespaceURI: string, localPart: string): Types {
-    if (namespaceURI === NS_XML_SCHEMA) {
-      const normalized = localPart.toLowerCase();
-
-      if (Types[capitalize(localPart) as keyof typeof Types]) {
-        return Types[capitalize(localPart) as keyof typeof Types];
-      }
-
-      switch (normalized) {
-        case 'string':
-        case 'normalizedstring':
-        case 'token':
-        case 'language':
-        case 'nmtoken':
-        case 'nmtokens':
-        case 'name':
-        case 'id':
-        case 'idref':
-        case 'idrefs':
-        case 'entity':
-        case 'entities':
-          return Types.String;
-
-        case 'int':
-        case 'integer':
-        case 'long':
-        case 'short':
-        case 'byte':
-        case 'unsignedint':
-        case 'unsignedlong':
-        case 'unsignedshort':
-        case 'unsignedbyte':
-        case 'nonpositiveinteger':
-        case 'negativeinteger':
-        case 'nonnegativeinteger':
-          return Types.Integer;
-
-        case 'datetime':
-          return Types.DateTime;
-
-        case 'duration':
-        case 'daytimeduration':
-        case 'yearmonthduration':
-          return Types.Duration;
-
-        case 'hexbinary':
-        case 'base64binary':
-          return Types.String;
-
-        case 'anyuri':
-          return Types.AnyURI;
-
-        case 'qname':
-          return Types.QName;
-
-        case 'notation':
-          return Types.String;
-
-        default:
-          return Types.AnyType;
-      }
-    }
-
-    return Types.Container;
+    return mapXmlSchemaTypeToEnum(namespaceURI, localPart);
   }
 
   /**

--- a/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-types.service.ts
@@ -26,7 +26,7 @@ import { ensureNamespaceRegistered, formatQNameWithPrefix, parseQNameString } fr
 import { DocumentUtilService } from '../document-util.service';
 import { XmlSchemaDocument } from './xml-schema-document.model';
 import { XmlSchemaDocumentUtilService } from './xml-schema-document-util.service';
-import { mapXmlSchemaTypeToEnum } from './xml-schema-type-mapping';
+import { mapXmlSchemaTypeToEnum, XML_SCHEMA_BUILT_IN_TYPES } from './xml-schema-type-mapping';
 
 /**
  * Service for XML Schema type-related operations.
@@ -604,32 +604,9 @@ export class XmlSchemaTypesService {
    * ```
    */
   static getAllBuiltInTypes(namespaceMap: Record<string, string>): Record<string, IFieldTypeInfo> {
-    const builtInTypes = [
-      { localName: 'string', type: Types.String },
-      { localName: 'boolean', type: Types.Boolean },
-      { localName: 'decimal', type: Types.Decimal },
-      { localName: 'float', type: Types.Float },
-      { localName: 'double', type: Types.Double },
-      { localName: 'integer', type: Types.Integer },
-      { localName: 'positiveInteger', type: Types.PositiveInteger },
-      { localName: 'int', type: Types.Integer },
-      { localName: 'long', type: Types.Integer },
-      { localName: 'short', type: Types.Integer },
-      { localName: 'byte', type: Types.Integer },
-      { localName: 'date', type: Types.Date },
-      { localName: 'dateTime', type: Types.DateTime },
-      { localName: 'time', type: Types.Time },
-      { localName: 'duration', type: Types.Duration },
-      { localName: 'dayTimeDuration', type: Types.DayTimeDuration },
-      { localName: 'anyURI', type: Types.AnyURI },
-      { localName: 'QName', type: Types.QName },
-      { localName: 'NCName', type: Types.NCName },
-      { localName: 'anyType', type: Types.AnyType },
-    ];
-
     const results: Record<string, IFieldTypeInfo> = {};
 
-    for (const bt of builtInTypes) {
+    for (const bt of XML_SCHEMA_BUILT_IN_TYPES) {
       const typeQName = new QName(NS_XML_SCHEMA, bt.localName);
       const key = formatQNameWithPrefix(typeQName, namespaceMap);
       results[key] = {


### PR DESCRIPTION
### Description

Fixes the DataMapper field-override type mapping so XSD aliases such as `xs:int`, `xs:long`, and derived string types use their canonical DataMapper primitive families instead of falling back to `AnyType`.

The change:

- centralizes the XSD QName-to-DataMapper mapping used by both document loading and override logic;
- keeps mapping namespace-aware, so a user-defined type named `int` is resolved through its own restriction rather than mistaken for `xs:int`;
- resolves named simple-type restriction chains for elements and attributes, with cycle protection and stable `AnyType` fallback for list/union types; and
- preserves `SAFE` semantics when a returned custom simple-type restriction is applied and later reloaded.

Closes #3461.

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?

- `yarn workspace @kaoto/kaoto test src/services/document/xml-schema/xml-schema-types.service.test.ts` — 79 passed
- `yarn workspace @kaoto/kaoto test src/components/Document/actions/FieldOverride/FieldOverrideModal.test.tsx` — 43 passed
- `yarn workspace @kaoto/kaoto test src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx` — 7 passed
- `yarn workspace @kaoto/kaoto test src/stubs/test-load-catalog.test.ts` — 2 passed
- `yarn workspace @kaoto/kaoto build` — passed
- `yarn workspace @kaoto/kaoto lint` — passed
- `yarn workspace @kaoto/kaoto lint:style` — passed
- `git diff --check` — passed

The full UI test command completed with 6,534 passed, 39 skipped, 2 todo, and 6 failures across unrelated suites. Those failures were timeouts, an order-sensitive snapshot, and an order-sensitive mock assertion; the three representative failed files listed above all passed when rerun independently.

#### Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation (no user-facing documentation changes were required).
- [x] I have added tests that prove my fix or feature works.

AI assistance was used to develop and verify this change. I reviewed the resulting code and take responsibility for the contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved XML Schema type recognition for built-in, date/time, duration, URI, QName, binary, and XML-specific types.
  - Improved namespace-aware attribute and inherited type resolution, including named schema types.
  - Enhanced safe field type overrides for restricted simple types, lists, unions, and custom types.
  - Added support for type-mapping schemas and nested field lookups.
  - Added safeguards for circular type definitions, providing a safe fallback instead of indefinite resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->