### PR TITLE
fix(DataMapper): Enable removing the copy-of from primitive target body

### DIFF
--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -867,6 +867,14 @@ describe('MappingService', () => {
       expect(shipOrderItem.children).not.toContain(variable);
       expect(fieldItem.children).not.toContain(vs);
     });
+
+    it('should delete CopyOfSelector with MappingTree parent', () => {
+      const copyOf = new CopyOfSelector(tree, CopyOfType.CONTAINER_NODE);
+      tree.children.push(copyOf);
+      expect(tree.children).toContain(copyOf);
+      MappingService.deleteMappingItem(copyOf);
+      expect(tree.children).not.toContain(copyOf);
+    });
   });
 
   describe('addVariable()', () => {

--- a/packages/ui/src/services/mapping/mapping.service.ts
+++ b/packages/ui/src/services/mapping/mapping.service.ts
@@ -1102,9 +1102,10 @@ export class MappingService {
   }
 
   /**
-   * First removes value selector children, then for {@link InstructionItem}/{@link VariableItem}
-   * or items under {@link FieldItem} parents, removes the item and recursively cleans up
-   * empty FieldItem ancestors.
+   * First removes value selector children, then for {@link InstructionItem}/{@link VariableItem},
+   * items under {@link FieldItem} parents, {@link CopyOfSelector} directly under {@link MappingTree}
+   * (primitive target body), or user-created {@link FieldItem}s, removes the item and recursively
+   * cleans up empty FieldItem ancestors.
    * @param item - the mapping item to delete
    */
   static deleteMappingItem(item: MappingParentType) {
@@ -1112,11 +1113,14 @@ export class MappingService {
     const isInstructionItem = item instanceof InstructionItem;
     const isVariableItem = item instanceof VariableItem;
     const isParentFieldItem = 'parent' in item && item.parent instanceof FieldItem;
+    // Primitive target body has no root FieldItem — CopyOfSelector sits directly under MappingTree.
+    // Structured targets don't need this: their copy-of parent is a FieldItem, handled by isParentFieldItem.
+    const isRootLevelCopyOf = item instanceof CopyOfSelector && item.parent instanceof MappingTree;
     const isUserCreatedFieldItem = item instanceof FieldItem && item.isUserCreated;
     if (isVariableItem) {
       MappingService.removeVariableReferences(item as VariableItem);
     }
-    if (isInstructionItem || isVariableItem || isParentFieldItem || isUserCreatedFieldItem) {
+    if (isInstructionItem || isVariableItem || isParentFieldItem || isRootLevelCopyOf || isUserCreatedFieldItem) {
       MappingService.deleteFromParent(item);
     }
   }

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -549,6 +549,28 @@ describe('MappingActionService', () => {
         const expressionItem = VisualizationService.getExpressionItemForNode(targetDocNode);
         expect(expressionItem).toBeUndefined();
       });
+
+      it('should delete copy-of added on primitive target body', () => {
+        const primitiveTargetDoc = new PrimitiveDocument(
+          new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+        );
+        tree = new MappingTree(
+          primitiveTargetDoc.documentType,
+          primitiveTargetDoc.documentId,
+          DocumentDefinitionType.Primitive,
+        );
+        targetDocNode = new TargetDocumentNodeData(primitiveTargetDoc, tree);
+        MappingActionService.applyCopyOfSelector(targetDocNode);
+        expect(tree.children).toHaveLength(1);
+        expect(tree.children[0]).toBeInstanceOf(CopyOfSelector);
+
+        const copyOfNodeData = VisualizationService.generatePrimitiveDocumentChildren(
+          targetDocNode,
+        )[0] as MappingNodeData;
+        expect(copyOfNodeData).toBeInstanceOf(MappingNodeData);
+        MappingActionService.deleteMappingItem(copyOfNodeData);
+        expect(tree.children).toHaveLength(0);
+      });
     });
   });
 


### PR DESCRIPTION
Resolves: [#3624](https://github.com/KaotoIO/kaoto/issues/3624)


https://github.com/user-attachments/assets/14df4899-4970-41ef-899b-c93511de3bf4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deletion of copied selectors directly associated with a mapping tree.
  * Copied selectors applied to primitive target documents can now be removed correctly through the visualization.
  * Improved cleanup when deleting mapping items to ensure removed selectors no longer remain in the mapping tree.

* **Tests**
  * Added regression coverage for selector deletion in mapping trees and visualized mapping nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->