### PR TITLE
fix(DataMapper): Disallow copy-of and value-of on unselected abstract…

### DIFF
--- a/packages/ui/src/services/visualization/mapping-action-registry.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action-registry.service.ts
@@ -134,6 +134,7 @@ export class MappingActionRegistryService {
       },
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
+        if (MappingActionRegistryService.isUnselectedWrapperField(n)) return false;
         if (!VisualizationUtilService.isMappingNode(n)) return true;
         return !MappingActionRegistryService.mappingIsOneOf(
           ValueSelector,
@@ -155,6 +156,7 @@ export class MappingActionRegistryService {
       },
       isAllowed: (n) => {
         if (n instanceof AddMappingNodeData) return false;
+        if (MappingActionRegistryService.isUnselectedWrapperField(n)) return false;
         if (!VisualizationUtilService.isMappingNode(n)) return true;
         return !MappingActionRegistryService.mappingIsOneOf(
           ValueSelector,
@@ -340,6 +342,7 @@ export class MappingActionRegistryService {
       isAllowed: (n) => {
         if (n instanceof VariableNodeData) return false;
         if (n instanceof TargetDocumentNodeData) return false;
+        if (MappingActionRegistryService.isUnselectedWrapperField(n)) return false;
         if (VisualizationUtilService.isFieldNode(n)) return DocumentService.hasChildren(n.field);
         return (
           VisualizationUtilService.isMappingNode(n) &&

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -2616,15 +2616,17 @@ describe('MappingActionService', () => {
     });
   });
 
-  describe('getAllowedActions() inner instructions on unselected wrapper fields', () => {
-    const innerInstructionKinds = [
+  describe('getAllowedActions() on unselected wrapper fields', () => {
+    const disallowedOnUnselectedWrapperKinds = [
       MappingActionKind.InnerForEach,
       MappingActionKind.InnerForEachGroup,
       MappingActionKind.InnerChoose,
       MappingActionKind.InnerIf,
+      MappingActionKind.ValueSelector,
+      MappingActionKind.CopyOfSelector,
     ];
 
-    it('should disallow inner instructions on unselected choice field', () => {
+    it('should disallow actions on unselected choice field', () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -2644,12 +2646,12 @@ describe('MappingActionService', () => {
 
       const unselectedNode = new TargetChoiceFieldNodeData(docNode, choiceField);
       const allowed = MappingActionRegistryService.getAllowedActions(unselectedNode);
-      for (const kind of innerInstructionKinds) {
+      for (const kind of disallowedOnUnselectedWrapperKinds) {
         expect(allowed).not.toContain(kind);
       }
     });
 
-    it('should allow inner instructions on selected choice field', () => {
+    it('should allow actions on selected choice field', () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -2670,12 +2672,12 @@ describe('MappingActionService', () => {
       const selectedNode = new TargetChoiceFieldNodeData(docNode, memberA);
       selectedNode.choiceField = choiceField;
       const allowed = MappingActionRegistryService.getAllowedActions(selectedNode);
-      for (const kind of innerInstructionKinds) {
+      for (const kind of disallowedOnUnselectedWrapperKinds) {
         expect(allowed).toContain(kind);
       }
     });
 
-    it('should disallow inner instructions on unsubstituted abstract field', () => {
+    it('should disallow actions on unsubstituted abstract field', () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -2695,12 +2697,12 @@ describe('MappingActionService', () => {
 
       const unselectedNode = new TargetAbstractFieldNodeData(docNode, abstractField);
       const allowed = MappingActionRegistryService.getAllowedActions(unselectedNode);
-      for (const kind of innerInstructionKinds) {
+      for (const kind of disallowedOnUnselectedWrapperKinds) {
         expect(allowed).not.toContain(kind);
       }
     });
 
-    it('should allow inner instructions on substituted abstract field', () => {
+    it('should allow actions on substituted abstract field', () => {
       const document = TestUtil.createTargetOrderDoc();
       const mappingTree = new MappingTree(
         document.documentType,
@@ -2721,9 +2723,53 @@ describe('MappingActionService', () => {
       const selectedNode = new TargetAbstractFieldNodeData(docNode, candidate);
       selectedNode.abstractField = abstractField;
       const allowed = MappingActionRegistryService.getAllowedActions(selectedNode);
-      for (const kind of innerInstructionKinds) {
+      for (const kind of disallowedOnUnselectedWrapperKinds) {
         expect(allowed).toContain(kind);
       }
+    });
+
+    it('should disallow Variable on unselected choice field', () => {
+      const document = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(
+        document.documentType,
+        document.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const docNode = new TargetDocumentNodeData(document, mappingTree);
+      const parentField = document.fields[0];
+
+      const choiceField = new XmlSchemaField(parentField, 'testChoice', false);
+      choiceField.type = Types.Container;
+      choiceField.wrapperKind = 'choice';
+      const memberA = new XmlSchemaField(choiceField, 'memberA', false);
+      memberA.type = Types.String;
+      choiceField.fields = [memberA];
+      parentField.fields.push(choiceField);
+
+      const unselectedNode = new TargetChoiceFieldNodeData(docNode, choiceField);
+      expect(MappingActionRegistryService.getAllowedActions(unselectedNode)).not.toContain(MappingActionKind.Variable);
+    });
+
+    it('should disallow Variable on unsubstituted abstract field', () => {
+      const document = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(
+        document.documentType,
+        document.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const docNode = new TargetDocumentNodeData(document, mappingTree);
+      const parentField = document.fields[0];
+
+      const abstractField = new XmlSchemaField(parentField, 'testAbstract', false);
+      abstractField.type = Types.Container;
+      abstractField.wrapperKind = 'abstract';
+      const candidate = new XmlSchemaField(abstractField, 'ConcreteType', false);
+      candidate.type = Types.String;
+      abstractField.fields = [candidate];
+      parentField.fields.push(abstractField);
+
+      const unselectedNode = new TargetAbstractFieldNodeData(docNode, abstractField);
+      expect(MappingActionRegistryService.getAllowedActions(unselectedNode)).not.toContain(MappingActionKind.Variable);
     });
   });
 


### PR DESCRIPTION
…/choice

Fixes: https://github.com/KaotoIO/kaoto/issues/3513

Also prohibit `Add Variable` which shouldn't be allowed for unselected abstract/choice

### Choice
#### maxOccurs=1
<img width="1301" height="222" alt="Screenshot From 2026-07-20 17-03-12" src="https://github.com/user-attachments/assets/3debcbb1-5e0d-4d73-949d-4364bc6adb85" />

#### maxOccurs>1
<img width="1252" height="215" alt="Screenshot From 2026-07-20 17-02-05" src="https://github.com/user-attachments/assets/a1207347-0343-47da-b655-3521b3c7eb9c" />

### Abstract
#### maxOccurs=1
<img width="1301" height="222" alt="Screenshot From 2026-07-20 17-02-40" src="https://github.com/user-attachments/assets/7d0f5a14-03c3-4221-bfcc-64d6bb8bf264" />

#### maxOccurs>1
<img width="1301" height="222" alt="Screenshot From 2026-07-20 17-02-25" src="https://github.com/user-attachments/assets/b2c74b4a-aa09-4836-9445-e2ac07a59763" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted value selection, copy, and variable actions for unselected or unsubstituted wrapper fields.
  * Preserved these actions for selected or substituted fields where they are valid.

* **Tests**
  * Expanded coverage to verify allowed and disallowed actions across wrapper field states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->