### PR TITLE
fix(canvas): catalog filter style fix

### DIFF
--- a/packages/ui/src/components/Catalog/CatalogFilter.scss
+++ b/packages/ui/src/components/Catalog/CatalogFilter.scss
@@ -2,11 +2,16 @@
   padding: 0 2px;
   display: flex;
   flex-flow: row;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: var(--pf-t--global--spacer--sm);
 
   &__search {
     flex: 1;
+  }
+
+  > div:not(:last-child) {
+    min-width: 20%;
   }
 }
 


### PR DESCRIPTION
Fixes the filters menu responsiveness by wrapping it and giving a minimum width to improve readability.

https://github.com/user-attachments/assets/e5dfabeb-305b-461a-bb38-cc7ba596f698

fix: https://github.com/KaotoIO/kaoto/issues/3314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved filter bar responsiveness by allowing filter controls to wrap on smaller screens.
  * Adjusted filter control sizing to create a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->