### PR TITLE
fix(storybook): fix unknown node types in CanvasFormBody

### DIFF
--- a/packages/ui-tests/stories/canvas/CanvasFormBody.stories.tsx
+++ b/packages/ui-tests/stories/canvas/CanvasFormBody.stories.tsx
@@ -12,7 +12,7 @@ import {
   VisibleFlowsProvider,
 } from '@kaoto/kaoto/testing';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import { ComponentProps } from 'react';
+import { ComponentProps, useEffect, useState } from 'react';
 
 import { storybookCamelRoute, storybookCamelRouteEntity } from './canvas.stub';
 
@@ -54,6 +54,43 @@ export default {
 type CanvasFormBodyProps = ComponentProps<typeof CanvasFormBody>;
 
 const Template: StoryFn<CanvasFormBodyProps> = (args) => {
+  const [isSchemaLoaded, setIsSchemaLoaded] = useState(false);
+
+  useEffect(() => {
+    // Reset loading state when vizNode changes
+    setIsSchemaLoaded(false);
+
+    let isCancelled = false;
+
+    const fetchSchema = async () => {
+      try {
+        await args.vizNode.fetchSchema();
+
+        // Only update state if this request is still current
+        if (!isCancelled) {
+          setIsSchemaLoaded(true);
+        }
+      } catch (error) {
+        // Ignore errors from stale requests
+        if (!isCancelled) {
+          console.error('[CanvasFormBody Story] Failed to fetch schema:', error);
+          setIsSchemaLoaded(true); // Still render to show the error
+        }
+      }
+    };
+
+    void fetchSchema();
+
+    // Cleanup: mark this request as stale when vizNode changes
+    return () => {
+      isCancelled = true;
+    };
+  }, [args.vizNode]);
+
+  if (!isSchemaLoaded) {
+    return <div>Loading schema...</div>;
+  }
+
   return <CanvasFormBody {...args} />;
 };
 
@@ -62,8 +99,6 @@ export const AggregateNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('aggregate', {
       path: 'route.from.steps.0.aggregate',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'aggregate',
       entity: storybookCamelRouteEntity,
       processorName: 'aggregate',
@@ -72,6 +107,8 @@ export const AggregateNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'aggregate', catalogKind: CatalogKind.Pattern },
     }),
   },
 };
@@ -81,8 +118,6 @@ export const MarshalNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('marshal', {
       path: 'route.from.steps.1.marshal',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'marshal',
       entity: storybookCamelRouteEntity,
       processorName: 'marshal',
@@ -91,6 +126,8 @@ export const MarshalNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'marshal', catalogKind: CatalogKind.Pattern },
     }),
   },
 };
@@ -100,8 +137,6 @@ export const ResequenceNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('resequence', {
       path: 'route.from.steps.2.resequence',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'resequence',
       entity: storybookCamelRouteEntity,
       processorName: 'resequence',
@@ -110,6 +145,8 @@ export const ResequenceNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'resequence', catalogKind: CatalogKind.Pattern },
     }),
   },
 };
@@ -119,8 +156,6 @@ export const SagaNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('saga', {
       path: 'route.from.steps.3.saga',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'saga',
       entity: storybookCamelRouteEntity,
       processorName: 'saga',
@@ -129,6 +164,8 @@ export const SagaNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'saga', catalogKind: CatalogKind.Pattern },
     }),
   },
 };
@@ -138,8 +175,6 @@ export const SetHeaderNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('setHeader', {
       path: 'route.from.steps.4.setHeader',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'setHeader',
       entity: storybookCamelRouteEntity,
       processorName: 'setHeader',
@@ -148,6 +183,8 @@ export const SetHeaderNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'setHeader', catalogKind: CatalogKind.Pattern },
     }),
   },
 };
@@ -157,8 +194,6 @@ export const TokenizerNode: StoryObj<CanvasFormBodyProps> = {
   args: {
     vizNode: createVisualizationNode('tokenizer', {
       path: 'route.from.steps.5.tokenizer',
-      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
-      catalogKind: CatalogKind.Processor,
       name: 'tokenizer',
       entity: storybookCamelRouteEntity,
       processorName: 'tokenizer',
@@ -167,6 +202,8 @@ export const TokenizerNode: StoryObj<CanvasFormBodyProps> = {
       iconUrl: '',
       title: '',
       description: '',
+      // @ts-expect-error Cannot access ambient const enums when 'isolatedModules' is enabled
+      primaryNodeId: { name: 'tokenizer', catalogKind: CatalogKind.Pattern },
     }),
   },
 };


### PR DESCRIPTION
  Problem

  All CanvasFormBody stories (AggregateNode, MarshalNode, ResequenceNode, etc.) were displaying "Unknown node type" warning instead of showing the actual component configuration forms.

  Root Cause

  1. VizNodes were missing the primaryNodeId field required for schema fetching
  2. Stories were using CatalogKind.Processor instead of the correct CatalogKind.Pattern
  3. Schemas were not being fetched asynchronously before rendering

  Solution

  - Added primaryNodeId with CatalogKind.Pattern to all 6 vizNode story definitions
  - Implemented async schema fetching in the Template component with proper loading state
  - Removed unused DynamicCatalogRegistry import

  Result

  Stories now correctly display component forms for aggregate, marshal, resequence, saga, setHeader, and tokenizer processors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loading and error states while canvas schemas are fetched.
  * Updated canvas examples to use the latest pattern-based node configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->