### PR TITLE
chore(catalog): bump @kaoto/camel-catalog to 0.7.1

### DIFF
--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -56,7 +56,7 @@
     "vite": "^5.4.0"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.7.0",
+    "@kaoto/camel-catalog": "^0.7.1",
     "@kaoto/forms": "^1.8.0",
     "@kaoto/kaoto": "workspace:*",
     "@patternfly/patternfly": "^6.5.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -85,7 +85,7 @@
     "zustand": "^5.0.11"
   },
   "peerDependencies": {
-    "@kaoto/camel-catalog": "^0.7.0",
+    "@kaoto/camel-catalog": "^0.7.1",
     "@patternfly/patternfly": "^6.5.2",
     "@patternfly/react-code-editor": "^6.5.1",
     "@patternfly/react-core": "^6.5.1",
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",
-    "@kaoto/camel-catalog": "^0.7.0",
+    "@kaoto/camel-catalog": "^0.7.1",
     "@patternfly/patternfly": "^6.5.2",
     "@patternfly/react-code-editor": "^6.5.1",
     "@patternfly/react-core": "^6.5.1",

--- a/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
+++ b/packages/ui/src/components/Settings/__snapshots__/SettingsForm.test.tsx.snap
@@ -344,7 +344,7 @@ exports[`SettingsForm > should render 1`] = `
           <span
             class="runtime-selector pf-v6-u-m-sm"
           >
-            Citrus 4.10.1
+            Citrus 5.0.0
           </span>
         </span>
         <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,10 +2727,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@kaoto/camel-catalog@npm:0.7.0"
-  checksum: 10/228cf4e7190700e9d16bcd8f87497cac0e886a54daf01a10213b5c1d9d5fbde9616a396686f8c967e2c5d4d1576a24e0e68893ccce6ac5c1178c789911bfdf22
+"@kaoto/camel-catalog@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@kaoto/camel-catalog@npm:0.7.1"
+  checksum: 10/6770b0560f58cec0a05f8c3dbbcbad4a7c027ab966fecbef164722b8f525d35b057ee309fc5db8a7fff60b5018d488ef5f6dafd05b9cbcf77f1f2867a11d6c7c
   languageName: node
   linkType: hard
 
@@ -2758,7 +2758,7 @@ __metadata:
   dependencies:
     "@cypress/grep": "npm:^4.1.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.7.0"
+    "@kaoto/camel-catalog": "npm:^0.7.1"
     "@kaoto/forms": "npm:^1.8.0"
     "@kaoto/kaoto": "workspace:*"
     "@patternfly/patternfly": "npm:^6.5.2"
@@ -2809,7 +2809,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.1.0"
     "@dnd-kit/modifiers": "npm:^9.0.0"
     "@eslint/js": "npm:^9.10.0"
-    "@kaoto/camel-catalog": "npm:^0.7.0"
+    "@kaoto/camel-catalog": "npm:^0.7.1"
     "@kaoto/forms": "npm:^1.8.0"
     "@kie-tools-core/editor": "npm:^10.0.0"
     "@kie-tools-core/notifications": "npm:^10.0.0"
@@ -2895,7 +2895,7 @@ __metadata:
     zundo: "npm:^2.3.0"
     zustand: "npm:^5.0.11"
   peerDependencies:
-    "@kaoto/camel-catalog": ^0.7.0
+    "@kaoto/camel-catalog": ^0.7.1
     "@patternfly/patternfly": ^6.5.2
     "@patternfly/react-code-editor": ^6.5.1
     "@patternfly/react-core": ^6.5.1


### PR DESCRIPTION
bump catalog version - introduces citrus new catalogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying catalog support to improve compatibility and ensure the latest definitions are available across the application and UI testing tools.
  * No user-facing features or workflow changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->