### PR TITLE
fix(canvas): fix addNewEntity template handling for XML routes

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -16,7 +16,7 @@
 
 import { CamelYamlDsl, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
-import { stringify } from 'yaml';
+import { parse, stringify } from 'yaml';
 
 import { TileFilter } from '../../components/Catalog';
 import { insertYamlComments } from '../../utils/yaml-comments';
@@ -190,8 +190,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     if (entityTemplate) {
       route = entityTemplate as RouteDefinition;
     } else {
-      const template = FlowTemplateService.getFlowTemplate(this.getType());
-      route = template[0] as RouteDefinition;
+      route = this.getRouteTemplate();
     }
     const entity = new CamelRouteVisualEntity(route);
 
@@ -199,6 +198,11 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
     this.entities.splice(insertIndex, 0, entity);
 
     return entity.id;
+  }
+
+  protected getRouteTemplate(): RouteDefinition {
+    const template = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
+    return template[0] as RouteDefinition;
   }
 
   /**

--- a/packages/ui/src/models/camel/camel-xml-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
+import { CamelYamlDsl, RouteDefinition } from '@kaoto/camel-catalog/types';
 import xmlFormat from 'xml-formatter';
 
+import { getCamelRandomId } from '../../camel-utils/camel-random-id';
 import { KaotoXmlParser } from '../../serializers/xml/kaoto-xml-parser';
 import { EntityDefinition } from '../../serializers/xml/serializers/entitiy-definition';
 import { KaotoXmlSerializer } from '../../serializers/xml/serializers/kaoto-xml-serializer';
 import { insertXmlComments, parseXmlComments } from '../../utils/xml-comments';
 import { EntityType } from '../entities';
 import { BaseVisualCamelEntityConstructor } from '../visualization/base-visual-entity';
+import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
 import { CamelRouteResource } from './camel-route-resource';
 import { SourceSchemaType } from './source-schema-type';
 
@@ -52,6 +54,7 @@ export class CamelXMLRouteResource extends CamelRouteResource {
   private readonly xmlDeclaration: string;
   private readonly rootElementDefinitions: { name: string; value: string }[];
   private readonly xmlSerializer = new XMLSerializer();
+  private parsedRouteTemplate: RouteDefinition | undefined;
 
   constructor(source: string = '') {
     super();
@@ -74,7 +77,16 @@ export class CamelXMLRouteResource extends CamelRouteResource {
     const parser = new KaotoXmlParser();
     const rawEntities = (await parser.parseXML(this.code)) as unknown as CamelYamlDsl;
     this.setRawEntities(rawEntities);
+    const xmlTemplate = FlowTemplateService.getFlowSourceTemplate(this.getType());
+    const parsedTemplate = (await parser.parseXML(xmlTemplate)) as Array<{ route: RouteDefinition }>;
+    this.parsedRouteTemplate = parsedTemplate[0] as unknown as RouteDefinition;
     await super.initialize();
+  }
+
+  protected override getRouteTemplate(): RouteDefinition {
+    const template = structuredClone((this.parsedRouteTemplate as unknown as { route: RouteDefinition }).route);
+    template.id = getCamelRandomId('route');
+    return { route: template } as unknown as RouteDefinition;
   }
 
   override async toSourceCode(): Promise<string> {


### PR DESCRIPTION
Extract `getRouteTemplate()` as a protected hook in `CamelRouteResource`, replacing the inline `getFlowTemplate` call and fixing it to use `getFlowSourceTemplate` + `parse` (avoiding the double-parse that the previous approach had).

`CamelXMLRouteResource` overrides the hook: during `initialize()` the XML template is parsed once via `KaotoXmlParser` and cached. `getRouteTemplate()` then returns a `structuredClone` of that cached route with a fresh random ID, ensuring each new entity is fully independent and mutation-safe.

fix: https://github.com/KaotoIO/kaoto/issues/3618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route creation from YAML and XML flow templates.
  * Ensured route definitions are correctly parsed and initialized before route generation.
  * Assigned unique identifiers to generated routes for more reliable handling.
  * Preserved route template data during initialization, helping maintain configuration details and improve consistency when creating routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->