### PR TITLE
fix(Canvas): normalize Camel enum types for form validation

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -262,7 +262,7 @@ exports[`CamelComponentSchemaService > getSchema > should build the appropriate 
             "OFF",
           ],
           "title": "Level",
-          "type": "enum",
+          "type": "string",
         },
         "logMask": {
           "$comment": "group:producer",
@@ -454,7 +454,7 @@ exports[`CamelComponentSchemaService > getSchema > should build the appropriate 
             "Fixed",
           ],
           "title": "Style",
-          "type": "enum",
+          "type": "string",
         },
       },
       "required": [

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -1,5 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types';
+import { getValidator } from '@kaoto/forms';
 
 import { DynamicCatalog } from '../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
@@ -138,6 +139,28 @@ describe('CamelComponentSchemaService', () => {
       const result = CamelComponentSchemaService.getSchema({ processorName: 'to', componentName: 'log' });
 
       expect(result.properties?.parameters['x-component-name']).toBe('log');
+    });
+
+    it('should produce valid JSON Schema for Camel catalog enum properties', () => {
+      const result = CamelComponentSchemaService.getSchema({
+        processorName: 'from' as keyof ProcessorDefinition,
+        componentName: 'timer',
+      });
+      const componentSchema = result.properties?.parameters;
+      if (!componentSchema) {
+        throw new Error('Expected the Timer component parameters schema');
+      }
+      const componentProperties = componentSchema.properties;
+
+      expect(componentProperties?.exchangePattern).toMatchObject({
+        type: 'string',
+        enum: ['InOnly', 'InOut'],
+      });
+      expect(componentProperties?.runLoggingLevel).toMatchObject({
+        type: 'string',
+        enum: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF'],
+      });
+      expect(getValidator(componentSchema)).toBeTypeOf('function');
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -309,13 +309,18 @@ export class CamelComponentSchemaService {
 
       // Filter out producer/consumer properties depending upon the endpoint usage
       const actualComponentProperties = Object.fromEntries(
-        Object.entries(componentSchema.properties ?? {}).filter((property) => {
-          if (camelElementLookup.processorName === ('from' as keyof ProcessorDefinition)) {
-            return !property[1].$comment?.includes('producer');
-          } else {
-            return !property[1].$comment?.includes('consumer');
-          }
-        }),
+        Object.entries(componentSchema.properties ?? {})
+          .filter((property) => {
+            if (camelElementLookup.processorName === ('from' as keyof ProcessorDefinition)) {
+              return !property[1].$comment?.includes('producer');
+            } else {
+              return !property[1].$comment?.includes('consumer');
+            }
+          })
+          .map(([name, property]) => [
+            name,
+            (property.type as string) === 'enum' ? { ...property, type: 'string' as const } : property,
+          ]),
       );
 
       if (catalogLookup.definition !== undefined && componentSchema !== undefined) {


### PR DESCRIPTION
### Description

While working with the Timer component, I noticed something odd: the form itself looked fine, but the console reported that the KaotoForm validator could not compile its schema.

That led me to #3178, which reports the same error for JDBC, File, AWS Config, and AS2. At first I thought Timer might be another component-specific case, but the underlying problem is shared: Camel catalogs use `type: "enum"` as catalog metadata, while AJV expects a standard JSON Schema type. Kaoto can still render these fields because it detects the `enum` values, but the validator rejects the schema.

This change normalizes those component properties when Kaoto composes the Canvas form schema:

- `type: "enum"` becomes `type: "string"`
- the `enum` values and all other property metadata are preserved
- the generic `@kaoto/forms` validator remains unchanged

I chose Timer for the regression test because that is where I encountered the problem, and it provides two clear examples: `exchangePattern` and `runLoggingLevel`. The production code does not contain any Timer-specific handling; the normalization applies to every Camel component schema that goes through this path.

I considered making the generic form validator tolerate `type: "enum"`, but that felt like the wrong boundary. The non-standard type comes from the Camel catalog model, so converting it while building the component form schema keeps the workaround local to the source of the mismatch.

Fixes #3178.

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?

- Added a regression test using the real Timer catalog schema.
- Verified that `exchangePattern` and `runLoggingLevel` become valid JSON Schema string enums.
- Verified that the resulting component parameters schema compiles with the KaotoForm validator.
- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`
- `yarn workspace @kaoto/kaoto build`
- Focused schema service suite: 166 tests passed.
- Full UI suite under Node 24: 6,830 tests passed; nine catalog-heavy files reached their local parallel-run timeouts. Re-running those files serially passed all 200 tests.

No Storybook or Cypress coverage was added because this change does not alter rendered UI behavior; it fixes schema composition and validator compilation.

#### Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation. No documentation changes were required.
- [x] I have added tests that prove my fix works.

This change was prepared with AI assistance. I reviewed the implementation, diff, and test results before submitting it.
