### PR TITLE
chore(mithril): fix tuple-group dedup, deep-clone groups snapshot, preserve node source on update

### DIFF
--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { CustomInstructionsParser } from './custom-instructions-parser';
 import { CUSTOM_INSTRUCTIONS_PREAMBLE, CUSTOM_INSTRUCTIONS_TRAILER } from './custom-mode-constants';
 import { CustomInstructionsNode } from './custom-mode-types';
@@ -927,6 +929,35 @@ Follow the below instructions strictly. These directives are mandatory and non-n
       // The ordered steps must still be present as numbered items.
       expect(serialized).toContain('1. Analyse ticket');
       expect(serialized).toContain('2. Return JSON');
+    });
+
+    it('round-trip preserves step count when a free-form block is sandwiched between list items', () => {
+      // With parts.join('\n'), the list item directly after the free-form prose
+      // (separated by only one newline) was parsed as a lazy paragraph continuation
+      // rather than a new ordered-list item, collapsing two steps into one.
+      const nodes: CustomInstructionsNode[] = [
+        { nodeType: 'step', source: 'list-item', index: 1, title: 'Step one', rawContent: '' },
+        {
+          nodeType: 'step',
+          source: 'free-form',
+          index: 2,
+          title: 'Prose block',
+          rawContent: '# Interlude\n\nSome prose here.',
+        },
+        { nodeType: 'step', source: 'list-item', index: 3, title: 'Step two', rawContent: '' },
+        { nodeType: 'step', source: 'list-item', index: 4, title: 'Step three', rawContent: '' },
+      ];
+
+      const serialized = CustomInstructionsParser.serialize(nodes);
+      const roundTripped = CustomInstructionsParser.parse(serialized);
+
+      // Must recover all four nodes — free-form + 3 list-items.
+      expect(roundTripped).toHaveLength(4);
+      // List-item counter must reset correctly after the free-form block.
+      expect(roundTripped.find((n) => n.title === 'Step two')).toBeDefined();
+      expect(roundTripped.find((n) => n.title === 'Step three')).toBeDefined();
+      // The free-form heading must survive the round-trip.
+      expect(roundTripped.find((n) => n.source === 'free-form')).toBeDefined();
     });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
+++ b/packages/ui/src/models/custom-mode/custom-instructions-parser.ts
@@ -348,6 +348,6 @@ export class CustomInstructionsParser {
         .join('\n');
     });
 
-    return `${CUSTOM_INSTRUCTIONS_PREAMBLE}\n\n${parts.join('\n')}\n\n${CUSTOM_INSTRUCTIONS_TRAILER}\n`;
+    return `${CUSTOM_INSTRUCTIONS_PREAMBLE}\n\n${parts.join('\n\n')}\n\n${CUSTOM_INSTRUCTIONS_TRAILER}\n`;
   }
 }

--- a/packages/ui/src/models/custom-mode/custom-mode-constants.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-constants.ts
@@ -26,8 +26,9 @@ Follow the below instructions strictly. These directives are mandatory and non-n
  * Hard rules are hidden from the user on the canvas (they never become step
  * nodes) and are always re-injected by `CustomInstructionsParser.serialize()`.
  *
- * TODO: consolidate the per-mode rule sets into a single canonical list.
  */
 export const CUSTOM_INSTRUCTIONS_TRAILER = `> Hard rules
-> - Do not invent content not present in the input.
-> - Follow the output format specified in the final step exactly.`;
+> - Never call any external API or query any live data source.
+> - Do NOT alter names, dates, email addresses, phone numbers, or any non-monetary text.
+> - If no target data is found, set the relevant count to 0 and return the content unchanged with a note.
+> - Never fabricate or skip a step — always wait for actual tool responses before proceeding.`;

--- a/packages/ui/src/models/custom-mode/custom-mode-groups.service.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-groups.service.test.ts
@@ -103,6 +103,17 @@ describe('CustomModeGroupsService (catalog-driven)', () => {
       expect((mode.groups as string[]).filter((g) => g === 'write')).toHaveLength(1);
     });
 
+    it('does not add a plain-string group when a tuple with the same name already exists', () => {
+      // Tuple ["write", { fileRegex: "..." }] must count as "write" for deduplication.
+      const mode = makeMode({ groups: [['write', { fileRegex: '\\.yaml$' }], 'file'] });
+      CustomModeGroupsService.syncGroupsForNode('write_file', mode);
+      // "write" is already represented by the tuple — must not be added again.
+      const writeEntries = mode.groups.filter((g) => (Array.isArray(g) ? g[0] === 'write' : g === 'write'));
+      expect(writeEntries).toHaveLength(1);
+      // "file" is already a plain string — must not be duplicated either.
+      expect(mode.groups.filter((g) => g === 'file')).toHaveLength(1);
+    });
+
     it('is a no-op for an unknown node name', () => {
       const mode = makeMode({ groups: ['read'] });
       CustomModeGroupsService.syncGroupsForNode('not_in_catalog', mode);

--- a/packages/ui/src/models/custom-mode/custom-mode-groups.service.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-groups.service.ts
@@ -54,7 +54,7 @@ export class CustomModeGroupsService {
     const required = CustomModeGroupsService.getRequiredGroups([nodeName]);
     if (required.length === 0) return;
 
-    const existing = new Set<string>(mode.groups.filter((g): g is string => typeof g === 'string'));
+    const existing = new Set<string>(mode.groups.map((g) => (Array.isArray(g) ? g[0] : g)));
 
     const missing = required.filter((g) => !existing.has(g));
     if (missing.length === 0) return;

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.test.ts
@@ -237,6 +237,21 @@ describe('CustomModeVisualEntity', () => {
       expect(def['content']).toBeUndefined();
       expect(def['label']).toBeUndefined();
     });
+
+    it('deep-clones tuple group entries so mutating the snapshot cannot affect this.mode.groups', () => {
+      // A restricted group is stored as a tuple [name, { fileRegex }].
+      // The shallow [...rest.groups] copy shared the inner object reference, so a form
+      // setValue() on 'groups.0.1.fileRegex' mutated the live mode before updateModel ran.
+      const tupleGroup: [string, { fileRegex: string }] = ['write', { fileRegex: '\\.yaml$' }];
+      const e = new CustomModeVisualEntity(makeMode({ groups: [tupleGroup] }));
+
+      const snapshot = e.getNodeDefinition('customMode') as { groups: unknown[] };
+      // Mutate the nested object in the snapshot — must NOT bleed into the live mode.
+      (snapshot.groups[0] as [string, { fileRegex: string }])[1].fileRegex = 'MUTATED';
+
+      // The live mode's tuple must be unchanged.
+      expect((e.toJSON().groups[0] as [string, { fileRegex: string }])[1].fileRegex).toBe('\\.yaml$');
+    });
   });
 
   describe('getOmitFormFields', () => {
@@ -398,6 +413,21 @@ describe('CustomModeVisualEntity', () => {
         const before = e.toJSON().customInstructions;
         e.updateModel('customMode.customInstructions.99.step', { content: 'Ghost', label: 'Ghost', order: 99 });
         expect(e.toJSON().customInstructions).toBe(before);
+      });
+
+      it('preserves source from the existing node when updating an ordinary step', () => {
+        // The parser assigns source: 'list-item' for ordered-list items.
+        // updateModel must not drop this field when rebuilding the node.
+        const e = new CustomModeVisualEntity(makeMode({ customInstructions: instructions }));
+        e.updateModel('customMode.customInstructions.0.step', {
+          content: 'Updated body',
+          label: 'Parse input',
+          order: 1,
+        });
+        // The node came from a list-item, so after update it must still serialize as a list item.
+        const serialized = e.toJSON().customInstructions ?? '';
+        expect(serialized).toMatch(/^1\. Parse input/m);
+        expect(serialized).toContain('Updated body');
       });
     });
   });
@@ -1014,6 +1044,21 @@ describe('CustomModeVisualEntity', () => {
       const def = e.getNodeDefinition('customMode.customInstructions.0.read_file') as Record<string, string>;
       expect(def['path']).toBe('roundtrip.md');
       expect(def['description']).toBe('round-trip value');
+    });
+
+    it('preserves source from the existing node when updating a tool-invocation step', () => {
+      // The parser always assigns source: 'list-item' for ordered-list items.
+      // updateModel must not drop this field when rebuilding the node.
+      const e = new CustomModeVisualEntity(makeMode({ customInstructions: toolInstructions }));
+      // Confirm the parsed node has source: 'list-item' (set by the parser).
+      const defBefore = e.getNodeDefinition('customMode.customInstructions.0.read_file') as Record<string, string>;
+      expect(defBefore).toBeDefined();
+      // Now update — source must survive the rebuild.
+      e.updateModel('customMode.customInstructions.0.read_file', { path: 'updated.md' });
+      // The node is still a list-item, so serialization must emit a list marker.
+      const serialized = e.toJSON().customInstructions ?? '';
+      expect(serialized).toMatch(/^1\. /m);
+      expect(serialized).toContain('updated.md');
     });
   });
 });

--- a/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
+++ b/packages/ui/src/models/custom-mode/custom-mode-visual-entity.ts
@@ -87,10 +87,15 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
     if (path === this.getRootPath()) {
       // Exclude customInstructions (managed via canvas nodes) from the form.
       // Deep-clone groups so the form widget works on an independent copy.
-      // Without this, sub-index paths (e.g. 'groups.0') in setValue() mutate
-      // this.mode.groups in-place before our updateModel merge can read it.
+      // Without this, sub-index paths (e.g. 'groups.0.1.fileRegex') in setValue() mutate
+      // nested tuple objects inside this.mode.groups before our updateModel merge can read them.
+      // Each entry is cloned individually: strings are primitives (no-op), tuples carry a
+      // nested constraint object that must not be shared with the live mode.
       const { customInstructions: _ci, ...rest } = this.mode as CustomMode & { customInstructions?: string };
-      return { ...rest, groups: Array.isArray(rest.groups) ? [...rest.groups] : rest.groups };
+      return {
+        ...rest,
+        groups: Array.isArray(rest.groups) ? rest.groups.map((g) => structuredClone(g)) : rest.groups,
+      };
     }
     if (path.startsWith(`${this.getRootPath()}.customInstructions.`)) {
       const index = this.extractStepIndex(path);
@@ -131,7 +136,7 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
       if (isDefined(v.whenToUse)) this.mode.whenToUse = v.whenToUse;
       if (Array.isArray(v.groups)) {
         const existing = new Set<string>(
-          (this.mode.groups as string[]).filter((g): g is string => typeof g === 'string'),
+          (this.mode.groups as (string | [string, unknown])[]).map((g) => (Array.isArray(g) ? g[0] : g)),
         );
         for (const g of v.groups as string[]) {
           if (typeof g === 'string' && g.trim() !== '' && !existing.has(g)) {
@@ -153,6 +158,7 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
           const params = value as Record<string, string>;
           this.parsedNodes[index] = {
             nodeType: 'tool-invocation',
+            source: existing.source,
             rawContent: CustomInstructionsParser.serializeToolParams(existing.toolName, params),
             title: existing.toolName,
             index: existing.index,
@@ -163,6 +169,7 @@ export class CustomModeVisualEntity implements BaseVisualEntity {
           const formValue = value as { content?: string; label?: string; order?: number };
           this.parsedNodes[index] = {
             nodeType: existing.nodeType,
+            source: existing.source,
             rawContent: formValue.content ?? existing.rawContent,
             title: formValue.label ?? existing.title,
             index: typeof formValue.order === 'number' ? formValue.order : existing.index,


### PR DESCRIPTION
**What**
Three related bugfixes for the custom-mode editor:

1. Tuple group deduplication — syncGroupsForNode and updateModel were only checking plain-string entries in mode.groups, so a tuple like ["write", { fileRegex: "…" }] was invisible to the dedup logic and a plain "write" could be appended alongside it. Fixed by extracting the name from both forms.
2. Deep-clone groups in getNodeDefinition — [...rest.groups] was a shallow copy, meaning the inner constraint object inside a tuple was shared with the live mode. A setValue() call on groups.0.1.fileRegex would mutate the live mode before updateModel could read it. Fixed with structuredClone.
3. Preserve source on updateModel — When rebuilding a CustomInstructionsNode after a form edit, the source field ('list-item' | 'free-form') was dropped, causing free-form nodes to be serialized as numbered list items. Fixed by forwarding existing.source in both the tool-invocation and ordinary-step branches.
4. Parser serialize join — parts.join('\n') produced a tight join that caused the Markdown parser to treat a list item immediately after a free-form block as a lazy-continuation paragraph, collapsing two steps into one. Changed to parts.join('\n\n').
5. Updated hard rules trailer — Replaced the two generic hard rules with four domain-specific rules matching the current Bob pipeline contract. Removed stale TODO comment.

**Tests added**

- Round-trip preserves step count when a free-form block is sandwiched between list items
- Tuple group entry is not duplicated when a plain-string match already exists as a tuple
- structuredClone prevents snapshot mutation from bleeding into the live mode
- source is preserved after updateModel for both ordinary steps and tool-invocation steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom instructions so free-form steps placed between ordered-list items are preserved after saving and reloading.
  * Improved custom mode editing to keep step/list structure accurate and avoid unintended changes to nested group settings.
  * Prevented duplicate groups from appearing during synchronization.
  * Strengthened “custom instructions” rules to better enforce content fidelity and ensure steps align with real tool responses.
* **Tests**
  * Added regression coverage for list preservation, group deduplication, and immutability of edited snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->