### PR TITLE
fix(CI): Remove extra . form the pipeline

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -113,21 +113,25 @@ jobs:
 
       - name: '🔧 Build Container Image'
         shell: bash
-        # to avoid template-injection: Now ${{ ... }} is expanded when setting the env var — safely,
-        # as a value — and the shell only ever sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference.
-        # No matter what the user types, it can never break out of the string and inject a new command.
+        # Security: Prevent script injection by using environment variables instead of direct expression syntax.
+        # The ${{ ... }} expression is evaluated when setting the env var (safely, as a value), and the shell
+        # only sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference. This ensures user input is
+        # treated as data, not executable code, preventing injection attacks like: 2.0.0"; malicious-command; "
+        # Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
         run: |
           docker build -t "quay.io/kaotoio/kaoto-app:${GITHUB_EVENT_INPUTS_TAG_VERSION}" .
         env:
-          GITHUB_EVENT_INPUTS_TAG_VERSION: ${{ github.event.inputs.tag_version }} 
+          GITHUB_EVENT_INPUTS_TAG_VERSION: ${{ github.event.inputs.tag_version }}
 
       - name: '📤 Upload Container Image'
         shell: bash
-        # to avoid template-injection: Now ${{ ... }} is expanded when setting the env var — safely,
-        # as a value — and the shell only ever sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference.
-        # No matter what the user types, it can never break out of the string and inject a new command.
+        # Security: Prevent script injection by using environment variables instead of direct expression syntax.
+        # The ${{ ... }} expression is evaluated when setting the env var (safely, as a value), and the shell
+        # only sees ${GITHUB_EVENT_INPUTS_TAG_VERSION} as a variable reference. This ensures user input is
+        # treated as data, not executable code, preventing injection attacks like: 2.0.0"; malicious-command; "
+        # Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
         run: |
-          docker push "quay.io/kaotoio/kaoto-app:${GITHUB_EVENT_INPUTS_TAG_VERSION}" .
+          docker push "quay.io/kaotoio/kaoto-app:${GITHUB_EVENT_INPUTS_TAG_VERSION}"
         env:
           GITHUB_EVENT_INPUTS_TAG_VERSION: ${{ github.event.inputs.tag_version }}
 


### PR DESCRIPTION
### Context
After hardening the security of the podman pipeline on https://github.com/KaotoIO/kaoto/pull/3568, we kept a stray . in the podman push command, so it was failing the pipeline.\

Apart from removing the ., we updated the comments to reference the documentation we followed for the hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded inline documentation for container image publishing and Docker tag handling.
  * Clarified security considerations for using workflow-provided tag values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->