### PR TITLE
fix(camel-to-tile): guard against undefined annotations and missing icon in kameletToTile

### DIFF
--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.test.ts
@@ -332,6 +332,75 @@ describe('camel-to-tile.adapter', () => {
 
       expect(tile.headerTags).toEqual(['Kamelet']);
       expect(tile.version).toBeUndefined();
+      expect(tile.iconUrl).toBeUndefined();
+    });
+
+    it('should not crash and should return undefined iconUrl when annotations is undefined', async () => {
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          annotations: undefined,
+          labels: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as unknown as IKameletDefinition;
+
+      expect(() => kameletToTile(kameletDef)).not.toThrow();
+      const tile = await kameletToTile(kameletDef);
+      expect(tile.iconUrl).toBeUndefined();
+    });
+
+    it('should return undefined iconUrl when the icon annotation is missing', async () => {
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          annotations: {
+            'camel.apache.org/kamelet.support.level': 'Stable',
+            'camel.apache.org/catalog.version': '1.0.0',
+          },
+          labels: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as unknown as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.iconUrl).toBeUndefined();
+    });
+
+    it('should return the annotation value as iconUrl when the icon annotation is present', async () => {
+      const iconData = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=';
+      const kameletDef = {
+        metadata: {
+          name: 'my-kamelet',
+          annotations: {
+            'camel.apache.org/kamelet.support.level': 'Stable',
+            'camel.apache.org/catalog.version': '1.0.0',
+            'camel.apache.org/kamelet.icon': iconData,
+          },
+          labels: {},
+        },
+        spec: {
+          definition: {
+            title: 'My Kamelet',
+            description: 'My Kamelet Description',
+          },
+        },
+      } as unknown as IKameletDefinition;
+
+      const tile = await kameletToTile(kameletDef);
+
+      expect(tile.iconUrl).toEqual(iconData);
     });
 
     it('should not include type tag when labels are absent', async () => {

--- a/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
+++ b/packages/ui/src/camel-utils/camel-to-tile.adapter.ts
@@ -5,6 +5,8 @@ import {
   ICamelProcessorDefinition,
   ICitrusComponentDefinition,
   IKameletDefinition,
+  KameletKnownAnnotations,
+  KameletKnownLabels,
 } from '../models';
 import { getIconRequest } from '../models/visualization/flows/nodes/resolvers/icon-resolver/getIconRequest';
 
@@ -79,21 +81,17 @@ export const camelEntityToTile = async (processorDef: ICamelProcessorDefinition)
 
 export const kameletToTile = async (kameletDef: IKameletDefinition): Promise<ITile> => {
   const headerTags: string[] = ['Kamelet'];
-  if (kameletDef.metadata.annotations?.['camel.apache.org/kamelet.support.level']) {
-    headerTags.push(kameletDef.metadata.annotations['camel.apache.org/kamelet.support.level']);
+  if (kameletDef.metadata.annotations?.[KameletKnownAnnotations.SupportLevel]) {
+    headerTags.push(kameletDef.metadata.annotations[KameletKnownAnnotations.SupportLevel]);
   }
 
   const tags: string[] = [];
-  if (kameletDef.metadata.labels?.['camel.apache.org/kamelet.type']) {
-    tags.push(kameletDef.metadata.labels['camel.apache.org/kamelet.type']);
+  if (kameletDef.metadata.labels?.[KameletKnownLabels.Type]) {
+    tags.push(kameletDef.metadata.labels[KameletKnownLabels.Type]);
   }
 
-  let version = undefined;
-  if (kameletDef.metadata.annotations?.['camel.apache.org/catalog.version']) {
-    version = kameletDef.metadata.annotations['camel.apache.org/catalog.version'];
-  }
-
-  const { icon: iconUrl } = await getIconRequest(CatalogKind.Kamelet, kameletDef.metadata.name);
+  const version = kameletDef.metadata.annotations?.[KameletKnownAnnotations.CatalogVersion];
+  const iconUrl = kameletDef.metadata.annotations?.[KameletKnownAnnotations.Icon];
 
   return {
     type: CatalogKind.Kamelet,


### PR DESCRIPTION
Closes https://github.com/KaotoIO/kaoto/issues/3543

## Summary

`kameletToTile` in [`camel-to-tile.adapter.ts`](packages/ui/src/camel-utils/camel-to-tile.adapter.ts) had two problems:

- Hard-coded annotation/label key strings instead of the existing typed enums.
- The icon was resolved via `getIconRequest`, but Kamelets embed their icon as a data URI directly in the `camel.apache.org/kamelet.icon` annotation.  Reading it directly removes an unnecessary look-up and avoids a crash when `annotations` is `undefined`.

## Changes

### `camel-to-tile.adapter.ts`
- Import and use `KameletKnownAnnotations` / `KameletKnownLabels` enums instead of raw strings.
- Read `iconUrl` via `annotations?.[KameletKnownAnnotations.Icon]` (optional chaining → safe against `undefined`).
- Remove the `getIconRequest` call from `kameletToTile`.

### `camel-to-tile.adapter.test.ts`
- Added **`should not crash and should return undefined iconUrl when annotations is undefined`** — asserts no throw and `iconUrl === undefined`.
- Added **`should return undefined iconUrl when the icon annotation is missing`** — asserts `iconUrl === undefined` when annotations exist but the icon key is absent.
- Extended the existing `should not include support level or version when annotations are absent` assertion to also check `iconUrl`.

All 22 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kamelet tile generation to reliably derive support level, type, catalog version, and icon details from Kamelet metadata.
  * Prevented issues when optional annotations are missing.
  * Ensures tile icons remain unset when no icon annotation is provided, even if related icon fields exist.
* **Tests**
  * Expanded adapter tests to cover missing metadata/annotations and icon scenarios, including cases where the icon annotation is present or absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->