### PR TITLE
refactor: replace FlowTemplateService.getFlowTemplate with parse for YAML source templates

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -1,4 +1,5 @@
 import { CamelYamlDsl, RouteConfigurationDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { parse } from 'yaml';
 
 import { beansJson } from '../../stubs/beans';
 import { camelFromJson } from '../../stubs/camel-from';
@@ -166,7 +167,7 @@ describe('CamelRouteResource', () => {
       resource.addNewEntity();
       const id = resource.addNewEntity(
         EntityType.Route,
-        FlowTemplateService.getFlowTemplate(SourceSchemaType.Route)[0],
+        parse(FlowTemplateService.getFlowSourceTemplate(SourceSchemaType.Route))[0],
       );
 
       expect(resource.getVisualEntities()).toHaveLength(2);

--- a/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
@@ -111,6 +111,20 @@ describe('CamelXMLRouteResource', () => {
     expect(resource.getType()).toEqual(SourceSchemaType.RouteXml);
   });
 
+  it('adds a default route without parsing the XML template as YAML', async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    setupDynamicCatalogRegistry(catalogsMap);
+    const resource = new CamelXMLRouteResource(xml);
+    await resource.initialize();
+
+    const id = resource.addNewEntity();
+
+    const visualEntities = resource.getVisualEntities();
+    expect(visualEntities).toHaveLength(2);
+    const addedRoute = visualEntities.find((entity) => entity.id === id);
+    expect(addedRoute?.toJSON().route.from).toBeDefined();
+  });
+
   it('includes Beans entities in toString() output', async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     setupDynamicCatalogRegistry(catalogsMap);

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -1,3 +1,5 @@
+import { parse } from 'yaml';
+
 import { TileFilter } from '../../components/Catalog/Catalog.models';
 import { setValue } from '../../utils';
 import { RouteTemplateBeansAwareResource } from '../kaoto-resource';
@@ -22,7 +24,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
     super(kamelet);
 
     if (!kamelet) {
-      this.resource = FlowTemplateService.getFlowTemplate(this.getType());
+      this.resource = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
     }
     this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
   }
@@ -41,7 +43,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
 
   removeEntity(): void {
     super.removeEntity();
-    this.resource = FlowTemplateService.getFlowTemplate(this.getType());
+    this.resource = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
     this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
     this.beans = undefined;
   }

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -1,4 +1,5 @@
 import { Pipe as PipeType } from '@kaoto/camel-catalog/types';
+import { parse } from 'yaml';
 
 import { ITile, TileFilter } from '../../components/Catalog/Catalog.models';
 import { CatalogKind } from '../catalog-kind';
@@ -38,7 +39,7 @@ export class PipeResource extends CamelKResource {
 
   removeEntity(): void {
     super.removeEntity();
-    const flowTemplate: PipeType = FlowTemplateService.getFlowTemplate(this.getType());
+    const flowTemplate: PipeType = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
     this.pipe = flowTemplate;
     this.flow = new PipeVisualEntity(flowTemplate);
   }

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -1,5 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { parse } from 'yaml';
 
 import { ITile } from '../../components/Catalog';
 import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
@@ -58,7 +59,10 @@ describe('CitrusTestResource', () => {
       const resource = new CitrusTestResource();
       await resource.initialize();
       resource.addNewEntity();
-      const id = resource.addNewEntity(EntityType.Test, FlowTemplateService.getFlowTemplate(SourceSchemaType.Test)[0]);
+      const id = resource.addNewEntity(
+        EntityType.Test,
+        parse(FlowTemplateService.getFlowSourceTemplate(SourceSchemaType.Test))[0],
+      );
 
       expect(resource.getVisualEntities()).toHaveLength(2);
       expect(resource.getVisualEntities()[1].id).toEqual(id);

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -1,5 +1,5 @@
 import { isDefined } from '@kaoto/forms';
-import { stringify } from 'yaml';
+import { parse, stringify } from 'yaml';
 
 import { ITile, TileFilter } from '../../components/Catalog';
 import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
@@ -137,7 +137,7 @@ export class CitrusTestResource implements KaotoResource {
     if (entityTemplate) {
       test = entityTemplate as Test;
     } else {
-      const template = FlowTemplateService.getFlowTemplate(this.getType());
+      const template = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
       test = template[0] as Test;
     }
     const entity = new CitrusTestVisualEntity(test);

--- a/packages/ui/src/models/visualization/flows/support/flow-templates-service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/flow-templates-service.test.ts
@@ -5,6 +5,7 @@ describe('FlowTemplateService', () => {
   describe('getFlowSourceTemplate', () => {
     it('returns an XML string containing <routes> for RouteXml', () => {
       const result = FlowTemplateService.getFlowSourceTemplate(SourceSchemaType.RouteXml);
+      expect(typeof result).toBe('string');
       expect(result).toContain('<routes');
       expect(result).not.toContain('route:');
     });
@@ -18,19 +19,6 @@ describe('FlowTemplateService', () => {
     it('returns empty string for unknown types', () => {
       const result = FlowTemplateService.getFlowSourceTemplate(SourceSchemaType.Integration);
       expect(result).toBe('');
-    });
-  });
-
-  describe('getFlowTemplate', () => {
-    it('returns a string (not a parsed object) for RouteXml', () => {
-      const result = FlowTemplateService.getFlowTemplate(SourceSchemaType.RouteXml);
-      expect(typeof result).toBe('string');
-      expect(result).toContain('<routes');
-    });
-
-    it('returns a parsed object (array) for Route', () => {
-      const result = FlowTemplateService.getFlowTemplate(SourceSchemaType.Route);
-      expect(Array.isArray(result)).toBe(true);
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/support/flow-templates-service.ts
+++ b/packages/ui/src/models/visualization/flows/support/flow-templates-service.ts
@@ -1,5 +1,3 @@
-import { parse } from 'yaml';
-
 import { SourceSchemaType } from '../../../camel/source-schema-type';
 import { testTemplate } from '../templates/citrus';
 import { kameletTemplate } from '../templates/kamelet';
@@ -8,13 +6,6 @@ import { routeTemplate } from '../templates/route';
 import { routeXmlTemplate } from '../templates/route-xml';
 
 export class FlowTemplateService {
-  static readonly getFlowTemplate = (type: SourceSchemaType) => {
-    if (type === SourceSchemaType.RouteXml) {
-      return this.getFlowSourceTemplate(type);
-    }
-    return parse(this.getFlowSourceTemplate(type));
-  };
-
   static readonly getFlowSourceTemplate = (type: SourceSchemaType): string => {
     switch (type) {
       case SourceSchemaType.Pipe:


### PR DESCRIPTION
Closes : #3589 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initialization, reset, and recreation of route, Kamelet, pipe, and Citrus resources.
  - Ensured source-based flow templates are consistently interpreted when creating and restoring visual entities.
  - Improved handling of route, Kamelet, pipe, and Citrus flow definitions, including XML-based routes.

- **Tests**
  - Updated coverage to verify source templates are parsed correctly and produce expected flow structures.
  - Added validation for parsed route template content and default XML route creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->