### PR TITLE
chore(workflows): pin versions to full commit SHAs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -41,7 +41,7 @@ jobs:
         run: yarn workspaces foreach --verbose --all --topological-dev run test
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # 👇 Fetches all Git history so that Chromatic can compare against the previous version
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -52,7 +52,7 @@ jobs:
 
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        uses: chromaui/action@v13
+        uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0 # v13.3.5
         # Chromatic GitHub Action options
         with:
           # This token needs to be specified directly here so forks of the repository can push their changes to the chromatic UI

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: '🛰️ Setup Node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -44,7 +44,7 @@ jobs:
           ls -lh ${{ runner.temp }}/kaoto-ui.tgz
 
       - name: '🔧 Persist UI Dist'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: 'kaoto-ui-${{ github.run_id }}'
           path: '${{ runner.temp }}/kaoto-ui.tgz'
@@ -60,15 +60,15 @@ jobs:
       - build-distribution
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: '🛰️ Setup Pages'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: '🛰️ Download UI Dist'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kaoto-ui-${{ github.run_id }}
           path: '${{ runner.temp }}'
@@ -80,13 +80,13 @@ jobs:
           tar -xzf "${{ runner.temp }}/kaoto-ui.tgz" -C packages/ui/dist
 
       - name: '📤 Upload artifact @kaoto/kaoto web application'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: 'packages/ui/dist'
 
       - name: '🚀 Deploy to GitHub Pages'
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24 - it is the same as v5
 
   deploy-images:
     if: github.repository == 'KaotoIO/kaoto'
@@ -97,12 +97,12 @@ jobs:
       - build-distribution
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: '🛰️ Download UI Dist'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kaoto-ui-${{ github.run_id }}
           path: '${{ runner.temp }}'
@@ -114,7 +114,7 @@ jobs:
           tar -xzf "${{ runner.temp }}/kaoto-ui.tgz" -C packages/ui/dist
 
       - name: '🛰️ Login to Container Registry'
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -39,7 +39,7 @@ jobs:
         run: yarn workspace @kaoto/kaoto run build:lib
 
       - name: 💾 Save build folder
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ui-dist
           if-no-files-found: error
@@ -57,18 +57,18 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: firefox
           # we have already installed all dependencies above
@@ -88,14 +88,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-firefox-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-firefox-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots
@@ -113,18 +113,18 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: chrome
           # we have already installed all dependencies above
@@ -144,14 +144,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-chrome-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-chrome-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots
@@ -168,18 +168,18 @@ jobs:
         containers: [1, 2, 3, 4]
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: edge
           # we have already installed all dependencies above
@@ -198,14 +198,14 @@ jobs:
           SPLIT_INDEX: ${{ strategy.job-index }}
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-edge-${{ matrix.containers }}
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-edge-${{ matrix.containers }}
           path: packages/ui-tests/cypress/screenshots

--- a/.github/workflows/e2e-weekly.yml
+++ b/.github/workflows/e2e-weekly.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -38,7 +38,7 @@ jobs:
         run: yarn workspace @kaoto/kaoto run build:lib
 
       - name: 💾 Save build folder
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ui-dist
           if-no-files-found: error
@@ -53,18 +53,18 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: firefox
           # we have already installed all dependencies above
@@ -82,14 +82,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-firefox
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-firefox
           path: packages/ui-tests/cypress/screenshots
@@ -103,18 +103,18 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: chrome
           # we have already installed all dependencies above
@@ -132,14 +132,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-chrome
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-chrome
           path: packages/ui-tests/cypress/screenshots
@@ -153,18 +153,18 @@ jobs:
 
     steps:
       - name: 👷‍♀️ Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🗄️ Download the UI build folder
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ui-dist
           path: packages/ui/dist
 
       - name: 🔨 Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           browser: edge
           # we have already installed all dependencies above
@@ -182,14 +182,14 @@ jobs:
 
       - name: 💾 Save videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: videos-edge
           path: packages/ui-tests/cypress/videos
 
       - name: 💾 Save screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-edge
           path: packages/ui-tests/cypress/screenshots

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -20,13 +20,13 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ github.event.inputs.tag_version }}
@@ -34,7 +34,7 @@ jobs:
           tag_prefix: ''
 
       - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
@@ -49,11 +49,11 @@ jobs:
 
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -86,11 +86,11 @@ jobs:
       - npm-release
     steps:
       - name: '🛰️ Checkout source code'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -105,7 +105,7 @@ jobs:
           yarn workspaces foreach --verbose --all --topological-dev run build
 
       - name: '🛰️ Login to Container Registry'
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -113,13 +113,23 @@ jobs:
 
       - name: '🔧 Build Container Image'
         shell: bash
+        # to avoid template-injection: Now ${{ ... }} is expanded when setting the env var — safely,
+        # as a value — and the shell only ever sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference.
+        # No matter what the user types, it can never break out of the string and inject a new command.
         run: |
-          docker build -t "quay.io/kaotoio/kaoto-app:${{ github.event.inputs.tag_version }}" .
+          docker build -t "quay.io/kaotoio/kaoto-app:${GITHUB_EVENT_INPUTS_TAG_VERSION}" .
+        env:
+          GITHUB_EVENT_INPUTS_TAG_VERSION: ${{ github.event.inputs.tag_version }} 
 
       - name: '📤 Upload Container Image'
         shell: bash
+        # to avoid template-injection: Now ${{ ... }} is expanded when setting the env var — safely,
+        # as a value — and the shell only ever sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference.
+        # No matter what the user types, it can never break out of the string and inject a new command.
         run: |
-          docker push quay.io/kaotoio/kaoto-app:${{ github.event.inputs.tag_version }}
+          docker push "quay.io/kaotoio/kaoto-app:${GITHUB_EVENT_INPUTS_TAG_VERSION}" .
+        env:
+          GITHUB_EVENT_INPUTS_TAG_VERSION: ${{ github.event.inputs.tag_version }}
 
       - name: '🔧 Build Container Image'
         shell: bash

--- a/.github/workflows/vscode-tests.yml
+++ b/.github/workflows/vscode-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger vscode-kaoto tests
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be # v1.6.5
         with:
           owner: KaotoIO
           repo: vscode-kaoto

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           operations-per-run: 500   # increase from default
           stale-issue-label: "stale"


### PR DESCRIPTION
Pin all GitHub Actions `uses:` references from floating version tags to immutable commit SHAs, preventing supply chain attacks where a tag could be silently moved to point to different code.

All SHAs were resolved and applied automatically via `zizmor --fix=all` and verified against the official upstream repositories.

Additionally, two `template-injection` vulnerabilities in `release-pipeline.yml` were fixed by moving `github.event.inputs.tag_version` out of inline shell expansion into a proper `env:` variable.

**Actions pinned:** `actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/upload-artifact`, `actions/download-artifact`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `actions/stale`, `codecov/codecov-action`, `chromaui/action`, `cypress-io/github-action`, `docker/login-action`, `mathieudutour/github-tag-action`, `ncipollo/release-action`, `convictional/trigger-workflow-and-wait`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third-party automation steps in build, lint, test, deployment, Chromatic, and release workflows to fixed versions for more consistent, secure runs.
  * Kept existing build, artifact, browser testing, page deployment, and container publishing behavior the same while updating the referenced action versions.
  * Improved release container image tagging reliability by using the workflow’s provided tag input consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->