### PR TITLE
fix(DataMapper): Preserve field expansion state when mapping is created

### DIFF
--- a/packages/ui/src/services/visualization/tree-ui.service.test.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.test.ts
@@ -6,7 +6,14 @@ import {
   PrimitiveDocument,
 } from '../../models/datamapper/document';
 import { DocumentTree } from '../../models/datamapper/document-tree';
-import { DocumentNodeData } from '../../models/datamapper/visualization';
+import { MappingTree } from '../../models/datamapper/mapping';
+import {
+  DocumentNodeData,
+  FieldItemNodeData,
+  TargetDocumentNodeData,
+  TargetFieldNodeData,
+} from '../../models/datamapper/visualization';
+import { MappingService } from '../../services/mapping/mapping.service';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
@@ -457,6 +464,64 @@ describe('TreeUIService', () => {
 
       // After odd number of toggles, state should be opposite of initial
       expect(store.isExpanded(documentId, nodePath)).toBe(!initialState);
+    });
+  });
+
+  describe('expansion state preservation across tree rebuild', () => {
+    it('should preserve collapsed state when tree is rebuilt for same document', () => {
+      const tree = TreeUIService.createTree(sourceDocNode);
+      const documentId = sourceDocNode.id;
+      const store = useDocumentTreeStore.getState();
+
+      const contentRoot = tree.contentRoots[0];
+      expect(store.isExpanded(documentId, contentRoot.path)).toBe(true);
+
+      TreeUIService.toggleNode(documentId, contentRoot.path);
+      expect(store.isExpanded(documentId, contentRoot.path)).toBe(false);
+
+      const tree2 = TreeUIService.createTree(sourceDocNode);
+      const contentRoot2 = tree2.contentRoots[0];
+      expect(store.isExpanded(documentId, contentRoot2.path)).toBe(false);
+    });
+
+    it('should preserve expansion state via field identity when node type transitions', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      const targetDocNode = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const tree1 = TreeUIService.createTree(targetDocNode);
+      const documentId = targetDocNode.id;
+      const store = useDocumentTreeStore.getState();
+
+      const contentRoot = tree1.contentRoots[0];
+      expect(contentRoot.nodeData).toBeInstanceOf(TargetFieldNodeData);
+      expect(store.isExpanded(documentId, contentRoot.path)).toBe(true);
+
+      TreeUIService.toggleNode(documentId, contentRoot.path);
+      expect(store.isExpanded(documentId, contentRoot.path)).toBe(false);
+
+      const field = (contentRoot.nodeData as TargetFieldNodeData).field;
+      MappingService.createFieldItem(mappingTree, field);
+
+      const newMappingTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      newMappingTree.children = mappingTree.children.map((child) => {
+        child.parent = newMappingTree;
+        return child;
+      });
+      const targetDocNode2 = new TargetDocumentNodeData(targetDoc, newMappingTree);
+      const tree2 = TreeUIService.createTree(targetDocNode2);
+
+      const newContentRoot = tree2.contentRoots[0];
+      expect(newContentRoot.nodeData).toBeInstanceOf(FieldItemNodeData);
+      expect(newContentRoot.path).not.toBe(contentRoot.path);
+      expect(store.isExpanded(documentId, newContentRoot.path)).toBe(false);
     });
   });
 });

--- a/packages/ui/src/services/visualization/tree-ui.service.ts
+++ b/packages/ui/src/services/visualization/tree-ui.service.ts
@@ -1,24 +1,49 @@
 import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
-import { useDocumentTreeStore } from '../../store/document-tree.store';
+import { TreeExpansionState, useDocumentTreeStore } from '../../store/document-tree.store';
+import { processTreeNode } from '../../utils';
 import { TreeParsingService } from './tree-parsing.service';
 
 /**
- * Service to manage tree UI state and operations
+ * Manages tree UI state: creation, expansion toggling, and node invalidation.
+ *
+ * Owns domain-specific logic for expansion state reconciliation across tree rebuilds.
+ * The store ({@link useDocumentTreeStore}) is a pure data layer — it provides path-based
+ * reconciliation via `updateTreeExpansion` and a direct setter via `setTreeExpansion`,
+ * but has no knowledge of field identity or node type transitions.
+ *
+ * **Future direction:** The current architecture rebuilds the entire tree whenever
+ * mappings change, then reconciles expansion state with a field-identity fallback.
+ * A per-node expansion update approach — updating individual node paths when a mapping
+ * is created or removed — would eliminate both the full-tree rebuild and the
+ * field-identity reconciliation map.
  */
 export class TreeUIService {
   private static readonly trees: Map<string, DocumentTree> = new Map();
 
   /**
-   * Create a tree for a document (works for both Source and Target documents)
-   * For Target documents that may change due to mapping updates, use rebuildTargetTree() instead
+   * Create and register a tree for a document node.
+   *
+   * When a tree already exists for the same document ID (i.e., a rebuild), expansion
+   * state is reconciled using both path matching and a field-identity fallback.
+   * The fallback handles the TargetFieldNodeData / FieldItemNodeData transition where
+   * the node's path segment changes (field.id vs mapping.id) but the underlying IField
+   * remains the same.
+   *
+   * This reconciliation is temporary scaffolding — once expansion state can be updated
+   * per-node when a mapping is created or removed, full-tree reconciliation and the
+   * field-identity map will no longer be necessary.
    */
   static createTree(documentNodeData: DocumentNodeData): DocumentTree {
+    const fieldExpansion = TreeUIService.buildFieldExpansionMap(documentNodeData.id);
+
     const tree = new DocumentTree(documentNodeData);
     TreeParsingService.parseTree(tree);
 
     this.trees.set(tree.documentNodeDataId, tree);
-    useDocumentTreeStore.getState().updateTreeExpansion(tree);
+
+    const newExpansion = TreeUIService.reconcileExpansion(documentNodeData.id, tree, fieldExpansion);
+    useDocumentTreeStore.getState().setTreeExpansion(tree.documentNodeDataId, newExpansion);
 
     return tree;
   }
@@ -62,5 +87,49 @@ export class TreeUIService {
     if (!node) return;
 
     node.invalidateDescendants();
+  }
+
+  private static reconcileExpansion(
+    documentNodeDataId: string,
+    newTree: DocumentTree,
+    fieldExpansion?: Record<string, boolean>,
+  ): TreeExpansionState {
+    const currentExpansionState = useDocumentTreeStore.getState().expansionState[documentNodeDataId] ?? {};
+    const newExpansionState: TreeExpansionState = {};
+
+    for (const contentRoot of newTree.contentRoots) {
+      processTreeNode(contentRoot, (treeNode) => {
+        const isNodeParsed = treeNode.isParsed;
+        let savedState = currentExpansionState[treeNode.path];
+        if (savedState === undefined && fieldExpansion && 'field' in treeNode.nodeData) {
+          savedState = fieldExpansion[(treeNode.nodeData as { field: { id: string } }).field.id];
+        }
+        newExpansionState[treeNode.path] = isNodeParsed && (savedState ?? true);
+      });
+    }
+
+    return newExpansionState;
+  }
+
+  private static buildFieldExpansionMap(documentNodeDataId: string): Record<string, boolean> | undefined {
+    const oldTree = this.trees.get(documentNodeDataId);
+    if (!oldTree) return undefined;
+
+    const currentExpansionState = useDocumentTreeStore.getState().expansionState[documentNodeDataId];
+    if (!currentExpansionState) return undefined;
+
+    const fieldExpansion: Record<string, boolean> = {};
+    for (const contentRoot of oldTree.contentRoots) {
+      processTreeNode(contentRoot, (treeNode) => {
+        if ('field' in treeNode.nodeData) {
+          const fieldId = (treeNode.nodeData as { field: { id: string } }).field.id;
+          const state = currentExpansionState[treeNode.path];
+          if (state !== undefined && !(fieldId in fieldExpansion)) {
+            fieldExpansion[fieldId] = state;
+          }
+        }
+      });
+    }
+    return Object.keys(fieldExpansion).length > 0 ? fieldExpansion : undefined;
   }
 }

--- a/packages/ui/src/store/document-tree.store.test.ts
+++ b/packages/ui/src/store/document-tree.store.test.ts
@@ -160,6 +160,29 @@ describe('useDocumentTreeStore', () => {
     });
   });
 
+  describe('setTreeExpansion', () => {
+    it('should set expansion state and array for a document', () => {
+      const documentId = 'test-doc-id';
+      const expansionState = { path1: true, path2: false, path3: true };
+
+      useDocumentTreeStore.getState().setTreeExpansion(documentId, expansionState);
+      const state = useDocumentTreeStore.getState();
+
+      expect(state.expansionState[documentId]).toEqual(expansionState);
+      expect(state.expansionStateArray[documentId]).toEqual(['path1', 'path2', 'path3']);
+    });
+
+    it('should overwrite previous expansion state for the same document', () => {
+      const documentId = 'test-doc-id';
+      useDocumentTreeStore.getState().setTreeExpansion(documentId, { path1: true, path2: false });
+      useDocumentTreeStore.getState().setTreeExpansion(documentId, { path3: true });
+      const state = useDocumentTreeStore.getState();
+
+      expect(state.expansionState[documentId]).toEqual({ path3: true });
+      expect(state.expansionStateArray[documentId]).toEqual(['path3']);
+    });
+  });
+
   describe('setNodesConnectionPorts', () => {
     it('should set connection ports for a document', () => {
       const documentId = 'test-doc-id';

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -37,7 +37,10 @@ export interface DocumentTreeState {
   /** Toggle expansion state of a node */
   toggleExpansion: (documentId: string, nodePath: string) => void;
 
-  /** Update the expansionState from a DocumentTree keeping the matching entries */
+  /** Set the document's expansion state with fresh data */
+  setTreeExpansion: (documentId: string, expansionState: TreeExpansionState) => void;
+
+  /** Reconcile expansion state from a DocumentTree, preserving matching entries by path */
   updateTreeExpansion: (documentTree: DocumentTree) => void;
 
   /** Get expansion state of a node */
@@ -106,6 +109,13 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
         }));
       },
 
+      setTreeExpansion: (documentId: string, expansionState: TreeExpansionState) => {
+        set((state) => ({
+          expansionState: { ...state.expansionState, [documentId]: expansionState },
+          expansionStateArray: { ...state.expansionStateArray, [documentId]: Object.keys(expansionState) },
+        }));
+      },
+
       updateTreeExpansion: (documentTree: DocumentTree) => {
         const currentExpansionState: TreeExpansionState = get().expansionState[documentTree.documentNodeDataId] ?? {};
         const newExpansionState: TreeExpansionState = {};
@@ -113,20 +123,12 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
         for (const contentRoot of documentTree.contentRoots) {
           processTreeNode(contentRoot, (treeNode) => {
             const isNodeParsed = treeNode.isParsed;
-            newExpansionState[treeNode.path] = isNodeParsed && (currentExpansionState[treeNode.path] ?? true);
+            const savedState = currentExpansionState[treeNode.path];
+            newExpansionState[treeNode.path] = isNodeParsed && (savedState ?? true);
           });
         }
 
-        set((state) => ({
-          expansionState: {
-            ...state.expansionState,
-            [documentTree.documentNodeDataId]: newExpansionState,
-          },
-          expansionStateArray: {
-            ...state.expansionStateArray,
-            [documentTree.documentNodeDataId]: Object.keys(newExpansionState),
-          },
-        }));
+        get().setTreeExpansion(documentTree.documentNodeDataId, newExpansionState);
       },
 
       isExpanded: (documentId: string, nodePath: string) => {


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3547

- Preserve expansion state over TargetFieldNodeData > FieldItemNodeData transition (mapping is created)


https://github.com/user-attachments/assets/eb8de636-1173-4939-bc31-f6f743e03ad7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tree node expansion and collapse states when documents are rebuilt.
  * Maintained expansion states when field mappings or node types change.
  * Prevented expansion settings from being incorrectly applied to newly created tree paths.

* **Tests**
  * Added coverage for expansion-state preservation across tree rebuilds and mapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->