### PR TITLE
fix(ui): engage Loading synchronously so the toolbar isn't interactive mid-reload

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -220,10 +220,10 @@ Cypress.Commands.add('selectCamelRouteType', (type: string, subType?: string) =>
 
 Cypress.Commands.add('retryClickDropdown', (dropdownSelector: string, listSelector: string) => {
   cy.get(dropdownSelector).click({ force: true });
-  // The toggle is a stateful flip (clicking an open menu closes it again), so the previous
-  // fixed-delay probe + blind re-click could close a menu that merely opened slowly — the
-  // cold-start, Chrome-only failure. Instead wait for the toggle to report expanded
-  // (aria-expanded is set by the PatternFly MenuToggle) and the list to render.
+  // Wait for the toggle to report expanded (PatternFly MenuToggle sets aria-expanded) and the
+  // list to render. The loading providers now engage Loading synchronously on catalog/schema
+  // changes, so the toolbar is never rendered mid-reload — Cypress's built-in existence retry
+  // waits for the reloaded toggle, and a single click is enough.
   cy.get(dropdownSelector).should('have.attr', 'aria-expanded', 'true');
   cy.get(listSelector).should('exist');
 });

--- a/packages/ui/src/dynamic-catalog/catalog.provider.tsx
+++ b/packages/ui/src/dynamic-catalog/catalog.provider.tsx
@@ -30,11 +30,11 @@ export const CatalogLoaderProvider: FunctionComponent<
   useEffect(() => {
     const indexFile = `${basePath}/${selectedCatalogIndexFile}`;
     const relativeBasePath = CatalogSchemaLoader.getRelativeBasePath(indexFile);
+    // Engage Loading synchronously, before the fetch — see the note in RuntimeProvider. Setting it
+    // inside the fetch's `.then` leaves a window where the toolbar renders as interactive while a
+    // catalog reload is already pending, which loses clicks (E2E flakiness) during the remount.
+    setLoadingStatus(LoadingStatus.Loading);
     fetch(indexFile)
-      .then((response) => {
-        setLoadingStatus(LoadingStatus.Loading);
-        return response;
-      })
       .then((response) => response.json())
       .then((catalogIndex: CatalogDefinition) => {
         if (catalogIndex.runtime === 'Citrus') {

--- a/packages/ui/src/providers/runtime.provider.tsx
+++ b/packages/ui/src/providers/runtime.provider.tsx
@@ -46,11 +46,13 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<IRuntimeProvid
   const basePath = catalogUrl.substring(0, catalogUrl.lastIndexOf('/'));
 
   useEffect(() => {
+    // Engage Loading synchronously, before the fetch. When currentSchemaType changes, doing this
+    // inside the fetch's `.then` leaves a window where the library is reloading but loadingStatus
+    // is still `Loaded`, so children (the whole toolbar) keep rendering as interactive while a
+    // remount is already pending — an untrue "ready" signal that loses clicks and flakes E2E.
+    setLoadingStatus(LoadingStatus.Loading);
     fetch(catalogUrl)
-      .then((response) => {
-        setLoadingStatus(LoadingStatus.Loading);
-        return response.json();
-      })
+      .then((response) => response.json())
       .then((catalogLibrary: CatalogLibrary) => {
         let catalogLibraryEntry: CatalogLibraryEntry | undefined = undefined;
         if (isDefined(catalogName)) {

--- a/packages/ui/src/providers/schemas.provider.tsx
+++ b/packages/ui/src/providers/schemas.provider.tsx
@@ -26,11 +26,11 @@ export const SchemasLoaderProvider: FunctionComponent<PropsWithChildren> = (prop
 
   useEffect(() => {
     const indexFile = `${basePath}/${selectedCatalogIndexFile}`;
+    // Engage Loading synchronously, before the fetch — see the note in RuntimeProvider. Setting it
+    // inside the fetch's `.then` leaves a window where the toolbar renders as interactive while a
+    // schema reload is already pending, which loses clicks (E2E flakiness) during the remount.
+    setLoadingStatus(LoadingStatus.Loading);
     fetch(indexFile)
-      .then((response) => {
-        setLoadingStatus(LoadingStatus.Loading);
-        return response;
-      })
       .then((response) => response.json())
       .then(async (catalogIndex: CatalogDefinition) => {
         const schemaFilesPromise = CatalogSchemaLoader.getSchemasFiles(indexFile, catalogIndex.schemas);


### PR DESCRIPTION
## What & why

Fixes #3523: the loader providers advertise a "ready" toolbar while a catalog/schema reload is already pending, so interactions that land in that window are lost. This surfaced as the flaky `multiflow/multiFlowDesigner.cy.ts` → *"User changes route type in the canvas"* test on the Firefox CI shard, but it also silently drops **real user clicks** during a catalog switch.

## Root cause

`RuntimeProvider`, `SchemasLoaderProvider`, and `CatalogLoaderProvider` set `loadingStatus = Loading` **inside the fetch's `.then`** (asynchronously) while gating their children behind `loadingStatus === Loaded`:

```ts
fetch(indexFile)
  .then((response) => { setLoadingStatus(Loading); return response; }) // runs a microtask later
```

When the selected catalog / integration type changes, the effect fires but `loadingStatus` stays `Loaded` until the fetch begins resolving. In that gap the toolbar keeps rendering as interactive, then unmounts and remounts when the reload lands. A click in that gap hits an element that is torn down and rebuilt collapsed — confirmed by instrumentation: `click → GONE/SCH → GONE/CAT → remounted collapsed`.

## The change

Move `setLoadingStatus(Loading)` to run **synchronously at the start of each effect, before the fetch**. Now the toolbar unmounts immediately when a reload starts and is never shown mid-reload, so the app's "ready" signal is truthful. In the test, Cypress's built-in existence retry simply waits for the reloaded toggle — a plain single click is enough, so no test-side retry is added.

```diff
  useEffect(() => {
+   setLoadingStatus(LoadingStatus.Loading);
    fetch(indexFile)
-     .then((response) => { setLoadingStatus(LoadingStatus.Loading); return response; })
      .then((response) => response.json())
```

(3 providers changed; `design.ts` gets a comment-only update explaining why a single click is now safe.)

## Verification

Reproduced the flake locally under CPU starvation (emulating a loaded CI runner):

| | Result |
|---|---|
| Original code, single click, under stress | **2/6 fail** (same `design.ts:227` timeout as CI) |
| This change, plain single click, under stress | **11/11 pass** |
| Provider unit tests | 21 pass |
| E2E regression smoke — catalog-switch, settings, special-route, both multiflow specs | all pass |

Closes #3523
