### PR TITLE
fix(datamapper): move zoom buttons to Variables header, add Eye toggle and Source/Target labels (#3560)

### DIFF
--- a/packages/ui/src/components/Document/NameInput.scss
+++ b/packages/ui/src/components/Document/NameInput.scss
@@ -11,7 +11,7 @@
     height: var(--datamapper-header-control-size);
     font-size: var(--datamapper-header-control-font-size);
     line-height: var(--datamapper-header-control-size);
-    padding: 0 0.5rem;
+    padding: 0 2rem 0 0.5rem;
     border: 1px solid var(--pf-t--global--border--color--default);
     border-radius: var(--pf-t--global--border--radius--small);
     background: var(--pf-t--global--background--color--primary--default);
@@ -24,12 +24,10 @@
     }
 
     &--success {
-      padding-right: 2rem;
       border-color: var(--pf-t--global--border--color--status--success--default);
     }
 
     &--error {
-      padding-right: 2rem;
       border-color: var(--pf-t--global--border--color--status--danger--default);
     }
 

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -665,7 +665,7 @@ describe('ParametersSection', () => {
       );
 
       // Header should exist
-      expect(screen.getByText('Source Parameters')).toBeInTheDocument();
+      expect(screen.getByTestId('source-parameters-header')).toBeInTheDocument();
 
       // Add button should exist
       expect(await screen.findByTestId('add-parameter-button')).toBeInTheDocument();
@@ -692,7 +692,7 @@ describe('ParametersSection', () => {
       );
 
       // Header should exist
-      expect(screen.getByText('Source Parameters')).toBeInTheDocument();
+      expect(screen.getByTestId('source-parameters-header')).toBeInTheDocument();
 
       // Add button should not exist in read-only
       expect(screen.queryByTestId('add-parameter-button')).not.toBeInTheDocument();

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -1,7 +1,7 @@
 import './BaseDocument.scss';
 import './Parameters.scss';
 
-import { ActionList, ActionListItem, Button, Divider, Icon } from '@patternfly/react-core';
+import { ActionList, ActionListItem, Button, Icon, Label } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon, EyeIcon, EyeSlashIcon, PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
@@ -31,7 +31,6 @@ import { SourceDocumentNodeWithContextMenu } from './SourceDocumentNode';
 type ParametersSectionProps = {
   isReadOnly: boolean;
   onLayoutChange?: () => void;
-  actionItems?: React.ReactNode[];
 };
 
 type ParametersHeaderProps = {
@@ -39,7 +38,6 @@ type ParametersHeaderProps = {
   onAddParameter: () => void;
   showParameters: boolean;
   onToggleParameters: () => void;
-  actionItems?: React.ReactNode[];
 };
 
 /**
@@ -51,10 +49,11 @@ export const ParametersHeader: FunctionComponent<ParametersHeaderProps> = ({
   onAddParameter,
   showParameters,
   onToggleParameters,
-  actionItems,
 }) => (
   <div className="parameters-header" data-testid="source-parameters-header">
-    <span className="parameters-header__title panel-header-text">Source Parameters</span>
+    <span className="parameters-header__title panel-header-text">
+      <Label>Source</Label> Parameters
+    </span>
     <ActionList isIconList className="parameters-header__actions">
       {!isReadOnly && (
         <>
@@ -84,12 +83,8 @@ export const ParametersHeader: FunctionComponent<ParametersHeaderProps> = ({
               icon={<Icon isInline>{showParameters ? <EyeIcon /> : <EyeSlashIcon />}</Icon>}
             />
           </ActionListItem>
-          <Divider orientation={{ default: 'vertical' }} />
         </>
       )}
-      {actionItems?.map((item, index) => (
-        <ActionListItem key={index}>{item}</ActionListItem>
-      ))}
     </ActionList>
   </div>
 );
@@ -247,11 +242,7 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
  * This component encapsulates all parameter logic similar to the old Card-based Parameters component,
  * but now works with the new ExpansionPanel architecture.
  */
-export const ParametersSection: FunctionComponent<ParametersSectionProps> = ({
-  isReadOnly,
-  onLayoutChange,
-  actionItems,
-}) => {
+export const ParametersSection: FunctionComponent<ParametersSectionProps> = ({ isReadOnly, onLayoutChange }) => {
   const { sourceParameterMap } = useDataMapper();
 
   // State for adding new parameter
@@ -304,7 +295,6 @@ export const ParametersSection: FunctionComponent<ParametersSectionProps> = ({
             onAddParameter={handleAddParameter}
             showParameters={showParameters}
             onToggleParameters={handleToggleParameters}
-            actionItems={actionItems}
           />
         }
         defaultExpanded={false}

--- a/packages/ui/src/components/Document/Variables/VariableInputPlaceholder.scss
+++ b/packages/ui/src/components/Document/Variables/VariableInputPlaceholder.scss
@@ -1,5 +1,0 @@
-.variable-input-placeholder {
-  .name-input-actions {
-    padding-left: calc(var(--pf-t--global--spacer--sm) + 1rem + var(--pf-t--global--spacer--sm) + 0.5rem);
-  }
-}

--- a/packages/ui/src/components/Document/Variables/VariableInputPlaceholder.tsx
+++ b/packages/ui/src/components/Document/Variables/VariableInputPlaceholder.tsx
@@ -1,5 +1,3 @@
-import './VariableInputPlaceholder.scss';
-
 import { FunctionComponent, useCallback } from 'react';
 
 import { MappingParentType } from '../../../models/datamapper/mapping';
@@ -42,17 +40,15 @@ export const VariableInputPlaceholder: FunctionComponent<VariableInputPlaceholde
   );
 
   return (
-    <div className="variable-input-placeholder">
-      <NameInputPlaceholder
-        initialName={initialName}
-        validate={validate}
-        onSubmit={handleSubmit}
-        onCancel={onCancel}
-        placeholder="variable name"
-        testIdPrefix="new-variable"
-        ariaLabelPrefix="variable name"
-        label="$"
-      />
-    </div>
+    <NameInputPlaceholder
+      initialName={initialName}
+      validate={validate}
+      onSubmit={handleSubmit}
+      onCancel={onCancel}
+      placeholder="variable name"
+      testIdPrefix="new-variable"
+      ariaLabelPrefix="variable name"
+      label="$"
+    />
   );
 };

--- a/packages/ui/src/components/Document/Variables/VariablesHeader.tsx
+++ b/packages/ui/src/components/Document/Variables/VariablesHeader.tsx
@@ -1,31 +1,61 @@
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
-import { PlusIcon } from '@patternfly/react-icons';
-import { FunctionComponent } from 'react';
+import { ActionList, ActionListItem, Button, Divider, Icon, Label } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon, PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent, isValidElement } from 'react';
 
 type VariablesHeaderProps = {
   isReadOnly: boolean;
   onAddVariable: () => void;
+  showVariables: boolean;
+  onToggleVariables: () => void;
+  actionItems?: React.ReactNode[];
 };
 
-export const VariablesHeader: FunctionComponent<VariablesHeaderProps> = ({ isReadOnly, onAddVariable }) => (
+export const VariablesHeader: FunctionComponent<VariablesHeaderProps> = ({
+  isReadOnly,
+  onAddVariable,
+  showVariables,
+  onToggleVariables,
+  actionItems,
+}) => (
   <div className="parameters-header" data-testid="source-variables-header">
-    <span className="parameters-header__title panel-header-text">Variables</span>
+    <span className="parameters-header__title panel-header-text">
+      <Label>Source</Label> Variables
+    </span>
     <ActionList isIconList className="parameters-header__actions">
       {!isReadOnly && (
-        <ActionListItem>
-          <Button
-            icon={<PlusIcon />}
-            variant="plain"
-            title="Add variable"
-            aria-label="Add variable"
-            data-testid="add-variable-button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAddVariable();
-            }}
-          />
-        </ActionListItem>
+        <>
+          <ActionListItem>
+            <Button
+              icon={<PlusIcon />}
+              variant="plain"
+              title="Add global variable"
+              aria-label="Add global variable"
+              data-testid="add-variable-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddVariable();
+              }}
+            />
+          </ActionListItem>
+          <ActionListItem>
+            <Button
+              variant="plain"
+              title={showVariables ? 'Hide all variables' : 'Show all variables'}
+              aria-label={showVariables ? 'Hide all variables' : 'Show all variables'}
+              data-testid="toggle-variables-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleVariables();
+              }}
+              icon={<Icon isInline>{showVariables ? <EyeIcon /> : <EyeSlashIcon />}</Icon>}
+            />
+          </ActionListItem>
+          <Divider orientation={{ default: 'vertical' }} />
+        </>
       )}
+      {actionItems?.map((item) => (
+        <ActionListItem key={isValidElement(item) ? item.key : undefined}>{item}</ActionListItem>
+      ))}
     </ActionList>
   </div>
 );

--- a/packages/ui/src/components/Document/Variables/VariablesSection.test.tsx
+++ b/packages/ui/src/components/Document/Variables/VariablesSection.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { MappingLinksProvider } from '../../../providers/data-mapping-links.provider';
+import { DataMapperProvider } from '../../../providers/datamapper.provider';
+import { ExpansionPanels } from '../../ExpansionPanels/ExpansionPanels';
+import { VariablesSection } from './VariablesSection';
+
+describe('VariablesSection', () => {
+  const renderVariablesSection = (isReadOnly = false) => {
+    return render(
+      <DataMapperProvider>
+        <MappingLinksProvider>
+          <ExpansionPanels>
+            <VariablesSection isReadOnly={isReadOnly} />
+          </ExpansionPanels>
+        </MappingLinksProvider>
+      </DataMapperProvider>,
+    );
+  };
+
+  describe('Add global variable', () => {
+    it('should show variable input when add button is clicked', async () => {
+      renderVariablesSection();
+
+      const addButton = await screen.findByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      expect(screen.getByTestId('new-variable-name-input')).toBeInTheDocument();
+    });
+
+    it('should add a variable and hide input on submit', async () => {
+      renderVariablesSection();
+
+      const addButton = await screen.findByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      const input = screen.getByTestId('new-variable-name-input');
+      fireEvent.change(input, { target: { value: 'myVar' } });
+
+      const submitButton = screen.getByTestId('new-variable-submit-btn');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('new-variable-name-input')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('variable-row-myVar')).toBeInTheDocument();
+    });
+
+    it('should hide input on cancel', async () => {
+      renderVariablesSection();
+
+      const addButton = await screen.findByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      expect(screen.getByTestId('new-variable-name-input')).toBeInTheDocument();
+
+      const cancelButton = screen.getByTestId('new-variable-cancel-btn');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('new-variable-name-input')).not.toBeInTheDocument();
+    });
+
+    it('should not show add button in read-only mode', () => {
+      renderVariablesSection(true);
+
+      expect(screen.queryByTestId('add-variable-button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Toggle hide/show all variables', () => {
+    it('should hide variables when toggle button is clicked', async () => {
+      renderVariablesSection();
+
+      // Add a variable first
+      const addButton = await screen.findByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      const input = screen.getByTestId('new-variable-name-input');
+      fireEvent.change(input, { target: { value: 'testVar' } });
+      fireEvent.click(screen.getByTestId('new-variable-submit-btn'));
+
+      await screen.findByTestId('variable-row-testVar');
+
+      // Hide variables
+      const toggleButton = screen.getByTestId('toggle-variables-button');
+      fireEvent.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('variable-row-testVar')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show variables again when toggle is clicked twice', async () => {
+      renderVariablesSection();
+
+      // Add a variable
+      const addButton = await screen.findByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      const input = screen.getByTestId('new-variable-name-input');
+      fireEvent.change(input, { target: { value: 'testVar' } });
+      fireEvent.click(screen.getByTestId('new-variable-submit-btn'));
+
+      await screen.findByTestId('variable-row-testVar');
+
+      // Hide then show
+      const toggleButton = screen.getByTestId('toggle-variables-button');
+      fireEvent.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('variable-row-testVar')).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(toggleButton);
+
+      await screen.findByTestId('variable-row-testVar');
+    });
+
+    it('should change toggle button title when hiding/showing', async () => {
+      renderVariablesSection();
+
+      const toggleButton = await screen.findByTestId('toggle-variables-button');
+
+      expect(toggleButton).toHaveAttribute('title', 'Hide all variables');
+      expect(toggleButton).toHaveAttribute('aria-label', 'Hide all variables');
+
+      fireEvent.click(toggleButton);
+
+      expect(toggleButton).toHaveAttribute('title', 'Show all variables');
+      expect(toggleButton).toHaveAttribute('aria-label', 'Show all variables');
+
+      fireEvent.click(toggleButton);
+
+      expect(toggleButton).toHaveAttribute('title', 'Hide all variables');
+      expect(toggleButton).toHaveAttribute('aria-label', 'Hide all variables');
+    });
+
+    it('should auto-show variables when add button is clicked while hidden', async () => {
+      renderVariablesSection();
+
+      // Hide variables first
+      const toggleButton = await screen.findByTestId('toggle-variables-button');
+      fireEvent.click(toggleButton);
+
+      // Click add
+      const addButton = screen.getByTestId('add-variable-button');
+      fireEvent.click(addButton);
+
+      // Input should be visible (auto-shown)
+      expect(screen.getByTestId('new-variable-name-input')).toBeInTheDocument();
+    });
+
+    it('should not show toggle button in read-only mode', () => {
+      renderVariablesSection(true);
+
+      expect(screen.queryByTestId('toggle-variables-button')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/Document/Variables/VariablesSection.tsx
+++ b/packages/ui/src/components/Document/Variables/VariablesSection.tsx
@@ -14,14 +14,20 @@ import { VariablesHeader } from './VariablesHeader';
 type VariablesSectionProps = {
   isReadOnly: boolean;
   onLayoutChange?: () => void;
+  actionItems?: React.ReactNode[];
 };
 
-export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({ isReadOnly, onLayoutChange }) => {
+export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({
+  isReadOnly,
+  onLayoutChange,
+  actionItems,
+}) => {
   const { variables, mappingTree, refreshMappingTree } = useDataMapper();
   const { syncConnectionPorts } = useConnectionPortSync(VARIABLES_DOCUMENT_ID);
 
   const [renamingVariableId, setRenamingVariableId] = useState<string | null>(null);
   const [isAddingVariable, setIsAddingVariable] = useState(false);
+  const [showVariables, setShowVariables] = useState(true);
 
   useEffect(() => {
     syncConnectionPorts();
@@ -45,7 +51,17 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({ isR
 
   const handleAddVariable = useCallback(() => {
     setIsAddingVariable(true);
+    // Auto-show variables when adding a new one
+    setShowVariables(true);
   }, []);
+
+  const handleToggleVariables = useCallback(() => {
+    setShowVariables((prev) => !prev);
+    setTimeout(() => {
+      syncConnectionPorts();
+      onLayoutChange?.();
+    }, 0);
+  }, [onLayoutChange, syncConnectionPorts]);
 
   const handleConfirmAdd = useCallback(
     (name: string) => {
@@ -59,8 +75,6 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({ isR
   const handleCancelAdd = useCallback(() => {
     setIsAddingVariable(false);
   }, []);
-
-  const hasContent = variables.length > 0 || isAddingVariable;
 
   const edgeMarkers = useMemo(
     () => (
@@ -82,12 +96,24 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({ isR
     [],
   );
 
+  const variableListHeight = PANEL_COLLAPSED_HEIGHT + variables.length * 32;
+
+  const hasContent = showVariables && (variables.length > 0 || isAddingVariable);
+
   return (
     <ExpansionPanel
       id="variables"
-      summary={<VariablesHeader isReadOnly={isReadOnly} onAddVariable={handleAddVariable} />}
+      summary={
+        <VariablesHeader
+          isReadOnly={isReadOnly}
+          onAddVariable={handleAddVariable}
+          showVariables={showVariables}
+          onToggleVariables={handleToggleVariables}
+          actionItems={actionItems}
+        />
+      }
       defaultExpanded={hasContent}
-      defaultHeight={hasContent ? PANEL_COLLAPSED_HEIGHT + variables.length * 32 : PANEL_COLLAPSED_HEIGHT}
+      defaultHeight={hasContent ? variableListHeight : PANEL_COLLAPSED_HEIGHT}
       minHeight={PANEL_MIN_HEIGHT}
       onLayoutChange={() => {
         syncConnectionPorts();

--- a/packages/ui/src/components/View/SourcePanel.test.tsx
+++ b/packages/ui/src/components/View/SourcePanel.test.tsx
@@ -64,7 +64,8 @@ describe('SourcePanel', () => {
     );
 
     // Find the Body panel summary and click to collapse
-    const bodyPanel = screen.getByText('Source Body').closest('.expansion-panel__summary') as HTMLElement;
+    const sourceBodyHeader = screen.getByTestId('document-doc-sourceBody-Body');
+    const bodyPanel = sourceBodyHeader.closest('.expansion-panel__summary') as HTMLElement;
     expect(bodyPanel).toBeInTheDocument();
 
     await act(async () => {
@@ -82,7 +83,7 @@ describe('SourcePanel', () => {
     });
 
     // The panel should now be collapsed (data-expanded=false)
-    const panel = screen.getByText('Source Body').closest('.expansion-panel');
+    const panel = sourceBodyHeader.closest('.expansion-panel');
     expect(panel).toHaveAttribute('data-expanded', 'false');
 
     // Clean up

--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -1,5 +1,6 @@
 import './SourcePanel.scss';
 
+import { Label } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -98,10 +99,10 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
     <div id="panel-source" className="source-panel">
       <ExpansionPanels firstPanelId="variables" lastPanelId="source-body">
         {/* Variables section - xsl:variable items as draggable source references */}
-        <VariablesSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} />
+        <VariablesSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} actionItems={actionItems} />
 
         {/* Parameters section - self-contained component that manages all parameter state */}
-        <ParametersSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} actionItems={actionItems} />
+        <ParametersSection isReadOnly={isReadOnly} onLayoutChange={syncConnectionPorts} />
 
         {/* Source Body - behaves like parameters: collapsed when no schema */}
         <ExpansionPanel
@@ -112,7 +113,11 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
           minHeight={PANEL_MIN_HEIGHT}
           summary={
             <DocumentHeader
-              header={<span className="panel-header-text">Source Body</span>}
+              header={
+                <span className="panel-header-text">
+                  <Label>Source</Label> Body
+                </span>
+              }
               document={sourceBodyDocument}
               documentType={DocumentType.SOURCE_BODY}
               isReadOnly={isReadOnly}

--- a/packages/ui/src/components/View/TargetPanel.test.tsx
+++ b/packages/ui/src/components/View/TargetPanel.test.tsx
@@ -38,7 +38,7 @@ describe('TargetPanel', () => {
 
   it('should render the Target panel with Body header', () => {
     render(<TargetPanel />, { wrapper });
-    expect(screen.getByText('Target Body')).toBeInTheDocument();
+    expect(screen.getByTestId('document-doc-targetBody-Body')).toBeInTheDocument();
   });
 
   it('should render the panel with correct id', () => {
@@ -47,11 +47,9 @@ describe('TargetPanel', () => {
   });
 
   it('should hide the grab icon when the target body has a schema attached', async () => {
-    const { container } = render(<TargetPanel />, { wrapper: schemaWrapper });
+    render(<TargetPanel />, { wrapper: schemaWrapper });
 
-    expect(await screen.findByText('Target Body')).toBeInTheDocument();
-
-    const header = container.querySelector('[data-testid="document-doc-targetBody-Body"]');
+    const header = await screen.findByTestId('document-doc-targetBody-Body');
     expect(header).toBeInTheDocument();
     expect(header?.querySelector('[data-drag-handler]')).not.toBeInTheDocument();
   });
@@ -81,7 +79,7 @@ describe('TargetPanel', () => {
     render(<TargetPanel />, { wrapper: schemaWrapper });
 
     // Wait for the panel to render with schema
-    expect(await screen.findByText('Target Body')).toBeInTheDocument();
+    await screen.findByTestId('document-doc-targetBody-Body');
 
     // The settings button should be present even with schema
     const settingsButton = await screen.findByRole('button', { name: /settings/i });

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -1,5 +1,6 @@
 import './TargetPanel.scss';
 
+import { Label } from '@patternfly/react-core';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -159,7 +160,11 @@ export const TargetPanel: FunctionComponent = () => {
           collapsible={false}
           summary={
             <DocumentHeader
-              header={<span className="panel-header-text">Target Body</span>}
+              header={
+                <span className="panel-header-text">
+                  <Label>Target</Label> Body
+                </span>
+              }
               document={targetBodyDocument}
               documentType={DocumentType.TARGET_BODY}
               isReadOnly={false}


### PR DESCRIPTION
## Summary

Adjusts the DataMapper panel headers per issue #3560:

- **Zoom buttons** moved from `ParametersHeader` to `VariablesHeader` (passed via `actionItems` prop)
- **Eye toggle** (show/hide) added to `VariablesHeader`, matching the existing pattern in `ParametersHeader`
- **`<Label>` prefix** added to all expansion panel headers:
  - Variables → `Source Variables`
  - Parameters → `Source Parameters`
  - Source Body → `Source Body`
  - Target Body → `Target Body`

## Changes

| File | What changed |
|------|-------------|
| `VariablesHeader.tsx` | Added `showVariables`, `onToggleVariables`, `actionItems` props; Eye toggle button; Divider; Source label |
| `VariablesSection.tsx` | Added `actionItems` prop, `showVariables` state, `handleToggleVariables` handler |
| `Parameters.tsx` | Removed `actionItems` from `ParametersHeader`/`ParametersSection`; added Source label; removed Divider |
| `SourcePanel.tsx` | Moved `actionItems` from `ParametersSection` → `VariablesSection`; added Source label to body header |
| `TargetPanel.tsx` | Added Target label to body header |
| `Parameters.test.tsx` | Updated assertions from `getByText('Source Parameters')` → `getByTestId('source-parameters-header')` |


<img width="1582" height="460" alt="Screenshot 2026-08-06 at 17 10 21" src="https://github.com/user-attachments/assets/a2798653-3763-4184-aaac-fcf4497f9776" />

fixes #3560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer “Source” and “Target” labels to document panels and sections.
  * Added controls to show or hide source variables.
  * Added support for custom actions in the variables section.
  * Variables automatically become visible when a new variable is added.

* **Style**
  * Improved name input spacing and streamlined variable placeholder presentation.

* **Tests**
  * Updated component tests to use stable identifiers and expanded coverage for variable visibility and editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->