### PR TITLE
feat(DataMapper): XPath Editor: function completion and hover help

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -13,7 +13,10 @@ import { getShipOrderToShipOrderXslt, getShipOrderXsd } from '../../stubs/datama
 import { DataMapper } from './DataMapper';
 
 vi.mock('monaco-editor', () => ({
-  languages: { CompletionItemKind: { Keyword: 17 } },
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
 }));
 
 describe('DataMapperPage', () => {

--- a/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathEditorAction.test.tsx
@@ -15,7 +15,10 @@ vi.mock('../../XPath/XPathEditor', () => ({
 }));
 
 vi.mock('monaco-editor', () => ({
-  languages: { CompletionItemKind: { Keyword: 17 } },
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
 }));
 
 describe('XPathEditorAction', () => {

--- a/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
+++ b/packages/ui/src/components/Document/actions/XPathInputAction.test.tsx
@@ -9,7 +9,10 @@ import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { XPathInputAction } from './XPathInputAction';
 
 vi.mock('monaco-editor', () => ({
-  languages: { CompletionItemKind: { Keyword: 17 } },
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
 }));
 
 describe('XPathInputAction', () => {

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -30,10 +30,11 @@ export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onCh
     monaco.languages.register({ id: xpathLanguage.id });
     monaco.languages.setMonarchTokensProvider(xpathLanguage.id, xpathLanguage.tokensProvider);
     monaco.languages.setLanguageConfiguration(xpathLanguage.id, xpathLanguage.languageConfiguration);
-    monaco.languages.registerCompletionItemProvider(xpathLanguage.id, xpathLanguage.completionItemProvider);
-    monaco.languages.registerHoverProvider(xpathLanguage.id, {
-      provideHover: () => ({ contents: [{ value: 'test' }] }),
-    });
+    const completionDisposable = monaco.languages.registerCompletionItemProvider(
+      xpathLanguage.id,
+      xpathLanguage.completionItemProvider,
+    );
+    const hoverDisposable = monaco.languages.registerHoverProvider(xpathLanguage.id, xpathLanguage.hoverProvider);
     const themeName = 'datamapperTheme';
     monaco.editor.defineTheme(themeName, xpathEditorTheme);
 
@@ -51,6 +52,8 @@ export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onCh
     setEditor(newEditor);
 
     return () => {
+      completionDisposable.dispose();
+      hoverDisposable.dispose();
       newEditor.dispose();
       setEditor(null);
     };

--- a/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
+++ b/packages/ui/src/components/XPath/XPathEditorLayout.test.tsx
@@ -20,7 +20,10 @@ vi.mock('./XPathEditor', () => ({
 }));
 
 vi.mock('monaco-editor', () => ({
-  languages: { CompletionItemKind: { Keyword: 17 } },
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
 }));
 
 // Shared test setup

--- a/packages/ui/src/services/xpath/monaco-language.test.ts
+++ b/packages/ui/src/services/xpath/monaco-language.test.ts
@@ -1,0 +1,352 @@
+import { IFunctionDefinition } from '../../models/datamapper/mapping';
+import { Types } from '../../models/datamapper/types';
+import { buildFunctionCompletionItem, buildFunctionSignature, monacoXPathLanguageMetadata } from './monaco-language';
+
+vi.mock('monaco-editor', () => ({
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
+}));
+
+const testRange = {
+  startLineNumber: 1,
+  endLineNumber: 1,
+  startColumn: 1,
+  endColumn: 5,
+};
+
+const concatFn: IFunctionDefinition = {
+  name: 'concat',
+  displayName: 'Concatenate',
+  description: 'Concatenates strings.',
+  returnType: Types.String,
+  arguments: [
+    {
+      name: 'args',
+      displayName: '$args',
+      description: 'Arguments',
+      type: Types.AnyAtomicType,
+      minOccurs: 2,
+      maxOccurs: Number.MAX_SAFE_INTEGER,
+    },
+  ],
+};
+
+const positionFn: IFunctionDefinition = {
+  name: 'position',
+  displayName: 'Position',
+  description: 'Returns the context position.',
+  returnType: Types.Integer,
+  arguments: [],
+};
+
+const tokenizeFn: IFunctionDefinition = {
+  name: 'tokenize',
+  displayName: 'Tokenize',
+  description: 'Returns a sequence of strings.',
+  returnType: Types.String,
+  returnCollection: true,
+  arguments: [
+    {
+      name: 'input',
+      displayName: '$input',
+      description: 'Input',
+      type: Types.String,
+      minOccurs: 1,
+      maxOccurs: 1,
+    },
+    {
+      name: 'pattern',
+      displayName: '$pattern',
+      description: 'Pattern',
+      type: Types.String,
+      minOccurs: 1,
+      maxOccurs: 1,
+    },
+  ],
+};
+
+function createMockModel(wordAtPosition: { word: string; startColumn: number; endColumn: number } | null) {
+  return {
+    getWordAtPosition: () => wordAtPosition,
+    getWordUntilPosition: () => wordAtPosition ?? { word: '', startColumn: 1, endColumn: 1 },
+  };
+}
+
+describe('monaco-language', () => {
+  describe('buildFunctionSignature()', () => {
+    it('should build signature for function with required arguments', () => {
+      expect(buildFunctionSignature(concatFn)).toBe('(args: anyAtomicType, ...): string');
+    });
+
+    it('should build signature for function with no arguments', () => {
+      expect(buildFunctionSignature(positionFn)).toBe('(): integer');
+    });
+
+    it('should build signature for function with optional arguments', () => {
+      const fn: IFunctionDefinition = {
+        name: 'string-length',
+        displayName: 'String Length',
+        description: 'Returns the length.',
+        returnType: Types.Integer,
+        arguments: [
+          {
+            name: 'arg',
+            displayName: '$arg',
+            description: 'Argument',
+            type: Types.String,
+            minOccurs: 0,
+            maxOccurs: 1,
+          },
+        ],
+      };
+      expect(buildFunctionSignature(fn)).toBe('(arg?: string): integer');
+    });
+
+    it('should build signature for function with mixed required and optional arguments', () => {
+      const fn: IFunctionDefinition = {
+        name: 'substring',
+        displayName: 'Substring',
+        description: 'Returns a substring.',
+        returnType: Types.String,
+        arguments: [
+          {
+            name: 'sourceString',
+            displayName: '$sourceString',
+            description: 'Source',
+            type: Types.String,
+            minOccurs: 1,
+            maxOccurs: 1,
+          },
+          {
+            name: 'startingLoc',
+            displayName: '$startingLoc',
+            description: 'Start',
+            type: Types.Double,
+            minOccurs: 1,
+            maxOccurs: 1,
+          },
+          {
+            name: 'length',
+            displayName: '$length',
+            description: 'Length',
+            type: Types.Double,
+            minOccurs: 0,
+            maxOccurs: 1,
+          },
+        ],
+      };
+      expect(buildFunctionSignature(fn)).toBe('(sourceString: string, startingLoc: double, length?: double): string');
+    });
+
+    it('should indicate collection return type', () => {
+      expect(buildFunctionSignature(tokenizeFn)).toBe('(input: string, pattern: string): string[]');
+    });
+  });
+
+  describe('buildFunctionCompletionItem()', () => {
+    it('should create completion item for function with arguments', () => {
+      const fn: IFunctionDefinition = {
+        name: 'contains',
+        displayName: 'Contains',
+        description: 'Checks if string contains another.',
+        returnType: Types.Boolean,
+        arguments: [
+          {
+            name: 'arg1',
+            displayName: '$arg1',
+            description: 'First arg',
+            type: Types.String,
+            minOccurs: 1,
+            maxOccurs: 1,
+          },
+          {
+            name: 'arg2',
+            displayName: '$arg2',
+            description: 'Second arg',
+            type: Types.String,
+            minOccurs: 1,
+            maxOccurs: 1,
+          },
+        ],
+      };
+      const item = buildFunctionCompletionItem(fn, testRange);
+      expect(item.label).toBe('contains');
+      expect(item.kind).toBe(1);
+      expect(item.insertText).toBe('contains($1)');
+      expect(item.insertTextRules).toBe(4);
+      expect(item.detail).toBe('(arg1: string, arg2: string): boolean');
+      expect(item.range).toBe(testRange);
+    });
+
+    it('should create completion item for zero-arg function', () => {
+      const item = buildFunctionCompletionItem(positionFn, testRange);
+      expect(item.label).toBe('position');
+      expect(item.insertText).toBe('position()$0');
+      expect(item.insertTextRules).toBe(4);
+      expect(item.detail).toBe('(): integer');
+    });
+
+    it('should include documentation with description and arguments', () => {
+      const fn: IFunctionDefinition = {
+        name: 'upper-case',
+        displayName: 'Uppercase',
+        description: 'Returns the upper-cased value.',
+        returnType: Types.String,
+        arguments: [
+          {
+            name: 'arg',
+            displayName: '$arg',
+            description: 'Argument',
+            type: Types.String,
+            minOccurs: 1,
+            maxOccurs: 1,
+          },
+        ],
+      };
+      const item = buildFunctionCompletionItem(fn, testRange);
+      const doc = item.documentation as { value: string };
+      expect(doc.value).toContain('**Uppercase**');
+      expect(doc.value).toContain('Returns the upper-cased value.');
+      expect(doc.value).toContain('`$arg`');
+      expect(doc.value).toContain('**Returns:** string');
+    });
+
+    it('should mark optional arguments in documentation', () => {
+      const fn: IFunctionDefinition = {
+        name: 'normalize-space',
+        displayName: 'Normalize Space',
+        description: 'Normalizes whitespace.',
+        returnType: Types.String,
+        arguments: [
+          {
+            name: 'arg',
+            displayName: '$arg',
+            description: 'Argument',
+            type: Types.String,
+            minOccurs: 0,
+            maxOccurs: 1,
+          },
+        ],
+      };
+      const item = buildFunctionCompletionItem(fn, testRange);
+      const doc = item.documentation as { value: string };
+      expect(doc.value).toContain('*(optional)*');
+    });
+
+    it('should mark variadic arguments in documentation', () => {
+      const item = buildFunctionCompletionItem(concatFn, testRange);
+      const doc = item.documentation as { value: string };
+      expect(doc.value).toContain('*(variadic)*');
+    });
+
+    it('should show collection return type in detail and documentation', () => {
+      const item = buildFunctionCompletionItem(tokenizeFn, testRange);
+      expect(item.detail).toBe('(input: string, pattern: string): string[]');
+      const doc = item.documentation as { value: string };
+      expect(doc.value).toContain('**Returns:** string[]');
+    });
+  });
+
+  describe('hoverProvider.provideHover()', () => {
+    beforeEach(() => {
+      monacoXPathLanguageMetadata.functionDefinitions = [concatFn, positionFn];
+    });
+
+    afterEach(() => {
+      monacoXPathLanguageMetadata.functionDefinitions = [];
+    });
+
+    it('should return hover content for a known function', () => {
+      const model = createMockModel({ word: 'concat', startColumn: 1, endColumn: 7 });
+      const position = { lineNumber: 1, column: 3 };
+      const result = monacoXPathLanguageMetadata.hoverProvider.provideHover(
+        model as never,
+        position as never,
+        {} as never,
+      );
+      expect(result).not.toBeNull();
+      const hover = result as { contents: { value: string }[]; range: object };
+      expect(hover.contents).toHaveLength(2);
+      expect(hover.contents[0].value).toContain('concat');
+      expect(hover.contents[1].value).toContain('**Concatenate**');
+      expect(hover.range).toEqual({
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 1,
+        endColumn: 7,
+      });
+    });
+
+    it('should return null for an unknown word', () => {
+      const model = createMockModel({ word: 'myVariable', startColumn: 1, endColumn: 11 });
+      const position = { lineNumber: 1, column: 3 };
+      const result = monacoXPathLanguageMetadata.hoverProvider.provideHover(
+        model as never,
+        position as never,
+        {} as never,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no word at position', () => {
+      const model = createMockModel(null);
+      const position = { lineNumber: 1, column: 1 };
+      const result = monacoXPathLanguageMetadata.hoverProvider.provideHover(
+        model as never,
+        position as never,
+        {} as never,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('completionItemProvider.provideCompletionItems()', () => {
+    beforeEach(() => {
+      monacoXPathLanguageMetadata.functionDefinitions = [concatFn, positionFn];
+    });
+
+    afterEach(() => {
+      monacoXPathLanguageMetadata.functionDefinitions = [];
+    });
+
+    it('should return keyword and function suggestions', () => {
+      const model = createMockModel({ word: 'co', startColumn: 1, endColumn: 3 });
+      const position = { lineNumber: 1, column: 3 };
+      const result = monacoXPathLanguageMetadata.completionItemProvider.provideCompletionItems(
+        model as never,
+        position as never,
+        {} as never,
+        {} as never,
+      );
+      const list = result as { suggestions: { label: string; kind: number }[] };
+      const keywordLabels = list.suggestions.filter((s) => s.kind === 17).map((s) => s.label);
+      const functionLabels = list.suggestions.filter((s) => s.kind === 1).map((s) => s.label);
+      expect(keywordLabels).toContain('if');
+      expect(keywordLabels).toContain('for');
+      expect(functionLabels).toContain('concat');
+      expect(functionLabels).toContain('position');
+    });
+
+    it('should set correct range from word position', () => {
+      const model = createMockModel({ word: 'pos', startColumn: 5, endColumn: 8 });
+      const position = { lineNumber: 2, column: 8 };
+      const result = monacoXPathLanguageMetadata.completionItemProvider.provideCompletionItems(
+        model as never,
+        position as never,
+        {} as never,
+        {} as never,
+      );
+      const list = result as { suggestions: { range: object }[] };
+      for (const suggestion of list.suggestions) {
+        expect(suggestion.range).toEqual({
+          startLineNumber: 2,
+          endLineNumber: 2,
+          startColumn: 5,
+          endColumn: 8,
+        });
+      }
+    });
+  });
+});

--- a/packages/ui/src/services/xpath/monaco-language.ts
+++ b/packages/ui/src/services/xpath/monaco-language.ts
@@ -1,11 +1,15 @@
 import * as monaco from 'monaco-editor';
 
+import { IFunctionArgumentDefinition, IFunctionDefinition } from '../../models/datamapper/mapping';
+
 export const xpathLanguageID = 'xpath';
 
 type MonacoXPathLanguageMetadata = monaco.languages.ILanguageExtensionPoint & {
   languageConfiguration: monaco.languages.LanguageConfiguration;
   tokensProvider: monaco.languages.IMonarchLanguage;
   completionItemProvider: monaco.languages.CompletionItemProvider;
+  hoverProvider: monaco.languages.HoverProvider;
+  functionDefinitions: IFunctionDefinition[];
 };
 
 const keywords = [
@@ -29,9 +33,61 @@ const keywords = [
 
 const operators = ['+', '-', '*', '<<', '>>', '|', ','];
 
+function formatReturnType(fn: IFunctionDefinition): string {
+  return fn.returnCollection ? `${fn.returnType}[]` : `${fn.returnType}`;
+}
+
+export function buildFunctionSignature(fn: IFunctionDefinition): string {
+  const params = fn.arguments.map((arg) => formatArgument(arg)).join(', ');
+  return `(${params}): ${formatReturnType(fn)}`;
+}
+
+function formatArgument(arg: IFunctionArgumentDefinition): string {
+  const optional = arg.minOccurs === 0 ? '?' : '';
+  const variadic = arg.maxOccurs > 1 ? ', ...' : '';
+  return `${arg.name}${optional}: ${arg.type}${variadic}`;
+}
+
+function buildDocumentation(fn: IFunctionDefinition): monaco.IMarkdownString {
+  const lines: string[] = [`**${fn.displayName}**`, '', fn.description];
+  if (fn.arguments.length > 0) {
+    lines.push('', '**Arguments:**');
+    for (const arg of fn.arguments) {
+      const optional = arg.minOccurs === 0 ? ' *(optional)*' : '';
+      const variadic = arg.maxOccurs > 1 ? ' *(variadic)*' : '';
+      lines.push(`- \`${arg.displayName}\`: ${arg.type}${optional}${variadic}`);
+    }
+  }
+  lines.push('', `**Returns:** ${formatReturnType(fn)}`);
+  return { value: lines.join('\n') };
+}
+
+export function buildFunctionCompletionItem(
+  fn: IFunctionDefinition,
+  range: monaco.IRange,
+): monaco.languages.CompletionItem {
+  const hasArgs = fn.arguments.length > 0;
+  return {
+    label: fn.name,
+    kind: monaco.languages.CompletionItemKind.Function,
+    detail: buildFunctionSignature(fn),
+    documentation: buildDocumentation(fn),
+    insertText: hasArgs ? `${fn.name}($1)` : `${fn.name}()$0`,
+    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    range: range,
+  };
+}
+
+function buildFunctionHoverContent(fn: IFunctionDefinition): monaco.IMarkdownString[] {
+  const signature = `\`${fn.name}${buildFunctionSignature(fn)}\``;
+  const doc = buildDocumentation(fn);
+  return [{ value: signature }, doc];
+}
+
 export const monacoXPathLanguageMetadata: MonacoXPathLanguageMetadata = {
   id: xpathLanguageID,
   languageConfiguration: {
+    wordPattern: /\d[\w.]*|[a-zA-Z_][\w-]*/,
     brackets: [
       ['[', ']'],
       ['(', ')'],
@@ -49,6 +105,29 @@ export const monacoXPathLanguageMetadata: MonacoXPathLanguageMetadata = {
     },
   },
 
+  functionDefinitions: [],
+
+  hoverProvider: {
+    provideHover: (
+      model: monaco.editor.ITextModel,
+      position: monaco.Position,
+    ): monaco.languages.ProviderResult<monaco.languages.Hover> => {
+      const wordInfo = model.getWordAtPosition(position);
+      if (!wordInfo) return null;
+      const fn = monacoXPathLanguageMetadata.functionDefinitions.find((f) => f.name === wordInfo.word);
+      if (!fn) return null;
+      return {
+        contents: buildFunctionHoverContent(fn),
+        range: {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: wordInfo.startColumn,
+          endColumn: wordInfo.endColumn,
+        },
+      };
+    },
+  },
+
   completionItemProvider: {
     provideCompletionItems: (
       model: monaco.editor.ITextModel,
@@ -56,24 +135,23 @@ export const monacoXPathLanguageMetadata: MonacoXPathLanguageMetadata = {
       _context: monaco.languages.CompletionContext,
       _token: monaco.CancellationToken,
     ): monaco.languages.ProviderResult<monaco.languages.CompletionList> => {
-      const suggestions = [
-        ...keywords.map((k) => {
-          const word = model.getWordUntilPosition(position);
-          const range: monaco.IRange = {
-            startLineNumber: position.lineNumber,
-            endLineNumber: position.lineNumber,
-            startColumn: word.startColumn,
-            endColumn: word.endColumn,
-          };
-          return {
-            label: k,
-            kind: monaco.languages.CompletionItemKind.Keyword,
-            insertText: k,
-            range: range,
-          };
-        }),
+      const word = model.getWordUntilPosition(position);
+      const range: monaco.IRange = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      const suggestions: monaco.languages.CompletionItem[] = [
+        ...keywords.map((k) => ({
+          label: k,
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: k,
+          range: range,
+        })),
+        ...monacoXPathLanguageMetadata.functionDefinitions.map((fn) => buildFunctionCompletionItem(fn, range)),
       ];
-      return { suggestions: suggestions };
+      return { suggestions };
     },
   },
 };

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -780,6 +780,10 @@ describe('XPathService', () => {
   it('getMonacoXPathLanguageMetadata()', () => {
     const metadata = XPathService.getMonacoXPathLanguageMetadata();
     expect(metadata.id).toBe('xpath');
+    expect(metadata.functionDefinitions.length).toBeGreaterThan(90);
+    expect(metadata.functionDefinitions.find((f) => f.name === 'concat')).toBeDefined();
+    expect(metadata.functionDefinitions.find((f) => f.name === 'position')).toBeDefined();
+    expect(metadata.functionDefinitions.find((f) => f.name === 'count')).toBeDefined();
   });
 
   describe('toPathExpression()', () => {

--- a/packages/ui/src/services/xpath/xpath.service.ts
+++ b/packages/ui/src/services/xpath/xpath.service.ts
@@ -97,6 +97,7 @@ export class XPathService {
    */
   static getMonacoXPathLanguageMetadata() {
     monacoXPathLanguageMetadata.tokensProvider.actions = XPathService.getXPathFunctionNames();
+    monacoXPathLanguageMetadata.functionDefinitions = Object.values(XPathService.getXPathFunctionDefinitions()).flat();
     return monacoXPathLanguageMetadata;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3596
Fixes: https://github.com/KaotoIO/kaoto/issues/3598

https://github.com/user-attachments/assets/8f1525c8-0326-46f0-a31f-6817f16b3dbc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced XPath editor autocomplete with function suggestions, signatures, and documentation.
  * Added hover information for recognized XPath functions.
  * Included a broader catalog of XPath functions, including `concat`, `position`, and `count`.

* **Bug Fixes**
  * Improved editor cleanup when navigating away from the XPath editor.

* **Tests**
  * Added coverage for XPath function completion, hover details, signatures, and suggestion ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->