### PR TITLE
fix(datamapper): scope schema elements to root include chain

### DIFF
--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.test.ts
@@ -27,6 +27,9 @@ import {
   getRestrictionComplexXsd,
   getRestrictionInheritanceXsd,
   getRestrictionSimpleXsd,
+  getReverseIncludeFileAXsd,
+  getReverseIncludeFileBXsd,
+  getReverseIncludeMainXsd,
   getSchemaTestXsd,
   getShipOrderEmptyFirstLineXsd,
   getShipOrderXsd,
@@ -1117,6 +1120,85 @@ describe('XmlSchemaDocumentService', () => {
       expect(rootElement.fields[0].name).toBe('partA');
       expect(rootElement.fields[1].name).toBe('partB');
     });
+
+    it('should detect shadowed elements and only use reachable schema definitions', () => {
+      const mainXsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:include schemaLocation="MainTypes.xsd"/>
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Order" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+      const mainTypesXsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:complexType name="BaseObject" abstract="true">
+    <xs:sequence>
+      <xs:element name="ObjectId" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Order">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="BaseObject">
+          <xs:sequence>
+            <xs:element name="OrderItem" type="xs:string"/>
+            <xs:element name="Quantity" type="xs:int"/>
+            <xs:element name="Price" type="xs:double"/>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+      const unrelatedXsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:element name="Order">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Status" type="xs:string"/>
+        <xs:element name="Action" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+
+      const definition = new DocumentDefinition(
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'test-doc',
+        {
+          'Main.xsd': mainXsd,
+          'MainTypes.xsd': mainTypesXsd,
+          'Unrelated.xsd': unrelatedXsd,
+        },
+      );
+      definition.rootElementChoice = { name: 'Root', namespaceUri: '' };
+
+      const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+      expect(result.validationStatus).toBe('warning');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings![0].message).toContain("Element 'Order'");
+      expect(result.warnings![0].filePath).toBe('Unrelated.xsd');
+
+      const document = result.document as XmlSchemaDocument;
+      expect(document).toBeDefined();
+
+      const rootElement = document.fields[0];
+      expect(rootElement.name).toBe('Root');
+      
+      const orderElement = rootElement.fields.find(f => f.name === 'Order');
+      expect(orderElement).toBeDefined();
+
+      const orderFields = orderElement!.fields.map(f => f.name);
+      expect(orderFields).toEqual(['ObjectId', 'OrderItem', 'Quantity', 'Price']);
+    });
   });
 
   describe('with xs:import', () => {
@@ -1396,5 +1478,28 @@ describe('XmlSchemaDocumentService', () => {
       expect(zipCodeField).toBeDefined();
       expect(zipCodeField!.description).toBe('Postal or ZIP code');
     });
+  });
+  it('should resolve types across sibling included schemas when root element is inside an include', () => {
+    const definition = new DocumentDefinition(
+      DocumentType.SOURCE_BODY,
+      DocumentDefinitionType.XML_SCHEMA,
+      BODY_DOCUMENT_ID,
+      {
+        'main.xsd': getReverseIncludeMainXsd(),
+        'A.xsd': getReverseIncludeFileAXsd(),
+        'B.xsd': getReverseIncludeFileBXsd(),
+      },
+      undefined,
+      'RootA',
+    );
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+    expect(result.validationStatus).toBe('success');
+    expect(result.warnings).toBeUndefined();
+
+    const document = result.document as XmlSchemaDocument;
+    const rootField = document.fields[0];
+    expect(rootField.name).toBe('RootA');
+    expect(rootField.fields.length).toBeGreaterThan(0);
+    expect(rootField.fields[0].name).toBe('FieldB');
   });
 });

--- a/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
+++ b/packages/ui/src/services/document/xml-schema/xml-schema-document.service.ts
@@ -39,6 +39,7 @@ import { XmlSchemaSimpleTypeList } from '../../../xml-schema-ts/simple/XmlSchema
 import { XmlSchemaSimpleTypeRestriction } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeRestriction';
 import { XmlSchemaSimpleTypeUnion } from '../../../xml-schema-ts/simple/XmlSchemaSimpleTypeUnion';
 import { XmlSchemaAnnotated } from '../../../xml-schema-ts/XmlSchemaAnnotated';
+import { XmlSchemaInclude } from '../../../xml-schema-ts/external/XmlSchemaInclude';
 import { parseQNameString } from '../../namespace-util';
 import { DocumentUtilService } from '../document-util.service';
 import { XmlSchemaAnalysisService } from './xml-schema-analysis.service';
@@ -99,7 +100,7 @@ export class XmlSchemaDocumentService {
 
     const document = new XmlSchemaDocument(definition, collection, rootElement);
 
-    XmlSchemaDocumentService.populateNamedTypeFragments(document);
+    XmlSchemaDocumentService.populateNamedTypeFragments(document, analysis.warnings);
     XmlSchemaDocumentService.populateElement(document, document.fields, document.rootElement!);
 
     DocumentUtilService.processOverrides(
@@ -276,7 +277,7 @@ export class XmlSchemaDocumentService {
     const collection = document.xmlSchemaCollection;
     collection.getSchemaResolver().addFiles(additionalFiles);
     XmlSchemaDocumentUtilService.loadXmlSchemaFiles(collection, additionalFiles);
-    XmlSchemaDocumentService.populateNamedTypeFragments(document);
+    XmlSchemaDocumentService.populateNamedTypeFragments(document, undefined, false);
     XmlSchemaDocumentService.rebuildAbstractWrapperChildren(document);
   }
 
@@ -504,8 +505,95 @@ export class XmlSchemaDocumentService {
    * Must be called before processing elements to ensure base types are available for extensions and restrictions.
    * @param document - The document whose schema collection will be traversed and whose namedTypeFragments will be populated
    */
-  static populateNamedTypeFragments(document: XmlSchemaDocument) {
-    const schemas = document.xmlSchemaCollection.getUserSchemas();
+  static populateNamedTypeFragments(
+    document: XmlSchemaDocument,
+    warnings?: Array<{ message: string; filePath?: string }>,
+    filterUnreachable: boolean = true,
+  ) {
+    let schemas = document.xmlSchemaCollection.getUserSchemas();
+
+    if (filterUnreachable && document.rootElement) {
+      const parentSchema = document.rootElement.getParent();
+      const reachableSchemas = new Set<XmlSchema>();
+      const queue: XmlSchema[] = [parentSchema];
+
+      const includeEdges = new Map<XmlSchema, XmlSchema[]>();
+      for (const schema of schemas) {
+        for (const ext of schema.getExternals()) {
+          if (ext instanceof XmlSchemaInclude) {
+            const includedSchema = ext.getSchema();
+            if (includedSchema) {
+              if (!includeEdges.has(includedSchema)) {
+                includeEdges.set(includedSchema, []);
+              }
+              includeEdges.get(includedSchema)!.push(schema);
+            }
+          }
+        }
+      }
+
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (!reachableSchemas.has(current)) {
+          reachableSchemas.add(current);
+          const externals = current.getExternals();
+          for (const ext of externals) {
+            const schema = ext.getSchema();
+            if (schema) {
+              queue.push(schema);
+            }
+          }
+          const includers = includeEdges.get(current);
+          if (includers) {
+            for (const inc of includers) {
+              queue.push(inc);
+            }
+          }
+        }
+      }
+
+      const reachableArray = schemas.filter((s) => reachableSchemas.has(s));
+      const nonReachableArray = schemas.filter((s) => !reachableSchemas.has(s));
+
+      if (warnings) {
+        const reachableElements = new Set<string>();
+        const reachableTypes = new Set<string>();
+
+        for (const rs of reachableArray) {
+          for (const elemQName of rs.getElements().keys()) {
+            reachableElements.add(elemQName.toString());
+          }
+          for (const typeQName of rs.getSchemaTypes().keys()) {
+            reachableTypes.add(typeQName.toString());
+          }
+        }
+
+        for (const nrs of nonReachableArray) {
+          const conflicts = [];
+          for (const elemQName of nrs.getElements().keys()) {
+            if (reachableElements.has(elemQName.toString())) {
+              conflicts.push(`Element '${elemQName.getLocalPart()}'`);
+            }
+          }
+          for (const typeQName of nrs.getSchemaTypes().keys()) {
+            if (reachableTypes.has(typeQName.toString())) {
+              conflicts.push(`Type '${typeQName.getLocalPart()}'`);
+            }
+          }
+
+          if (conflicts.length > 0) {
+            const filePath = nrs.getSourceURI() ?? undefined;
+            warnings.push({
+              message: `Unrelated schema shadows reachable schema definitions. ${conflicts.join(', ')} will be ignored.`,
+              filePath,
+            });
+          }
+        }
+      }
+
+      schemas = reachableArray;
+    }
+
     for (const schema of schemas) {
       XmlSchemaDocumentService.populateNamedTypeFragmentsForSchema(document, schema);
     }

--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -256,6 +256,32 @@ export function getMainWithImportXsd(): string {
 export function getImportedTypesXsd(): string {
   return readStubFile('./xml/ImportedTypes.xsd');
 }
+export function getReverseIncludeMainXsd(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:include schemaLocation="A.xsd"/>
+  <xs:include schemaLocation="B.xsd"/>
+</xs:schema>`;
+}
+
+export function getReverseIncludeFileAXsd(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="RootA" type="TypeB"/>
+</xs:schema>`;
+}
+
+export function getReverseIncludeFileBXsd(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:complexType name="TypeB">
+    <xs:sequence>
+      <xs:element name="FieldB" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`;
+}
+
 export function getMultiIncludeMainXsd(): string {
   return readStubFile('./xml/MultiIncludeMain.xsd');
 }


### PR DESCRIPTION
Fixes #3462

## Problem
When multiple XSD files are loaded into the DataMapper, unrelated schemas can shadow elements/types if they have the same name as the ones in the root element's include chain. This happens because `populateNamedTypeFragments` and `populateGlobalElementFragmentsForSchema` iterated through all loaded schemas.

## Solution
- Performed a BFS traversal from the root element's parent schema using `getExternals()` to find only reachable schemas.
- Scoped the schema loop in `populateNamedTypeFragments` to just these reachable schemas.
- If unreachable schemas define elements/types with the same name as the reachable ones, we now generate a warning.
- Added a test case that ensures shadowing is avoided and reachable schemas' types are used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML schema document generation to build named type fragments only from schemas reachable from the selected root (including include relationships).
  - Prevented unrelated/included schemas from overriding reachable element/type definitions.
  - Added warnings when duplicate definitions are shadowed by non-reachable schemas.
- **Tests**
  - Extended Jest coverage for reverse-include scenarios to verify shadowing warnings and correct resolved root structure.
  - Added validation for type resolution across sibling schemas when the root element is inside an included schema.
- **Chores**
  - Added additional XSD stub helpers to support reverse-include test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->