### PR TITLE
feat(node-identity): populate primaryNodeId in Pipe and Citrus visual entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ storybook-static
 
 # Superpowers skill
 docs/superpowers/**
+.worktrees/

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -1314,5 +1314,21 @@ describe('CitrusTestVisualEntity', () => {
       expect(placeHolderNode.data.path).toBe('actions.1.placeholder');
       expect(placeHolderNode.getNextNode()).toBeUndefined();
     });
+
+    it('should set primaryNodeId on the root group node', async () => {
+      const vizNode = await citrusTestEntity.toVizNode();
+
+      expect(vizNode.data.primaryNodeId).toEqual({ name: citrusTestEntity.type, catalogKind: CatalogKind.Entity });
+    });
+
+    it('should set primaryNodeId on each action child node', async () => {
+      const vizNode = await citrusTestEntity.toVizNode();
+      const actionNode = vizNode.getChildren()?.[0];
+
+      expect(actionNode?.data.primaryNodeId).toEqual({
+        name: actionNode?.data.name,
+        catalogKind: CatalogKind.TestAction,
+      });
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -19,6 +19,7 @@ import {
   NodeInteraction,
 } from '../base-visual-entity';
 import { IClipboardCopyObject } from '../clipboard';
+import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
 import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
@@ -357,6 +358,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       title: '',
       description: '',
       processorIconTooltip: '',
+      primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
     await NodeEnrichmentService.enrichNodeFromCatalog(testGroupNode, CatalogKind.TestAction);
@@ -442,6 +444,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       title: '',
       description: '',
       processorIconTooltip: '',
+      primaryNodeId: { name: actionName, catalogKind: CatalogKind.TestAction } satisfies NodeIdentity,
     };
 
     const vizNode = createVisualizationNode(path, data);

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -695,6 +695,55 @@ describe('Pipe', () => {
       const stepNode = vizNode.getChildren()![1];
       expect(stepNode.data.isPlaceholder).toBe(true);
     });
+
+    it('should set primaryNodeId on the root Pipe group node', async () => {
+      const vizNode = await pipeVisualEntity.toVizNode();
+
+      expect(vizNode.data.primaryNodeId).toEqual({ name: pipeVisualEntity.type, catalogKind: CatalogKind.Entity });
+    });
+
+    it('should set primaryNodeId on Kamelet step nodes (source, step, sink)', async () => {
+      const vizNode = await pipeVisualEntity.toVizNode();
+
+      const sourceNode = vizNode.getChildren()![0];
+      const stepNode = vizNode.getChildren()![1];
+      const sinkNode = vizNode.getChildren()![2];
+
+      expect(sourceNode.data.primaryNodeId).toEqual({ name: 'webhook-source', catalogKind: CatalogKind.Kamelet });
+      expect(stepNode.data.primaryNodeId).toEqual({ name: 'delay-action', catalogKind: CatalogKind.Kamelet });
+      expect(sinkNode.data.primaryNodeId).toEqual({ name: 'log-sink', catalogKind: CatalogKind.Kamelet });
+    });
+
+    it('should NOT set primaryNodeId on placeholder step nodes', async () => {
+      const pipeWithPlaceholder = cloneDeep(pipeJson);
+      pipeWithPlaceholder.spec!.steps = [
+        {
+          ref: {
+            kind: 'Kamelet',
+            apiVersion: 'camel.apache.org/v1',
+          },
+        },
+      ];
+      const entity = new PipeVisualEntity(pipeWithPlaceholder);
+      const vizNode = await entity.toVizNode();
+
+      const stepNode = vizNode.getChildren()![1];
+      expect(stepNode.data.isPlaceholder).toBe(true);
+      expect(stepNode.data.primaryNodeId).toBeUndefined();
+    });
+
+    it('should NOT set primaryNodeId on placeholder source/sink nodes', async () => {
+      const entity = new PipeVisualEntity({});
+      const vizNode = await entity.toVizNode();
+
+      const sourceNode = vizNode.getChildren()![0];
+      const sinkNode = vizNode.getChildren()![1];
+
+      expect(sourceNode.data.isPlaceholder).toBe(true);
+      expect(sourceNode.data.primaryNodeId).toBeUndefined();
+      expect(sinkNode.data.isPlaceholder).toBe(true);
+      expect(sinkNode.data.primaryNodeId).toBeUndefined();
+    });
   });
 
   describe('pasteStep', () => {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -24,6 +24,7 @@ import {
   NodeInteraction,
 } from '../base-visual-entity';
 import { IClipboardCopyObject } from '../clipboard';
+import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
 import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
@@ -226,6 +227,7 @@ export class PipeVisualEntity implements BaseVisualEntity {
       title: '',
       description: '',
       processorIconTooltip: '',
+      primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
     await NodeEnrichmentService.enrichNodeFromCatalog(pipeGroupNode, CatalogKind.Entity);
@@ -287,10 +289,11 @@ export class PipeVisualEntity implements BaseVisualEntity {
   }
 
   private async getVizNodeFromStep(step: PipeStep, path: string, isRoot = false): Promise<IVisualizationNode> {
-    const isPlaceholder = step?.ref?.name === undefined;
+    const kameletName = step?.ref?.name;
+    const isPlaceholder = kameletName === undefined;
 
     const data: IVisualizationNodeData = {
-      name: step?.ref?.name ?? PlaceholderType.Placeholder,
+      name: kameletName ?? PlaceholderType.Placeholder,
       path,
       entity: isRoot ? this : undefined,
       isPlaceholder,
@@ -299,6 +302,9 @@ export class PipeVisualEntity implements BaseVisualEntity {
       title: '',
       description: '',
       processorIconTooltip: '',
+      ...(kameletName !== undefined
+        ? { primaryNodeId: { name: kameletName, catalogKind: CatalogKind.Kamelet } satisfies NodeIdentity }
+        : {}),
     };
 
     const vizNode = createVisualizationNode(path, data);


### PR DESCRIPTION
## Summary

Populates `primaryNodeId` on all visualization node data objects created by `PipeVisualEntity` and `CitrusTestVisualEntity`.

Part of the node identity rollout — see [`docs/GLOSSARY.md`](docs/GLOSSARY.md) → *Node Identity*. Builds on #3511; can run in parallel with #3517.

## Changes

- **`PipeVisualEntity`**
  - Root group node → `primaryNodeId = {type, Entity}`
  - Kamelet step nodes (source/steps/sink) → `primaryNodeId = {kameletName, Kamelet}`
  - Placeholder step nodes → `primaryNodeId` intentionally omitted
- **`CitrusTestVisualEntity`**
  - Root group node → `primaryNodeId = {type, Entity}`
  - Test action nodes → `primaryNodeId = {actionName, TestAction}`

## Definition of done

- All non-Camel nodes have `primaryNodeId`; placeholder pipe steps correctly skip it
- Tests + lint pass

Closes #3520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Visualization nodes now include identity metadata for test entities, test actions, pipes, and referenced Kamelets.
  * Placeholder visualization nodes no longer display identity metadata when no underlying resource is available.

* **Tests**
  * Added coverage validating identity metadata for root nodes, action nodes, Kamelet steps, and placeholder nodes.

* **Chores**
  * Updated ignore rules for worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->