### PR TITLE
feat(mithril): Add required group to mode "groups" when a step is added

### DIFF
--- a/packages/ui/src/models/custom-mode/custom-mode-groups.service.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-groups.service.test.ts
@@ -1,0 +1,163 @@
+import componentsStub from '../../stubs/bob-catalog/bob-components.json';
+import modesStub from '../../stubs/bob-catalog/bob-modes.json';
+import toolsStub from '../../stubs/bob-catalog/bob-tools.json';
+import { BOB_CUSTOM_MODE_ROOT_ENTITY_NAME } from '../bob/bob-catalog-index';
+import { ICamelProcessorDefinition } from '../camel/camel-processors-catalog';
+import { CatalogKind } from '../catalog-kind';
+import { CamelCatalogService } from '../visualization/flows/camel-catalog.service';
+import { CustomModeGroupsService } from './custom-mode-groups.service';
+import { CustomMode } from './custom-mode-types';
+
+const makeMode = (overrides?: Partial<CustomMode>): CustomMode => ({
+  slug: 'test-mode',
+  name: 'Test Mode',
+  description: 'A test mode',
+  roleDefinition: 'You are a test assistant.',
+  whenToUse: 'Use this for testing.',
+  groups: [],
+  ...overrides,
+});
+
+/** Load the stub catalogs into CamelCatalogService (mirrors what fetchBobCatalog does at runtime). */
+function loadStubCatalog() {
+  CamelCatalogService.setCatalogKey(CatalogKind.BobTool, toolsStub as never);
+  CamelCatalogService.setCatalogKey(CatalogKind.BobComponent, componentsStub as never);
+  const rootModeEntry = (modesStub as Record<string, { propertiesSchema?: unknown }>)['mode'];
+  CamelCatalogService.setCatalogKey(CatalogKind.Entity, {
+    [BOB_CUSTOM_MODE_ROOT_ENTITY_NAME]: {
+      propertiesSchema: rootModeEntry?.propertiesSchema,
+    } as ICamelProcessorDefinition,
+  });
+}
+
+describe('CustomModeGroupsService (catalog-driven)', () => {
+  beforeEach(() => {
+    loadStubCatalog();
+  });
+
+  afterEach(() => {
+    CamelCatalogService.clearCatalogs();
+  });
+
+  describe('getRequiredGroups', () => {
+    it('returns groups from the catalog for a known tool', () => {
+      // write_file stub has group: "file,write"
+      expect(CustomModeGroupsService.getRequiredGroups(['write_file'])).toEqual(
+        expect.arrayContaining(['file', 'write']),
+      );
+    });
+
+    it('deduplicates groups shared by multiple tools', () => {
+      // read_file: "file,read"  write_file: "file,write" — "file" appears once
+      const groups = CustomModeGroupsService.getRequiredGroups(['read_file', 'write_file']);
+      expect(groups.filter((g) => g === 'file')).toHaveLength(1);
+    });
+
+    it('returns an empty array for an empty list', () => {
+      expect(CustomModeGroupsService.getRequiredGroups([])).toEqual([]);
+    });
+
+    it('silently ignores names not in the catalog', () => {
+      expect(CustomModeGroupsService.getRequiredGroups(['not_a_tool'])).toEqual([]);
+    });
+
+    it('returns groups for a bobComponent (text-node has no group field — returns empty)', () => {
+      // text-node stub has no `group` field
+      expect(CustomModeGroupsService.getRequiredGroups(['text-node'])).toEqual([]);
+    });
+  });
+
+  describe('extractNodeNames', () => {
+    it('detects bold-markdown tool references present in catalog', () => {
+      expect(CustomModeGroupsService.extractNodeNames('Use **write_file** here.')).toContain('write_file');
+    });
+
+    it('detects inline-code tool references', () => {
+      expect(CustomModeGroupsService.extractNodeNames('Call `read_file` here.')).toContain('read_file');
+    });
+
+    it('deduplicates repeated references', () => {
+      const nodes = CustomModeGroupsService.extractNodeNames('**write_file** and **write_file** again');
+      expect(nodes.filter((n) => n === 'write_file')).toHaveLength(1);
+    });
+
+    it('ignores words that are not in the catalog', () => {
+      expect(CustomModeGroupsService.extractNodeNames('**unknown_thing**')).toEqual([]);
+    });
+
+    it('returns empty array for empty string', () => {
+      expect(CustomModeGroupsService.extractNodeNames('')).toEqual([]);
+    });
+  });
+
+  describe('syncGroupsForNode', () => {
+    it('adds groups for a known tool', () => {
+      const mode = makeMode({ groups: [] });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      expect(mode.groups).toEqual(expect.arrayContaining(['file', 'write']));
+    });
+
+    it('does not duplicate groups already present', () => {
+      const mode = makeMode({ groups: ['file', 'write'] });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      expect((mode.groups as string[]).filter((g) => g === 'write')).toHaveLength(1);
+    });
+
+    it('is a no-op for an unknown node name', () => {
+      const mode = makeMode({ groups: ['read'] });
+      CustomModeGroupsService.syncGroupsForNode('not_in_catalog', mode);
+      expect(mode.groups).toEqual(['read']);
+    });
+
+    it('never removes existing groups', () => {
+      // Existing groups are preserved regardless of what the node requires.
+      const mode = makeMode({ groups: ['read', 'mcp', 'subagent'] });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      expect(mode.groups).toContain('read');
+      expect(mode.groups).toContain('mcp');
+      expect(mode.groups).toContain('subagent');
+      expect(mode.groups).toContain('file');
+      expect(mode.groups).toContain('write');
+    });
+
+    it('inserts multiple groups in enum order', () => {
+      // read_file: "file,read" — read(0) is in enum, file is not
+      // switch_mode: "mode" — mode(8) is in enum
+      // Calling for each: read(0) must appear before mode(8) in the groups array
+      const mode = makeMode({ groups: [] });
+      CustomModeGroupsService.syncGroupsForNode('read_file', mode);
+      CustomModeGroupsService.syncGroupsForNode('switch_mode', mode);
+      const groups = mode.groups as string[];
+      expect(groups.indexOf('read')).toBeLessThan(groups.indexOf('mode'));
+    });
+
+    it('within a single call, enum-ordered groups come before non-enum groups', () => {
+      // write_file: "file,write" — write(11) is in enum, file is not
+      // A single syncGroupsForNode call must place write before file.
+      const mode = makeMode({ groups: [] });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      const groups = mode.groups as string[];
+      expect(groups.indexOf('write')).toBeLessThan(groups.indexOf('file'));
+    });
+  });
+
+  describe('catalog not loaded (graceful fallback)', () => {
+    beforeEach(() => {
+      CamelCatalogService.clearCatalogs();
+    });
+
+    it('getRequiredGroups returns empty array when catalog is absent', () => {
+      expect(CustomModeGroupsService.getRequiredGroups(['write_file'])).toEqual([]);
+    });
+
+    it('extractNodeNames returns empty array when catalog is absent', () => {
+      expect(CustomModeGroupsService.extractNodeNames('Use **write_file**.')).toEqual([]);
+    });
+
+    it('syncGroupsForNode is a no-op when catalog is absent', () => {
+      const mode = makeMode({ groups: ['read'], customInstructions: 'Use **write_file**.' });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      expect(mode.groups).toEqual(['read']);
+    });
+  });
+});

--- a/packages/ui/src/models/custom-mode/custom-mode-groups.service.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-groups.service.ts
@@ -1,0 +1,107 @@
+import { IBobComponentDefinition } from '../bob/bob-catalog';
+import { BOB_CUSTOM_MODE_ROOT_ENTITY_NAME } from '../bob/bob-catalog-index';
+import { CatalogKind } from '../catalog-kind';
+import { CamelCatalogService } from '../visualization/flows/camel-catalog.service';
+import { CustomMode, CustomModeGroup } from './custom-mode-types';
+
+/**
+ * Pattern that matches a Bob catalog node reference inside a `customInstructions`
+ * string in either bold (`**name**`) or inline-code (`` `name` ``) form.
+ * Identifiers may contain letters, digits, underscores, and hyphens (e.g. `text-node`).
+ */
+const NODE_REFERENCE_RE = /\*\*([A-Za-z][A-Za-z0-9_-]*)\*\*|`([A-Za-z][A-Za-z0-9_-]*)`/g;
+
+export class CustomModeGroupsService {
+  /**
+   * Returns the deduplicated list of group names required by the given catalog
+   * node names, derived live from the loaded Bob catalog.
+   * Unknown names are silently ignored.
+   */
+  static getRequiredGroups(nodeNames: string[]): string[] {
+    const groups = new Set<string>();
+    for (const name of nodeNames) {
+      for (const g of CustomModeGroupsService.getNodeGroupsFromCatalog(name)) {
+        groups.add(g);
+      }
+    }
+    return Array.from(groups);
+  }
+
+  /**
+   * Scans a raw `customInstructions` string and returns every catalog node name
+   * that appears as a bold or inline-code reference and is present in the Bob catalog.
+   */
+  static extractNodeNames(customInstructions: string): string[] {
+    const found = new Set<string>();
+    const re = new RegExp(NODE_REFERENCE_RE.source, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(customInstructions)) !== null) {
+      const candidate = match[1] ?? match[2];
+      if (candidate && CustomModeGroupsService.getNodeGroupsFromCatalog(candidate).length > 0) {
+        found.add(candidate);
+      }
+    }
+    return Array.from(found);
+  }
+
+  /**
+   * Ensures every group required by the given catalog node is present in `mode.groups`.
+   * Missing groups are appended in the order defined by the modes catalog enum.
+   * Groups not in the enum are appended after all enum-ordered ones.
+   * Existing groups are never removed or reordered.
+   */
+  static syncGroupsForNode(nodeName: string, mode: CustomMode): void {
+    const required = CustomModeGroupsService.getRequiredGroups([nodeName]);
+    if (required.length === 0) return;
+
+    const existing = new Set<string>(mode.groups.filter((g): g is string => typeof g === 'string'));
+
+    const missing = required.filter((g) => !existing.has(g));
+    if (missing.length === 0) return;
+
+    const enumOrder = CustomModeGroupsService.getGroupsEnumOrder();
+    const enumIndex = (g: string): number => {
+      const i = enumOrder.indexOf(g);
+      return i === -1 ? enumOrder.length : i;
+    };
+    missing.sort((a, b) => enumIndex(a) - enumIndex(b));
+
+    for (const group of missing) {
+      (mode.groups as CustomModeGroup[]).push(group);
+    }
+  }
+
+  /**
+   * Returns the set of permission groups required by the named catalog node.
+   * Looks up `group` (comma-separated) on the `bobTool` or `bobComponent` entry.
+   * Returns an empty array when the name is not in either catalog.
+   */
+  private static getNodeGroupsFromCatalog(nodeName: string): string[] {
+    const entry: IBobComponentDefinition | undefined =
+      CamelCatalogService.getComponent(CatalogKind.BobTool, nodeName) ??
+      CamelCatalogService.getComponent(CatalogKind.BobComponent, nodeName);
+
+    if (!entry?.group) return [];
+    return entry.group
+      .split(',')
+      .map((g) => g.trim())
+      .filter(Boolean);
+  }
+
+  /**
+   * Returns the canonical group insertion order derived from the `groups.items.enum`
+   * in the Bob modes catalog (`bob-catalog-aggregate-modes.json`).
+   * Falls back to an empty array when the catalog is not yet loaded.
+   */
+  private static getGroupsEnumOrder(): string[] {
+    const rootSchema = CamelCatalogService.getComponent(
+      CatalogKind.Entity,
+      BOB_CUSTOM_MODE_ROOT_ENTITY_NAME,
+    )?.propertiesSchema;
+    const items = (rootSchema?.properties?.['groups'] as Record<string, unknown> | undefined)?.['items'] as
+      | Record<string, unknown>
+      | undefined;
+    const enumValues = items?.['enum'];
+    return Array.isArray(enumValues) ? (enumValues as string[]) : [];
+  }
+}

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -1,6 +1,9 @@
 import { JSONSchema4 } from 'json-schema';
+import { set } from 'lodash';
 
+import componentsStub from '../../stubs/bob-catalog/bob-components.json';
 import modesStub from '../../stubs/bob-catalog/bob-modes.json';
+import toolsStub from '../../stubs/bob-catalog/bob-tools.json';
 import { BOB_CUSTOM_MODE_ROOT_ENTITY_NAME } from '../bob/bob-catalog-index';
 import { ICamelProcessorDefinition } from '../camel/camel-processors-catalog';
 import { SourceSchemaType } from '../camel/source-schema-type';
@@ -13,6 +16,18 @@ import { NodeIconResolver } from '../visualization/flows/nodes/resolvers/icon-re
 import { CustomInstructionsParser } from './custom-instructions-parser';
 import { CustomInstructionsNode, CustomMode } from './custom-mode-types';
 import { CustomModeVisualEntity } from './custom-mode-visual-entity';
+
+/** Loads stub Bob catalogs into CamelCatalogService, mirroring fetchBobCatalog at runtime. */
+function loadBobStubCatalog() {
+  CamelCatalogService.setCatalogKey(CatalogKind.BobTool, toolsStub as never);
+  CamelCatalogService.setCatalogKey(CatalogKind.BobComponent, componentsStub as never);
+  const rootModeEntry = (modesStub as Record<string, { propertiesSchema?: unknown }>)['mode'];
+  CamelCatalogService.setCatalogKey(CatalogKind.Entity, {
+    [BOB_CUSTOM_MODE_ROOT_ENTITY_NAME]: {
+      propertiesSchema: rootModeEntry?.propertiesSchema,
+    } as ICamelProcessorDefinition,
+  });
+}
 
 const makeMode = (overrides?: Partial<CustomMode>): CustomMode => ({
   slug: 'test-mode',
@@ -30,8 +45,13 @@ describe('CustomModeVisualEntity', () => {
   let entity: CustomModeVisualEntity;
 
   beforeEach(() => {
+    loadBobStubCatalog();
     vi.spyOn(NodeEnrichmentService, 'enrichNodeFromCatalog').mockResolvedValue(undefined);
     entity = new CustomModeVisualEntity(makeMode());
+  });
+
+  afterEach(() => {
+    CamelCatalogService.clearCatalogs();
   });
 
   describe('constructor', () => {
@@ -47,6 +67,28 @@ describe('CustomModeVisualEntity', () => {
       const e = new CustomModeVisualEntity(makeMode({ slug: undefined as unknown as string }));
       expect(e.id).toMatch(/^custom-mode-/);
       expect(e.toJSON().slug).toBe(e.id);
+    });
+
+    it('does not add groups from customInstructions on construction — YAML groups are the source of truth', () => {
+      // The constructor must not scan customInstructions and add groups.
+      // If the user removed a group from the YAML source panel, the constructor
+      // must not restore it just because a matching tool node is in customInstructions.
+      const e = new CustomModeVisualEntity(
+        makeMode({
+          groups: ['read'],
+          customInstructions: serializeSteps([
+            {
+              nodeType: 'tool-invocation',
+              index: 1,
+              title: 'write_file',
+              toolName: 'write_file',
+              rawContent: '**write_file**',
+            },
+          ]),
+        }),
+      );
+      // groups must be exactly what was passed in — constructor adds nothing
+      expect(e.toJSON().groups).toEqual(['read']);
     });
   });
 
@@ -131,8 +173,12 @@ describe('CustomModeVisualEntity', () => {
       expect(schema!.properties).toHaveProperty('groups');
     });
 
-    it('returns undefined for customInstructions child paths (stub)', () => {
-      expect(entity.getNodeSchema('customMode.customInstructions.0.section')).toBeUndefined();
+    it('returns the text-node fallback schema for unrecognised customInstructions child paths', () => {
+      // CustomModeSchemaService falls back to the text-node schema when neither BobTool
+      // nor BobComponent has a matching entry — so any unknown node type yields text-node's schema.
+      const schema = entity.getNodeSchema('customMode.customInstructions.0.section');
+      expect(schema).toBeDefined();
+      expect(schema!.type).toBe('object');
     });
 
     it('returns undefined for unrecognised paths', () => {
@@ -210,6 +256,73 @@ describe('CustomModeVisualEntity', () => {
       entity.updateModel('customMode', { name: 'Only Name Changed' });
       expect(entity.id).toBe('test-mode');
       expect(entity.toJSON().name).toBe('Only Name Changed');
+    });
+
+    it('merges groups from the form with existing groups — never overwrites', () => {
+      // The form panel reads groups at open-time, then submits all fields including groups.
+      // Submitting a stale empty groups array must NOT remove catalog-derived groups added
+      // by addStep (merge semantics: only add, never remove).
+      const e = new CustomModeVisualEntity(makeMode({ groups: [] }));
+      e.addStep({
+        definedComponent: { name: 'write_file', type: CatalogKind.BobTool } as never,
+        mode: AddStepMode.AppendStep,
+        data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+      });
+      // groups now contains write_file's groups (e.g. 'file', 'write' from stub)
+      const groupsAfterAdd = [...e.toJSON().groups] as string[];
+      expect(groupsAfterAdd.length).toBeGreaterThan(0);
+
+      // Simulate form submitting with stale empty groups (form opened before addStep)
+      e.updateModel('customMode', { name: 'New Name', groups: [] });
+
+      // Catalog-derived groups must still be present — the empty submission is a no-op for groups
+      expect(e.toJSON().groups).toEqual(groupsAfterAdd);
+      expect(e.toJSON().name).toBe('New Name');
+    });
+
+    it('adds a group manually typed into the config form', () => {
+      // User opens the form when groups: ['read'], types 'edit', submits ['read', 'edit'].
+      // Both groups must be present — the form-submitted value is merged in.
+      const e = new CustomModeVisualEntity(makeMode({ groups: ['read'] }));
+      e.updateModel('customMode', { name: 'Test Mode', groups: ['read', 'edit'] });
+      expect(e.toJSON().groups).toContain('read');
+      expect(e.toJSON().groups).toContain('edit');
+      expect((e.toJSON().groups as string[]).filter((g) => g === 'read')).toHaveLength(1);
+    });
+
+    it('does not duplicate a group already present when form re-submits it', () => {
+      const e = new CustomModeVisualEntity(makeMode({ groups: ['read', 'edit'] }));
+      e.updateModel('customMode', { groups: ['read', 'edit'] });
+      expect((e.toJSON().groups as string[]).filter((g) => g === 'read')).toHaveLength(1);
+      expect((e.toJSON().groups as string[]).filter((g) => g === 'edit')).toHaveLength(1);
+    });
+
+    it('regression: sub-index setValue mutation does not destroy existing groups', () => {
+      // The form fires onChangeProp('groups.0', 'edit') when replacing the first item.
+      // setValue(snapshot, 'groups.0', 'edit') mutates the snapshot's groups array in-place.
+      // Because getNodeDefinition() used to return the same groups array reference as
+      // this.mode.groups, this mutation destroyed the original value before updateModel
+      // could merge it. getNodeDefinition() must return a cloned groups array.
+      const e = new CustomModeVisualEntity(makeMode({ groups: ['read'] }));
+      // Simulate what CanvasFormBody does: get a snapshot, mutate it via setValue, call updateModel
+      const snapshot = e.getNodeDefinition('customMode') as Record<string, unknown>;
+      // Mutate in-place (lodash set with sub-index path) — must NOT affect this.mode.groups
+      set(snapshot, 'groups.0', 'edit'); // replaces 'read' with 'edit' in the snapshot
+      e.updateModel('customMode', snapshot); // snapshot.groups is now ['edit']
+      // mode.groups should contain both 'read' (original) and 'edit' (from snapshot)
+      expect(e.toJSON().groups).toContain('read');
+      expect(e.toJSON().groups).toContain('edit');
+    });
+
+    it('filters out empty strings from form-submitted groups', () => {
+      // The array widget appends an empty trailing entry; it must be discarded.
+      const e = new CustomModeVisualEntity(makeMode({ groups: ['read'] }));
+      e.updateModel('customMode', { groups: ['read', 'edit', ''] });
+      const groups = e.toJSON().groups as string[];
+      expect(groups).toContain('read');
+      expect(groups).toContain('edit');
+      expect(groups).not.toContain('');
+      expect(groups.filter((g) => g === 'read')).toHaveLength(1);
     });
 
     it('is a no-op for unrecognised paths', () => {
@@ -496,6 +609,107 @@ describe('CustomModeVisualEntity', () => {
         data: { path: 'customMode' } as never,
       });
       expect(e.toJSON().customInstructions).toBe(before);
+    });
+
+    describe('group sync on addStep', () => {
+      it('adds required groups when a BobTool is added', () => {
+        // write_file stub has group: "file,write"
+        const e = new CustomModeVisualEntity(makeMode({ groups: ['read'] }));
+        e.addStep({
+          definedComponent: { name: 'write_file', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        expect(e.toJSON().groups).toContain('file');
+        expect(e.toJSON().groups).toContain('write');
+      });
+
+      it('does not duplicate groups already present', () => {
+        // write_file stub has group: "file,write"; both already present → no duplication
+        const e = new CustomModeVisualEntity(makeMode({ groups: ['file', 'write'] }));
+        e.addStep({
+          definedComponent: { name: 'write_file', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        expect((e.toJSON().groups as string[]).filter((g) => g === 'file')).toHaveLength(1);
+        expect((e.toJSON().groups as string[]).filter((g) => g === 'write')).toHaveLength(1);
+      });
+
+      it('adds groups for two tools in enum order', () => {
+        // use_skill: "skill" (enum index 4), switch_mode: "mode" (enum index 8)
+        // Adding both: "skill" must appear before "mode" in the groups array.
+        const e = new CustomModeVisualEntity(makeMode({ groups: [] }));
+        e.addStep({
+          definedComponent: { name: 'use_skill', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        e.addStep({
+          definedComponent: { name: 'switch_mode', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.1.placeholder' } as never,
+        });
+        const groups = e.toJSON().groups as string[];
+        // skill(4) before mode(8) in the stub enum
+        expect(groups.indexOf('skill')).toBeLessThan(groups.indexOf('mode'));
+      });
+
+      it('is a no-op for an unknown component name', () => {
+        const e = new CustomModeVisualEntity(makeMode({ groups: ['read'] }));
+        e.addStep({
+          definedComponent: { name: 'some-custom-node', type: CatalogKind.BobComponent } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        expect(e.toJSON().groups).toEqual(['read']);
+      });
+    });
+
+    describe('group sync on removeStep', () => {
+      it('preserves groups after removeStep — groups are additive-only', () => {
+        // Groups are only ever added, never removed. Removing a node does not
+        // remove the groups that were added when it was added.
+        const e = new CustomModeVisualEntity(makeMode({ groups: [] }));
+        e.addStep({
+          definedComponent: { name: 'write_file', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        expect(e.toJSON().groups).toContain('file');
+
+        e.removeStep('customMode.customInstructions.0.write_file');
+
+        // Groups from write_file remain — groups are never removed.
+        expect(e.toJSON().groups).toContain('file');
+        expect(e.toJSON().groups).toContain('write');
+      });
+
+      it('regression: reconstructing from the raw mode object after removeStep does not re-add removed tool groups', () => {
+        // The framework calls initialize() → new CustomModeVisualEntity(mode) on the shared
+        // mode object WITHOUT calling toJSON() first. If removeStep does not flush
+        // customInstructions immediately, the stale string still contains **write_file**
+        // and the constructor re-adds its groups on reconstruction.
+        const rawMode = makeMode({ groups: [] });
+        const e = new CustomModeVisualEntity(rawMode);
+        e.addStep({
+          definedComponent: { name: 'write_file', type: CatalogKind.BobTool } as never,
+          mode: AddStepMode.AppendStep,
+          data: { path: 'customMode.customInstructions.0.placeholder' } as never,
+        });
+        expect(rawMode.groups as string[]).toContain('file');
+
+        e.removeStep('customMode.customInstructions.0.write_file');
+
+        // Reconstruct directly from rawMode — no toJSON() call in between.
+        // This is exactly what initialize() does in production.
+        const reconstructed = new CustomModeVisualEntity(rawMode);
+
+        // The constructor must not have re-added write_file groups from the stale customInstructions.
+        expect(reconstructed.toJSON().customInstructions).not.toContain('write_file');
+        // groups must not grow from reconstruction — write_file groups already present but no new ones
+        expect(reconstructed.toJSON().groups).toEqual(rawMode.groups);
+      });
     });
   });
 

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -20,6 +20,7 @@ import { CustomModeSchemaService } from '../visualization/flows/support/custom-m
 import { ModelValidationService } from '../visualization/flows/support/validators/model-validation.service';
 import { createVisualizationNode } from '../visualization/visualization-node';
 import { CustomInstructionsParser } from './custom-instructions-parser';
+import { CustomModeGroupsService } from './custom-mode-groups.service';
 import { CustomInstructionsNode, CustomMode } from './custom-mode-types';
 
 export class CustomModeVisualEntity implements BaseVisualEntity {
@@ -85,8 +86,11 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
     if (!path) return undefined;
     if (path === this.getRootPath()) {
       // Exclude customInstructions (managed via canvas nodes) from the form.
+      // Deep-clone groups so the form widget works on an independent copy.
+      // Without this, sub-index paths (e.g. 'groups.0') in setValue() mutate
+      // this.mode.groups in-place before our updateModel merge can read it.
       const { customInstructions: _ci, ...rest } = this.mode as CustomMode & { customInstructions?: string };
-      return rest;
+      return { ...rest, groups: Array.isArray(rest.groups) ? [...rest.groups] : rest.groups };
     }
     if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
       const index = this.extractStepIndex(path);
@@ -116,12 +120,26 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
       const v = value as Partial<CustomMode>;
       // Explicitly pick only known CustomMode fields to prevent arbitrary key injection.
       // customInstructions is intentionally excluded — it is managed via canvas step nodes.
+      // groups is merged (never replaced) — the form may add groups manually, but it must
+      // not overwrite catalog-derived groups added by addStep. We union form-submitted groups
+      // with the current groups so that: (a) manual additions via the form are accepted, and
+      // (b) a stale form submission that lacks catalog-derived groups does not remove them.
       if (isDefined(v.slug)) this.mode.slug = v.slug;
       if (isDefined(v.name)) this.mode.name = v.name;
       if (isDefined(v.description)) this.mode.description = v.description;
       if (isDefined(v.roleDefinition)) this.mode.roleDefinition = v.roleDefinition;
       if (isDefined(v.whenToUse)) this.mode.whenToUse = v.whenToUse;
-      if (isDefined(v.groups)) this.mode.groups = v.groups;
+      if (Array.isArray(v.groups)) {
+        const existing = new Set<string>(
+          (this.mode.groups as string[]).filter((g): g is string => typeof g === 'string'),
+        );
+        for (const g of v.groups as string[]) {
+          if (typeof g === 'string' && g.trim() !== '' && !existing.has(g)) {
+            (this.mode.groups as string[]).push(g);
+            existing.add(g);
+          }
+        }
+      }
       this.id = isDefined(this.mode.slug) && this.mode.slug !== '' ? this.mode.slug : this.id;
       return;
     }
@@ -156,14 +174,7 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
   }
 
   toJSON(): CustomMode {
-    if (this.parsedNodesDirty) {
-      // Sort by node.index so that a user-edited `order` field takes effect before serializing,
-      // then normalize indexes back to 1…n so they stay in sync with the array position.
-      this.parsedNodes.sort((a, b) => a.index - b.index);
-      this.reindexNodes();
-      this.mode.customInstructions = CustomInstructionsParser.serialize(this.parsedNodes);
-      this.parsedNodesDirty = false;
-    }
+    this.flushParsedNodes();
     return this.mode;
   }
 
@@ -260,6 +271,8 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
 
     this.reindexNodes();
     this.parsedNodesDirty = true;
+    // Sync groups for the newly added node immediately — before toJSON() is called.
+    CustomModeGroupsService.syncGroupsForNode(options.definedComponent.name, this.mode);
   }
 
   removeStep(path?: string): void {
@@ -270,6 +283,11 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
     this.parsedNodes.splice(index, 1);
     this.reindexNodes();
     this.parsedNodesDirty = true;
+    // Flush immediately so this.mode.customInstructions reflects the removal.
+    // The framework reconstructs entities from this.mode (by reference) via initialize()
+    // without calling toJSON() first. Without this flush the stale customInstructions
+    // still contains the removed node reference, and the constructor re-adds its groups.
+    this.flushParsedNodes();
   }
 
   pasteStep(options: {
@@ -370,6 +388,16 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
 
     return modeGroupNode;
   }
+  private flushParsedNodes(): void {
+    if (!this.parsedNodesDirty) return;
+    // Sort by node.index so that a user-edited `order` field takes effect before serializing,
+    // then normalize indexes back to 1…n so they stay in sync with the array position.
+    this.parsedNodes.sort((a, b) => a.index - b.index);
+    this.reindexNodes();
+    this.mode.customInstructions = CustomInstructionsParser.serialize(this.parsedNodes);
+    this.parsedNodesDirty = false;
+  }
+
   private extractStepIndex(path: string): number {
     const prefix = `${this.getRootPath()}.customInstructions.`;
     if (!path.startsWith(prefix)) return -1;

--- a/packages/ui/src/models/custom-mode/index.ts
+++ b/packages/ui/src/models/custom-mode/index.ts
@@ -1,5 +1,6 @@
 export * from './custom-instructions-parser';
 export * from './custom-mode-constants';
+export * from './custom-mode-groups.service';
 export * from './custom-mode-resource';
 export * from './custom-mode-resource-factory';
 export * from './custom-mode-types';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom modes now automatically add required groups when tools are added.
  * Groups are deduplicated and follow the catalog-defined ordering.
  * Removing tools preserves existing groups and immediately updates custom instructions.
  * Unknown tools and unavailable catalog data are handled safely.

* **Bug Fixes**
  * Prevented form edits from unintentionally mutating saved group data.
  * Preserved catalog-derived groups during updates and prevented empty group entries.
  * Improved fallback handling for unrecognized instruction fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->