### PR TITLE
fix(DataMapper): Entering space is blocked in Primitive Target Body X…

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperModal.scss
+++ b/packages/ui/src/components/DataMapper/DataMapperModal.scss
@@ -1,0 +1,3 @@
+.datamapper-modal {
+  display: contents;
+}

--- a/packages/ui/src/components/DataMapper/DataMapperModal.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperModal.tsx
@@ -1,3 +1,5 @@
+import './DataMapperModal.scss';
+
 import { Modal, ModalProps } from '@patternfly/react-core';
 import { FunctionComponent, MouseEvent, PointerEvent, TouchEvent, useCallback } from 'react';
 
@@ -31,7 +33,7 @@ export const DataMapperModal: FunctionComponent<Omit<ModalProps, 'ref'>> = (prop
 
   return (
     <div // NOSONAR - intentional non-interactive event barrier for DnD isolation, not a user-facing element
-      style={{ display: 'contents' }}
+      className="datamapper-modal"
       onClick={stopPropagation}
       onPointerDown={stopPropagation}
       onMouseDown={stopPropagation}

--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -4,7 +4,6 @@ import {
   HelperTextItem,
   InputGroup,
   InputGroupItem,
-  Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -14,7 +13,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { FileImportIcon, TrashIcon } from '@patternfly/react-icons';
-import { FunctionComponent, KeyboardEvent, MouseEvent, useCallback, useContext, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import {
@@ -27,6 +26,7 @@ import {
 } from '../../../../models/datamapper/document';
 import { MetadataContext } from '../../../../providers';
 import { DocumentService } from '../../../../services/document/document.service';
+import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
 import { createSchemaFileItems, getFileExtension, isJsonExtension, pickAndValidateSchemaFiles } from '../utils';
 import { RootElementSelect } from './RootElementSelect';
 import { SchemaFileDataList } from './SchemaFileDataList';
@@ -210,10 +210,6 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
     setFilePaths([]);
   }, [onModalClose]);
 
-  const handleStopPropagation = useCallback((event: MouseEvent | KeyboardEvent) => {
-    event.stopPropagation();
-  }, []);
-
   const isReadyToSubmit = useMemo(() => {
     return filePaths.length > 0 && createDocumentResult?.validationStatus !== 'error' && createDocumentResult?.document;
   }, [filePaths.length, createDocumentResult]);
@@ -224,14 +220,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   );
 
   return (
-    <Modal
-      isOpen={isModalOpen}
-      variant="medium"
-      data-testid="attach-schema-modal"
-      onClick={handleStopPropagation}
-      onMouseDown={handleStopPropagation}
-      onKeyDown={handleStopPropagation}
-    >
+    <DataMapperModal isOpen={isModalOpen} variant="medium" data-testid="attach-schema-modal">
       <ModalHeader title={`${actionName} schema : ( ${documentTypeLabel} )`} />
       <ModalBody>
         <Stack hasGutter>
@@ -336,6 +325,6 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
           Cancel
         </Button>
       </ModalFooter>
-    </Modal>
+    </DataMapperModal>
   );
 };

--- a/packages/ui/src/components/Document/actions/AttachSchema/UpdateSchemaWarningModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/UpdateSchemaWarningModal.tsx
@@ -1,5 +1,7 @@
-import { Alert, Button, Modal, ModalBody, ModalFooter, ModalHeader, Stack, StackItem } from '@patternfly/react-core';
-import { FunctionComponent, KeyboardEvent, MouseEvent, useCallback } from 'react';
+import { Alert, Button, ModalBody, ModalFooter, ModalHeader, Stack, StackItem } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+
+import { DataMapperModal } from '../../../DataMapper/DataMapperModal';
 
 type UpdateSchemaWarningModalProps = {
   actionName: string;
@@ -16,19 +18,8 @@ export const UpdateSchemaWarningModal: FunctionComponent<UpdateSchemaWarningModa
   onProceed,
   onCancel,
 }) => {
-  const handleStopPropagation = useCallback((event: MouseEvent | KeyboardEvent) => {
-    event.stopPropagation();
-  }, []);
-
   return (
-    <Modal
-      isOpen={isModalOpen}
-      variant="small"
-      data-testid="update-schema-warning-modal"
-      onClick={handleStopPropagation}
-      onMouseDown={handleStopPropagation}
-      onKeyDown={handleStopPropagation}
-    >
+    <DataMapperModal isOpen={isModalOpen} variant="small" data-testid="update-schema-warning-modal">
       <ModalHeader title={`${actionName} schema : ( ${documentTypeLabel} )`} />
       <ModalBody>
         <Stack hasGutter>
@@ -53,6 +44,6 @@ export const UpdateSchemaWarningModal: FunctionComponent<UpdateSchemaWarningModa
           Cancel
         </Button>
       </ModalFooter>
-    </Modal>
+    </DataMapperModal>
   );
 };

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -14,6 +14,7 @@ import {
 import { MappingService } from '../../../../services/mapping/mapping.service';
 import { MappingActionService } from '../../../../services/visualization/mapping-action.service';
 import { MappingActionRegistryService } from '../../../../services/visualization/mapping-action-registry.service';
+import { useDocumentTreeStore } from '../../../../store/document-tree.store';
 import { TestUtil } from '../../../../stubs/datamapper/data-mapper';
 import { MappingContextMenuAction } from './MappingContextMenuAction';
 
@@ -48,6 +49,7 @@ describe('MappingContextMenuAction', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    useDocumentTreeStore.getState().setOpenMappingMenuId(null);
   });
 
   it('should apply ValueSelector', async () => {
@@ -473,6 +475,44 @@ describe('MappingContextMenuAction', () => {
 
       const sortAction = screen.getByTestId('transformation-actions-sort');
       expect(sortAction).toHaveTextContent('Edit Sort');
+    });
+  });
+
+  describe('Single open menu enforcement', () => {
+    afterEach(() => {
+      useDocumentTreeStore.getState().setOpenMappingMenuId(null);
+    });
+
+    it('should close first menu when second menu toggle is clicked', async () => {
+      const nodeData1 = new TargetFieldNodeData(
+        documentNodeData,
+        targetDoc.fields[0],
+        new FieldItem(mappingTree, targetDoc.fields[0]),
+      );
+      const nodeData2 = new TargetFieldNodeData(
+        documentNodeData,
+        targetDoc.fields[0].fields[0],
+        new FieldItem(mappingTree, targetDoc.fields[0].fields[0]),
+      );
+      render(
+        <>
+          <MappingContextMenuAction nodeData={nodeData1} onUpdate={vi.fn()} />
+          <MappingContextMenuAction nodeData={nodeData2} onUpdate={vi.fn()} />
+        </>,
+      );
+
+      const toggles = screen.getAllByTestId('transformation-actions-menu-toggle');
+
+      fireEvent.click(toggles[0]);
+      await waitFor(() => {
+        expect(toggles[0].getAttribute('aria-expanded')).toBe('true');
+      });
+
+      fireEvent.click(toggles[1]);
+      await waitFor(() => {
+        expect(toggles[0].getAttribute('aria-expanded')).toBe('false');
+        expect(toggles[1].getAttribute('aria-expanded')).toBe('true');
+      });
     });
   });
 

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.test.tsx
@@ -1,5 +1,5 @@
 import { DraggableObject } from '@patternfly/react-drag-drop';
-import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FunctionComponent } from 'react';
 
 import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../../../models/datamapper/document';
@@ -480,7 +480,9 @@ describe('MappingContextMenuAction', () => {
 
   describe('Single open menu enforcement', () => {
     afterEach(() => {
-      useDocumentTreeStore.getState().setOpenMappingMenuId(null);
+      act(() => {
+        useDocumentTreeStore.getState().setOpenMappingMenuId(null);
+      });
     });
 
     it('should close first menu when second menu toggle is clicked', async () => {
@@ -501,17 +503,17 @@ describe('MappingContextMenuAction', () => {
         </>,
       );
 
-      const toggles = screen.getAllByTestId('transformation-actions-menu-toggle');
+      const [firstToggle, secondToggle] = screen.getAllByTestId('transformation-actions-menu-toggle');
 
-      fireEvent.click(toggles[0]);
+      fireEvent.click(firstToggle);
       await waitFor(() => {
-        expect(toggles[0].getAttribute('aria-expanded')).toBe('true');
+        expect(firstToggle.getAttribute('aria-expanded')).toBe('true');
       });
 
-      fireEvent.click(toggles[1]);
+      fireEvent.click(secondToggle);
       await waitFor(() => {
-        expect(toggles[0].getAttribute('aria-expanded')).toBe('false');
-        expect(toggles[1].getAttribute('aria-expanded')).toBe('true');
+        expect(firstToggle.getAttribute('aria-expanded')).toBe('false');
+        expect(secondToggle.getAttribute('aria-expanded')).toBe('true');
       });
     });
   });

--- a/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
+++ b/packages/ui/src/components/Document/actions/MappingMenu/MappingContextMenuAction.tsx
@@ -8,7 +8,7 @@ import {
   MenuToggle,
 } from '@patternfly/react-core';
 import { AddCircleOIcon, EllipsisVIcon } from '@patternfly/react-icons';
-import { Fragment, FunctionComponent, MouseEvent, useCallback, useMemo, useRef, useState } from 'react';
+import { Fragment, FunctionComponent, MouseEvent, useCallback, useMemo, useRef } from 'react';
 
 import { MappingItem } from '../../../../models/datamapper/mapping';
 import {
@@ -19,6 +19,7 @@ import {
 import { TargetNodeData } from '../../../../models/datamapper/visualization';
 import { DEFAULT_POPPER_PROPS } from '../../../../models/popper-default';
 import { MappingActionRegistryService } from '../../../../services/visualization/mapping-action-registry.service';
+import { useDocumentTreeStore } from '../../../../store/document-tree.store';
 import { useMappingActionModals } from './useMappingActionModals';
 
 type MappingContextMenuProps = {
@@ -32,7 +33,9 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
   nodeData,
   onUpdate,
 }) => {
-  const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
+  const openMappingMenuId = useDocumentTreeStore((state) => state.openMappingMenuId);
+  const setOpenMappingMenuId = useDocumentTreeStore((state) => state.setOpenMappingMenuId);
+  const isActionMenuOpen = openMappingMenuId === nodeData.id;
   const menuRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const menuItems = useMemo(() => MappingActionRegistryService.getMappingContextMenuItems(nodeData), [nodeData]);
@@ -75,16 +78,19 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
       const item = menuItems.find((mi) => mi.key === itemId);
       if (item) {
         item.apply(nodeData, callbacks);
-        setIsActionMenuOpen(false);
+        setOpenMappingMenuId(null);
       }
     },
-    [menuItems, nodeData, callbacks],
+    [menuItems, nodeData, callbacks, setOpenMappingMenuId],
   );
 
-  const onToggleClick = useCallback((event: MouseEvent) => {
-    event.stopPropagation();
-    setIsActionMenuOpen((prev) => !prev);
-  }, []);
+  const onToggleClick = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      setOpenMappingMenuId(isActionMenuOpen ? null : nodeData.id);
+    },
+    [isActionMenuOpen, nodeData.id, setOpenMappingMenuId],
+  );
 
   return (
     <>
@@ -92,7 +98,7 @@ export const MappingContextMenuAction: FunctionComponent<MappingContextMenuProps
         <MenuContainer
           isOpen={isActionMenuOpen}
           onOpenChange={(isOpen) => {
-            setIsActionMenuOpen(isOpen);
+            setOpenMappingMenuId(isOpen ? nodeData.id : null);
           }}
           menu={
             <Menu ref={menuRef} containsFlyout onSelect={onSelectAction}>

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
@@ -1,7 +1,7 @@
 import './TargetNodeActions.scss';
 
 import { ActionListGroup } from '@patternfly/react-core';
-import { FunctionComponent, KeyboardEvent, MouseEvent, useCallback } from 'react';
+import { FunctionComponent } from 'react';
 
 import { MappingActionKind } from '../../../models/datamapper/mapping-action';
 import { TargetNodeData } from '../../../models/datamapper/visualization';
@@ -22,13 +22,8 @@ export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({ c
   const expressionItem = VisualizationService.getExpressionItemForNode(nodeData);
   const allowedActions = new Set(MappingActionRegistryService.getAllowedActions(nodeData));
 
-  const handleStopPropagation = useCallback((event: MouseEvent | KeyboardEvent) => {
-    if (!(event.currentTarget as HTMLElement).contains(event.target as Node)) return;
-    event.stopPropagation();
-  }, []);
-
   return (
-    <ActionListGroup key={`target-node-actions-${nodeData.id}`} onKeyDown={handleStopPropagation} className={className}>
+    <ActionListGroup key={`target-node-actions-${nodeData.id}`} className={className}>
       {expressionItem && (
         <>
           <XPathInputAction nodeData={nodeData} mapping={expressionItem} onUpdate={onUpdate} />

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -458,6 +458,44 @@ describe('ExpansionPanel', () => {
       // Activating the button must not toggle the surrounding panel.
       expect(mockSetExpanded).not.toHaveBeenCalled();
     });
+
+    it('should NOT toggle on Space key from a child input inside summary', () => {
+      renderPanel({
+        defaultExpanded: true,
+        summary: (
+          <div>
+            Test Summary
+            <input data-testid="child-input" type="text" />
+          </div>
+        ),
+      });
+
+      const input = screen.getByTestId('child-input');
+      fireEvent.keyDown(input, { key: ' ' });
+
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+      const panel = screen.getByText('Test Summary').closest('.expansion-panel');
+      expect(panel).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('should NOT toggle on Enter key from a child input inside summary', () => {
+      renderPanel({
+        defaultExpanded: true,
+        summary: (
+          <div>
+            Test Summary
+            <input data-testid="child-input" type="text" />
+          </div>
+        ),
+      });
+
+      const input = screen.getByTestId('child-input');
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+      const panel = screen.getByText('Test Summary').closest('.expansion-panel');
+      expect(panel).toHaveAttribute('data-expanded', 'true')
+    });
   });
 
   describe('Layout Callback Registration', () => {

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -494,7 +494,7 @@ describe('ExpansionPanel', () => {
 
       expect(mockSetExpanded).not.toHaveBeenCalled();
       const panel = screen.getByText('Test Summary').closest('.expansion-panel');
-      expect(panel).toHaveAttribute('data-expanded', 'true')
+      expect(panel).toHaveAttribute('data-expanded', 'true');
     });
   });
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -112,10 +112,8 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-      // Let interactive descendants (buttons, inputs) handle their own Enter/Space.
-      // Calling preventDefault() here would otherwise suppress their activation.
       if (event.target !== event.currentTarget) return;
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/ui/src/store/document-tree.store.ts
+++ b/packages/ui/src/store/document-tree.store.ts
@@ -68,6 +68,10 @@ export interface DocumentTreeState {
   /** Variable mapping ID currently being renamed inline. */
   renamingVariableId: string | null;
   setRenamingVariable: (variableId: string | null) => void;
+
+  /** Node ID whose mapping context menu (3-dot) is currently open. */
+  openMappingMenuId: string | null;
+  setOpenMappingMenuId: (id: string | null) => void;
 }
 
 export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
@@ -82,6 +86,7 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
       targetXPathInputForFocus: null,
       addingVariableToNodePath: null,
       renamingVariableId: null,
+      openMappingMenuId: null,
 
       setNodesConnectionPorts: (documentId: string, ports: TreeConnectionPorts) => {
         set((state) => ({
@@ -173,6 +178,10 @@ export const useDocumentTreeStore = createWithEqualityFn<DocumentTreeState>()(
 
       setRenamingVariable: (variableId: string | null) => {
         set({ renamingVariableId: variableId, addingVariableToNodePath: null });
+      },
+
+      setOpenMappingMenuId: (id: string | null) => {
+        set({ openMappingMenuId: id });
       },
     }),
     { name: 'Document Tree Store' },


### PR DESCRIPTION
…Path

Fixes: https://github.com/KaotoIO/kaoto/issues/3621
Fixes: https://github.com/KaotoIO/kaoto/issues/3600
Fixes: https://github.com/KaotoIO/kaoto/issues/3622

- ExpansionPanel's `preventDefault()` against `Enter` and `Space` prevents browser's regular character input, which both input field and monaco-editor depend on for entering a line break and a space. Make sure the event target is the panel itself
- Make AttachSchemaModal and UpdateSchemaWarningModal also be based on DataMapperModal to share key/mouse event propagation control with other DataMapper modals
- Remove stale onKeyDown stopPropagation from TargetNodeActions
- Introduce the state in document-tree.store to manage which node currently has mapping context menu open instead of depending on event bubbling up


https://github.com/user-attachments/assets/db27c518-6525-45d8-8ae2-e4a66f80f500


https://github.com/user-attachments/assets/a8cbb90a-f795-4f5f-b9a8-30e75cc2e0a6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mapping context menus now coordinate so only one remains open at a time.

* **Bug Fixes**
  * Prevented nested controls from unintentionally toggling expansion panels when using Enter or Space.
  * Improved modal interactions for schema attachment and update warnings.
  * Streamlined keyboard and mouse behavior across document and mapping controls.

* **Tests**
  * Added coverage for exclusive context-menu behavior and expansion-panel keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->