### PR TITLE
refactor(canvas): extract `useSelectedVizNode` and `useSelectedNodePanIntoView` hooks

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Canvas.tsx
@@ -28,10 +28,9 @@ import {
 } from 'react';
 
 import { CatalogModalContext } from '../../../dynamic-catalog/catalog-modal.provider';
-import { useLocalStorage } from '../../../hooks';
-import { LocalStorageKeys } from '../../../models';
+import { useLocalStorage, useSelectedNodePanIntoView, useSelectedVizNode } from '../../../hooks';
+import { IVisualizationNode, LocalStorageKeys } from '../../../models';
 import { CanvasLayoutDirection } from '../../../models/settings/settings.model';
-import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 import { SettingsContext } from '../../../providers/settings.provider';
 import { getInitialLayout } from '../../../utils/get-initial-layout';
 import { HorizontalLayoutIcon } from '../../Icons/HorizontalLayout';
@@ -76,7 +75,6 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
     () => controller.hasGraph() && controller.getGraph().getLayout() !== undefined,
   );
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [selectedNode, setSelectedNode] = useState<CanvasNode | undefined>(undefined);
   const [sidebarWidth, setSidebarWidth] = useLocalStorage(
     LocalStorageKeys.CanvasSidebarWidth,
     CanvasDefaults.DEFAULT_SIDEBAR_WIDTH,
@@ -100,10 +98,10 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
 
   const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    setSelectedNode(undefined);
   }, []);
 
-  useDeleteHotkey(selectedNode?.data?.vizNode, clearSelection);
+  const selectedVizNode = useSelectedVizNode(selectedIds);
+  useDeleteHotkey(selectedVizNode, clearSelection);
 
   /** Draw graph */
   useEffect(() => {
@@ -152,32 +150,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
   }, [controller, vizNodes, isVizNodesResolving]);
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, setSelectedIds);
-
-  /** Set select node and pan it into view */
-  useEffect(() => {
-    let resizeTimeout: number | undefined;
-
-    if (selectedIds[0]) {
-      const selectedNode = controller.getNodeById(selectedIds[0]);
-      if (selectedNode) {
-        setSelectedNode(selectedNode as unknown as CanvasNode);
-        resizeTimeout = setTimeout(
-          action(() => {
-            controller.getGraph().panIntoView(selectedNode, { offset: 20, minimumVisible: 100 });
-            resizeTimeout = undefined;
-          }),
-          500,
-        ) as unknown as number;
-      }
-      return () => {
-        if (resizeTimeout) {
-          clearTimeout(resizeTimeout);
-        }
-      };
-    } else {
-      setSelectedNode(undefined);
-    }
-  }, [selectedIds, controller]);
+  useSelectedNodePanIntoView(selectedIds);
 
   const controlButtons = useMemo(() => {
     const customButtons: TopologyControlButton[] = [];
@@ -263,7 +236,7 @@ export const Canvas: FunctionComponent<PropsWithChildren<CanvasProps>> = ({
       onSideBarResize={setSidebarWidth}
       sideBarResizable
       sideBarOpen={isSidebarOpen}
-      sideBar={isSidebarOpen ? <CanvasSideBar selectedNode={selectedNode} onClose={clearSelection} /> : null}
+      sideBar={isSidebarOpen ? <CanvasSideBar vizNode={selectedVizNode} onClose={clearSelection} /> : null}
       contextToolbar={contextToolbar}
       controlBar={<TopologyControlBar controlButtons={controlButtons} />}
       onClick={handleCanvasClick}

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -6,14 +6,14 @@ import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../models/camel';
 import { EntityType } from '../../../models/entities';
+import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 import { mockRandomValues } from '../../../stubs';
 import { TestProvidersWrapper } from '../../../stubs/TestProvidersWrapper';
-import { CanvasNode } from './canvas.models';
 import { CanvasSideBar } from './CanvasSideBar';
 import { FlowService } from './flow.service';
 
 describe('CanvasSideBar', () => {
-  let selectedNode: CanvasNode;
+  let selectedVizNode: IVisualizationNode;
   let Provider: FunctionComponent<PropsWithChildren>;
 
   beforeAll(async () => {
@@ -25,15 +25,16 @@ describe('CanvasSideBar', () => {
     const camelResource = new CamelRouteResource(parse(await baseResource.toSourceCode()) as CamelYamlDsl);
     await camelResource.initialize();
     const visualEntity = camelResource.getVisualEntities()[0];
-    selectedNode = FlowService.getFlowDiagram('test', await visualEntity.toVizNode()).nodes[0];
+    const node = FlowService.getFlowDiagram('test', await visualEntity.toVizNode()).nodes[0];
+    selectedVizNode = node.data!.vizNode!;
     Provider = (await TestProvidersWrapper({ camelResource })).Provider;
   });
 
-  it('does not render anything if there is no selectedNode', async () => {
+  it('does not render anything if there is no selectedVizNode', async () => {
     const wrapper = await act(async () =>
       render(
         <CanvasFormTabsProvider>
-          <CanvasSideBar selectedNode={undefined} onClose={() => {}} />
+          <CanvasSideBar vizNode={undefined} onClose={() => {}} />
         </CanvasFormTabsProvider>,
       ),
     );
@@ -46,7 +47,7 @@ describe('CanvasSideBar', () => {
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasSideBar selectedNode={selectedNode} onClose={() => {}} />
+            <CanvasSideBar vizNode={selectedVizNode} onClose={() => {}} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),
@@ -62,7 +63,7 @@ describe('CanvasSideBar', () => {
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasSideBar selectedNode={selectedNode} onClose={onCloseSpy} />
+            <CanvasSideBar vizNode={selectedVizNode} onClose={onCloseSpy} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.tsx
@@ -4,17 +4,17 @@ import { FilteredFieldProvider } from '@kaoto/forms';
 import { TopologySideBar } from '@patternfly/react-topology';
 import { FunctionComponent } from 'react';
 
+import { IVisualizationNode } from '../../../models';
 import { ErrorBoundary } from '../../ErrorBoundary';
-import { CanvasNode } from './canvas.models';
 import { CanvasForm } from './Form/CanvasForm';
 
 interface CanvasSideBarProps {
-  selectedNode: CanvasNode | undefined;
+  vizNode: IVisualizationNode | undefined;
   onClose: () => void;
 }
 
-export const CanvasSideBar: FunctionComponent<CanvasSideBarProps> = (props) => {
-  if (props.selectedNode === undefined) {
+export const CanvasSideBar: FunctionComponent<CanvasSideBarProps> = ({ vizNode, onClose }) => {
+  if (vizNode === undefined) {
     return null;
   }
 
@@ -24,9 +24,9 @@ export const CanvasSideBar: FunctionComponent<CanvasSideBarProps> = (props) => {
      * and doesn't take into account the sidebar children.
      */
     <TopologySideBar resizable className="canvas-sidebar">
-      <ErrorBoundary key={props.selectedNode.id} fallback={<p>Something did not work as expected</p>}>
+      <ErrorBoundary key={vizNode.id} fallback={<p>Something did not work as expected</p>}>
         <FilteredFieldProvider>
-          <CanvasForm selectedNode={props.selectedNode} onClose={props.onClose} />
+          <CanvasForm vizNode={vizNode} onClose={onClose} />
         </FilteredFieldProvider>
       </ErrorBoundary>
     </TopologySideBar>

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -21,13 +21,12 @@ import { VisualFlowsApi } from '../../../../models/visualization/flows/support/f
 import { camelRouteJson, kameletJson, TestProvidersWrapper } from '../../../../stubs';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { ROOT_PATH } from '../../../../utils';
-import { CanvasNode } from '../canvas.models';
 import { FlowService } from '../flow.service';
 import { CanvasForm } from './CanvasForm';
 
 describe('CanvasForm', () => {
   let camelRouteVisualEntity: CamelRouteVisualEntity;
-  let selectedNode: CanvasNode;
+  let vizNode: IVisualizationNode;
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
   let patternCatalogMap: Record<string, ICamelProcessorDefinition>;
   let kameletCatalogMap: Record<string, IKameletDefinition>;
@@ -51,7 +50,8 @@ describe('CanvasForm', () => {
   beforeEach(async () => {
     camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson);
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-    selectedNode = nodes.find((node) => node.id === 'test|route.from.steps.1.choice')!; // choice
+    const choiceNode = nodes.find((node) => node.id === 'test|route.from.steps.1.choice')!;
+    vizNode = choiceNode.data!.vizNode!;
   });
 
   afterEach(() => {
@@ -64,7 +64,7 @@ describe('CanvasForm', () => {
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={vizNode} onClose={vi.fn()} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),
@@ -73,31 +73,8 @@ describe('CanvasForm', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should return null when vizNode is not available', async () => {
-    const selectedNode = {
-      id: '1',
-      type: 'node',
-      data: {
-        vizNode: undefined,
-      },
-    } as CanvasNode;
-
-    const { Provider } = await TestProvidersWrapper();
-    const { container } = await act(async () =>
-      render(
-        <Provider>
-          <CanvasFormTabsProvider>
-            <CanvasForm selectedNode={selectedNode} />
-          </CanvasFormTabsProvider>
-        </Provider>,
-      ),
-    );
-
-    expect(container.firstChild).toBeNull();
-  });
-
   it('should render nothing if no schema is available', async () => {
-    const vizNode = createVisualizationNode('route', {
+    const noSchemaVizNode = createVisualizationNode('route', {
       name: EntityType.Route,
       path: CamelRouteVisualEntity.ROOT_PATH,
       entity: new CamelRouteVisualEntity(camelRouteJson),
@@ -109,23 +86,15 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    const selectedNode: CanvasNode = {
-      id: '1',
-      type: 'node',
-      data: {
-        vizNode,
-      },
-    };
-
-    vi.spyOn(vizNode, 'getNodeSchema').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
+    vi.spyOn(noSchemaVizNode, 'getNodeSchema').mockReturnValue(undefined);
+    vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(undefined);
 
     const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={noSchemaVizNode} onClose={vi.fn()} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),
@@ -135,7 +104,7 @@ describe('CanvasForm', () => {
   });
 
   it('should render nothing if no schema and no definition is available', async () => {
-    const vizNode = createVisualizationNode('route', {
+    const noSchemaVizNode = createVisualizationNode('route', {
       name: EntityType.Route,
       path: CamelRouteVisualEntity.ROOT_PATH,
       entity: new CamelRouteVisualEntity(camelRouteJson),
@@ -147,23 +116,15 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    const selectedNode: CanvasNode = {
-      id: '1',
-      type: 'node',
-      data: {
-        vizNode,
-      },
-    };
-
-    vi.spyOn(vizNode, 'getNodeSchema').mockReturnValue(null as unknown as KaotoSchemaDefinition['schema']);
-    vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(null);
+    vi.spyOn(noSchemaVizNode, 'getNodeSchema').mockReturnValue(null as unknown as KaotoSchemaDefinition['schema']);
+    vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(null);
 
     const { Provider } = await TestProvidersWrapper();
     const { container } = await act(async () =>
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={noSchemaVizNode} onClose={vi.fn()} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),
@@ -177,7 +138,7 @@ describe('CanvasForm', () => {
     const dispatchSpy = vi.fn();
     const visualFlowsApi = new VisualFlowsApi(dispatchSpy);
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-    selectedNode = nodes[nodes.length - 1];
+    const lastVizNode = nodes[nodes.length - 1].data!.vizNode!;
 
     const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
@@ -192,7 +153,7 @@ describe('CanvasForm', () => {
               setSelectedTab: vi.fn(),
             }}
           >
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={lastVizNode} onClose={vi.fn()} />
           </CanvasFormTabsContext.Provider>
         </Provider>,
       ),
@@ -216,7 +177,7 @@ describe('CanvasForm', () => {
     const dispatchSpy = vi.fn();
     const visualFlowsApi = new VisualFlowsApi(dispatchSpy);
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-    selectedNode = nodes[nodes.length - 1];
+    const lastVizNode = nodes[nodes.length - 1].data!.vizNode!;
 
     const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
@@ -231,7 +192,7 @@ describe('CanvasForm', () => {
               setSelectedTab: vi.fn(),
             }}
           >
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={lastVizNode} onClose={vi.fn()} />
           </CanvasFormTabsContext.Provider>
         </Provider>,
       ),
@@ -256,7 +217,7 @@ describe('CanvasForm', () => {
     const dispatchSpy = vi.fn();
     const visualFlowsApi = new VisualFlowsApi(dispatchSpy);
     const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-    selectedNode = nodes[nodes.length - 1];
+    const lastVizNode = nodes[nodes.length - 1].data!.vizNode!;
 
     const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
@@ -271,7 +232,7 @@ describe('CanvasForm', () => {
               setSelectedTab: vi.fn(),
             }}
           >
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={lastVizNode} onClose={vi.fn()} />
           </CanvasFormTabsContext.Provider>
         </Provider>,
       ),
@@ -298,7 +259,7 @@ describe('CanvasForm', () => {
     const dispatchSpy = vi.fn();
     const visualFlowsApi = new VisualFlowsApi(dispatchSpy);
     const { nodes } = FlowService.getFlowDiagram('test', await kameletVisualEntity.toVizNode());
-    selectedNode = nodes[nodes.length - 1];
+    const lastVizNode = nodes[nodes.length - 1].data!.vizNode!;
 
     const { Provider } = await TestProvidersWrapper({
       visibleFlowsContext: { allFlowsVisible: true, visibleFlows: { [flowId]: true }, visualFlowsApi },
@@ -308,7 +269,7 @@ describe('CanvasForm', () => {
       render(
         <Provider>
           <CanvasFormTabsProvider>
-            <CanvasForm selectedNode={selectedNode} />
+            <CanvasForm vizNode={lastVizNode} onClose={vi.fn()} />
           </CanvasFormTabsProvider>
         </Provider>,
       ),
@@ -332,7 +293,7 @@ describe('CanvasForm', () => {
     beforeEach(async () => {
       camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson);
       const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-      selectedNode = nodes[0]; // timer
+      vizNode = nodes[0].data!.vizNode!; // timer
     });
 
     it('normal text field', async () => {
@@ -342,7 +303,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode} />
+              <CanvasForm vizNode={vizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -384,14 +345,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const setHeaderNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: setHeaderNode,
-        },
-      };
+      const setHeaderVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -399,7 +353,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={setHeaderVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -449,14 +403,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const marshalNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: marshalNode,
-        },
-      };
+      const marshalVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -464,7 +411,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={marshalVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -518,14 +465,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const loadBalanceNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: loadBalanceNode,
-        },
-      };
+      const loadBalanceVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -533,7 +473,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={loadBalanceVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -571,7 +511,7 @@ describe('CanvasForm', () => {
     beforeEach(async () => {
       camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson);
       const { nodes } = FlowService.getFlowDiagram('test', await camelRouteVisualEntity.toVizNode());
-      selectedNode = nodes[0]; // timer
+      vizNode = nodes[0].data!.vizNode!; // timer
     });
 
     it('normal text field', async () => {
@@ -581,7 +521,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode} />
+              <CanvasForm vizNode={vizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -619,14 +559,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const setHeaderNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: setHeaderNode,
-        },
-      };
+      const setHeaderVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -634,7 +567,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={setHeaderVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -680,14 +613,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const marshalNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: marshalNode,
-        },
-      };
+      const marshalVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -695,7 +621,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={marshalVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),
@@ -742,14 +668,7 @@ describe('CanvasForm', () => {
       } as RouteDefinition;
       const entity = new CamelRouteVisualEntity(camelRoute);
       const rootNode: IVisualizationNode = await entity.toVizNode();
-      const loadBalanceNode = rootNode.getChildren()![1];
-      const selectedNode = {
-        id: '1',
-        type: 'node',
-        data: {
-          vizNode: loadBalanceNode,
-        },
-      };
+      const loadBalanceVizNode = rootNode.getChildren()![1];
 
       const { Provider } = await TestProvidersWrapper();
 
@@ -757,7 +676,7 @@ describe('CanvasForm', () => {
         render(
           <Provider>
             <CanvasFormTabsProvider>
-              <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+              <CanvasForm vizNode={loadBalanceVizNode} onClose={vi.fn()} />
             </CanvasFormTabsProvider>
           </Provider>,
         ),

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.tsx
@@ -3,52 +3,49 @@ import './CanvasForm.scss';
 import { Card, CardBody, CardHeader } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useContext, useEffect, useRef } from 'react';
 
+import { IVisualizationNode } from '../../../../models';
 import { VisibleFlowsContext } from '../../../../providers';
 import { ErrorBoundary } from '../../../ErrorBoundary';
 import { Anchors } from '../../../registers/anchors';
 import { RenderingAnchor } from '../../../RenderingAnchor/RenderingAnchor';
-import { CanvasNode } from '../canvas.models';
 import { CanvasFormBody } from './CanvasFormBody';
 import { CanvasFormHeader } from './CanvasFormHeader';
 
 interface CanvasFormProps {
-  selectedNode: CanvasNode;
-  onClose?: () => void;
+  vizNode: IVisualizationNode;
+  onClose: () => void;
 }
 
-export const CanvasForm: FunctionComponent<CanvasFormProps> = ({ selectedNode, onClose }) => {
+export const CanvasForm: FunctionComponent<CanvasFormProps> = ({ vizNode, onClose }) => {
   const { visualFlowsApi } = useContext(VisibleFlowsContext)!;
   const flowIdRef = useRef<string | undefined>(undefined);
-  const vizNode = selectedNode.data?.vizNode;
-  const title = vizNode?.getNodeTitle();
+  const title = vizNode.getNodeTitle();
 
   /** Store the flow's initial Id */
   useEffect(() => {
-    flowIdRef.current = vizNode?.getId();
+    flowIdRef.current = vizNode.getId();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onCloseFn = useCallback(() => {
-    onClose?.();
-    const newId = vizNode?.getId();
+    onClose();
+    const newId = vizNode.getId();
     if (typeof flowIdRef.current === 'string' && typeof newId === 'string' && flowIdRef.current !== newId) {
       visualFlowsApi.renameFlow(flowIdRef.current, newId);
     }
   }, [onClose, visualFlowsApi, vizNode]);
 
-  if (!vizNode) {
-    return null;
-  }
-
   return (
-    <ErrorBoundary key={selectedNode.id} fallback={<p>This node cannot be configured yet</p>}>
+    <ErrorBoundary key={vizNode.id} fallback={<p>This node cannot be configured yet</p>}>
       <Card className="canvas-form">
         <CardHeader>
-          <CanvasFormHeader nodeId={selectedNode.id} title={title} onClose={onCloseFn} iconUrl={vizNode.data.iconUrl} />
+          <CanvasFormHeader nodeId={vizNode.id} title={title} onClose={onCloseFn} iconUrl={vizNode.data.iconUrl} />
           <RenderingAnchor anchorTag={Anchors.CanvasFormHeader} vizNode={vizNode} />
         </CardHeader>
 
-        <CardBody className="canvas-form__body">{vizNode && <CanvasFormBody vizNode={vizNode} />}</CardBody>
+        <CardBody className="canvas-form__body">
+          <CanvasFormBody vizNode={vizNode} />
+        </CardBody>
       </Card>
     </ErrorBoundary>
   );

--- a/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/Form/__snapshots__/CanvasForm.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`CanvasForm > should render 1`] = `
           >
             <img
               alt="choice"
-              class="form-header__icon-test|route.from.steps.1.choice"
+              class="form-header__icon-route.from.steps.1.choice"
               src="/src/assets/eip/choice.png"
             />
             <h2

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasSideBar.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`CanvasSideBar > displays selected node information 1`] = `
             >
               <img
                 alt="timer"
-                class="form-header__icon-test|route.from"
+                class="form-header__icon-route.from"
                 src="/src/assets/components/timer.svg"
               />
               <h2

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,3 +1,6 @@
 export * from './local-storage.hook';
 export * from './previous.hook';
+export * from './useCanvasEntities';
 export * from './useConnectionPortSync.hook';
+export * from './useSelectedNodePanIntoView';
+export * from './useSelectedVizNode';

--- a/packages/ui/src/hooks/useSelectedNodePanIntoView.test.ts
+++ b/packages/ui/src/hooks/useSelectedNodePanIntoView.test.ts
@@ -1,0 +1,127 @@
+/*
+    Copyright (C) 2026 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { action, useVisualizationController } from '@patternfly/react-topology';
+import { act, renderHook } from '@testing-library/react';
+import type { Mock } from 'vitest';
+
+import { useSelectedNodePanIntoView } from './useSelectedNodePanIntoView';
+
+vi.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: vi.fn(),
+  action: vi.fn((fn) => fn),
+}));
+
+function makeController(nodeFound = true) {
+  const panIntoView = vi.fn();
+  const graphNode = nodeFound ? { id: 'scope|timer-1' } : undefined;
+  return {
+    panIntoView,
+    controller: {
+      getNodeById: vi.fn(() => graphNode),
+      getGraph: vi.fn(() => ({ panIntoView })),
+    },
+  };
+}
+
+describe('useSelectedNodePanIntoView', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (action as unknown as Mock).mockImplementation((fn: () => void) => fn);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not call panIntoView when selectedIds is empty', async () => {
+    const { panIntoView, controller } = makeController();
+    (useVisualizationController as Mock).mockReturnValue(controller);
+
+    renderHook(() => {
+      useSelectedNodePanIntoView([]);
+    });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(panIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does not call panIntoView when selectedIds has more than one element', async () => {
+    const { panIntoView, controller } = makeController();
+    (useVisualizationController as Mock).mockReturnValue(controller);
+
+    renderHook(() => {
+      useSelectedNodePanIntoView(['scope|timer-1', 'scope|timer-2']);
+    });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(panIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does not call panIntoView when node is not found', async () => {
+    const { panIntoView, controller } = makeController(false);
+    (useVisualizationController as Mock).mockReturnValue(controller);
+
+    renderHook(() => {
+      useSelectedNodePanIntoView(['scope|unknown']);
+    });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(panIntoView).not.toHaveBeenCalled();
+  });
+
+  it('calls panIntoView with correct options after the timeout fires', async () => {
+    const { panIntoView, controller } = makeController(true);
+    (useVisualizationController as Mock).mockReturnValue(controller);
+
+    renderHook(() => {
+      useSelectedNodePanIntoView(['scope|timer-1']);
+    });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(panIntoView).toHaveBeenCalledWith(expect.objectContaining({ id: 'scope|timer-1' }), {
+      offset: 150,
+      minimumVisible: 100,
+    });
+  });
+
+  it('cancels the timeout when selectedIds changes before it fires', async () => {
+    const { panIntoView, controller } = makeController(true);
+    (useVisualizationController as Mock).mockReturnValue(controller);
+
+    let ids = ['scope|timer-1'];
+    const { rerender } = renderHook(() => {
+      useSelectedNodePanIntoView(ids);
+    });
+
+    // Change selection before 500ms elapses
+    ids = [];
+    rerender();
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(panIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useSelectedNodePanIntoView.ts
+++ b/packages/ui/src/hooks/useSelectedNodePanIntoView.ts
@@ -1,0 +1,48 @@
+/*
+    Copyright (C) 2026 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { action, useVisualizationController } from '@patternfly/react-topology';
+import { useEffect } from 'react';
+
+/**
+ * Pans the topology graph to bring the selected node into view.
+ *
+ * Fires a delayed panIntoView when exactly one id is selected and the
+ * controller resolves it to a live graph node. Does nothing for empty
+ * selection, multi-selection, or unresolvable ids.
+ *
+ * The 500ms delay allows layout animations to settle before panning.
+ */
+export const useSelectedNodePanIntoView = (selectedIds: string[]): void => {
+  const controller = useVisualizationController();
+
+  useEffect(() => {
+    if (selectedIds.length !== 1) return;
+
+    const resizeTimeout = setTimeout(
+      action(() => {
+        const graphNode = controller.getNodeById(selectedIds[0]);
+        if (graphNode) {
+          controller.getGraph().panIntoView(graphNode, { offset: 150, minimumVisible: 100 });
+        }
+      }),
+      500,
+    );
+
+    return () => {
+      clearTimeout(resizeTimeout);
+    };
+  }, [selectedIds, controller]);
+};

--- a/packages/ui/src/hooks/useSelectedVizNode.test.ts
+++ b/packages/ui/src/hooks/useSelectedVizNode.test.ts
@@ -1,0 +1,91 @@
+/*
+    Copyright (C) 2026 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { useVisualizationController } from '@patternfly/react-topology';
+import { act, renderHook } from '@testing-library/react';
+import type { Mock } from 'vitest';
+
+import { IVisualizationNode } from '../models/visualization/base-visual-entity';
+import { useSelectedVizNode } from './useSelectedVizNode';
+
+vi.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: vi.fn(),
+}));
+
+const mockVizNode = { id: 'timer-1' } as unknown as IVisualizationNode;
+
+function makeController(vizNode?: IVisualizationNode) {
+  return {
+    getNodeById: vi.fn((id: string) => {
+      if (id === 'scope|timer-1' && vizNode) {
+        return { getData: () => ({ vizNode }) };
+      }
+      return undefined;
+    }),
+  };
+}
+
+describe('useSelectedVizNode', () => {
+  beforeEach(() => {
+    (useVisualizationController as Mock).mockReturnValue(makeController(mockVizNode));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when selectedIds is empty', () => {
+    const { result } = renderHook(() => useSelectedVizNode([]));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when selectedIds has more than one element', () => {
+    const { result } = renderHook(() => useSelectedVizNode(['scope|timer-1', 'scope|timer-2']));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the vizNode when exactly one id resolves to a node with vizNode', async () => {
+    const { result } = renderHook(() => useSelectedVizNode(['scope|timer-1']));
+    await act(async () => {});
+    expect(result.current).toBe(mockVizNode);
+  });
+
+  it('returns undefined when controller returns no node for the given id', async () => {
+    (useVisualizationController as Mock).mockReturnValue(makeController(undefined));
+    const { result } = renderHook(() => useSelectedVizNode(['scope|unknown']));
+    await act(async () => {});
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when the node has no vizNode in its data', async () => {
+    const controller = { getNodeById: vi.fn(() => ({ getData: () => ({}) })) };
+    (useVisualizationController as Mock).mockReturnValue(controller);
+    const { result } = renderHook(() => useSelectedVizNode(['scope|timer-1']));
+    await act(async () => {});
+    expect(result.current).toBeUndefined();
+  });
+
+  it('updates when selectedIds changes', async () => {
+    let ids = ['scope|timer-1'];
+    const { result, rerender } = renderHook(() => useSelectedVizNode(ids));
+    await act(async () => {});
+    expect(result.current).toBe(mockVizNode);
+
+    ids = [];
+    rerender();
+    await act(async () => {});
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/ui/src/hooks/useSelectedVizNode.ts
+++ b/packages/ui/src/hooks/useSelectedVizNode.ts
@@ -1,0 +1,44 @@
+/*
+    Copyright (C) 2026 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { useVisualizationController } from '@patternfly/react-topology';
+import { useEffect, useState } from 'react';
+
+import { IVisualizationNode } from '../models/visualization/base-visual-entity';
+
+/**
+ * Resolves the selected IVisualizationNode from the topology controller.
+ *
+ * Returns the vizNode when exactly one id is selected and the controller
+ * can resolve it. Returns undefined for empty selection, multi-selection,
+ * or when the id does not match any node in the controller.
+ */
+export const useSelectedVizNode = (selectedIds: string[]): IVisualizationNode | undefined => {
+  const controller = useVisualizationController();
+  const [selectedVizNode, setSelectedVizNode] = useState<IVisualizationNode | undefined>(undefined);
+
+  useEffect(() => {
+    if (selectedIds.length !== 1) {
+      setSelectedVizNode(undefined);
+      return;
+    }
+
+    const graphNode = controller.getNodeById(selectedIds[0]);
+    const vizNode = graphNode?.getData()?.vizNode as IVisualizationNode | undefined;
+    setSelectedVizNode(vizNode);
+  }, [selectedIds, controller]);
+
+  return selectedVizNode;
+};


### PR DESCRIPTION
### Context
Move the selected-node resolution and pan-into-view logic out of Canvas into two dedicated, tested hooks:

- useSelectedVizNode(selectedIds): resolves the IVisualizationNode for the single selected id by querying the topology controller; returns undefined for empty/multi-selection or unresolvable ids.
- useSelectedNodePanIntoView(selectedIds): pans the graph to bring the single selected node into view after a 500 ms debounce; cancels the timeout on cleanup.

Both hooks are exported from hooks/index.ts and covered by unit tests.

CanvasSideBar and CanvasForm now receive vizNode: IVisualizationNode directly instead of the opaque CanvasNode wrapper, removing the internal selectedNode.data?.vizNode dereference and the associated null-guard in CanvasForm. The null-guard in CanvasSideBar is preserved (vizNode can be undefined when nothing is selected)."

fix: https://github.com/KaotoIO/kaoto/issues/3534
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The visualization sidebar and canvas forms now use the selected visualization node directly.
  * When exactly one node is selected, the canvas automatically pans it into view.

* **Bug Fixes**
  * Delete hotkey actions now apply to the currently selected visualization node.
  * Improved behavior for empty, multi-node, or unresolved selections, including canceling scheduled auto-panning when selection changes.
  * Canvas forms render consistently without depending on missing node data.

* **Tests**
  * Added unit tests for the selection-derived hooks and the new auto-panning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->