### PR TITLE
fix(tests): keep Monaco out of non-editor unit tests

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -12,6 +12,10 @@ import { EMPTY_XSL } from '../../services/mapping/mapping-serializer.service';
 import { getShipOrderToShipOrderXslt, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { DataMapper } from './DataMapper';
 
+vi.mock('monaco-editor', () => ({
+  languages: { CompletionItemKind: { Keyword: 17 } },
+}));
+
 describe('DataMapperPage', () => {
   const vizNode = {
     getId: () => 'route-1234',

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
@@ -37,6 +37,8 @@ vi.mock('@patternfly/react-code-editor', async () => {
   };
 });
 
+vi.mock('monaco-editor', () => ({}));
+
 const dndHandler = new SourceTargetDnDHandler();
 
 const TestProviders: FunctionComponent<PropsWithChildren> = ({ children }) => (

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
@@ -8,6 +8,16 @@ import { DataMapperProvider } from '../../../providers/datamapper.provider';
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { XPathEditorAction } from './XPathEditorAction';
 
+vi.mock('../../XPath/XPathEditor', () => ({
+  XPathEditor: ({ mapping }: { mapping: ValueOfSelector }) => (
+    <input data-testid="xpath-editor" value={mapping.expression} readOnly />
+  ),
+}));
+
+vi.mock('monaco-editor', () => ({
+  languages: { CompletionItemKind: { Keyword: 17 } },
+}));
+
 describe('XPathEditorAction', () => {
   it('should open xpath editor modal', async () => {
     const doc = TestUtil.createTargetOrderDoc();

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -8,6 +8,10 @@ import { useDocumentTreeStore } from '../../../store/document-tree.store';
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { XPathInputAction } from './XPathInputAction';
 
+vi.mock('monaco-editor', () => ({
+  languages: { CompletionItemKind: { Keyword: 17 } },
+}));
+
 describe('XPathInputAction', () => {
   let tree: MappingTree;
   let mapping: ValueSelector;

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -13,6 +13,16 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { XPathEditorLayout } from './XPathEditorLayout';
 
+vi.mock('./XPathEditor', () => ({
+  XPathEditor: ({ mapping }: { mapping: IExpressionHolder }) => (
+    <div data-testid="xpath-editor">{mapping.expression}</div>
+  ),
+}));
+
+vi.mock('monaco-editor', () => ({
+  languages: { CompletionItemKind: { Keyword: 17 } },
+}));
+
 // Shared test setup
 globalThis.ResizeObserver = class ResizeObserver {
   observe() {


### PR DESCRIPTION
### Description

Fixes #3583.

Several unit test suites were importing the real `monaco-editor` even though they do not verify editor behavior. This change replaces Monaco with focused Vitest mocks in those suites, avoiding the editor import and instantiation costs while preserving their existing assertions.

`XPathEditorModal.test.tsx`, which exercises the real editor, remains unchanged.

#### Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?

All existing assertions remain in place.

| Test suite | Before duration / import | After duration / import | Duration reduction |
| --- | ---: | ---: | ---: |
| `XPathEditorLayout.test.tsx` | 31.69s / 30.10s | 11.11s / 10.09s | 65% |
| `DataMapper.test.tsx` | 24.76s / 22.59s | 11.41s / 9.26s | 54% |
| `XPathEditorAction.test.tsx` | 22.30s / 21.35s | 8.42s / 7.80s | 62% |
| `XPathInputAction.test.tsx` | 16.93s / 16.32s | 3.63s / 3.00s | 79% |
| `ExportMappingFileModal.test.tsx` | 17.53s / 16.71s | 4.03s / 3.24s | 77% |

Validation performed:

- Targeted suites: 42 tests passed
- Full UI suite: 479 files passed, 1 skipped; 6,935 tests passed, 5 skipped, 2 todo
- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`

#### Checklist

- [x] I have read the contributing guidelines.
- [x] I have followed the project's coding style and conventions.
- [x] I have tested the changes and confirmed that the affected suites pass.
- [x] No documentation changes are required for this test-only improvement.
- [x] The editor-specific test suite remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated test reliability for data mapping, XPath editing, and mapping export workflows.
  - Added controlled test environments for editor-related components, reducing failures caused by external editor behavior.
  - Enabled layout and action tests to run consistently without rendering the full editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->