### PR TITLE
fix(DataMapper): Render 1-to-1 container copy-of over a field after deserialize

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/node-title-util.test.ts
+++ b/packages/ui/src/components/Document/NodeTitle/node-title-util.test.ts
@@ -7,7 +7,7 @@ import {
   IfItem,
   MappingTree,
   UnknownMappingItem,
-  ValueSelector,
+  ValueOfSelector,
   VariableItem,
   WhenItem,
 } from '../../../models/datamapper/mapping';
@@ -69,7 +69,7 @@ describe('NodeTitleUtil.getMappingItemLabelInfo()', () => {
 
     it('should not warn when children exist', () => {
       const item = new VariableItem(tree, 'myVar');
-      item.children.push(new ValueSelector(item));
+      item.children.push(new ValueOfSelector(item));
 
       const result = NodeTitleUtil.getMappingItemLabelInfo(item);
 

--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -8,7 +8,7 @@ import {
   DocumentType,
   PrimitiveDocument,
 } from '../../../models/datamapper/document';
-import { MappingTree, UnknownMappingItem, ValueSelector, VariableItem } from '../../../models/datamapper/mapping';
+import { MappingTree, UnknownMappingItem, ValueOfSelector, VariableItem } from '../../../models/datamapper/mapping';
 import {
   AddMappingNodeData,
   DocumentNodeData,
@@ -463,12 +463,12 @@ describe('BaseNode', () => {
   });
 
   describe('Comment Functionality', () => {
-    let mockMapping: ValueSelector;
+    let mockMapping: ValueOfSelector;
     let mockOnUpdate: Mock;
 
     beforeEach(() => {
       const tree = new MappingTree(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-      mockMapping = new ValueSelector(tree);
+      mockMapping = new ValueOfSelector(tree);
       mockOnUpdate = vi.fn();
     });
 

--- a/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteMappingItemAction.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
-import { ForEachItem, MappingTree, ValueSelector } from '../../../models/datamapper/mapping';
+import { ForEachItem, MappingTree, ValueOfSelector } from '../../../models/datamapper/mapping';
 import { MappingNodeData, TargetDocumentNodeData } from '../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
@@ -14,7 +14,7 @@ describe('DeleteMappingItemAction', () => {
     const targetDoc = TestUtil.createTargetOrderDoc();
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const docData = new TargetDocumentNodeData(targetDoc, mappingTree);
-    const nodeData = new MappingNodeData(docData, new ValueSelector(mappingTree));
+    const nodeData = new MappingNodeData(docData, new ValueOfSelector(mappingTree));
     const onDeleteMock = vi.fn();
     render(
       <DataMapperProvider>

--- a/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Comment/CommentModal.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../../models/datamapper/document';
-import { MappingTree, ValueSelector } from '../../../../../models/datamapper/mapping';
+import { MappingTree, ValueOfSelector, ValueSelector } from '../../../../../models/datamapper/mapping';
 import { CommentModal } from './CommentModal';
 
 describe('CommentModal', () => {
@@ -13,7 +13,7 @@ describe('CommentModal', () => {
 
   beforeEach(() => {
     tree = new MappingTree(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-    mapping = new ValueSelector(tree);
+    mapping = new ValueOfSelector(tree);
     onCloseMock = vi.fn();
     onUpdateMock = vi.fn();
   });

--- a/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/ForEachGroup/ForEachGroupModal.tsx
@@ -20,8 +20,9 @@ import {
   ForEachGroupItem,
   GROUPING_STRATEGY_LABELS,
   GroupingStrategy,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
 } from '../../../../../models/datamapper/mapping';
 import { DataMapperModal } from '../../../../DataMapper/DataMapperModal';
 import { XPathEditorModal } from '../../../../XPath/XPathEditorModal';
@@ -76,7 +77,7 @@ export const ForEachGroupModal: FunctionComponent<ForEachGroupModalProps> = ({
   const groupingXPathProxyRef = useRef<ValueSelector | null>(null);
 
   const handleOpenGroupingXPathEditor = useCallback(() => {
-    const proxy = new ValueSelector(mapping, ValueType.VALUE);
+    const proxy = new ValueOfSelector(mapping, ValueOfType.VALUE);
     proxy.expression = groupingExpression;
     groupingXPathProxyRef.current = proxy;
     setIsGroupingXPathEditorOpen(true);

--- a/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortKey.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/Sort/SortKey.tsx
@@ -18,8 +18,9 @@ import {
   ForEachGroupItem,
   ForEachItem,
   SortItem,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
 } from '../../../../../models/datamapper/mapping';
 import { LANG_OPTIONS } from '../../../../../models/datamapper/types';
 import { XPathEditorModal } from '../../../../XPath/XPathEditorModal';
@@ -70,7 +71,7 @@ export const SortKey: FunctionComponent<SortKeyProps> = ({ index, sortItem, mapp
   const xpathProxyRef = useRef<ValueSelector | null>(null);
 
   const handleOpenXPathEditor = useCallback(() => {
-    const proxy = new ValueSelector(mapping, ValueType.VALUE);
+    const proxy = new ValueOfSelector(mapping, ValueOfType.VALUE);
     proxy.expression = sortItem.expression;
     xpathProxyRef.current = proxy;
     setIsXpathEditorOpen(true);

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
@@ -7,7 +7,7 @@ import {
   DocumentType,
   PrimitiveDocument,
 } from '../../../models/datamapper/document';
-import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';
+import { MappingTree, ValueOfSelector } from '../../../models/datamapper/mapping';
 import { MappingNodeData, TargetDocumentNodeData } from '../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
@@ -51,7 +51,7 @@ describe('TargetNodeActions', () => {
     );
     const tree = new MappingTree(primitiveDoc.documentType, primitiveDoc.documentId, DocumentDefinitionType.Primitive);
     const docData = new TargetDocumentNodeData(primitiveDoc, tree);
-    const mappingData = new MappingNodeData(docData, new ValueSelector(tree));
+    const mappingData = new MappingNodeData(docData, new ValueOfSelector(tree));
     render(
       <DataMapperProvider>
         <MappingLinksProvider>

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
-import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';
+import { MappingTree, ValueOfSelector } from '../../../models/datamapper/mapping';
 import { TargetDocumentNodeData } from '../../../models/datamapper/visualization';
 import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../../providers/datamapper.provider';
@@ -16,7 +16,7 @@ describe('XPathEditorAction', () => {
     render(
       <DataMapperProvider>
         <MappingLinksProvider>
-          <XPathEditorAction mapping={new ValueSelector(tree)} nodeData={docData} onUpdate={vi.fn()} />
+          <XPathEditorAction mapping={new ValueOfSelector(tree)} nodeData={docData} onUpdate={vi.fn()} />
         </MappingLinksProvider>
       </DataMapperProvider>,
     );

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
-import { MappingTree, ValueSelector } from '../../../models/datamapper/mapping';
+import { MappingTree, ValueOfSelector, ValueSelector } from '../../../models/datamapper/mapping';
 import { TargetDocumentNodeData } from '../../../models/datamapper/visualization';
 import { XmlSchemaDocument } from '../../../services/document/xml-schema/xml-schema-document.model';
 import { useDocumentTreeStore } from '../../../store/document-tree.store';
@@ -17,7 +17,7 @@ describe('XPathInputAction', () => {
   beforeEach(() => {
     doc = TestUtil.createTargetOrderDoc();
     tree = new MappingTree(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-    mapping = new ValueSelector(tree);
+    mapping = new ValueOfSelector(tree);
     docData = new TargetDocumentNodeData(doc, tree);
     // Reset store state before each test
     useDocumentTreeStore.getState().clearXPathInputFocusRequest();

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -1,7 +1,13 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
-import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
+import {
+  BODY_DOCUMENT_ID,
+  IExpressionHolder,
+  MappingItem,
+  MappingTree,
+  ValueOfSelector,
+} from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
@@ -22,7 +28,7 @@ globalThis.ResizeObserver = class ResizeObserver {
 
 const createTestMapping = () => {
   const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-  const mapping: IExpressionHolder & MappingItem = new ValueSelector(tree);
+  const mapping: IExpressionHolder & MappingItem = new ValueOfSelector(tree);
   mapping.expression = '/to/some/field';
   return mapping;
 };

--- a/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorModal.test.tsx
@@ -1,6 +1,12 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import { BODY_DOCUMENT_ID, IExpressionHolder, MappingItem, MappingTree, ValueSelector } from '../../models/datamapper';
+import {
+  BODY_DOCUMENT_ID,
+  IExpressionHolder,
+  MappingItem,
+  MappingTree,
+  ValueOfSelector,
+} from '../../models/datamapper';
 import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
@@ -8,7 +14,7 @@ import { XPathEditorModal } from './XPathEditorModal';
 
 describe('XPathEditorModal', () => {
   const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
-  const mapping: IExpressionHolder & MappingItem = new ValueSelector(tree);
+  const mapping: IExpressionHolder & MappingItem = new ValueOfSelector(tree);
   mapping.expression = '/to/some/field';
   const onClose = vi.fn();
   const onUpdate = vi.fn();

--- a/packages/ui/src/models/datamapper/mapping.test.ts
+++ b/packages/ui/src/models/datamapper/mapping.test.ts
@@ -9,8 +9,9 @@ import {
   MappingTree,
   OtherwiseItem,
   SortItem,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
   VariableItem,
   WhenItem,
 } from './mapping';
@@ -28,7 +29,7 @@ describe('mapping.ts', () => {
       expect(isExpressionHolder(new WhenItem(tree))).toBe(true);
       expect(isExpressionHolder(new ForEachItem(tree))).toBe(true);
       expect(isExpressionHolder(new ForEachGroupItem(tree))).toBe(true);
-      expect(isExpressionHolder(new ValueSelector(tree))).toBe(true);
+      expect(isExpressionHolder(new ValueOfSelector(tree))).toBe(true);
       expect(isExpressionHolder(new VariableItem(tree, 'myVar'))).toBe(true);
     });
 
@@ -42,7 +43,7 @@ describe('mapping.ts', () => {
     it('clone() should copy expression and children', () => {
       const item = new IfItem(tree);
       item.expression = 'count($x) > 0';
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       child.expression = '$x/name';
       item.children = [child];
 
@@ -56,7 +57,7 @@ describe('mapping.ts', () => {
 
     it('clone() should reparent cloned children to the cloned parent', () => {
       const item = new IfItem(tree);
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       item.children = [child];
 
       const cloned = item.clone();
@@ -82,7 +83,7 @@ describe('mapping.ts', () => {
       const choose = new ChooseItem(tree);
       const item = new WhenItem(choose);
       item.expression = '@type = "express"';
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       child.expression = '$x/value';
       item.children = [child];
 
@@ -124,7 +125,7 @@ describe('mapping.ts', () => {
     it('clone() should copy expression and children', () => {
       const item = new ForEachItem(tree);
       item.expression = '/Order/Items/Item';
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       child.expression = 'ItemId';
       item.children = [child];
 
@@ -179,7 +180,7 @@ describe('mapping.ts', () => {
       item.expression = '/Order/Items/Item';
       item.groupingStrategy = GroupingStrategy.GROUP_ADJACENT;
       item.groupingExpression = 'Category';
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       child.expression = 'ItemId';
       item.children = [child];
 
@@ -210,13 +211,13 @@ describe('mapping.ts', () => {
 
   describe('ValueSelector', () => {
     it('clone() should copy expression and valueType', () => {
-      const item = new ValueSelector(tree, ValueType.ATTRIBUTE);
+      const item = new ValueOfSelector(tree, ValueOfType.ATTRIBUTE);
       item.expression = '/Order/@id';
 
       const cloned = item.clone();
 
       expect(cloned.expression).toBe('/Order/@id');
-      expect(cloned.valueType).toBe(ValueType.ATTRIBUTE);
+      expect(cloned.valueType).toBe(ValueOfType.ATTRIBUTE);
       expect(cloned).not.toBe(item);
     });
   });
@@ -225,7 +226,7 @@ describe('mapping.ts', () => {
     it('clone() should copy name, expression, and children', () => {
       const item = new VariableItem(tree, 'myVar');
       item.expression = '/Order/Id';
-      const child = new ValueSelector(item);
+      const child = new ValueOfSelector(item);
       child.expression = 'ItemId';
       item.children = [child];
 

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -29,8 +29,8 @@ export class MappingTree {
 
 /**
  * Abstract base for every node in the mapping tree.
- * Subclasses represent either data mappings ({@link FieldItem}, {@link ValueSelector})
- * or XSLT instruction elements ({@link InstructionItem} subtypes).
+ * Subclasses represent either data mappings ({@link FieldItem}, {@link ValueOfSelector},
+ * {@link CopyOfSelector}) or XSLT instruction elements ({@link InstructionItem} subtypes).
  */
 export abstract class MappingItem {
   constructor(
@@ -108,7 +108,8 @@ export class FieldItem extends MappingItem {
 
 /**
  * Implemented by any mapping item that carries an XPath expression,
- * such as {@link IfItem}, {@link WhenItem}, {@link ForEachItem}, and {@link ValueSelector}.
+ * such as {@link IfItem}, {@link WhenItem}, {@link ForEachItem}, {@link ValueOfSelector},
+ * and {@link CopyOfSelector}.
  */
 export interface IExpressionHolder {
   expression: string;
@@ -317,11 +318,19 @@ export class SortItem {
 }
 
 /**
- * Distinguishes how a {@link ValueSelector} produces its output in the generated XSLT
- * and how it is rendered in the visualization tree.
+ * How a {@link ValueOfSelector} produces its output in the generated XSLT.
+ * Both types are always rendered **inline** (XPath input on the field row).
+ */
+export enum ValueOfType {
+  /** Emits a text value via `xsl:value-of`. */
+  VALUE = 'value',
+  /** Emits an XML attribute. */
+  ATTRIBUTE = 'attribute',
+}
+
+/**
+ * How a {@link CopyOfSelector} produces its output in the generated XSLT.
  *
- * Rendering rules:
- * - `VALUE` / `ATTRIBUTE` — always rendered **inline** (XPath input on the field row).
  * - `CONTAINER` — always rendered **inline**. Used for 1-to-1 container copy-of
  *   from DnD. `FieldItemHandler` skips target element creation so `xsl:copy-of`
  *   appears directly under the parent XSLT element.
@@ -329,44 +338,74 @@ export class SortItem {
  *   explicit copy-of added from the context menu or xs:anyType mappings. Target
  *   element is always created, with `xsl:copy-of` nested inside it.
  */
-export enum ValueType {
-  /** Emits a text value via `xsl:value-of`. Always rendered inline. */
-  VALUE = 'value',
+export enum CopyOfType {
   /** Emits `xsl:copy-of`. Always inline — `FieldItemHandler` skips target element creation. */
   CONTAINER = 'container',
   /** Emits `xsl:copy-of` inside a target element. Always rendered as a tree node. */
   CONTAINER_NODE = 'container_node',
-  /** Emits an XML attribute. Always rendered inline. */
-  ATTRIBUTE = 'attribute',
 }
 
 /**
- * Leaf node that supplies the value for a target {@link FieldItem}.
- * Serializes as `xsl:value-of` for scalar values and attributes,
- * or `xsl:copy-of` for container nodes, depending on {@link valueType}.
+ * Abstract base for leaf nodes that supply the value for a target {@link FieldItem}.
+ * Concrete subclasses:
+ * - {@link ValueOfSelector} — `xsl:value-of` and `xsl:text`
+ * - {@link CopyOfSelector} — `xsl:copy-of`
  *
  * A ValueSelector may render either inline on its parent field row or as a
  * dedicated tree node in the target visualization. The rendering mode is
- * determined solely by {@link valueType} — see {@link ValueType}.
+ * determined by each subclass's `valueType` property.
  */
-export class ValueSelector extends MappingItem implements IExpressionHolder {
+export abstract class ValueSelector extends MappingItem implements IExpressionHolder {
   constructor(
     public parent: MappingParentType,
-    public valueType: ValueType = ValueType.VALUE,
+    label: string,
   ) {
-    const label = valueType === ValueType.CONTAINER || valueType === ValueType.CONTAINER_NODE ? 'copy-of' : 'value';
     super(parent, label, getCamelRandomId(label, 4));
   }
   expression = '';
-  isLiteral = false;
-  doClone() {
-    return new ValueSelector(this.parent, this.valueType);
-  }
   clone() {
     const cloned = super.clone() as ValueSelector;
     cloned.expression = this.expression;
+    return cloned;
+  }
+}
+
+/**
+ * Leaf node that produces a text value via `xsl:value-of` or a literal via `xsl:text`.
+ * {@link valueType} is {@link ValueOfType.VALUE} or {@link ValueOfType.ATTRIBUTE}.
+ */
+export class ValueOfSelector extends ValueSelector {
+  constructor(
+    public parent: MappingParentType,
+    public valueType: ValueOfType = ValueOfType.VALUE,
+  ) {
+    super(parent, 'value');
+  }
+  isLiteral = false;
+  doClone() {
+    return new ValueOfSelector(this.parent, this.valueType);
+  }
+  clone() {
+    const cloned = super.clone() as ValueOfSelector;
     cloned.isLiteral = this.isLiteral;
     return cloned;
+  }
+}
+
+/**
+ * Leaf node that copies a subtree via `xsl:copy-of`.
+ * {@link valueType} is {@link CopyOfType.CONTAINER} (inline, wrapper element skipped)
+ * or {@link CopyOfType.CONTAINER_NODE} (separate tree node, wrapper element kept).
+ */
+export class CopyOfSelector extends ValueSelector {
+  constructor(
+    public parent: MappingParentType,
+    public valueType: CopyOfType = CopyOfType.CONTAINER,
+  ) {
+    super(parent, 'copy-of');
+  }
+  doClone() {
+    return new CopyOfSelector(this.parent, this.valueType);
   }
 }
 

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -6,12 +6,15 @@ import {
 } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachItem,
   IfItem,
   MappingTree,
   OtherwiseItem,
   UnknownMappingItem,
+  ValueOfSelector,
   ValueSelector,
   VariableItem,
   WhenItem,
@@ -134,8 +137,9 @@ describe('MappingSerializerService', () => {
       expect(shipToFieldItem.field.namespaceURI).toBe('');
       expect(shipToFieldItem.field.maxOccurs).toBe(1);
       expect(shipToFieldItem.children).toHaveLength(1);
-      selector = shipToFieldItem.children[0] as ValueSelector;
-      expect(selector.expression).toBe('/ns0:ShipOrder/ShipTo');
+      const copyOfSelector = shipToFieldItem.children[0] as CopyOfSelector;
+      expect(copyOfSelector.expression).toBe('/ns0:ShipOrder/ShipTo');
+      expect(copyOfSelector.valueType).toBe(CopyOfType.CONTAINER_NODE);
 
       const forEachItem = shipOrderFieldItem.children[3] as ForEachItem;
       expect(forEachItem.expression).toBe('/ns0:ShipOrder/Item');
@@ -207,7 +211,48 @@ describe('MappingSerializerService', () => {
       expect(selector.expression).toBe('Price');
     });
 
-    it('should deserialize a raw text node as a literal ValueSelector', () => {
+    it('should reconstruct intermediate FieldItem for CONTAINER copy-of with skipped wrapper', () => {
+      const xslt = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="io.kaoto.datamapper.poc.test">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ShipOrder xmlns="io.kaoto.datamapper.poc.test">
+      <xsl:copy-of select="/ns0:ShipOrder/ShipTo"/>
+    </ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+
+      let mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      ({ mappingTree } = MappingSerializerService.deserialize(xslt, targetDoc, mappingTree, sourceParameterMap));
+
+      const shipOrderFieldItem = mappingTree.children[0] as FieldItem;
+      expect(shipOrderFieldItem.field.name).toBe('ShipOrder');
+      expect(shipOrderFieldItem.children).toHaveLength(1);
+
+      const shipToFieldItem = shipOrderFieldItem.children[0] as FieldItem;
+      expect(shipToFieldItem).toBeInstanceOf(FieldItem);
+      expect(shipToFieldItem.field.name).toBe('ShipTo');
+      expect(shipToFieldItem.children).toHaveLength(1);
+
+      const selector = shipToFieldItem.children[0] as CopyOfSelector;
+      expect(selector).toBeInstanceOf(CopyOfSelector);
+      expect(selector.valueType).toBe(CopyOfType.CONTAINER);
+      expect(selector.expression).toBe('/ns0:ShipOrder/ShipTo');
+
+      const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const xsltDocument = domParser.parseFromString(serialized, 'text/xml');
+      const copyOfSelect = xsltDocument
+        .evaluate(
+          '/xsl:stylesheet/xsl:template/ShipOrder/xsl:copy-of/@select',
+          xsltDocument,
+          xslNsResolver,
+          XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+        )
+        .iterateNext();
+      expect(copyOfSelect?.nodeValue).toBe('/ns0:ShipOrder/ShipTo');
+    });
+
+    it('should deserialize a raw text node as a literal ValueOfSelector', () => {
       const mappingTree = new MappingTree(
         DocumentType.TARGET_BODY,
         BODY_DOCUMENT_ID,
@@ -220,12 +265,12 @@ describe('MappingSerializerService', () => {
         sourceParameterMap,
       );
       expect(result.children).toHaveLength(1);
-      const selector = result.children[0] as ValueSelector;
+      const selector = result.children[0] as ValueOfSelector;
       expect(selector.expression).toBe('TEST');
       expect(selector.isLiteral).toBeTruthy();
     });
 
-    it('should deserialize xsl:text as a literal ValueSelector', () => {
+    it('should deserialize xsl:text as a literal ValueOfSelector', () => {
       const mappingTree = new MappingTree(
         DocumentType.TARGET_BODY,
         BODY_DOCUMENT_ID,
@@ -238,7 +283,7 @@ describe('MappingSerializerService', () => {
         sourceParameterMap,
       );
       expect(result.children).toHaveLength(1);
-      const selector = result.children[0] as ValueSelector;
+      const selector = result.children[0] as ValueOfSelector;
       expect(selector.expression).toBe('TEST');
       expect(selector.isLiteral).toBeTruthy();
     });

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -18,8 +18,8 @@ import {
   MappingTree,
   OtherwiseItem,
   UnknownMappingItem,
-  ValueSelector,
-  ValueType,
+  ValueOfSelector,
+  ValueOfType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import { DeserializeItemResult, DeserializeResult, MappingItemClass } from '../../models/datamapper/serialization';
@@ -297,7 +297,7 @@ export class MappingSerializerService {
   private static restoreTextNode(item: Node, parentMapping: MappingParentType) {
     const literal = (item.textContent || '').trim();
     if (!literal) return;
-    const selector = new ValueSelector(parentMapping, ValueType.VALUE);
+    const selector = new ValueOfSelector(parentMapping, ValueOfType.VALUE);
     selector.expression = literal;
     selector.isLiteral = true;
     parentMapping.children.push(selector);
@@ -412,6 +412,7 @@ export class MappingSerializerService {
     if (result.mappingItem) {
       MappingSerializerService.restoreCommentFromPreviousSibling(element, result.mappingItem);
     }
+
     return result;
   }
 

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -1,13 +1,16 @@
 import { DocumentDefinitionType, DocumentType, IDocument, IField } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachItem,
   IfItem,
   MappingTree,
   OtherwiseItem,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
@@ -725,7 +728,7 @@ describe('MappingService', () => {
   describe('wrapWithFunction()', () => {
     it('should wrap with xpath function', () => {
       const concatFx = XPathService.functions.String.find((f) => f.name === 'concat');
-      const valueSelector = new ValueSelector(tree);
+      const valueSelector = new ValueOfSelector(tree);
       valueSelector.expression = '/path/to/field';
       MappingService.wrapWithFunction(valueSelector, concatFx!);
       expect(valueSelector.expression).toBe('concat(/path/to/field)');
@@ -774,13 +777,13 @@ describe('MappingService', () => {
     });
   });
 
-  describe('createValueSelector()', () => {
-    it('should create ValueSelector', () => {
+  describe('createValueOfSelector()', () => {
+    it('should create ValueOfSelector', () => {
       const orderIdFieldItem = tree.children[0].children[0] as FieldItem;
       expect(orderIdFieldItem.children[0] instanceof ValueSelector).toBeTruthy();
       orderIdFieldItem.children = [];
-      const valueSelector = MappingService.createValueSelector(orderIdFieldItem);
-      expect(valueSelector.valueType).toEqual(ValueType.ATTRIBUTE);
+      const valueSelector = MappingService.createValueOfSelector(orderIdFieldItem);
+      expect(valueSelector.valueType).toEqual(ValueOfType.ATTRIBUTE);
     });
   });
 
@@ -834,7 +837,7 @@ describe('MappingService', () => {
       const targetField = targetDoc.fields[0].fields[0];
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
       const variable = MappingService.addVariable(shipOrderItem, 'myVar');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$myVar';
       fieldItem.children.push(vs);
       expect(fieldItem.children).toContain(vs);
@@ -1030,7 +1033,7 @@ describe('MappingService', () => {
       const variable = MappingService.addVariable(tree, 'taxRate');
 
       // Simulate mapping: add a ValueSelector with $taxRate expression
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$taxRate';
       fieldItem.children.push(vs);
 
@@ -1049,7 +1052,7 @@ describe('MappingService', () => {
       const targetField = targetDoc.fields[0].fields[0];
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
 
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$otherVar';
       fieldItem.children.push(vs);
 
@@ -1065,7 +1068,7 @@ describe('MappingService', () => {
       const childFieldItem = forEachItem.children.find((c) => c instanceof FieldItem) as FieldItem;
       if (!childFieldItem) return;
 
-      const vs = new ValueSelector(childFieldItem);
+      const vs = new ValueOfSelector(childFieldItem);
       vs.expression = '$loopVar';
       childFieldItem.children.push(vs);
 
@@ -1083,7 +1086,7 @@ describe('MappingService', () => {
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
 
       const localVar = MappingService.addVariable(shipOrderItem, 'x');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
 
@@ -1098,7 +1101,7 @@ describe('MappingService', () => {
     it('should remove a direct following sibling that references the variable', () => {
       const shipOrderItem = tree.children[0] as FieldItem;
       const variable = MappingService.addVariable(shipOrderItem, 'myVar');
-      const vs = new ValueSelector(shipOrderItem);
+      const vs = new ValueOfSelector(shipOrderItem);
       vs.expression = '$myVar';
       shipOrderItem.children.push(vs);
 
@@ -1130,7 +1133,7 @@ describe('MappingService', () => {
       const varX2 = new VariableItem(shipOrderItem, 'x');
       varX2.expression = '2';
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
       shipOrderItem.children.unshift(varX1, varX2);
@@ -1152,7 +1155,7 @@ describe('MappingService', () => {
       const varX2 = new VariableItem(shipOrderItem, 'x');
       varX2.expression = '$x + 1';
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
       shipOrderItem.children.unshift(varX1, varX2);
@@ -1172,7 +1175,7 @@ describe('MappingService', () => {
       const varX2 = new VariableItem(shipOrderItem, 'x');
       varX2.expression = '5';
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
       shipOrderItem.children.unshift(varX1, varX2);
@@ -1190,7 +1193,7 @@ describe('MappingService', () => {
       const targetField = targetDoc.fields[0].fields[0];
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
       const variable = MappingService.addVariable(shipOrderItem, 'myVar');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$myVar';
       fieldItem.children.push(vs);
 
@@ -1204,7 +1207,7 @@ describe('MappingService', () => {
       const targetField = targetDoc.fields[0].fields[0];
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
       const variable = MappingService.addVariable(shipOrderItem, 'my');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$myVar + $my';
       fieldItem.children.push(vs);
 
@@ -1218,7 +1221,7 @@ describe('MappingService', () => {
       const targetField = targetDoc.fields[0].fields[0];
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
       const variable = MappingService.addVariable(shipOrderItem, 'x');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x + $x';
       fieldItem.children.push(vs);
 
@@ -1233,7 +1236,7 @@ describe('MappingService', () => {
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
 
       MappingService.addVariable(shipOrderItem, 'x');
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
 
@@ -1252,7 +1255,7 @@ describe('MappingService', () => {
       const varX2 = new VariableItem(shipOrderItem, 'x');
       varX2.expression = '2';
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
       shipOrderItem.children.unshift(varX1, varX2);
@@ -1272,7 +1275,7 @@ describe('MappingService', () => {
       const varX2 = new VariableItem(shipOrderItem, 'x');
       varX2.expression = '$x + 1';
       const fieldItem = MappingService.createFieldItem(shipOrderItem, targetField);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$x';
       fieldItem.children.push(vs);
       shipOrderItem.children.unshift(varX1, varX2);
@@ -1313,9 +1316,9 @@ describe('MappingService', () => {
 
       MappingService.applyContainerMapping(sourceShipTo, targetShipTo, shipToItem);
 
-      const vs = shipToItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      const vs = shipToItem.children.find((c) => c instanceof CopyOfSelector) as CopyOfSelector;
       expect(vs).toBeDefined();
-      expect(vs.valueType).toBe(ValueType.CONTAINER);
+      expect(vs.valueType).toBe(CopyOfType.CONTAINER);
     });
 
     it('generateAutoChildMappings should create value-of for terminal matching children', () => {
@@ -1341,7 +1344,7 @@ describe('MappingService', () => {
       const childFieldItems = shipToItem.children.filter((c) => c instanceof FieldItem);
       expect(childFieldItems).toHaveLength(4);
       childFieldItems.forEach((fi) => {
-        const vs = fi.children.find((c) => c instanceof ValueSelector);
+        const vs = fi.children.find((c) => c instanceof ValueOfSelector);
         expect(vs).toBeDefined();
       });
     });
@@ -1363,9 +1366,9 @@ describe('MappingService', () => {
       expect(childFieldItems.length).toBeGreaterThan(0);
       const shipToChild = childFieldItems.find((c) => c.field.name === 'ShipTo')!;
       expect(shipToChild).toBeDefined();
-      const shipToVs = shipToChild.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      const shipToVs = shipToChild.children.find((c) => c instanceof CopyOfSelector) as CopyOfSelector;
       expect(shipToVs).toBeDefined();
-      expect(shipToVs.valueType).toBe(ValueType.CONTAINER);
+      expect(shipToVs.valueType).toBe(CopyOfType.CONTAINER);
     });
 
     it('applyContainerMapping should recurse when canUseCopyOf is false', () => {
@@ -1397,7 +1400,7 @@ describe('MappingService', () => {
     it('getContainerValueType should return CONTAINER for normal fields', () => {
       const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
       const sourceShipTo = sourceRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
-      expect(MappingService.getContainerValueType(sourceShipTo, targetShipTo)).toBe(ValueType.CONTAINER);
+      expect(MappingService.getContainerValueType(sourceShipTo, targetShipTo)).toBe(CopyOfType.CONTAINER);
     });
   });
 
@@ -1407,7 +1410,7 @@ describe('MappingService', () => {
       const freshFieldItem = new FieldItem(tree, targetDoc.fields[0]);
       const field1 = new FieldItem(freshFieldItem, targetDoc.fields[0].fields[0]);
       const field2 = new FieldItem(freshFieldItem, targetDoc.fields[0].fields[1]);
-      const valueSelector = new ValueSelector(freshFieldItem, ValueType.VALUE);
+      const valueSelector = new ValueOfSelector(freshFieldItem, ValueOfType.VALUE);
       freshFieldItem.children = [field1, field2, valueSelector];
 
       MappingService.addInnerForEach(freshFieldItem);
@@ -1433,7 +1436,7 @@ describe('MappingService', () => {
       const parentForEach = new ForEachItem(shipOrderItem);
       const fieldItem = new FieldItem(parentForEach, targetDoc.fields[0].fields[0]);
       parentForEach.children.push(fieldItem);
-      const valueSelector = new ValueSelector(parentForEach, ValueType.VALUE);
+      const valueSelector = new ValueOfSelector(parentForEach, ValueOfType.VALUE);
       parentForEach.children.push(valueSelector);
 
       MappingService.addInnerForEach(parentForEach);

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -1,6 +1,8 @@
 import { DocumentType, IDocument, IField, PrimitiveDocument } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachGroupItem,
   ForEachItem,
@@ -13,8 +15,9 @@ import {
   MappingParentType,
   MappingTree,
   OtherwiseItem,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
@@ -347,7 +350,7 @@ export class MappingService {
   ): T {
     const ensureBodyPlaceholder = () => {
       if (item.children.length === 0) {
-        item.children.push(MappingService.createValueSelector(item));
+        item.children.push(MappingService.createValueOfSelector(item));
       }
     };
 
@@ -500,14 +503,14 @@ export class MappingService {
   }
 
   /**
-   * When no mapping is provided, creates an empty {@link ValueSelector} as a placeholder child.
+   * When no mapping is provided, creates an empty {@link ValueOfSelector} as a placeholder child.
    * @param parent - the parent container to add the if-item to
    * @param mapping - optional existing mapping to place inside the if-item
    */
   static addIf(parent: MappingParentType, mapping?: MappingItem) {
     const ifItem = new IfItem(parent);
     parent.children.push(ifItem);
-    ifItem.children.push(mapping ?? MappingService.createValueSelector(ifItem));
+    ifItem.children.push(mapping ?? MappingService.createValueOfSelector(ifItem));
   }
 
   /**
@@ -529,7 +532,7 @@ export class MappingService {
 
   /**
    * Content is resolved by priority: mapping argument, then field argument,
-   * then a default empty {@link ValueSelector}.
+   * then a default empty {@link ValueOfSelector}.
    * @param chooseItem - the choose item to add a when-branch to
    * @param mapping - optional existing mapping for the when content
    * @param field - optional field to create a {@link FieldItem} for
@@ -543,7 +546,7 @@ export class MappingService {
     } else if (field) {
       MappingService.createFieldItem(whenItem, field);
     } else {
-      whenItem.children.push(MappingService.createValueSelector(whenItem));
+      whenItem.children.push(MappingService.createValueOfSelector(whenItem));
     }
     chooseItem.children.push(whenItem);
     return whenItem;
@@ -565,7 +568,7 @@ export class MappingService {
     } else if (field) {
       MappingService.createFieldItem(otherwiseItem, field);
     } else {
-      otherwiseItem.children.push(MappingService.createValueSelector(otherwiseItem));
+      otherwiseItem.children.push(MappingService.createValueOfSelector(otherwiseItem));
     }
     newChildren.push(otherwiseItem);
     chooseItem.children = newChildren;
@@ -593,17 +596,12 @@ export class MappingService {
    *
    * @param pathExpr - the pre-built source path expression
    * @param target - where to apply: {@link MappingTree} (document root), or any {@link MappingItem}
-   * @param valueType - value type for field-target {@link ValueSelector}; defaults to VALUE
    */
-  static applyMapping(
-    pathExpr: PathExpression,
-    target: MappingItem | MappingTree,
-    valueType: ValueType = ValueType.VALUE,
-  ): void {
+  static applyMapping(pathExpr: PathExpression, target: MappingItem | MappingTree): void {
     if (target instanceof MappingTree) {
-      let vs = target.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+      let vs = target.children.find((c) => c instanceof ValueOfSelector) as ValueOfSelector;
       if (!vs) {
-        vs = MappingService.createValueSelector(target);
+        vs = MappingService.createValueOfSelector(target);
         target.children.push(vs);
       }
       vs.expression = XPathService.addSource(vs.expression, pathExpr);
@@ -612,8 +610,7 @@ export class MappingService {
     } else if (isExpressionHolder(target)) {
       target.expression = XPathService.addSource(target.expression, pathExpr);
     } else {
-      const vs = MappingService.ensureValueSelector(target, valueType);
-      vs.valueType = valueType;
+      const vs = MappingService.ensureValueOfSelector(target);
       vs.expression = XPathService.addSource(vs.expression, pathExpr);
     }
   }
@@ -664,34 +661,39 @@ export class MappingService {
    * @param targetFieldItem - the target mapping item to map the source to
    */
   static mapToField(source: PrimitiveDocument | IField, targetFieldItem: MappingItem) {
-    const valueSelector = MappingService.ensureValueSelector(targetFieldItem);
+    const valueSelector = MappingService.ensureValueOfSelector(targetFieldItem);
     MappingService.applySourceExpression(source, targetFieldItem, valueSelector);
   }
 
   /**
-   * Like {@link mapToField} but sets an explicit {@link ValueType} on the selector.
-   * Used for container copy-of scenarios where we need CONTAINER or CONTAINER_NODE.
+   * Like {@link mapToField} but creates a {@link CopyOfSelector} for container copy-of scenarios.
    */
   static mapToFieldWithValueType(
     source: PrimitiveDocument | IField,
     targetFieldItem: MappingItem,
-    valueType: ValueType,
+    valueType: CopyOfType,
   ) {
-    const valueSelector = MappingService.ensureValueSelector(targetFieldItem, valueType);
-    valueSelector.valueType = valueType;
-    MappingService.applySourceExpression(source, targetFieldItem, valueSelector);
-    if (valueType === ValueType.CONTAINER_NODE && !valueSelector.expression.endsWith('/node()')) {
-      valueSelector.expression = `${valueSelector.expression}/node()`;
+    let copyOfSelector = targetFieldItem?.children.find((child) => child instanceof CopyOfSelector) as
+      | CopyOfSelector
+      | undefined;
+    if (!copyOfSelector) {
+      copyOfSelector = new CopyOfSelector(targetFieldItem, valueType);
+      targetFieldItem.children.push(copyOfSelector);
+    } else {
+      copyOfSelector.valueType = valueType;
+    }
+    MappingService.applySourceExpression(source, targetFieldItem, copyOfSelector);
+    if (valueType === CopyOfType.CONTAINER_NODE && !copyOfSelector.expression.endsWith('/node()')) {
+      copyOfSelector.expression = `${copyOfSelector.expression}/node()`;
     }
   }
 
-  private static ensureValueSelector(targetFieldItem: MappingItem, valueType?: ValueType): ValueSelector {
-    let valueSelector = targetFieldItem?.children.find((child) => child instanceof ValueSelector) as ValueSelector;
+  private static ensureValueOfSelector(targetFieldItem: MappingItem): ValueOfSelector {
+    let valueSelector = targetFieldItem?.children.find((child) => child instanceof ValueOfSelector) as
+      | ValueOfSelector
+      | undefined;
     if (!valueSelector) {
-      valueSelector =
-        valueType == null
-          ? MappingService.createValueSelector(targetFieldItem)
-          : new ValueSelector(targetFieldItem, valueType);
+      valueSelector = MappingService.createValueOfSelector(targetFieldItem);
       targetFieldItem.children.push(valueSelector);
     }
     return valueSelector;
@@ -771,12 +773,12 @@ export class MappingService {
    * @param targetField - Target field
    * @returns CONTAINER_NODE if xs:anyType is involved, otherwise CONTAINER
    */
-  static getContainerValueType(sourceField: IField, targetField: IField): ValueType {
+  static getContainerValueType(sourceField: IField, targetField: IField): CopyOfType {
     const anyTypeInvolved =
       (sourceField instanceof XmlSchemaField && sourceField.type === Types.AnyType) ||
       (targetField instanceof XmlSchemaField && targetField.type === Types.AnyType);
 
-    return anyTypeInvolved ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
+    return anyTypeInvolved ? CopyOfType.CONTAINER_NODE : CopyOfType.CONTAINER;
   }
 
   /**
@@ -799,14 +801,12 @@ export class MappingService {
   }
 
   /**
-   * {@link ValueType} is inferred from the parent's target field context: ATTRIBUTE for attribute fields,
-   * CONTAINER for fields with children, VALUE otherwise. {@link MappingTree} root defaults to VALUE.
-   * @param parent - the parent container that determines the value type
-   * @returns the created value selector
+   * {@link ValueOfType} is inferred from the parent's target field context: ATTRIBUTE for attribute fields,
+   * VALUE otherwise. {@link MappingTree} root defaults to VALUE.
    */
-  static createValueSelector(parent: MappingParentType) {
-    const valueType = parent instanceof MappingTree ? ValueType.VALUE : MappingService.getValueTypeFor(parent);
-    return new ValueSelector(parent, valueType);
+  static createValueOfSelector(parent: MappingParentType): ValueOfSelector {
+    const valueType = parent instanceof MappingTree ? ValueOfType.VALUE : MappingService.getValueTypeFor(parent);
+    return new ValueOfSelector(parent, valueType);
   }
 
   /**
@@ -1000,13 +1000,9 @@ export class MappingService {
     variable.expression = expression;
   }
 
-  private static getValueTypeFor(mapping: MappingItem): ValueType {
+  private static getValueTypeFor(mapping: MappingItem): ValueOfType {
     const field = MappingService.getTargetField(mapping);
-    return field?.isAttribute
-      ? ValueType.ATTRIBUTE
-      : field?.fields?.length && field.fields.length > 0
-        ? ValueType.CONTAINER
-        : ValueType.VALUE;
+    return field?.isAttribute ? ValueOfType.ATTRIBUTE : ValueOfType.VALUE;
   }
 
   private static getTargetField(mapping: MappingItem) {
@@ -1016,7 +1012,7 @@ export class MappingService {
   }
 
   /**
-   * First removes {@link ValueSelector} children, then for {@link InstructionItem}/{@link VariableItem}
+   * First removes value selector children, then for {@link InstructionItem}/{@link VariableItem}
    * or items under {@link FieldItem} parents, removes the item and recursively cleans up
    * empty FieldItem ancestors.
    * @param item - the mapping item to delete

--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -1,5 +1,7 @@
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType, IParentType } from '../../models/datamapper/document';
 import {
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachGroupItem,
   ForEachItem,
@@ -8,8 +10,8 @@ import {
   MappingTree,
   SortItem,
   UnknownMappingItem,
-  ValueSelector,
-  ValueType,
+  ValueOfSelector,
+  ValueOfType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import { NS_XSL } from '../../models/datamapper/standard-namespaces';
@@ -23,6 +25,7 @@ import { MappingSerializerService } from './mapping-serializer.service';
 import * as handlerModule from './xslt-item-handlers';
 import {
   allHandlers,
+  CopyOfSelectorHandler,
   deserializeHandlers,
   FieldItemHandler,
   ForEachGroupItemHandler,
@@ -30,7 +33,6 @@ import {
   serializeHandlers,
   SortItemHandler,
   UnknownMappingItemHandler,
-  ValueSelectorHandler,
 } from './xslt-item-handlers';
 
 describe('xslt-item-handlers registry', () => {
@@ -96,11 +98,11 @@ describe('FieldItemHandler copy-of with value-of', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
 
-    const copyOf = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    const copyOf = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER);
     copyOf.expression = '.';
     fieldItem.children.push(copyOf);
 
-    const valueOf = new ValueSelector(fieldItem, ValueType.VALUE);
+    const valueOf = new ValueOfSelector(fieldItem, ValueOfType.VALUE);
     valueOf.expression = '/ns0:ShipOrder/ns0:OrderId';
     fieldItem.children.push(valueOf);
 
@@ -116,7 +118,7 @@ describe('FieldItemHandler copy-of with value-of', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
 
-    const copyOf = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    const copyOf = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER);
     copyOf.expression = '.';
     fieldItem.children.push(copyOf);
 
@@ -128,14 +130,14 @@ describe('FieldItemHandler copy-of with value-of', () => {
   });
 });
 
-describe('ValueSelectorHandler copy-of', () => {
-  const handler = new ValueSelectorHandler();
+describe('CopyOfSelectorHandler', () => {
+  const handler = new CopyOfSelectorHandler();
   const targetDoc = TestUtil.createTargetOrderDoc();
 
   it('should serialize CONTAINER_NODE without appending /node()', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
-    const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+    const vs = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER_NODE);
     vs.expression = '/ns0:Envelope/Payload/node()';
 
     const xslt = MappingSerializerService.createNew();
@@ -146,7 +148,7 @@ describe('ValueSelectorHandler copy-of', () => {
   it('should serialize CONTAINER expression as-is', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
-    const vs = new ValueSelector(fieldItem, ValueType.CONTAINER);
+    const vs = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER);
     vs.expression = '/ns0:ShipOrder/Item';
 
     const xslt = MappingSerializerService.createNew();
@@ -163,8 +165,8 @@ describe('ValueSelectorHandler copy-of', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
     const result = handler.deserialize(element, targetDoc.fields[0], fieldItem);
-    const mappingItem = result.mappingItem as ValueSelector;
-    expect(mappingItem.valueType).toBe(ValueType.CONTAINER_NODE);
+    const mappingItem = result.mappingItem as CopyOfSelector;
+    expect(mappingItem.valueType).toBe(CopyOfType.CONTAINER_NODE);
     expect(mappingItem.expression).toBe('/ns0:Envelope/Payload/node()');
   });
 
@@ -177,9 +179,41 @@ describe('ValueSelectorHandler copy-of', () => {
     const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
     const forEachItem = new ForEachItem(mappingTree);
     const result = handler.deserialize(element, targetDoc.fields[0], forEachItem);
-    const mappingItem = result.mappingItem as ValueSelector;
-    expect(mappingItem.valueType).toBe(ValueType.CONTAINER);
+    const mappingItem = result.mappingItem as CopyOfSelector;
+    expect(mappingItem.valueType).toBe(CopyOfType.CONTAINER);
     expect(mappingItem.expression).toBe('/ns0:ShipOrder/Item');
+  });
+
+  it('should deserialize copy-of as CONTAINER when select target differs from parent field name', () => {
+    const xslt = new DOMParser().parseFromString(
+      `<xsl:stylesheet xmlns:xsl="${NS_XSL}"><xsl:copy-of select="/ns0:ShipOrder/ShipTo"/></xsl:stylesheet>`,
+      'application/xml',
+    );
+    const element = xslt.getElementsByTagNameNS(NS_XSL, 'copy-of')[0];
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    const result = handler.deserialize(element, targetDoc.fields[0], fieldItem);
+    expect(result.mappingItem).toBeInstanceOf(FieldItem);
+    const wrappedFieldItem = result.mappingItem as FieldItem;
+    const copyOfSelector = wrappedFieldItem.children[0] as CopyOfSelector;
+    expect(copyOfSelector).toBeInstanceOf(CopyOfSelector);
+    expect(copyOfSelector.valueType).toBe(CopyOfType.CONTAINER);
+    expect(copyOfSelector.expression).toBe('/ns0:ShipOrder/ShipTo');
+  });
+
+  it('should deserialize copy-of as CONTAINER_NODE when select target matches parent field name', () => {
+    const ns = 'io.kaoto.datamapper.poc.test';
+    const xslt = new DOMParser().parseFromString(
+      `<xsl:stylesheet xmlns:xsl="${NS_XSL}" xmlns:ns0="${ns}"><xsl:copy-of select="/root/ns0:ShipOrder"/></xsl:stylesheet>`,
+      'application/xml',
+    );
+    const element = xslt.getElementsByTagNameNS(NS_XSL, 'copy-of')[0];
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    const result = handler.deserialize(element, targetDoc.fields[0], fieldItem);
+    const mappingItem = result.mappingItem as CopyOfSelector;
+    expect(mappingItem.valueType).toBe(CopyOfType.CONTAINER_NODE);
+    expect(mappingItem.expression).toBe('/root/ns0:ShipOrder');
   });
 });
 

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -1,6 +1,8 @@
 import { BaseField, IField, IParentType, PrimitiveDocument } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachGroupItem,
   ForEachItem,
@@ -11,8 +13,8 @@ import {
   OtherwiseItem,
   SortItem,
   UnknownMappingItem,
-  ValueSelector,
-  ValueType,
+  ValueOfSelector,
+  ValueOfType,
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
@@ -22,19 +24,13 @@ import { FROM_JSON_SOURCE_SUFFIX } from '../document/json-schema/json-schema-doc
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
 import { MappingSerializerJsonAddon, TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
-/** Handles {@link ValueSelector} — maps to `xsl:copy-of`, `xsl:value-of`, or `xsl:text`. */
-export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
-  readonly itemClass = ValueSelector;
-  readonly xsltElementNames = ['copy-of', 'value-of', 'text'];
+/** Handles {@link ValueOfSelector} — maps to `xsl:value-of` or `xsl:text`. */
+export class ValueOfSelectorHandler implements XsltItemHandler<ValueOfSelector> {
+  readonly itemClass = ValueOfSelector;
+  readonly xsltElementNames = ['value-of', 'text'];
 
-  serialize(parent: Element, mapping: ValueSelector): Element {
+  serialize(parent: Element, mapping: ValueOfSelector): Element {
     const doc = parent.ownerDocument;
-    if (mapping.valueType === ValueType.CONTAINER || mapping.valueType === ValueType.CONTAINER_NODE) {
-      const copyOf = doc.createElementNS(NS_XSL, 'copy-of');
-      copyOf.setAttribute('select', mapping.expression);
-      parent.appendChild(copyOf);
-      return copyOf;
-    }
     const valueOf = doc.createElementNS(NS_XSL, 'value-of');
     valueOf.setAttribute('select', mapping.expression);
     parent.appendChild(valueOf);
@@ -44,33 +40,138 @@ export class ValueSelectorHandler implements XsltItemHandler<ValueSelector> {
   deserialize(
     element: Element,
     parentField: IParentType,
-    parentMapping: MappingParentType,
-  ): DeserializeItemResult<ValueSelector> {
-    switch (element.localName) {
-      case 'copy-of': {
-        const valueType = parentMapping instanceof FieldItem ? ValueType.CONTAINER_NODE : ValueType.CONTAINER;
-        const selector = new ValueSelector(parentMapping, valueType);
-        selector.expression = element.getAttribute('select') || '';
-        return { mappingItem: selector, fieldItem: null };
-      }
-      case 'text': {
-        const selector = new ValueSelector(parentMapping, ValueType.VALUE);
-        selector.expression = element.textContent || '';
-        selector.isLiteral = true;
-        return { mappingItem: selector, fieldItem: null };
-      }
-      default: {
-        const valueType =
-          'isAttribute' in parentField && parentField.isAttribute ? ValueType.ATTRIBUTE : ValueType.VALUE;
-        const selector = new ValueSelector(parentMapping, valueType);
-        selector.expression = element.getAttribute('select') || '';
-        return { mappingItem: selector, fieldItem: null };
-      }
+    _parentMapping: MappingParentType,
+  ): DeserializeItemResult<ValueOfSelector> {
+    if (element.localName === 'text') {
+      const selector = new ValueOfSelector(_parentMapping, ValueOfType.VALUE);
+      selector.expression = element.textContent || '';
+      selector.isLiteral = true;
+      return { mappingItem: selector, fieldItem: null };
     }
+    const valueType =
+      'isAttribute' in parentField && parentField.isAttribute ? ValueOfType.ATTRIBUTE : ValueOfType.VALUE;
+    const selector = new ValueOfSelector(_parentMapping, valueType);
+    selector.expression = element.getAttribute('select') || '';
+    return { mappingItem: selector, fieldItem: null };
   }
 }
 
-/** Handles {@link FieldItem} — serializes target element or `xsl:attribute`, deserializes `xsl:attribute`. */
+/**
+ * Handles {@link CopyOfSelector} — maps to `xsl:copy-of`.
+ *
+ * When a CONTAINER copy-of is deserialized (wrapper element was skipped during
+ * serialization), this handler reconstructs the intermediate {@link FieldItem}
+ * so that the mapping model is consistent regardless of how it was created.
+ */
+export class CopyOfSelectorHandler implements XsltItemHandler<MappingItem> {
+  readonly itemClass = CopyOfSelector;
+  readonly xsltElementNames = ['copy-of'];
+
+  serialize(parent: Element, mapping: CopyOfSelector): Element {
+    const doc = parent.ownerDocument;
+    const copyOf = doc.createElementNS(NS_XSL, 'copy-of');
+    copyOf.setAttribute('select', mapping.expression);
+    parent.appendChild(copyOf);
+    return copyOf;
+  }
+
+  private static resolveContainerValueType(
+    selectExpr: string,
+    parentMapping: MappingParentType,
+    element: Element,
+  ): CopyOfType {
+    if (selectExpr.endsWith('/node()')) return CopyOfType.CONTAINER_NODE;
+    if (parentMapping instanceof FieldItem) {
+      const { localName, namespaceURI } = CopyOfSelectorHandler.resolveFieldFromSelectExpression(selectExpr, element);
+      if (localName === parentMapping.field.name && namespaceURI === parentMapping.field.namespaceURI) {
+        return CopyOfType.CONTAINER_NODE;
+      }
+    }
+    return CopyOfType.CONTAINER;
+  }
+
+  private static resolveFieldFromSelectExpression(
+    selectExpr: string,
+    element: Element,
+  ): { localName: string; namespaceURI: string } {
+    const segments = selectExpr.split('/');
+    const lastSegment = segments[segments.length - 1];
+    if (!lastSegment) return { localName: '', namespaceURI: '' };
+
+    const colonIndex = lastSegment.indexOf(':');
+    const localName = colonIndex >= 0 ? lastSegment.substring(colonIndex + 1) : lastSegment;
+    const prefix = colonIndex >= 0 ? lastSegment.substring(0, colonIndex) : '';
+    const namespaceURI = prefix ? element.lookupNamespaceURI(prefix) || '' : '';
+
+    return { localName, namespaceURI };
+  }
+
+  private static wrapContainerCopyOfInFieldItem(
+    selector: CopyOfSelector,
+    element: Element,
+    parentField: IParentType,
+    parentMapping: FieldItem,
+  ): DeserializeItemResult<MappingItem> | null {
+    const { localName, namespaceURI } = CopyOfSelectorHandler.resolveFieldFromSelectExpression(
+      selector.expression,
+      element,
+    );
+    if (!localName) return null;
+
+    let targetField = XmlSchemaDocumentUtilService.getChildField(parentField, localName, namespaceURI);
+    if (!targetField) {
+      targetField = new BaseField(
+        parentField,
+        'ownerDocument' in parentField ? parentField.ownerDocument : parentField,
+        localName,
+      );
+      targetField.namespaceURI = namespaceURI;
+      parentField.fields.push(targetField);
+    }
+
+    const fieldItem = new FieldItem(parentMapping, targetField);
+    if (selector.comment) {
+      fieldItem.comment = selector.comment;
+      selector.comment = undefined;
+    }
+    selector.parent = fieldItem;
+    fieldItem.children.push(selector);
+    return { mappingItem: fieldItem, fieldItem: targetField };
+  }
+
+  deserialize(
+    element: Element,
+    parentField: IParentType,
+    parentMapping: MappingParentType,
+  ): DeserializeItemResult<MappingItem> {
+    const selectExpr = element.getAttribute('select') || '';
+    const valueType = CopyOfSelectorHandler.resolveContainerValueType(selectExpr, parentMapping, element);
+    const selector = new CopyOfSelector(parentMapping, valueType);
+    selector.expression = selectExpr;
+
+    if (
+      valueType === CopyOfType.CONTAINER &&
+      parentMapping instanceof FieldItem &&
+      !(parentField instanceof PrimitiveDocument)
+    ) {
+      const wrapped = CopyOfSelectorHandler.wrapContainerCopyOfInFieldItem(
+        selector,
+        element,
+        parentField,
+        parentMapping,
+      );
+      if (wrapped) return wrapped;
+    }
+
+    return { mappingItem: selector, fieldItem: null };
+  }
+}
+
+/**
+ * Handles {@link FieldItem} — serializes target element or `xsl:attribute`, deserializes `xsl:attribute`.
+ * When the sole child is a CONTAINER {@link CopyOfSelector}, the target element is skipped
+ * during serialization (copy-of appears directly under the parent).
+ */
 export class FieldItemHandler implements XsltItemHandler<FieldItem> {
   readonly itemClass = FieldItem;
   readonly xsltElementNames = ['attribute'];
@@ -86,12 +187,10 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
     }
 
     const hasContainerCopyOf = mapping.children.some(
-      (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER,
+      (c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER,
     );
     const hasChildFieldItems = mapping.children.some((c) => c instanceof FieldItem);
-    const hasValueOf = mapping.children.some(
-      (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
-    );
+    const hasValueOf = mapping.children.some((c) => c instanceof ValueOfSelector);
     if (hasContainerCopyOf && !hasChildFieldItems && !hasValueOf) return parent;
 
     const jsonElement = MappingSerializerJsonAddon.populateFieldItem(parent, mapping);
@@ -471,7 +570,8 @@ export class UnknownMappingItemHandler implements XsltItemHandler<UnknownMapping
 
 /** Single source of truth — every {@link XsltItemHandler} instance. Lookup maps are derived from this array. */
 export const allHandlers: XsltItemHandler<MappingItem | SortItem>[] = [
-  new ValueSelectorHandler(),
+  new ValueOfSelectorHandler(),
+  new CopyOfSelectorHandler(),
   new FieldItemHandler(),
   new IfItemHandler(),
   new ChooseItemHandler(),

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachGroupItem,
   ForEachItem,
@@ -15,8 +17,9 @@ import {
   MappingTree,
   OtherwiseItem,
   UnknownMappingItem,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
   VariableItem,
   WhenItem,
 } from '../../models/datamapper/mapping';
@@ -874,9 +877,9 @@ describe('MappingActionService', () => {
         const shipOrderFI = tree.children[0] as FieldItem;
         const orderPersonFI = shipOrderFI.children[0] as FieldItem;
         expect(orderPersonFI.children).toHaveLength(1);
-        const vs = orderPersonFI.children[0] as ValueSelector;
-        expect(vs).toBeInstanceOf(ValueSelector);
-        expect(vs.valueType).toBe(ValueType.VALUE);
+        const vs = orderPersonFI.children[0] as ValueOfSelector;
+        expect(vs).toBeInstanceOf(ValueOfSelector);
+        expect(vs.valueType).toBe(ValueOfType.VALUE);
       });
 
       it('should create ATTRIBUTE ValueSelector for attribute field', () => {
@@ -889,9 +892,9 @@ describe('MappingActionService', () => {
         const shipOrderFI = tree.children[0] as FieldItem;
         const orderIdFI = shipOrderFI.children[0] as FieldItem;
         expect(orderIdFI.children).toHaveLength(1);
-        const vs = orderIdFI.children[0] as ValueSelector;
-        expect(vs).toBeInstanceOf(ValueSelector);
-        expect(vs.valueType).toBe(ValueType.ATTRIBUTE);
+        const vs = orderIdFI.children[0] as ValueOfSelector;
+        expect(vs).toBeInstanceOf(ValueOfSelector);
+        expect(vs.valueType).toBe(ValueOfType.ATTRIBUTE);
       });
 
       it('should prevent duplicate VALUE ValueSelector', () => {
@@ -902,9 +905,7 @@ describe('MappingActionService', () => {
 
         const shipOrderFI = tree.children[0] as FieldItem;
         const orderPersonFI = shipOrderFI.children[0] as FieldItem;
-        const valueSelectors = orderPersonFI.children.filter(
-          (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
-        );
+        const valueSelectors = orderPersonFI.children.filter((c) => c instanceof ValueOfSelector);
         expect(valueSelectors).toHaveLength(1);
       });
     });
@@ -919,9 +920,9 @@ describe('MappingActionService', () => {
         const shipOrderFI = tree.children[0] as FieldItem;
         const orderIdFI = shipOrderFI.children[0] as FieldItem;
         expect(orderIdFI.children).toHaveLength(1);
-        const vs = orderIdFI.children[0] as ValueSelector;
-        expect(vs).toBeInstanceOf(ValueSelector);
-        expect(vs.valueType).toBe(ValueType.CONTAINER_NODE);
+        const vs = orderIdFI.children[0] as CopyOfSelector;
+        expect(vs).toBeInstanceOf(CopyOfSelector);
+        expect(vs.valueType).toBe(CopyOfType.CONTAINER_NODE);
       });
 
       it('should allow multiple CONTAINER_NODE ValueSelectors', () => {
@@ -942,7 +943,7 @@ describe('MappingActionService', () => {
         const shipOrderFI = tree.children[0] as FieldItem;
         const orderPersonFI = shipOrderFI.children[0] as FieldItem;
         const containerSelectors = orderPersonFI.children.filter(
-          (c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE,
+          (c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER_NODE,
         );
         expect(containerSelectors).toHaveLength(2);
       });
@@ -998,7 +999,7 @@ describe('MappingActionService', () => {
         const itemNode = forEachChildren[0] as FieldItemNodeData;
         const itemMapping = itemNode.mapping;
         expect(
-          itemMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+          itemMapping.children.some((c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER),
         ).toBe(true);
 
         const sourceItemChildren = VisualizationService.generateNonDocumentNodeDataChildren(sourceShipOrderChildren[3]);
@@ -1008,7 +1009,7 @@ describe('MappingActionService', () => {
         MappingActionService.engageMapping(tree, sourceTitleField, targetTitleField);
 
         expect(
-          itemMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+          itemMapping.children.some((c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER),
         ).toBe(false);
         expect(itemMapping.children.some((c) => c instanceof FieldItem && c.field.name === 'Title')).toBe(true);
       });
@@ -1026,7 +1027,7 @@ describe('MappingActionService', () => {
           (c) => c instanceof FieldItem && c.field.name === 'ShipTo',
         ) as FieldItem;
         expect(
-          shipToMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE),
+          shipToMapping.children.some((c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER_NODE),
         ).toBe(true);
 
         const sourceDocChildren = VisualizationService.generateStructuredDocumentChildren(sourceDocNode);
@@ -1052,7 +1053,7 @@ describe('MappingActionService', () => {
         MappingActionService.engageMapping(tree, sourceNameField, targetNameField);
 
         expect(
-          shipToMapping.children.some((c) => c instanceof ValueSelector && c.valueType === ValueType.CONTAINER_NODE),
+          shipToMapping.children.some((c) => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER_NODE),
         ).toBe(true);
         expect(shipToMapping.children.some((c) => c instanceof FieldItem && c.field.name === 'Name')).toBe(true);
       });
@@ -1739,7 +1740,7 @@ describe('MappingActionService', () => {
         expect(vs.expression).toBe('$myVar');
       });
 
-      it('should create CONTAINER mapping for content-form variable to document', () => {
+      it('should create mapping for content-form variable to document', () => {
         const variable = new VariableItem(tree, 'contentVar');
         variable.children.push(new FieldItem(variable, targetDoc.fields[0]));
         tree.children.push(variable);
@@ -1799,9 +1800,9 @@ describe('MappingActionService', () => {
         ) as FieldItem;
         expect(itemFieldItem).toBeDefined();
 
-        const copyOf = itemFieldItem.children.find((c) => c instanceof ValueSelector) as ValueSelector;
+        const copyOf = itemFieldItem.children.find((c) => c instanceof CopyOfSelector) as CopyOfSelector;
         expect(copyOf).toBeDefined();
-        expect(copyOf.valueType).toEqual(ValueType.CONTAINER_NODE);
+        expect(copyOf.valueType).toEqual(CopyOfType.CONTAINER_NODE);
         expect(copyOf.expression).toMatch(/\/node\(\)$/);
       });
     });
@@ -2212,7 +2213,7 @@ describe('MappingActionService', () => {
       it('should not include Variable for ValueSelector, ChooseItem, or UnknownMappingItem MappingNodeData', () => {
         const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
         tree.children.push(fieldItem);
-        const valueSelector = new ValueSelector(fieldItem);
+        const valueSelector = new ValueOfSelector(fieldItem);
         fieldItem.children.push(valueSelector);
         const valueSelectorNode = new MappingNodeData(targetDocNode, valueSelector);
         expect(MappingActionRegistryService.getAllowedActions(valueSelectorNode)).not.toContain(

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -1,6 +1,8 @@
 import { IField, PrimitiveDocument } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachGroupItem,
   ForEachItem,
@@ -8,8 +10,9 @@ import {
   MappingItem,
   MappingParentType,
   MappingTree,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
 } from '../../models/datamapper/mapping';
 import { Types } from '../../models/datamapper/types';
 import {
@@ -57,11 +60,7 @@ export class MappingActionService {
   }
 
   static hasValueOfSelector(nodeData: TargetNodeData) {
-    return (
-      nodeData.mapping?.children.some(
-        (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
-      ) ?? false
-    );
+    return nodeData.mapping?.children.some((c) => c instanceof ValueOfSelector) ?? false;
   }
 
   /**
@@ -305,7 +304,7 @@ export class MappingActionService {
         : nodeData.mapping;
     if (!mapping) return;
     if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
-      const valueSelector = MappingService.createValueSelector(mapping);
+      const valueSelector = MappingService.createValueOfSelector(mapping);
       mapping.children.push(valueSelector);
       useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
     }
@@ -317,13 +316,10 @@ export class MappingActionService {
         ? MappingActionService.getOrCreateFieldItem(nodeData)
         : nodeData.mapping;
     if (!mapping) return;
-    const hasExisting = mapping.children.some(
-      (c) => c instanceof ValueSelector && (c.valueType === ValueType.VALUE || c.valueType === ValueType.ATTRIBUTE),
-    );
-    if (hasExisting) return;
+    if (mapping.children.some((c) => c instanceof ValueOfSelector)) return;
     const valueType =
-      nodeData instanceof TargetFieldNodeData && nodeData.field.isAttribute ? ValueType.ATTRIBUTE : ValueType.VALUE;
-    const valueSelector = new ValueSelector(mapping, valueType);
+      nodeData instanceof TargetFieldNodeData && nodeData.field.isAttribute ? ValueOfType.ATTRIBUTE : ValueOfType.VALUE;
+    const valueSelector = new ValueOfSelector(mapping, valueType);
     mapping.children.push(valueSelector);
     useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
   }
@@ -334,7 +330,7 @@ export class MappingActionService {
         ? MappingActionService.getOrCreateFieldItem(nodeData)
         : nodeData.mapping;
     if (!mapping) return;
-    const copyOfSelector = new ValueSelector(mapping, ValueType.CONTAINER_NODE);
+    const copyOfSelector = new CopyOfSelector(mapping, CopyOfType.CONTAINER_NODE);
     mapping.children.push(copyOfSelector);
     useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
   }
@@ -378,11 +374,9 @@ export class MappingActionService {
     targetNode: TargetNodeData,
     mappingTree: MappingTree,
   ) {
-    // TODO(#2362-content-form): CONTAINER for condition/document targets not yet handled
-    const valueType = sourceNode.variable.children.length > 0 ? ValueType.CONTAINER : ValueType.VALUE;
     const pathExpr = MappingService.variablePathExpression(sourceNode.variable.name);
     const target = MappingActionService.resolveTarget(targetNode, mappingTree);
-    if (target) MappingService.applyMapping(pathExpr, target, valueType);
+    if (target) MappingService.applyMapping(pathExpr, target);
   }
 
   private static engageChoiceMapping(
@@ -472,7 +466,7 @@ export class MappingActionService {
 
     if (anyTypeInvolved && (!sourceHasChildren || !targetHasChildren)) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
-      MappingService.mapToFieldWithValueType(sourceFieldFromNode, item, ValueType.CONTAINER_NODE);
+      MappingService.mapToFieldWithValueType(sourceFieldFromNode, item, CopyOfType.CONTAINER_NODE);
       return true;
     }
 
@@ -632,7 +626,7 @@ export class MappingActionService {
     const parent = item.parent;
     if (!(parent instanceof MappingItem)) return;
     parent.children = parent.children.filter(
-      (c) => !(c instanceof ValueSelector && c.valueType === ValueType.CONTAINER),
+      (c) => !(c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER),
     );
   }
 }

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -7,7 +7,14 @@ import {
   IDocument,
   IField,
 } from '../../models/datamapper/document';
-import { FieldItem, MappingTree, ValueSelector, ValueType, VariableItem } from '../../models/datamapper/mapping';
+import {
+  CopyOfSelector,
+  CopyOfType,
+  FieldItem,
+  MappingTree,
+  ValueOfSelector,
+  VariableItem,
+} from '../../models/datamapper/mapping';
 import { MappingLineStyle, variableNodePath, VARIABLES_DOCUMENT_ID } from '../../models/datamapper/visualization';
 import { useDocumentTreeStore } from '../../store';
 import { mockRandomValues } from '../../stubs';
@@ -327,7 +334,7 @@ describe('MappingLinksService', () => {
       rootItem.children.push(personItem);
       const emailItem = new FieldItem(personItem, emailField);
       personItem.children.push(emailItem);
-      const valueSelector = new ValueSelector(emailItem);
+      const valueSelector = new ValueOfSelector(emailItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       emailItem.children.push(valueSelector);
 
@@ -373,7 +380,7 @@ describe('MappingLinksService', () => {
       rootItem.children.push(personItem);
       const emailItem = new FieldItem(personItem, emailField);
       personItem.children.push(emailItem);
-      const valueSelector = new ValueSelector(emailItem);
+      const valueSelector = new ValueOfSelector(emailItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       emailItem.children.push(valueSelector);
 
@@ -415,7 +422,7 @@ describe('MappingLinksService', () => {
       rootItem.children.push(personItem);
       const emailItem = new FieldItem(personItem, emailField);
       personItem.children.push(emailItem);
-      const valueSelector = new ValueSelector(emailItem);
+      const valueSelector = new ValueOfSelector(emailItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       emailItem.children.push(valueSelector);
 
@@ -466,7 +473,7 @@ describe('MappingLinksService', () => {
       largeItem.children.push(emailItem);
       const subjectItem = new FieldItem(emailItem, subjectField);
       emailItem.children.push(subjectItem);
-      const valueSelector = new ValueSelector(subjectItem);
+      const valueSelector = new ValueOfSelector(subjectItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       subjectItem.children.push(valueSelector);
 
@@ -518,7 +525,7 @@ describe('MappingLinksService', () => {
       abstractTree.children.push(rootItem);
       const orderIdItem = new FieldItem(rootItem, orderIdField);
       rootItem.children.push(orderIdItem);
-      const valueSelector = new ValueSelector(orderIdItem);
+      const valueSelector = new ValueOfSelector(orderIdItem);
       valueSelector.expression = '/ns0:Zoo/ns0:Cat/ns0:indoor';
       orderIdItem.children.push(valueSelector);
 
@@ -551,7 +558,7 @@ describe('MappingLinksService', () => {
       rootItem.children.push(catItem);
       const indoorItem = new FieldItem(catItem, indoorField);
       catItem.children.push(indoorItem);
-      const valueSelector = new ValueSelector(indoorItem);
+      const valueSelector = new ValueOfSelector(indoorItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       indoorItem.children.push(valueSelector);
 
@@ -585,7 +592,7 @@ describe('MappingLinksService', () => {
       rootItem.children.push(catItem);
       const indoorItem = new FieldItem(catItem, indoorField);
       catItem.children.push(indoorItem);
-      const valueSelector = new ValueSelector(indoorItem);
+      const valueSelector = new ValueOfSelector(indoorItem);
       valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
       indoorItem.children.push(valueSelector);
 
@@ -655,7 +662,7 @@ describe('MappingLinksService', () => {
       for (const childField of targetShipTo.fields) {
         const childItem = new FieldItem(shipToItem, childField);
         shipToItem.children.push(childItem);
-        const vs = new ValueSelector(childItem);
+        const vs = new ValueOfSelector(childItem);
         vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
         childItem.children.push(vs);
       }
@@ -691,7 +698,7 @@ describe('MappingLinksService', () => {
       targetShipTo.fields.forEach((targetChild: IField, i: number) => {
         const childItem = new FieldItem(shipToItem, targetChild);
         shipToItem.children.push(childItem);
-        const vs = new ValueSelector(childItem);
+        const vs = new ValueOfSelector(childItem);
         vs.expression = `/ns0:ShipOrder/ShipTo/${shuffledSourceNames[i]}`;
         childItem.children.push(vs);
       });
@@ -723,7 +730,7 @@ describe('MappingLinksService', () => {
       for (const childField of mappedFields) {
         const childItem = new FieldItem(shipToItem, childField);
         shipToItem.children.push(childItem);
-        const vs = new ValueSelector(childItem);
+        const vs = new ValueOfSelector(childItem);
         vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
         childItem.children.push(vs);
       }
@@ -760,7 +767,7 @@ describe('MappingLinksService', () => {
         for (const childField of targetShipTo.fields) {
           const childItem = new FieldItem(shipToItem, childField);
           shipToItem.children.push(childItem);
-          const vs = new ValueSelector(childItem);
+          const vs = new ValueOfSelector(childItem);
           vs.expression = `/ns0:ShipOrder/ShipTo/${childField.name}`;
           childItem.children.push(vs);
         }
@@ -801,7 +808,7 @@ describe('MappingLinksService', () => {
         targetChildren.forEach((childField: IField, i: number) => {
           const childItem = new FieldItem(shipToItem, childField);
           shipToItem.children.push(childItem);
-          const vs = new ValueSelector(childItem);
+          const vs = new ValueOfSelector(childItem);
           // Map first two target children to the same source child (Name),
           // so mappedSourceCount would be 4 but unique mapped sources is only 3
           const sourceName = i < 2 ? 'Name' : targetChildren[i].name;
@@ -833,7 +840,7 @@ describe('MappingLinksService', () => {
       manualTree.children.push(rootItem);
       const shipToItem = new FieldItem(rootItem, targetShipTo);
       rootItem.children.push(shipToItem);
-      const vs = new ValueSelector(shipToItem, ValueType.CONTAINER_NODE);
+      const vs = new CopyOfSelector(shipToItem, CopyOfType.CONTAINER_NODE);
       vs.expression = '/ns0:ShipOrder/ShipTo';
       shipToItem.children.push(vs);
 
@@ -860,7 +867,7 @@ describe('MappingLinksService', () => {
       manualTree.children.push(rootItem);
       const fieldItem = new FieldItem(rootItem, targetField);
       rootItem.children.push(fieldItem);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = '$myVar';
       fieldItem.children.push(vs);
 
@@ -884,7 +891,7 @@ describe('MappingLinksService', () => {
       const fieldItem = new FieldItem(rootItem, targetField);
       rootItem.children.push(fieldItem);
       const paramName = Array.from(paramsMap.values())[0].getReferenceId(manualTree.namespaceMap);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = `$${paramName}`;
       fieldItem.children.push(vs);
 
@@ -909,7 +916,7 @@ describe('MappingLinksService', () => {
       manualTree.children.push(rootItem);
       const fieldItem = new FieldItem(rootItem, targetField);
       rootItem.children.push(fieldItem);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = `$${paramName}`;
       fieldItem.children.push(vs);
 
@@ -937,7 +944,7 @@ describe('MappingLinksService', () => {
       manualTree.children.push(rootItem);
       const fieldItem = new FieldItem(rootItem, targetField);
       rootItem.children.push(fieldItem);
-      const vs = new ValueSelector(fieldItem);
+      const vs = new ValueOfSelector(fieldItem);
       vs.expression = 'concat($a, $b)';
       fieldItem.children.push(vs);
 

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -1,5 +1,7 @@
 import {
   BODY_DOCUMENT_ID,
+  CopyOfSelector,
+  CopyOfType,
   DocumentNodeData,
   DocumentType,
   FieldItem,
@@ -16,7 +18,6 @@ import {
   NodePath,
   PrimitiveDocument,
   ValueSelector,
-  ValueType,
   VariableItem,
   variableNodePath,
   VARIABLES_DOCUMENT_ID,
@@ -67,7 +68,7 @@ export class MappingLinksService {
           item instanceof FieldItem &&
           !(item.field.ownerDocument instanceof PrimitiveDocument) &&
           child instanceof ValueSelector &&
-          child.valueType !== ValueType.CONTAINER_NODE
+          !(child instanceof CopyOfSelector && child.valueType === CopyOfType.CONTAINER_NODE)
         ) {
           const links = MappingLinksService.doExtractMappingLinks(
             child,
@@ -222,12 +223,7 @@ export class MappingLinksService {
   private static classifyContainerLineStyle(item: FieldItem): MappingLineStyle {
     const childFieldItems = item.children.filter((c): c is FieldItem => c instanceof FieldItem);
 
-    const vs = item.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
-    if (
-      childFieldItems.length === 0 &&
-      vs &&
-      (vs.valueType === ValueType.CONTAINER || vs.valueType === ValueType.CONTAINER_NODE)
-    ) {
+    if (childFieldItems.length === 0 && item.children.some((c) => c instanceof CopyOfSelector)) {
       return MappingLineStyle.COPY_OF;
     }
 
@@ -239,10 +235,7 @@ export class MappingLinksService {
 
     const allContainerChildrenCopyOf = childFieldItems
       .filter((child) => DocumentService.hasChildren(child.field))
-      .every((child) => {
-        const childVs = child.children.find((c) => c instanceof ValueSelector) as ValueSelector | undefined;
-        return childVs && (childVs.valueType === ValueType.CONTAINER || childVs.valueType === ValueType.CONTAINER_NODE);
-      });
+      .every((child) => child.children.some((c) => c instanceof CopyOfSelector));
 
     return allContainerChildrenCopyOf ? MappingLineStyle.COMPLETE : MappingLineStyle.PARTIAL;
   }

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -8,12 +8,15 @@ import {
 } from '../../models/datamapper/document';
 import {
   ChooseItem,
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   ForEachItem,
   IfItem,
   MappingTree,
+  ValueOfSelector,
+  ValueOfType,
   ValueSelector,
-  ValueType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import {
@@ -620,25 +623,25 @@ describe('VisualizationService', () => {
   describe('isInlineValueSelector()', () => {
     it('should return true for VALUE ValueSelector', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
-      const vs = new ValueSelector(fieldItem, ValueType.VALUE);
+      const vs = new ValueOfSelector(fieldItem, ValueOfType.VALUE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
     });
 
     it('should return true for ATTRIBUTE ValueSelector', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
-      const vs = new ValueSelector(fieldItem, ValueType.ATTRIBUTE);
+      const vs = new ValueOfSelector(fieldItem, ValueOfType.ATTRIBUTE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
     });
 
     it('should return true for CONTAINER ValueSelector', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
-      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER);
+      const vs = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
     });
 
     it('should return false for CONTAINER_NODE ValueSelector', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
-      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+      const vs = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER_NODE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(false);
     });
 
@@ -652,7 +655,7 @@ describe('VisualizationService', () => {
     it('should show CONTAINER_NODE copy-of as tree node in hasChildren', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
       tree.children.push(fieldItem);
-      const vs = new ValueSelector(fieldItem, ValueType.CONTAINER_NODE);
+      const vs = new CopyOfSelector(fieldItem, CopyOfType.CONTAINER_NODE);
       fieldItem.children.push(vs);
       targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
       const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -665,7 +668,7 @@ describe('VisualizationService', () => {
       const orderPersonField = targetDoc.fields[0].fields[0];
       const orderPersonFI = new FieldItem(shipOrderFI, orderPersonField);
       shipOrderFI.children.push(orderPersonFI);
-      const vs = new ValueSelector(orderPersonFI, ValueType.VALUE);
+      const vs = new ValueOfSelector(orderPersonFI, ValueOfType.VALUE);
       orderPersonFI.children.push(vs);
       targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
       const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -683,7 +686,7 @@ describe('VisualizationService', () => {
         primitiveTargetDoc.documentId,
         DocumentDefinitionType.Primitive,
       );
-      const vs = new ValueSelector(primitiveTree, ValueType.CONTAINER_NODE);
+      const vs = new CopyOfSelector(primitiveTree, CopyOfType.CONTAINER_NODE);
       primitiveTree.children.push(vs);
       const primitiveDocNode = new TargetDocumentNodeData(primitiveTargetDoc, primitiveTree);
       const children = VisualizationService.generatePrimitiveDocumentChildren(primitiveDocNode);

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -3,6 +3,8 @@ import { qname } from 'xml-name-validator';
 
 import { IDocument, IField } from '../../models/datamapper/document';
 import {
+  CopyOfSelector,
+  CopyOfType,
   FieldItem,
   IExpressionHolder,
   InstructionItem,
@@ -11,8 +13,8 @@ import {
   MappingParentType,
   MappingTree,
   UnknownMappingItem,
+  ValueOfSelector,
   ValueSelector,
-  ValueType,
   VariableItem,
 } from '../../models/datamapper/mapping';
 import {
@@ -273,7 +275,8 @@ export class VisualizationService {
     mappings: MappingItem[] | undefined,
   ): void {
     if (!mappings) return;
-    let filterPriorityMappingItem = (m: MappingItem) => m instanceof UnknownMappingItem || m instanceof VariableItem;
+    let filterPriorityMappingItem: (m: MappingItem) => boolean = (m) =>
+      m instanceof UnknownMappingItem || m instanceof VariableItem;
     if (parent.isPrimitive) {
       filterPriorityMappingItem = (m: MappingItem) =>
         m instanceof UnknownMappingItem || VisualizationService.isInlineValueSelector(m);
@@ -539,8 +542,8 @@ export class VisualizationService {
   }
 
   static isInlineValueSelector(item: MappingItem): item is ValueSelector {
-    if (!(item instanceof ValueSelector)) return false;
-    return item.valueType !== ValueType.CONTAINER_NODE;
+    if (item instanceof CopyOfSelector) return item.valueType !== CopyOfType.CONTAINER_NODE;
+    return item instanceof ValueOfSelector;
   }
 
   private static getFieldValueSelector(nodeData: TargetNodeData) {


### PR DESCRIPTION

Fixes: https://github.com/KaotoIO/kaoto/issues/3546

- Fixed deserializer to detect 1-to-1 container mapping
- Refactor: Split model and logics explicitly around value selector into 2 parts: xsl:value-of and xsl:copy-of


https://github.com/user-attachments/assets/2ec08aa3-8605-407f-bddb-150b0e5ca4c9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Corrected XSLT mapping import/export for `value-of` and `copy-of`, including container vs container-node behavior and skipped-wrapper handling.
  * Improved preservation of literal `xsl:text`/text-content and accurate `select` expression round-trips.
  * Fixed visualization/link rendering decisions for inline value selectors in container copy-of scenarios.
* **Tests**
  * Updated and expanded unit coverage for the refined `value-of`/`copy-of` selector handling across mapping, serialization, XPath editing, comments, and visualization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->