### PR TITLE
chore: disable yarn 3rd party scripts

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,7 +22,8 @@ jobs:
           cache: 'yarn'
 
       # Install dependencies
-      - run: yarn
+      - name: 🔧 Install dependencies
+        run: yarn install --immutable --mode=skip-build
 
       # Lint files
       - name: 💅 Run eslint

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,9 +38,9 @@ jobs:
           scope: '@kaoto'
           cache: 'yarn'
 
-      # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
-      - name: Install dependencies
-        run: yarn
+      # Install dependencies
+      - name: 🔧 Install dependencies
+        run: yarn install --immutable --mode=skip-build
 
       # 👇 Builds the kaoto/ui in library mode
       - name: Build ui library

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -29,8 +29,9 @@ jobs:
           scope: '@kaoto'
           cache: 'yarn'
 
-      - name: '🔧 Install dependencies'
-        run: yarn
+      # Install dependencies
+      - name: 🔧 Install dependencies
+        run: yarn install --immutable --mode=skip-build
 
       # Build packages
       - name: '🔧 Build packages'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,8 @@ jobs:
             ${{ runner.os }}-yarn-
 
       # Install dependencies
-      - run: yarn install --immutable
+      - name: 🔧 Install dependencies
+        run: yarn install --immutable --mode=skip-build
 
       - name: Build packages
         run: yarn workspace @kaoto/kaoto run build:dev

--- a/.github/workflows/e2e-weekly.yml
+++ b/.github/workflows/e2e-weekly.yml
@@ -27,7 +27,8 @@ jobs:
             ${{ runner.os }}-yarn-
 
       # Install dependencies
-      - run: yarn install --immutable --mode=skip-build
+      - name: 🔧 Install dependencies
+        run: yarn install --immutable --mode=skip-build
 
       # Build packages excluding @kaoto/camel-catalog since it was build during installing dependencies
       - name: Build packages

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -60,8 +60,9 @@ jobs:
           scope: '@kaoto'
           cache: 'yarn'
 
+      # Install dependencies
       - name: 🔧 Install dependencies
-        run: yarn
+        run: yarn install --immutable --mode=skip-build
 
       # Build lib
       - name: Build @kaoto/kaoto package in lib mode
@@ -97,8 +98,9 @@ jobs:
           scope: '@kaoto'
           cache: 'yarn'
 
+      # Install dependencies
       - name: 🔧 Install dependencies
-        run: yarn
+        run: yarn install --immutable --mode=skip-build
 
       - name: '🔧 Build packages'
         run: |


### PR DESCRIPTION
### Lifecycle scripts are enabled by default in Yarn v2+.

JavaScript package manager scripts should not be executed during installation [githubactions:S6505](https://sonarcloud.io/organizations/kaotoio-org/rules?open=githubactions%3AS6505&rule_key=githubactions%3AS6505)

When package managers execute installation scripts, they run arbitrary code distributed with third-party packages. A compromised package can use this mechanism to execute malicious code on the build system, potentially stealing credentials, injecting backdoors, or otherwise compromising the supply chain.

What is the potential impact?
If a dependency is compromised and its scripts are executed, an attacker can run arbitrary code with the permissions of the process performing the installation. This can lead to credential theft from the build environment, introduction of backdoors into the application, or lateral movement within CI/CD infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized dependency installation across build, test, deployment, and release workflows.
  * Added immutable installation checks to ensure dependencies match the lockfile.
  * Skipped dependency build steps during automated workflow runs for more consistent execution.
  * Improved workflow step labels for clearer progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->