### PR TITLE
fix(tests): prevent Zustand devtools from mounting during tests

### DIFF
--- a/packages/ui/src/components/LoadDefaultCatalog/__snapshots__/LoadDefaultCatalog.test.tsx.snap
+++ b/packages/ui/src/components/LoadDefaultCatalog/__snapshots__/LoadDefaultCatalog.test.tsx.snap
@@ -4,15 +4,6 @@ exports[`LoadDefaultCatalog > should render correctly 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
-    <div
-      id="simple-zustand-devtools-Schemas Store"
-    />
-    <div
-      id="simple-zustand-devtools-SourceCode Store"
-    />
-    <div
-      id="simple-zustand-devtools-Document Tree Store"
-    />
     <div>
       <div
         class="pf-v6-l-bullseye"

--- a/packages/ui/src/global.d.ts
+++ b/packages/ui/src/global.d.ts
@@ -1,6 +1,5 @@
 declare module '*.png';
 declare module '*.svg';
-declare let NODE_ENV: string;
 declare let __GIT_HASH: string;
 declare let __GIT_DATE: string;
 declare let __KAOTO_VERSION: string;

--- a/packages/ui/src/store/index.test.ts
+++ b/packages/ui/src/store/index.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mountStoreDevtoolMock } = vi.hoisted(() => ({
+  mountStoreDevtoolMock: vi.fn(),
+}));
+
+vi.mock('simple-zustand-devtools', () => ({
+  mountStoreDevtool: mountStoreDevtoolMock,
+}));
+
+describe('store devtools', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mountStoreDevtoolMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not mount store devtools in the test environment', async () => {
+    await import('./index');
+
+    expect(mountStoreDevtoolMock).not.toHaveBeenCalled();
+  });
+
+  it('mounts all store devtools in the development environment', async () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('MODE', 'development');
+
+    await import('./index');
+
+    expect(mountStoreDevtoolMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui/src/store/index.ts
+++ b/packages/ui/src/store/index.ts
@@ -4,12 +4,7 @@ import { useDocumentTreeStore } from './document-tree.store';
 import { useSchemasStore } from './schemas.store';
 import { useSourceCodeStore } from './sourcecode.store';
 
-let isDevMode = true;
-try {
-  isDevMode = NODE_ENV === 'development';
-} catch (error) {
-  console.warn('NODE_ENV is not defined');
-}
+const isDevMode = import.meta.env?.DEV === true && import.meta.env.MODE !== 'test';
 
 if (isDevMode) {
   mountStoreDevtool('Schemas Store', useSchemasStore);

--- a/packages/ui/tsconfig.lib.json
+++ b/packages/ui/tsconfig.lib.json
@@ -30,7 +30,7 @@
       "@testing-library/jest-dom",
     ]
   },
-  "include": ["src/public-api.ts", "src/models-api.ts", "src/testing-api.ts","src/components-api.ts", "src/global.d.ts"],
+  "include": ["src/public-api.ts", "src/models-api.ts", "src/testing-api.ts","src/components-api.ts", "src/global.d.ts", "src/vite-env.d.ts"],
   "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "src/**/stubs/**"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/ui/vitest-setup.ts
+++ b/packages/ui/vitest-setup.ts
@@ -98,10 +98,7 @@ Object.defineProperty(window, 'matchMedia', {
 vi.spyOn(globalThis, 'crypto', 'get').mockImplementation(() => ({ getRandomValues, subtle }) as unknown as Crypto);
 
 // Suppress specific known warnings to reduce noise in test output
-const suppressedWarnings = [
-  '[mobx-react-lite] importing batchingForReactDom is no longer needed',
-  'NODE_ENV is not defined',
-];
+const suppressedWarnings = ['[mobx-react-lite] importing batchingForReactDom is no longer needed'];
 
 vi.spyOn(console, 'warn').mockImplementation((...args) => {
   const message = args[0]?.toString() ?? '';


### PR DESCRIPTION
Fixes #3582.

The store devtools were being mounted during tests because the environment check defaulted to development mode when `NODE_ENV` was unavailable. This added three devtool roots to component tests and could cause React `act()` warnings.

This change uses Vite's environment values and prevents the devtools from mounting in test mode. It also removes the obsolete `NODE_ENV` handling, adds regression tests for test and development modes, updates the affected snapshot, and includes the Vite environment types in the library build.

Tested with:

- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`
- `yarn workspace @kaoto/kaoto build:lib`
- `yarn workspace @kaoto/kaoto test --maxWorkers=4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-tool initialization so it runs only in development environments and remains disabled during tests.
  - Reduced unnecessary environment-related warnings in test output.

- **Tests**
  - Added coverage for development-tool behavior across development and test modes.

- **Chores**
  - Updated TypeScript environment configuration and removed an obsolete global declaration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->