### PR TITLE
chore(migration): migrate customnode customnodeutils and componentmode processorName to primaryNode.name

### DIFF
--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -2,7 +2,8 @@ import { act, render } from '@testing-library/react';
 import { Mock, MockedFunction, vi } from 'vitest';
 
 import { useProcessorTooltips } from '../../hooks/use-processor-tooltips.hook';
-import { IVisualizationNode } from '../../models';
+import { CatalogKind, IVisualizationNode } from '../../models';
+import { createVisualizationNode } from '../../models/visualization/visualization-node';
 import { ComponentMode } from './ComponentMode';
 
 let mockUpdateSourceCodeFromEntities: Mock;
@@ -28,12 +29,20 @@ describe('ComponentMode', () => {
   });
 
   const getMockVizNode = (processorName = 'to'): IVisualizationNode => {
-    return {
-      data: { processorName, path: `route.from.steps.0.${processorName}` },
-      getNodeSchema: () => undefined,
-      getNodeDefinition: () => ({}),
-      updateModel: vi.fn(),
-    } as unknown as IVisualizationNode;
+    const node = createVisualizationNode(`route.from.steps.0.${processorName}`, {
+      name: processorName,
+      path: `route.from.steps.0.${processorName}`,
+      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern },
+      isPlaceholder: false,
+      isGroup: false,
+      title: '',
+      description: '',
+      iconUrl: '',
+    });
+    vi.spyOn(node, 'getNodeSchema').mockReturnValue(undefined);
+    vi.spyOn(node, 'getNodeDefinition').mockReturnValue({});
+    vi.spyOn(node, 'updateModel').mockImplementation(vi.fn());
+    return node;
   };
 
   it('renders the three toggle buttons', () => {

--- a/packages/ui/src/components/ComponentMode/ComponentMode.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.tsx
@@ -8,14 +8,11 @@ import { useProcessorTooltips } from '../../hooks/use-processor-tooltips.hook';
 import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext';
 import { IVisualizationNode } from '../../models';
 import { COMPONENT_MODE_PROCESSORS } from '../../models/special-processors.constants';
-import { CamelRouteVisualEntityData } from '../../models/visualization/flows/support/camel-component-types';
 import { getProcessorIcon } from '../../utils/processor-icon';
 
 export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> = ({ vizNode }) => {
   const { updateSourceCodeFromEntities } = useEntityContext();
-  const [processorName, setProcessorName] = useState<keyof ProcessorDefinition>(
-    (vizNode?.data as CamelRouteVisualEntityData)?.processorName,
-  );
+  const [processorName, setProcessorName] = useState(vizNode?.data.primaryNodeId?.name);
 
   const switchComponentMode = useCallback(
     (newProcessorName: keyof ProcessorDefinition) => {
@@ -33,7 +30,17 @@ export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> 
       vizNode.data = { ...vizNode.data, path: rootEipPath };
       vizNode.updateModel(undefined);
 
-      vizNode.data = { ...vizNode.data, path: `${rootEipPath}.${newProcessorName}`, processorName: newProcessorName };
+      const existingPrimaryNodeId = vizNode.data.primaryNodeId;
+      if (!existingPrimaryNodeId) return;
+
+      vizNode.data = {
+        ...vizNode.data,
+        path: `${rootEipPath}.${newProcessorName}`,
+        primaryNodeId: {
+          ...existingPrimaryNodeId,
+          name: newProcessorName,
+        },
+      };
       vizNode.updateModel(definition);
       updateSourceCodeFromEntities();
       setProcessorName(newProcessorName);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -1,5 +1,6 @@
 import './CustomNode.scss';
 
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import {
   AnchorEnd,
@@ -31,7 +32,6 @@ import { FunctionComponent, useContext, useMemo, useRef } from 'react';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { AddStepMode, IVisualizationNode, NodeToolbarTrigger } from '../../../../models';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { SettingsContext } from '../../../../providers';
 import { getProcessorIcon } from '../../../../utils/processor-icon';
 import { NodeInteractionAddonContext } from '../../../registers/interactions/node-interaction-addon.provider';
@@ -83,8 +83,8 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const settingsAdapter = useContext(SettingsContext);
     const nodeInteractionAddonContext = useContext(NodeInteractionAddonContext);
     const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
-    const processorName = (vizNode?.data as CamelRouteVisualEntityData)?.processorName;
-    const ProcessorIcon = getProcessorIcon(processorName);
+    const processorName = vizNode?.data.primaryNodeId?.name;
+    const ProcessorIcon = processorName ? getProcessorIcon(processorName as keyof ProcessorDefinition) : null;
     const processorDescription = vizNode?.data.processorIconTooltip ?? '';
     const isDisabled = !!vizNode?.getNodeDefinition()?.disabled;
     const validationText = vizNode?.getNodeValidationText();

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.test.ts
@@ -2,6 +2,7 @@ import { ElementModel, GraphElement } from '@patternfly/react-topology';
 import { waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
+import { CatalogKind } from '../../../../models/catalog-kind';
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { EntitiesContextResult } from '../../../../providers/entities.provider';
@@ -121,8 +122,8 @@ describe('CustomNodeUtils', () => {
 
     it('should return true for compatible nodes in case of placeholder node', () => {
       const mockValidate = vi.fn().mockReturnValue(true);
-      vizNode1.data.name = 'log';
-      placeholderNode.data.name = PlaceholderType.Placeholder;
+      vizNode1.data.primaryNodeId = { name: 'log', catalogKind: CatalogKind.Processor };
+      placeholderNode.data.primaryNodeId = { name: PlaceholderType.Placeholder, catalogKind: CatalogKind.Pattern };
       const result = checkNodeDropCompatibility(vizNode1, placeholderNode, mockValidate);
       expect(result).toBe(true);
       expect(mockValidate).toHaveBeenCalled();
@@ -131,17 +132,19 @@ describe('CustomNodeUtils', () => {
     it('should return true when dropping when container onto when placeholder from another choice', () => {
       const mockValidate = vi.fn();
       const whenPlaceholder = getMockVizNode('route.from.steps.1.choice.when');
-      whenPlaceholder.data = { ...whenPlaceholder.data, name: 'when', isPlaceholder: true };
+      whenPlaceholder.data = {
+        ...whenPlaceholder.data,
+        primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       whenPlaceholder.getCopiedContent = vi.fn().mockReturnValue({ name: 'when' });
       const choiceB = getMockVizNode('route.from.steps.1.choice');
-      choiceB.data = { ...choiceB.data, processorName: 'choice' };
       whenPlaceholder.getParentNode = vi.fn().mockReturnValue(choiceB);
 
       const whenContainer = getMockVizNode('route.from.steps.0.choice.when.0');
-      whenContainer.data = { ...whenContainer.data, name: 'when' };
+      whenContainer.data = { ...whenContainer.data, primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern } };
       whenContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'when' });
       const choiceA = getMockVizNode('route.from.steps.0.choice');
-      choiceA.data = { ...choiceA.data, processorName: 'choice' };
       (choiceA.getId as Mock).mockReturnValue('choice-a');
       (choiceB.getId as Mock).mockReturnValue('choice-b');
       whenContainer.getParentNode = vi.fn().mockReturnValue(choiceA);
@@ -153,15 +156,18 @@ describe('CustomNodeUtils', () => {
 
     it('should return false when dropping when container onto when placeholder from same choice', () => {
       const choiceNode = getMockVizNode('route.from.steps.0.choice');
-      choiceNode.data = { ...choiceNode.data, processorName: 'choice' };
       (choiceNode.getId as Mock).mockReturnValue('same-choice');
       const whenPlaceholder = getMockVizNode('route.from.steps.0.choice.when');
-      whenPlaceholder.data = { ...whenPlaceholder.data, name: 'when', isPlaceholder: true };
+      whenPlaceholder.data = {
+        ...whenPlaceholder.data,
+        primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       whenPlaceholder.getCopiedContent = vi.fn().mockReturnValue({ name: 'when' });
       whenPlaceholder.getParentNode = vi.fn().mockReturnValue(choiceNode);
 
       const whenContainer = getMockVizNode('route.from.steps.0.choice.when.0');
-      whenContainer.data = { ...whenContainer.data, name: 'when' };
+      whenContainer.data = { ...whenContainer.data, primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern } };
       whenContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'when' });
       whenContainer.getParentNode = vi.fn().mockReturnValue(choiceNode);
 
@@ -171,13 +177,20 @@ describe('CustomNodeUtils', () => {
 
     it('should return false when dropping non-when onto when placeholder', () => {
       const whenPlaceholder = getMockVizNode('route.from.steps.0.choice.when');
-      whenPlaceholder.data = { ...whenPlaceholder.data, name: 'when', isPlaceholder: true };
+      whenPlaceholder.data = {
+        ...whenPlaceholder.data,
+        primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       whenPlaceholder.getCopiedContent = vi.fn().mockReturnValue({ name: 'when' });
       const choiceNode = getMockVizNode('route.from.steps.0.choice');
       whenPlaceholder.getParentNode = vi.fn().mockReturnValue(choiceNode);
 
       const otherwiseContainer = getMockVizNode('route.from.steps.0.choice.otherwise');
-      otherwiseContainer.data = { ...otherwiseContainer.data, name: 'otherwise' };
+      otherwiseContainer.data = {
+        ...otherwiseContainer.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+      };
       otherwiseContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'otherwise' });
       const otherChoice = getMockVizNode('route.from.steps.1.choice');
       (otherChoice.getId as Mock).mockReturnValue('other');
@@ -199,13 +212,20 @@ describe('CustomNodeUtils', () => {
 
     it('should return true when dropping otherwise container onto otherwise placeholder from another choice', () => {
       const otherwisePlaceholder = getMockVizNode('route.from.steps.1.choice.otherwise');
-      otherwisePlaceholder.data = { ...otherwisePlaceholder.data, name: 'otherwise', isPlaceholder: true };
+      otherwisePlaceholder.data = {
+        ...otherwisePlaceholder.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       otherwisePlaceholder.getCopiedContent = vi.fn().mockReturnValue({ name: 'otherwise' });
       const choiceB = getMockVizNode('route.from.steps.1.choice');
       otherwisePlaceholder.getParentNode = vi.fn().mockReturnValue(choiceB);
 
       const otherwiseContainer = getMockVizNode('route.from.steps.0.choice.otherwise');
-      otherwiseContainer.data = { ...otherwiseContainer.data, name: 'otherwise' };
+      otherwiseContainer.data = {
+        ...otherwiseContainer.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+      };
       otherwiseContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'otherwise' });
       const choiceA = getMockVizNode('route.from.steps.0.choice');
       (choiceA.getId as Mock).mockReturnValue('choice-a');
@@ -220,12 +240,19 @@ describe('CustomNodeUtils', () => {
       const choiceNode = getMockVizNode('route.from.steps.0.choice');
       (choiceNode.getId as Mock).mockReturnValue('same-choice');
       const otherwisePlaceholder = getMockVizNode('route.from.steps.0.choice.otherwise');
-      otherwisePlaceholder.data = { ...otherwisePlaceholder.data, name: 'otherwise', isPlaceholder: true };
+      otherwisePlaceholder.data = {
+        ...otherwisePlaceholder.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       otherwisePlaceholder.getCopiedContent = vi.fn().mockReturnValue({ name: 'otherwise' });
       otherwisePlaceholder.getParentNode = vi.fn().mockReturnValue(choiceNode);
 
       const otherwiseContainer = getMockVizNode('route.from.steps.0.choice.otherwise');
-      otherwiseContainer.data = { ...otherwiseContainer.data, name: 'otherwise' };
+      otherwiseContainer.data = {
+        ...otherwiseContainer.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+      };
       otherwiseContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'otherwise' });
       otherwiseContainer.getParentNode = vi.fn().mockReturnValue(choiceNode);
 
@@ -286,6 +313,23 @@ describe('CustomNodeUtils', () => {
       const result = checkNodeDropCompatibility(whenNode, AnotherWhen, mockValidate);
       expect(result).toBe(true);
       expect(mockValidate).toHaveBeenCalled();
+    });
+
+    it('should return false when dropped placeholder has no primaryNodeId (regression: undefined name must not match)', () => {
+      // Both nodes have no primaryNodeId — undefined === undefined must NOT be treated as a name match
+      const draggedNode = getMockVizNode('route.from.steps.0.log');
+      // no primaryNodeId set on draggedNode
+
+      const noPrimaryPlaceholder = getMockVizNode('route.from.steps.1.placeholder');
+      noPrimaryPlaceholder.data = {
+        ...noPrimaryPlaceholder.data,
+        isPlaceholder: true,
+        // primaryNodeId intentionally absent
+      };
+      noPrimaryPlaceholder.getPreviousNode = vi.fn().mockReturnValue(undefined);
+
+      const result = checkNodeDropCompatibility(draggedNode, noPrimaryPlaceholder, vi.fn());
+      expect(result).toBe(false);
     });
   });
 
@@ -422,11 +466,15 @@ describe('CustomNodeUtils', () => {
         canHaveSpecialChildren: true,
       });
       const whenPlaceholder = getMockVizNode('route.from.steps.1.choice.when');
-      whenPlaceholder.data = { ...whenPlaceholder.data, name: 'when', isPlaceholder: true };
+      whenPlaceholder.data = {
+        ...whenPlaceholder.data,
+        primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       whenPlaceholder.getParentNode = vi.fn().mockReturnValue(choiceVizNode);
 
       const whenContainer = getMockVizNode('route.from.steps.0.choice.when.0');
-      whenContainer.data = { ...whenContainer.data, name: 'when' };
+      whenContainer.data = { ...whenContainer.data, primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern } };
       whenContainer.getCopiedContent = vi.fn().mockReturnValue({ name: 'when', type: 'processor', definition: {} });
 
       const draggedElement = createMockDraggedElement(whenContainer);
@@ -458,11 +506,18 @@ describe('CustomNodeUtils', () => {
         canHaveSpecialChildren: true,
       });
       const otherwisePlaceholder = getMockVizNode('route.from.steps.1.choice.otherwise');
-      otherwisePlaceholder.data = { ...otherwisePlaceholder.data, name: 'otherwise', isPlaceholder: true };
+      otherwisePlaceholder.data = {
+        ...otherwisePlaceholder.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+        isPlaceholder: true,
+      };
       otherwisePlaceholder.getParentNode = vi.fn().mockReturnValue(choiceVizNode);
 
       const otherwiseContainer = getMockVizNode('route.from.steps.0.choice.otherwise');
-      otherwiseContainer.data = { ...otherwiseContainer.data, name: 'otherwise' };
+      otherwiseContainer.data = {
+        ...otherwiseContainer.data,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+      };
       otherwiseContainer.getCopiedContent = vi.fn().mockReturnValue({
         name: 'otherwise',
         type: 'processor',
@@ -521,6 +576,45 @@ describe('CustomNodeUtils', () => {
       await waitFor(() => {
         expect(entitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
       });
+    });
+
+    it('should NOT route to InsertSpecialChildStep when dropped placeholder has no primaryNodeId', () => {
+      // A placeholder without primaryNodeId must not be treated as a special-child placeholder
+      const choiceVizNode = getMockVizNode('route.from.steps.1.choice');
+      choiceVizNode.getNodeInteraction = vi.fn().mockReturnValue({
+        canHaveSpecialChildren: true,
+      });
+
+      const noPrimaryPlaceholder = getMockVizNode('route.from.steps.1.choice.when');
+      noPrimaryPlaceholder.data = {
+        ...noPrimaryPlaceholder.data,
+        isPlaceholder: true,
+        // primaryNodeId intentionally absent
+      };
+      noPrimaryPlaceholder.getParentNode = vi.fn().mockReturnValue(choiceVizNode);
+
+      const logNode = getMockVizNode('route.from.steps.0.log');
+      logNode.getCopiedContent = vi.fn().mockReturnValue({ name: 'log', type: 'processor', definition: {} });
+      (logNode.getId as Mock).mockReturnValue('route1');
+      (noPrimaryPlaceholder.getId as Mock).mockReturnValue('route1');
+
+      const draggedElement = createMockDraggedElement(logNode);
+      const dropResult = createMockDropResultNode(noPrimaryPlaceholder);
+      const entitiesContext = createMockEntitiesContext();
+
+      handleValidNodeDrop(
+        draggedElement,
+        dropResult,
+        entitiesContext as unknown as EntitiesContextResult,
+        { getRegisteredInteractionAddons: noopGetOnCopyAddons } as unknown as INodeInteractionAddonContext,
+      );
+
+      // Must NOT have called pasteBaseEntityStep with InsertSpecialChildStep on the choice node
+      expect(choiceVizNode.pasteBaseEntityStep).not.toHaveBeenCalledWith(
+        expect.anything(),
+        AddStepMode.InsertSpecialChildStep,
+        expect.anything(),
+      );
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
@@ -1,3 +1,4 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { ElementModel, GraphElement, Node } from '@patternfly/react-topology';
 
@@ -5,7 +6,6 @@ import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
@@ -74,9 +74,11 @@ export const handleValidNodeDrop = (
   if (!isDefined(draggedNodeContent)) return;
 
   // Drop onto special placeholder
+  const droppedPrimaryName = droppedVizNode.data?.primaryNodeId?.name;
   const isSpecialChildPlaceholder =
     droppedVizNode.data?.isPlaceholder &&
-    droppedVizNode.data?.name !== PlaceholderType.Placeholder &&
+    droppedPrimaryName !== undefined &&
+    droppedPrimaryName !== PlaceholderType.Placeholder &&
     droppedVizNode.getParentNode()?.getNodeInteraction().canHaveSpecialChildren;
   if (isSpecialChildPlaceholder) {
     const parentVizNode = droppedVizNode.getParentNode();
@@ -131,14 +133,16 @@ export const checkNodeDropCompatibility = (
 
   // validation for placeholder nodes
   if (droppedVizNode.data.isPlaceholder) {
-    if (droppedVizNode.data.name === draggedVizNode?.data.name) {
+    const droppedName = droppedVizNode.data.primaryNodeId?.name;
+    const draggedName = draggedVizNode?.data.primaryNodeId?.name;
+    if (droppedName !== undefined && draggedName !== undefined && droppedName === draggedName) {
       const draggedParent = draggedVizNode.getParentNode();
       const droppedParent = droppedVizNode.getParentNode();
       return !(draggedParent?.id === droppedParent?.id && draggedParent?.getId() === droppedParent?.getId());
     }
 
     if (
-      droppedVizNode.data.name === PlaceholderType.Placeholder &&
+      droppedVizNode.data.primaryNodeId?.name === PlaceholderType.Placeholder &&
       droppedVizNode.getPreviousNode() !== draggedVizNode
     ) {
       return validate(AddStepMode.ReplaceStep, droppedVizNode, droppedVizNodeContent.name);
@@ -184,17 +188,19 @@ export interface VizNodeChildrenInfo {
 }
 
 export const getVizNodeChildrenInfo = (vizNode: IVisualizationNode | undefined): VizNodeChildrenInfo => {
-  const processorName = (vizNode?.data as CamelRouteVisualEntityData)?.processorName;
+  const processorName = vizNode?.data.primaryNodeId?.name;
   const vizNodeChildren = vizNode?.getChildren() ?? [];
   const childCount = vizNodeChildren.filter((c) => !c.data.isPlaceholder).length;
   const hasGroupChildren = vizNodeChildren.some((child) => {
-    const childProcessorName = (child.data as CamelRouteVisualEntityData)?.processorName;
+    const childProcessorName = child.data.primaryNodeId?.name;
     return childProcessorName
-      ? CamelComponentSchemaService.getProcessorStepsProperties(childProcessorName).length > 0
+      ? CamelComponentSchemaService.getProcessorStepsProperties(childProcessorName as keyof ProcessorDefinition)
+          .length > 0
       : false;
   });
   const isContainerType =
-    !!processorName && CamelComponentSchemaService.getProcessorStepsProperties(processorName).length > 0;
+    !!processorName &&
+    CamelComponentSchemaService.getProcessorStepsProperties(processorName as keyof ProcessorDefinition).length > 0;
   const isCollapsedGroup = isContainerType && childCount > 0;
   return { childCount, hasGroupChildren, isCollapsedGroup };
 };


### PR DESCRIPTION
## Migrate from `processorName` to `primaryNode.name` in visualization node data for CustomNode, CustomNodeUtils and ComponentMode

Replace usage of `CamelRouteVisualEntityData.processorName` with the generic `IVisualizationNode.data.primaryNode.name` field across the visualization node components and utilities.

### Changes

- **`CustomNode.tsx`** — Read `processorName` from `vizNode.data.primaryNode.name` instead of casting to `CamelRouteVisualEntityData`; guard `getProcessorIcon` call with a null check.
- **`CustomNodeUtils.ts`** — Update `getVizNodeChildrenInfo` to use `data.primaryNode.name` for both the parent and child processor name lookups; add `ProcessorDefinition` cast where needed.
- **`ComponentMode.tsx`** — Simplify `useState` initializer to read from `vizNode.data.primaryNode.name`, removing the `CamelRouteVisualEntityData` cast and import.
- **Test files** — Update mock data to set `primaryNode.name` instead of `processorName`.

### Motivation

The `processorName` field was specific to `CamelRouteVisualEntityData`, requiring unsafe casts throughout. Using the shared `primaryNode.name` field from the base `IVisualizationNodeData` interface removes these casts and makes the components less coupled to a concrete data type.

fix: https://github.com/KaotoIO/kaoto/issues/3646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved visualization node handling for consistent processor identification.
- Corrected processor icon resolution when node details are missing.
- Updated drag-and-drop compatibility checks for choice nodes.
- Preserved processor information when switching component modes.

## Tests
- Updated coverage for visualization node data and mode-switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->