### PR TITLE
fix: citrus placeholder nodes show "Add placeholder" instead of "Add step"

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.test.tsx
@@ -9,6 +9,7 @@ import {
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { createVisualizationNode, IVisualizationNode, IVisualizationNodeData } from '../../../../models';
+import { CatalogKind } from '../../../../models/catalog-kind';
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { TestProvidersWrapper } from '../../../../stubs';
 import { ControllerService } from '../../../../testing-api';
@@ -296,7 +297,7 @@ describe('PlaceholderNode', () => {
       ['PlusCircleIcon for regular placeholder', PlaceholderType.Placeholder],
       ['CodeBranchIcon for other placeholders', 'when'],
     ])('should render %s', async (_label, name) => {
-      const wrapper = await setupWithVizNode({ name });
+      const wrapper = await setupWithVizNode({ name, primaryNodeId: { name, catalogKind: CatalogKind.Pattern } });
 
       const svgIcon = wrapper.container.querySelector('svg');
       expect(svgIcon).toBeInTheDocument();
@@ -304,7 +305,10 @@ describe('PlaceholderNode', () => {
     });
 
     it('should call onInsertStep when clicking on special child placeholder', async () => {
-      await setupWithVizNode({ name: PlaceholderType.PlaceholderSpecialChild });
+      await setupWithVizNode({
+        name: PlaceholderType.PlaceholderSpecialChild,
+        primaryNodeId: { name: PlaceholderType.PlaceholderSpecialChild, catalogKind: CatalogKind.Pattern },
+      });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -314,7 +318,10 @@ describe('PlaceholderNode', () => {
     });
 
     it('should call onReplaceNode when clicking on regular placeholder', async () => {
-      await setupWithVizNode({ name: PlaceholderType.Placeholder });
+      await setupWithVizNode({
+        name: PlaceholderType.Placeholder,
+        primaryNodeId: { name: PlaceholderType.Placeholder, catalogKind: CatalogKind.Pattern },
+      });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -324,7 +331,11 @@ describe('PlaceholderNode', () => {
     });
 
     it('should call onInsertStep when clicking on otherwise placeholder', async () => {
-      await setupWithVizNode({ name: 'otherwise', isPlaceholder: true });
+      await setupWithVizNode({
+        name: 'otherwise',
+        isPlaceholder: true,
+        primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern },
+      });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);
@@ -334,7 +345,11 @@ describe('PlaceholderNode', () => {
     });
 
     it('should call onInsertStep when clicking on when placeholder', async () => {
-      await setupWithVizNode({ name: 'when', isPlaceholder: true });
+      await setupWithVizNode({
+        name: 'when',
+        isPlaceholder: true,
+        primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
+      });
 
       const placeholderNode = screen.getByTestId('placeholder-node__test-placeholder');
       fireEvent.click(placeholderNode);

--- a/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx
@@ -114,7 +114,7 @@ const PlaceholderNodeInner: FunctionComponent<PlaceholderNodeInnerProps> = obser
   const entitiesContext = useEntityContext();
   const catalogModalContext = useContext(CatalogModalContext);
   const label = vizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
-  const updatedLabel = label === '' ? 'Add step' : `Add ${label}`;
+  const updatedLabel = label === '' || label === PlaceholderType.Placeholder ? 'Add step' : `Add ${label}`;
   const boxRef = useRef<Rect | null>(null);
   const boxXRef = useRef<number | null>(null);
   const boxYRef = useRef<number | null>(null);
@@ -128,19 +128,23 @@ const PlaceholderNodeInner: FunctionComponent<PlaceholderNodeInnerProps> = obser
   }
   const { onReplaceNode } = useReplaceStep(vizNode);
   const isSpecialPlaceholder =
-    vizNode.data.name !== PlaceholderType.Placeholder && vizNode.data.name !== PlaceholderType.PlaceholderSpecialChild;
-  const isSpecialChildPlaceholder = vizNode.data.name === PlaceholderType.PlaceholderSpecialChild;
+    vizNode.data.primaryNodeId?.name !== PlaceholderType.Placeholder &&
+    vizNode.data.primaryNodeId?.name !== PlaceholderType.PlaceholderSpecialChild;
+  const isSpecialChildPlaceholder = vizNode.data.primaryNodeId?.name === PlaceholderType.PlaceholderSpecialChild;
 
   const parentVizNode = vizNode.getParentNode();
   const insertStepTargetNode = isSpecialPlaceholder ? (parentVizNode ?? vizNode) : vizNode;
-  const insertStepOptions = isSpecialPlaceholder
-    ? {
-        predefinedComponent: { name: vizNode.data.name, type: CatalogKind.Processor },
-        insertAtStart: true,
-      }
-    : undefined;
+  const insertStepOptions =
+    isSpecialPlaceholder && vizNode.data.primaryNodeId?.name !== undefined
+      ? {
+          predefinedComponent: { name: vizNode.data.primaryNodeId?.name, type: CatalogKind.Processor },
+          insertAtStart: true,
+        }
+      : undefined;
   const { onInsertStep } = useInsertStep(insertStepTargetNode, AddStepMode.InsertSpecialChildStep, insertStepOptions);
-  const tooltipContent = isSpecialPlaceholder ? `Click to add ${vizNode?.data.name} branch` : 'Click to add a step';
+  const tooltipContent = isSpecialPlaceholder
+    ? `Click to add ${vizNode?.data.primaryNodeId?.name} branch`
+    : 'Click to add a step';
 
   const placeholderNodeDropTargetSpec: DropTargetSpec<
     GraphElement,
@@ -248,16 +252,13 @@ const PlaceholderNodeInner: FunctionComponent<PlaceholderNodeInnerProps> = obser
           </foreignObject>
         )}
 
-        {/** Label rendering - regular label when nothing is dragging */}
-        {updatedLabel && !dndDropProps.droppable && <PlaceholderNodeLabel label={updatedLabel} x={labelX} y={labelY} />}
-
-        {/** Label which appears when dragging the group/node, but for the dummy node */}
+        {/** Label for the dummy node when dragging within group */}
         {updatedLabel && dndDropProps.droppable && isDraggingWithinGroup && (
           <PlaceholderNodeLabel label={updatedLabel} x={labelX} y={labelY} transform={labelTransform} />
         )}
 
-        {/** This label, appears for the node which are not dragging within the container */}
-        {updatedLabel && (isDraggingNodeType || (isDraggingGroupType && !isDraggingWithinGroup)) && (
+        {/** Label for all other cases (not dragging, or dragging outside group) */}
+        {updatedLabel && !(dndDropProps.droppable && isDraggingWithinGroup) && (
           <PlaceholderNodeLabel label={updatedLabel} x={labelX} y={labelY} />
         )}
       </g>

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -11,6 +11,7 @@ import { CatalogKind } from '../../catalog-kind';
 import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../citrus/citrus-catalog-index';
 import { Test } from '../../citrus/entities/Test';
 import { EntityType } from '../../entities/base-entity';
+import { PlaceholderType } from '../../placeholder.constants';
 import { NodeLabelType } from '../../settings/settings.model';
 import { AddStepMode } from '../base-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
@@ -1330,6 +1331,18 @@ describe('CitrusTestVisualEntity', () => {
 
       expect(actionNode?.data.primaryNodeId).toEqual({
         name: actionNode?.data.name,
+        catalogKind: CatalogKind.TestAction,
+      });
+    });
+
+    it('should set primaryNodeId on placeholder nodes', async () => {
+      const vizNode = await citrusTestEntity.toVizNode();
+      const children = vizNode.getChildren()!;
+      const placeholderNode = children[children.length - 1];
+
+      expect(placeholderNode.data.isPlaceholder).toBeTruthy();
+      expect(placeholderNode.data.primaryNodeId).toEqual({
+        name: PlaceholderType.Placeholder,
         catalogKind: CatalogKind.TestAction,
       });
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -9,6 +9,7 @@ import { CITRUS_TEST_ROOT_ENTITY_NAME } from '../../citrus/citrus-catalog-index'
 import { Test, TestAction, TestActions } from '../../citrus/entities/Test';
 import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import { PlaceholderType } from '../../placeholder.constants';
 import { NodeLabelType } from '../../settings';
 import {
   AddStepMode,
@@ -510,7 +511,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const placeholderPath = `${actionsPath}.${vizNodes.length}.placeholder`;
     const previousNode = vizNodes[vizNodes.length - 1];
     const placeholderNode = createVisualizationNode(placeholderPath, {
-      name: 'placeholder',
+      name: PlaceholderType.Placeholder,
       isPlaceholder: true,
       isGroup: false,
       iconUrl: '',
@@ -518,6 +519,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       description: '',
       processorIconTooltip: '',
       path: placeholderPath,
+      primaryNodeId: { name: PlaceholderType.Placeholder, catalogKind: CatalogKind.TestAction } satisfies NodeIdentity,
     });
     vizNodes.push(placeholderNode);
 
@@ -567,7 +569,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       /** Empty steps branch placeholder */
       const placeholderPath = `${path}.placeholder`;
       const placeholderNode = createVisualizationNode(placeholderPath, {
-        name: 'placeholder',
+        name: PlaceholderType.Placeholder,
         isPlaceholder: true,
         isGroup: false,
         iconUrl: '',
@@ -575,6 +577,10 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
         description: '',
         processorIconTooltip: '',
         path: placeholderPath,
+        primaryNodeId: {
+          name: PlaceholderType.Placeholder,
+          catalogKind: CatalogKind.TestAction,
+        } satisfies NodeIdentity,
       });
       return [placeholderNode];
     }
@@ -604,7 +610,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const placeholderPath = `${path}.${children.length}.placeholder`;
     const previousNode = children[children.length - 1];
     const placeholderNode = createVisualizationNode(placeholderPath, {
-      name: 'placeholder',
+      name: PlaceholderType.Placeholder,
       isPlaceholder: true,
       isGroup: false,
       iconUrl: '',
@@ -612,6 +618,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       description: '',
       processorIconTooltip: '',
       path: placeholderPath,
+      primaryNodeId: { name: PlaceholderType.Placeholder, catalogKind: CatalogKind.TestAction } satisfies NodeIdentity,
     });
     children.push(placeholderNode);
 


### PR DESCRIPTION
**Problem**

Citrus test placeholder nodes displayed **"Add placeholder"** on the canvas instead of **"Add step"**. The root cause was that `PlaceholderNode` resolved the label and step-insertion logic from `vizNode.data.name`, but `CitrusTestVisualEntity` was creating placeholder nodes with the raw string `'placeholder'` and no `primaryNodeId` — the field `PlaceholderNode` had already been migrated to rely on.

**Changes**

- **[`citrus-test-visual-entity.ts`](packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts)** — Set `primaryNodeId: { name: PlaceholderType.Placeholder, catalogKind: CatalogKind.TestAction }` on all three placeholder creation sites; replace the raw `'placeholder'` string with the `PlaceholderType.Placeholder` constant.
- **[`PlaceholderNode.tsx`](packages/ui/src/components/Visualization/Custom/Node/PlaceholderNode.tsx)** — Read placeholder type from `vizNode.data.primaryNodeId?.name` instead of `vizNode.data.name`; treat `PlaceholderType.Placeholder` as an "Add step" label (same as empty string); guard `insertStepOptions` against an undefined `primaryNodeId.name`.
- **Tests** — Update `PlaceholderNode.test.tsx` to pass `primaryNodeId` in all relevant test setups; add a new assertion in `citrus-test-visual-entity.test.ts` verifying that placeholder nodes carry the correct `primaryNodeId`.

fix: https://github.com/KaotoIO/kaoto/issues/3652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Placeholder nodes now display “Add step” when no specific action is assigned.
  * Branch placeholders show clearer names and tooltips based on their associated action.
  * Insert options are available only when a valid branch action is identified.

* **Bug Fixes**
  * Improved placeholder identification and behavior across visualized test flows.
  * Corrected placeholder rendering, insertion, and replacement scenarios.
  * Improved consistency for placeholders across root, single-clause, and array-clause flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->