### PR TITLE
refactor: centralize Camel URI syntax analysis

### DIFF
--- a/packages/ui/src/utils/camel-uri-helper.test.ts
+++ b/packages/ui/src/utils/camel-uri-helper.test.ts
@@ -448,4 +448,61 @@ describe('CamelUriHelper', () => {
       },
     );
   });
+
+  describe('analyzeSyntax', () => {
+    it.each([
+      {
+        uriSyntax: 'log',
+        expected: {
+          schema: 'log',
+          syntax: '',
+          delimiters: null,
+          delimiterRegex: null,
+          keys: [''],
+        },
+      },
+      {
+        uriSyntax: 'timer:timerName',
+        expected: {
+          schema: 'timer',
+          syntax: 'timerName',
+          delimiters: null,
+          delimiterRegex: null,
+          keys: ['timerName'],
+        },
+      },
+      {
+        uriSyntax: 'avro:transport:host:port/messageName',
+        expected: {
+          schema: 'avro',
+          syntax: 'transport:host:port/messageName',
+          delimiters: [':', ':', '/'],
+          delimiterRegex: /:|:|\//g,
+          keys: ['transport', 'host', 'port', 'messageName'],
+        },
+      },
+      {
+        uriSyntax: 'http://httpUri',
+        expected: {
+          schema: 'http',
+          syntax: '//httpUri',
+          delimiters: ['//'],
+          delimiterRegex: /\/\//g,
+          keys: ['', 'httpUri'],
+        },
+      },
+      {
+        uriSyntax: 'rest-openapi:specificationUri#operationId',
+        expected: {
+          schema: 'rest-openapi',
+          syntax: 'specificationUri#operationId',
+          delimiters: ['#'],
+          delimiterRegex: /#/g,
+          keys: ['specificationUri', 'operationId'],
+        },
+      },
+    ])('should analyze $uriSyntax as canonical syntax metadata', ({ uriSyntax, expected }) => {
+      expect(CamelUriHelper['analyzeSyntax'](uriSyntax)).toEqual(expected);
+    });
+  });
 });

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -215,8 +215,14 @@ export class CamelUriHelper {
   /** Analyze a URI syntax template once for both path serialization and parsing. */
   private static analyzeSyntax(uriSyntax: string): SyntaxAnalysis {
     const { schema, syntax } = this.getSyntaxWithoutSchema(uriSyntax);
-    const delimiters = syntax.match(this.URI_SEPARATORS_REGEX);
+    const delimiterMatches: string[] = [];
+    let separatorMatch = this.URI_SEPARATORS_REGEX.exec(syntax);
+    while (separatorMatch !== null) {
+      delimiterMatches.push(separatorMatch[0]);
+      separatorMatch = this.URI_SEPARATORS_REGEX.exec(syntax);
+    }
     this.URI_SEPARATORS_REGEX.lastIndex = 0;
+    const delimiters = delimiterMatches.length === 0 ? null : delimiterMatches;
 
     const delimiterRegex = delimiters === null ? null : new RegExp(delimiters.join('|'), 'g');
     const keys = delimiterRegex === null ? [syntax] : syntax.split(delimiterRegex);

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -6,6 +6,14 @@ import { getValue } from './get-value';
 
 export type ParsedParameters = Record<string, string | boolean | number>;
 
+interface SyntaxAnalysis {
+  schema: string;
+  syntax: string;
+  delimiters: string[] | null;
+  delimiterRegex: RegExp | null;
+  keys: string[];
+}
+
 /**
  * Helper class for working with Camel URIs
  */
@@ -94,17 +102,10 @@ export class CamelUriHelper {
     parameters?: ParsedParameters,
     options?: { requiredParameters?: string[]; defaultValues?: ParsedParameters },
   ): string {
-    const { schema, syntax: syntaxWithoutScheme } = this.getSyntaxWithoutSchema(uriSyntax);
+    const { schema, syntax: syntaxWithoutScheme, delimiters, keys } = this.analyzeSyntax(uriSyntax);
     /** Prepare options */
     const requiredParameters = options?.requiredParameters ?? [];
     const defaultValues = options?.defaultValues ?? {};
-
-    /**
-     * Retrieve the delimiters from the syntax by matching the delimiters
-     * Example: 'transport:host:port/messageName' => [':', ':', '/']
-     */
-    const delimiters = syntaxWithoutScheme.match(this.URI_SEPARATORS_REGEX);
-    this.URI_SEPARATORS_REGEX.lastIndex = 0;
 
     /** If the syntax does not contain any delimiters, we can return the URI string as is */
     if (
@@ -123,14 +124,6 @@ export class CamelUriHelper {
       return paramQueryString && paramQueryString !== '' ? uri + '?' + paramQueryString : uri;
     }
 
-    /** Otherwise, we create a RegExp using the delimiters found [':', ':', '/'] */
-    const delimitersRegex = new RegExp(delimiters.join('|'), 'g');
-
-    /**
-     * Splitting the syntax string using the delimiters
-     * keys: [ 'transport', 'host', 'port', 'messageName' ]
-     */
-    const keys = syntaxWithoutScheme.split(delimitersRegex);
     const values = keys.map((key, keyIndex) => {
       const valueOrUndefined = parameters[key] === '' ? undefined : parameters[key];
       const value = valueOrUndefined ?? defaultValues[key] ?? '';
@@ -174,30 +167,19 @@ export class CamelUriHelper {
     /** Holder for parsed parameters */
     const parameters: ParsedParameters = {};
 
-    const syntaxWithoutScheme = this.getSyntaxWithoutSchema(uriSyntax).syntax;
+    const { syntax: syntaxWithoutScheme, delimiters, delimiterRegex, keys } = this.analyzeSyntax(uriSyntax);
     const uriWithoutScheme = this.getUriWithoutScheme(uriString, uriSyntax);
-
-    /**
-     * Retrieve the delimiters from the syntax by matching the delimiters
-     * Example: 'transport:host:port/messageName' => [':', ':', '/']
-     */
-    const delimiters = syntaxWithoutScheme.match(this.URI_SEPARATORS_REGEX);
-    this.URI_SEPARATORS_REGEX.lastIndex = 0;
 
     /** If the syntax does not contain any delimiters, we can return the URI string as is */
     if (delimiters === null && uriWithoutScheme !== '') {
       parameters[syntaxWithoutScheme] = uriWithoutScheme;
-    } else if (delimiters !== null) {
-      /** Otherwise, we create a RegExp using the delimiters found [':', ':', '/'] */
-      const delimitersRegex = new RegExp(delimiters.join('|'), 'g');
-
+    } else if (delimiters !== null && delimiterRegex !== null) {
       /**
-       * Splitting the syntax and the URI string using the delimiters
+       * Split the URI string using the delimiters from the analyzed syntax.
        * keys: [ 'transport', 'host', 'port', 'messageName' ]
        * values: [ 'netty', 'localhost', '41414', 'foo' ]
        */
-      const keys = syntaxWithoutScheme.split(delimitersRegex);
-      const values = uriWithoutScheme.split(delimitersRegex);
+      const values = uriWithoutScheme.split(delimiterRegex);
 
       /**
        * There are special cases where some keys are not required, and the user didn't provide them.
@@ -228,6 +210,18 @@ export class CamelUriHelper {
     }
 
     return parameters;
+  }
+
+  /** Analyze a URI syntax template once for both path serialization and parsing. */
+  private static analyzeSyntax(uriSyntax: string): SyntaxAnalysis {
+    const { schema, syntax } = this.getSyntaxWithoutSchema(uriSyntax);
+    const delimiters = syntax.match(this.URI_SEPARATORS_REGEX);
+    this.URI_SEPARATORS_REGEX.lastIndex = 0;
+
+    const delimiterRegex = delimiters === null ? null : new RegExp(delimiters.join('|'), 'g');
+    const keys = delimiterRegex === null ? [syntax] : syntax.split(delimiterRegex);
+
+    return { schema, syntax, delimiters, delimiterRegex, keys };
   }
 
   /** Transform the query string portion of a URI `param1=12&param2=hey`, into a key-value object */


### PR DESCRIPTION
### Description

Centralize Camel URI syntax-template analysis in one private `analyzeSyntax` helper. Path serialization and parsing now obtain their syntax-template metadata from the same helper, while keeping runtime URI handling separate.

The maintainer-requested follow-up replaces the global-regex `String.match()` call with iterative `RegExp.exec()` matching to address Sonar S6594 without dropping repeated or mixed URI delimiters.

Closes #3558

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?
- `yarn workspace @kaoto/kaoto test src/utils/camel-uri-helper.test.ts` (103 passed)
- `yarn workspace @kaoto/kaoto test --maxWorkers=8` (480 test files passed, 1 skipped; 6947 tests passed, 5 skipped, 2 todo)
- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`
- `yarn workspace @kaoto/kaoto build`

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation.
- [x] I have added tests that prove my fix or feature works.

#### AI assistance
AI assistance: I used an AI coding assistant to help implement and review this refactor. I reviewed the changes and test results and take responsibility for the contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URI parsing and parameter serialization for consistent handling across supported URI formats.
  * Enhanced support for simple, delimited, protocol-style, and fragment-based URI patterns.

* **Tests**
  * Added comprehensive coverage for URI syntax handling, including delimiters, schemas, and parameter extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->