### PR TITLE
fix(dataMapper): dispose Monaco editor instance on unmount

### DIFF
--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -8,34 +8,34 @@ import { XPathService } from '../../services/xpath/xpath.service';
 import { xpathEditorConstrufctionOption, xpathEditorTheme } from './monaco-options';
 
 type XPathEditorProps = {
-    mapping: IExpressionHolder;
-    onChange: (expression: string | undefined) => void;
+  mapping: IExpressionHolder;
+  onChange: (expression: string | undefined) => void;
 };
 
 export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onChange }) => {
-    const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
-    const monacoEl = useRef(null);
-    const onChangeRef = useRef(onChange);
-    onChangeRef.current = onChange;
-    const xpathLanguage = XPathService.getMonacoXPathLanguageMetadata();
+  const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const monacoEl = useRef(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const xpathLanguage = XPathService.getMonacoXPathLanguageMetadata();
 
-    useEffect(() => {
-          const previousExpression = editor?.getModel()?.getValue();
-          if (previousExpression !== mapping.expression) editor?.getModel()?.setValue(mapping.expression);
-    }, [editor, mapping.expression]);
+  useEffect(() => {
+    const previousExpression = editor?.getModel()?.getValue();
+    if (previousExpression !== mapping.expression) editor?.getModel()?.setValue(mapping.expression);
+  }, [editor, mapping.expression]);
 
-    useEffect(() => {
-          if (!monacoEl.current) return;
+  useEffect(() => {
+    if (!monacoEl.current) return;
 
-        monaco.languages.register({ id: xpathLanguage.id });
-          monaco.languages.setMonarchTokensProvider(xpathLanguage.id, xpathLanguage.tokensProvider);
-          monaco.languages.setLanguageConfiguration(xpathLanguage.id, xpathLanguage.languageConfiguration);
-          monaco.languages.registerCompletionItemProvider(xpathLanguage.id, xpathLanguage.completionItemProvider);
-          monaco.languages.registerHoverProvider(xpathLanguage.id, {
-                  provideHover: () => ({ contents: [{ value: 'test' }] }),
-          });
-          const themeName = 'datamapperTheme';
-          monaco.editor.defineTheme(themeName, xpathEditorTheme);
+    monaco.languages.register({ id: xpathLanguage.id });
+    monaco.languages.setMonarchTokensProvider(xpathLanguage.id, xpathLanguage.tokensProvider);
+    monaco.languages.setLanguageConfiguration(xpathLanguage.id, xpathLanguage.languageConfiguration);
+    monaco.languages.registerCompletionItemProvider(xpathLanguage.id, xpathLanguage.completionItemProvider);
+    monaco.languages.registerHoverProvider(xpathLanguage.id, {
+      provideHover: () => ({ contents: [{ value: 'test' }] }),
+    });
+    const themeName = 'datamapperTheme';
+    monaco.editor.defineTheme(themeName, xpathEditorTheme);
 
     const newEditor = monaco.editor.create(monacoEl.current, {
       ...xpathEditorConstrufctionOption,

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -8,68 +8,54 @@ import { XPathService } from '../../services/xpath/xpath.service';
 import { xpathEditorConstrufctionOption, xpathEditorTheme } from './monaco-options';
 
 type XPathEditorProps = {
-  mapping: IExpressionHolder;
-  onChange: (expression: string | undefined) => void;
+    mapping: IExpressionHolder;
+    onChange: (expression: string | undefined) => void;
 };
 
 export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onChange }) => {
-  const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const monacoEl = useRef(null);
-  const xpathLanguage = XPathService.getMonacoXPathLanguageMetadata();
+    const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
+    const monacoEl = useRef(null);
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const xpathLanguage = XPathService.getMonacoXPathLanguageMetadata();
 
-  useEffect(() => {
-    const previousExpression = editor?.getModel()?.getValue();
-    if (previousExpression !== mapping.expression) editor?.getModel()?.setValue(mapping.expression);
-  }, [editor, mapping.expression]);
+    useEffect(() => {
+          const previousExpression = editor?.getModel()?.getValue();
+          if (previousExpression !== mapping.expression) editor?.getModel()?.setValue(mapping.expression);
+    }, [editor, mapping.expression]);
 
-  useEffect(() => {
-    if (monacoEl) {
-      setEditor((editor) => {
-        if (editor) return editor;
+    useEffect(() => {
+          if (!monacoEl.current) return;
 
         monaco.languages.register({ id: xpathLanguage.id });
-        monaco.languages.setMonarchTokensProvider(xpathLanguage.id, xpathLanguage.tokensProvider);
-        monaco.languages.setLanguageConfiguration(xpathLanguage.id, xpathLanguage.languageConfiguration);
-        monaco.languages.registerCompletionItemProvider(xpathLanguage.id, xpathLanguage.completionItemProvider);
-        monaco.languages.registerHoverProvider(xpathLanguage.id, {
-          provideHover: (model, position, token, context) => {
-            console.log(`#### ${model}, ${position}, ${token}, ${context}`);
-            return { contents: [{ value: 'test' }] };
-          },
-        });
-        const themeName = 'datamapperTheme';
-        monaco.editor.defineTheme(themeName, xpathEditorTheme);
+          monaco.languages.setMonarchTokensProvider(xpathLanguage.id, xpathLanguage.tokensProvider);
+          monaco.languages.setLanguageConfiguration(xpathLanguage.id, xpathLanguage.languageConfiguration);
+          monaco.languages.registerCompletionItemProvider(xpathLanguage.id, xpathLanguage.completionItemProvider);
+          monaco.languages.registerHoverProvider(xpathLanguage.id, {
+                  provideHover: () => ({ contents: [{ value: 'test' }] }),
+          });
+          const themeName = 'datamapperTheme';
+          monaco.editor.defineTheme(themeName, xpathEditorTheme);
 
-        const newEditor = monaco.editor.create(monacoEl.current!, {
-          ...xpathEditorConstrufctionOption,
-          theme: themeName,
-          value: mapping.expression,
-          minimap: {
-            enabled: false,
-          },
-        });
-        newEditor.onDidChangeModelContent((_e) => {
-          onChange(newEditor.getModel()?.getValue());
-        });
-        return newEditor;
-      });
-    }
+    const newEditor = monaco.editor.create(monacoEl.current, {
+      ...xpathEditorConstrufctionOption,
+      theme: themeName,
+      value: mapping.expression,
+      minimap: {
+        enabled: false,
+      },
+    });
+    newEditor.onDidChangeModelContent(() => {
+      onChangeRef.current(newEditor.getModel()?.getValue());
+    });
+    setEditor(newEditor);
 
     return () => {
-      if (!monacoEl) {
-        editor?.dispose();
-        setEditor(null);
-      }
+      newEditor.dispose();
+      setEditor(null);
     };
-  }, [
-    editor,
-    mapping.expression,
-    onChange,
-    xpathLanguage.completionItemProvider,
-    xpathLanguage.id,
-    xpathLanguage.languageConfiguration,
-    xpathLanguage.tokensProvider,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <div className="xpath-editor" data-testid="xpath-editor" ref={monacoEl} />;
 };


### PR DESCRIPTION
XPathEditor's cleanup function guarded disposal on if (!monacoEl), but monacoEl is a ref object that is always truthy, so that branch never ran and the Monaco editor instance was never disposed. Every time the XPath editor mounted and unmounted, a live editor instance leaked, along with the completion, hover, and language registrations it created.

Simply flipping that guard would not have been safe, since editor sat in the effect's dependency array alongside several other values. An unconditional dispose in that shape would fire on every dependency change, not just on unmount, tearing down and recreating the editor whenever the language metadata or callbacks changed identity. So I restructured the effect to create the editor once, using an empty dependency array, and dispose it only when the component actually unmounts. Because the onChange prop is no longer in that dependency array, I read it through a ref instead, so the change listener always calls the latest callback rather than the one captured at mount time.

I also removed a leftover console.log in the hover provider that was flagged in the same issue.

Closes #3581.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XPath editor change handling so updates consistently reflect the latest input.
  * Enhanced editor startup and cleanup for more reliable performance.
  * Improved hover interactions for a smoother editing experience.
  * Increased editor stability when the editing area is unavailable or not yet ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->