### PR TITLE
fix(DataMapper): activate summary buttons with Enter and Space

### DIFF
--- a/packages/ui/src/components/Document/NameInputPlaceholder.test.tsx
+++ b/packages/ui/src/components/Document/NameInputPlaceholder.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { Mock } from 'vitest';
 
 import { NameValidation, NameValidationStatus } from '../../models/datamapper/visualization';
+import { ExpansionContext } from '../ExpansionPanels/ExpansionContext';
+import { ExpansionPanel } from '../ExpansionPanels/ExpansionPanel';
 import { NameInputPlaceholder } from './NameInputPlaceholder';
 
 describe('NameInputPlaceholder', () => {
@@ -132,5 +135,115 @@ describe('NameInputPlaceholder', () => {
 
     const input = screen.getByTestId(`${TEST_PREFIX}-name-input`);
     expect(input).toHaveValue('existing');
+  });
+
+  describe('inside an ExpansionPanel summary', () => {
+    let mockSetExpanded: Mock;
+
+    function renderInPanel() {
+      mockSetExpanded = vi.fn();
+
+      return render(
+        <ExpansionContext.Provider
+          value={{
+            register: vi.fn(),
+            unregister: vi.fn(),
+            resize: vi.fn(),
+            setExpanded: mockSetExpanded,
+            queueLayoutChange: vi.fn(),
+            registerLayoutCallback: vi.fn(),
+            unregisterLayoutCallback: vi.fn(),
+          }}
+        >
+          <ExpansionPanel
+            id="test-panel"
+            summary={
+              <NameInputPlaceholder
+                validate={mockValidate}
+                onSubmit={mockOnSubmit}
+                onCancel={mockOnCancel}
+                placeholder="test name"
+                testIdPrefix={TEST_PREFIX}
+                ariaLabelPrefix="test"
+              />
+            }
+          >
+            <div>Test Content</div>
+          </ExpansionPanel>
+        </ExpansionContext.Provider>,
+      );
+    }
+
+    it.each(['{Enter}', ' '])('should submit via Tab then "%s" on the confirm button', async (key) => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      // The name input is auto-focused on mount.
+      await user.keyboard('testparam');
+      await user.tab();
+      expect(screen.getByTestId(`${TEST_PREFIX}-submit-btn`)).toHaveFocus();
+
+      await user.keyboard(key);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith('testparam');
+      // Confirming must not toggle the surrounding panel.
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+    });
+
+    it('should submit on Enter in the name field without tabbing', async () => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      await user.keyboard('testparam{Enter}');
+
+      expect(mockOnSubmit).toHaveBeenCalledWith('testparam');
+      // Confirming must not toggle the surrounding panel.
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+    });
+
+    it('should cancel on Escape in the name field', async () => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      await user.keyboard('testparam{Escape}');
+
+      expect(mockOnCancel).toHaveBeenCalled();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      `${TEST_PREFIX}-name-input`,
+      `${TEST_PREFIX}-submit-btn`,
+      `${TEST_PREFIX}-cancel-btn`,
+      `${TEST_PREFIX}-name-input-error`,
+    ])('should not toggle the panel when clicking "%s"', async (testId) => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      await user.keyboard('testparam');
+      await user.click(screen.getByTestId(testId));
+
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+    });
+
+    it('should submit when clicking the confirm button', async () => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      await user.keyboard('testparam');
+      await user.click(screen.getByTestId(`${TEST_PREFIX}-submit-btn`));
+
+      expect(mockOnSubmit).toHaveBeenCalledWith('testparam');
+    });
+
+    it('should cancel when clicking the cancel button', async () => {
+      const user = userEvent.setup();
+      renderInPanel();
+
+      await user.click(screen.getByTestId(`${TEST_PREFIX}-cancel-btn`));
+
+      expect(mockOnCancel).toHaveBeenCalled();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/Document/NameInputPlaceholder.tsx
+++ b/packages/ui/src/components/Document/NameInputPlaceholder.tsx
@@ -2,7 +2,7 @@ import './NameInputPlaceholder.scss';
 
 import { ActionList, ActionListGroup, ActionListItem, Button, Label } from '@patternfly/react-core';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
-import { FunctionComponent, KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, KeyboardEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { NameValidation, NameValidationStatus } from '../../models/datamapper/visualization';
 import { NameInput } from './NameInput';
@@ -59,6 +59,12 @@ export const NameInputPlaceholder: FunctionComponent<NameInputPlaceholderProps> 
     [onCancel],
   );
 
+  // Keep clicks from reaching an enclosing panel summary or node container,
+  // which would otherwise toggle or select it while the name is being edited.
+  const handleClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -71,8 +77,10 @@ export const NameInputPlaceholder: FunctionComponent<NameInputPlaceholderProps> 
   }, [initialName]);
 
   return (
-    <>
-      <ActionList className="name-input-actions" onKeyDown={handleEscapeKeyDown}>
+    // role="none": this wrapper is scaffolding that bounds event propagation, not a
+    // control. It must not be exposed or focusable in its own right.
+    <div className="name-input-placeholder" role="none" onClick={handleClick} onKeyDown={handleEscapeKeyDown}>
+      <ActionList className="name-input-actions">
         <ActionListGroup>
           <ActionListItem>
             {label && <Label>{label}</Label>}
@@ -116,6 +124,6 @@ export const NameInputPlaceholder: FunctionComponent<NameInputPlaceholderProps> 
       <div className="name-input-error" data-testid={`${testIdPrefix}-name-input-error`}>
         {validation.error}
       </div>
-    </>
+    </div>
   );
 };

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { Mock } from 'vitest';
 
 import { ExpansionContext } from './ExpansionContext';
@@ -427,6 +428,34 @@ describe('ExpansionPanel', () => {
 
       fireEvent.keyDown(summary, { key: 'Enter', ctrlKey: true });
 
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+    });
+
+    it.each(['{Enter}', ' '])('should let a focused button inside the summary be activated with "%s"', async (key) => {
+      const user = userEvent.setup();
+      const onButtonClick = vi.fn();
+      renderPanel({
+        defaultExpanded: true,
+        summary: (
+          // Summary buttons stop click propagation so activating them does not toggle the panel.
+          <button
+            type="button"
+            data-testid="summary-button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onButtonClick();
+            }}
+          >
+            Confirm
+          </button>
+        ),
+      });
+
+      screen.getByTestId('summary-button').focus();
+      await user.keyboard(key);
+
+      expect(onButtonClick).toHaveBeenCalledTimes(1);
+      // Activating the button must not toggle the surrounding panel.
       expect(mockSetExpanded).not.toHaveBeenCalled();
     });
   });

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -113,6 +113,9 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      // Let interactive descendants (buttons, inputs) handle their own Enter/Space.
+      // Calling preventDefault() here would otherwise suppress their activation.
+      if (event.target !== event.currentTarget) return;
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
The ExpansionPanel summary is a role="button" div whose keydown handler called preventDefault() on Enter/Space. Because React's onKeyDown bubbles, this also cancelled the browser's activation behaviour for any focused descendant, so no click was ever synthesised and the button's onClick never ran. Only mouse clicks worked.

This affected every button rendered in a panel summary, including the add/rename/delete parameter actions, not just the add-parameter confirm button reported in the issue.

- Ignore keydown events that did not originate on the summary itself, so interactive descendants keep their native Enter/Space activation.
- Stop click propagation on the name input confirm/cancel buttons, so activating them no longer toggles the enclosing panel. This was also reachable with the mouse, most visibly when renaming a parameter, where the panel survives the action and toggled underneath the user.

Fixes #3536

- Scope is wider than the issue. The preventDefault on a bubbled keydown disabled Enter/Space for every button in every panel summary (add, rename, delete, cancel) not just the confirm button. This is a WCAG 2.1.1 fix.
- The stopPropagation change is mouse-reachable too, and wasn't in the issue. Flag it so a maintainer can ask for it separately if they'd rather. The keyboard fix is incomplete without it, activating confirm would otherwise toggle the panel.
- How it was tested. 6753 tests pass, lint clean, and the 4 new bug-proving tests were confirmed to fail with the source fixes reverted. Worth saying that the 2 remaining new tests (Enter-in-field, Escape) pass either way they're regression guards, not proof.

I used a stack of agents, Fable in front, a mix of local models on my Spark and workstation, to address this issue and solve it. I'm learning the trade via "project based learning", so i read the diff here and spent time with my agents to understand what we did and why. I think I've put my inference to good use here for you guys and the open source movement. 

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented buttons and inputs inside expansion panel summaries from unintentionally toggling panels.
  * Improved keyboard and mouse interactions for document name submission and cancellation.
  * Ensured Enter and Space activate only the intended focused control.

* **Accessibility**
  * Enhanced keyboard navigation and activation behavior in expansion panels and document name editing.

* **Tests**
  * Added coverage for keyboard, focus, cancellation, submission, and mouse interactions in expansion panels and name input controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->