### PR TITLE
fix(canvas): support pasting single-entity resources

### DIFF
--- a/packages/ui/src/hooks/usePasteEntity.ts
+++ b/packages/ui/src/hooks/usePasteEntity.ts
@@ -118,10 +118,12 @@ export const usePasteEntity = () => {
     // Clone and update IDs to prevent duplication
     const updatedContent = updateIds(cloneDeep(clipboardContent));
 
+    const template = supportsMultiple
+      ? { [updatedContent.name]: updatedContent.definition }
+      : updatedContent.definition;
+
     // Add the new entity
-    const newId = camelResource.addNewEntity(updatedContent.name as EntityType, {
-      [updatedContent.name]: updatedContent.definition,
-    });
+    const newId = camelResource.addNewEntity(updatedContent.name as EntityType, template);
 
     // Make the new entity visible
     if (newId) {

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -50,6 +50,14 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
     return SourceSchemaType.Kamelet;
   }
 
+  addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
+    if (entityTemplate) {
+      this.resource = entityTemplate as IKameletDefinition;
+      this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
+    }
+    return this.flow?.id ?? '';
+  }
+
   getVisualEntities(): KameletVisualEntity[] {
     /** A kamelet always have a single flow defined, even if is empty */
     return [this.flow];

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -55,6 +55,15 @@ export class PipeResource extends CamelKResource {
     return SourceSchemaType.Pipe;
   }
 
+  addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
+    if (entityTemplate) {
+      this.resource = entityTemplate as PipeType;
+      this.pipe = this.resource;
+      this.flow = new PipeVisualEntity(this.pipe);
+    }
+    return this.flow?.id ?? '';
+  }
+
   refreshVisualMetadata() {
     this.flow = new PipeVisualEntity(this.pipe);
   }


### PR DESCRIPTION
Fixes #3445 and #3446 by passing the raw entity template instead of wrapping it in an object literal, and implementing `addNewEntity` to actually apply the template for Pipe and Kamelet resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pasting entities into resources that support multiple visual entities.
  * Preserved the correct entity structure when adding pasted definitions to single-entity resources.
  * Added support for creating and refreshing visual entities when adding new Kamelet and Pipe resources.
  * Improved reliability of visual entity identification after pasted or newly added content is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->