### PR TITLE
fix(DataMapper): Preserve sibling variable after choice

### DIFF
--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -654,6 +654,25 @@ describe('MappingService', () => {
     });
   });
 
+  describe('removeStaleMappingsForDocument() preserving VariableItem', () => {
+    it('should preserve the exact VariableItem instance when a choice member is selected', () => {
+      // Bug regression: variable disappears when a sibling choice member is selected.
+      // updateDocument() calls removeStaleMappingsForDocument() which was pruning VariableItems.
+      const parentItem = tree.children[0] as FieldItem;
+      const variable = new VariableItem(parentItem, 'myVar');
+      parentItem.children.splice(0, 0, variable); // insert at front, as addVariable() would
+
+      MappingService.removeStaleMappingsForDocument(tree, targetDoc);
+
+      // The parent FieldItem may be replaced by updateFieldItemField; resolve it from the tree.
+      const replacedParent = tree.children[0] as FieldItem;
+      // Reference identity: the exact VariableItem instance must still be present, not pruned.
+      expect(replacedParent.children).toContain(variable);
+      // Its parent pointer must be updated to the replacement FieldItem it now lives under.
+      expect(variable.parent).toBe(replacedParent);
+    });
+  });
+
   describe('addIf()', () => {
     it('should add if with mapping', () => {
       const parent = tree.children[0];

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -195,7 +195,8 @@ export class MappingService {
         (compatibleField && child instanceof FieldItem && child.isUserCreated) ||
         child.parent instanceof InstructionItem ||
         child instanceof InstructionItem ||
-        child instanceof ValueSelector
+        child instanceof ValueSelector ||
+        child instanceof VariableItem
       ) {
         acc.push(child);
       }

--- a/packages/ui/src/services/visualization/visualization.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.choice.test.ts
@@ -91,6 +91,63 @@ describe('VisualizationService / choice fields', () => {
       const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
       expect(VisualizationService.hasChildren(choiceNode)).toBe(false);
     });
+
+    it('should return false for selected target choice whose leaf member has no schema children and empty FieldItem', () => {
+      const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }], 0);
+      const parentFieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(parentFieldItem);
+      const memberFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      parentFieldItem.children.push(memberFieldItem);
+
+      const parentNode = new TargetFieldNodeData(targetDocNode, targetDoc.fields[0]);
+      parentNode.mapping = parentFieldItem;
+      const selectedNode = new TargetChoiceFieldNodeData(parentNode, choiceField.fields[0]);
+      selectedNode.choiceField = choiceField;
+      selectedNode.mapping = memberFieldItem;
+
+      expect(VisualizationService.hasChildren(selectedNode)).toBe(false);
+    });
+
+    it('should return true for selected target choice whose member has schema children', () => {
+      const memberWithChildren = {
+        ...targetDoc.fields[0],
+        name: 'address',
+        displayName: 'address',
+        fields: [{ ...targetDoc.fields[0], name: 'street', displayName: 'street', fields: [] }],
+      } as unknown as (typeof targetDoc.fields)[0];
+      const choiceField = createMockChoiceField([{ name: 'phone' }]);
+      (choiceField as unknown as Record<string, unknown>).fields = [memberWithChildren];
+      const parentFieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(parentFieldItem);
+      const memberFieldItem = new FieldItem(parentFieldItem, memberWithChildren);
+      parentFieldItem.children.push(memberFieldItem);
+
+      const parentNode = new TargetFieldNodeData(targetDocNode, targetDoc.fields[0]);
+      parentNode.mapping = parentFieldItem;
+      const selectedNode = new TargetChoiceFieldNodeData(parentNode, memberWithChildren);
+      selectedNode.choiceField = choiceField;
+      selectedNode.mapping = memberFieldItem;
+
+      expect(VisualizationService.hasChildren(selectedNode)).toBe(true);
+    });
+
+    it('should return true for selected target choice whose FieldItem has instruction children', () => {
+      const choiceField = createMockChoiceField([{ name: 'email' }], 0);
+      const parentFieldItem = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(parentFieldItem);
+      const memberFieldItem = new FieldItem(parentFieldItem, choiceField.fields[0]);
+      const ifItem = new IfItem(memberFieldItem);
+      memberFieldItem.children.push(ifItem);
+      parentFieldItem.children.push(memberFieldItem);
+
+      const parentNode = new TargetFieldNodeData(targetDocNode, targetDoc.fields[0]);
+      parentNode.mapping = parentFieldItem;
+      const selectedNode = new TargetChoiceFieldNodeData(parentNode, choiceField.fields[0]);
+      selectedNode.choiceField = choiceField;
+      selectedNode.mapping = memberFieldItem;
+
+      expect(VisualizationService.hasChildren(selectedNode)).toBe(true);
+    });
   });
 
   describe('doGenerateNodeDataFromFields with choice fields', () => {

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -493,28 +493,50 @@ export class VisualizationService {
    * @param nodeData - The node to inspect.
    */
   static hasChildren(nodeData: NodeData) {
-    if (nodeData instanceof DocumentNodeData) {
-      if (DocumentService.hasFields(nodeData.document)) return true;
-      const isPrimitiveDocument = nodeData instanceof TargetDocumentNodeData && nodeData.isPrimitive;
-      const isPrimitiveDocumentWithConditionItem =
-        isPrimitiveDocument && nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m));
-      if (isPrimitiveDocumentWithConditionItem) return true;
-    }
-    if (nodeData instanceof FieldNodeData) {
-      if (VisualizationService.resolveWrapperSpec(nodeData)?.spec.isTargetInstance(nodeData)) {
-        return (nodeData as TargetFieldNodeData).mapping instanceof FieldItem;
-      }
-      return DocumentService.hasChildren(nodeData.field);
-    }
-    if (nodeData instanceof FieldItemNodeData) {
-      if (nodeData.wrapperField && nodeData.field === nodeData.wrapperField) return false;
-      return (
-        DocumentService.hasChildren(nodeData.field) ||
-        nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
-      );
-    }
+    if (nodeData instanceof DocumentNodeData) return VisualizationService.documentHasChildren(nodeData);
+    if (nodeData instanceof FieldNodeData) return VisualizationService.fieldNodeHasChildren(nodeData);
+    if (nodeData instanceof FieldItemNodeData) return VisualizationService.fieldItemNodeHasChildren(nodeData);
     if (nodeData instanceof MappingNodeData) return nodeData.mapping.children.length > 0;
     return false;
+  }
+
+  private static documentHasChildren(nodeData: DocumentNodeData): boolean {
+    if (DocumentService.hasFields(nodeData.document)) return true;
+    return (
+      nodeData instanceof TargetDocumentNodeData &&
+      nodeData.isPrimitive &&
+      nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
+    );
+  }
+
+  /**
+   * Returns whether a selected target wrapper node (choice/abstract) is expandable.
+   * A FieldItem that exists solely because of the selection but has nothing inside
+   * should not show an expand arrow — only schema sub-fields or non-trivial mapping
+   * children (e.g. instructions) justify expansion.
+   */
+  private static selectedWrapperHasChildren(nodeData: TargetFieldNodeData): boolean {
+    const mapping = nodeData.mapping;
+    if (!(mapping instanceof FieldItem)) return false;
+    return (
+      DocumentService.hasChildren(nodeData.field) ||
+      mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
+    );
+  }
+
+  private static fieldNodeHasChildren(nodeData: FieldNodeData): boolean {
+    if (VisualizationService.resolveWrapperSpec(nodeData)?.spec.isTargetInstance(nodeData)) {
+      return VisualizationService.selectedWrapperHasChildren(nodeData as TargetFieldNodeData);
+    }
+    return DocumentService.hasChildren(nodeData.field);
+  }
+
+  private static fieldItemNodeHasChildren(nodeData: FieldItemNodeData): boolean {
+    if (nodeData.wrapperField && nodeData.field === nodeData.wrapperField) return false;
+    return (
+      DocumentService.hasChildren(nodeData.field) ||
+      nodeData.mapping.children.some((m) => !VisualizationService.isInlineValueSelector(m))
+    );
   }
 
   /**


### PR DESCRIPTION
Resolves: [#3452](https://github.com/KaotoIO/kaoto/issues/3452)


https://github.com/user-attachments/assets/a31eb787-3996-4b4d-86e8-70430d13e46c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved variable items when cleaning up stale document mappings.
  - Prevented valid mapping content from being removed during stale-mapping cleanup.
  - Improved target choice expansion so only items with relevant schema or mapping content are expanded.

- **Tests**
  - Added regression coverage for preserving variable items.
  - Added coverage for target choices with and without schema or mapping children.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->