### PR TITLE
feat(DataMapper): Introduce XSLT 3.0 / XPath 3.1 functions catalog

### DIFF
--- a/packages/ui/src/components/XPath/XPathEditorLayout.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.tsx
@@ -129,9 +129,10 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({
                   <MenuContent>
                     {Object.keys(functionDefinitions).map((value) => {
                       const isExpanded = expandedGroups.has(value);
-                      const hasVisibleItems = functionDefinitions[value as FunctionGroup].some((func) =>
-                        func.displayName.toLocaleLowerCase().includes(getSearchValue),
-                      );
+                      const groupFunctions = functionDefinitions[value as FunctionGroup];
+                      const hasVisibleItems =
+                        groupFunctions?.some((func) => func.displayName.toLocaleLowerCase().includes(getSearchValue)) ??
+                        false;
 
                       if (!hasVisibleItems) return null;
 
@@ -154,7 +155,7 @@ export const XPathEditorLayout: FunctionComponent<XPathEditorLayoutProps> = ({
                           }
                         >
                           {isExpanded &&
-                            functionDefinitions[value as FunctionGroup]
+                            (functionDefinitions[value as FunctionGroup] ?? [])
                               .filter((func) => func.displayName.toLocaleLowerCase().includes(getSearchValue))
                               .map((func) => (
                                 <DraggableContainer

--- a/packages/ui/src/dynamic-catalog/support/fetch-xslt-xpath-functions.ts
+++ b/packages/ui/src/dynamic-catalog/support/fetch-xslt-xpath-functions.ts
@@ -1,0 +1,30 @@
+import { CatalogDefinition, CatalogLibrary, XPathFunction } from '@kaoto/camel-catalog/types';
+
+import { XSLT_CATALOG_VERSION } from '../../services/xpath/catalog/xpath-catalog-constants';
+import { XPathCatalogConverter } from '../../services/xpath/catalog/xpath-catalog-converter';
+import { XPathFunctionCatalogService } from '../../services/xpath/catalog/xpath-function-catalog.service';
+import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
+
+/**
+ * Fetches the XSLT XPath functions catalog from {@link @kaoto/camel-catalog} and stores the
+ * converted result in {@link XPathFunctionCatalogService}. The XSLT catalog version to load
+ * is determined by {@link XSLT_CATALOG_VERSION}.
+ */
+export async function fetchXsltXPathFunctions(basePath: string, catalogLibrary: CatalogLibrary): Promise<void> {
+  const xsltEntry = catalogLibrary.definitions.find((d) => d.runtime === 'XSLT' && d.version === XSLT_CATALOG_VERSION);
+  if (!xsltEntry) return;
+
+  const indexFile = `${basePath}/${xsltEntry.fileName}`;
+  const relativeBasePath = CatalogSchemaLoader.getRelativeBasePath(indexFile);
+
+  const subIndex = await CatalogSchemaLoader.fetchFile<CatalogDefinition>(indexFile);
+  const xpathFunctionsEntry = subIndex.body.catalogs['xpathFunctions'];
+  if (!xpathFunctionsEntry) return;
+
+  const functionsData = await CatalogSchemaLoader.fetchFile<Record<string, Record<string, XPathFunction>>>(
+    `${relativeBasePath}/${xpathFunctionsEntry.file}`,
+  );
+
+  const converted = XPathCatalogConverter.convertCatalog(functionsData.body);
+  XPathFunctionCatalogService.setCatalog(converted);
+}

--- a/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
+++ b/packages/ui/src/hooks/useRuntimeContext/useRuntimeContext.test.tsx
@@ -10,6 +10,10 @@ import { RuntimeProvider } from '../../providers/runtime.provider';
 import { CatalogSchemaLoader } from '../../utils/catalog-schema-loader';
 import { errorMessage, useRuntimeContext } from './useRuntimeContext';
 
+vi.mock('../../dynamic-catalog/support/fetch-xslt-xpath-functions', () => ({
+  fetchXsltXPathFunctions: vi.fn().mockResolvedValue(undefined),
+}));
+
 const kaotoResource = { getType: () => SourceSchemaType.Integration } as unknown as KaotoResource;
 
 const wrapper = ({ children }: PropsWithChildren) => (

--- a/packages/ui/src/models/datamapper/types.ts
+++ b/packages/ui/src/models/datamapper/types.ts
@@ -32,6 +32,36 @@ export enum Types {
   Array = 'Array',
 }
 
+/** Maps XSD / XPath type notation strings to the {@link Types} enum. */
+export const TYPE_STRING_TO_TYPES: Record<string, Types> = {
+  'xs:string': Types.String,
+  'xs:boolean': Types.Boolean,
+  'xs:integer': Types.Integer,
+  'xs:decimal': Types.Decimal,
+  'xs:double': Types.Double,
+  'xs:float': Types.Float,
+  'xs:numeric': Types.Numeric,
+  'xs:date': Types.Date,
+  'xs:dateTime': Types.DateTime,
+  'xs:dateTimeStamp': Types.DateTime,
+  'xs:time': Types.Time,
+  'xs:duration': Types.Duration,
+  'xs:dayTimeDuration': Types.DayTimeDuration,
+  'xs:anyAtomicType': Types.AnyAtomicType,
+  'xs:anyType': Types.AnyType,
+  'xs:anyURI': Types.AnyURI,
+  'xs:QName': Types.QName,
+  'xs:NCName': Types.NCName,
+  'xs:language': Types.String,
+  'xs:base64Binary': Types.AnyAtomicType,
+  'xs:positiveInteger': Types.PositiveInteger,
+  'item()': Types.Item,
+  'node()': Types.Node,
+  'element()': Types.Element,
+  'document-node()': Types.DocumentNode,
+  none: Types.Item,
+};
+
 export enum FieldOverrideVariant {
   NONE = 'NONE',
   SAFE = 'SAFE',

--- a/packages/ui/src/providers/runtime.provider.tsx
+++ b/packages/ui/src/providers/runtime.provider.tsx
@@ -5,9 +5,11 @@ import { createContext, FunctionComponent, PropsWithChildren, useEffect, useMemo
 
 import { LoadDefaultCatalog } from '../components/LoadDefaultCatalog';
 import { Loading } from '../components/Loading';
+import { fetchXsltXPathFunctions } from '../dynamic-catalog/support/fetch-xslt-xpath-functions';
 import { useKaotoResourceContext } from '../hooks/useKaotoResourceContext/useKaotoResourceContext';
 import { LoadingStatus } from '../models';
 import { SourceSchemaType } from '../models/camel/source-schema-type';
+import { XPathFunctionCatalogService } from '../services/xpath/catalog/xpath-function-catalog.service';
 import { findCatalog } from '../utils/catalog-helper';
 
 export interface IRuntimeContext {
@@ -66,6 +68,10 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<IRuntimeProvid
         if (isDefined(catalogLibraryEntry)) {
           setSelectedCatalog(catalogLibraryEntry);
         }
+
+        return fetchXsltXPathFunctions(basePath, catalogLibrary).catch(() => {
+          /* XSLT catalog load failure is non-fatal — XPath editor falls back to hardcoded functions */
+        });
       })
       .then(() => {
         setLoadingStatus(LoadingStatus.Loaded);
@@ -74,6 +80,10 @@ export const RuntimeProvider: FunctionComponent<PropsWithChildren<IRuntimeProvid
         setErrorMessage(error.message);
         setLoadingStatus(LoadingStatus.Error);
       });
+
+    return () => {
+      XPathFunctionCatalogService.clear();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentSchemaType]);
 

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -31,6 +31,7 @@ import { DocumentUtilService } from '../document/document-util.service';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { MappingLinksService } from '../visualization/mapping-links.service';
 import { XPathService } from '../xpath/xpath.service';
+import { FunctionGroup } from '../xpath/xpath-model';
 import { FieldMatchingService } from './field-matching.service';
 import { MappingService } from './mapping.service';
 import { MappingSerializerService } from './mapping-serializer.service';
@@ -746,7 +747,9 @@ describe('MappingService', () => {
 
   describe('wrapWithFunction()', () => {
     it('should wrap with xpath function', () => {
-      const concatFx = XPathService.functions.String.find((f) => f.name === 'concat');
+      const concatFx = XPathService.getXPathFunctionDefinitions()[FunctionGroup.String]?.find(
+        (f) => f.name === 'concat',
+      );
       const valueSelector = new ValueOfSelector(tree);
       valueSelector.expression = '/path/to/field';
       MappingService.wrapWithFunction(valueSelector, concatFx!);

--- a/packages/ui/src/services/xpath/2.0/xpath-2.0-functions.ts
+++ b/packages/ui/src/services/xpath/2.0/xpath-2.0-functions.ts
@@ -14,7 +14,7 @@ import { patternMatchingFunctions, stringFunctions, substringMatchingFunctions }
  * https://www.w3.org/TR/2010/REC-xpath-functions-20101214/
  */
 
-export const XPATH_2_0_FUNCTIONS: Record<FunctionGroup, IFunctionDefinition[]> = {
+export const XPATH_2_0_FUNCTIONS: Partial<Record<FunctionGroup, IFunctionDefinition[]>> = {
   [FunctionGroup.String]: stringFunctions,
   [FunctionGroup.SubstringMatching]: substringMatchingFunctions,
   [FunctionGroup.PatternMatching]: patternMatchingFunctions,

--- a/packages/ui/src/services/xpath/catalog/xpath-catalog-constants.ts
+++ b/packages/ui/src/services/xpath/catalog/xpath-catalog-constants.ts
@@ -1,0 +1,2 @@
+/** Pins which XSLT catalog version the DataMapper loads from {@link @kaoto/camel-catalog}. */
+export const XSLT_CATALOG_VERSION = '3.0';

--- a/packages/ui/src/services/xpath/catalog/xpath-catalog-converter.test.ts
+++ b/packages/ui/src/services/xpath/catalog/xpath-catalog-converter.test.ts
@@ -1,0 +1,256 @@
+import { XPathFunction } from '@kaoto/camel-catalog/types';
+
+import { Types } from '../../../models/datamapper/types';
+import { FunctionGroup } from '../xpath-model';
+import { XPathCatalogConverter } from './xpath-catalog-converter';
+
+describe('XPathCatalogConverter.mapXPathTypeToTypes', () => {
+  it.each([
+    ['xs:string', Types.String],
+    ['xs:boolean', Types.Boolean],
+    ['xs:integer', Types.Integer],
+    ['xs:decimal', Types.Decimal],
+    ['xs:double', Types.Double],
+    ['xs:float', Types.Float],
+    ['xs:numeric', Types.Numeric],
+    ['xs:date', Types.Date],
+    ['xs:dateTime', Types.DateTime],
+    ['xs:dateTimeStamp', Types.DateTime],
+    ['xs:time', Types.Time],
+    ['xs:duration', Types.Duration],
+    ['xs:dayTimeDuration', Types.DayTimeDuration],
+    ['xs:anyAtomicType', Types.AnyAtomicType],
+    ['xs:anyType', Types.AnyType],
+    ['xs:anyURI', Types.AnyURI],
+    ['xs:QName', Types.QName],
+    ['xs:NCName', Types.NCName],
+    ['xs:language', Types.String],
+    ['xs:base64Binary', Types.AnyAtomicType],
+    ['xs:positiveInteger', Types.PositiveInteger],
+    ['item()', Types.Item],
+    ['node()', Types.Node],
+    ['element()', Types.Element],
+    ['document-node()', Types.DocumentNode],
+    ['none', Types.Item],
+  ])('should map %s to %s', (input, expected) => {
+    expect(XPathCatalogConverter.mapXPathTypeToTypes(input)).toBe(expected);
+  });
+
+  it('should strip cardinality suffixes', () => {
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('xs:string?')).toBe(Types.String);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('item()*')).toBe(Types.Item);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('node()+')).toBe(Types.Node);
+  });
+
+  it('should handle complex types as Item', () => {
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('map(*)')).toBe(Types.Item);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('map(xs:string, item())')).toBe(Types.Item);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('array(*)')).toBe(Types.Item);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('function(*)')).toBe(Types.Item);
+  });
+
+  it('should handle typed element/document-node', () => {
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('element(fn:analyze-string-result)')).toBe(Types.Element);
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('document-node(element(*))')).toBe(Types.DocumentNode);
+  });
+
+  it('should default unknown types to Item', () => {
+    expect(XPathCatalogConverter.mapXPathTypeToTypes('unknown-type')).toBe(Types.Item);
+  });
+});
+
+describe('XPathCatalogConverter.convertCatalog', () => {
+  const sampleCatalog: Record<string, Record<string, XPathFunction>> = {
+    _metadata: { fieldSemantics: {} } as never,
+    namespaces: { fn: 'http://www.w3.org/2005/xpath-functions' } as never,
+    String: {
+      concat: {
+        name: 'concat',
+        displayName: 'Concatenate',
+        description: 'Returns the concatenation of the string values of the arguments.',
+        returnType: 'xs:string',
+        returnCollection: false,
+        arguments: [
+          {
+            name: 'args',
+            type: 'xs:anyAtomicType',
+            displayName: '$args',
+            description: 'Arguments',
+            minOccurs: 2,
+            maxOccurs: 2147483647,
+            cardinality: '',
+            usage: '',
+            default: '',
+          },
+        ],
+        prefix: 'fn',
+        returnCardinality: '',
+        signatures: [],
+      },
+    },
+    XSLT: {
+      'current-group': {
+        name: 'current-group',
+        displayName: 'Current Group',
+        description: 'Returns the contents of the current group selected by xsl:for-each-group.',
+        returnType: 'item()',
+        returnCollection: true,
+        arguments: [],
+        prefix: 'fn',
+        returnCardinality: '*',
+        signatures: [],
+      },
+      'current-grouping-key': {
+        name: 'current-grouping-key',
+        displayName: 'Current Grouping Key',
+        description: 'Returns the grouping key of the current group within xsl:for-each-group.',
+        returnType: 'xs:anyAtomicType',
+        returnCollection: true,
+        arguments: [],
+        prefix: 'fn',
+        returnCardinality: '*',
+        signatures: [],
+      },
+    },
+    MapFunctions: {
+      'map:contains': {
+        name: 'map:contains',
+        displayName: 'Map Contains',
+        description: 'Tests whether a supplied map contains an entry for a given key.',
+        returnType: 'xs:boolean',
+        returnCollection: false,
+        arguments: [
+          {
+            name: 'map',
+            type: 'map(*)',
+            displayName: '$map',
+            description: 'The map',
+            minOccurs: 1,
+            maxOccurs: 1,
+            cardinality: '',
+            usage: '',
+            default: '',
+          },
+          {
+            name: 'key',
+            type: 'xs:anyAtomicType',
+            displayName: '$key',
+            description: 'The key',
+            minOccurs: 1,
+            maxOccurs: 1,
+            cardinality: '',
+            usage: '',
+            default: '',
+          },
+        ],
+        prefix: 'map',
+        returnCardinality: '',
+        signatures: [],
+      },
+    },
+    Math: {
+      'math:sin': {
+        name: 'math:sin',
+        displayName: 'Sine',
+        description: 'Returns the sine of the argument.',
+        returnType: 'xs:double',
+        returnCollection: false,
+        arguments: [
+          {
+            name: 'theta',
+            type: 'xs:double',
+            displayName: '$theta',
+            description: 'The angle in radians',
+            minOccurs: 0,
+            maxOccurs: 1,
+            cardinality: '?',
+            usage: '',
+            default: '',
+          },
+        ],
+        prefix: 'math',
+        returnCardinality: '?',
+        signatures: [],
+      },
+    },
+  };
+
+  it('should skip _metadata and namespaces', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    expect(Object.keys(result)).not.toContain('_metadata');
+    expect(Object.keys(result)).not.toContain('namespaces');
+  });
+
+  it('should convert categories to FunctionGroup keys', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    expect(result[FunctionGroup.String]).toBeDefined();
+    expect(result[FunctionGroup.XSLT]).toBeDefined();
+    expect(result[FunctionGroup.Map]).toBeDefined();
+    expect(result[FunctionGroup.Math]).toBeDefined();
+  });
+
+  it('should map MapFunctions category to FunctionGroup.Map', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    expect(result[FunctionGroup.Map]).toHaveLength(1);
+    expect(result[FunctionGroup.Map]![0].name).toBe('map:contains');
+  });
+
+  it('should convert function definitions correctly', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    const concat = result[FunctionGroup.String]![0];
+    expect(concat.name).toBe('concat');
+    expect(concat.displayName).toBe('Concatenate');
+    expect(concat.returnType).toBe(Types.String);
+    expect(concat.arguments).toHaveLength(1);
+    expect(concat.arguments[0].type).toBe(Types.AnyAtomicType);
+    expect(concat.arguments[0].maxOccurs).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('should include current-group and current-grouping-key in XSLT group', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    const xsltFunctions = result[FunctionGroup.XSLT]!;
+    expect(xsltFunctions).toHaveLength(2);
+    const names = xsltFunctions.map((f) => f.name);
+    expect(names).toContain('current-group');
+    expect(names).toContain('current-grouping-key');
+  });
+
+  it('should set returnCollection on functions that return collections', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    const currentGroup = result[FunctionGroup.XSLT]!.find((f) => f.name === 'current-group')!;
+    expect(currentGroup.returnCollection).toBe(true);
+    const concat = result[FunctionGroup.String]![0];
+    expect(concat.returnCollection).toBeUndefined();
+  });
+
+  it('should convert argument types', () => {
+    const result = XPathCatalogConverter.convertCatalog(sampleCatalog);
+    const mapContains = result[FunctionGroup.Map]![0];
+    expect(mapContains.arguments[0].type).toBe(Types.Item);
+    expect(mapContains.arguments[1].type).toBe(Types.AnyAtomicType);
+  });
+
+  it('should handle empty catalog', () => {
+    const result = XPathCatalogConverter.convertCatalog({});
+    expect(result).toEqual({});
+  });
+
+  it('should skip unknown category keys', () => {
+    const result = XPathCatalogConverter.convertCatalog({
+      UnknownCategory: {
+        'some-func': {
+          name: 'some-func',
+          displayName: 'Some Func',
+          description: 'desc',
+          returnType: 'xs:string',
+          returnCollection: false,
+          arguments: [],
+          prefix: 'fn',
+          returnCardinality: '',
+          signatures: [],
+        },
+      },
+    });
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/services/xpath/catalog/xpath-catalog-converter.ts
+++ b/packages/ui/src/services/xpath/catalog/xpath-catalog-converter.ts
@@ -1,0 +1,77 @@
+import { XPathFunction, XPathFunctionArgument } from '@kaoto/camel-catalog/types';
+
+import { IFunctionArgumentDefinition, IFunctionDefinition } from '../../../models/datamapper/mapping';
+import { TYPE_STRING_TO_TYPES, Types } from '../../../models/datamapper/types';
+import { CATEGORY_TO_FUNCTION_GROUP, FunctionGroup } from '../xpath-model';
+
+const JAVA_MAX_INT = 2147483647;
+
+/**
+ * Converts the raw XPath/XSLT function catalog from {@link @kaoto/camel-catalog} into
+ * the DataMapper's {@link IFunctionDefinition} format, bridging the catalog's string-based
+ * type system (e.g. `"xs:string"`) to the {@link Types} enum.
+ */
+export class XPathCatalogConverter {
+  /** Maps a catalog type string (e.g. `"xs:string?"`, `"map(*)"`) to the DataMapper {@link Types} enum. */
+  static mapXPathTypeToTypes(typeStr: string): Types {
+    const base = XPathCatalogConverter.stripCardinality(typeStr);
+
+    const direct = TYPE_STRING_TO_TYPES[base];
+    if (direct) return direct;
+
+    if (base.startsWith('document-node(')) return Types.DocumentNode;
+    if (base.startsWith('element(')) return Types.Element;
+    if (base.startsWith('array(')) return Types.Item;
+    if (base.startsWith('map(')) return Types.Item;
+    if (base.startsWith('function(')) return Types.Item;
+
+    return Types.Item;
+  }
+
+  /** Converts the raw catalog JSON into grouped {@link IFunctionDefinition} arrays keyed by {@link FunctionGroup}. */
+  static convertCatalog(
+    raw: Record<string, Record<string, XPathFunction>>,
+  ): Partial<Record<FunctionGroup, IFunctionDefinition[]>> {
+    const result: Partial<Record<FunctionGroup, IFunctionDefinition[]>> = {};
+
+    for (const categoryKey of Object.keys(raw)) {
+      const group = CATEGORY_TO_FUNCTION_GROUP[categoryKey];
+      if (!group) continue;
+
+      const functions = raw[categoryKey];
+      result[group] = Object.values(functions).map(XPathCatalogConverter.convertFunction);
+    }
+
+    return result;
+  }
+
+  private static stripCardinality(typeStr: string): string {
+    const last = typeStr[typeStr.length - 1];
+    if (last === '?' || last === '*' || last === '+') {
+      return typeStr.slice(0, -1);
+    }
+    return typeStr;
+  }
+
+  private static convertArgument(arg: XPathFunctionArgument): IFunctionArgumentDefinition {
+    return {
+      name: arg.name,
+      displayName: arg.displayName,
+      description: arg.description,
+      type: XPathCatalogConverter.mapXPathTypeToTypes(arg.type),
+      minOccurs: arg.minOccurs,
+      maxOccurs: arg.maxOccurs === JAVA_MAX_INT ? Number.MAX_SAFE_INTEGER : arg.maxOccurs,
+    };
+  }
+
+  private static convertFunction(func: XPathFunction): IFunctionDefinition {
+    return {
+      name: func.name,
+      displayName: func.displayName,
+      description: func.description,
+      returnType: XPathCatalogConverter.mapXPathTypeToTypes(func.returnType),
+      returnCollection: func.returnCollection || undefined,
+      arguments: func.arguments.map(XPathCatalogConverter.convertArgument),
+    };
+  }
+}

--- a/packages/ui/src/services/xpath/catalog/xpath-function-catalog.service.test.ts
+++ b/packages/ui/src/services/xpath/catalog/xpath-function-catalog.service.test.ts
@@ -1,0 +1,34 @@
+import { FunctionGroup } from '../xpath-model';
+import { XPathFunctionCatalogService } from './xpath-function-catalog.service';
+
+describe('XPathFunctionCatalogService', () => {
+  afterEach(() => {
+    XPathFunctionCatalogService.clear();
+  });
+
+  it('should return undefined when no catalog is set', () => {
+    expect(XPathFunctionCatalogService.getCatalog()).toBeUndefined();
+  });
+
+  it('should store and retrieve a catalog', () => {
+    const catalog = {
+      [FunctionGroup.String]: [
+        {
+          name: 'concat',
+          displayName: 'Concatenate',
+          description: 'Concatenates strings',
+          returnType: 'string' as never,
+          arguments: [],
+        },
+      ],
+    };
+    XPathFunctionCatalogService.setCatalog(catalog);
+    expect(XPathFunctionCatalogService.getCatalog()).toBe(catalog);
+  });
+
+  it('should clear the catalog', () => {
+    XPathFunctionCatalogService.setCatalog({});
+    XPathFunctionCatalogService.clear();
+    expect(XPathFunctionCatalogService.getCatalog()).toBeUndefined();
+  });
+});

--- a/packages/ui/src/services/xpath/catalog/xpath-function-catalog.service.ts
+++ b/packages/ui/src/services/xpath/catalog/xpath-function-catalog.service.ts
@@ -1,0 +1,23 @@
+import { IFunctionDefinition } from '../../../models/datamapper/mapping';
+import { FunctionGroup } from '../xpath-model';
+
+/**
+ * Static store for the converted XPath/XSLT function catalog loaded from {@link @kaoto/camel-catalog}.
+ * Populated by {@link fetchXsltXPathFunctions} at startup; consumed by {@link XPathService} with a
+ * fallback to the hardcoded XPath 2.0 definitions when the catalog is unavailable.
+ */
+export class XPathFunctionCatalogService {
+  private static catalog: Partial<Record<FunctionGroup, IFunctionDefinition[]>> | undefined;
+
+  static setCatalog(catalog: Partial<Record<FunctionGroup, IFunctionDefinition[]>>): void {
+    this.catalog = catalog;
+  }
+
+  static getCatalog(): Partial<Record<FunctionGroup, IFunctionDefinition[]>> | undefined {
+    return this.catalog;
+  }
+
+  static clear(): void {
+    this.catalog = undefined;
+  }
+}

--- a/packages/ui/src/services/xpath/xpath-model.ts
+++ b/packages/ui/src/services/xpath/xpath-model.ts
@@ -34,7 +34,31 @@ export enum FunctionGroup {
   Node = 'Node',
   Sequence = 'Sequence',
   Context = 'Context',
+  Math = 'Math',
+  Map = 'Map',
+  Array = 'Array',
+  HigherOrder = 'Higher-Order',
+  XSLT = 'XSLT',
 }
+
+/** Maps {@link @kaoto/camel-catalog} XPath function category keys to {@link FunctionGroup} values. */
+export const CATEGORY_TO_FUNCTION_GROUP: Record<string, FunctionGroup> = {
+  String: FunctionGroup.String,
+  SubstringMatching: FunctionGroup.SubstringMatching,
+  PatternMatching: FunctionGroup.PatternMatching,
+  Numeric: FunctionGroup.Numeric,
+  DateAndTime: FunctionGroup.DateAndTime,
+  Boolean: FunctionGroup.Boolean,
+  QName: FunctionGroup.QName,
+  Node: FunctionGroup.Node,
+  Sequence: FunctionGroup.Sequence,
+  Context: FunctionGroup.Context,
+  Math: FunctionGroup.Math,
+  MapFunctions: FunctionGroup.Map,
+  ArrayFunctions: FunctionGroup.Array,
+  HigherOrder: FunctionGroup.HigherOrder,
+  XSLT: FunctionGroup.XSLT,
+};
 
 /**
  * Contains validation results for an XPath expression including parser results, errors, and warnings

--- a/packages/ui/src/services/xpath/xpath.service.ts
+++ b/packages/ui/src/services/xpath/xpath.service.ts
@@ -11,6 +11,7 @@ import { DocumentUtilService } from '../document/document-util.service';
 import { getPrefixForNamespaceURI } from '../namespace-util';
 import { XPATH_2_0_FUNCTIONS } from './2.0/xpath-2.0-functions';
 import { XPath2Parser } from './2.0/xpath-2.0-parser';
+import { XPathFunctionCatalogService } from './catalog/xpath-function-catalog.service';
 import { monacoXPathLanguageMetadata } from './monaco-language';
 import { CstVisitor } from './syntaxtree/xpath-syntaxtree-cst-visitor';
 import {
@@ -36,7 +37,6 @@ import { FunctionGroup, ValidatedXPathParseResult, XPathParserResult } from './x
  */
 export class XPathService {
   static readonly parser = new XPath2Parser();
-  static readonly functions = XPATH_2_0_FUNCTIONS;
 
   /**
    * Parses an XPath expression string into a parser result
@@ -80,8 +80,8 @@ export class XPathService {
    * Gets all XPath function definitions grouped by function category
    * @returns record of function definitions organized by function group
    */
-  static getXPathFunctionDefinitions(): Record<FunctionGroup, IFunctionDefinition[]> {
-    return XPathService.functions;
+  static getXPathFunctionDefinitions(): Partial<Record<FunctionGroup, IFunctionDefinition[]>> {
+    return XPathFunctionCatalogService.getCatalog() ?? XPATH_2_0_FUNCTIONS;
   }
 
   private static getXPathFunctionNames(): string[] {


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3370
Fixes: https://github.com/KaotoIO/kaoto/issues/2867


https://github.com/user-attachments/assets/bc5c4cf7-0b66-4fbc-a897-09efb1e421ad

<img width="838" height="1226" alt="Screenshot From 2026-08-03 15-18-34" src="https://github.com/user-attachments/assets/54b67389-cd78-4ee0-ab07-8a2ced1911f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamically loading XSLT XPath function catalogs.
  * Expanded XPath function categories, including Math, Map, Array, Higher-Order, and XSLT.
  * Improved recognition of XPath types, function metadata, arguments, and collection return values.

* **Bug Fixes**
  * Improved handling of missing function groups and incomplete catalog data.
  * Added safe fallback behavior when catalog loading fails.

* **Tests**
  * Added comprehensive coverage for catalog conversion, type mapping, storage, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->