### PR TITLE
refactor(DataMapper): Extract field context menu types and builders i…

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu.test.tsx
@@ -1,14 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
-import { FieldContextMenu, MenuGroup } from './FieldContextMenu';
+import { IFieldMenuGroup } from '../../../models/datamapper/field-action';
+import { FieldContextMenu } from './FieldContextMenu';
 
 describe('FieldContextMenu', () => {
-  const overrideGroup: MenuGroup = {
+  const overrideGroup: IFieldMenuGroup = {
     actions: [{ label: 'Override Field...', onClick: vi.fn(), testId: 'override-field' }],
   };
 
-  const resetGroup = (onClick: Mock): MenuGroup => ({
+  const resetGroup = (onClick: Mock): IFieldMenuGroup => ({
     actions: [{ label: 'Reset Override', onClick }],
   });
 
@@ -21,7 +22,7 @@ describe('FieldContextMenu', () => {
   it('should call onClick and onClose when Override type is clicked', () => {
     const onClick = vi.fn();
     const onClose = vi.fn();
-    const group: MenuGroup = { actions: [{ label: 'Override Field...', onClick }] };
+    const group: IFieldMenuGroup = { actions: [{ label: 'Override Field...', onClick }] };
 
     render(<FieldContextMenu groups={[group]} onClose={onClose} />);
 
@@ -56,7 +57,7 @@ describe('FieldContextMenu', () => {
   });
 
   it('should skip empty groups and not render extra dividers', () => {
-    const emptyGroup: MenuGroup = { actions: [] };
+    const emptyGroup: IFieldMenuGroup = { actions: [] };
 
     const { container } = render(<FieldContextMenu groups={[emptyGroup, overrideGroup]} />);
 
@@ -65,8 +66,8 @@ describe('FieldContextMenu', () => {
   });
 
   it('should render dividers between non-empty groups', () => {
-    const group1: MenuGroup = { actions: [{ label: 'Action 1', onClick: vi.fn() }] };
-    const group2: MenuGroup = { actions: [{ label: 'Action 2', onClick: vi.fn() }] };
+    const group1: IFieldMenuGroup = { actions: [{ label: 'Action 1', onClick: vi.fn() }] };
+    const group2: IFieldMenuGroup = { actions: [{ label: 'Action 2', onClick: vi.fn() }] };
 
     const { container } = render(<FieldContextMenu groups={[group1, group2]} />);
 
@@ -79,11 +80,11 @@ describe('FieldContextMenu', () => {
       selectedIndex?: number,
       onSelect = vi.fn(),
       onClear = vi.fn(),
-    ): MenuGroup[] => {
+    ): IFieldMenuGroup[] => {
       const ChoicesIcon = () => <span data-testid="choices-icon" />;
       const CheckIcon = () => <span data-testid="check-icon" />;
 
-      const membersGroup: MenuGroup = {
+      const membersGroup: IFieldMenuGroup = {
         actions: members.map((name, index) => ({
           label: name,
           onClick: () => onSelect(index),
@@ -92,7 +93,7 @@ describe('FieldContextMenu', () => {
         })),
       };
 
-      const clearGroup: MenuGroup = {
+      const clearGroup: IFieldMenuGroup = {
         actions: [{ label: 'Clear selection', onClick: onClear, testId: 'clear-choice' }],
       };
 
@@ -158,10 +159,10 @@ describe('FieldContextMenu', () => {
     it('should show Select Member... for large choice lists', () => {
       const onOpenModal = vi.fn();
       const onClose = vi.fn();
-      const modalGroup: MenuGroup = {
+      const modalGroup: IFieldMenuGroup = {
         actions: [{ label: 'Select Member...', onClick: onOpenModal, testId: 'open-choice-modal' }],
       };
-      const clearGroup: MenuGroup = {
+      const clearGroup: IFieldMenuGroup = {
         actions: [{ label: 'Clear selection', onClick: vi.fn(), testId: 'clear-choice' }],
       };
 
@@ -187,7 +188,7 @@ describe('FieldContextMenu', () => {
 
   describe('Selected choice context menu (Case B)', () => {
     it('should show Clear selection above Override Field', () => {
-      const clearGroup: MenuGroup = {
+      const clearGroup: IFieldMenuGroup = {
         actions: [{ label: 'Clear selection', onClick: vi.fn(), testId: 'clear-choice' }],
       };
 
@@ -200,7 +201,7 @@ describe('FieldContextMenu', () => {
     it('should call onClearChoice when Clear selection is clicked', () => {
       const onClear = vi.fn();
       const onClose = vi.fn();
-      const clearGroup: MenuGroup = {
+      const clearGroup: IFieldMenuGroup = {
         actions: [{ label: 'Clear selection', onClick: onClear, testId: 'clear-choice' }],
       };
 
@@ -215,7 +216,7 @@ describe('FieldContextMenu', () => {
 
   describe('Choice member context menu (Case C)', () => {
     it('should show Select with member name above Override Field', () => {
-      const selectGroup: MenuGroup = {
+      const selectGroup: IFieldMenuGroup = {
         actions: [{ label: "Select 'Fax'", onClick: vi.fn(), testId: 'select-choice-member' }],
       };
 
@@ -231,7 +232,7 @@ describe('FieldContextMenu', () => {
         onClick: vi.fn(),
         testId: 'select-choice-member',
       };
-      const selectGroup: MenuGroup = { actions: [selectAction] };
+      const selectGroup: IFieldMenuGroup = { actions: [selectAction] };
 
       render(<FieldContextMenu groups={[selectGroup, overrideGroup]} />);
 
@@ -241,7 +242,7 @@ describe('FieldContextMenu', () => {
     it('should call onSelectSelfAsChoiceMember when Select is clicked', () => {
       const onSelectSelf = vi.fn();
       const onClose = vi.fn();
-      const selectGroup: MenuGroup = {
+      const selectGroup: IFieldMenuGroup = {
         actions: [{ label: "Select 'Fax'", onClick: onSelectSelf, testId: 'select-choice-member' }],
       };
 

--- a/packages/ui/src/components/Document/actions/FieldContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu.tsx
@@ -1,21 +1,12 @@
 import './FieldContextMenu.scss';
 
 import { Divider, Menu, MenuContent, MenuItem, MenuList } from '@patternfly/react-core';
-import { Fragment, FunctionComponent, ReactNode } from 'react';
+import { Fragment, FunctionComponent } from 'react';
 
-export interface MenuAction {
-  label: string;
-  onClick: () => void;
-  icon?: ReactNode;
-  testId?: string;
-}
-
-export interface MenuGroup {
-  actions: MenuAction[];
-}
+import { IFieldMenuGroup } from '../../../models/datamapper/field-action';
 
 export interface IFieldContextMenuProps {
-  groups: MenuGroup[];
+  groups: IFieldMenuGroup[];
   onClose?: () => void;
 }
 

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.test.ts
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.test.ts
@@ -1,13 +1,6 @@
-import { DocumentDefinitionType, DocumentType, IField } from '../../../../models/datamapper/document';
-import { DocumentDefinition } from '../../../../models/datamapper/document';
-import { FieldItem, MappingTree } from '../../../../models/datamapper/mapping';
-import { IFieldSubstituteInfo, Types } from '../../../../models/datamapper/types';
-import { FieldOverrideService } from '../../../../services/document/field-override.service';
-import { XmlSchemaDocument, XmlSchemaField } from '../../../../services/document/xml-schema/xml-schema-document.model';
-import { WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
-import { XmlSchemaCollection } from '../../../../xml-schema-ts';
-import { QName } from '../../../../xml-schema-ts/QName';
-import { computeAddFieldCandidates } from './menu-utils';
+import { IField } from '../../../../models/datamapper/document';
+import { Types } from '../../../../models/datamapper/types';
+import { buildSelectSelfAction } from './menu-utils';
 
 function mockField(overrides: Partial<IField> = {}): IField {
   return {
@@ -26,346 +19,54 @@ function mockField(overrides: Partial<IField> = {}): IField {
   } as IField;
 }
 
-function mockSubstituteInfo(name: string, type: Types = Types.Container): IFieldSubstituteInfo {
-  return {
-    qname: new QName('http://test', name),
-    displayName: name,
-    type,
-    typeQName: null,
-    namedTypeFragmentRefs: [],
-  };
-}
+describe('buildSelectSelfAction', () => {
+  it('should build action with member and parent names', () => {
+    const member = mockField({ displayName: 'Email' });
+    const parent = mockField({ displayName: 'ContactInfo' });
+    const onClick = vi.fn();
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+    const action = buildSelectSelfAction(member, parent, onClick, 'test-id');
 
-describe('dissolveChoiceMembers', () => {
-  it('should pass through regular members', () => {
-    const members = [
-      mockField({ name: 'email', displayName: 'Email', type: Types.String }),
-      mockField({ name: 'phone', displayName: 'Phone', type: Types.String }),
-    ];
-    const result = WrapperActionService.dissolveChoiceMembers(members, {});
-
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual(expect.objectContaining({ key: '0', label: 'Email', selection: { memberIndex: 0 } }));
-    expect(result[1]).toEqual(expect.objectContaining({ key: '1', label: 'Phone', selection: { memberIndex: 1 } }));
+    expect(action.label).toBe("Select 'Email' in 'ContactInfo'");
+    expect(action.testId).toBe('test-id');
+    action.onClick();
+    expect(onClick).toHaveBeenCalled();
   });
 
-  it('should dissolve abstract members into substitution candidates', () => {
-    const abstractMember = mockField({ wrapperKind: 'abstract' });
-    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({
-      'ns:Cat': mockSubstituteInfo('Cat'),
-      'ns:Dog': mockSubstituteInfo('Dog'),
-    });
+  it('should build action without parent name when parentField is undefined', () => {
+    const member = mockField({ displayName: 'Email' });
+    const onClick = vi.fn();
 
-    const result = WrapperActionService.dissolveChoiceMembers([abstractMember], {});
+    const action = buildSelectSelfAction(member, undefined, onClick, 'test-id');
 
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual(
-      expect.objectContaining({
-        key: '0:ns:Cat',
-        label: 'Cat',
-        selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
-      }),
-    );
-    expect(result[1]).toEqual(
-      expect.objectContaining({
-        key: '0:ns:Dog',
-        label: 'Dog',
-        selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
-      }),
-    );
+    expect(action.label).toBe("Select 'Email'");
   });
 
-  it('should skip sequence members', () => {
-    const members = [
-      mockField({ name: 'normal', displayName: 'Normal' }),
-      mockField({ wrapperKind: 'sequence', name: 'seq' }),
-    ];
-    const result = WrapperActionService.dissolveChoiceMembers(members, {});
+  it('should use empty string when memberField is undefined', () => {
+    const onClick = vi.fn();
 
-    expect(result).toHaveLength(1);
-    expect(result[0].label).toBe('Normal');
+    const action = buildSelectSelfAction(undefined, undefined, onClick, 'test-id');
+
+    expect(action.label).toBe("Select ''");
   });
 
-  it('should include children preview for complex members', () => {
-    const member = mockField({
-      name: 'address',
-      displayName: 'Address',
-      type: Types.Container,
-      fields: [mockField({ displayName: 'Street' }), mockField({ displayName: 'City' })],
-    });
-    const result = WrapperActionService.dissolveChoiceMembers([member], {});
+  it('should fall back to field.name when displayName is empty', () => {
+    const member = mockField({ displayName: '', name: 'emailAddr' });
+    const onClick = vi.fn();
 
-    expect(result[0].childrenPreview).toEqual(['Street', 'City']);
+    const action = buildSelectSelfAction(member, undefined, onClick, 'test-id');
+
+    expect(action.label).toBe("Select 'emailAddr'");
   });
 
-  it('should handle empty members list', () => {
-    expect(WrapperActionService.dissolveChoiceMembers([], {})).toEqual([]);
-  });
-});
+  it('should use custom displayName function when provided', () => {
+    const member = mockField({ displayName: 'Email' });
+    const parent = mockField({ displayName: 'Contact' });
+    const onClick = vi.fn();
+    const customDisplay = (f: IField) => f.name.toUpperCase();
 
-describe('buildAbstractCandidates', () => {
-  it('should convert substitution candidates to WrapperCandidates', () => {
-    const abstractField = mockField({ wrapperKind: 'abstract' });
-    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({
-      'ns:Cat': mockSubstituteInfo('Cat'),
-      'ns:Dog': mockSubstituteInfo('Dog'),
-    });
+    const action = buildSelectSelfAction(member, parent, onClick, 'test-id', customDisplay);
 
-    const result = WrapperActionService.buildAbstractCandidates(abstractField, {});
-
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({
-      key: 'ns:Cat',
-      label: 'Cat',
-      typeBadge: Types.Container,
-      selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
-    });
-    expect(result[1]).toEqual({
-      key: 'ns:Dog',
-      label: 'Dog',
-      typeBadge: Types.Container,
-      selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
-    });
-  });
-
-  it('should return empty array when no candidates', () => {
-    const abstractField = mockField({ wrapperKind: 'abstract' });
-    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({});
-
-    const result = WrapperActionService.buildAbstractCandidates(abstractField, {});
-    expect(result).toEqual([]);
-  });
-});
-
-describe('computeAddFieldCandidates', () => {
-  function createXmlSchemaDocument(): XmlSchemaDocument {
-    const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, 'test');
-    return new XmlSchemaDocument(definition, new XmlSchemaCollection());
-  }
-
-  it('should return all candidates when no existing field items', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const childA = new XmlSchemaField(parent, 'ChildA', false);
-    childA.type = Types.String;
-    const childB = new XmlSchemaField(parent, 'ChildB', false);
-    childB.type = Types.String;
-    parent.fields = [childA, childB];
-    doc.fields = [parent];
-
-    const result = computeAddFieldCandidates(parent.fields, {}, []);
-
-    expect(result.candidates).toHaveLength(2);
-    expect(result.fields).toHaveLength(2);
-    expect(result.fields[0]).toBe(childA);
-    expect(result.fields[1]).toBe(childB);
-  });
-
-  it('should exclude maxOccurs=1 child when slot is occupied by direct field match', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const childA = new XmlSchemaField(parent, 'ChildA', false);
-    childA.type = Types.String;
-    childA.maxOccurs = 1;
-    const childB = new XmlSchemaField(parent, 'ChildB', false);
-    childB.type = Types.String;
-    childB.maxOccurs = 1;
-    parent.fields = [childA, childB];
-    doc.fields = [parent];
-
-    const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
-    const existingFieldItem = new FieldItem(tree, childA);
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
-
-    expect(result.candidates).toHaveLength(1);
-    expect(result.fields).toHaveLength(1);
-    expect(result.fields[0]).toBe(childB);
-  });
-
-  it('should not exclude maxOccurs=unbounded child even when occupied', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const child = new XmlSchemaField(parent, 'Child', false);
-    child.type = Types.String;
-    child.maxOccurs = 'unbounded';
-    parent.fields = [child];
-    doc.fields = [parent];
-
-    const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
-    const existingFieldItem = new FieldItem(tree, child);
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
-
-    expect(result.candidates).toHaveLength(1);
-    expect(result.fields[0]).toBe(child);
-  });
-
-  it('should exclude abstract wrapper (maxOccurs=1) when a descendant substitute is mapped', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const abstractField = new XmlSchemaField(parent, 'Abstract', false);
-    abstractField.type = Types.Container;
-    abstractField.wrapperKind = 'abstract';
-    abstractField.maxOccurs = 1;
-    const concreteChild = new XmlSchemaField(abstractField, 'Concrete', false);
-    concreteChild.type = Types.String;
-    abstractField.fields = [concreteChild];
-    parent.fields = [abstractField];
-    doc.fields = [parent];
-
-    const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
-    const existingFieldItem = new FieldItem(tree, concreteChild);
-
-    vi.spyOn(FieldOverrideService, 'getFieldSubstitutionCandidates').mockReturnValue({
-      'ns:Concrete': mockSubstituteInfo('Concrete'),
-    });
-    vi.spyOn(WrapperActionService, 'resolveCandidateField').mockReturnValue(concreteChild);
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
-
-    expect(result.candidates).toHaveLength(0);
-    expect(result.fields).toHaveLength(0);
-  });
-
-  it('should exclude choice wrapper (maxOccurs=1) when a member is mapped', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const choiceField = new XmlSchemaField(parent, '__choice__', false);
-    choiceField.type = Types.Container;
-    choiceField.wrapperKind = 'choice';
-    choiceField.maxOccurs = 1;
-    const memberA = new XmlSchemaField(choiceField, 'MemberA', false);
-    memberA.type = Types.String;
-    const memberB = new XmlSchemaField(choiceField, 'MemberB', false);
-    memberB.type = Types.String;
-    choiceField.fields = [memberA, memberB];
-    parent.fields = [choiceField];
-    doc.fields = [parent];
-
-    const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
-    const existingFieldItem = new FieldItem(tree, memberA);
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
-
-    expect(result.candidates).toHaveLength(0);
-    expect(result.fields).toHaveLength(0);
-  });
-
-  it('should not exclude choice wrapper (maxOccurs=unbounded) when a member is mapped', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const choiceField = new XmlSchemaField(parent, '__choice__', false);
-    choiceField.type = Types.Container;
-    choiceField.wrapperKind = 'choice';
-    choiceField.maxOccurs = 'unbounded';
-    const memberA = new XmlSchemaField(choiceField, 'MemberA', false);
-    memberA.type = Types.String;
-    const memberB = new XmlSchemaField(choiceField, 'MemberB', false);
-    memberB.type = Types.String;
-    choiceField.fields = [memberA, memberB];
-    parent.fields = [choiceField];
-    doc.fields = [parent];
-
-    const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
-    const existingFieldItem = new FieldItem(tree, memberA);
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
-
-    expect(result.candidates).toHaveLength(2);
-    expect(result.fields[0]).toBe(memberA);
-    expect(result.fields[1]).toBe(memberB);
-  });
-
-  it('should dissolve sequence wrappers and include their member fields', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const seqWrapper = new XmlSchemaField(parent, 'seq', false);
-    seqWrapper.wrapperKind = 'sequence';
-    const seqChildA = new XmlSchemaField(seqWrapper, 'SeqChildA', false);
-    seqChildA.type = Types.String;
-    const seqChildB = new XmlSchemaField(seqWrapper, 'SeqChildB', false);
-    seqChildB.type = Types.String;
-    seqWrapper.fields = [seqChildA, seqChildB];
-    parent.fields = [seqWrapper];
-    doc.fields = [parent];
-
-    const result = computeAddFieldCandidates(parent.fields, {}, []);
-
-    expect(result.candidates).toHaveLength(2);
-    expect(result.fields[0]).toBe(seqChildA);
-    expect(result.fields[1]).toBe(seqChildB);
-  });
-
-  it('should exclude maxOccurs=1 children in forEachContext', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const singleChild = new XmlSchemaField(parent, 'Single', false);
-    singleChild.type = Types.String;
-    singleChild.maxOccurs = 1;
-    const collectionChild = new XmlSchemaField(parent, 'Collection', false);
-    collectionChild.type = Types.String;
-    collectionChild.maxOccurs = 'unbounded';
-    parent.fields = [singleChild, collectionChild];
-    doc.fields = [parent];
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [], true);
-
-    expect(result.candidates).toHaveLength(1);
-    expect(result.fields[0]).toBe(collectionChild);
-  });
-
-  it('should include all children when forEachContext is false (default)', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const singleChild = new XmlSchemaField(parent, 'Single', false);
-    singleChild.type = Types.String;
-    singleChild.maxOccurs = 1;
-    const collectionChild = new XmlSchemaField(parent, 'Collection', false);
-    collectionChild.type = Types.String;
-    collectionChild.maxOccurs = 'unbounded';
-    parent.fields = [singleChild, collectionChild];
-    doc.fields = [parent];
-
-    const result = computeAddFieldCandidates(parent.fields, {}, []);
-
-    expect(result.candidates).toHaveLength(2);
-    expect(result.fields[0]).toBe(singleChild);
-    expect(result.fields[1]).toBe(collectionChild);
-  });
-
-  it('should dissolve sequences and apply forEachContext filter to members', () => {
-    const doc = createXmlSchemaDocument();
-    const parent = new XmlSchemaField(doc, 'Parent', false);
-    parent.type = Types.Container;
-    const seqWrapper = new XmlSchemaField(parent, 'seq', false);
-    seqWrapper.wrapperKind = 'sequence';
-    const singleMember = new XmlSchemaField(seqWrapper, 'Single', false);
-    singleMember.type = Types.String;
-    singleMember.maxOccurs = 1;
-    const collectionMember = new XmlSchemaField(seqWrapper, 'Collection', false);
-    collectionMember.type = Types.String;
-    collectionMember.maxOccurs = 'unbounded';
-    seqWrapper.fields = [singleMember, collectionMember];
-    parent.fields = [seqWrapper];
-    doc.fields = [parent];
-
-    const result = computeAddFieldCandidates(parent.fields, {}, [], true);
-
-    expect(result.candidates).toHaveLength(1);
-    expect(result.fields[0]).toBe(collectionMember);
+    expect(action.label).toBe("Select 'FIELD' in 'FIELD'");
   });
 });

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.ts
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/menu-utils.ts
@@ -1,21 +1,23 @@
 import { IField } from '../../../../models/datamapper/document';
-import { FieldItem } from '../../../../models/datamapper/mapping';
-import { DocumentService } from '../../../../services/document/document.service';
-import { FieldOverrideService } from '../../../../services/document/field-override.service';
-import { WrapperActionService, WrapperCandidate } from '../../../../services/visualization/wrapper-action.service';
-import { MenuAction } from '../FieldContextMenu';
+import { IFieldMenuAction } from '../../../../models/datamapper/field-action';
 
 function getFieldDisplayName(field: IField): string {
   return field.displayName || field.name;
 }
 
+/**
+ * Builds the "Select 'X' in 'Y'" action shown for substitution candidates
+ * and choice members that are not currently selected. Hooks call this to
+ * create the entry that lets the user pick this specific field as the active
+ * member/substitute from the parent wrapper's context menu.
+ */
 export function buildSelectSelfAction(
   memberField: IField | undefined,
   parentField: IField | undefined,
   onClick: () => void,
   testId: string,
   displayName: (field: IField) => string = getFieldDisplayName,
-): MenuAction {
+): IFieldMenuAction {
   const memberName = memberField ? displayName(memberField) : '';
   const parentName = parentField ? displayName(parentField) : undefined;
   return {
@@ -23,104 +25,4 @@ export function buildSelectSelfAction(
     onClick,
     testId,
   };
-}
-
-interface CandidateEntry {
-  candidate: WrapperCandidate;
-  field: IField;
-}
-
-function resolveAbstractSubstitutes(abstractField: IField, namespaceMap: Record<string, string>): CandidateEntry[] {
-  const subs = FieldOverrideService.getFieldSubstitutionCandidates(abstractField, namespaceMap);
-  const entries: CandidateEntry[] = [];
-  for (const [qname, info] of Object.entries(subs)) {
-    const field = WrapperActionService.resolveCandidateField(abstractField, qname, subs, abstractField, namespaceMap);
-    if (!field) continue;
-    entries.push({
-      candidate: {
-        key: '',
-        label: info.displayName,
-        typeBadge: info.type,
-        selection: { memberIndex: 0, substituteQName: qname },
-      },
-      field,
-    });
-  }
-  return entries;
-}
-
-function resolveChoiceMembers(choiceField: IField, namespaceMap: Record<string, string>): CandidateEntry[] {
-  const entries: CandidateEntry[] = [];
-  for (const member of choiceField.fields) {
-    if (member.wrapperKind === 'abstract') {
-      entries.push(...resolveAbstractSubstitutes(member, namespaceMap));
-    } else if (member.wrapperKind !== 'sequence') {
-      entries.push({ candidate: WrapperActionService.fieldToCandidate(member, '', 0), field: member });
-    }
-  }
-  return entries;
-}
-
-function resolveFieldEntries(child: IField, namespaceMap: Record<string, string>): CandidateEntry[] {
-  if (child.wrapperKind === 'choice') return resolveChoiceMembers(child, namespaceMap);
-  if (child.wrapperKind === 'abstract') return resolveAbstractSubstitutes(child, namespaceMap);
-  return [{ candidate: WrapperActionService.fieldToCandidate(child, '', 0), field: child }];
-}
-
-function shouldSkipField(child: IField, forEachContext: boolean): boolean {
-  if (!forEachContext) return false;
-  return (
-    child.wrapperKind !== 'choice' &&
-    child.wrapperKind !== 'abstract' &&
-    child.maxOccurs !== 'unbounded' &&
-    Number(child.maxOccurs) <= 1
-  );
-}
-
-function isSlotExhausted(child: IField, existingFieldItems: FieldItem[]): boolean {
-  if (child.maxOccurs === 'unbounded') return false;
-  const occupied = existingFieldItems.filter(
-    (fi) => fi.field === child || DocumentService.isDescendant(child, fi.field),
-  ).length;
-  return occupied >= Number(child.maxOccurs);
-}
-
-export function computeAddFieldCandidates(
-  schemaFields: IField[],
-  namespaceMap: Record<string, string>,
-  existingFieldItems: FieldItem[] = [],
-  forEachContext = false,
-): { candidates: WrapperCandidate[]; fields: IField[] } {
-  const candidates: WrapperCandidate[] = [];
-  const fields: IField[] = [];
-  let index = 0;
-
-  for (const child of schemaFields) {
-    if (child.wrapperKind === 'sequence') {
-      const nested = computeAddFieldCandidates(child.fields, namespaceMap, existingFieldItems, forEachContext);
-      for (let i = 0; i < nested.candidates.length; i++) {
-        candidates.push({
-          ...nested.candidates[i],
-          key: `${index}`,
-          selection: { ...nested.candidates[i].selection, memberIndex: index },
-        });
-        fields.push(nested.fields[i]);
-        index++;
-      }
-      continue;
-    }
-
-    if (shouldSkipField(child, forEachContext)) continue;
-    if (isSlotExhausted(child, existingFieldItems)) continue;
-
-    for (const { candidate, field } of resolveFieldEntries(child, namespaceMap)) {
-      candidate.key = `${index}`;
-      candidate.selection.memberIndex = index;
-      candidates.push(candidate);
-      fields.push(field);
-      index++;
-    }
-  }
-
-  return { candidates, fields };
 }

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/types.ts
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/types.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 
-import { MenuGroup } from '../FieldContextMenu';
+import { IFieldMenuGroup } from '../../../../models/datamapper/field-action';
 
 export interface MenuContributor {
-  groups: MenuGroup[];
+  groups: IFieldMenuGroup[];
   modals: ReactNode;
 }

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useAbstractFieldSubstitutionMenu.tsx
@@ -4,103 +4,13 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
-import { IFieldSubstituteInfo } from '../../../../models/datamapper/types';
+import { IFieldMenuAction, IMemberSelection } from '../../../../models/datamapper/field-action';
 import { NodeData } from '../../../../models/datamapper/visualization';
 import { WrapperSelectionService } from '../../../../services/document/wrapper-selection.service';
-import { MemberSelection, WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
-import { MenuAction, MenuGroup } from '../FieldContextMenu';
+import { WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
 import { buildSelectSelfAction } from './menu-utils';
 import { MenuContributor } from './types';
-
-const INLINE_SUBSTITUTION_LIMIT = 10;
-
-interface AbstractMenuGroupsConfig {
-  isAbstractWrapper: boolean;
-  isAbstractWrapperMember: boolean;
-  isInsideChoiceWrapper: boolean;
-  isSelectedSubstitution: boolean;
-  candidates: Record<string, IFieldSubstituteInfo>;
-  selectedQName: string | undefined;
-  memberSelectedQName: string | undefined;
-  selectSelfAction: MenuAction | undefined;
-  clearSubstitutionAction: MenuAction;
-  changeSubstituteAction: MenuAction;
-  onSelectSubstitution: (qname: string) => void;
-  onOpenSubstitutionModal: () => void;
-}
-
-function buildMenuGroupsForAbstractNode(config: AbstractMenuGroupsConfig): MenuGroup[] {
-  if (config.isInsideChoiceWrapper && config.isAbstractWrapper) {
-    const hasSelection = config.selectedQName !== undefined;
-    return hasSelection ? [{ actions: [config.clearSubstitutionAction] }] : [];
-  }
-  if (config.isAbstractWrapper || config.isAbstractWrapperMember) {
-    return buildAbstractWrapperMenuGroups(
-      config.candidates,
-      config.isAbstractWrapperMember ? config.memberSelectedQName : config.selectedQName,
-      config.isAbstractWrapperMember ? undefined : config.selectSelfAction,
-      config.clearSubstitutionAction,
-      config.onSelectSubstitution,
-      config.onOpenSubstitutionModal,
-    );
-  }
-  const substitutionActions: MenuAction[] = [];
-  if (config.isSelectedSubstitution)
-    substitutionActions.push(config.clearSubstitutionAction, config.changeSubstituteAction);
-  if (config.selectSelfAction) substitutionActions.push(config.selectSelfAction);
-  return [{ actions: substitutionActions }];
-}
-
-function handleAbstractModalSelect(selection: MemberSelection, onSelectSubstitution: (qname: string) => void): void {
-  if (selection.substituteQName) onSelectSubstitution(selection.substituteQName);
-}
-
-function buildInlineSubstitutionActions(
-  candidates: Record<string, IFieldSubstituteInfo>,
-  selectedQName: string | undefined,
-  onSelect: (qname: string) => void,
-): MenuAction[] {
-  return Object.entries(candidates).map(([qname, info]) => ({
-    label: info.displayName,
-    onClick: () => {
-      onSelect(qname);
-    },
-    icon: selectedQName === qname ? <CheckIcon /> : <Choices />,
-    testId: `substitution-menu-item-${qname}`,
-  }));
-}
-
-function buildAbstractWrapperMenuGroups(
-  candidates: Record<string, IFieldSubstituteInfo>,
-  selectedQName: string | undefined,
-  selectSelfAction: MenuAction | undefined,
-  clearSubstitutionAction: MenuAction,
-  handleSelectSubstitution: (qname: string) => void,
-  handleOpenSubstitutionModal: () => void,
-): MenuGroup[] {
-  const candidateCount = Object.keys(candidates).length;
-
-  if (candidateCount === 0 && selectedQName === undefined) {
-    return selectSelfAction ? [{ actions: [selectSelfAction] }] : [];
-  }
-
-  const candidatesGroup: MenuGroup =
-    candidateCount <= INLINE_SUBSTITUTION_LIMIT
-      ? { actions: buildInlineSubstitutionActions(candidates, selectedQName, handleSelectSubstitution) }
-      : {
-          actions: [
-            { label: 'Select Substitute...', onClick: handleOpenSubstitutionModal, testId: 'open-substitution-modal' },
-          ],
-        };
-
-  const hasSelection = selectedQName !== undefined;
-  return [
-    { actions: selectSelfAction ? [selectSelfAction] : [] },
-    candidatesGroup,
-    { actions: hasSelection ? [clearSubstitutionAction] : [] },
-  ];
-}
 
 export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContributor {
   const { mappingTree, updateDocument } = useDataMapper();
@@ -183,7 +93,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
     applySubstitution(parentAbstractField, candidateQName);
   }, [parentAbstractField, candidateQName, applySubstitution]);
 
-  const clearSubstitutionAction: MenuAction = {
+  const clearSubstitutionAction: IFieldMenuAction = {
     label: 'Clear substitution',
     onClick: handleClearSubstitution,
     testId: 'clear-substitution',
@@ -198,7 +108,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
       ? buildSelectSelfAction(field, parentAbstractField, handleSelectSelfAsCandidate, 'select-substitution-member')
       : undefined;
 
-  const changeSubstituteAction: MenuAction = {
+  const changeSubstituteAction: IFieldMenuAction = {
     label: 'Select Substitute...',
     onClick: handleOpenSubstitutionModal,
     testId: 'change-substitution',
@@ -210,7 +120,7 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
     [isAbstractWrapperMember, field, abstractWrapperField, candidates],
   );
 
-  const menuGroups = buildMenuGroupsForAbstractNode({
+  const menuGroups = WrapperActionService.buildMenuGroupsForAbstractNode({
     isAbstractWrapper,
     isAbstractWrapperMember,
     isInsideChoiceWrapper,
@@ -223,6 +133,8 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
     changeSubstituteAction,
     onSelectSubstitution: handleSelectSubstitution,
     onOpenSubstitutionModal: handleOpenSubstitutionModal,
+    selectedIcon: <CheckIcon />,
+    unselectedIcon: <Choices />,
   });
 
   const closeSubstitutionModal = useCallback(() => {
@@ -238,8 +150,8 @@ export function useAbstractFieldSubstitutionMenu(nodeData: NodeData): MenuContri
   );
 
   const handleModalSelect = useCallback(
-    (selection: MemberSelection) => {
-      handleAbstractModalSelect(selection, handleSelectSubstitution);
+    (selection: IMemberSelection) => {
+      if (selection.substituteQName) handleSelectSubstitution(selection.substituteQName);
     },
     [handleSelectSubstitution],
   );

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.tsx
@@ -4,94 +4,13 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { IField } from '../../../../models/datamapper/document';
+import { IFieldMenuAction, IMemberSelection } from '../../../../models/datamapper/field-action';
 import { NodeData } from '../../../../models/datamapper/visualization';
 import { VisualizationUtilService } from '../../../../services/visualization/visualization-util.service';
-import {
-  MemberSelection,
-  WrapperActionService,
-  WrapperCandidate,
-} from '../../../../services/visualization/wrapper-action.service';
-import { MenuAction, MenuGroup } from '../FieldContextMenu';
+import { WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
 import { buildSelectSelfAction } from './menu-utils';
 import { MenuContributor } from './types';
-
-const INLINE_CHOICE_LIMIT = 10;
-
-function buildInlineMemberActions(
-  dissolvedMembers: WrapperCandidate[],
-  selectedKey: string | null,
-  onSelect: (selection: MemberSelection) => void,
-): MenuAction[] {
-  return dissolvedMembers.map(({ key, label, selection }) => ({
-    label,
-    onClick: () => {
-      onSelect(selection);
-    },
-    icon: selectedKey === key ? <CheckIcon /> : <Choices />,
-    testId: selection.substituteQName
-      ? 'choice-menu-item-' + selection.memberIndex + '-' + selection.substituteQName
-      : 'choice-menu-item-' + selection.memberIndex,
-  }));
-}
-
-interface ChoiceMenuGroupsConfig {
-  isChoiceWrapper: boolean;
-  isChoiceWrapperMember: boolean;
-  isNestedSelectedChoice: boolean;
-  isSelectedChoice: boolean;
-  dissolved: WrapperCandidate[];
-  selectedModalKey: string | null;
-  selectSelfAction: MenuAction | undefined;
-  clearChoiceAction: MenuAction;
-  changeMemberAction: MenuAction;
-  onSelectChoiceMember: (selection: MemberSelection) => void;
-  onOpenChoiceModal: () => void;
-}
-
-function buildMenuGroupsForChoiceNode(config: ChoiceMenuGroupsConfig): MenuGroup[] {
-  if (config.isChoiceWrapper || config.isChoiceWrapperMember) {
-    const groups = buildChoiceWrapperMenuGroups(
-      config.dissolved,
-      config.selectedModalKey,
-      config.isChoiceWrapperMember ? undefined : config.selectSelfAction,
-      config.clearChoiceAction,
-      config.onSelectChoiceMember,
-      config.onOpenChoiceModal,
-    );
-    if (config.isNestedSelectedChoice) groups.push({ actions: [config.clearChoiceAction, config.changeMemberAction] });
-    return groups;
-  }
-  const choiceActions: MenuAction[] = [];
-  if (config.isSelectedChoice) choiceActions.push(config.clearChoiceAction, config.changeMemberAction);
-  if (config.selectSelfAction) choiceActions.push(config.selectSelfAction);
-  return [{ actions: choiceActions }];
-}
-
-function buildChoiceWrapperMenuGroups(
-  dissolved: WrapperCandidate[],
-  selectedKey: string | null,
-  selectSelfAction: MenuAction | undefined,
-  clearChoiceAction: MenuAction,
-  handleSelectChoiceMember: (selection: MemberSelection) => void,
-  handleOpenChoiceModal: () => void,
-): MenuGroup[] {
-  if (dissolved.length === 0 && selectedKey === null) {
-    return selectSelfAction ? [{ actions: [selectSelfAction] }] : [];
-  }
-
-  const membersGroup: MenuGroup =
-    dissolved.length <= INLINE_CHOICE_LIMIT
-      ? { actions: buildInlineMemberActions(dissolved, selectedKey, handleSelectChoiceMember) }
-      : { actions: [{ label: 'Select Member...', onClick: handleOpenChoiceModal, testId: 'open-choice-modal' }] };
-
-  const hasSelection = selectedKey !== null;
-  return [
-    { actions: selectSelfAction ? [selectSelfAction] : [] },
-    membersGroup,
-    { actions: hasSelection ? [clearChoiceAction] : [] },
-  ];
-}
 
 export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   const { mappingTree, updateDocument } = useDataMapper();
@@ -120,7 +39,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
   }, [effectiveChoiceWrapper?.fields, mappingTree.namespaceMap]);
 
   const applyChoiceSelection = useCallback(
-    (wrapper: IField, selection: MemberSelection) => {
+    (wrapper: IField, selection: IMemberSelection) => {
       WrapperActionService.dispatchChoiceSelection(
         nodeData,
         wrapper,
@@ -147,7 +66,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
 
   // Case A: select a member from this node's own wrapper member list
   const handleSelectChoiceMember = useCallback(
-    (selection: MemberSelection) => {
+    (selection: IMemberSelection) => {
       const wrapper = WrapperActionService.resolveChoiceWrapper(
         isChoiceWrapperMember,
         choiceWrapperMemberField,
@@ -197,7 +116,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     applyChoiceSelection(parentChoiceWrapperField, { memberIndex: choiceMemberIndex });
   }, [parentChoiceWrapperField, choiceMemberIndex, applyChoiceSelection]);
 
-  const clearChoiceAction: MenuAction = {
+  const clearChoiceAction: IFieldMenuAction = {
     label: 'Clear selection',
     onClick: handleClearChoice,
     testId: 'clear-choice',
@@ -214,7 +133,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
         )
       : undefined;
 
-  const changeMemberAction: MenuAction = {
+  const changeMemberAction: IFieldMenuAction = {
     label: 'Select Member...',
     onClick: handleOpenChoiceModal,
     testId: 'change-choice-member',
@@ -244,7 +163,7 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     [isChoiceWrapperMember, memberSelectedKey, activeChoiceWrapperForMembers, dissolved],
   );
 
-  const menuGroups = buildMenuGroupsForChoiceNode({
+  const menuGroups = WrapperActionService.buildMenuGroupsForChoiceNode({
     isChoiceWrapper,
     isChoiceWrapperMember,
     isNestedSelectedChoice,
@@ -256,6 +175,8 @@ export function useChoiceContextMenu(nodeData: NodeData): MenuContributor {
     changeMemberAction,
     onSelectChoiceMember: handleSelectChoiceMember,
     onOpenChoiceModal: handleOpenChoiceModal,
+    selectedIcon: <CheckIcon />,
+    unselectedIcon: <Choices />,
   });
 
   const closeChoiceModal = useCallback(() => {

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useFieldOverrideMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
+import { IFieldMenuGroup } from '../../../../models/datamapper/field-action';
 import { FieldOverrideVariant } from '../../../../models/datamapper/types';
 import {
   AbstractFieldNodeData,
@@ -9,7 +10,6 @@ import {
 } from '../../../../models/datamapper/visualization';
 import { VisualizationUtilService } from '../../../../services/visualization/visualization-util.service';
 import { WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
-import { MenuGroup } from '../FieldContextMenu';
 import { FieldOverride } from '../FieldOverride/FieldOverride';
 import { MenuContributor } from './types';
 
@@ -43,7 +43,7 @@ export function useFieldOverrideMenu(nodeData: NodeData): MenuContributor {
     }
   }, [abstractWrapperField, field, mappingTree.namespaceMap, updateDocument]);
 
-  const groups = useMemo((): MenuGroup[] => {
+  const groups = useMemo((): IFieldMenuGroup[] => {
     if (field?.wrapperKind === 'choice' || field?.wrapperKind === 'sequence' || field?.wrapperKind === 'abstract')
       return [];
     if (abstractWrapperField) return [];

--- a/packages/ui/src/components/Document/actions/MappingMenu/useMappingActionModals.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/useMappingActionModals.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { IMemberSelection } from '../../../../models/datamapper/field-action';
 import { FieldItem, ForEachGroupItem, ForEachItem, MappingItem } from '../../../../models/datamapper/mapping';
 import { MappingActionKind } from '../../../../models/datamapper/mapping-action';
 import { MappingService } from '../../../../services/mapping/mapping.service';
-import { MemberSelection } from '../../../../services/visualization/wrapper-action.service';
-import { computeAddFieldCandidates } from '../FieldContextMenu/menu-utils';
+import { WrapperActionService } from '../../../../services/visualization/wrapper-action.service';
 import { WrapperSelectionModal } from '../WrapperSelectionModal';
 import { CommentModal } from './Comment/CommentModal';
 import { ForEachGroupModal } from './ForEachGroup/ForEachGroupModal';
@@ -73,11 +73,16 @@ export function useMappingActionModals(mapping: MappingItem | undefined, onUpdat
     if (!ancestorFieldItem || !mapping) return undefined;
     const namespaceMap = ancestorFieldItem.mappingTree.namespaceMap;
     const existingFieldItems = mapping.children.filter((c): c is FieldItem => c instanceof FieldItem);
-    return computeAddFieldCandidates(ancestorFieldItem.field.fields, namespaceMap, existingFieldItems, forEachContext);
+    return WrapperActionService.computeAddFieldCandidates(
+      ancestorFieldItem.field.fields,
+      namespaceMap,
+      existingFieldItems,
+      forEachContext,
+    );
   })();
 
   const handleAddFieldSelect = useCallback(
-    (selection: MemberSelection) => {
+    (selection: IMemberSelection) => {
       if (!addFieldData || !mapping) return;
       const selectedField = addFieldData.fields[selection.memberIndex];
       if (!selectedField) return;

--- a/packages/ui/src/components/Document/actions/WrapperSelectionModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/WrapperSelectionModal.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { IWrapperCandidate } from '../../../models/datamapper/field-action';
 import { Types } from '../../../models/datamapper/types';
-import { WrapperCandidate } from '../../../services/visualization/wrapper-action.service';
 import { WrapperSelectionModal, WrapperSelectionModalProps } from './WrapperSelectionModal';
 
-function makeCandidates(count: number): WrapperCandidate[] {
+function makeCandidates(count: number): IWrapperCandidate[] {
   return Array.from({ length: count }, (_, i) => ({
     key: `key-${i}`,
     label: `Candidate ${i}`,
@@ -145,7 +145,7 @@ describe('WrapperSelectionModal', () => {
   });
 
   it('should handle candidates with substituteQName', () => {
-    const candidates: WrapperCandidate[] = [
+    const candidates: IWrapperCandidate[] = [
       {
         key: '0:ns:Cat',
         label: 'Cat',

--- a/packages/ui/src/components/Document/actions/WrapperSelectionModal.tsx
+++ b/packages/ui/src/components/Document/actions/WrapperSelectionModal.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useMemo, useState } from 'react';
 
-import { MemberSelection, WrapperCandidate } from '../../../services/visualization/wrapper-action.service';
+import { IMemberSelection, IWrapperCandidate } from '../../../models/datamapper/field-action';
 import { DataMapperModal } from '../../DataMapper/DataMapperModal';
 
 const SEARCH_THRESHOLD = 10;
@@ -22,9 +22,9 @@ export interface WrapperSelectionModalProps {
   title: string;
   description?: string;
   testId: string;
-  candidates: WrapperCandidate[];
+  candidates: IWrapperCandidate[];
   selectedKey: string | null;
-  onSelect: (selection: MemberSelection) => void;
+  onSelect: (selection: IMemberSelection) => void;
   onClose: () => void;
 }
 

--- a/packages/ui/src/components/Document/actions/withFieldContextMenu.tsx
+++ b/packages/ui/src/components/Document/actions/withFieldContextMenu.tsx
@@ -1,8 +1,9 @@
 import { ComponentType, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DocumentTreeNode } from '../../../models/datamapper/document-tree-node';
+import { IFieldMenuGroup } from '../../../models/datamapper/field-action';
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
-import { FieldContextMenu, MenuGroup } from './FieldContextMenu';
+import { FieldContextMenu } from './FieldContextMenu';
 import { useAbstractFieldSubstitutionMenu } from './FieldContextMenu/useAbstractFieldSubstitutionMenu';
 import { useChoiceContextMenu } from './FieldContextMenu/useChoiceContextMenu';
 import { useFieldOverrideMenu } from './FieldContextMenu/useFieldOverrideMenu';
@@ -74,7 +75,7 @@ export function withFieldContextMenu<P extends WithTreeNode>(
     );
 
     const menuGroups = useMemo(
-      (): MenuGroup[] =>
+      (): IFieldMenuGroup[] =>
         [...choice.groups, ...override.groups, ...abstractSubstitution.groups].filter(
           (group) => group.actions.length > 0,
         ),

--- a/packages/ui/src/models/datamapper/field-action.ts
+++ b/packages/ui/src/models/datamapper/field-action.ts
@@ -1,0 +1,152 @@
+import type { ReactNode } from 'react';
+
+import type { IField } from './document';
+import type { IFieldSubstituteInfo } from './types';
+import { Types } from './types';
+
+// ── Menu rendering contracts ──
+
+/**
+ * Model-layer contract for a single field context menu item.
+ * Mirrors the mapping side's `IMappingContextMenuAction` but carries
+ * a pre-built `onClick` closure instead of a separate `apply` method,
+ * because field actions need hook-scoped state (modal openers, document
+ * updaters) that cannot be threaded through a static registry.
+ */
+export interface IFieldMenuAction {
+  label: string;
+  onClick: () => void;
+  icon?: ReactNode;
+  testId?: string;
+}
+
+/**
+ * A logical group of field menu actions rendered with a visual separator
+ * between groups. Empty groups are filtered out before rendering.
+ */
+export interface IFieldMenuGroup {
+  actions: IFieldMenuAction[];
+}
+
+// ── Selection / candidate contracts ──
+
+/**
+ * Outcome of a user picking a member from a wrapper selection modal or inline
+ * menu. `memberIndex` identifies the chosen field within the wrapper's
+ * `fields` array. For abstract-in-choice selections, `substituteQName` carries
+ * the concrete substitute so both the choice member and the abstract substitute
+ * are applied in a single dispatch.
+ */
+export interface IMemberSelection {
+  memberIndex: number;
+  substituteQName?: string;
+}
+
+/**
+ * Display-ready candidate for the wrapper selection modal or inline menu.
+ * Built by {@link WrapperActionService} from schema fields; consumed by
+ * {@link WrapperSelectionModal} and inline menu builders without further
+ * transformation.
+ */
+export interface IWrapperCandidate {
+  key: string;
+  label: string;
+  typeBadge: Types;
+  description?: string;
+  childrenPreview?: string[];
+  selection: IMemberSelection;
+}
+
+// ── Resolved-state contracts ──
+
+/**
+ * Resolved abstract-field context for a visualization node. Pure read result
+ * from {@link WrapperActionService.resolveAbstractFieldInfo} — classifies what
+ * role the node plays relative to abstract wrappers so the hook can decide
+ * which menu actions to offer without re-deriving wrapper relationships.
+ */
+export interface IAbstractFieldInfo {
+  isAbstractWrapper: boolean;
+  isAbstractWrapperMember: boolean;
+  isSelectedSubstitution: boolean;
+  isSubstitutionCandidate: boolean;
+  abstractWrapperField: IField | undefined;
+  field: IField | undefined;
+  parentAbstractField: IField | undefined;
+  candidateQName: string | undefined;
+}
+
+/**
+ * Full choice context resolved for a given node. Each field captures one aspect
+ * of the node's relationship to choice wrappers.
+ *
+ * @property isChoiceWrapper - The node's own field has `wrapperKind === 'choice'`
+ * @property isSelectedChoice - The node is a choice field with a selected member (flattened view)
+ * @property isChoiceMember - The node's field is a direct child of a choice wrapper
+ * @property isChoiceWrapperMember - The node is a per-instance FieldItem belonging to a collection wrapper
+ * @property activeChoiceWrapperForMembers - The choice wrapper whose members should be offered in the context menu
+ * @property effectiveChoiceWrapper - The wrapper that governs this node (wrapper member takes priority)
+ * @property choiceWrapperField - The outermost selected choice wrapper (walks up through nested choices)
+ * @property choiceWrapperMemberField - The wrapper field from a per-instance FieldItem
+ * @property choiceMemberField - The field representing this node as a choice member
+ * @property parentChoiceWrapperField - The parent choice wrapper field if this node is a direct member
+ * @property choiceMemberIndex - The 0-based index of this member within its parent choice
+ */
+export interface IChoiceNodeInfo {
+  isChoiceWrapper: boolean;
+  isSelectedChoice: boolean;
+  isChoiceMember: boolean;
+  isChoiceWrapperMember: boolean;
+  activeChoiceWrapperForMembers: IField | undefined;
+  effectiveChoiceWrapper: IField | undefined;
+  choiceWrapperField: IField | undefined;
+  choiceWrapperMemberField: IField | undefined;
+  choiceMemberField: IField | undefined;
+  parentChoiceWrapperField: IField | undefined;
+  choiceMemberIndex: number | undefined;
+}
+
+// ── Menu builder configs ──
+
+/**
+ * Config for {@link WrapperActionService.buildMenuGroupsForAbstractNode}.
+ * Hooks populate this with resolved state and pre-built action closures;
+ * the service assembles groups without touching React state.
+ *
+ * `selectedIcon` and `unselectedIcon` are `ReactNode` values injected by
+ * the hook — this keeps the `.ts` service file free of JSX while letting
+ * inline menu items render selection indicators.
+ */
+export interface IAbstractMenuGroupsConfig {
+  isAbstractWrapper: boolean;
+  isAbstractWrapperMember: boolean;
+  isInsideChoiceWrapper: boolean;
+  isSelectedSubstitution: boolean;
+  candidates: Record<string, IFieldSubstituteInfo>;
+  selectedQName: string | undefined;
+  memberSelectedQName: string | undefined;
+  selectSelfAction: IFieldMenuAction | undefined;
+  clearSubstitutionAction: IFieldMenuAction;
+  changeSubstituteAction: IFieldMenuAction;
+  onSelectSubstitution: (qname: string) => void;
+  onOpenSubstitutionModal: () => void;
+  selectedIcon: ReactNode;
+  unselectedIcon: ReactNode;
+}
+
+/** Config for {@link WrapperActionService.buildMenuGroupsForChoiceNode}. See {@link IAbstractMenuGroupsConfig}. */
+export interface IChoiceMenuGroupsConfig {
+  isChoiceWrapper: boolean;
+  isChoiceWrapperMember: boolean;
+  isNestedSelectedChoice: boolean;
+  isSelectedChoice: boolean;
+  dissolved: IWrapperCandidate[];
+  selectedModalKey: string | null;
+  selectSelfAction: IFieldMenuAction | undefined;
+  clearChoiceAction: IFieldMenuAction;
+  changeMemberAction: IFieldMenuAction;
+  onSelectChoiceMember: (selection: IMemberSelection) => void;
+  onOpenChoiceModal: () => void;
+  selectedIcon: ReactNode;
+  unselectedIcon: ReactNode;
+}

--- a/packages/ui/src/services/visualization/mapping-action-registry.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action-registry.service.ts
@@ -1,4 +1,3 @@
-import { computeAddFieldCandidates } from '../../components/Document/actions/FieldContextMenu/menu-utils';
 import {
   ChooseItem,
   FieldItem,
@@ -30,6 +29,7 @@ import { useDocumentTreeStore } from '../../store/document-tree.store';
 import { DocumentService } from '../document/document.service';
 import { MappingActionService } from './mapping-action.service';
 import { VisualizationUtilService } from './visualization-util.service';
+import { WrapperActionService } from './wrapper-action.service';
 
 /**
  * Static service that owns the action registry for the DataMapper
@@ -419,7 +419,7 @@ export class MappingActionRegistryService {
             forEachContext = true;
           if (current instanceof FieldItem) {
             const existingFieldItems = n.mapping.children.filter((c): c is FieldItem => c instanceof FieldItem);
-            const result = computeAddFieldCandidates(
+            const result = WrapperActionService.computeAddFieldCandidates(
               current.field.fields,
               current.mappingTree.namespaceMap,
               existingFieldItems,

--- a/packages/ui/src/services/visualization/wrapper-action.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.abstract.test.ts
@@ -1,0 +1,664 @@
+import { DocumentDefinitionType, DocumentType, IField } from '../../models/datamapper/document';
+import { IAbstractMenuGroupsConfig } from '../../models/datamapper/field-action';
+import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
+import { FieldOverrideVariant, IFieldSubstituteInfo, Types } from '../../models/datamapper/types';
+import {
+  FieldItemNodeData,
+  FieldNodeData,
+  TargetAbstractFieldNodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../../models/datamapper/visualization';
+import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
+import { DocumentUtilService } from '../document/document-util.service';
+import { FieldOverrideService } from '../document/field-override.service';
+import { WrapperSelectionService } from '../document/wrapper-selection.service';
+import { MappingService } from '../mapping/mapping.service';
+import { SchemaPathService } from '../schema-path.service';
+import { MappingActionService } from './mapping-action.service';
+import { VisualizationUtilService } from './visualization-util.service';
+import { WrapperActionService } from './wrapper-action.service';
+
+vi.mock('../document/field-override.service', () => ({
+  FieldOverrideService: {
+    revertFieldTypeOverride: vi.fn(),
+    revertFieldSubstitution: vi.fn(),
+    getFieldSubstitutionCandidates: vi.fn().mockReturnValue({}),
+    applyFieldSubstitution: vi.fn(),
+  },
+}));
+
+vi.mock('./visualization-util.service', () => ({
+  VisualizationUtilService: {
+    getField: vi.fn(),
+    isAbstractWrapperMember: vi.fn().mockReturnValue(false),
+    isAbstractField: vi.fn().mockReturnValue(false),
+  },
+}));
+
+vi.mock('../document/document-util.service', () => ({
+  DocumentUtilService: {
+    getSelectedMember: vi.fn(),
+    invalidateDescendants: vi.fn(),
+    processOverrides: vi.fn(),
+  },
+}));
+
+vi.mock('../document/wrapper-selection.service', () => ({
+  WrapperSelectionService: {
+    clearChoiceSelection: vi.fn(),
+    findParentWrapper: vi.fn().mockReturnValue(undefined),
+  },
+}));
+
+vi.mock('../mapping/mapping.service', () => ({
+  MappingService: {
+    updateFieldItemField: vi.fn(),
+    createFieldItem: vi.fn(),
+  },
+}));
+
+vi.mock('./mapping-action.service', () => ({
+  MappingActionService: {
+    getOrCreateFieldItem: vi.fn(),
+  },
+}));
+
+vi.mock('../schema-path.service', () => ({
+  SchemaPathService: {
+    build: vi.fn().mockReturnValue('mock-schema-path'),
+  },
+}));
+
+function mockField(overrides: Partial<IField> = {}): IField {
+  return {
+    name: 'field',
+    displayName: 'Field',
+    id: 'field-id',
+    type: Types.String,
+    fields: [],
+    minOccurs: 1,
+    maxOccurs: 1,
+    namespacePrefix: null,
+    namespaceURI: '',
+    namedTypeFragmentRefs: [],
+    typeOverride: FieldOverrideVariant.NONE,
+    ...overrides,
+  } as IField;
+}
+
+function mockSubstituteInfo(
+  name: string,
+  ns: string = 'http://test',
+  type: Types = Types.Container,
+): IFieldSubstituteInfo {
+  return {
+    qname: new QName(ns, name),
+    displayName: name,
+    type,
+    typeQName: null,
+    namedTypeFragmentRefs: [],
+  };
+}
+
+function createMappingTree(): MappingTree {
+  return new MappingTree(DocumentType.TARGET_BODY, 'test-doc', DocumentDefinitionType.XML_SCHEMA);
+}
+
+function createTargetDocNodeData(): TargetDocumentNodeData {
+  const targetDoc = TestUtil.createTargetOrderDoc();
+  const tree = createMappingTree();
+  return new TargetDocumentNodeData(targetDoc, tree);
+}
+
+function createTargetFieldNodeData(field: IField, mapping?: FieldItem): TargetFieldNodeData {
+  const parentNode = createTargetDocNodeData();
+  return new TargetFieldNodeData(parentNode, field, mapping);
+}
+
+function createFieldItemNodeData(fieldItem: FieldItem, wrapperField?: IField): FieldItemNodeData {
+  const parentNode = createTargetDocNodeData();
+  return new FieldItemNodeData(parentNode, fieldItem, wrapperField);
+}
+
+describe('WrapperActionService (abstract)', () => {
+  const namespaceMap = { xs: 'http://www.w3.org/2001/XMLSchema' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveAbstractFieldInfo', () => {
+    it('should identify an abstract wrapper field', () => {
+      const field = mockField({ wrapperKind: 'abstract' });
+      const nodeData = { field } as unknown as FieldNodeData;
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isAbstractWrapper).toBe(true);
+      expect(result.abstractWrapperField).toBe(field);
+    });
+
+    it('should identify a selected substitution with abstractField from nodeData', () => {
+      const abstractField = mockField({ wrapperKind: 'abstract' });
+      const field = mockField();
+      const nodeData = { field, abstractField } as unknown as TargetAbstractFieldNodeData;
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(true);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isSelectedSubstitution).toBe(true);
+      expect(result.abstractWrapperField).toBe(abstractField);
+    });
+
+    it('should identify an abstract wrapper member via FieldItemNodeData with wrapperField', () => {
+      const wrapperField = mockField({ wrapperKind: 'abstract' });
+      const field = mockField();
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, field);
+      const nodeData = createFieldItemNodeData(fieldItem, wrapperField);
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(true);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isAbstractWrapperMember).toBe(true);
+      expect(result.abstractWrapperField).toBe(wrapperField);
+    });
+
+    it('should identify an abstract wrapper member via parent fallback', () => {
+      const abstractField = mockField({ wrapperKind: 'abstract' });
+      const field = mockField();
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, field);
+      const parentNodeData = createTargetDocNodeData();
+      const parentTarget = new TargetAbstractFieldNodeData(parentNodeData, abstractField);
+      const nodeData = new FieldItemNodeData(parentTarget, fieldItem);
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(true);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isAbstractWrapperMember).toBe(true);
+      expect(result.abstractWrapperField).toBe(abstractField);
+    });
+
+    it('should compute candidateQName when field has an abstract parent', () => {
+      const parent = mockField({ wrapperKind: 'abstract' });
+      const field = mockField({ name: 'Cat', namespaceURI: 'http://test', parent: parent as IField });
+      const nodeData = { field } as unknown as FieldNodeData;
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      });
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isSubstitutionCandidate).toBe(true);
+      expect(result.parentAbstractField).toBe(parent);
+      expect(result.candidateQName).toBe('ns:Cat');
+    });
+
+    it('should return undefined candidateQName when parent is not abstract', () => {
+      const parent = mockField({ wrapperKind: 'choice' });
+      const field = mockField({ parent: parent as IField });
+      const nodeData = { field } as unknown as FieldNodeData;
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isSubstitutionCandidate).toBe(false);
+      expect(result.parentAbstractField).toBeUndefined();
+      expect(result.candidateQName).toBeUndefined();
+    });
+
+    it('should return all-false flags for a regular non-wrapper field', () => {
+      const field = mockField();
+      const nodeData = { field } as unknown as FieldNodeData;
+      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
+      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
+      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
+
+      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
+
+      expect(result.isAbstractWrapper).toBe(false);
+      expect(result.isAbstractWrapperMember).toBe(false);
+      expect(result.isSelectedSubstitution).toBe(false);
+      expect(result.isSubstitutionCandidate).toBe(false);
+      expect(result.abstractWrapperField).toBeUndefined();
+      expect(result.parentAbstractField).toBeUndefined();
+      expect(result.candidateQName).toBeUndefined();
+    });
+  });
+
+  describe('buildAbstractCandidates', () => {
+    it('should return candidates with memberIndex 0 and substituteQName', () => {
+      const abstractField = mockField({ wrapperKind: 'abstract' });
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+        'ns:Dog': mockSubstituteInfo('Dog'),
+      });
+
+      const result = WrapperActionService.buildAbstractCandidates(abstractField, namespaceMap);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          key: 'ns:Cat',
+          label: 'Cat',
+          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
+        }),
+      );
+      expect(result[1]).toEqual(
+        expect.objectContaining({
+          key: 'ns:Dog',
+          label: 'Dog',
+          selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
+        }),
+      );
+    });
+
+    it('should return empty array when no candidates', () => {
+      const abstractField = mockField({ wrapperKind: 'abstract' });
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({});
+
+      const result = WrapperActionService.buildAbstractCandidates(abstractField, namespaceMap);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('resolveSubstitutionCandidates', () => {
+    it('should return empty record when abstractWrapperField is undefined', () => {
+      const result = WrapperActionService.resolveSubstitutionCandidates(undefined, namespaceMap);
+
+      expect(result).toEqual({});
+      expect(FieldOverrideService.getFieldSubstitutionCandidates).not.toHaveBeenCalled();
+    });
+
+    it('should delegate to FieldOverrideService when field is present', () => {
+      const field = mockField();
+      const expected = { 'ns:Cat': mockSubstituteInfo('Cat') };
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue(expected);
+
+      const result = WrapperActionService.resolveSubstitutionCandidates(field, namespaceMap);
+
+      expect(result).toBe(expected);
+      expect(FieldOverrideService.getFieldSubstitutionCandidates).toHaveBeenCalledWith(field, namespaceMap);
+    });
+  });
+
+  describe('resolveSelectedQName', () => {
+    it('should return undefined when abstractWrapperField is undefined', () => {
+      const result = WrapperActionService.resolveSelectedQName(undefined, {});
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return QName when selectedField matches a candidate', () => {
+      const field = mockField({ wrapperKind: 'abstract' });
+      const selectedMember = mockField({ name: 'Cat', namespaceURI: 'http://test' });
+      vi.mocked(DocumentUtilService.getSelectedMember).mockReturnValue(selectedMember);
+      const candidates: Record<string, IFieldSubstituteInfo> = {
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      };
+
+      const result = WrapperActionService.resolveSelectedQName(field, candidates);
+
+      expect(result).toBe('ns:Cat');
+    });
+
+    it('should return undefined when no selectedField found', () => {
+      const field = mockField({ wrapperKind: 'abstract' });
+      vi.mocked(DocumentUtilService.getSelectedMember).mockReturnValue(undefined);
+
+      const result = WrapperActionService.resolveSelectedQName(field, {});
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resolveMemberSelectedQName', () => {
+    it('should return undefined when not abstract wrapper member', () => {
+      const field = mockField();
+      const result = WrapperActionService.resolveMemberSelectedQName(false, field, mockField(), {});
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when field is undefined', () => {
+      const result = WrapperActionService.resolveMemberSelectedQName(true, undefined, mockField(), {});
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when abstractWrapperField is undefined', () => {
+      const result = WrapperActionService.resolveMemberSelectedQName(true, mockField(), undefined, {});
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return QName when all inputs are valid', () => {
+      const field = mockField({ name: 'Cat', namespaceURI: 'http://test' });
+      const abstractField = mockField({ wrapperKind: 'abstract' });
+      const candidates: Record<string, IFieldSubstituteInfo> = {
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      };
+
+      const result = WrapperActionService.resolveMemberSelectedQName(true, field, abstractField, candidates);
+
+      expect(result).toBe('ns:Cat');
+    });
+  });
+
+  describe('applyAbstractSubstitution', () => {
+    it('should route to per-instance when target side and maxOccurs > 1', () => {
+      const wrapperField = mockField({ maxOccurs: -1 });
+      const childField = mockField({ name: 'Cat', namespaceURI: 'http://test' });
+      wrapperField.fields = [childField];
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+      const candidates: Record<string, IFieldSubstituteInfo> = {
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      };
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue(candidates);
+      const mockFieldItem = new FieldItem(tree, childField);
+      vi.mocked(MappingActionService.getOrCreateFieldItem).mockReturnValue(mockFieldItem);
+      vi.mocked(MappingService.createFieldItem).mockReturnValue(mockFieldItem);
+
+      WrapperActionService.applyAbstractSubstitution(
+        nodeData,
+        wrapperField,
+        'ns:Cat',
+        candidates,
+        undefined,
+        namespaceMap,
+        true,
+      );
+
+      expect(FieldOverrideService.applyFieldSubstitution).not.toHaveBeenCalled();
+      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, childField);
+    });
+
+    it('should route to document-level when source side', () => {
+      const wrapperField = mockField({ maxOccurs: -1 });
+      const nodeData = {} as FieldNodeData;
+
+      WrapperActionService.applyAbstractSubstitution(
+        nodeData,
+        wrapperField,
+        'ns:Cat',
+        {},
+        undefined,
+        namespaceMap,
+        false,
+      );
+
+      expect(FieldOverrideService.applyFieldSubstitution).toHaveBeenCalledWith(wrapperField, 'ns:Cat', namespaceMap);
+    });
+
+    it('should route to document-level when maxOccurs is 1', () => {
+      const wrapperField = mockField({ maxOccurs: 1 });
+      const nodeData = {} as FieldNodeData;
+
+      WrapperActionService.applyAbstractSubstitution(
+        nodeData,
+        wrapperField,
+        'ns:Cat',
+        {},
+        undefined,
+        namespaceMap,
+        true,
+      );
+
+      expect(FieldOverrideService.applyFieldSubstitution).toHaveBeenCalledWith(wrapperField, 'ns:Cat', namespaceMap);
+    });
+  });
+
+  describe('clearAbstractSubstitution', () => {
+    it('should route to per-instance when target side and maxOccurs > 1', () => {
+      const wrapperField = mockField({ maxOccurs: -1 });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).not.toHaveBeenCalled();
+      expect(SchemaPathService.build).not.toHaveBeenCalled();
+      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, wrapperField);
+    });
+
+    it('should route to document-level when source side', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapperField = mockField({ maxOccurs: -1, ownerDocument });
+      const nodeData = {} as FieldNodeData;
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, false);
+
+      expect(SchemaPathService.build).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+    });
+
+    it('should route to document-level when maxOccurs is 1', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapperField = mockField({ maxOccurs: 1, ownerDocument });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+    });
+  });
+
+  describe('clearAbstractSubstitution / choice>abstract cascade (#3532)', () => {
+    it('should cascade clear to parent choice when document-level maxOccurs=1', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
+      const wrapperField = mockField({ maxOccurs: 1, ownerDocument, parent: parentChoiceField });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
+        ownerDocument,
+        parentChoiceField,
+        namespaceMap,
+      );
+    });
+
+    it('should cascade clear to parent choice when document-level source maxOccurs>1', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
+      const wrapperField = mockField({ maxOccurs: -1, ownerDocument, parent: parentChoiceField });
+      const nodeData = {} as FieldNodeData;
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, false);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
+        ownerDocument,
+        parentChoiceField,
+        namespaceMap,
+      );
+    });
+
+    it('should NOT cascade for per-instance clear (target maxOccurs>1)', () => {
+      const wrapperField = mockField({ maxOccurs: -1 });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+    });
+
+    it('should NOT cascade when no choice parent', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapperField = mockField({ maxOccurs: 1, ownerDocument });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapperField);
+      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+
+      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(undefined);
+
+      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+
+      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
+      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildMenuGroupsForAbstractNode', () => {
+    function baseAbstractConfig(overrides: Partial<IAbstractMenuGroupsConfig> = {}): IAbstractMenuGroupsConfig {
+      return {
+        isAbstractWrapper: false,
+        isAbstractWrapperMember: false,
+        isInsideChoiceWrapper: false,
+        isSelectedSubstitution: false,
+        candidates: {},
+        selectedQName: undefined,
+        memberSelectedQName: undefined,
+        selectSelfAction: undefined,
+        clearSubstitutionAction: { label: 'Clear', onClick: vi.fn() },
+        changeSubstituteAction: { label: 'Change', onClick: vi.fn() },
+        onSelectSubstitution: vi.fn(),
+        onOpenSubstitutionModal: vi.fn(),
+        selectedIcon: 'selected-icon',
+        unselectedIcon: 'unselected-icon',
+        ...overrides,
+      };
+    }
+
+    it('should return clear action when abstract wrapper inside choice has selection', () => {
+      const clearAction = { label: 'Clear', onClick: vi.fn() };
+      const config = baseAbstractConfig({
+        isAbstractWrapper: true,
+        isInsideChoiceWrapper: true,
+        selectedQName: 'ns:Cat',
+        clearSubstitutionAction: clearAction,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].actions).toEqual([clearAction]);
+    });
+
+    it('should return empty when abstract wrapper inside choice has no selection', () => {
+      const config = baseAbstractConfig({
+        isAbstractWrapper: true,
+        isInsideChoiceWrapper: true,
+        selectedQName: undefined,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups).toEqual([]);
+    });
+
+    it('should build inline substitution actions when candidates <= 10', () => {
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({});
+      const config = baseAbstractConfig({
+        isAbstractWrapper: true,
+        candidates: {
+          'ns:Cat': mockSubstituteInfo('Cat'),
+          'ns:Dog': mockSubstituteInfo('Dog'),
+        },
+        selectedQName: 'ns:Cat',
+        selectSelfAction: { label: 'Select self', onClick: vi.fn() },
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups).toHaveLength(3);
+      expect(groups[0].actions[0].label).toBe('Select self');
+      expect(groups[1].actions).toHaveLength(2);
+      expect(groups[1].actions[0].label).toBe('Cat');
+      expect(groups[1].actions[0].icon).toBe('selected-icon');
+      expect(groups[1].actions[1].label).toBe('Dog');
+      expect(groups[1].actions[1].icon).toBe('unselected-icon');
+      expect(groups[2].actions[0].label).toBe('Clear');
+    });
+
+    it('should show modal button when candidates > 10', () => {
+      const candidates: Record<string, IFieldSubstituteInfo> = {};
+      for (let i = 0; i < 11; i++) {
+        candidates[`ns:Type${i}`] = mockSubstituteInfo(`Type${i}`);
+      }
+      const config = baseAbstractConfig({
+        isAbstractWrapper: true,
+        candidates,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups[1].actions).toHaveLength(1);
+      expect(groups[1].actions[0].label).toBe('Select Substitute...');
+      expect(groups[1].actions[0].testId).toBe('open-substitution-modal');
+    });
+
+    it('should return empty when no candidates and no selectSelfAction', () => {
+      const config = baseAbstractConfig({
+        isAbstractWrapper: true,
+        candidates: {},
+        selectSelfAction: undefined,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups).toEqual([]);
+    });
+
+    it('should omit selectSelfAction for abstract wrapper members', () => {
+      const config = baseAbstractConfig({
+        isAbstractWrapperMember: true,
+        candidates: { 'ns:Cat': mockSubstituteInfo('Cat') },
+        selectSelfAction: { label: 'Select self', onClick: vi.fn() },
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups[0].actions).toHaveLength(0);
+    });
+
+    it('should return clear and change actions for selected substitution', () => {
+      const clearAction = { label: 'Clear', onClick: vi.fn() };
+      const changeAction = { label: 'Change', onClick: vi.fn() };
+      const config = baseAbstractConfig({
+        isSelectedSubstitution: true,
+        clearSubstitutionAction: clearAction,
+        changeSubstituteAction: changeAction,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForAbstractNode(config);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].actions).toEqual([clearAction, changeAction]);
+    });
+  });
+});

--- a/packages/ui/src/services/visualization/wrapper-action.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.choice.test.ts
@@ -1,0 +1,596 @@
+import { DocumentDefinitionType, DocumentType, IField } from '../../models/datamapper/document';
+import { IChoiceMenuGroupsConfig, IWrapperCandidate } from '../../models/datamapper/field-action';
+import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
+import { FieldOverrideVariant, IFieldSubstituteInfo, Types } from '../../models/datamapper/types';
+import {
+  FieldItemNodeData,
+  FieldNodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../../models/datamapper/visualization';
+import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
+import { DocumentUtilService } from '../document/document-util.service';
+import { FieldOverrideService } from '../document/field-override.service';
+import { WrapperSelectionService } from '../document/wrapper-selection.service';
+import { MappingService } from '../mapping/mapping.service';
+import { MappingActionService } from './mapping-action.service';
+import { VisualizationService } from './visualization.service';
+import { WrapperActionService } from './wrapper-action.service';
+
+vi.mock('../document/field-override.service', () => ({
+  FieldOverrideService: {
+    revertFieldTypeOverride: vi.fn(),
+    revertFieldSubstitution: vi.fn(),
+    getFieldSubstitutionCandidates: vi.fn().mockReturnValue({}),
+    applyFieldSubstitution: vi.fn(),
+  },
+}));
+
+vi.mock('./visualization.service', () => ({
+  VisualizationService: {
+    getChoiceMemberLabel: vi.fn().mockReturnValue('choice-label'),
+  },
+}));
+
+vi.mock('../document/document-util.service', () => ({
+  DocumentUtilService: {
+    invalidateDescendants: vi.fn(),
+    processOverrides: vi.fn(),
+  },
+}));
+
+vi.mock('../document/wrapper-selection.service', () => ({
+  WrapperSelectionService: {
+    setChoiceSelection: vi.fn(),
+    clearChoiceSelection: vi.fn(),
+    clearDescendantWrapperSelections: vi.fn(),
+  },
+}));
+
+vi.mock('../mapping/mapping.service', () => ({
+  MappingService: {
+    updateFieldItemField: vi.fn(),
+    createFieldItem: vi.fn(),
+  },
+}));
+
+vi.mock('./mapping-action.service', () => ({
+  MappingActionService: {
+    getOrCreateFieldItem: vi.fn(),
+  },
+}));
+
+vi.mock('../schema-path.service', () => ({
+  SchemaPathService: {
+    build: vi.fn().mockReturnValue('mock-schema-path'),
+  },
+}));
+
+function mockField(overrides: Partial<IField> = {}): IField {
+  return {
+    name: 'field',
+    displayName: 'Field',
+    id: 'field-id',
+    type: Types.String,
+    fields: [],
+    minOccurs: 1,
+    maxOccurs: 1,
+    namespacePrefix: null,
+    namespaceURI: '',
+    namedTypeFragmentRefs: [],
+    typeOverride: FieldOverrideVariant.NONE,
+    ...overrides,
+  } as IField;
+}
+
+function mockSubstituteInfo(
+  name: string,
+  ns: string = 'http://test',
+  type: Types = Types.Container,
+): IFieldSubstituteInfo {
+  return {
+    qname: new QName(ns, name),
+    displayName: name,
+    type,
+    typeQName: null,
+    namedTypeFragmentRefs: [],
+  };
+}
+
+function createMappingTree(): MappingTree {
+  return new MappingTree(DocumentType.TARGET_BODY, 'test-doc', DocumentDefinitionType.XML_SCHEMA);
+}
+
+function createTargetDocNodeData(): TargetDocumentNodeData {
+  const targetDoc = TestUtil.createTargetOrderDoc();
+  const tree = createMappingTree();
+  return new TargetDocumentNodeData(targetDoc, tree);
+}
+
+function createTargetFieldNodeData(field: IField, mapping?: FieldItem): TargetFieldNodeData {
+  const parentNode = createTargetDocNodeData();
+  return new TargetFieldNodeData(parentNode, field, mapping);
+}
+
+function createFieldItemNodeData(fieldItem: FieldItem, wrapperField?: IField): FieldItemNodeData {
+  const parentNode = createTargetDocNodeData();
+  return new FieldItemNodeData(parentNode, fieldItem, wrapperField);
+}
+
+describe('WrapperActionService (choice)', () => {
+  const namespaceMap = { xs: 'http://www.w3.org/2001/XMLSchema' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('dissolveChoiceMembers', () => {
+    it('should dissolve abstract members into substitution candidates', () => {
+      const abstractMember = mockField({ wrapperKind: 'abstract' });
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+        'ns:Dog': mockSubstituteInfo('Dog'),
+      });
+
+      const result = WrapperActionService.dissolveChoiceMembers([abstractMember], namespaceMap);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          key: '0:ns:Cat',
+          label: 'Cat',
+          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
+        }),
+      );
+      expect(result[1]).toEqual(
+        expect.objectContaining({
+          key: '0:ns:Dog',
+          label: 'Dog',
+          selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
+        }),
+      );
+    });
+
+    it('should skip sequence members', () => {
+      const sequenceMember = mockField({ wrapperKind: 'sequence' });
+
+      const result = WrapperActionService.dissolveChoiceMembers([sequenceMember], namespaceMap);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should pass through normal members via fieldToCandidate', () => {
+      const normalMember = mockField({ name: 'email', displayName: 'Email', type: Types.String });
+
+      const result = WrapperActionService.dissolveChoiceMembers([normalMember], namespaceMap);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          key: '0',
+          label: 'Email',
+          typeBadge: Types.String,
+          selection: { memberIndex: 0 },
+        }),
+      );
+    });
+
+    it('should handle mixed members in correct order', () => {
+      const normal = mockField({ name: 'email', displayName: 'Email', type: Types.String });
+      const abstract = mockField({ wrapperKind: 'abstract' });
+      const sequence = mockField({ wrapperKind: 'sequence' });
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      });
+
+      const result = WrapperActionService.dissolveChoiceMembers([normal, abstract, sequence], namespaceMap);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe('0');
+      expect(result[0].selection.memberIndex).toBe(0);
+      expect(result[1].key).toBe('1:ns:Cat');
+      expect(result[1].selection.memberIndex).toBe(1);
+    });
+  });
+
+  describe('dissolveChoiceMembers (additional)', () => {
+    it('should include children preview for complex members', () => {
+      const member = mockField({
+        name: 'address',
+        displayName: 'Address',
+        type: Types.Container,
+        fields: [mockField({ displayName: 'Street' }), mockField({ displayName: 'City' })],
+      });
+      const result = WrapperActionService.dissolveChoiceMembers([member], namespaceMap);
+
+      expect(result[0].childrenPreview).toEqual(['Street', 'City']);
+    });
+
+    it('should handle empty members list', () => {
+      expect(WrapperActionService.dissolveChoiceMembers([], namespaceMap)).toEqual([]);
+    });
+  });
+
+  describe('getChoiceFieldDisplayName', () => {
+    it('should use getChoiceMemberLabel for choice wrapper', () => {
+      const field = mockField({ wrapperKind: 'choice' });
+      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('(A | B)');
+
+      const result = WrapperActionService.getChoiceFieldDisplayName(field);
+
+      expect(result).toBe('(A | B)');
+      expect(VisualizationService.getChoiceMemberLabel).toHaveBeenCalledWith(field);
+    });
+
+    it('should use displayName for non-choice field', () => {
+      const field = mockField({ displayName: 'MyField' });
+
+      const result = WrapperActionService.getChoiceFieldDisplayName(field);
+
+      expect(result).toBe('MyField');
+    });
+
+    it('should fall back to name when displayName is empty', () => {
+      const field = mockField({ displayName: '', name: 'fallback' });
+
+      const result = WrapperActionService.getChoiceFieldDisplayName(field);
+
+      expect(result).toBe('fallback');
+    });
+  });
+
+  describe('dispatchChoiceSelection', () => {
+    it('should route to per-instance when target side and maxOccurs > 1', () => {
+      const memberField = mockField({ name: 'email' });
+      const wrapper = mockField({ maxOccurs: -1, fields: [memberField] });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapper);
+      const nodeData = createFieldItemNodeData(fieldItem);
+      vi.mocked(MappingActionService.getOrCreateFieldItem).mockReturnValue(fieldItem);
+      vi.mocked(MappingService.createFieldItem).mockReturnValue(new FieldItem(tree, memberField));
+
+      WrapperActionService.dispatchChoiceSelection(nodeData, wrapper, { memberIndex: 0 }, namespaceMap, true);
+
+      expect(WrapperSelectionService.setChoiceSelection).not.toHaveBeenCalled();
+      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, memberField);
+    });
+
+    it('should route to document-level otherwise', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
+      const nodeData = {} as FieldNodeData;
+
+      WrapperActionService.dispatchChoiceSelection(nodeData, wrapper, { memberIndex: 0 }, namespaceMap, false);
+
+      expect(WrapperSelectionService.setChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, 0, namespaceMap);
+    });
+  });
+
+  describe('clearChoiceSelectionOnField', () => {
+    it('should route to per-instance when target side and maxOccurs > 1', () => {
+      const wrapper = mockField({ maxOccurs: -1 });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapper);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, true);
+
+      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, wrapper);
+    });
+
+    it('should route to document-level when source side', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
+      const nodeData = {} as FieldNodeData;
+
+      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, false);
+
+      expect(WrapperSelectionService.clearDescendantWrapperSelections).toHaveBeenCalledWith(wrapper, namespaceMap);
+      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, namespaceMap);
+    });
+
+    it('should route to document-level when maxOccurs is 1 and target side', () => {
+      const ownerDocument = TestUtil.createTargetOrderDoc();
+      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, wrapper);
+      const nodeData = createTargetFieldNodeData(wrapper, fieldItem);
+
+      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, true);
+
+      expect(WrapperSelectionService.clearDescendantWrapperSelections).toHaveBeenCalledWith(wrapper, namespaceMap);
+      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
+      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, namespaceMap);
+    });
+  });
+
+  describe('resolveChoiceWrapper', () => {
+    it('should return choiceWrapperMemberField when isChoiceWrapperMember is true', () => {
+      const choiceField = mockField({ wrapperKind: 'choice' });
+      const fallback = mockField();
+
+      const result = WrapperActionService.resolveChoiceWrapper(true, choiceField, fallback);
+
+      expect(result).toBe(choiceField);
+    });
+
+    it('should return fallback when isChoiceWrapperMember is false', () => {
+      const choiceField = mockField({ wrapperKind: 'choice' });
+      const fallback = mockField();
+
+      const result = WrapperActionService.resolveChoiceWrapper(false, choiceField, fallback);
+
+      expect(result).toBe(fallback);
+    });
+  });
+
+  describe('resolveMemberSelectedKey', () => {
+    it('should return null when nodeData is not FieldItemNodeData', () => {
+      const nodeData = {} as FieldNodeData;
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, mockField(), [], namespaceMap);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when wrapper is undefined', () => {
+      const field = mockField();
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, field);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, undefined, [], namespaceMap);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when member field not in wrapper.fields and no parent', () => {
+      const memberField = mockField({ name: 'unknown' });
+      const wrapper = mockField({ fields: [] });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, memberField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, [], namespaceMap);
+
+      expect(result).toBeNull();
+    });
+
+    it('should resolve via parent when idx < 0 with abstract parent', () => {
+      const abstractParent = mockField({ wrapperKind: 'abstract' }) as IField;
+      const memberField = mockField({ name: 'Cat', namespaceURI: 'http://test', parent: abstractParent });
+      const wrapper = mockField({ fields: [abstractParent] });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, memberField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+      });
+      const dissolved = [
+        {
+          key: '0:ns:Cat',
+          label: 'Cat',
+          typeBadge: Types.Container,
+          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
+        },
+      ];
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, dissolved, namespaceMap);
+
+      expect(result).toBe('0:ns:Cat');
+    });
+
+    it('should return matching dissolved key when idx >= 0', () => {
+      const memberField = mockField({ name: 'email' });
+      const wrapper = mockField({ fields: [memberField] });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, memberField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+      const dissolved = [{ key: '0', label: 'Email', typeBadge: Types.String, selection: { memberIndex: 0 } }];
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, dissolved, namespaceMap);
+
+      expect(result).toBe('0');
+    });
+
+    it('should return null when idx >= 0 but no dissolved match', () => {
+      const memberField = mockField({ name: 'email' });
+      const wrapper = mockField({ fields: [memberField] });
+      const tree = createMappingTree();
+      const fieldItem = new FieldItem(tree, memberField);
+      const nodeData = createFieldItemNodeData(fieldItem);
+
+      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, [], namespaceMap);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('resolveSelectedModalKey', () => {
+    it('should return memberSelectedKey when isChoiceWrapperMember is true', () => {
+      const result = WrapperActionService.resolveSelectedModalKey(true, 'key1', undefined, []);
+
+      expect(result).toBe('key1');
+    });
+
+    it('should return null when selectedMemberIndex is undefined', () => {
+      const wrapper = mockField();
+
+      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, []);
+
+      expect(result).toBeNull();
+    });
+
+    it('should match dissolved with substituteQName for abstract member', () => {
+      const qname = new QName('http://test', 'Cat');
+      const abstractMember = mockField({
+        wrapperKind: 'abstract',
+        selectedMemberQName: qname,
+      });
+      const wrapper = mockField({ selectedMemberIndex: 0, fields: [abstractMember] });
+      const dissolved = [
+        {
+          key: '0:ns:Cat',
+          label: 'Cat',
+          typeBadge: Types.Container,
+          selection: { memberIndex: 0, substituteQName: qname.toString() },
+        },
+      ];
+
+      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, dissolved);
+
+      expect(result).toBe('0:ns:Cat');
+    });
+
+    it('should match dissolved without substituteQName for normal member', () => {
+      const normalMember = mockField({ name: 'email' });
+      const wrapper = mockField({ selectedMemberIndex: 0, fields: [normalMember] });
+      const dissolved = [{ key: '0', label: 'Email', typeBadge: Types.String, selection: { memberIndex: 0 } }];
+
+      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, dissolved);
+
+      expect(result).toBe('0');
+    });
+
+    it('should return null when no dissolved candidate matches', () => {
+      const normalMember = mockField({ name: 'email' });
+      const wrapper = mockField({ selectedMemberIndex: 0, fields: [normalMember] });
+
+      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, []);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('buildMenuGroupsForChoiceNode', () => {
+    function baseChoiceConfig(overrides: Partial<IChoiceMenuGroupsConfig> = {}): IChoiceMenuGroupsConfig {
+      return {
+        isChoiceWrapper: false,
+        isChoiceWrapperMember: false,
+        isNestedSelectedChoice: false,
+        isSelectedChoice: false,
+        dissolved: [],
+        selectedModalKey: null,
+        selectSelfAction: undefined,
+        clearChoiceAction: { label: 'Clear choice', onClick: vi.fn() },
+        changeMemberAction: { label: 'Change member', onClick: vi.fn() },
+        onSelectChoiceMember: vi.fn(),
+        onOpenChoiceModal: vi.fn(),
+        selectedIcon: 'selected-icon',
+        unselectedIcon: 'unselected-icon',
+        ...overrides,
+      };
+    }
+
+    function makeDissolved(count: number): IWrapperCandidate[] {
+      return Array.from({ length: count }, (_, i) => ({
+        key: `${i}`,
+        label: `Member${i}`,
+        typeBadge: Types.String,
+        selection: { memberIndex: i },
+      }));
+    }
+
+    it('should build inline member actions when dissolved <= 10', () => {
+      const config = baseChoiceConfig({
+        isChoiceWrapper: true,
+        dissolved: makeDissolved(3),
+        selectedModalKey: '1',
+        selectSelfAction: { label: 'Select self', onClick: vi.fn() },
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups).toHaveLength(3);
+      expect(groups[0].actions[0].label).toBe('Select self');
+      expect(groups[1].actions).toHaveLength(3);
+      expect(groups[1].actions[0].icon).toBe('unselected-icon');
+      expect(groups[1].actions[1].icon).toBe('selected-icon');
+      expect(groups[2].actions[0].label).toBe('Clear choice');
+    });
+
+    it('should show modal button when dissolved > 10', () => {
+      const config = baseChoiceConfig({
+        isChoiceWrapper: true,
+        dissolved: makeDissolved(11),
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups[1].actions).toHaveLength(1);
+      expect(groups[1].actions[0].label).toBe('Select Member...');
+      expect(groups[1].actions[0].testId).toBe('open-choice-modal');
+    });
+
+    it('should omit selectSelfAction for choice wrapper members', () => {
+      const config = baseChoiceConfig({
+        isChoiceWrapperMember: true,
+        dissolved: makeDissolved(2),
+        selectSelfAction: { label: 'Select self', onClick: vi.fn() },
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups[0].actions).toHaveLength(0);
+    });
+
+    it('should add clear+change group when isNestedSelectedChoice', () => {
+      const clearAction = { label: 'Clear choice', onClick: vi.fn() };
+      const changeAction = { label: 'Change member', onClick: vi.fn() };
+      const config = baseChoiceConfig({
+        isChoiceWrapper: true,
+        isNestedSelectedChoice: true,
+        dissolved: makeDissolved(2),
+        clearChoiceAction: clearAction,
+        changeMemberAction: changeAction,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      const lastGroup = groups[groups.length - 1];
+      expect(lastGroup.actions).toEqual([clearAction, changeAction]);
+    });
+
+    it('should return clear+change for selected choice (non-wrapper)', () => {
+      const clearAction = { label: 'Clear choice', onClick: vi.fn() };
+      const changeAction = { label: 'Change member', onClick: vi.fn() };
+      const config = baseChoiceConfig({
+        isSelectedChoice: true,
+        clearChoiceAction: clearAction,
+        changeMemberAction: changeAction,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].actions).toEqual([clearAction, changeAction]);
+    });
+
+    it('should return empty when dissolved is empty and no selectSelfAction', () => {
+      const config = baseChoiceConfig({
+        isChoiceWrapper: true,
+        dissolved: [],
+        selectSelfAction: undefined,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups).toEqual([]);
+    });
+
+    it('should include selectSelfAction for selected choice', () => {
+      const selectSelf = { label: 'Select self', onClick: vi.fn() };
+      const config = baseChoiceConfig({
+        isSelectedChoice: true,
+        selectSelfAction: selectSelf,
+      });
+
+      const groups = WrapperActionService.buildMenuGroupsForChoiceNode(config);
+
+      expect(groups[0].actions).toContainEqual(selectSelf);
+    });
+  });
+});

--- a/packages/ui/src/services/visualization/wrapper-action.service.test.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.test.ts
@@ -1,24 +1,12 @@
-import { IField } from '../../models/datamapper/document';
-import { DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
+import { DocumentDefinition, DocumentDefinitionType, DocumentType, IField } from '../../models/datamapper/document';
 import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
 import { FieldOverrideVariant, IFieldSubstituteInfo, Types } from '../../models/datamapper/types';
-import {
-  FieldItemNodeData,
-  FieldNodeData,
-  TargetAbstractFieldNodeData,
-  TargetDocumentNodeData,
-  TargetFieldNodeData,
-} from '../../models/datamapper/visualization';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { XmlSchemaCollection } from '../../xml-schema-ts';
 import { QName } from '../../xml-schema-ts/QName';
-import { DocumentUtilService } from '../document/document-util.service';
 import { FieldOverrideService } from '../document/field-override.service';
-import { WrapperSelectionService } from '../document/wrapper-selection.service';
-import { MappingService } from '../mapping/mapping.service';
-import { SchemaPathService } from '../schema-path.service';
-import { MappingActionService } from './mapping-action.service';
+import { XmlSchemaDocument, XmlSchemaField } from '../document/xml-schema/xml-schema-document.model';
 import { VisualizationService } from './visualization.service';
-import { VisualizationUtilService } from './visualization-util.service';
 import { WrapperActionService } from './wrapper-action.service';
 
 vi.mock('../document/field-override.service', () => ({
@@ -30,53 +18,9 @@ vi.mock('../document/field-override.service', () => ({
   },
 }));
 
-vi.mock('./visualization-util.service', () => ({
-  VisualizationUtilService: {
-    getField: vi.fn(),
-    isAbstractWrapperMember: vi.fn().mockReturnValue(false),
-    isAbstractField: vi.fn().mockReturnValue(false),
-  },
-}));
-
 vi.mock('./visualization.service', () => ({
   VisualizationService: {
     getChoiceMemberLabel: vi.fn().mockReturnValue('choice-label'),
-  },
-}));
-
-vi.mock('../document/document-util.service', () => ({
-  DocumentUtilService: {
-    getSelectedMember: vi.fn(),
-    invalidateDescendants: vi.fn(),
-    processOverrides: vi.fn(),
-  },
-}));
-
-vi.mock('../document/wrapper-selection.service', () => ({
-  WrapperSelectionService: {
-    setChoiceSelection: vi.fn(),
-    clearChoiceSelection: vi.fn(),
-    clearDescendantWrapperSelections: vi.fn(),
-    findParentWrapper: vi.fn().mockReturnValue(undefined),
-  },
-}));
-
-vi.mock('../mapping/mapping.service', () => ({
-  MappingService: {
-    updateFieldItemField: vi.fn(),
-    createFieldItem: vi.fn(),
-  },
-}));
-
-vi.mock('./mapping-action.service', () => ({
-  MappingActionService: {
-    getOrCreateFieldItem: vi.fn(),
-  },
-}));
-
-vi.mock('../schema-path.service', () => ({
-  SchemaPathService: {
-    build: vi.fn().mockReturnValue('mock-schema-path'),
   },
 }));
 
@@ -109,26 +53,6 @@ function mockSubstituteInfo(
     typeQName: null,
     namedTypeFragmentRefs: [],
   };
-}
-
-function createMappingTree(): MappingTree {
-  return new MappingTree(DocumentType.TARGET_BODY, 'test-doc', DocumentDefinitionType.XML_SCHEMA);
-}
-
-function createTargetDocNodeData(): TargetDocumentNodeData {
-  const targetDoc = TestUtil.createTargetOrderDoc();
-  const tree = createMappingTree();
-  return new TargetDocumentNodeData(targetDoc, tree);
-}
-
-function createTargetFieldNodeData(field: IField, mapping?: FieldItem): TargetFieldNodeData {
-  const parentNode = createTargetDocNodeData();
-  return new TargetFieldNodeData(parentNode, field, mapping);
-}
-
-function createFieldItemNodeData(fieldItem: FieldItem, wrapperField?: IField): FieldItemNodeData {
-  const parentNode = createTargetDocNodeData();
-  return new FieldItemNodeData(parentNode, fieldItem, wrapperField);
 }
 
 describe('WrapperActionService', () => {
@@ -222,120 +146,6 @@ describe('WrapperActionService', () => {
     });
   });
 
-  describe('resolveAbstractFieldInfo', () => {
-    it('should identify an abstract wrapper field', () => {
-      const field = mockField({ wrapperKind: 'abstract' });
-      const nodeData = { field } as unknown as FieldNodeData;
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isAbstractWrapper).toBe(true);
-      expect(result.abstractWrapperField).toBe(field);
-    });
-
-    it('should identify a selected substitution with abstractField from nodeData', () => {
-      const abstractField = mockField({ wrapperKind: 'abstract' });
-      const field = mockField();
-      const nodeData = { field, abstractField } as unknown as TargetAbstractFieldNodeData;
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(true);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isSelectedSubstitution).toBe(true);
-      expect(result.abstractWrapperField).toBe(abstractField);
-    });
-
-    it('should identify an abstract wrapper member via FieldItemNodeData with wrapperField', () => {
-      const wrapperField = mockField({ wrapperKind: 'abstract' });
-      const field = mockField();
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, field);
-      const nodeData = createFieldItemNodeData(fieldItem, wrapperField);
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(true);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isAbstractWrapperMember).toBe(true);
-      expect(result.abstractWrapperField).toBe(wrapperField);
-    });
-
-    it('should identify an abstract wrapper member via parent fallback', () => {
-      const abstractField = mockField({ wrapperKind: 'abstract' });
-      const field = mockField();
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, field);
-      const parentNodeData = createTargetDocNodeData();
-      const parentTarget = new TargetAbstractFieldNodeData(parentNodeData, abstractField);
-      const nodeData = new FieldItemNodeData(parentTarget, fieldItem);
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(true);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isAbstractWrapperMember).toBe(true);
-      expect(result.abstractWrapperField).toBe(abstractField);
-    });
-
-    it('should compute candidateQName when field has an abstract parent', () => {
-      const parent = mockField({ wrapperKind: 'abstract' });
-      const field = mockField({ name: 'Cat', namespaceURI: 'http://test', parent: parent as IField });
-      const nodeData = { field } as unknown as FieldNodeData;
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      });
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isSubstitutionCandidate).toBe(true);
-      expect(result.parentAbstractField).toBe(parent);
-      expect(result.candidateQName).toBe('ns:Cat');
-    });
-
-    it('should return undefined candidateQName when parent is not abstract', () => {
-      const parent = mockField({ wrapperKind: 'choice' });
-      const field = mockField({ parent: parent as IField });
-      const nodeData = { field } as unknown as FieldNodeData;
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isSubstitutionCandidate).toBe(false);
-      expect(result.parentAbstractField).toBeUndefined();
-      expect(result.candidateQName).toBeUndefined();
-    });
-
-    it('should return all-false flags for a regular non-wrapper field', () => {
-      const field = mockField();
-      const nodeData = { field } as unknown as FieldNodeData;
-      vi.mocked(VisualizationUtilService.getField).mockReturnValue(field);
-      vi.mocked(VisualizationUtilService.isAbstractWrapperMember).mockReturnValue(false);
-      vi.mocked(VisualizationUtilService.isAbstractField).mockReturnValue(false);
-
-      const result = WrapperActionService.resolveAbstractFieldInfo(nodeData, namespaceMap);
-
-      expect(result.isAbstractWrapper).toBe(false);
-      expect(result.isAbstractWrapperMember).toBe(false);
-      expect(result.isSelectedSubstitution).toBe(false);
-      expect(result.isSubstitutionCandidate).toBe(false);
-      expect(result.abstractWrapperField).toBeUndefined();
-      expect(result.parentAbstractField).toBeUndefined();
-      expect(result.candidateQName).toBeUndefined();
-    });
-  });
-
   describe('fieldToCandidate', () => {
     it('should use getChoiceMemberLabel for choice wrapper fields', () => {
       const field = mockField({ wrapperKind: 'choice', type: Types.Container });
@@ -389,552 +199,6 @@ describe('WrapperActionService', () => {
     });
   });
 
-  describe('dissolveChoiceMembers', () => {
-    it('should dissolve abstract members into substitution candidates', () => {
-      const abstractMember = mockField({ wrapperKind: 'abstract' });
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
-        'ns:Cat': mockSubstituteInfo('Cat'),
-        'ns:Dog': mockSubstituteInfo('Dog'),
-      });
-
-      const result = WrapperActionService.dissolveChoiceMembers([abstractMember], namespaceMap);
-
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          key: '0:ns:Cat',
-          label: 'Cat',
-          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
-        }),
-      );
-      expect(result[1]).toEqual(
-        expect.objectContaining({
-          key: '0:ns:Dog',
-          label: 'Dog',
-          selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
-        }),
-      );
-    });
-
-    it('should skip sequence members', () => {
-      const sequenceMember = mockField({ wrapperKind: 'sequence' });
-
-      const result = WrapperActionService.dissolveChoiceMembers([sequenceMember], namespaceMap);
-
-      expect(result).toHaveLength(0);
-    });
-
-    it('should pass through normal members via fieldToCandidate', () => {
-      const normalMember = mockField({ name: 'email', displayName: 'Email', type: Types.String });
-
-      const result = WrapperActionService.dissolveChoiceMembers([normalMember], namespaceMap);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          key: '0',
-          label: 'Email',
-          typeBadge: Types.String,
-          selection: { memberIndex: 0 },
-        }),
-      );
-    });
-
-    it('should handle mixed members in correct order', () => {
-      const normal = mockField({ name: 'email', displayName: 'Email', type: Types.String });
-      const abstract = mockField({ wrapperKind: 'abstract' });
-      const sequence = mockField({ wrapperKind: 'sequence' });
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      });
-
-      const result = WrapperActionService.dissolveChoiceMembers([normal, abstract, sequence], namespaceMap);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].key).toBe('0');
-      expect(result[0].selection.memberIndex).toBe(0);
-      expect(result[1].key).toBe('1:ns:Cat');
-      expect(result[1].selection.memberIndex).toBe(1);
-    });
-  });
-
-  describe('buildAbstractCandidates', () => {
-    it('should return candidates with memberIndex 0 and substituteQName', () => {
-      const abstractField = mockField({ wrapperKind: 'abstract' });
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
-        'ns:Cat': mockSubstituteInfo('Cat'),
-        'ns:Dog': mockSubstituteInfo('Dog'),
-      });
-
-      const result = WrapperActionService.buildAbstractCandidates(abstractField, namespaceMap);
-
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          key: 'ns:Cat',
-          label: 'Cat',
-          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
-        }),
-      );
-      expect(result[1]).toEqual(
-        expect.objectContaining({
-          key: 'ns:Dog',
-          label: 'Dog',
-          selection: { memberIndex: 0, substituteQName: 'ns:Dog' },
-        }),
-      );
-    });
-
-    it('should return empty array when no candidates', () => {
-      const abstractField = mockField({ wrapperKind: 'abstract' });
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({});
-
-      const result = WrapperActionService.buildAbstractCandidates(abstractField, namespaceMap);
-
-      expect(result).toHaveLength(0);
-    });
-  });
-
-  describe('resolveSubstitutionCandidates', () => {
-    it('should return empty record when abstractWrapperField is undefined', () => {
-      const result = WrapperActionService.resolveSubstitutionCandidates(undefined, namespaceMap);
-
-      expect(result).toEqual({});
-      expect(FieldOverrideService.getFieldSubstitutionCandidates).not.toHaveBeenCalled();
-    });
-
-    it('should delegate to FieldOverrideService when field is present', () => {
-      const field = mockField();
-      const expected = { 'ns:Cat': mockSubstituteInfo('Cat') };
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue(expected);
-
-      const result = WrapperActionService.resolveSubstitutionCandidates(field, namespaceMap);
-
-      expect(result).toBe(expected);
-      expect(FieldOverrideService.getFieldSubstitutionCandidates).toHaveBeenCalledWith(field, namespaceMap);
-    });
-  });
-
-  describe('resolveSelectedQName', () => {
-    it('should return undefined when abstractWrapperField is undefined', () => {
-      const result = WrapperActionService.resolveSelectedQName(undefined, {});
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should return QName when selectedField matches a candidate', () => {
-      const field = mockField({ wrapperKind: 'abstract' });
-      const selectedMember = mockField({ name: 'Cat', namespaceURI: 'http://test' });
-      vi.mocked(DocumentUtilService.getSelectedMember).mockReturnValue(selectedMember);
-      const candidates: Record<string, IFieldSubstituteInfo> = {
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      };
-
-      const result = WrapperActionService.resolveSelectedQName(field, candidates);
-
-      expect(result).toBe('ns:Cat');
-    });
-
-    it('should return undefined when no selectedField found', () => {
-      const field = mockField({ wrapperKind: 'abstract' });
-      vi.mocked(DocumentUtilService.getSelectedMember).mockReturnValue(undefined);
-
-      const result = WrapperActionService.resolveSelectedQName(field, {});
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('resolveMemberSelectedQName', () => {
-    it('should return undefined when not abstract wrapper member', () => {
-      const field = mockField();
-      const result = WrapperActionService.resolveMemberSelectedQName(false, field, mockField(), {});
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when field is undefined', () => {
-      const result = WrapperActionService.resolveMemberSelectedQName(true, undefined, mockField(), {});
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when abstractWrapperField is undefined', () => {
-      const result = WrapperActionService.resolveMemberSelectedQName(true, mockField(), undefined, {});
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should return QName when all inputs are valid', () => {
-      const field = mockField({ name: 'Cat', namespaceURI: 'http://test' });
-      const abstractField = mockField({ wrapperKind: 'abstract' });
-      const candidates: Record<string, IFieldSubstituteInfo> = {
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      };
-
-      const result = WrapperActionService.resolveMemberSelectedQName(true, field, abstractField, candidates);
-
-      expect(result).toBe('ns:Cat');
-    });
-  });
-
-  describe('applyAbstractSubstitution', () => {
-    it('should route to per-instance when target side and maxOccurs > 1', () => {
-      const wrapperField = mockField({ maxOccurs: -1 });
-      const childField = mockField({ name: 'Cat', namespaceURI: 'http://test' });
-      wrapperField.fields = [childField];
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-      const candidates: Record<string, IFieldSubstituteInfo> = {
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      };
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue(candidates);
-      const mockFieldItem = new FieldItem(tree, childField);
-      vi.mocked(MappingActionService.getOrCreateFieldItem).mockReturnValue(mockFieldItem);
-      vi.mocked(MappingService.createFieldItem).mockReturnValue(mockFieldItem);
-
-      WrapperActionService.applyAbstractSubstitution(
-        nodeData,
-        wrapperField,
-        'ns:Cat',
-        candidates,
-        undefined,
-        namespaceMap,
-        true,
-      );
-
-      expect(FieldOverrideService.applyFieldSubstitution).not.toHaveBeenCalled();
-      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, childField);
-    });
-
-    it('should route to document-level when source side', () => {
-      const wrapperField = mockField({ maxOccurs: -1 });
-      const nodeData = {} as FieldNodeData;
-
-      WrapperActionService.applyAbstractSubstitution(
-        nodeData,
-        wrapperField,
-        'ns:Cat',
-        {},
-        undefined,
-        namespaceMap,
-        false,
-      );
-
-      expect(FieldOverrideService.applyFieldSubstitution).toHaveBeenCalledWith(wrapperField, 'ns:Cat', namespaceMap);
-    });
-
-    it('should route to document-level when maxOccurs is 1', () => {
-      const wrapperField = mockField({ maxOccurs: 1 });
-      const nodeData = {} as FieldNodeData;
-
-      WrapperActionService.applyAbstractSubstitution(
-        nodeData,
-        wrapperField,
-        'ns:Cat',
-        {},
-        undefined,
-        namespaceMap,
-        true,
-      );
-
-      expect(FieldOverrideService.applyFieldSubstitution).toHaveBeenCalledWith(wrapperField, 'ns:Cat', namespaceMap);
-    });
-  });
-
-  describe('clearAbstractSubstitution', () => {
-    it('should route to per-instance when target side and maxOccurs > 1', () => {
-      const wrapperField = mockField({ maxOccurs: -1 });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
-
-      expect(FieldOverrideService.revertFieldSubstitution).not.toHaveBeenCalled();
-      expect(SchemaPathService.build).not.toHaveBeenCalled();
-      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, wrapperField);
-    });
-
-    it('should route to document-level when source side', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapperField = mockField({ maxOccurs: -1, ownerDocument });
-      const nodeData = {} as FieldNodeData;
-
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, false);
-
-      expect(SchemaPathService.build).toHaveBeenCalledWith(wrapperField, namespaceMap);
-      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
-      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
-    });
-
-    it('should route to document-level when maxOccurs is 1', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapperField = mockField({ maxOccurs: 1, ownerDocument });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
-
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
-
-      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
-    });
-  });
-
-  describe('getChoiceFieldDisplayName', () => {
-    it('should use getChoiceMemberLabel for choice wrapper', () => {
-      const field = mockField({ wrapperKind: 'choice' });
-      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('(A | B)');
-
-      const result = WrapperActionService.getChoiceFieldDisplayName(field);
-
-      expect(result).toBe('(A | B)');
-      expect(VisualizationService.getChoiceMemberLabel).toHaveBeenCalledWith(field);
-    });
-
-    it('should use displayName for non-choice field', () => {
-      const field = mockField({ displayName: 'MyField' });
-
-      const result = WrapperActionService.getChoiceFieldDisplayName(field);
-
-      expect(result).toBe('MyField');
-    });
-
-    it('should fall back to name when displayName is empty', () => {
-      const field = mockField({ displayName: '', name: 'fallback' });
-
-      const result = WrapperActionService.getChoiceFieldDisplayName(field);
-
-      expect(result).toBe('fallback');
-    });
-  });
-
-  describe('dispatchChoiceSelection', () => {
-    it('should route to per-instance when target side and maxOccurs > 1', () => {
-      const memberField = mockField({ name: 'email' });
-      const wrapper = mockField({ maxOccurs: -1, fields: [memberField] });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapper);
-      const nodeData = createFieldItemNodeData(fieldItem);
-      vi.mocked(MappingActionService.getOrCreateFieldItem).mockReturnValue(fieldItem);
-      vi.mocked(MappingService.createFieldItem).mockReturnValue(new FieldItem(tree, memberField));
-
-      WrapperActionService.dispatchChoiceSelection(nodeData, wrapper, { memberIndex: 0 }, namespaceMap, true);
-
-      expect(WrapperSelectionService.setChoiceSelection).not.toHaveBeenCalled();
-      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, memberField);
-    });
-
-    it('should route to document-level otherwise', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
-      const nodeData = {} as FieldNodeData;
-
-      WrapperActionService.dispatchChoiceSelection(nodeData, wrapper, { memberIndex: 0 }, namespaceMap, false);
-
-      expect(WrapperSelectionService.setChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, 0, namespaceMap);
-    });
-  });
-
-  describe('clearChoiceSelectionOnField', () => {
-    it('should route to per-instance when target side and maxOccurs > 1', () => {
-      const wrapper = mockField({ maxOccurs: -1 });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapper);
-      const nodeData = createFieldItemNodeData(fieldItem);
-
-      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, true);
-
-      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
-      expect(MappingService.updateFieldItemField).toHaveBeenCalledWith(fieldItem, wrapper);
-    });
-
-    it('should route to document-level when source side', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
-      const nodeData = {} as FieldNodeData;
-
-      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, false);
-
-      expect(WrapperSelectionService.clearDescendantWrapperSelections).toHaveBeenCalledWith(wrapper, namespaceMap);
-      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
-      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, namespaceMap);
-    });
-
-    it('should route to document-level when maxOccurs is 1 and target side', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapper = mockField({ maxOccurs: 1, ownerDocument });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapper);
-      const nodeData = createTargetFieldNodeData(wrapper, fieldItem);
-
-      WrapperActionService.clearChoiceSelectionOnField(nodeData, wrapper, namespaceMap, true);
-
-      expect(WrapperSelectionService.clearDescendantWrapperSelections).toHaveBeenCalledWith(wrapper, namespaceMap);
-      expect(DocumentUtilService.invalidateDescendants).toHaveBeenCalled();
-      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(ownerDocument, wrapper, namespaceMap);
-    });
-  });
-
-  describe('resolveChoiceWrapper', () => {
-    it('should return choiceWrapperMemberField when isChoiceWrapperMember is true', () => {
-      const choiceField = mockField({ wrapperKind: 'choice' });
-      const fallback = mockField();
-
-      const result = WrapperActionService.resolveChoiceWrapper(true, choiceField, fallback);
-
-      expect(result).toBe(choiceField);
-    });
-
-    it('should return fallback when isChoiceWrapperMember is false', () => {
-      const choiceField = mockField({ wrapperKind: 'choice' });
-      const fallback = mockField();
-
-      const result = WrapperActionService.resolveChoiceWrapper(false, choiceField, fallback);
-
-      expect(result).toBe(fallback);
-    });
-  });
-
-  describe('resolveMemberSelectedKey', () => {
-    it('should return null when nodeData is not FieldItemNodeData', () => {
-      const nodeData = {} as FieldNodeData;
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, mockField(), [], namespaceMap);
-
-      expect(result).toBeNull();
-    });
-
-    it('should return null when wrapper is undefined', () => {
-      const field = mockField();
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, field);
-      const nodeData = createFieldItemNodeData(fieldItem);
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, undefined, [], namespaceMap);
-
-      expect(result).toBeNull();
-    });
-
-    it('should return null when member field not in wrapper.fields and no parent', () => {
-      const memberField = mockField({ name: 'unknown' });
-      const wrapper = mockField({ fields: [] });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, memberField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, [], namespaceMap);
-
-      expect(result).toBeNull();
-    });
-
-    it('should resolve via parent when idx < 0 with abstract parent', () => {
-      const abstractParent = mockField({ wrapperKind: 'abstract' }) as IField;
-      const memberField = mockField({ name: 'Cat', namespaceURI: 'http://test', parent: abstractParent });
-      const wrapper = mockField({ fields: [abstractParent] });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, memberField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
-        'ns:Cat': mockSubstituteInfo('Cat'),
-      });
-      const dissolved = [
-        {
-          key: '0:ns:Cat',
-          label: 'Cat',
-          typeBadge: Types.Container,
-          selection: { memberIndex: 0, substituteQName: 'ns:Cat' },
-        },
-      ];
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, dissolved, namespaceMap);
-
-      expect(result).toBe('0:ns:Cat');
-    });
-
-    it('should return matching dissolved key when idx >= 0', () => {
-      const memberField = mockField({ name: 'email' });
-      const wrapper = mockField({ fields: [memberField] });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, memberField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-      const dissolved = [{ key: '0', label: 'Email', typeBadge: Types.String, selection: { memberIndex: 0 } }];
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, dissolved, namespaceMap);
-
-      expect(result).toBe('0');
-    });
-
-    it('should return null when idx >= 0 but no dissolved match', () => {
-      const memberField = mockField({ name: 'email' });
-      const wrapper = mockField({ fields: [memberField] });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, memberField);
-      const nodeData = createFieldItemNodeData(fieldItem);
-
-      const result = WrapperActionService.resolveMemberSelectedKey(nodeData, wrapper, [], namespaceMap);
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('resolveSelectedModalKey', () => {
-    it('should return memberSelectedKey when isChoiceWrapperMember is true', () => {
-      const result = WrapperActionService.resolveSelectedModalKey(true, 'key1', undefined, []);
-
-      expect(result).toBe('key1');
-    });
-
-    it('should return null when selectedMemberIndex is undefined', () => {
-      const wrapper = mockField();
-
-      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, []);
-
-      expect(result).toBeNull();
-    });
-
-    it('should match dissolved with substituteQName for abstract member', () => {
-      const qname = new QName('http://test', 'Cat');
-      const abstractMember = mockField({
-        wrapperKind: 'abstract',
-        selectedMemberQName: qname,
-      });
-      const wrapper = mockField({ selectedMemberIndex: 0, fields: [abstractMember] });
-      const dissolved = [
-        {
-          key: '0:ns:Cat',
-          label: 'Cat',
-          typeBadge: Types.Container,
-          selection: { memberIndex: 0, substituteQName: qname.toString() },
-        },
-      ];
-
-      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, dissolved);
-
-      expect(result).toBe('0:ns:Cat');
-    });
-
-    it('should match dissolved without substituteQName for normal member', () => {
-      const normalMember = mockField({ name: 'email' });
-      const wrapper = mockField({ selectedMemberIndex: 0, fields: [normalMember] });
-      const dissolved = [{ key: '0', label: 'Email', typeBadge: Types.String, selection: { memberIndex: 0 } }];
-
-      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, dissolved);
-
-      expect(result).toBe('0');
-    });
-
-    it('should return null when no dissolved candidate matches', () => {
-      const normalMember = mockField({ name: 'email' });
-      const wrapper = mockField({ selectedMemberIndex: 0, fields: [normalMember] });
-
-      const result = WrapperActionService.resolveSelectedModalKey(false, null, wrapper, []);
-
-      expect(result).toBeNull();
-    });
-  });
-
   describe('revertOverride', () => {
     it('should call revertFieldSubstitution when field has SUBSTITUTION override', () => {
       const testTargetDoc = TestUtil.createTargetOrderDoc();
@@ -982,69 +246,232 @@ describe('WrapperActionService', () => {
     });
   });
 
-  describe('clearAbstractSubstitution / choice>abstract cascade (#3532)', () => {
-    it('should cascade clear to parent choice when document-level maxOccurs=1', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
-      const wrapperField = mockField({ maxOccurs: 1, ownerDocument, parent: parentChoiceField });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+  describe('computeAddFieldCandidates', () => {
+    function createXmlSchemaDocument(): XmlSchemaDocument {
+      const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, 'test');
+      return new XmlSchemaDocument(definition, new XmlSchemaCollection());
+    }
 
-      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+    it('should return all candidates when no existing field items', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const childA = new XmlSchemaField(parent, 'ChildA', false);
+      childA.type = Types.String;
+      const childB = new XmlSchemaField(parent, 'ChildB', false);
+      childB.type = Types.String;
+      parent.fields = [childA, childB];
+      doc.fields = [parent];
 
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, []);
 
-      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
-      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
-        ownerDocument,
-        parentChoiceField,
-        namespaceMap,
-      );
+      expect(result.candidates).toHaveLength(2);
+      expect(result.fields).toHaveLength(2);
+      expect(result.fields[0]).toBe(childA);
+      expect(result.fields[1]).toBe(childB);
     });
 
-    it('should cascade clear to parent choice when document-level source maxOccurs>1', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const parentChoiceField = mockField({ wrapperKind: 'choice', ownerDocument });
-      const wrapperField = mockField({ maxOccurs: -1, ownerDocument, parent: parentChoiceField });
-      const nodeData = {} as FieldNodeData;
+    it('should exclude maxOccurs=1 child when slot is occupied by direct field match', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const childA = new XmlSchemaField(parent, 'ChildA', false);
+      childA.type = Types.String;
+      childA.maxOccurs = 1;
+      const childB = new XmlSchemaField(parent, 'ChildB', false);
+      childB.type = Types.String;
+      childB.maxOccurs = 1;
+      parent.fields = [childA, childB];
+      doc.fields = [parent];
 
-      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(parentChoiceField);
+      const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+      const existingFieldItem = new FieldItem(tree, childA);
 
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, false);
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
 
-      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
-      expect(WrapperSelectionService.clearChoiceSelection).toHaveBeenCalledWith(
-        ownerDocument,
-        parentChoiceField,
-        namespaceMap,
-      );
+      expect(result.candidates).toHaveLength(1);
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0]).toBe(childB);
     });
 
-    it('should NOT cascade for per-instance clear (target maxOccurs>1)', () => {
-      const wrapperField = mockField({ maxOccurs: -1 });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createFieldItemNodeData(fieldItem);
+    it('should not exclude maxOccurs=unbounded child even when occupied', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const child = new XmlSchemaField(parent, 'Child', false);
+      child.type = Types.String;
+      child.maxOccurs = 'unbounded';
+      parent.fields = [child];
+      doc.fields = [parent];
 
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+      const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+      const existingFieldItem = new FieldItem(tree, child);
 
-      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
+
+      expect(result.candidates).toHaveLength(1);
+      expect(result.fields[0]).toBe(child);
     });
 
-    it('should NOT cascade when no choice parent', () => {
-      const ownerDocument = TestUtil.createTargetOrderDoc();
-      const wrapperField = mockField({ maxOccurs: 1, ownerDocument });
-      const tree = createMappingTree();
-      const fieldItem = new FieldItem(tree, wrapperField);
-      const nodeData = createTargetFieldNodeData(wrapperField, fieldItem);
+    it('should exclude abstract wrapper (maxOccurs=1) when a descendant substitute is mapped', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const abstractField = new XmlSchemaField(parent, 'Abstract', false);
+      abstractField.type = Types.Container;
+      abstractField.wrapperKind = 'abstract';
+      abstractField.maxOccurs = 1;
+      const concreteChild = new XmlSchemaField(abstractField, 'Concrete', false);
+      concreteChild.type = Types.String;
+      abstractField.fields = [concreteChild];
+      parent.fields = [abstractField];
+      doc.fields = [parent];
 
-      vi.mocked(WrapperSelectionService.findParentWrapper).mockReturnValue(undefined);
+      const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+      const existingFieldItem = new FieldItem(tree, concreteChild);
 
-      WrapperActionService.clearAbstractSubstitution(nodeData, wrapperField, namespaceMap, true);
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Concrete': mockSubstituteInfo('Concrete'),
+      });
+      vi.spyOn(WrapperActionService, 'resolveCandidateField').mockReturnValue(concreteChild);
 
-      expect(FieldOverrideService.revertFieldSubstitution).toHaveBeenCalledWith(wrapperField, namespaceMap);
-      expect(WrapperSelectionService.clearChoiceSelection).not.toHaveBeenCalled();
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.fields).toHaveLength(0);
+    });
+
+    it('should exclude choice wrapper (maxOccurs=1) when a member is mapped', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const choiceField = new XmlSchemaField(parent, '__choice__', false);
+      choiceField.type = Types.Container;
+      choiceField.wrapperKind = 'choice';
+      choiceField.maxOccurs = 1;
+      const memberA = new XmlSchemaField(choiceField, 'MemberA', false);
+      memberA.type = Types.String;
+      const memberB = new XmlSchemaField(choiceField, 'MemberB', false);
+      memberB.type = Types.String;
+      choiceField.fields = [memberA, memberB];
+      parent.fields = [choiceField];
+      doc.fields = [parent];
+
+      const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+      const existingFieldItem = new FieldItem(tree, memberA);
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
+
+      expect(result.candidates).toHaveLength(0);
+      expect(result.fields).toHaveLength(0);
+    });
+
+    it('should not exclude choice wrapper (maxOccurs=unbounded) when a member is mapped', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const choiceField = new XmlSchemaField(parent, '__choice__', false);
+      choiceField.type = Types.Container;
+      choiceField.wrapperKind = 'choice';
+      choiceField.maxOccurs = 'unbounded';
+      const memberA = new XmlSchemaField(choiceField, 'MemberA', false);
+      memberA.type = Types.String;
+      const memberB = new XmlSchemaField(choiceField, 'MemberB', false);
+      memberB.type = Types.String;
+      choiceField.fields = [memberA, memberB];
+      parent.fields = [choiceField];
+      doc.fields = [parent];
+
+      const tree = new MappingTree(DocumentType.TARGET_BODY, 'test', DocumentDefinitionType.XML_SCHEMA);
+      const existingFieldItem = new FieldItem(tree, memberA);
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [existingFieldItem]);
+
+      expect(result.candidates).toHaveLength(2);
+      expect(result.fields[0]).toBe(memberA);
+      expect(result.fields[1]).toBe(memberB);
+    });
+
+    it('should dissolve sequence wrappers and include their member fields', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const seqWrapper = new XmlSchemaField(parent, 'seq', false);
+      seqWrapper.wrapperKind = 'sequence';
+      const seqChildA = new XmlSchemaField(seqWrapper, 'SeqChildA', false);
+      seqChildA.type = Types.String;
+      const seqChildB = new XmlSchemaField(seqWrapper, 'SeqChildB', false);
+      seqChildB.type = Types.String;
+      seqWrapper.fields = [seqChildA, seqChildB];
+      parent.fields = [seqWrapper];
+      doc.fields = [parent];
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, []);
+
+      expect(result.candidates).toHaveLength(2);
+      expect(result.fields[0]).toBe(seqChildA);
+      expect(result.fields[1]).toBe(seqChildB);
+    });
+
+    it('should exclude maxOccurs=1 children in forEachContext', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const singleChild = new XmlSchemaField(parent, 'Single', false);
+      singleChild.type = Types.String;
+      singleChild.maxOccurs = 1;
+      const collectionChild = new XmlSchemaField(parent, 'Collection', false);
+      collectionChild.type = Types.String;
+      collectionChild.maxOccurs = 'unbounded';
+      parent.fields = [singleChild, collectionChild];
+      doc.fields = [parent];
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [], true);
+
+      expect(result.candidates).toHaveLength(1);
+      expect(result.fields[0]).toBe(collectionChild);
+    });
+
+    it('should include all children when forEachContext is false (default)', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const singleChild = new XmlSchemaField(parent, 'Single', false);
+      singleChild.type = Types.String;
+      singleChild.maxOccurs = 1;
+      const collectionChild = new XmlSchemaField(parent, 'Collection', false);
+      collectionChild.type = Types.String;
+      collectionChild.maxOccurs = 'unbounded';
+      parent.fields = [singleChild, collectionChild];
+      doc.fields = [parent];
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, []);
+
+      expect(result.candidates).toHaveLength(2);
+      expect(result.fields[0]).toBe(singleChild);
+      expect(result.fields[1]).toBe(collectionChild);
+    });
+
+    it('should dissolve sequences and apply forEachContext filter to members', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const seqWrapper = new XmlSchemaField(parent, 'seq', false);
+      seqWrapper.wrapperKind = 'sequence';
+      const singleMember = new XmlSchemaField(seqWrapper, 'Single', false);
+      singleMember.type = Types.String;
+      singleMember.maxOccurs = 1;
+      const collectionMember = new XmlSchemaField(seqWrapper, 'Collection', false);
+      collectionMember.type = Types.String;
+      collectionMember.maxOccurs = 'unbounded';
+      seqWrapper.fields = [singleMember, collectionMember];
+      parent.fields = [seqWrapper];
+      doc.fields = [parent];
+
+      const result = WrapperActionService.computeAddFieldCandidates(parent.fields, {}, [], true);
+
+      expect(result.candidates).toHaveLength(1);
+      expect(result.fields[0]).toBe(collectionMember);
     });
   });
 });

--- a/packages/ui/src/services/visualization/wrapper-action.service.ts
+++ b/packages/ui/src/services/visualization/wrapper-action.service.ts
@@ -1,6 +1,18 @@
+import type { ReactNode } from 'react';
+
 import { IField } from '../../models/datamapper/document';
+import {
+  IAbstractFieldInfo,
+  IAbstractMenuGroupsConfig,
+  IChoiceMenuGroupsConfig,
+  IChoiceNodeInfo,
+  IFieldMenuAction,
+  IFieldMenuGroup,
+  IMemberSelection,
+  IWrapperCandidate,
+} from '../../models/datamapper/field-action';
 import { FieldItem, InstructionItem } from '../../models/datamapper/mapping';
-import { FieldOverrideVariant, IFieldSubstituteInfo, Types } from '../../models/datamapper/types';
+import { FieldOverrideVariant, IFieldSubstituteInfo } from '../../models/datamapper/types';
 import {
   FieldItemNodeData,
   NodeData,
@@ -9,6 +21,7 @@ import {
   TargetFieldNodeData,
   TargetNodeData,
 } from '../../models/datamapper/visualization';
+import { DocumentService } from '../document/document.service';
 import { DocumentUtilService } from '../document/document-util.service';
 import { FieldOverrideService } from '../document/field-override.service';
 import { WrapperSelectionService } from '../document/wrapper-selection.service';
@@ -18,37 +31,20 @@ import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 import { VisualizationUtilService } from './visualization-util.service';
 
-export interface MemberSelection {
-  memberIndex: number;
-  substituteQName?: string;
-}
-
-export interface WrapperCandidate {
-  key: string;
-  label: string;
-  typeBadge: Types;
-  description?: string;
-  childrenPreview?: string[];
-  selection: MemberSelection;
-}
-
-export interface AbstractFieldInfo {
-  isAbstractWrapper: boolean;
-  isAbstractWrapperMember: boolean;
-  isSelectedSubstitution: boolean;
-  isSubstitutionCandidate: boolean;
-  abstractWrapperField: IField | undefined;
-  field: IField | undefined;
-  parentAbstractField: IField | undefined;
-  candidateQName: string | undefined;
-}
-
 const MAX_CHILDREN_PREVIEW = 3;
 
 function childrenPreview(field: IField): string[] | undefined {
   const children = field.fields;
   if (!children || children.length === 0) return undefined;
   return children.slice(0, MAX_CHILDREN_PREVIEW).map((c) => c.displayName || c.name);
+}
+
+const INLINE_SUBSTITUTION_LIMIT = 10;
+const INLINE_CHOICE_LIMIT = 10;
+
+interface CandidateEntry {
+  candidate: IWrapperCandidate;
+  field: IField;
 }
 
 /**
@@ -58,7 +54,7 @@ function childrenPreview(field: IField): string[] | undefined {
  * menu-utils, and revert-override — leaving hooks as thin UI adapters.
  */
 export class WrapperActionService {
-  // ── Group A: Field Classification / Resolution ──
+  // ── Field Classification / Resolution ──
 
   private static findCandidateQName(
     candidates: Record<string, IFieldSubstituteInfo>,
@@ -88,7 +84,7 @@ export class WrapperActionService {
     );
   }
 
-  static resolveAbstractFieldInfo(nodeData: NodeData, namespaceMap: Record<string, string>): AbstractFieldInfo {
+  static resolveAbstractFieldInfo(nodeData: NodeData, namespaceMap: Record<string, string>): IAbstractFieldInfo {
     const field = VisualizationUtilService.getField(nodeData);
     const isAbstractWrapper = field?.wrapperKind === 'abstract';
     const isAbstractWrapperMember = VisualizationUtilService.isAbstractWrapperMember(nodeData);
@@ -125,9 +121,9 @@ export class WrapperActionService {
     };
   }
 
-  // ── Group B: Candidate Building ──
+  // ── Candidate Building ──
 
-  static fieldToCandidate(field: IField, key: string, memberIndex: number): WrapperCandidate {
+  static fieldToCandidate(field: IField, key: string, memberIndex: number): IWrapperCandidate {
     const label =
       field.wrapperKind === 'choice'
         ? VisualizationService.getChoiceMemberLabel(field)
@@ -150,7 +146,7 @@ export class WrapperActionService {
    * without navigating through the intermediate abstract element. On confirm,
    * both `selectedMemberIndex` and `selectedMemberQName` are set in one action.
    */
-  static dissolveChoiceMembers(members: IField[], namespaceMap: Record<string, string>): WrapperCandidate[] {
+  static dissolveChoiceMembers(members: IField[], namespaceMap: Record<string, string>): IWrapperCandidate[] {
     return members.flatMap((member, index) => {
       if (member.wrapperKind === 'abstract') {
         const candidates = FieldOverrideService.getFieldSubstitutionCandidates(member, namespaceMap);
@@ -171,7 +167,7 @@ export class WrapperActionService {
    * `memberIndex` is set to 0 — abstract wrappers have a single logical
    * member slot (the selected substitute replaces the wrapper).
    */
-  static buildAbstractCandidates(abstractField: IField, namespaceMap: Record<string, string>): WrapperCandidate[] {
+  static buildAbstractCandidates(abstractField: IField, namespaceMap: Record<string, string>): IWrapperCandidate[] {
     const candidates = FieldOverrideService.getFieldSubstitutionCandidates(abstractField, namespaceMap);
     return Object.entries(candidates).map(([qname, info]) => ({
       key: qname,
@@ -181,7 +177,7 @@ export class WrapperActionService {
     }));
   }
 
-  // ── Group C: Abstract Substitution Orchestration ──
+  // ── Abstract Substitution Orchestration ──
 
   static resolveSubstitutionCandidates(
     abstractWrapperField: IField | undefined,
@@ -310,7 +306,7 @@ export class WrapperActionService {
     }
   }
 
-  // ── Group D: Choice Selection Orchestration ──
+  // ── Choice Selection Orchestration ──
 
   static getChoiceFieldDisplayName(field: IField): string {
     return field.wrapperKind === 'choice'
@@ -321,7 +317,7 @@ export class WrapperActionService {
   static dispatchChoiceSelection(
     nodeData: NodeData,
     wrapper: IField,
-    selection: MemberSelection,
+    selection: IMemberSelection,
     namespaceMap: Record<string, string>,
     isTargetSide: boolean,
   ): void {
@@ -356,7 +352,7 @@ export class WrapperActionService {
   static resolveMemberSelectedKey(
     nodeData: NodeData,
     choiceWrapperMemberField: IField | undefined,
-    dissolved: WrapperCandidate[],
+    dissolved: IWrapperCandidate[],
     namespaceMap: Record<string, string>,
   ): string | null {
     if (!(nodeData instanceof FieldItemNodeData)) return null;
@@ -385,7 +381,7 @@ export class WrapperActionService {
     isChoiceWrapperMember: boolean,
     memberSelectedKey: string | null,
     activeChoiceWrapperForMembers: IField | undefined,
-    dissolved: WrapperCandidate[],
+    dissolved: IWrapperCandidate[],
   ): string | null {
     if (isChoiceWrapperMember) return memberSelectedKey;
     const idx = activeChoiceWrapperForMembers?.selectedMemberIndex;
@@ -401,7 +397,7 @@ export class WrapperActionService {
   private static applyPerInstanceChoiceSelection(
     nodeData: NodeData,
     wrapper: IField,
-    selection: MemberSelection,
+    selection: IMemberSelection,
     namespaceMap: Record<string, string>,
   ): void {
     let candidateField: IField | undefined = wrapper.fields[selection.memberIndex];
@@ -422,7 +418,7 @@ export class WrapperActionService {
   private static applyDocumentLevelChoiceSelection(
     nodeData: NodeData,
     wrapper: IField,
-    selection: MemberSelection,
+    selection: IMemberSelection,
     namespaceMap: Record<string, string>,
     isTargetSide: boolean,
   ): void {
@@ -461,7 +457,7 @@ export class WrapperActionService {
     WrapperSelectionService.clearChoiceSelection(doc, wrapper, namespaceMap);
   }
 
-  // ── Group E: Mapping Mutations (moved from MappingActionService) ──
+  // ── Mapping Mutations ──
 
   /**
    * Creates or updates a per-instance member selection for a wrapper field. Unlike the
@@ -520,7 +516,7 @@ export class WrapperActionService {
     WrapperActionService.clearTargetSelection(nodeData, wrapperField);
   }
 
-  // ── Group F: Revert Override ──
+  // ── Revert Override ──
 
   /**
    * Revert a field override (type override or substitution) without opening the modal.
@@ -543,7 +539,7 @@ export class WrapperActionService {
    * no side effects. Used by {@link useChoiceContextMenu} to determine what menu
    * actions to offer.
    */
-  static resolveChoiceNodeInfo(nodeData: NodeData): ChoiceNodeInfo {
+  static resolveChoiceNodeInfo(nodeData: NodeData): IChoiceNodeInfo {
     const field = VisualizationUtilService.getField(nodeData);
     const isChoiceWrapper = field?.wrapperKind === 'choice';
     const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
@@ -588,34 +584,267 @@ export class WrapperActionService {
       choiceMemberIndex,
     };
   }
-}
 
-/**
- * Full choice context resolved for a given node. Each field captures one aspect
- * of the node's relationship to choice wrappers.
- *
- * @property isChoiceWrapper - The node's own field has `wrapperKind === 'choice'`
- * @property isSelectedChoice - The node is a choice field with a selected member (flattened view)
- * @property isChoiceMember - The node's field is a direct child of a choice wrapper
- * @property isChoiceWrapperMember - The node is a per-instance FieldItem belonging to a collection wrapper
- * @property activeChoiceWrapperForMembers - The choice wrapper whose members should be offered in the context menu
- * @property effectiveChoiceWrapper - The wrapper that governs this node (wrapper member takes priority)
- * @property choiceWrapperField - The outermost selected choice wrapper (walks up through nested choices)
- * @property choiceWrapperMemberField - The wrapper field from a per-instance FieldItem
- * @property choiceMemberField - The field representing this node as a choice member
- * @property parentChoiceWrapperField - The parent choice wrapper field if this node is a direct member
- * @property choiceMemberIndex - The 0-based index of this member within its parent choice
- */
-export interface ChoiceNodeInfo {
-  isChoiceWrapper: boolean;
-  isSelectedChoice: boolean;
-  isChoiceMember: boolean;
-  isChoiceWrapperMember: boolean;
-  activeChoiceWrapperForMembers: IField | undefined;
-  effectiveChoiceWrapper: IField | undefined;
-  choiceWrapperField: IField | undefined;
-  choiceWrapperMemberField: IField | undefined;
-  choiceMemberField: IField | undefined;
-  parentChoiceWrapperField: IField | undefined;
-  choiceMemberIndex: number | undefined;
+  // ── Menu Builders ──
+
+  /**
+   * Assembles context menu groups for a node involved with abstract wrappers.
+   * Dispatches to one of three paths: (1) abstract-inside-choice — only a
+   * clear action when a substitute is already selected, since the choice menu
+   * owns member selection; (2) abstract wrapper or wrapper member — inline
+   * candidates or a modal launcher depending on count; (3) substitution
+   * candidate — clear/change actions for the current selection.
+   */
+  static buildMenuGroupsForAbstractNode(config: IAbstractMenuGroupsConfig): IFieldMenuGroup[] {
+    if (config.isInsideChoiceWrapper && config.isAbstractWrapper) {
+      const hasSelection = config.selectedQName !== undefined;
+      return hasSelection ? [{ actions: [config.clearSubstitutionAction] }] : [];
+    }
+    if (config.isAbstractWrapper || config.isAbstractWrapperMember) {
+      return WrapperActionService.buildAbstractWrapperMenuGroups(config);
+    }
+    const substitutionActions: IFieldMenuAction[] = [];
+    if (config.isSelectedSubstitution)
+      substitutionActions.push(config.clearSubstitutionAction, config.changeSubstituteAction);
+    if (config.selectSelfAction) substitutionActions.push(config.selectSelfAction);
+    return [{ actions: substitutionActions }];
+  }
+
+  /**
+   * Assembles context menu groups for a node involved with choice wrappers.
+   * Wrapper/wrapper-member nodes get inline members or a modal launcher;
+   * nested selected choices additionally get clear/change actions appended.
+   * Non-wrapper selected choices get only clear/change.
+   */
+  static buildMenuGroupsForChoiceNode(config: IChoiceMenuGroupsConfig): IFieldMenuGroup[] {
+    if (config.isChoiceWrapper || config.isChoiceWrapperMember) {
+      const groups = WrapperActionService.buildChoiceWrapperMenuGroups(config);
+      if (config.isNestedSelectedChoice)
+        groups.push({ actions: [config.clearChoiceAction, config.changeMemberAction] });
+      return groups;
+    }
+    const choiceActions: IFieldMenuAction[] = [];
+    if (config.isSelectedChoice) choiceActions.push(config.clearChoiceAction, config.changeMemberAction);
+    if (config.selectSelfAction) choiceActions.push(config.selectSelfAction);
+    return [{ actions: choiceActions }];
+  }
+
+  private static buildAbstractWrapperMenuGroups(config: IAbstractMenuGroupsConfig): IFieldMenuGroup[] {
+    const selectedQName = config.isAbstractWrapperMember ? config.memberSelectedQName : config.selectedQName;
+    const selectSelfAction = config.isAbstractWrapperMember ? undefined : config.selectSelfAction;
+    const candidateCount = Object.keys(config.candidates).length;
+
+    if (candidateCount === 0 && selectedQName === undefined) {
+      return selectSelfAction ? [{ actions: [selectSelfAction] }] : [];
+    }
+
+    const candidatesGroup: IFieldMenuGroup =
+      candidateCount <= INLINE_SUBSTITUTION_LIMIT
+        ? {
+            actions: WrapperActionService.buildInlineSubstitutionActions(
+              config.candidates,
+              selectedQName,
+              config.onSelectSubstitution,
+              config.selectedIcon,
+              config.unselectedIcon,
+            ),
+          }
+        : {
+            actions: [
+              {
+                label: 'Select Substitute...',
+                onClick: config.onOpenSubstitutionModal,
+                testId: 'open-substitution-modal',
+              },
+            ],
+          };
+
+    const hasSelection = selectedQName !== undefined;
+    return [
+      { actions: selectSelfAction ? [selectSelfAction] : [] },
+      candidatesGroup,
+      { actions: hasSelection ? [config.clearSubstitutionAction] : [] },
+    ];
+  }
+
+  private static buildInlineSubstitutionActions(
+    candidates: Record<string, IFieldSubstituteInfo>,
+    selectedQName: string | undefined,
+    onSelect: (qname: string) => void,
+    selectedIcon: ReactNode,
+    unselectedIcon: ReactNode,
+  ): IFieldMenuAction[] {
+    return Object.entries(candidates).map(([qname, info]) => ({
+      label: info.displayName,
+      onClick: () => {
+        onSelect(qname);
+      },
+      icon: selectedQName === qname ? selectedIcon : unselectedIcon,
+      testId: `substitution-menu-item-${qname}`,
+    }));
+  }
+
+  private static buildChoiceWrapperMenuGroups(config: IChoiceMenuGroupsConfig): IFieldMenuGroup[] {
+    const selectSelfAction = config.isChoiceWrapperMember ? undefined : config.selectSelfAction;
+
+    if (config.dissolved.length === 0 && config.selectedModalKey === null) {
+      return selectSelfAction ? [{ actions: [selectSelfAction] }] : [];
+    }
+
+    const membersGroup: IFieldMenuGroup =
+      config.dissolved.length <= INLINE_CHOICE_LIMIT
+        ? {
+            actions: WrapperActionService.buildInlineMemberActions(
+              config.dissolved,
+              config.selectedModalKey,
+              config.onSelectChoiceMember,
+              config.selectedIcon,
+              config.unselectedIcon,
+            ),
+          }
+        : { actions: [{ label: 'Select Member...', onClick: config.onOpenChoiceModal, testId: 'open-choice-modal' }] };
+
+    const hasSelection = config.selectedModalKey !== null;
+    return [
+      { actions: selectSelfAction ? [selectSelfAction] : [] },
+      membersGroup,
+      { actions: hasSelection ? [config.clearChoiceAction] : [] },
+    ];
+  }
+
+  private static buildInlineMemberActions(
+    dissolvedMembers: IWrapperCandidate[],
+    selectedKey: string | null,
+    onSelect: (selection: IMemberSelection) => void,
+    selectedIcon: ReactNode,
+    unselectedIcon: ReactNode,
+  ): IFieldMenuAction[] {
+    return dissolvedMembers.map(({ key, label, selection }) => ({
+      label,
+      onClick: () => {
+        onSelect(selection);
+      },
+      icon: selectedKey === key ? selectedIcon : unselectedIcon,
+      testId: selection.substituteQName
+        ? 'choice-menu-item-' + selection.memberIndex + '-' + selection.substituteQName
+        : 'choice-menu-item-' + selection.memberIndex,
+    }));
+  }
+
+  // ── Add-Field Candidates ──
+
+  /**
+   * Builds the candidate list for the "Add field" modal in the mapping context
+   * menu. Walks `schemaFields` and flattens wrapper layers: sequences are
+   * dissolved recursively, choices and abstract wrappers are expanded into
+   * their concrete members/substitutes. Fields whose `maxOccurs` slot is
+   * already occupied by `existingFieldItems` are excluded. In `forEachContext`,
+   * non-collection (maxOccurs=1) plain fields are skipped because for-each
+   * iterates collections only.
+   *
+   * Returns parallel arrays: `candidates` for the modal UI and `fields` for
+   * resolving the selected `memberIndex` back to the schema field.
+   */
+  static computeAddFieldCandidates(
+    schemaFields: IField[],
+    namespaceMap: Record<string, string>,
+    existingFieldItems: FieldItem[] = [],
+    forEachContext = false,
+  ): { candidates: IWrapperCandidate[]; fields: IField[] } {
+    const candidates: IWrapperCandidate[] = [];
+    const fields: IField[] = [];
+    let index = 0;
+
+    for (const child of schemaFields) {
+      if (child.wrapperKind === 'sequence') {
+        const nested = WrapperActionService.computeAddFieldCandidates(
+          child.fields,
+          namespaceMap,
+          existingFieldItems,
+          forEachContext,
+        );
+        for (let i = 0; i < nested.candidates.length; i++) {
+          candidates.push({
+            ...nested.candidates[i],
+            key: `${index}`,
+            selection: { ...nested.candidates[i].selection, memberIndex: index },
+          });
+          fields.push(nested.fields[i]);
+          index++;
+        }
+        continue;
+      }
+
+      if (WrapperActionService.shouldSkipField(child, forEachContext)) continue;
+      if (WrapperActionService.isSlotExhausted(child, existingFieldItems)) continue;
+
+      for (const { candidate, field } of WrapperActionService.resolveFieldEntries(child, namespaceMap)) {
+        candidate.key = `${index}`;
+        candidate.selection.memberIndex = index;
+        candidates.push(candidate);
+        fields.push(field);
+        index++;
+      }
+    }
+
+    return { candidates, fields };
+  }
+
+  private static resolveAbstractSubstitutes(
+    abstractField: IField,
+    namespaceMap: Record<string, string>,
+  ): CandidateEntry[] {
+    const subs = FieldOverrideService.getFieldSubstitutionCandidates(abstractField, namespaceMap);
+    const entries: CandidateEntry[] = [];
+    for (const [qname, info] of Object.entries(subs)) {
+      const field = WrapperActionService.resolveCandidateField(abstractField, qname, subs, abstractField, namespaceMap);
+      if (!field) continue;
+      entries.push({
+        candidate: {
+          key: '',
+          label: info.displayName,
+          typeBadge: info.type,
+          selection: { memberIndex: 0, substituteQName: qname },
+        },
+        field,
+      });
+    }
+    return entries;
+  }
+
+  private static resolveChoiceMembers(choiceField: IField, namespaceMap: Record<string, string>): CandidateEntry[] {
+    const entries: CandidateEntry[] = [];
+    for (const member of choiceField.fields) {
+      if (member.wrapperKind === 'abstract') {
+        entries.push(...WrapperActionService.resolveAbstractSubstitutes(member, namespaceMap));
+      } else if (member.wrapperKind !== 'sequence') {
+        entries.push({ candidate: WrapperActionService.fieldToCandidate(member, '', 0), field: member });
+      }
+    }
+    return entries;
+  }
+
+  private static resolveFieldEntries(child: IField, namespaceMap: Record<string, string>): CandidateEntry[] {
+    if (child.wrapperKind === 'choice') return WrapperActionService.resolveChoiceMembers(child, namespaceMap);
+    if (child.wrapperKind === 'abstract') return WrapperActionService.resolveAbstractSubstitutes(child, namespaceMap);
+    return [{ candidate: WrapperActionService.fieldToCandidate(child, '', 0), field: child }];
+  }
+
+  private static shouldSkipField(child: IField, forEachContext: boolean): boolean {
+    if (!forEachContext) return false;
+    return (
+      child.wrapperKind !== 'choice' &&
+      child.wrapperKind !== 'abstract' &&
+      child.maxOccurs !== 'unbounded' &&
+      Number(child.maxOccurs) <= 1
+    );
+  }
+
+  private static isSlotExhausted(child: IField, existingFieldItems: FieldItem[]): boolean {
+    if (child.maxOccurs === 'unbounded') return false;
+    const occupied = existingFieldItems.filter(
+      (fi) => fi.field === child || DocumentService.isDescendant(child, fi.field),
+    ).length;
+    return occupied >= Number(child.maxOccurs);
+  }
 }


### PR DESCRIPTION
…nto model/service layer

Fixes: https://github.com/KaotoIO/kaoto/issues/3538

- Extract field context menu logic from hooks/components into WrapperActionService methods
- Introduce field-action.ts model collection as a contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved context menus for abstract and choice fields with consistent selection, substitution, and clear/change actions.
  * Enhanced “Add field” modal candidates, including better support for sequences, wrappers, and occurrence-limit filtering, with inline vs modal selection options.
* **Bug Fixes**
  * More reliable handling of per-instance vs document-level selection/substitution and clearing, especially for wrapper/choice interactions.
* **Tests**
  * Expanded automated coverage for menu behavior and wrapper action/candidate workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->