### PR TITLE
fix(datamapper): support mixed value-of and copy-of content

### DIFF
--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -1,7 +1,13 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../models/datamapper/document';
-import { MappingTree, ValueOfSelector, ValueSelector } from '../../../models/datamapper/mapping';
+import {
+  CopyOfSelector,
+  CopyOfType,
+  MappingTree,
+  ValueOfSelector,
+  ValueSelector,
+} from '../../../models/datamapper/mapping';
 import { TargetDocumentNodeData } from '../../../models/datamapper/visualization';
 import { XmlSchemaDocument } from '../../../services/document/xml-schema/xml-schema-document.model';
 import { useDocumentTreeStore } from '../../../store/document-tree.store';
@@ -38,6 +44,20 @@ describe('XPathInputAction', () => {
     fireEvent.change(input, { target: { value: '/ShipOrder' } });
     expect(mapping.expression).toBe('/ShipOrder');
     expect(onUpdateMock.mock.calls).toHaveLength(1);
+  });
+
+  it('should label an inline container copy-of input', () => {
+    mapping = new CopyOfSelector(tree, CopyOfType.CONTAINER);
+
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={vi.fn()} />);
+
+    expect(screen.getByTestId('xpath-input-copy-of-label')).toHaveTextContent('copy-of');
+  });
+
+  it('should not show the copy-of label for a value-of input', () => {
+    render(<XPathInputAction nodeData={docData} mapping={mapping} onUpdate={vi.fn()} />);
+
+    expect(screen.queryByTestId('xpath-input-copy-of-label')).not.toBeInTheDocument();
   });
 
   it('should show error popover button if xpath has a parse error', async () => {

--- a/packages/ui/src/components/Document/actions/XPathInputAction.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   InputGroup,
   InputGroupItem,
+  Label,
   List,
   ListItem,
   Popover,
@@ -15,7 +16,7 @@ import {
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { FormEvent, FunctionComponent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { IExpressionHolder } from '../../../models/datamapper/mapping';
+import { CopyOfSelector, CopyOfType, IExpressionHolder } from '../../../models/datamapper/mapping';
 import { ExpressionHolderNodeData } from '../../../models/datamapper/visualization';
 import { XPathService } from '../../../services/xpath/xpath.service';
 import { ValidatedXPathParseResult } from '../../../services/xpath/xpath-model';
@@ -83,6 +84,13 @@ export const XPathInputAction: FunctionComponent<XPathInputProps> = ({ nodeData,
   return (
     <ActionListItem key="xpath-input" className="input-group">
       <InputGroup>
+        {mapping instanceof CopyOfSelector && mapping.valueType === CopyOfType.CONTAINER && (
+          <InputGroupItem>
+            <Label isCompact data-testid="xpath-input-copy-of-label">
+              copy-of
+            </Label>
+          </InputGroupItem>
+        )}
         <InputGroupItem className="input-group__text">
           <TextInput
             ref={inputRef}

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -322,7 +322,9 @@ export class SortItem {
 
 /**
  * How a {@link ValueOfSelector} produces its output in the generated XSLT.
- * Both types are always rendered **inline** (XPath input on the field row).
+ * Attributes and values on leaf fields render **inline**. Values on expandable
+ * fields render as dedicated tree nodes so they remain distinguishable from
+ * an inline container {@link CopyOfSelector}.
  */
 export enum ValueOfType {
   /** Emits a text value via `xsl:value-of`. */

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -426,6 +426,39 @@ describe('MappingSerializerService', () => {
   });
 
   describe('serialize()', () => {
+    it('should preserve copy-of and value-of on the same container through a round trip', () => {
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      mappingTree.namespaceMap = { ns0: targetDoc.fields[0].namespaceURI };
+      const shipOrderFieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+      mappingTree.children.push(shipOrderFieldItem);
+
+      const copyOf = new CopyOfSelector(shipOrderFieldItem, CopyOfType.CONTAINER);
+      copyOf.expression = '/ns0:ShipOrder';
+      const valueOf = new ValueOfSelector(shipOrderFieldItem);
+      valueOf.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      shipOrderFieldItem.children.push(copyOf, valueOf);
+
+      const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const { mappingTree: reloaded } = MappingSerializerService.deserialize(
+        serialized,
+        targetDoc,
+        new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA),
+        sourceParameterMap,
+      );
+      const reloadedShipOrder = reloaded.children[0] as FieldItem;
+
+      expect(reloadedShipOrder.children.find((child) => child instanceof CopyOfSelector)?.expression).toBe(
+        copyOf.expression,
+      );
+      expect(reloadedShipOrder.children.find((child) => child instanceof ValueOfSelector)?.expression).toBe(
+        valueOf.expression,
+      );
+    });
+
     it('should return an empty XSLT document with empty mappings', () => {
       const empty = MappingSerializerService.serialize(
         new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA),

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -98,6 +98,23 @@ describe('MappingActionService', () => {
         const targetDocChildren = VisualizationService.generatePrimitiveDocumentChildren(targetDocNode);
         expect(targetDocChildren).toHaveLength(0);
       });
+
+      it('should apply value-of when copy-of already exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        MappingActionService.applyCopyOfSelector(docChildren[0] as TargetNodeData);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        MappingActionService.applyValueSelector(updatedDocChildren[0] as TargetNodeData);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        expect(shipOrderFieldItem.children.filter((child) => child instanceof CopyOfSelector)).toHaveLength(1);
+        expect(shipOrderFieldItem.children.filter((child) => child instanceof ValueOfSelector)).toHaveLength(1);
+        const valueOfSelector = shipOrderFieldItem.children.find(
+          (child) => child instanceof ValueOfSelector,
+        ) as ValueOfSelector;
+        expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(valueOfSelector.nodePath.toString());
+      });
     });
 
     describe('applyValueOfSelector()', () => {

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -294,7 +294,7 @@ export class MappingActionService {
   /**
    * Adds a {@link ValueSelector} child to the node's mapping.
    * Creates the underlying field item first if the node is a {@link TargetFieldNodeData} without a mapping.
-   * No-op if a `ValueSelector` already exists.
+   * No-op if a `ValueOfSelector` already exists.
    * @param nodeData - The target node to add the value selector to.
    */
   static applyValueSelector(nodeData: TargetNodeData) {
@@ -303,10 +303,10 @@ export class MappingActionService {
         ? MappingActionService.getOrCreateFieldItem(nodeData)
         : nodeData.mapping;
     if (!mapping) return;
-    if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
+    if (!mapping.children.some((c: MappingItem) => c instanceof ValueOfSelector)) {
       const valueSelector = MappingService.createValueOfSelector(mapping);
       mapping.children.push(valueSelector);
-      useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
+      MappingActionService.requestValueOfSelectorFocus(mapping, valueSelector);
     }
   }
 
@@ -321,7 +321,13 @@ export class MappingActionService {
       nodeData instanceof TargetFieldNodeData && nodeData.field.isAttribute ? ValueOfType.ATTRIBUTE : ValueOfType.VALUE;
     const valueSelector = new ValueOfSelector(mapping, valueType);
     mapping.children.push(valueSelector);
-    useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
+    MappingActionService.requestValueOfSelectorFocus(mapping, valueSelector);
+  }
+
+  private static requestValueOfSelectorFocus(mapping: MappingParentType, valueSelector: ValueOfSelector) {
+    const focusTarget =
+      mapping instanceof FieldItem && DocumentService.hasChildren(mapping.field) ? valueSelector : mapping;
+    useDocumentTreeStore.getState().requestXPathInputFocus(focusTarget.nodePath.toString());
   }
 
   static applyCopyOfSelector(nodeData: TargetNodeData) {

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -638,6 +638,37 @@ describe('MappingLinksService', () => {
       expect(shipToLink!.lineStyle).toBe(MappingLineStyle.COPY_OF);
     });
 
+    it('should connect mixed container value-of to its node with a regular line', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      const copyOf = new CopyOfSelector(shipToItem, CopyOfType.CONTAINER);
+      copyOf.expression = '/ns0:ShipOrder/ShipTo';
+      shipToItem.children.push(copyOf);
+      const valueOf = new ValueOfSelector(shipToItem);
+      valueOf.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      shipToItem.children.push(valueOf);
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      const copyOfLink = links.find((link) => link.sourceNodePath.includes('ShipTo'))!;
+      const valueOfLink = links.find((link) => link.sourceNodePath.includes('OrderPerson'))!;
+
+      expect(copyOfLink.targetNodePath).toBe(shipToItem.nodePath.toString());
+      expect(copyOfLink.lineStyle).toBe(MappingLineStyle.COPY_OF);
+      expect(valueOfLink.targetNodePath).toBe(valueOf.nodePath.toString());
+      expect(valueOfLink.lineStyle).toBe(MappingLineStyle.REGULAR);
+    });
+
     it('should classify links inside InstructionItem as REGULAR', () => {
       const links = MappingLinksService.extractMappingLinks(tree, paramsMap, sourceDoc);
       const itemChildLinks = links.filter((l) => /for-each-.*fx-(Title|Quantity|Price)/.exec(l.targetNodePath));

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -1,7 +1,6 @@
 import {
   BODY_DOCUMENT_ID,
   CopyOfSelector,
-  CopyOfType,
   DocumentNodeData,
   DocumentType,
   FieldItem,
@@ -17,6 +16,7 @@ import {
   MappingTree,
   NodePath,
   PrimitiveDocument,
+  ValueOfSelector,
   ValueSelector,
   VariableItem,
   variableNodePath,
@@ -25,6 +25,7 @@ import {
 import { DocumentService } from '../document/document.service';
 import { MappingService } from '../mapping/mapping.service';
 import { XPathService } from '../xpath/xpath.service';
+import { VisualizationService } from './visualization.service';
 
 /**
  * A collection of the business logic for rendering mapping link lines.
@@ -69,11 +70,12 @@ export class MappingLinksService {
       const effectiveStyle = item instanceof FieldItem ? ownLineStyle : lineStyle;
       const childLineStyle = effectiveStyle === MappingLineStyle.REGULAR ? undefined : effectiveStyle;
       item.children.forEach((child) => {
+        const isInlineValueSelector =
+          child instanceof ValueSelector && VisualizationService.isInlineValueSelector(child);
         if (
           item instanceof FieldItem &&
           !(item.field.ownerDocument instanceof PrimitiveDocument) &&
-          child instanceof ValueSelector &&
-          !(child instanceof CopyOfSelector && child.valueType === CopyOfType.CONTAINER_NODE)
+          isInlineValueSelector
         ) {
           const links = MappingLinksService.doExtractMappingLinks(
             child,
@@ -92,7 +94,7 @@ export class MappingLinksService {
             sourceBody,
             selectedNodePath,
             selectedNodeIsSource,
-            childLineStyle,
+            child instanceof ValueOfSelector ? undefined : childLineStyle,
           );
           answer.push(...links);
         }

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -764,7 +764,7 @@ describe('VisualizationService / abstract fields', () => {
       ) as FieldItem;
 
       const candidateChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshAbstractNode);
-      expect(candidateChildren.map((c) => c.title)).toEqual(['catName']);
+      expect(candidateChildren.map((c) => c.title)).toEqual(['catName', 'value']);
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -630,8 +630,8 @@ describe('VisualizationService', () => {
   });
 
   describe('isInlineValueSelector()', () => {
-    it('should return true for VALUE ValueOfSelector', () => {
-      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+    it('should return true for VALUE ValueOfSelector on a leaf field', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0].fields[0]);
       const vs = new ValueOfSelector(fieldItem, ValueOfType.VALUE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
     });
@@ -640,6 +640,12 @@ describe('VisualizationService', () => {
       const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
       const vs = new ValueOfSelector(fieldItem, ValueOfType.ATTRIBUTE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
+    });
+
+    it('should return false for VALUE ValueOfSelector on an expandable field', () => {
+      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueOfSelector(fieldItem, ValueOfType.VALUE);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(false);
     });
 
     it('should return true for CONTAINER CopyOfSelector', () => {
@@ -684,6 +690,22 @@ describe('VisualizationService', () => {
       const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
       const orderPersonNode = shipOrderChildren.find((c) => c.title === orderPersonField.name) as FieldItemNodeData;
       expect(VisualizationService.hasChildren(orderPersonNode)).toBe(false);
+    });
+
+    it('should show VALUE ValueOfSelector as a tree node child on an expandable field', () => {
+      const shipOrderFI = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(shipOrderFI);
+      const vs = new ValueOfSelector(shipOrderFI, ValueOfType.VALUE);
+      shipOrderFI.children.push(vs);
+      targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+      const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+      const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+      const valueNode = shipOrderChildren.find(
+        (child) => child instanceof MappingNodeData && child.mapping === vs,
+      ) as MappingNodeData;
+
+      expect(valueNode).toBeDefined();
+      expect(valueNode.title).toBe('value');
     });
 
     it('should show CONTAINER_NODE copy-of as tree node in primitive document children', () => {

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -14,6 +14,7 @@ import {
   MappingTree,
   UnknownMappingItem,
   ValueOfSelector,
+  ValueOfType,
   ValueSelector,
   VariableItem,
 } from '../../models/datamapper/mapping';
@@ -565,7 +566,9 @@ export class VisualizationService {
 
   static isInlineValueSelector(item: MappingItem): item is ValueSelector {
     if (item instanceof CopyOfSelector) return item.valueType !== CopyOfType.CONTAINER_NODE;
-    return item instanceof ValueOfSelector;
+    if (!(item instanceof ValueOfSelector)) return false;
+    if (item.valueType === ValueOfType.ATTRIBUTE) return true;
+    return !(item.parent instanceof FieldItem && DocumentService.hasChildren(item.parent.field));
   }
 
   private static getFieldValueSelector(nodeData: TargetNodeData) {


### PR DESCRIPTION
### Description

Allow mixed `value-of` and `copy-of` content on expandable DataMapper target fields.

- make double-click use the same duplicate guard as the context-menu `value-of` action, so an existing `copy-of` no longer blocks it
- render `value-of` as a dedicated `value` child node on expandable fields while keeping leaf values and attributes inline
- label inline container `copy-of` inputs so the two selectors are visually distinguishable
- focus the newly created child input so it remains immediately editable
- cover serialization and reload of both selectors on the same container

Closes #3466.

#### Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?

- `corepack yarn workspace @kaoto/kaoto test src/services/visualization/mapping-action.service.test.ts src/services/visualization/visualization.service.test.ts src/components/Document/actions/XPathInputAction.test.tsx src/services/mapping/mapping-serializer.service.test.ts src/services/visualization/visualization.service.abstract.test.ts` — 242 passed
- `corepack yarn workspace @kaoto/kaoto test --hookTimeout=60000 --testTimeout=60000` — 6,907 passed; 5 skipped; 2 todo
- `corepack yarn workspace @kaoto/kaoto lint`
- `corepack yarn workspace @kaoto/kaoto lint:style`
- `corepack yarn workspace @kaoto/kaoto build`
- `git diff --check`

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation.
- [x] I have added tests that prove my fix or feature works.

---

AI-assisted contribution: developed with OpenAI Codex. I reviewed the proposed diff and take personal responsibility for its correctness and for responding to maintainer feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible “copy-of” label for container copy operations.
  * Improved handling of value mappings on expandable fields by displaying them as distinct tree nodes.
  * Preserved combined copy-of and value-of mappings during serialization.
  * Improved editor focus behavior when adding value mappings.

* **Bug Fixes**
  * Corrected link styling and classification for mixed copy-of and value-of mappings.

* **Tests**
  * Expanded coverage for labels, mapping persistence, visualization, focus behavior, and link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->