### PR TITLE
refactor(ExpansionPanel): Extract connection port calculations

### DIFF
--- a/packages/ui/src/hooks/useConnectionPortSync.hook.tsx
+++ b/packages/ui/src/hooks/useConnectionPortSync.hook.tsx
@@ -1,37 +1,12 @@
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
 import { VirtuosoProps } from 'react-virtuoso';
 
+import { ConnectionPortSyncHelper } from '../services/connection-port-sync.helper';
 import { TreeConnectionPorts, useDocumentTreeStore } from '../store/document-tree.store';
 
 export const useConnectionPortSync = (documentId: string) => {
   const setNodesConnectionPorts = useDocumentTreeStore((state) => state.setNodesConnectionPorts);
   const rafId = useRef<number | null>(null);
-
-  /**
-   * Checks if an element is actually visible within its scroll container
-   * (not just in the DOM due to overscan)
-   */
-  const isElementVisibleInContainer = (element: HTMLElement): boolean => {
-    const scrollContainer = element.closest('.expansion-panel__content');
-    if (!scrollContainer) return true; // No scroll container, assume visible
-
-    const elemRect = element.getBoundingClientRect();
-    const containerRect = scrollContainer.getBoundingClientRect();
-
-    // Check vertical bounds only. Horizontal bounds are intentionally ignored because
-    // target connection ports are positioned with a negative `left` value (outside the
-    // container's left boundary) via CSS, so checking horizontal bounds would incorrectly
-    // exclude all target ports.
-    if (elemRect.top < containerRect.top - 1 || elemRect.bottom > containerRect.bottom + 1) {
-      return false;
-    }
-
-    const panelsContainer = element.closest('.expansion-panels');
-    if (!panelsContainer) return true;
-
-    const panelsRect = panelsContainer.getBoundingClientRect();
-    return elemRect.top >= panelsRect.top - 1 && elemRect.bottom <= panelsRect.bottom + 1;
-  };
 
   useEffect(() => {
     return () => {
@@ -60,28 +35,20 @@ export const useConnectionPortSync = (documentId: string) => {
 
       const documentVisiblePorts: TreeConnectionPorts = {};
 
-      documentPortElements.forEach((element) => {
+      for (const element of documentPortElements) {
         const nodePath = element.dataset.nodePath;
-        if (!nodePath) return;
+        if (!nodePath) continue;
 
         /* EDGE elements are always visible, document elements need visibility check */
         const isEdgeElement = nodePath.endsWith(':EDGE:top') || nodePath.endsWith(':EDGE:bottom');
-        if (isEdgeElement || isElementVisibleInContainer(element)) {
+
+        if (isEdgeElement) {
+          documentVisiblePorts[nodePath] = ConnectionPortSyncHelper.getClampedEdgePosition(element);
+        } else if (ConnectionPortSyncHelper.isElementVisible(element)) {
           const rect = element.getBoundingClientRect();
-          let y = rect.y + rect.height / 2;
-
-          if (isEdgeElement) {
-            const panelsContainer = element.closest('.expansion-panels');
-            if (panelsContainer) {
-              const panelsRect = panelsContainer.getBoundingClientRect();
-              y = Math.max(panelsRect.top, Math.min(panelsRect.bottom, y));
-            }
-          }
-
-          const position: [number, number] = [rect.x + rect.width / 2, y];
-          documentVisiblePorts[nodePath] = position;
+          documentVisiblePorts[nodePath] = [rect.x + rect.width / 2, rect.y + rect.height / 2];
         }
-      });
+      }
 
       setNodesConnectionPorts(documentId, documentVisiblePorts);
     });

--- a/packages/ui/src/services/connection-port-sync.helper.test.ts
+++ b/packages/ui/src/services/connection-port-sync.helper.test.ts
@@ -1,0 +1,169 @@
+import { ConnectionPortSyncHelper } from './connection-port-sync.helper';
+
+describe('ConnectionPortSyncHelper', () => {
+  const createMockElement = (
+    elemRect: Partial<DOMRect>,
+    containers: { panelContent?: Partial<DOMRect>; panels?: Partial<DOMRect> },
+  ): HTMLElement => {
+    return {
+      getBoundingClientRect: () => elemRect as DOMRect,
+      closest: (selector: string) => {
+        if (selector === '.expansion-panel__content' && containers.panelContent) {
+          return { getBoundingClientRect: () => containers.panelContent as DOMRect };
+        }
+        if (selector === '.expansion-panels' && containers.panels) {
+          return { getBoundingClientRect: () => containers.panels as DOMRect };
+        }
+        return null;
+      },
+    } as unknown as HTMLElement;
+  };
+
+  describe('isVisibleWithinPanelContent', () => {
+    it('should return true when no scroll container exists', () => {
+      const element = createMockElement({ top: 200, bottom: 230 }, {});
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(true);
+    });
+
+    it('should return true when element is within container bounds', () => {
+      const element = createMockElement({ top: 100, bottom: 130 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(true);
+    });
+
+    it('should return false when element is above container', () => {
+      const element = createMockElement({ top: -20, bottom: 10 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(false);
+    });
+
+    it('should return false when element is below container', () => {
+      const element = createMockElement({ top: 480, bottom: 510 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(false);
+    });
+
+    it('should allow 1px tolerance at top boundary', () => {
+      const element = createMockElement({ top: -1, bottom: 30 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(true);
+    });
+
+    it('should allow 1px tolerance at bottom boundary', () => {
+      const element = createMockElement({ top: 470, bottom: 501 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(true);
+    });
+
+    it('should return false when element exceeds tolerance at top', () => {
+      const element = createMockElement({ top: -2, bottom: 30 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(false);
+    });
+
+    it('should return false when element exceeds tolerance at bottom', () => {
+      const element = createMockElement({ top: 470, bottom: 502 }, { panelContent: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelContent(element)).toBe(false);
+    });
+  });
+
+  describe('isVisibleWithinPanelsViewport', () => {
+    it('should return true when no panels container exists', () => {
+      const element = createMockElement({ top: 200, bottom: 230 }, {});
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(true);
+    });
+
+    it('should return true when element is within panels bounds', () => {
+      const element = createMockElement({ top: 100, bottom: 130 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(true);
+    });
+
+    it('should return false when element is above panels viewport', () => {
+      const element = createMockElement({ top: -20, bottom: 10 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(false);
+    });
+
+    it('should return false when element is below panels viewport', () => {
+      const element = createMockElement({ top: 480, bottom: 510 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(false);
+    });
+
+    it('should allow 1px tolerance at top boundary', () => {
+      const element = createMockElement({ top: -1, bottom: 30 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(true);
+    });
+
+    it('should allow 1px tolerance at bottom boundary', () => {
+      const element = createMockElement({ top: 470, bottom: 501 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(true);
+    });
+
+    it('should return false when element exceeds tolerance at top', () => {
+      const element = createMockElement({ top: -2, bottom: 30 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(false);
+    });
+
+    it('should return false when element exceeds tolerance at bottom', () => {
+      const element = createMockElement({ top: 470, bottom: 502 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isVisibleWithinPanelsViewport(element)).toBe(false);
+    });
+  });
+
+  describe('isElementVisible', () => {
+    it('should return true when element has no panel content ancestor (e.g. in summary)', () => {
+      const element = createMockElement({ top: -50, bottom: -20 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.isElementVisible(element)).toBe(true);
+    });
+
+    it('should return true when element has no panel content and no panels ancestor', () => {
+      const element = createMockElement({ top: 200, bottom: 230 }, {});
+      expect(ConnectionPortSyncHelper.isElementVisible(element)).toBe(true);
+    });
+
+    it('should return true when element is within both containers', () => {
+      const element = createMockElement(
+        { top: 100, bottom: 130 },
+        { panelContent: { top: 0, bottom: 500 }, panels: { top: 0, bottom: 500 } },
+      );
+      expect(ConnectionPortSyncHelper.isElementVisible(element)).toBe(true);
+    });
+
+    it('should return false when element is outside panel content bounds', () => {
+      const element = createMockElement(
+        { top: -20, bottom: 10 },
+        { panelContent: { top: 0, bottom: 500 }, panels: { top: 0, bottom: 500 } },
+      );
+      expect(ConnectionPortSyncHelper.isElementVisible(element)).toBe(false);
+    });
+
+    it('should return false when element is outside panels viewport bounds', () => {
+      const element = createMockElement(
+        { top: 100, bottom: 130 },
+        { panelContent: { top: 0, bottom: 500 }, panels: { top: 200, bottom: 500 } },
+      );
+      expect(ConnectionPortSyncHelper.isElementVisible(element)).toBe(false);
+    });
+  });
+
+  describe('getClampedEdgePosition', () => {
+    it('should return unclamped center position when no panels container exists', () => {
+      const element = createMockElement({ x: 100, y: 200, width: 50, height: 30 }, {});
+      expect(ConnectionPortSyncHelper.getClampedEdgePosition(element)).toEqual([125, 215]);
+    });
+
+    it('should return unclamped position when Y is within panels bounds', () => {
+      const element = createMockElement({ x: 100, y: 200, width: 50, height: 30 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.getClampedEdgePosition(element)).toEqual([125, 215]);
+    });
+
+    it('should clamp Y to panels top when element is above viewport', () => {
+      const element = createMockElement({ x: 100, y: -50, width: 50, height: 30 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.getClampedEdgePosition(element)).toEqual([125, 0]);
+    });
+
+    it('should clamp Y to panels bottom when element is below viewport', () => {
+      const element = createMockElement({ x: 100, y: 600, width: 50, height: 30 }, { panels: { top: 0, bottom: 500 } });
+      expect(ConnectionPortSyncHelper.getClampedEdgePosition(element)).toEqual([125, 500]);
+    });
+
+    it('should always compute X as horizontal center regardless of clamping', () => {
+      const element = createMockElement({ x: 40, y: -100, width: 20, height: 10 }, { panels: { top: 0, bottom: 500 } });
+      const [x] = ConnectionPortSyncHelper.getClampedEdgePosition(element);
+      expect(x).toBe(50);
+    });
+  });
+});

--- a/packages/ui/src/services/connection-port-sync.helper.ts
+++ b/packages/ui/src/services/connection-port-sync.helper.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure DOM helpers for connection port visibility and positioning within
+ * the {@link ExpansionPanels} scroll hierarchy, consumed by
+ * {@link useConnectionPortSync}. Separates the two visibility concerns
+ * (inner panel content vs. outer panels viewport) from the EDGE marker
+ * clamping logic so each can be reasoned about independently.
+ */
+export class ConnectionPortSyncHelper {
+  private static readonly TOLERANCE = 1;
+
+  /**
+   * Determine whether a connection port element is visible inside its nearest
+   * `.expansion-panel__content` scroll container (vertical bounds only).
+   *
+   * Horizontal bounds are intentionally ignored because target connection ports
+   * are positioned with a negative `left` value (outside the container's left
+   * boundary) via CSS, so checking horizontal bounds would incorrectly exclude
+   * all target ports.
+   */
+  static isVisibleWithinPanelContent(element: HTMLElement): boolean {
+    const scrollContainer = element.closest('.expansion-panel__content');
+    if (!scrollContainer) return true;
+
+    const elemRect = element.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+
+    return (
+      elemRect.top >= containerRect.top - this.TOLERANCE && elemRect.bottom <= containerRect.bottom + this.TOLERANCE
+    );
+  }
+
+  /**
+   * Determine whether a connection port element is visible inside the outer
+   * `.expansion-panels` viewport (vertical bounds only).
+   */
+  static isVisibleWithinPanelsViewport(element: HTMLElement): boolean {
+    const panelsContainer = element.closest('.expansion-panels');
+    if (!panelsContainer) return true;
+
+    const elemRect = element.getBoundingClientRect();
+    const panelsRect = panelsContainer.getBoundingClientRect();
+
+    return elemRect.top >= panelsRect.top - this.TOLERANCE && elemRect.bottom <= panelsRect.bottom + this.TOLERANCE;
+  }
+
+  /**
+   * Elements without a `.expansion-panel__content` ancestor (e.g. primitive
+   * document header ports in `.expansion-panel__summary`) are always visible.
+   */
+  static isElementVisible(element: HTMLElement): boolean {
+    if (!element.closest('.expansion-panel__content')) return true;
+    return this.isVisibleWithinPanelContent(element) && this.isVisibleWithinPanelsViewport(element);
+  }
+
+  /**
+   * Calculate the rendered position for an EDGE marker, clamping its Y coordinate
+   * to the visible `.expansion-panels` bounds so that anchors stay pinned to the
+   * nearest visible edge of the panels container.
+   */
+  static getClampedEdgePosition(element: HTMLElement): [number, number] {
+    const rect = element.getBoundingClientRect();
+    const x = rect.x + rect.width / 2;
+    let y = rect.y + rect.height / 2;
+
+    const panelsContainer = element.closest('.expansion-panels');
+    if (panelsContainer) {
+      const panelsRect = panelsContainer.getBoundingClientRect();
+      y = Math.max(panelsRect.top, Math.min(panelsRect.bottom, y));
+    }
+
+    return [x, y];
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/KaotoIO/kaoto/issues/3542

- Create ConnectionPortSyncHelper class with 3 public static methods extracted from useConnectionPortSync hook
  - isVisibleWithinPanelContent
  - isVisibleWithinPanelsViewport
  - getClampedEdgePosition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-port visibility handling within panel content and the panels viewport.
  * Added tolerance for edge cases near viewport boundaries.
  * Clamped EDGE marker positions to remain within the visible panels area while preserving horizontal alignment.

* **Tests**
  * Added comprehensive coverage for visibility checks, missing containers, boundary conditions, and position clamping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->