### PR TITLE
Migration processor name: get-move-icons.util, TopologyNode, insert-step, paste-step

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.test.ts
@@ -1,4 +1,3 @@
-import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import {
   AngleDoubleDownIcon,
   AngleDoubleLeftIcon,
@@ -10,25 +9,24 @@ import {
   ArrowUpIcon,
 } from '@patternfly/react-icons';
 
+import { CatalogKind } from '../../../../models';
 import { IVisualizationNode, IVisualizationNodeData } from '../../../../models/visualization/base-visual-entity';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { LayoutType } from '../../Canvas/canvas.models';
 import { getMoveIcons } from './get-move-icons.util';
 
 describe('getMoveIcons', () => {
   const createMockVizNode = (processorName: string): IVisualizationNode => {
-    const data: CamelRouteVisualEntityData = {
+    return createVisualizationNode(`test-${processorName}`, {
       name: processorName,
       path: `route.from.steps.0.${processorName}`,
-      processorName: processorName as keyof ProcessorDefinition,
+      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern },
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',
       title: '',
       description: '',
-    };
-    return createVisualizationNode(`test-${processorName}`, data);
+    });
   };
 
   describe('Regular steps (non-special children)', () => {
@@ -67,16 +65,19 @@ describe('getMoveIcons', () => {
   });
 
   describe('Special child nodes (array-clause processors) - inverted direction', () => {
-    it('should return horizontal icons for "when" node in vertical layout (inverted)', () => {
-      const vizNode = createMockVizNode('when');
+    it.each(['when', 'doCatch', 'get', 'onFallback'])(
+      'should return horizontal icons for "%s" node in vertical layout (inverted)',
+      (processorName) => {
+        const vizNode = createMockVizNode(processorName);
 
-      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
+        const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
 
-      expect(icons.prepend.type).toBe(ArrowLeftIcon);
-      expect(icons.append.type).toBe(ArrowRightIcon);
-      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
-      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
-    });
+        expect(icons.prepend.type).toBe(ArrowLeftIcon);
+        expect(icons.append.type).toBe(ArrowRightIcon);
+        expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
+        expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
+      },
+    );
 
     it('should return vertical icons for "when" node in horizontal layout (inverted)', () => {
       const vizNode = createMockVizNode('when');
@@ -87,39 +88,6 @@ describe('getMoveIcons', () => {
       expect(icons.append.type).toBe(ArrowDownIcon);
       expect(icons.moveBefore.type).toBe(AngleDoubleUpIcon);
       expect(icons.moveNext.type).toBe(AngleDoubleDownIcon);
-    });
-
-    it('should return horizontal icons for "doCatch" node in vertical layout (inverted)', () => {
-      const vizNode = createMockVizNode('doCatch');
-
-      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
-
-      expect(icons.prepend.type).toBe(ArrowLeftIcon);
-      expect(icons.append.type).toBe(ArrowRightIcon);
-      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
-      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
-    });
-
-    it('should return horizontal icons for REST DSL verb "get" in vertical layout (inverted)', () => {
-      const vizNode = createMockVizNode('get');
-
-      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
-
-      expect(icons.prepend.type).toBe(ArrowLeftIcon);
-      expect(icons.append.type).toBe(ArrowRightIcon);
-      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
-      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
-    });
-
-    it('should return horizontal icons for "onFallback" node in vertical layout (inverted)', () => {
-      const vizNode = createMockVizNode('onFallback');
-
-      const icons = getMoveIcons(LayoutType.DagreVertical, vizNode);
-
-      expect(icons.prepend.type).toBe(ArrowLeftIcon);
-      expect(icons.append.type).toBe(ArrowRightIcon);
-      expect(icons.moveBefore.type).toBe(AngleDoubleLeftIcon);
-      expect(icons.moveNext.type).toBe(AngleDoubleRightIcon);
     });
   });
 

--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
@@ -12,7 +12,6 @@ import { ReactElement } from 'react';
 
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { LayoutType } from '../../Canvas/canvas.models';
 
 export interface MoveIcons {
@@ -71,7 +70,7 @@ function isSpecialChildNode(vizNode?: IVisualizationNode): boolean {
     return false;
   }
 
-  const processorName = (vizNode.data as CamelRouteVisualEntityData).processorName;
+  const processorName = vizNode.data.primaryNodeId?.name;
   if (!processorName) {
     return false;
   }

--- a/packages/ui/src/components/Visualization/Custom/Node/TopologyNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/TopologyNode.tsx
@@ -1,8 +1,8 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { AnchorEnd, ElementModel, GraphElement, isNode, observer, useAnchor } from '@patternfly/react-topology';
 import { FunctionComponent, useCallback } from 'react';
 
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { getProcessorIcon } from '../../../../utils/processor-icon';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { CanvasNode } from '../../Canvas/canvas.models';
@@ -33,8 +33,8 @@ export const TopologyNode: FunctionComponent<TopologyRouteNodeProps> = observer(
     return null;
   }
 
-  const processorName = (vizNode.data as CamelRouteVisualEntityData).processorName;
-  const ProcessorIcon = getProcessorIcon(processorName);
+  const processorName = vizNode.data.primaryNodeId?.name;
+  const ProcessorIcon = getProcessorIcon(processorName as keyof ProcessorDefinition);
   const processorDescription = vizNode.data.processorIconTooltip ?? '';
   const definition = vizNode.getNodeDefinition() as { disabled?: boolean; description?: string } | undefined;
   const label = definition?.description?.trim() || vizNode.getNodeLabel();

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -7,7 +7,6 @@ import { CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { createMockEntitiesContext } from '../../../../stubs';
@@ -48,7 +47,7 @@ describe('useInsertStep', () => {
   beforeEach(() => {
     mockVizNode = createVisualizationNode('test', {
       name: 'test',
-      processorName: 'test',
+      primaryNodeId: { name: 'test', catalogKind: CatalogKind.Pattern },
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',
@@ -165,9 +164,7 @@ describe('useInsertStep', () => {
       undefined,
       undefined,
     );
-    expect(getProcessorStepsPropertiesMock).toHaveBeenCalledWith(
-      (mockVizNode.data as CamelRouteVisualEntityData).processorName,
-    );
+    expect(getProcessorStepsPropertiesMock).toHaveBeenCalledWith(mockVizNode.data.primaryNodeId?.name);
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.tsx
@@ -1,3 +1,4 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { useVisualizationController } from '@patternfly/react-topology';
 import { useCallback, useContext, useMemo } from 'react';
@@ -6,7 +7,6 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { DefinedComponent } from '../../../../models';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 
 export interface UseInsertStepOptions {
@@ -46,7 +46,7 @@ export const useInsertStep = (
     // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
     if (mode === AddStepMode.InsertSpecialChildStep) {
       const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-        (vizNode.data as CamelRouteVisualEntityData).processorName,
+        vizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
       );
       if (
         stepsProperties.some(

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -3,11 +3,11 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import type { Mock } from 'vitest';
 
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
+import { CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { ClipboardService } from '../../../../services/visualization/clipboard.service';
@@ -173,7 +173,7 @@ describe('usePasteStep', () => {
   describe('onPasteStep', () => {
     const mockChoiceVizNode = createVisualizationNode('choice', {
       name: 'choice',
-      processorName: 'choice',
+      primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern },
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',
@@ -220,9 +220,7 @@ describe('usePasteStep', () => {
         AddStepMode.InsertSpecialChildStep,
       );
 
-      expect(getProcessorStepsPropertiesMock).toHaveBeenCalledWith(
-        (mockChoiceVizNode.data as CamelRouteVisualEntityData).processorName,
-      );
+      expect(getProcessorStepsPropertiesMock).toHaveBeenCalledWith(mockChoiceVizNode.data.primaryNodeId?.name);
 
       expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
     });

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
@@ -1,3 +1,4 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { useVisualizationController } from '@patternfly/react-topology';
 import { cloneDeep } from 'lodash';
@@ -7,7 +8,6 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { ActionConfirmationModalContext } from '../../../../providers/action-confirmation-modal.provider';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { ClipboardService } from '../../../../services/visualization/clipboard.service';
@@ -99,7 +99,7 @@ export const usePasteStep = (vizNode: IVisualizationNode, mode: AddStepMode) => 
     // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
     if (mode === AddStepMode.InsertSpecialChildStep) {
       const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-        (vizNode.data as CamelRouteVisualEntityData).processorName,
+        vizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
       );
       if (
         stepsProperties.some(


### PR DESCRIPTION
**Migration processor name: get-move-icons.util, TopologyNode, insert-step, paste-step**

Replace all usages of `(vizNode.data as CamelRouteVisualEntityData).processorName` with the generic `vizNode.data.primaryNodeId.name` across the Custom visualization components. This removes the dependency on the `CamelRouteVisualEntityData` cast — which was tying these components to a specific entity type — and aligns with the shared `IVisualizationNode` base interface.

Where `keyof ProcessorDefinition` is required (calls to `getProcessorStepsProperties` and `getProcessorIcon`), a type cast `as keyof ProcessorDefinition` is added, consistent with the existing pattern in the codebase. The `CamelRouteVisualEntityData` import is removed from all four affected files.

**Files changed:**
- [`get-move-icons.util.tsx`](kaoto/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx)
- [`TopologyNode.tsx`](kaoto/packages/ui/src/components/Visualization/Custom/Node/TopologyNode.tsx)
- [`insert-step.hook.tsx`](kaoto/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.tsx)
- [`paste-step.hook.tsx`](kaoto/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx)

fix: https://github.com/KaotoIO/kaoto/issues/3646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements
- Improved processor recognition in route visualizations.
- Topology nodes now display the appropriate processor icons more reliably.
- Improved context-menu actions for special processor nodes.
- Improved inserting and pasting processor steps during visual route editing.

## Bug Fixes
- Corrected handling for conditional and fallback processor nodes during move, insert, and paste interactions.
- Improved consistency when working with processor nodes across route visualization and editing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->