### PR TITLE
fix(DataMapper): Add vertical scrolling when panels overflow containe…

### DIFF
--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.scss
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.scss
@@ -4,7 +4,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: hidden auto;
   display: grid;
   grid-template-rows: var(--grid-template, 1fr);
   transition: grid-template-rows var(--expansion-panel-animation);

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.tsx
@@ -30,6 +30,9 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
   // Track pending layout change callbacks - executed after CSS transition completes
   const layoutChangeQueueRef = useRef<Array<() => void>>([]);
 
+  // rAF handle for throttling container scroll events
+  const scrollRafRef = useRef(0);
+
   // Track registered layout callbacks per panel - used to broadcast updates to all panels
   const panelCallbacksRef = useRef<Map<string, () => void>>(new Map());
 
@@ -72,6 +75,13 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
       callback();
     });
   }, []);
+
+  const handleContainerScroll = useCallback(() => {
+    cancelAnimationFrame(scrollRafRef.current);
+    scrollRafRef.current = requestAnimationFrame(() => {
+      executeAllLayoutCallbacks();
+    });
+  }, [executeAllLayoutCallbacks]);
 
   /**
    * Queue all registered panel callbacks
@@ -351,15 +361,25 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
    */
   const handlePanelExpand = useCallback(
     (panel: PanelData, panels: PanelData[], totalHeight: number) => {
+      if (panel.height <= panel.collapsedHeight) {
+        panel.height = Math.max(panel.minHeight, Math.min(totalHeight * 0.5, 240));
+      }
+
       const otherExpandedPanels = panels.filter((p) => p.isExpanded && p.id !== panel.id);
       const collapsedPanels = panels.filter((p) => !p.isExpanded && p.id !== panel.id);
 
       const collapsedSpace = calculateCollapsedSpace(collapsedPanels);
       const availableSpace = totalHeight - collapsedSpace;
+      const allExpandedPanels = [...otherExpandedPanels, panel];
+      const totalMinHeight = allExpandedPanels.reduce((sum, p) => sum + p.minHeight, 0);
+
+      if (availableSpace < totalMinHeight) {
+        panel.isExpanded = true;
+        return;
+      }
 
       if (otherExpandedPanels.length > 0) {
         // Redistribute space among all expanded panels (including the newly expanded one)
-        const allExpandedPanels = [...otherExpandedPanels, panel];
         redistributeSpace(allExpandedPanels, availableSpace);
       } else {
         // This is the only expanded panel - give it all available space
@@ -503,7 +523,7 @@ export const ExpansionPanels: FunctionComponent<PropsWithChildren<ExpansionPanel
   // No spacer needed - panels stack naturally in order
 
   return (
-    <div className="expansion-panels" ref={containerRef}>
+    <div className="expansion-panels" ref={containerRef} onScroll={handleContainerScroll}>
       <ExpansionContext.Provider value={value}>{children}</ExpansionContext.Provider>
     </div>
   );

--- a/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
+++ b/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
@@ -530,6 +530,81 @@ describe('expansion-utils', () => {
       expect(result.changed).toBe(false);
     });
 
+    it('should allow overflow when expanded panels at minHeight exceed available space', () => {
+      const panels: PanelResizeInfo[] = [
+        { id: 'collapsed-1', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-2', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-3', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-4', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-5', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'expanded-body', height: 200, minHeight: 100, collapsedHeight: 32, isExpanded: true },
+      ];
+
+      // Container is 250px, collapsed space is 5*32=160, available space is 90
+      // Expanded panel minHeight is 100 > available 90 — overflow guard triggers
+      // Panel keeps its current 200px height instead of being force-fit to 90px
+      const result = calculateContainerResize(panels, 250);
+
+      // Collapsed panels stay at collapsed height
+      expect(result.newHeights.get('collapsed-1')).toBe(32);
+      // Expanded panel should NOT be squished below its current height
+      // Total (360) exceeds container (250) - scrollbar handles it
+      const total = Array.from(result.newHeights.values()).reduce((sum, h) => sum + h, 0);
+      expect(total).toBeGreaterThan(250);
+      expect(result.newHeights.get('expanded-body')).toBe(200);
+    });
+
+    it('should allow overflow when collapsed panels alone exceed container height', () => {
+      const panels: PanelResizeInfo[] = [];
+      for (let i = 0; i < 10; i++) {
+        panels.push({ id: `collapsed-${i}`, height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false });
+      }
+      panels.push({ id: 'expanded-body', height: 100, minHeight: 50, collapsedHeight: 32, isExpanded: true });
+
+      // Container is 300px, collapsed space is 10*32=320 > 300, available space is -20
+      const result = calculateContainerResize(panels, 300);
+
+      // Expanded panel keeps current height (100 > minHeight 50)
+      expect(result.newHeights.get('expanded-body')).toBe(100);
+    });
+
+    it('should return changed=false on repeated calls in overflow mode (no ResizeObserver loop)', () => {
+      const panels: PanelResizeInfo[] = [
+        { id: 'collapsed-1', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-2', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-3', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-4', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-5', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'expanded-body', height: 30, minHeight: 100, collapsedHeight: 32, isExpanded: true },
+      ];
+
+      const firstResult = calculateContainerResize(panels, 250);
+      expect(firstResult.changed).toBe(true);
+
+      const settledPanels = panels.map((p) => ({
+        ...p,
+        height: firstResult.newHeights.get(p.id) ?? p.height,
+      }));
+      const result = calculateContainerResize(settledPanels, 250);
+
+      expect(result.changed).toBe(false);
+    });
+
+    it('should clamp expanded panel to minHeight when below minimum in overflow mode', () => {
+      const panels: PanelResizeInfo[] = [
+        { id: 'collapsed-1', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-2', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'collapsed-3', height: 32, minHeight: 32, collapsedHeight: 32, isExpanded: false },
+        { id: 'expanded-a', height: 30, minHeight: 80, collapsedHeight: 32, isExpanded: true },
+      ];
+
+      // expanded-a has height 30 < minHeight 80 — should be clamped up
+      const result = calculateContainerResize(panels, 150);
+
+      expect(result.changed).toBe(true);
+      expect(result.newHeights.get('expanded-a')).toBe(80);
+    });
+
     it('should ensure pixel-perfect fit (total equals container height)', () => {
       const panels: PanelResizeInfo[] = [
         { id: 'a', height: 333, minHeight: 100, collapsedHeight: 50, isExpanded: true },

--- a/packages/ui/src/components/ExpansionPanels/expansion-utils.ts
+++ b/packages/ui/src/components/ExpansionPanels/expansion-utils.ts
@@ -112,6 +112,18 @@ export const calculateContainerResize = (
   const collapsedSpace = collapsedPanels.reduce((sum, p) => sum + p.collapsedHeight, 0);
   const availableSpace = newContainerHeight - collapsedSpace;
 
+  // Overflow guard: if panels can't fit at their minimum heights, allow overflow
+  const expandedMinTotal = expandedPanels.reduce((sum, p) => sum + p.minHeight, 0);
+  if (expandedMinTotal > availableSpace) {
+    let anyChanged = false;
+    for (const p of expandedPanels) {
+      const newHeight = Math.max(p.minHeight, p.height);
+      if (newHeight !== p.height) anyChanged = true;
+      newHeights.set(p.id, newHeight);
+    }
+    return { newHeights, changed: anyChanged };
+  }
+
   // Calculate proportional heights for expanded panels
   const expandedHeights = calculateProportionalHeights(expandedPanels, availableSpace);
 

--- a/packages/ui/src/components/View/SourcePanel.scss
+++ b/packages/ui/src/components/View/SourcePanel.scss
@@ -1,5 +1,6 @@
 .source-panel {
   position: relative;
-  overflow: auto;
-  height: 100%;
+  overflow: hidden;
+  flex: 1 1 0;
+  min-height: 0;
 }

--- a/packages/ui/src/components/View/TargetPanel.scss
+++ b/packages/ui/src/components/View/TargetPanel.scss
@@ -1,5 +1,6 @@
 .target-panel {
   position: relative;
-  overflow: auto;
-  height: 100%;
+  overflow: hidden;
+  flex: 1 1 0;
+  min-height: 0;
 }

--- a/packages/ui/src/hooks/useConnectionPortSync.hook.test.tsx
+++ b/packages/ui/src/hooks/useConnectionPortSync.hook.test.tsx
@@ -224,10 +224,12 @@ describe('useConnectionPortSync', () => {
       const mockElement1 = {
         dataset: { nodePath: 'path1:EDGE:top' },
         getBoundingClientRect: vi.fn().mockReturnValue({ x: 0, y: 0, width: 10, height: 10 }),
+        closest: vi.fn().mockReturnValue(null),
       };
       const mockElement2 = {
         dataset: { nodePath: 'path2:EDGE:bottom' },
         getBoundingClientRect: vi.fn().mockReturnValue({ x: 50, y: 50, width: 20, height: 20 }),
+        closest: vi.fn().mockReturnValue(null),
       };
       document.querySelectorAll = vi.fn().mockReturnValue([mockElement1, mockElement2]);
 

--- a/packages/ui/src/hooks/useConnectionPortSync.hook.tsx
+++ b/packages/ui/src/hooks/useConnectionPortSync.hook.tsx
@@ -18,13 +18,19 @@ export const useConnectionPortSync = (documentId: string) => {
     const elemRect = element.getBoundingClientRect();
     const containerRect = scrollContainer.getBoundingClientRect();
 
-    // Check if element is within the container's visible vertical bounds only.
-    // Horizontal bounds are intentionally ignored because target connection ports
-    // are positioned with a negative `left` value (outside the container's left
-    // boundary) via CSS `left: calc(var(--rank-margin) * -0.7)`, so checking
-    // horizontal bounds would incorrectly exclude all target ports.
-    // Add small buffer to account for rounding errors.
-    return elemRect.top >= containerRect.top - 1 && elemRect.bottom <= containerRect.bottom + 1;
+    // Check vertical bounds only. Horizontal bounds are intentionally ignored because
+    // target connection ports are positioned with a negative `left` value (outside the
+    // container's left boundary) via CSS, so checking horizontal bounds would incorrectly
+    // exclude all target ports.
+    if (elemRect.top < containerRect.top - 1 || elemRect.bottom > containerRect.bottom + 1) {
+      return false;
+    }
+
+    const panelsContainer = element.closest('.expansion-panels');
+    if (!panelsContainer) return true;
+
+    const panelsRect = panelsContainer.getBoundingClientRect();
+    return elemRect.top >= panelsRect.top - 1 && elemRect.bottom <= panelsRect.bottom + 1;
   };
 
   useEffect(() => {
@@ -62,7 +68,17 @@ export const useConnectionPortSync = (documentId: string) => {
         const isEdgeElement = nodePath.endsWith(':EDGE:top') || nodePath.endsWith(':EDGE:bottom');
         if (isEdgeElement || isElementVisibleInContainer(element)) {
           const rect = element.getBoundingClientRect();
-          const position: [number, number] = [rect.x + rect.width / 2, rect.y + rect.height / 2];
+          let y = rect.y + rect.height / 2;
+
+          if (isEdgeElement) {
+            const panelsContainer = element.closest('.expansion-panels');
+            if (panelsContainer) {
+              const panelsRect = panelsContainer.getBoundingClientRect();
+              y = Math.max(panelsRect.top, Math.min(panelsRect.bottom, y));
+            }
+          }
+
+          const position: [number, number] = [rect.x + rect.width / 2, y];
           documentVisiblePorts[nodePath] = position;
         }
       });


### PR DESCRIPTION
…r (#2915)

Fixes: https://github.com/KaotoIO/kaoto/issues/2915

- Too many parameters causes the panels overflow the viewport and the Source Body becomes inaccessible. Enable whole-source-panel scrollbar for the case
- Individual parameter and Source Body get it's own scrollbar (nested)
- Adjust line drawing to accommodate nested scroll



https://github.com/user-attachments/assets/4391d732-fe4c-4ee1-a97b-ecbb0ccc3455




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expansion panel resizing when content exceeds available space, preserving minimum panel heights instead of compressing panels too far.
  * Added smoother, more reliable layout updates while scrolling within expansion panels.
  * Improved visibility and positioning of connection points within scrollable panel areas.
  * Fixed panel layout behavior in split views and other flexible containers.

* **Tests**
  * Added coverage for overflow sizing, minimum-height handling, and stable repeated resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->