### PR TITLE
e2e(weekly): skip XSLT catalog version tests

### DIFF
--- a/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
+++ b/packages/ui-tests/cypress/e2e/catalogVersions/catalogVersions.cy.ts
@@ -8,7 +8,7 @@ describe('Test for catalog versions', () => {
   const testData: { version: string; type: string }[] = [];
 
   catalogLibrary.definitions.forEach((library) => {
-    if (library.runtime === 'Citrus') {
+    if (library.runtime === 'Citrus' || library.runtime === 'XSLT') {
       return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated catalog version test coverage to skip libraries using either the Citrus or XSLT runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->