### PR TITLE
fix(canvas): fix routeconfiguration inner entities + duplicate step migration

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
@@ -1,3 +1,4 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { useVisualizationController } from '@patternfly/react-topology';
 import { cloneDeep } from 'lodash';
@@ -8,7 +9,6 @@ import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
 import { EntityType } from '../../../../models/entities';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 import { updateIds } from '../../../../utils/update-ids';
@@ -109,7 +109,7 @@ export const useDuplicateStep = (vizNode: IVisualizationNode) => {
       // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
       if (parentVizNode?.getNodeInteraction().canHaveSpecialChildren) {
         const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-          (parentVizNode.data as CamelRouteVisualEntityData).processorName,
+          parentVizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
         );
         if (
           stepsProperties.some(

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
@@ -42,6 +42,14 @@ export class BaseNodeMapper implements INodeMapper {
       name: componentLookup.processorName,
       catalogKind: CatalogKind.Pattern,
     };
+
+    if (
+      SPECIAL_PROCESSORS_PARENTS_MAP['routeConfiguration'].includes(
+        primaryNodeId.name as (typeof SPECIAL_PROCESSORS_PARENTS_MAP)['routeConfiguration'][number],
+      )
+    ) {
+      primaryNodeId.catalogKind = CatalogKind.Entity;
+    }
     let secondaryNodeId: NodeIdentity | undefined;
     let tertiaryNodeId: NodeIdentity | undefined;
 


### PR DESCRIPTION
### What changed:

duplicate-step.hook.tsx: Replaced the CamelRouteVisualEntityData cast (which assumed a specific entity type) with a generic access via parentVizNode.data.primaryNodeId?.name when resolving processor step properties during a duplicate operation. This removes the tight coupling to CamelRouteVisualEntityData and makes the hook work correctly across all node types.

base-node-mapper.ts: After building the primaryNodeId, the mapper now checks if the processor belongs to SPECIAL_PROCESSORS_PARENTS_MAP['routeConfiguration'] and, if so, overrides its catalogKind to CatalogKind.Entity. This ensures that route-configuration-scoped processors (e.g. intercept, onException) are correctly identified and resolved through the entity catalog rather than the pattern catalog.

### Why it matters:
Previously, nodes belonging to route configuration contexts could be assigned the wrong catalogKind, leading to incorrect resolution and rendering. The duplicate-step hook also relied on an unsafe cast that would break for non-route-configuration nodes.

fix: https://github.com/KaotoIO/kaoto/issues/3654