### PR TITLE
fix(DataMapper): Fix choice>abstract nest dissolution rendering

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.test.tsx
@@ -569,4 +569,28 @@ describe('useAbstractFieldSubstitutionMenu', () => {
       updateSpy.mockRestore();
     });
   });
+
+  describe('source-side abstract wrapper with maxOccurs>1', () => {
+    it('should show substitution candidates in context menu for source-side maxOccurs>1 abstract', () => {
+      const { documentNodeData, abstractNode, abstractAnimalField } = createAbstractFieldNode(false);
+      abstractAnimalField.maxOccurs = 'unbounded';
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={abstractNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      fireEvent.contextMenu(screen.getByTestId(`node-source-${abstractNode.nodeData.id}`));
+
+      expect(screen.getByText('Cat')).toBeInTheDocument();
+      expect(screen.getByText('Dog')).toBeInTheDocument();
+      expect(screen.getByText('Fish')).toBeInTheDocument();
+      expect(screen.getByText('Kitten')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
@@ -6,6 +6,7 @@ import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
 import { IFieldSubstituteInfo } from '../../../../models/datamapper/types';
 import { NodeData } from '../../../../models/datamapper/visualization';
+import { WrapperSelectionService } from '../../../../services/document/wrapper-selection.service';
 import { MemberSelection, WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
 import { MenuAction, MenuGroup } from '../FieldContextMenu';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
@@ -17,6 +18,7 @@ const INLINE_SUBSTITUTION_LIMIT = 10;
 interface AbstractMenuGroupsConfig {
   isAbstractWrapper: boolean;
   isAbstractWrapperMember: boolean;
+  isInsideChoiceWrapper: boolean;
   isSelectedSubstitution: boolean;
   candidates: Record<string, IFieldSubstituteInfo>;
   selectedQName: string | undefined;
@@ -29,6 +31,10 @@ interface AbstractMenuGroupsConfig {
 }
 
 function buildMenuGroupsForAbstractNode(config: AbstractMenuGroupsConfig): MenuGroup[] {
+  if (config.isInsideChoiceWrapper && config.isAbstractWrapper) {
+    const hasSelection = config.selectedQName !== undefined;
+    return hasSelection ? [{ actions: [config.clearSubstitutionAction] }] : [];
+  }
   if (config.isAbstractWrapper || config.isAbstractWrapperMember) {
     return buildAbstractWrapperMenuGroups(
       config.candidates,
@@ -183,8 +189,12 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
     testId: 'clear-substitution',
   };
 
+  const isInsideChoiceWrapper =
+    abstractWrapperField !== undefined &&
+    WrapperSelectionService.findParentWrapper(abstractWrapperField, 'choice') !== undefined;
+
   const selectSelfAction =
-    isSubstitutionCandidate && !isSelectedSubstitution
+    isSubstitutionCandidate && !isSelectedSubstitution && !isInsideChoiceWrapper
       ? buildSelectSelfAction(field, parentAbstractField, handleSelectSelfAsCandidate, 'select-substitution-member')
       : undefined;
 
@@ -203,6 +213,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
   const menuGroups = buildMenuGroupsForAbstractNode({
     isAbstractWrapper,
     isAbstractWrapperMember,
+    isInsideChoiceWrapper,
     isSelectedSubstitution,
     candidates,
     selectedQName,

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -1052,4 +1052,27 @@ describe('useChoiceContextMenu', () => {
       dispatchSpy.mockRestore();
     });
   });
+
+  describe('source-side choice wrapper with maxOccurs>1', () => {
+    it('should show choice members in context menu for source-side maxOccurs>1 choice', () => {
+      const { documentNodeData, choiceNode, choiceField } = createChoiceFieldNode(false);
+      choiceField.maxOccurs = 'unbounded';
+
+      render(
+        <SourceDocumentNodeWithContextMenu
+          treeNode={choiceNode}
+          documentId={documentNodeData.id}
+          isReadOnly={false}
+          rank={1}
+        />,
+        { wrapper },
+      );
+
+      fireEvent.contextMenu(screen.getByTestId(`node-source-${choiceNode.nodeData.id}`));
+
+      expect(screen.getByText('Email')).toBeInTheDocument();
+      expect(screen.getByText('Phone')).toBeInTheDocument();
+      expect(screen.getByText('Fax')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
@@ -107,7 +107,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     choiceMemberField,
     parentChoiceWrapperField,
     choiceMemberIndex,
-  } = VisualizationUtilService.resolveChoiceNodeInfo(nodeData);
+  } = WrapperActionService.resolveChoiceNodeInfo(nodeData);
 
   const isNestedSelectedChoice = isSelectedChoice && isChoiceWrapper;
   const isTargetSide = !nodeData.isSource;

--- a/packages/ui/src/services/document/wrapper-selection.service.test.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.test.ts
@@ -4,6 +4,7 @@ import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { getChoiceWithAbstractXsd } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaCollection } from '../../xml-schema-ts';
 import { SchemaPathService } from '../schema-path.service';
+import { DocumentUtilService } from './document-util.service';
 import { FieldOverrideService } from './field-override.service';
 import { WrapperSelectionService } from './wrapper-selection.service';
 import { XmlSchemaDocument, XmlSchemaField } from './xml-schema/xml-schema-document.model';
@@ -547,6 +548,179 @@ describe('WrapperSelectionService', () => {
         expect(doc.definition.fieldTypeOverrides).toHaveLength(1);
         expect(idField.typeOverride).toBe(FieldOverrideVariant.SAFE);
       });
+    });
+  });
+
+  describe('wrapper field queries', () => {
+    describe('resolveOutermostSelectedWrapper', () => {
+      it('should return the field itself and depth 1 when no parent wrapper', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        choiceField.selectedMemberIndex = 0;
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(choiceField);
+        expect(result.outermost).toBe(choiceField);
+        expect(result.depth).toBe(1);
+      });
+
+      it('should walk up through selected parent wrappers', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const inner = new XmlSchemaField(choiceField, 'innerChoice', false);
+        inner.wrapperKind = 'choice';
+        inner.selectedMemberIndex = 1;
+        choiceField.fields.push(inner);
+        choiceField.selectedMemberIndex = choiceField.fields.indexOf(inner);
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(inner);
+        expect(result.outermost).toBe(choiceField);
+        expect(result.depth).toBe(2);
+      });
+
+      it('should walk up through three levels of selected wrappers', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const middle = new XmlSchemaField(choiceField, 'middleChoice', false);
+        middle.wrapperKind = 'choice';
+        choiceField.fields.push(middle);
+        const inner = new XmlSchemaField(middle, 'innerChoice', false);
+        inner.wrapperKind = 'choice';
+        inner.selectedMemberIndex = 1;
+        middle.fields.push(inner);
+        middle.selectedMemberIndex = middle.fields.indexOf(inner);
+        choiceField.selectedMemberIndex = choiceField.fields.indexOf(middle);
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(inner);
+        expect(result.outermost).toBe(choiceField);
+        expect(result.depth).toBe(3);
+      });
+
+      it('should stop when parent selects a different member', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const inner = new XmlSchemaField(choiceField, 'innerChoice', false);
+        inner.wrapperKind = 'choice';
+        inner.selectedMemberIndex = 0;
+        choiceField.fields.push(inner);
+        choiceField.selectedMemberIndex = 0;
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(inner);
+        expect(result.outermost).toBe(inner);
+        expect(result.depth).toBe(1);
+      });
+
+      it('should stop at parent without selectedMemberIndex', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const inner = new XmlSchemaField(choiceField, 'innerChoice', false);
+        inner.wrapperKind = 'choice';
+        inner.selectedMemberIndex = 0;
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(inner);
+        expect(result.outermost).toBe(inner);
+        expect(result.depth).toBe(1);
+      });
+
+      it('should return depth 1 and undefined for undefined input', () => {
+        const result = WrapperSelectionService.resolveOutermostSelectedWrapper(undefined);
+        expect(result.outermost).toBeUndefined();
+        expect(result.depth).toBe(1);
+      });
+    });
+
+    describe('shouldFlattenNestedWrapper', () => {
+      it('should flatten cross-kind nesting (choice>abstract) even without inner selection', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const abstractField = findAbstractField(choiceField);
+        expect(WrapperSelectionService.shouldFlattenNestedWrapper('choice', abstractField)).toBe(true);
+      });
+
+      it('should flatten cross-kind nesting when inner has selection (choice>abstract>Email)', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const nsMap = { ca: NS_CHOICE_ABSTRACT };
+        const choiceField = findChoiceField(doc);
+        const abstractField = findAbstractField(choiceField);
+        FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
+        expect(DocumentUtilService.getSelectedMember(abstractField)).toBeDefined();
+        expect(WrapperSelectionService.shouldFlattenNestedWrapper('choice', abstractField)).toBe(true);
+      });
+
+      it('should NOT flatten same-kind nesting (choice>choice) when inner has no selection', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const choiceField = findChoiceField(doc);
+        const innerChoice = new XmlSchemaField(choiceField, 'innerChoice', false);
+        innerChoice.wrapperKind = 'choice';
+        expect(WrapperSelectionService.shouldFlattenNestedWrapper('choice', innerChoice)).toBe(false);
+      });
+    });
+
+    describe('findParentWrapper', () => {
+      it('should return parent choice when abstract is inside selected choice', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const nsMap = { ca: NS_CHOICE_ABSTRACT };
+        const choiceField = findChoiceField(doc);
+        const abstractField = findAbstractField(choiceField);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+        expect(WrapperSelectionService.findParentWrapper(abstractField, 'choice')).toBe(choiceField);
+      });
+
+      it('should return undefined for standalone abstract', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const root = doc.fields[0];
+        const standaloneAbstract = new XmlSchemaField(root, 'standalone', false);
+        standaloneAbstract.wrapperKind = 'abstract';
+        root.fields.push(standaloneAbstract);
+        expect(WrapperSelectionService.findParentWrapper(standaloneAbstract, 'choice')).toBeUndefined();
+      });
+
+      it('should return undefined when choice selects a different member', () => {
+        const doc = createChoiceWithAbstractDoc();
+        const nsMap = { ca: NS_CHOICE_ABSTRACT };
+        const choiceField = findChoiceField(doc);
+        const abstractField = findAbstractField(choiceField);
+        WrapperSelectionService.setChoiceSelection(doc, choiceField, 1, nsMap);
+        expect(WrapperSelectionService.findParentWrapper(abstractField, 'choice')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('cascade clear: abstract substitution clears parent choice (#3532)', () => {
+    it('should cascade abstract substitution clear to parent choice (source maxOccurs=1)', () => {
+      const doc = createChoiceWithAbstractDoc();
+      const nsMap = { ca: NS_CHOICE_ABSTRACT };
+      const choiceField = findChoiceField(doc);
+      const abstractField = findAbstractField(choiceField);
+
+      WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+      FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
+      expect(choiceField.selectedMemberIndex).toBe(0);
+      expect(abstractField.selectedMemberQName).toBeDefined();
+
+      FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
+      const parentChoice = WrapperSelectionService.findParentWrapper(abstractField, 'choice');
+      if (parentChoice) {
+        WrapperSelectionService.clearChoiceSelection(doc, parentChoice, nsMap);
+      }
+
+      expect(choiceField.selectedMemberIndex).toBeUndefined();
+      expect(abstractField.selectedMemberQName).toBeUndefined();
+    });
+
+    it('should clean up both choiceSelections and fieldSubstitutions after cascade', () => {
+      const doc = createChoiceWithAbstractDoc();
+      const nsMap = { ca: NS_CHOICE_ABSTRACT };
+      const choiceField = findChoiceField(doc);
+      const abstractField = findAbstractField(choiceField);
+
+      WrapperSelectionService.setChoiceSelection(doc, choiceField, 0, nsMap);
+      FieldOverrideService.applyFieldSubstitution(abstractField, 'ca:Email', nsMap);
+      expect(doc.definition.choiceSelections).toHaveLength(1);
+      expect(doc.definition.fieldSubstitutions).toHaveLength(1);
+
+      FieldOverrideService.revertFieldSubstitution(abstractField, nsMap);
+      const parentChoice = WrapperSelectionService.findParentWrapper(abstractField, 'choice');
+      if (parentChoice) {
+        WrapperSelectionService.clearChoiceSelection(doc, parentChoice, nsMap);
+      }
+
+      expect(doc.definition.choiceSelections ?? []).toHaveLength(0);
+      expect(doc.definition.fieldSubstitutions ?? []).toHaveLength(0);
     });
   });
 });

--- a/packages/ui/src/services/document/wrapper-selection.service.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.ts
@@ -1,4 +1,4 @@
-import { IDocument, IField } from '../../models/datamapper/document';
+import { IDocument, IField, WrapperKind } from '../../models/datamapper/document';
 import { IChoiceSelection } from '../../models/datamapper/metadata';
 import { SchemaPathService } from '../schema-path.service';
 import { DocumentUtilService } from './document-util.service';
@@ -123,5 +123,64 @@ export class WrapperSelectionService {
     if (member.wrapperKind === 'abstract' && member.selectedMemberQName) {
       FieldOverrideService.revertFieldSubstitution(member, namespaceMap);
     }
+  }
+
+  /**
+   * Walks up from `wrapper` through ancestor choice fields that also have a selection,
+   * returning the outermost selected wrapper and the number of levels traversed.
+   */
+  static resolveOutermostSelectedWrapper(wrapper: IField | undefined): {
+    outermost: IField | undefined;
+    depth: number;
+  } {
+    let depth = 1;
+    let current = wrapper;
+    while (
+      current?.parent &&
+      'wrapperKind' in current.parent &&
+      current.parent.wrapperKind === 'choice' &&
+      current.parent.selectedMemberIndex !== undefined &&
+      DocumentUtilService.getSelectedMember(current.parent) === current
+    ) {
+      depth++;
+      current = current.parent;
+    }
+    return { outermost: current, depth };
+  }
+
+  /**
+   * Determines whether a nested wrapper field should be flattened (recursed through)
+   * during node data generation.
+   *
+   * Cross-kind nesting (e.g. choice>abstract) always flattens so the inner wrapper can
+   * present its own UI (e.g. AbstractFieldNodeData for substitution selection).
+   * Same-kind nesting (e.g. choice>choice) only flattens when the inner wrapper already
+   * has a selection — otherwise the inner wrapper is shown as an unselected wrapper node.
+   *
+   * @param outerKind - The wrapper kind of the outer wrapper being processed
+   * @param innerField - The selected member that is itself a wrapper field
+   */
+  static shouldFlattenNestedWrapper(outerKind: WrapperKind, innerField: IField): boolean {
+    if (innerField.wrapperKind !== outerKind) return true;
+    return DocumentUtilService.getSelectedMember(innerField) !== undefined;
+  }
+
+  /**
+   * Finds the active parent wrapper of a given wrapper field.
+   *
+   * Returns the parent only when its current selection points at the given field — a choice
+   * can have multiple wrapper children (e.g. several abstract members), but only the selected
+   * one is the active nesting context. Returns undefined for top-level wrappers or when the
+   * parent's selection targets a different member.
+   *
+   * @param wrapperField - The inner wrapper field to check
+   * @param parentKind - The wrapper kind to look for in the parent
+   */
+  static findParentWrapper(wrapperField: IField, parentKind: WrapperKind): IField | undefined {
+    const parent = wrapperField.parent;
+    if (!parent || !('wrapperKind' in parent) || parent.wrapperKind !== parentKind) return undefined;
+    const selectedMember = DocumentUtilService.getSelectedMember(parent);
+    if (selectedMember !== wrapperField) return undefined;
+    return parent;
   }
 }

--- a/packages/ui/src/services/visualization/visualization-util.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.test.ts
@@ -211,62 +211,6 @@ describe('VisualizationUtilService', () => {
     });
   });
 
-  describe('resolveOutermostSelectedWrapper', () => {
-    it('should return the field itself and depth 1 when no parent wrapper', () => {
-      const field = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice', selectedMemberIndex: 0 });
-      const result = VisualizationUtilService.resolveOutermostSelectedWrapper(field);
-      expect(result.outermost).toBe(field);
-      expect(result.depth).toBe(1);
-    });
-
-    it('should walk up through selected parent wrappers', () => {
-      const outer = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice', selectedMemberIndex: 0 });
-      const inner = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 1,
-        parent: outer,
-      });
-      const result = VisualizationUtilService.resolveOutermostSelectedWrapper(inner);
-      expect(result.outermost).toBe(outer);
-      expect(result.depth).toBe(2);
-    });
-
-    it('should walk up through three levels of selected wrappers', () => {
-      const outermost = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice', selectedMemberIndex: 0 });
-      const middle = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 0,
-        parent: outermost,
-      });
-      const inner = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 1,
-        parent: middle,
-      });
-      const result = VisualizationUtilService.resolveOutermostSelectedWrapper(inner);
-      expect(result.outermost).toBe(outermost);
-      expect(result.depth).toBe(3);
-    });
-
-    it('should stop at parent without selectedMemberIndex', () => {
-      const outer = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice' });
-      const inner = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 0,
-        parent: outer,
-      });
-      const result = VisualizationUtilService.resolveOutermostSelectedWrapper(inner);
-      expect(result.outermost).toBe(inner);
-      expect(result.depth).toBe(1);
-    });
-
-    it('should return depth 1 and undefined for undefined input', () => {
-      const result = VisualizationUtilService.resolveOutermostSelectedWrapper(undefined);
-      expect(result.outermost).toBeUndefined();
-      expect(result.depth).toBe(1);
-    });
-  });
-
   describe('getSelectedChoiceDepth', () => {
     it('should return 0 for non-choice nodes', () => {
       const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
@@ -296,20 +240,17 @@ describe('VisualizationUtilService', () => {
     });
 
     it('should return 3 for triple-nested selected choice', () => {
-      const outermost = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 0,
-      });
-      const middle = createMockField(sourceDoc.fields[0], {
-        wrapperKind: 'choice',
-        selectedMemberIndex: 0,
-        parent: outermost,
-      });
+      const outermost = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice' });
+      const middle = createMockField(sourceDoc.fields[0], { wrapperKind: 'choice', parent: outermost });
       const inner = createMockField(sourceDoc.fields[0], {
         wrapperKind: 'choice',
         selectedMemberIndex: 0,
         parent: middle,
       });
+      middle.fields = [inner];
+      middle.selectedMemberIndex = 0;
+      outermost.fields = [middle];
+      outermost.selectedMemberIndex = 0;
       const choiceNode = new ChoiceFieldNodeData(sourceDocNode, sourceDoc.fields[0]);
       choiceNode.choiceField = inner;
       expect(VisualizationUtilService.getSelectedChoiceDepth(choiceNode)).toBe(3);

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -14,6 +14,7 @@ import {
   TargetSequenceFieldNodeData,
 } from '../../models/datamapper/visualization';
 import { DocumentService } from '../document/document.service';
+import { WrapperSelectionService } from '../document/wrapper-selection.service';
 
 /**
  * Static utility service for inspecting {@link NodeData} properties in the
@@ -112,28 +113,6 @@ export class VisualizationUtilService {
   }
 
   /**
-   * Walks up from `wrapper` through ancestor choice fields that also have a selection,
-   * returning the outermost selected wrapper and the number of levels traversed.
-   */
-  static resolveOutermostSelectedWrapper(wrapper: IField | undefined): {
-    outermost: IField | undefined;
-    depth: number;
-  } {
-    let depth = 1;
-    let current = wrapper;
-    while (
-      current?.parent &&
-      'wrapperKind' in current.parent &&
-      current.parent.wrapperKind === 'choice' &&
-      current.parent.selectedMemberIndex !== undefined
-    ) {
-      depth++;
-      current = current.parent;
-    }
-    return { outermost: current, depth };
-  }
-
-  /**
    * Returns the number of resolved choice wrapper levels for a selected choice node.
    * A simple selected choice returns 1. A flattened nested choice (both outer and inner
    * selected) returns 2+, indicating how many wrapper levels were collapsed.
@@ -141,7 +120,7 @@ export class VisualizationUtilService {
    */
   static getSelectedChoiceDepth(nodeData: NodeData): number {
     if (!VisualizationUtilService.isSelectedChoiceField(nodeData)) return 0;
-    return VisualizationUtilService.resolveOutermostSelectedWrapper(nodeData.choiceField).depth;
+    return WrapperSelectionService.resolveOutermostSelectedWrapper(nodeData.choiceField).depth;
   }
 
   /**
@@ -243,70 +222,4 @@ export class VisualizationUtilService {
   static isMappingNode(nodeData: NodeData): nodeData is MappingNodeData {
     return nodeData instanceof MappingNodeData;
   }
-
-  /**
-   * Resolves the full choice context for a given node — which wrapper it belongs to,
-   * whether it's a selected member, a per-instance wrapper member, etc. Pure read,
-   * no side effects. Used by {@link useChoiceContextMenu} to determine what menu
-   * actions to offer.
-   */
-  static resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
-    const field = VisualizationUtilService.getField(nodeData);
-    const isChoiceWrapper = field?.wrapperKind === 'choice';
-    const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
-
-    const choiceMemberField =
-      VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
-    const choiceMemberParent =
-      choiceMemberField?.parent && 'wrapperKind' in choiceMemberField.parent ? choiceMemberField.parent : undefined;
-    const isChoiceMember = choiceMemberParent?.wrapperKind === 'choice';
-    const parentChoiceWrapperField = isChoiceMember ? choiceMemberParent : undefined;
-    const choiceMemberIndex =
-      isChoiceMember && parentChoiceWrapperField && choiceMemberField
-        ? parentChoiceWrapperField.fields.indexOf(choiceMemberField)
-        : undefined;
-
-    let choiceWrapperField: IField | undefined;
-    if (isSelectedChoice) {
-      choiceWrapperField = VisualizationUtilService.resolveOutermostSelectedWrapper(nodeData.choiceField).outermost;
-    } else if (isChoiceWrapper) {
-      choiceWrapperField = field;
-    }
-    const activeChoiceWrapperForMembers = isSelectedChoice && isChoiceWrapper ? field : choiceWrapperField;
-
-    const isChoiceWrapperMember = VisualizationUtilService.isChoiceWrapperMember(nodeData);
-    const choiceWrapperMemberField =
-      isChoiceWrapperMember && nodeData instanceof FieldItemNodeData
-        ? (nodeData.wrapperField ?? ((nodeData.parent as TargetChoiceFieldNodeData).field as IField))
-        : undefined;
-    const effectiveChoiceWrapper = isChoiceWrapperMember ? choiceWrapperMemberField : activeChoiceWrapperForMembers;
-
-    return {
-      isChoiceWrapper,
-      isSelectedChoice,
-      isChoiceMember,
-      isChoiceWrapperMember,
-      activeChoiceWrapperForMembers,
-      effectiveChoiceWrapper,
-      choiceWrapperField,
-      choiceWrapperMemberField,
-      choiceMemberField,
-      parentChoiceWrapperField,
-      choiceMemberIndex,
-    };
-  }
-}
-
-export interface ChoiceNodeInfo {
-  isChoiceWrapper: boolean;
-  isSelectedChoice: boolean;
-  isChoiceMember: boolean;
-  isChoiceWrapperMember: boolean;
-  activeChoiceWrapperForMembers: IField | undefined;
-  effectiveChoiceWrapper: IField | undefined;
-  choiceWrapperField: IField | undefined;
-  choiceWrapperMemberField: IField | undefined;
-  choiceMemberField: IField | undefined;
-  parentChoiceWrapperField: IField | undefined;
-  choiceMemberIndex: number | undefined;
 }

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -659,6 +659,46 @@ describe('VisualizationService / abstract fields', () => {
       expect(children).toHaveLength(3);
       expect(children.map((c) => c.title)).toEqual(['Cat', 'Dog', 'Fish']);
     });
+
+    it('source max=1 render after clear: should revert to unselected AbstractFieldNodeData', () => {
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Cat'),
+      );
+      const parentField = { ...sourceDoc.fields[0], fields: [abstractField] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+
+      const before = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(before).toHaveLength(1);
+      expect(before[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(before[0].title).toBe('Cat');
+      expect((before[0] as AbstractFieldNodeData).abstractField).toBeDefined();
+
+      abstractField.selectedMemberQName = undefined;
+
+      const after = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(after).toHaveLength(1);
+      expect(after[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect((after[0] as AbstractFieldNodeData).abstractField).toBeUndefined();
+      const candidates = VisualizationService.generateNonDocumentNodeDataChildren(after[0]);
+      expect(candidates).toHaveLength(2);
+      expect(candidates.map((c) => c.title)).toEqual(['Cat', 'Dog']);
+    });
+
+    it('source max>1 render after select: should show selected candidate through wrapper', () => {
+      const abstractField = createMockAbstractField(
+        [{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }],
+        new QName('io.kaoto.datamapper.poc.test', 'Dog'),
+      );
+      abstractField.maxOccurs = 'unbounded';
+      const parentField = { ...sourceDoc.fields[0], fields: [abstractField] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(children[0].title).toBe('Dog');
+      expect((children[0] as AbstractFieldNodeData).abstractField).toBeDefined();
+    });
   });
 
   describe('mapping through selected target abstract wrapper', () => {

--- a/packages/ui/src/services/visualization/visualization.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.choice.test.ts
@@ -514,38 +514,62 @@ describe('VisualizationService / choice fields', () => {
     });
   });
 
-  describe('choice with abstract member', () => {
-    function createChoiceWithAbstractMember(outerSelectedIndex?: number, innerSelectedQName?: QName) {
-      const baseField = sourceDoc.fields[0];
-      const abstractCandidates = [
-        { ...baseField, name: 'Email', displayName: 'Email', fields: [] },
-        { ...baseField, name: 'SMS', displayName: 'SMS', fields: [] },
-      ];
-      const abstractMember = {
-        ...baseField,
-        name: 'AbstractMessage',
-        displayName: 'AbstractMessage',
-        wrapperKind: 'abstract' as const,
-        selectedMemberQName: innerSelectedQName,
-        fields: abstractCandidates,
-      };
-      const regularMember = {
-        ...baseField,
-        name: 'Webhook',
-        displayName: 'Webhook',
-        fields: [],
-      };
-      const outerChoice = {
-        ...baseField,
-        name: '__choice__',
-        displayName: 'choice',
-        wrapperKind: 'choice' as const,
-        selectedMemberIndex: outerSelectedIndex,
-        fields: [abstractMember, regularMember],
-      } as unknown as typeof baseField;
-      return { outerChoice, abstractMember, regularMember, abstractCandidates };
-    }
+  describe('source max=1 render after clear', () => {
+    it('should revert to unselected ChoiceFieldNodeData after clearing selection', () => {
+      const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 0);
+      const parentField = { ...sourceDoc.fields[0], fields: [choiceField] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
 
+      const before = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(before).toHaveLength(1);
+      expect(before[0].title).toBe('email');
+      expect((before[0] as ChoiceFieldNodeData).choiceField).toBe(choiceField);
+
+      choiceField.selectedMemberIndex = undefined;
+
+      const after = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(after).toHaveLength(1);
+      expect(after[0]).toBeInstanceOf(ChoiceFieldNodeData);
+      expect((after[0] as ChoiceFieldNodeData).choiceField).toBeUndefined();
+      const members = VisualizationService.generateNonDocumentNodeDataChildren(after[0]);
+      expect(members).toHaveLength(2);
+      expect(members[0].title).toBe('email');
+      expect(members[1].title).toBe('phone');
+    });
+  });
+
+  function createChoiceWithAbstractMember(outerSelectedIndex?: number, innerSelectedQName?: QName) {
+    const baseField = sourceDoc.fields[0];
+    const abstractCandidates = [
+      { ...baseField, name: 'Email', displayName: 'Email', fields: [] },
+      { ...baseField, name: 'SMS', displayName: 'SMS', fields: [] },
+    ];
+    const abstractMember = {
+      ...baseField,
+      name: 'AbstractMessage',
+      displayName: 'AbstractMessage',
+      wrapperKind: 'abstract' as const,
+      selectedMemberQName: innerSelectedQName,
+      fields: abstractCandidates,
+    };
+    const regularMember = {
+      ...baseField,
+      name: 'Webhook',
+      displayName: 'Webhook',
+      fields: [],
+    };
+    const outerChoice = {
+      ...baseField,
+      name: '__choice__',
+      displayName: 'choice',
+      wrapperKind: 'choice' as const,
+      selectedMemberIndex: outerSelectedIndex,
+      fields: [abstractMember, regularMember],
+    } as unknown as typeof baseField;
+    return { outerChoice, abstractMember, regularMember, abstractCandidates };
+  }
+
+  describe('choice with abstract member', () => {
     it('selecting abstract member without substitution should create AbstractFieldNodeData', () => {
       const { outerChoice } = createChoiceWithAbstractMember(0);
       const parentField = { ...sourceDoc.fields[0], fields: [outerChoice] };
@@ -1628,6 +1652,214 @@ describe('VisualizationService / choice fields', () => {
       const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
       const addNodes = children.filter((c) => c instanceof AddMappingNodeData);
       expect(addNodes).toHaveLength(0);
+    });
+  });
+
+  describe('choice>abstract nesting — target maxOccurs>1 (#3532)', () => {
+    function createChoiceAbstractCollectionField() {
+      const baseField = targetDoc.fields[0];
+      const emailChild = { ...baseField, name: 'subject', displayName: 'subject', fields: [] };
+      const smsChild = { ...baseField, name: 'phoneNumber', displayName: 'phoneNumber', fields: [] };
+      const emailCandidate = {
+        ...baseField,
+        name: 'Email',
+        displayName: 'Email',
+        namespaceURI: 'io.kaoto.datamapper.poc.test',
+        fields: [emailChild],
+      } as unknown as typeof baseField;
+      const smsCandidate = {
+        ...baseField,
+        name: 'SMS',
+        displayName: 'SMS',
+        namespaceURI: 'io.kaoto.datamapper.poc.test',
+        fields: [smsChild],
+      } as unknown as typeof baseField;
+      const abstractMember = {
+        ...baseField,
+        name: 'AbstractMessage',
+        displayName: 'AbstractMessage',
+        wrapperKind: 'abstract' as const,
+        selectedMemberQName: undefined,
+        fields: [emailCandidate, smsCandidate],
+      } as unknown as typeof baseField;
+      const webhookMember = {
+        ...baseField,
+        name: 'Webhook',
+        displayName: 'Webhook',
+        fields: [],
+      } as unknown as typeof baseField;
+      const choiceField = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        selectedMemberIndex: undefined,
+        maxOccurs: 'unbounded',
+        fields: [abstractMember, webhookMember],
+      } as unknown as typeof baseField;
+      abstractMember.parent = choiceField;
+      emailCandidate.parent = abstractMember;
+      smsCandidate.parent = abstractMember;
+      webhookMember.parent = choiceField;
+      return { choiceField, abstractMember, webhookMember, emailCandidate, smsCandidate };
+    }
+
+    it('should render Email FieldItem through abstract child as FieldItemNodeData with wrapperField', () => {
+      const { choiceField, emailCandidate } = createChoiceAbstractCollectionField();
+      const parentField = { ...targetDoc.fields[0], fields: [choiceField] };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem = new FieldItem(parentFieldItem, emailCandidate);
+      parentFieldItem.children.push(emailFieldItem);
+      localTree.children.push(parentFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const emailNodes = children.filter((c) => c.title === 'Email');
+      expect(emailNodes).toHaveLength(1);
+      expect(emailNodes[0]).toBeInstanceOf(FieldItemNodeData);
+      expect((emailNodes[0] as FieldItemNodeData).wrapperField).toBe(choiceField);
+    });
+
+    it('should render multiple substituted FieldItems (Email + SMS)', () => {
+      const { choiceField, emailCandidate, smsCandidate } = createChoiceAbstractCollectionField();
+      const parentField = { ...targetDoc.fields[0], fields: [choiceField] };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem = new FieldItem(parentFieldItem, emailCandidate);
+      const smsFieldItem = new FieldItem(parentFieldItem, smsCandidate);
+      parentFieldItem.children.push(emailFieldItem, smsFieldItem);
+      localTree.children.push(parentFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const emailNodes = children.filter((c) => c.title === 'Email');
+      const smsNodes = children.filter((c) => c.title === 'SMS');
+      expect(emailNodes).toHaveLength(1);
+      expect(smsNodes).toHaveLength(1);
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('should render duplicate FieldItem (two Email instances)', () => {
+      const { choiceField, emailCandidate } = createChoiceAbstractCollectionField();
+      const parentField = { ...targetDoc.fields[0], fields: [choiceField] };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem1 = new FieldItem(parentFieldItem, emailCandidate);
+      const emailFieldItem2 = new FieldItem(parentFieldItem, emailCandidate);
+      emailFieldItem2.isUserCreated = true;
+      parentFieldItem.children.push(emailFieldItem1, emailFieldItem2);
+      localTree.children.push(parentFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const emailNodes = children.filter((c) => c.title === 'Email');
+      expect(emailNodes).toHaveLength(2);
+      for (const node of emailNodes) {
+        expect(node).toBeInstanceOf(FieldItemNodeData);
+        expect((node as FieldItemNodeData).wrapperField).toBe(choiceField);
+      }
+    });
+
+    it('should render mixed members: Email (via abstract) + Webhook (direct)', () => {
+      const { choiceField, emailCandidate, webhookMember } = createChoiceAbstractCollectionField();
+      const parentField = { ...targetDoc.fields[0], fields: [choiceField] };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      const emailFieldItem = new FieldItem(parentFieldItem, emailCandidate);
+      const webhookFieldItem = new FieldItem(parentFieldItem, webhookMember);
+      parentFieldItem.children.push(emailFieldItem, webhookFieldItem);
+      localTree.children.push(parentFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      const emailNodes = children.filter((c) => c.title === 'Email');
+      const webhookNodes = children.filter((c) => c.title === 'Webhook');
+      expect(emailNodes).toHaveLength(1);
+      expect(webhookNodes).toHaveLength(1);
+      expect(children[children.length - 1]).toBeInstanceOf(AddMappingNodeData);
+    });
+
+    it('should revert to bare wrapper when no FieldItems remain', () => {
+      const { choiceField } = createChoiceAbstractCollectionField();
+      const parentField = { ...targetDoc.fields[0], fields: [choiceField] };
+      const localTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const parentFieldItem = new FieldItem(localTree, parentField as (typeof targetDoc.fields)[0]);
+      localTree.children.push(parentFieldItem);
+
+      const freshTargetDocNode = new TargetDocumentNodeData(targetDoc, localTree);
+      const freshParentNode = new TargetFieldNodeData(freshTargetDocNode, parentFieldItem.field);
+      freshParentNode.mapping = parentFieldItem;
+
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(TargetChoiceFieldNodeData);
+    });
+  });
+
+  describe('choice>abstract nesting — target maxOccurs=1 render after clear (#3532)', () => {
+    it('should revert to unconfigured TargetChoiceFieldNodeData after cascade clear', () => {
+      const { outerChoice, abstractMember } = createChoiceWithAbstractMember(
+        0,
+        new QName('io.kaoto.datamapper.poc.test', 'Email'),
+      );
+      const parentField = { ...targetDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new TargetFieldNodeData(targetDocNode, parentField as (typeof targetDoc.fields)[0]);
+
+      const before = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(before).toHaveLength(1);
+      expect(before[0]).toBeInstanceOf(TargetAbstractFieldNodeData);
+
+      abstractMember.selectedMemberQName = undefined;
+      outerChoice.selectedMemberIndex = undefined;
+
+      const after = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(after).toHaveLength(1);
+      expect(after[0]).toBeInstanceOf(TargetChoiceFieldNodeData);
+    });
+  });
+
+  describe('choice>abstract nesting — unselected inner abstract (#3532)', () => {
+    it('should show AbstractFieldNodeData when choice selects abstract but abstract has no substitution', () => {
+      const { outerChoice } = createChoiceWithAbstractMember(0);
+      const parentField = { ...sourceDoc.fields[0], fields: [outerChoice] };
+      const parentNode = new FieldNodeData(sourceDocNode, parentField as (typeof sourceDoc.fields)[0]);
+      const children = VisualizationService.generateNonDocumentNodeDataChildren(parentNode);
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(AbstractFieldNodeData);
+      expect(children[0].title).toBe('AbstractMessage');
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -38,6 +38,7 @@ import {
 } from '../../models/datamapper/visualization';
 import { DocumentService } from '../document/document.service';
 import { DocumentUtilService } from '../document/document-util.service';
+import { WrapperSelectionService } from '../document/wrapper-selection.service';
 import { MappingService } from '../mapping/mapping.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
@@ -186,9 +187,9 @@ export class VisualizationService {
   ): NodeData | null {
     const selectedMember = DocumentUtilService.getSelectedMember(field);
 
-    if (selectedMember?.wrapperKind) {
-      const innerSpec = selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
-      if (innerSpec !== spec || DocumentUtilService.getSelectedMember(selectedMember) !== undefined) {
+    if (selectedMember?.wrapperKind && field.wrapperKind) {
+      if (WrapperSelectionService.shouldFlattenNestedWrapper(field.wrapperKind, selectedMember)) {
+        const innerSpec = selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
         return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, innerSpec);
       }
     }
@@ -209,15 +210,6 @@ export class VisualizationService {
     return node;
   }
 
-  private static isDescendantWithinWrapper(wrapper: IField, target: IField): boolean {
-    for (const child of wrapper.fields) {
-      if (child === target) return true;
-      if (child.wrapperKind === 'choice' || child.wrapperKind === 'abstract') continue;
-      if (VisualizationService.isDescendantWithinWrapper(child, target)) return true;
-    }
-    return false;
-  }
-
   private static generateCollectionWrapperNodes(
     parent: NodeData,
     field: IField,
@@ -227,15 +219,13 @@ export class VisualizationService {
     const wrapperSpec = field.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
     const wrapperFieldItems = mappings.filter(
       (m): m is FieldItem =>
-        m instanceof FieldItem && (m.field === field || VisualizationService.isDescendantWithinWrapper(field, m.field)),
+        m instanceof FieldItem && (m.field === field || DocumentService.isDescendant(field, m.field)),
     );
     const wrapperInstructionItems = mappings.filter(
       (m): m is InstructionItem =>
         m instanceof InstructionItem &&
         !VisualizationService.isExistingMapping(renderedNodes as TargetNodeData[], m) &&
-        MappingService.getInstructionFields(m).some(
-          (f) => f === field || VisualizationService.isDescendantWithinWrapper(field, f),
-        ),
+        MappingService.getInstructionFields(m).some((f) => f === field || DocumentService.isDescendant(field, f)),
     );
     if (wrapperFieldItems.length === 0 && wrapperInstructionItems.length === 0) {
       const node = VisualizationService.doGenerateNodeDataFromWrapperField(parent, field, mappings, wrapperSpec);

--- a/packages/ui/src/services/visualization/wrapper-action.service.test.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.test.ts
@@ -57,6 +57,7 @@ vi.mock('../document/wrapper-selection.service', () => ({
     setChoiceSelection: vi.fn(),
     clearChoiceSelection: vi.fn(),
     clearDescendantWrapperSelections: vi.fn(),
+    findParentWrapper: vi.fn().mockReturnValue(undefined),
   },
 }));
 
@@ -978,6 +979,72 @@ describe('WrapperActionService', () => {
 
       expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(field, namespaceMap);
       expect(FieldOverrideService.revertFieldTypeOverride).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearAbstractSubstitution / choice>abstract cascade (#3532)', () => {
+    it('should cascade clear to parent choice when document-level maxOccurs=1', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
+      const wrapperField = mockField({ maxOccurs: 1, ownerDocument, parent: parentChoiceField });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
+        ownerDocument,
+        parentChoiceField,
+        namespaceMap,
+      );
+    });
+
+    it('should cascade clear to parent choice when document-level source maxOccurs>1', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
+      const wrapperField = mockField({ maxOccurs: -1, ownerDocument, parent: parentChoiceField });
+      const nodeData = {} as FieldNodeData;
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, false);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
+        ownerDocument,
+        parentChoiceField,
+        namespaceMap,
+      );
+    });
+
+    it('should NOT cascade for per-instance clear (target maxOccurs>1)', () => {
+      const wrapperField = mockField({ maxOccurs: -1 });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+    });
+
+    it('should NOT cascade when no choice parent', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapperField = mockField({ maxOccurs: 1, ownerDocument });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(undefined);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/services/visualization/wrapper-action.service.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.ts
@@ -5,6 +5,7 @@ import {
   FieldItemNodeData,
   NodeData,
   TargetAbstractFieldNodeData,
+  TargetChoiceFieldNodeData,
   TargetFieldNodeData,
   TargetNodeData,
 } from '../../models/datamapper/visualization';
@@ -284,6 +285,13 @@ export class WrapperActionService {
     if (selectedMember) WrapperActionService.applyTargetSelection(nodeData as TargetNodeData, selectedMember);
   }
 
+  /**
+   * Clears a document-level abstract substitution, reverting the wrapper to its
+   * unresolved state. When the abstract wrapper is nested inside a choice wrapper,
+   * the parent choice selection is also cleared — the choice's selectedMemberIndex
+   * still points at the abstract member, which is now unresolved, leaving the
+   * choice state inconsistent if not cleared.
+   */
   private static clearDocumentLevelAbstractSubstitution(
     nodeData: NodeData,
     wrapperField: IField,
@@ -295,6 +303,11 @@ export class WrapperActionService {
     const schemaPath = SchemaPathService.build(wrapperField, namespaceMap);
     DocumentUtilService.invalidateDescendants(doc, schemaPath);
     FieldOverrideService.revertFieldSubstitution(wrapperField, namespaceMap);
+
+    const parentChoice = WrapperSelectionService.findParentWrapper(wrapperField, 'choice');
+    if (parentChoice) {
+      WrapperSelectionService.clearChoiceSelection(doc, parentChoice, namespaceMap);
+    }
   }
 
   // ── Group D: Choice Selection Orchestration ──
@@ -523,4 +536,86 @@ export class WrapperActionService {
       FieldOverrideService.revertFieldTypeOverride(field, namespaceMap);
     }
   }
+
+  /**
+   * Resolves the full choice context for a given node — which wrapper it belongs to,
+   * whether it's a selected member, a per-instance wrapper member, etc. Pure read,
+   * no side effects. Used by {@link useChoiceContextMenu} to determine what menu
+   * actions to offer.
+   */
+  static resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
+    const field = VisualizationUtilService.getField(nodeData);
+    const isChoiceWrapper = field?.wrapperKind === 'choice';
+    const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
+
+    const choiceMemberField =
+      VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
+    const choiceMemberParent =
+      choiceMemberField?.parent && 'wrapperKind' in choiceMemberField.parent ? choiceMemberField.parent : undefined;
+    const isChoiceMember = choiceMemberParent?.wrapperKind === 'choice';
+    const parentChoiceWrapperField = isChoiceMember ? choiceMemberParent : undefined;
+    const choiceMemberIndex =
+      isChoiceMember && parentChoiceWrapperField && choiceMemberField
+        ? parentChoiceWrapperField.fields.indexOf(choiceMemberField)
+        : undefined;
+
+    let choiceWrapperField: IField | undefined;
+    if (isSelectedChoice) {
+      choiceWrapperField = WrapperSelectionService.resolveOutermostSelectedWrapper(nodeData.choiceField).outermost;
+    } else if (isChoiceWrapper) {
+      choiceWrapperField = field;
+    }
+    const activeChoiceWrapperForMembers = isSelectedChoice && isChoiceWrapper ? field : choiceWrapperField;
+
+    const isChoiceWrapperMember = VisualizationUtilService.isChoiceWrapperMember(nodeData);
+    const choiceWrapperMemberField =
+      isChoiceWrapperMember && nodeData instanceof FieldItemNodeData
+        ? (nodeData.wrapperField ?? ((nodeData.parent as TargetChoiceFieldNodeData).field as IField))
+        : undefined;
+    const effectiveChoiceWrapper = isChoiceWrapperMember ? choiceWrapperMemberField : activeChoiceWrapperForMembers;
+
+    return {
+      isChoiceWrapper,
+      isSelectedChoice,
+      isChoiceMember,
+      isChoiceWrapperMember,
+      activeChoiceWrapperForMembers,
+      effectiveChoiceWrapper,
+      choiceWrapperField,
+      choiceWrapperMemberField,
+      choiceMemberField,
+      parentChoiceWrapperField,
+      choiceMemberIndex,
+    };
+  }
+}
+
+/**
+ * Full choice context resolved for a given node. Each field captures one aspect
+ * of the node's relationship to choice wrappers.
+ *
+ * @property isChoiceWrapper - The node's own field has `wrapperKind === 'choice'`
+ * @property isSelectedChoice - The node is a choice field with a selected member (flattened view)
+ * @property isChoiceMember - The node's field is a direct child of a choice wrapper
+ * @property isChoiceWrapperMember - The node is a per-instance FieldItem belonging to a collection wrapper
+ * @property activeChoiceWrapperForMembers - The choice wrapper whose members should be offered in the context menu
+ * @property effectiveChoiceWrapper - The wrapper that governs this node (wrapper member takes priority)
+ * @property choiceWrapperField - The outermost selected choice wrapper (walks up through nested choices)
+ * @property choiceWrapperMemberField - The wrapper field from a per-instance FieldItem
+ * @property choiceMemberField - The field representing this node as a choice member
+ * @property parentChoiceWrapperField - The parent choice wrapper field if this node is a direct member
+ * @property choiceMemberIndex - The 0-based index of this member within its parent choice
+ */
+export interface ChoiceNodeInfo {
+  isChoiceWrapper: boolean;
+  isSelectedChoice: boolean;
+  isChoiceMember: boolean;
+  isChoiceWrapperMember: boolean;
+  activeChoiceWrapperForMembers: IField | undefined;
+  effectiveChoiceWrapper: IField | undefined;
+  choiceWrapperField: IField | undefined;
+  choiceWrapperMemberField: IField | undefined;
+  choiceMemberField: IField | undefined;
+  parentChoiceWrapperField: IField | undefined;
+  choiceMemberIndex: number | undefined;
 }


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3532

- Fixed choice>abstract nest wrapper dissolution behavior for both maxOccurs=1 and maxOccurs>1
- Migrate more logic from context menu hook to WrapperSelectionService and WrapperActionService
- Add comprehensive regression tests for wrapper selection pattern including dissolution cases


https://github.com/user-attachments/assets/7aa558ad-edcd-4c43-b506-d730df5b9ae5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering and selection behavior for nested choice and abstract fields.
  * Clearing an abstract substitution now also clears its related choice selection when applicable.
  * Corrected context-menu actions for abstract fields nested within choice wrappers.
  * Improved handling of multiple occurrences, nested wrappers, and substitution candidates.
  * Restored complete candidate lists when selections are cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->