### PR TITLE
feat(DataMapper): Abstract UX: S10: Context menu grouping with flyout…

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/datamapper.ts
+++ b/packages/ui-tests/cypress/support/next-commands/datamapper.ts
@@ -191,6 +191,7 @@ Cypress.Commands.add(
   (sourceNodePath: string[], targetNodePath: string[], testXPath: string) => {
     const targetNode = cy.getDataMapperTargetNode(targetNodePath);
     targetNode.find('[data-testid="transformation-actions-menu-toggle"]').first().click();
+    cy.get('[data-testid="transformation-actions-group-Wrap with Instruction"]').find('button').first().click();
     cy.get('[data-testid="transformation-actions-foreach"]').click();
 
     const updatedTargetNodePath = [...targetNodePath.slice(0, -1), 'node-target-for-each'];

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -1,9 +1,10 @@
 import { DraggableObject } from '@patternfly/react-drag-drop';
-import { act, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent } from 'react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
 import { ChooseItem, FieldItem, ForEachItem, MappingTree, SortItem } from '../../../../models/datamapper/mapping';
+import { MappingActionGroup } from '../../../../models/datamapper/mapping-action';
 import {
   AddMappingNodeData,
   MappingNodeData,
@@ -12,6 +13,7 @@ import {
 } from '../../../../models/datamapper/visualization';
 import { MappingService } from '../../../../services/mapping/mapping.service';
 import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
+import { MappingActionRegistryService } from '../../../../services/visualization/mapping-action-registry.service';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { MappingContextMenuAction } from './MappingContextMenuAction';
 
@@ -58,13 +60,9 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingActionService, 'applyValueOfSelector');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
+    fireEvent.click(actionToggle);
     const selectorItem = screen.getByTestId('transformation-actions-selector');
-    act(() => {
-      fireEvent.click(selectorItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(selectorItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -82,13 +80,11 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingActionService, 'applyIf');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
-    const ifItem = screen.getByTestId('transformation-actions-if');
-    act(() => {
-      fireEvent.click(ifItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(actionToggle);
+    const wrapFlyout = screen.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+    const ifItem = await screen.findByTestId('transformation-actions-if');
+    fireEvent.click(ifItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -106,13 +102,11 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingActionService, 'applyChooseWhenOtherwise');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
-    const chooseItem = screen.getByTestId('transformation-actions-choose');
-    act(() => {
-      fireEvent.click(chooseItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(actionToggle);
+    const wrapFlyout = screen.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+    const chooseItem = await screen.findByTestId('transformation-actions-choose');
+    fireEvent.click(chooseItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -126,13 +120,9 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingService, 'addWhen');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
+    fireEvent.click(actionToggle);
     const whenItem = screen.getByTestId('transformation-actions-when');
-    act(() => {
-      fireEvent.click(whenItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(whenItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -147,13 +137,9 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingService, 'addOtherwise');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
+    fireEvent.click(actionToggle);
     const otherwiseItem = screen.getByTestId('transformation-actions-otherwise');
-    act(() => {
-      fireEvent.click(otherwiseItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(otherwiseItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -172,13 +158,11 @@ describe('MappingContextMenuAction', () => {
     const spyOnApply = vi.spyOn(MappingActionService, 'applyForEach');
     render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
     const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-    act(() => {
-      fireEvent.click(actionToggle);
-    });
-    const foreachItem = screen.getByTestId('transformation-actions-foreach');
-    act(() => {
-      fireEvent.click(foreachItem.getElementsByTagName('button')[0]);
-    });
+    fireEvent.click(actionToggle);
+    const wrapFlyout = screen.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+    const foreachItem = await screen.findByTestId('transformation-actions-foreach');
+    fireEvent.click(foreachItem.getElementsByTagName('button')[0]);
     await waitFor(() => {
       expect(screen.getByTestId('transformation-actions-menu-toggle').getAttribute('aria-expanded')).toBe('false');
     });
@@ -199,9 +183,7 @@ describe('MappingContextMenuAction', () => {
     const clickEvent = createEvent.click(actionToggle);
     const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation');
 
-    act(() => {
-      fireEvent(actionToggle, clickEvent);
-    });
+    fireEvent(actionToggle, clickEvent);
 
     await waitFor(() => {
       expect(stopPropagationSpy).toHaveBeenCalled();
@@ -217,17 +199,13 @@ describe('MappingContextMenuAction', () => {
 
     const wrapper = render(<MappingContextMenuAction nodeData={nodeData} onUpdate={() => {}} />);
 
-    act(() => {
-      fireEvent.click(wrapper.getByTestId('transformation-actions-menu-toggle'));
-    });
+    fireEvent.click(wrapper.getByTestId('transformation-actions-menu-toggle'));
 
     const selectorButton = wrapper.getByTestId('transformation-actions-selector').getElementsByTagName('button')[0];
     const clickEvent = createEvent.click(selectorButton);
     const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation');
 
-    act(() => {
-      fireEvent(selectorButton, clickEvent);
-    });
+    fireEvent(selectorButton, clickEvent);
 
     await waitFor(() => {
       expect(stopPropagationSpy).toHaveBeenCalled();
@@ -241,17 +219,15 @@ describe('MappingContextMenuAction', () => {
       <MappingContextMenuAction nodeData={nodeData} dropdownLabel="Add Mapping Instruction" onUpdate={onUpdateSpy} />,
     );
 
-    act(() => {
-      const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
-      expect(actionToggle.textContent).toBe('Add Mapping Instruction');
-      fireEvent.click(actionToggle);
-    });
+    const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
+    expect(actionToggle.textContent).toBe('Add Mapping Instruction');
+    fireEvent.click(actionToggle);
 
-    act(() => {
-      const forEachList = wrapper.getByTestId('transformation-actions-foreach');
-      const forEachButton = forEachList.getElementsByTagName('button');
-      fireEvent.click(forEachButton[0]);
-    });
+    const wrapFlyout = wrapper.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+
+    const forEachItem = await wrapper.findByTestId('transformation-actions-foreach');
+    fireEvent.click(forEachItem.getElementsByTagName('button')[0]);
 
     await waitFor(() => {
       expect(onUpdateSpy).toHaveBeenCalled();
@@ -266,16 +242,14 @@ describe('MappingContextMenuAction', () => {
       <MappingContextMenuAction nodeData={nodeData} dropdownLabel="Add Mapping Instruction" onUpdate={onUpdateSpy} />,
     );
 
-    act(() => {
-      const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
-      fireEvent.click(actionToggle);
-    });
+    const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
+    fireEvent.click(actionToggle);
 
-    act(() => {
-      const ifItem = wrapper.getByTestId('transformation-actions-if');
-      const ifButton = ifItem.getElementsByTagName('button');
-      fireEvent.click(ifButton[0]);
-    });
+    const wrapFlyout = wrapper.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+
+    const ifItem = await wrapper.findByTestId('transformation-actions-if');
+    fireEvent.click(ifItem.getElementsByTagName('button')[0]);
 
     await waitFor(() => {
       expect(onUpdateSpy).toHaveBeenCalled();
@@ -291,16 +265,14 @@ describe('MappingContextMenuAction', () => {
       <MappingContextMenuAction nodeData={nodeData} dropdownLabel="Add Mapping Instruction" onUpdate={onUpdateSpy} />,
     );
 
-    act(() => {
-      const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
-      fireEvent.click(actionToggle);
-    });
+    const actionToggle = wrapper.getByTestId('transformation-actions-menu-toggle');
+    fireEvent.click(actionToggle);
 
-    act(() => {
-      const chooseItem = wrapper.getByTestId('transformation-actions-choose');
-      const chooseButton = chooseItem.getElementsByTagName('button');
-      fireEvent.click(chooseButton[0]);
-    });
+    const wrapFlyout = wrapper.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+    fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+
+    const chooseItem = await wrapper.findByTestId('transformation-actions-choose');
+    fireEvent.click(chooseItem.getElementsByTagName('button')[0]);
 
     await waitFor(() => {
       expect(onUpdateSpy).toHaveBeenCalled();
@@ -321,9 +293,7 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Comment item should be visible
         expect(screen.getByTestId('transformation-actions-comment')).toBeInTheDocument();
@@ -338,9 +308,7 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         const commentItem = screen.getByTestId('transformation-actions-comment');
         expect(commentItem).toHaveTextContent('Edit Comment');
@@ -359,15 +327,11 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Click the comment item
         const commentItem = screen.getByTestId('transformation-actions-comment');
-        act(() => {
-          fireEvent.click(commentItem.getElementsByTagName('button')[0]);
-        });
+        fireEvent.click(commentItem.getElementsByTagName('button')[0]);
 
         // Modal should be open
         await waitFor(() => {
@@ -385,15 +349,11 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Click the comment item to open modal
         const commentItem = screen.getByTestId('transformation-actions-comment');
-        act(() => {
-          fireEvent.click(commentItem.getElementsByTagName('button')[0]);
-        });
+        fireEvent.click(commentItem.getElementsByTagName('button')[0]);
 
         await waitFor(() => {
           expect(screen.getByTestId('comment-modal')).toBeInTheDocument();
@@ -409,15 +369,11 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Click the comment item to open modal
         const commentItem = screen.getByTestId('transformation-actions-comment');
-        act(() => {
-          fireEvent.click(commentItem.getElementsByTagName('button')[0]);
-        });
+        fireEvent.click(commentItem.getElementsByTagName('button')[0]);
 
         // Modal should display the comment
         const textarea = screen.getByTestId('comment-textarea') as HTMLTextAreaElement;
@@ -434,23 +390,17 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Click the comment item to open modal
         const commentItem = screen.getByTestId('transformation-actions-comment');
-        act(() => {
-          fireEvent.click(commentItem.getElementsByTagName('button')[0]);
-        });
+        fireEvent.click(commentItem.getElementsByTagName('button')[0]);
 
         expect(screen.getByTestId('comment-modal')).toBeInTheDocument();
 
         // Close the modal
         const cancelButton = screen.getByTestId('cancel-comment-btn');
-        act(() => {
-          fireEvent.click(cancelButton);
-        });
+        fireEvent.click(cancelButton);
 
         // Modal should be closed
         await waitFor(() => {
@@ -468,26 +418,18 @@ describe('MappingContextMenuAction', () => {
 
         // Open the dropdown menu
         const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-        act(() => {
-          fireEvent.click(actionToggle);
-        });
+        fireEvent.click(actionToggle);
 
         // Click the comment item to open modal
         const commentItem = screen.getByTestId('transformation-actions-comment');
-        act(() => {
-          fireEvent.click(commentItem.getElementsByTagName('button')[0]);
-        });
+        fireEvent.click(commentItem.getElementsByTagName('button')[0]);
 
         // Add a comment
         const textarea = screen.getByTestId('comment-textarea');
-        act(() => {
-          fireEvent.change(textarea, { target: { value: 'New test comment' } });
-        });
+        fireEvent.change(textarea, { target: { value: 'New test comment' } });
 
         const createButton = screen.getByTestId('create-comment-btn');
-        act(() => {
-          fireEvent.click(createButton);
-        });
+        fireEvent.click(createButton);
 
         // Modal should close
         await waitFor(() => {
@@ -508,14 +450,10 @@ describe('MappingContextMenuAction', () => {
       render(<MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdateMock} />);
 
       const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-      act(() => {
-        fireEvent.click(actionToggle);
-      });
+      fireEvent.click(actionToggle);
 
       const sortItem = screen.getByTestId('transformation-actions-sort');
-      act(() => {
-        fireEvent.click(sortItem.getElementsByTagName('button')[0]);
-      });
+      fireEvent.click(sortItem.getElementsByTagName('button')[0]);
 
       await waitFor(() => {
         expect(screen.getByTestId('sort-modal')).toBeInTheDocument();
@@ -531,12 +469,97 @@ describe('MappingContextMenuAction', () => {
       render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
 
       const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
-      act(() => {
-        fireEvent.click(actionToggle);
-      });
+      fireEvent.click(actionToggle);
 
       const sortAction = screen.getByTestId('transformation-actions-sort');
       expect(sortAction).toHaveTextContent('Edit Sort');
+    });
+  });
+
+  describe('Flyout Submenus', () => {
+    it('should render "Wrap with Instruction" flyout when wrap actions are allowed', () => {
+      const nodeData = new TargetFieldNodeData(
+        documentNodeData,
+        targetDoc.fields[0],
+        new FieldItem(mappingTree, targetDoc.fields[0]),
+      );
+      render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
+
+      const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
+      fireEvent.click(actionToggle);
+
+      expect(
+        screen.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`),
+      ).toBeInTheDocument();
+    });
+
+    it('should contain correct actions in "Wrap with Instruction" flyout', async () => {
+      const nodeData = new TargetFieldNodeData(
+        documentNodeData,
+        targetDoc.fields[0],
+        new FieldItem(mappingTree, targetDoc.fields[0]),
+      );
+      render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
+
+      const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
+      fireEvent.click(actionToggle);
+
+      const wrapFlyout = screen.getByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`);
+      fireEvent.click(wrapFlyout.getElementsByTagName('button')[0]);
+
+      expect(await screen.findByTestId('transformation-actions-if')).toBeInTheDocument();
+      expect(screen.getByTestId('transformation-actions-choose')).toBeInTheDocument();
+    });
+
+    it('should contain correct actions in "Inner Instruction" flyout', async () => {
+      const forEachItem = new ForEachItem(mappingTree);
+      const nodeData = new MappingNodeData(documentNodeData, forEachItem);
+      render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
+
+      const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
+      fireEvent.click(actionToggle);
+
+      const innerFlyout = screen.getByTestId(`transformation-actions-group-${MappingActionGroup.InnerInstruction}`);
+      fireEvent.click(innerFlyout.getElementsByTagName('button')[0]);
+
+      expect(await screen.findByTestId('transformation-actions-foreach-inner')).toBeInTheDocument();
+      expect(screen.getByTestId('transformation-actions-if-inner')).toBeInTheDocument();
+      expect(screen.getByTestId('transformation-actions-choose-inner')).toBeInTheDocument();
+    });
+
+    it('should render ungrouped actions as direct top-level items', () => {
+      const nodeData = new TargetFieldNodeData(
+        documentNodeData,
+        targetDoc.fields[0],
+        new FieldItem(mappingTree, targetDoc.fields[0]),
+      );
+      render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
+
+      const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
+      fireEvent.click(actionToggle);
+
+      expect(screen.getByTestId('transformation-actions-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('transformation-actions-comment')).toBeInTheDocument();
+    });
+
+    it('should not render flyout parent when all group actions are filtered out', () => {
+      const nodeData = new MappingNodeData(documentNodeData, new ChooseItem(mappingTree, targetDoc.fields[0]));
+      render(<MappingContextMenuAction nodeData={nodeData} onUpdate={vi.fn()} />);
+
+      const actionToggle = screen.getByTestId('transformation-actions-menu-toggle');
+      fireEvent.click(actionToggle);
+
+      const menuItems = MappingActionRegistryService.getMappingContextMenuItems(nodeData);
+      const hasWrapGroup = menuItems.some((item) => item.group === MappingActionGroup.WrapWithInstruction);
+      const hasInnerGroup = menuItems.some((item) => item.group === MappingActionGroup.InnerInstruction);
+      expect(hasWrapGroup).toBe(false);
+      expect(hasInnerGroup).toBe(false);
+      expect(
+        screen.queryByTestId(`transformation-actions-group-${MappingActionGroup.WrapWithInstruction}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`transformation-actions-group-${MappingActionGroup.InnerInstruction}`),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
@@ -1,16 +1,21 @@
 import {
   ActionListItem,
-  Dropdown,
-  DropdownItem,
-  DropdownList,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuItem,
+  MenuList,
   MenuToggle,
-  MenuToggleElement,
 } from '@patternfly/react-core';
 import { AddCircleOIcon, EllipsisVIcon } from '@patternfly/react-icons';
-import { Fragment, FunctionComponent, MouseEvent, Ref, useCallback, useMemo, useState } from 'react';
+import { Fragment, FunctionComponent, MouseEvent, useCallback, useMemo, useRef, useState } from 'react';
 
 import { MappingItem } from '../../../../models/datamapper/mapping';
-import { IMappingActionCallbacks } from '../../../../models/datamapper/mapping-action';
+import {
+  IMappingActionCallbacks,
+  IMappingContextMenuAction,
+  MappingActionGroup,
+} from '../../../../models/datamapper/mapping-action';
 import { TargetNodeData } from '../../../../models/datamapper/visualization';
 import { DEFAULT_POPPER_PROPS } from '../../../../models/popper-default';
 import { MappingActionRegistryService } from '../../../../services/visualization/mapping-action-registry.service';
@@ -28,6 +33,8 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
   onUpdate,
 }) => {
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const menuItems = useMemo(() => MappingActionRegistryService.getMappingContextMenuItems(nodeData), [nodeData]);
 
   const mappingItem = nodeData.mapping instanceof MappingItem ? nodeData.mapping : undefined;
@@ -44,35 +51,28 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
     [onUpdate, modalActions],
   );
 
-  const onToggleActionMenu = useCallback(
-    (event: MouseEvent | undefined) => {
-      event?.stopPropagation();
-      setIsActionMenuOpen(!isActionMenuOpen);
-    },
-    [isActionMenuOpen],
-  );
-
-  const renderToggle = useCallback(
-    (toggleRef: Ref<MenuToggleElement>) => (
-      <MenuToggle
-        icon={dropdownLabel ? <AddCircleOIcon /> : <EllipsisVIcon />}
-        ref={toggleRef}
-        onClick={onToggleActionMenu}
-        variant={dropdownLabel ? 'secondary' : 'plain'}
-        isExpanded={isActionMenuOpen}
-        aria-label="Transformation Action list"
-        data-testid="transformation-actions-menu-toggle"
-      >
-        {dropdownLabel}
-      </MenuToggle>
-    ),
-    [dropdownLabel, onToggleActionMenu, isActionMenuOpen],
-  );
+  const { ungrouped, groups } = useMemo(() => {
+    const ungroupedItems: IMappingContextMenuAction[] = [];
+    const groupMap = new Map<MappingActionGroup, IMappingContextMenuAction[]>();
+    for (const item of menuItems) {
+      if (item.group) {
+        const existing = groupMap.get(item.group);
+        if (existing) {
+          existing.push(item);
+        } else {
+          groupMap.set(item.group, [item]);
+        }
+      } else {
+        ungroupedItems.push(item);
+      }
+    }
+    return { ungrouped: ungroupedItems, groups: groupMap };
+  }, [menuItems]);
 
   const onSelectAction = useCallback(
-    (event: MouseEvent | undefined, value: string | number | undefined) => {
+    (event: MouseEvent | undefined, itemId: string | number | undefined) => {
       event?.stopPropagation();
-      const item = menuItems.find((mi) => mi.key === value);
+      const item = menuItems.find((mi) => mi.key === itemId);
       if (item) {
         item.apply(nodeData, callbacks);
         setIsActionMenuOpen(false);
@@ -81,32 +81,81 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
     [menuItems, nodeData, callbacks],
   );
 
+  const onToggleClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+    setIsActionMenuOpen((prev) => !prev);
+  }, []);
+
   return (
     <>
       <ActionListItem key="transformation-actions">
-        <Dropdown
-          onSelect={onSelectAction}
-          toggle={renderToggle}
+        <MenuContainer
           isOpen={isActionMenuOpen}
-          onOpenChange={(isOpen: boolean) => {
+          onOpenChange={(isOpen) => {
             setIsActionMenuOpen(isOpen);
           }}
-          popperProps={DEFAULT_POPPER_PROPS}
-          zIndex={100}
-        >
-          <DropdownList>
-            {menuItems.map((item) => (
-              <DropdownItem
-                key={item.key}
-                value={item.key}
-                isDisabled={item.isDisabled?.(nodeData)}
-                data-testid={item.testId}
-              >
-                {item.getLabel(nodeData)}
-              </DropdownItem>
-            ))}
-          </DropdownList>
-        </Dropdown>
+          menu={
+            <Menu ref={menuRef} containsFlyout onSelect={onSelectAction}>
+              <MenuContent>
+                <MenuList>
+                  {ungrouped.map((item) => (
+                    <MenuItem
+                      key={item.key}
+                      itemId={item.key}
+                      isDisabled={item.isDisabled?.(nodeData)}
+                      data-testid={item.testId}
+                    >
+                      {item.getLabel(nodeData)}
+                    </MenuItem>
+                  ))}
+
+                  {[...groups.entries()].map(([group, groupItems]) => (
+                    <MenuItem
+                      key={group}
+                      data-testid={`transformation-actions-group-${group}`}
+                      flyoutMenu={
+                        <Menu onSelect={onSelectAction}>
+                          <MenuContent>
+                            <MenuList>
+                              {groupItems.map((item) => (
+                                <MenuItem
+                                  key={item.key}
+                                  itemId={item.key}
+                                  isDisabled={item.isDisabled?.(nodeData)}
+                                  data-testid={item.testId}
+                                >
+                                  {item.getLabel(nodeData)}
+                                </MenuItem>
+                              ))}
+                            </MenuList>
+                          </MenuContent>
+                        </Menu>
+                      }
+                    >
+                      {group}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </MenuContent>
+            </Menu>
+          }
+          menuRef={menuRef}
+          toggle={
+            <MenuToggle
+              icon={dropdownLabel ? <AddCircleOIcon /> : <EllipsisVIcon />}
+              ref={toggleRef}
+              onClick={onToggleClick}
+              variant={dropdownLabel ? 'secondary' : 'plain'}
+              isExpanded={isActionMenuOpen}
+              aria-label="Transformation Action list"
+              data-testid="transformation-actions-menu-toggle"
+            >
+              {dropdownLabel}
+            </MenuToggle>
+          }
+          toggleRef={toggleRef}
+          popperProps={{ ...DEFAULT_POPPER_PROPS, minWidth: '0', zIndex: 100 }}
+        />
       </ActionListItem>
 
       {modalActions.map((action) => (

--- a/packages/ui/src/models/datamapper/mapping-action.ts
+++ b/packages/ui/src/models/datamapper/mapping-action.ts
@@ -32,6 +32,28 @@ export enum MappingActionKind {
 }
 
 /**
+ * Groups related context menu actions into flyout submenus.
+ *
+ * "Wrap with Instruction" vs "Inner Instruction" reflects the structural
+ * difference: wrap actions enclose the current field's mapping with an
+ * instruction element, while inner actions insert a new instruction inside
+ * the current instruction scope.
+ *
+ * Flyout submenus were chosen over a flat `DropdownGroup` to reduce visual
+ * noise when up to 17 items are shown simultaneously, and to align with
+ * the future Carbon Design System migration (Carbon's `Menu` component
+ * uses the same flyout submenu pattern natively).
+ *
+ * The component derives groups from visible actions rather than referencing
+ * concrete group names, so adding a new group only requires an enum value
+ * and `group` on the registry entry.
+ */
+export enum MappingActionGroup {
+  WrapWithInstruction = 'Wrap with Instruction',
+  InnerInstruction = 'Inner Instruction',
+}
+
+/**
  * Callbacks passed to {@link IMappingContextMenuAction.apply} so that action
  * handlers can trigger side effects uniformly — both immediate actions
  * (call service + `onUpdate`) and modal-based actions (`openModal`).
@@ -59,6 +81,7 @@ export interface IMappingAction {
  */
 export interface IMappingContextMenuAction extends IMappingAction {
   testId: string;
+  group?: MappingActionGroup;
   getLabel: (nodeData: TargetNodeData) => string;
   apply: (nodeData: TargetNodeData, callbacks: IMappingActionCallbacks) => void;
 }

--- a/packages/ui/src/services/visualization/mapping-action-registry.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action-registry.service.ts
@@ -11,7 +11,12 @@ import {
   ValueSelector,
   WhenItem,
 } from '../../models/datamapper/mapping';
-import { IMappingAction, IMappingContextMenuAction, MappingActionKind } from '../../models/datamapper/mapping-action';
+import {
+  IMappingAction,
+  IMappingContextMenuAction,
+  MappingActionGroup,
+  MappingActionKind,
+} from '../../models/datamapper/mapping-action';
 import {
   AddMappingNodeData,
   FieldItemNodeData,
@@ -184,6 +189,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.ForEach,
       testId: 'transformation-actions-foreach',
+      group: MappingActionGroup.WrapWithInstruction,
       getLabel: () => 'Wrap with "for-each"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyForEach(n as ForEachCapableNodeData);
@@ -196,6 +202,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.ForEachGroup,
       testId: 'transformation-actions-foreachgroup',
+      group: MappingActionGroup.WrapWithInstruction,
       getLabel: () => 'Wrap with "for-each-group"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyForEachGroup(n as ForEachCapableNodeData);
@@ -208,6 +215,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.ForEachCurrentGroup,
       testId: 'transformation-actions-foreach-current-group',
+      group: MappingActionGroup.WrapWithInstruction,
       getLabel: () => 'Wrap with "for-each current-group()"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyForEachCurrentGroup(n as ForEachCapableNodeData);
@@ -222,6 +230,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.If,
       testId: 'transformation-actions-if',
+      group: MappingActionGroup.WrapWithInstruction,
       getLabel: () => 'Wrap with "if"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyIf(n);
@@ -234,6 +243,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.Choose,
       testId: 'transformation-actions-choose',
+      group: MappingActionGroup.WrapWithInstruction,
       getLabel: () => 'Wrap with "choose-when-otherwise"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyChooseWhenOtherwise(n);
@@ -246,6 +256,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.InnerForEach,
       testId: 'transformation-actions-foreach-inner',
+      group: MappingActionGroup.InnerInstruction,
       getLabel: () => 'Inner "for-each"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyInnerForEach(n);
@@ -260,6 +271,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.InnerForEachGroup,
       testId: 'transformation-actions-foreachgroup-inner',
+      group: MappingActionGroup.InnerInstruction,
       getLabel: () => 'Inner "for-each-group"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyInnerForEachGroup(n);
@@ -274,6 +286,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.InnerForEachCurrentGroup,
       testId: 'transformation-actions-foreach-current-group-inner',
+      group: MappingActionGroup.InnerInstruction,
       getLabel: () => 'Inner "for-each current-group()"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyInnerForEachCurrentGroup(n);
@@ -292,6 +305,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.InnerChoose,
       testId: 'transformation-actions-choose-inner',
+      group: MappingActionGroup.InnerInstruction,
       getLabel: () => 'Inner "choose-when-otherwise"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyInnerChooseWhenOtherwise(n);
@@ -305,6 +319,7 @@ export class MappingActionRegistryService {
     {
       key: MappingActionKind.InnerIf,
       testId: 'transformation-actions-if-inner',
+      group: MappingActionGroup.InnerInstruction,
       getLabel: () => 'Inner "if"',
       apply: (n, { onUpdate }) => {
         MappingActionService.applyInnerIf(n);


### PR DESCRIPTION
… submenus

Fixes: https://github.com/KaotoIO/kaoto/issues/3416


https://github.com/user-attachments/assets/4bbf426c-0f90-4085-84c0-9eca2d6231f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organized mapping transformation actions into flyout submenus for easier navigation.
  * Added dedicated groups for “Wrap with Instruction” and “Inner Instruction” actions.
  * Ungrouped actions remain available directly in the context menu.

* **Bug Fixes**
  * Improved menu interaction and selection behavior across mapping actions.

* **Tests**
  * Added coverage for flyout rendering, available actions, and hidden groups when actions are unavailable.
  * Updated end-to-end interaction flows for grouped transformation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->