### PR TITLE
chore: migrate getNodeInteraction from processorName to primaryNodeId.name

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/Canvas.test.tsx.snap
@@ -697,10 +697,10 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-_r_3o_"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-_r_40_"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-_r_3m_"
+                    id="pf-topology-control-bar-_r_3u_"
                     style="background-color: transparent;"
                   >
                     <div
@@ -721,7 +721,7 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3q_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_42_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -773,7 +773,7 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3s_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_44_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -825,7 +825,7 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3u_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_46_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -876,7 +876,7 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_40_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_48_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -914,7 +914,7 @@ exports[`Canvas > Catalog button > should NOT be present if \`CatalogModalContex
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_42_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_4a_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1670,10 +1670,10 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                 >
                   <div
                     class="pf-v6-c-toolbar"
-                    data-ouia-component-id="OUIA-Generated-Toolbar-_r_38_"
+                    data-ouia-component-id="OUIA-Generated-Toolbar-_r_3g_"
                     data-ouia-component-type="PF6/Toolbar"
                     data-ouia-safe="true"
-                    id="pf-topology-control-bar-_r_36_"
+                    id="pf-topology-control-bar-_r_3e_"
                     style="background-color: transparent;"
                   >
                     <div
@@ -1694,7 +1694,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3a_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3i_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-in"
@@ -1746,7 +1746,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3c_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3k_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="zoom-out"
@@ -1798,7 +1798,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                               <button
                                 aria-disabled="false"
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3e_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3m_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="reset-view"
@@ -1849,7 +1849,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3g_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3o_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-h_layout-button"
@@ -1887,7 +1887,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3i_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3q_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-v_layout-button"
@@ -1925,7 +1925,7 @@ exports[`Canvas > Catalog button > should be present if \`CatalogModalContext\` 
                             >
                               <button
                                 class="pf-v6-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3k_"
+                                data-ouia-component-id="OUIA-Generated-Button-tertiary-_r_3s_"
                                 data-ouia-component-type="PF6/Button"
                                 data-ouia-safe="true"
                                 id="topology-control-bar-catalog-button"

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-from-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'from', catalogKind: 'entity' }, path: 'from' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -13,7 +13,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'intercept', catalogKind: 'entity' }, path: 'intercept' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -26,7 +26,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptFrom', path: 'interceptFrom' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptFrom', catalogKind: 'entity' }, path: 'interceptFrom' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -39,7 +39,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: 'entity' }, path: 'interceptSendToEndpoint' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -52,7 +52,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'log', catalogKind: 'pattern' }, path: 'log' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -65,7 +65,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onCompletion', catalogKind: 'entity' }, path: 'onCompletion' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -78,7 +78,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onException', catalogKind: 'entity' }, path: 'onException' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -91,7 +91,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'route', catalogKind: 'entity' }, path: 'route' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -104,7 +104,7 @@ exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the
 }
 `;
 
-exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+exports[`CamelInterceptFromVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'to', catalogKind: 'pattern' }, path: 'to' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-send-to-endpoint-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'from', catalogKind: 'entity' }, path: 'from' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -13,7 +13,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'intercept', catalogKind: 'entity' }, path: 'intercept' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -26,7 +26,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: 'entity' }, path: 'interceptSendToEndpoint' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -39,7 +39,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'log', catalogKind: 'pattern' }, path: 'log' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -52,7 +52,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onCompletion', catalogKind: 'entity' }, path: 'onCompletion' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -65,7 +65,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onException', catalogKind: 'entity' }, path: 'onException' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -78,7 +78,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'route', catalogKind: 'entity' }, path: 'route' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -91,7 +91,7 @@ exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should 
 }
 `;
 
-exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+exports[`CamelInterceptSendToEndpointVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'to', catalogKind: 'pattern' }, path: 'to' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-intercept-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'from', catalogKind: 'entity' }, path: 'from' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -13,7 +13,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'intercept', catalogKind: 'entity' }, path: 'intercept' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -26,7 +26,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: 'entity' }, path: 'interceptSendToEndpoint' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -39,7 +39,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'log', catalogKind: 'pattern' }, path: 'log' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -52,7 +52,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onCompletion', catalogKind: 'entity' }, path: 'onCompletion' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -65,7 +65,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onException', catalogKind: 'entity' }, path: 'onException' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -78,7 +78,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'route', catalogKind: 'entity' }, path: 'route' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -91,7 +91,7 @@ exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the cor
 }
 `;
 
-exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+exports[`CamelInterceptVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'to', catalogKind: 'pattern' }, path: 'to' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-completion-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'from', path: 'from' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'from', catalogKind: 'entity' }, path: 'from' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -13,7 +13,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'intercept', path: 'intercept' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'intercept', catalogKind: 'entity' }, path: 'intercept' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -26,7 +26,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: 'entity' }, path: 'interceptSendToEndpoint' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -39,7 +39,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'log', path: 'log' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'log', catalogKind: 'pattern' }, path: 'log' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -52,7 +52,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onCompletion', path: 'onCompletion' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onCompletion', catalogKind: 'entity' }, path: 'onCompletion' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -65,7 +65,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onException', path: 'onException' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onException', catalogKind: 'entity' }, path: 'onException' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -78,7 +78,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'route', path: 'route' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'route', catalogKind: 'entity' }, path: 'route' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -91,7 +91,7 @@ exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the 
 }
 `;
 
-exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'to', path: 'to' }' processor 1`] = `
+exports[`CamelOnCompletionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'to', catalogKind: 'pattern' }, path: 'to' }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-on-exception-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'from', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'from', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -13,7 +13,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'intercept', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'intercept', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -26,7 +26,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptFrom', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptFrom', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -39,7 +39,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'interceptSendToEndpoint', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -52,7 +52,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'log', catalogKind: 'processor' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'log', catalogKind: 'pattern' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -65,7 +65,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onCompletion', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onCompletion', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -78,7 +78,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'onException', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'onException', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": true,
@@ -91,7 +91,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'route', catalogKind: 'entity' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'route', catalogKind: 'entity' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,
@@ -104,7 +104,7 @@ exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the c
 }
 `;
 
-exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ processorName: 'to', catalogKind: 'processor' }' processor 1`] = `
+exports[`CamelOnExceptionVisualEntity > getNodeInteraction > should return the correct interaction for the '{ primaryNodeId: { name: 'to', catalogKind: 'pattern' } }' processor 1`] = `
 {
   "canBeDisabled": false,
   "canHaveChildren": false,

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -10,10 +10,9 @@ import { NonStringEIP } from '../../camel/types';
 import { CatalogKind } from '../../catalog-kind';
 import { PlaceholderType } from '../../placeholder.constants';
 import { NodeLabelType } from '../../settings';
-import { AddStepMode } from '../base-visual-entity';
+import { AddStepMode, IVisualizationNodeData } from '../base-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CamelRouteVisualEntity } from './camel-route-visual-entity';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 describe('AbstractCamelVisualEntity', () => {
   let abstractVisualEntity: CamelRouteVisualEntity;
@@ -39,20 +38,18 @@ describe('AbstractCamelVisualEntity', () => {
   });
 
   // Test helper to create mock node data with consistent defaults
-  const createMockNodeData = (overrides: Partial<CamelRouteVisualEntityData> = {}): CamelRouteVisualEntityData =>
-    ({
-      name: 'log',
-      path: 'route.from.steps.0.to',
-      processorName: 'to',
-      componentName: 'log',
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: 'Log',
-      description: '',
-      processorIconTooltip: '',
-      ...overrides,
-    }) as CamelRouteVisualEntityData;
+  const createMockNodeData = (overrides: Partial<IVisualizationNodeData> = {}): IVisualizationNodeData => ({
+    name: 'log',
+    path: 'route.from.steps.0.to',
+    isPlaceholder: false,
+    isGroup: false,
+    iconUrl: '',
+    title: 'Log',
+    description: '',
+    processorIconTooltip: '',
+    primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+    ...overrides,
+  });
 
   describe('getNodeLabel', () => {
     it('should return an empty string if the path is `undefined`', () => {
@@ -97,7 +94,10 @@ describe('AbstractCamelVisualEntity', () => {
   describe('getNodeInteraction', () => {
     it('should not allow marked processors to have previous/next steps', () => {
       const result = abstractVisualEntity.getNodeInteraction(
-        createMockNodeData({ name: 'from', processorName: 'from' as keyof ProcessorDefinition, title: 'From' }),
+        createMockNodeData({
+          name: 'from',
+          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Pattern },
+        }),
       );
       expect(result.canHavePreviousStep).toBe(false);
       expect(result.canHaveNextStep).toBe(false);
@@ -105,7 +105,10 @@ describe('AbstractCamelVisualEntity', () => {
 
     it('should allow processors to have previous/next steps', () => {
       const result = abstractVisualEntity.getNodeInteraction(
-        createMockNodeData({ name: 'to', processorName: 'to', title: 'To' }),
+        createMockNodeData({
+          name: 'to',
+          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+        }),
       );
       expect(result.canHavePreviousStep).toBe(true);
       expect(result.canHaveNextStep).toBe(true);
@@ -125,8 +128,7 @@ describe('AbstractCamelVisualEntity', () => {
       const result = abstractVisualEntity.getNodeInteraction(
         createMockNodeData({
           name: processorName,
-          processorName: processorName as keyof ProcessorDefinition,
-          title: 'From',
+          primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern },
         }),
       );
       expect(result).toMatchSnapshot();

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -268,14 +268,14 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const processorName = (data as CamelRouteVisualEntityData).processorName;
+    const processorName = data.primaryNodeId?.name as keyof ProcessorDefinition;
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(processorName);
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(processorName);
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = CamelComponentSchemaService.canReplaceStep(processorName);
-    const canRemoveStep = !CamelComponentSchemaService.DISABLED_REMOVE_STEPS.includes(processorName);
     const canRemoveFlow = data.path === this.getRootPath();
+    const canRemoveStep = !canRemoveFlow && !CamelComponentSchemaService.DISABLED_REMOVE_STEPS.includes(processorName);
     const canBeDisabled = CamelComponentSchemaService.canBeDisabled(processorName);
 
     return {

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -64,23 +64,25 @@ describe('CamelInterceptFromVisualEntity', () => {
 
   describe('getNodeInteraction', () => {
     it.each([
-      { processorName: 'route', path: 'route' },
-      { processorName: 'from', path: 'from' },
-      { processorName: 'to', path: 'to' },
-      { processorName: 'log', path: 'log' },
-      { processorName: 'onException', path: 'onException' },
-      { processorName: 'onCompletion', path: 'onCompletion' },
-      { processorName: 'intercept', path: 'intercept' },
-      { processorName: 'interceptFrom', path: 'interceptFrom' },
-      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
-    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity }, path: 'route' },
+      { primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity }, path: 'from' },
+      { primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern }, path: 'to' },
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern }, path: 'log' },
+      { primaryNodeId: { name: 'onException', catalogKind: CatalogKind.Entity }, path: 'onException' },
+      { primaryNodeId: { name: 'onCompletion', catalogKind: CatalogKind.Entity }, path: 'onCompletion' },
+      { primaryNodeId: { name: 'intercept', catalogKind: CatalogKind.Entity }, path: 'intercept' },
+      { primaryNodeId: { name: 'interceptFrom', catalogKind: CatalogKind.Entity }, path: 'interceptFrom' },
+      {
+        primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity },
+        path: 'interceptSendToEndpoint',
+      },
+    ])(`should return the correct interaction for the '%s' processor`, (data) => {
       const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
         interceptFrom: { id: 'id', uri: 'direct:a-reference' },
       });
 
       const result = interceptFromVisualEntity.getNodeInteraction({
         ...data,
-        name: data.processorName,
         isPlaceholder: false,
         isGroup: false,
         iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -8,7 +8,6 @@ import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInter
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 export class CamelInterceptFromVisualEntity
   extends AbstractCamelVisualEntity<{ interceptFrom: InterceptFrom }>
@@ -67,16 +66,18 @@ export class CamelInterceptFromVisualEntity
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptFromVisualEntity.ROOT_PATH;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
+    );
 
     return {
       canHavePreviousStep,

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -64,22 +64,24 @@ describe('CamelInterceptSendToEndpointVisualEntity', () => {
 
   describe('getNodeInteraction', () => {
     it.each([
-      { processorName: 'route', path: 'route' },
-      { processorName: 'from', path: 'from' },
-      { processorName: 'to', path: 'to' },
-      { processorName: 'log', path: 'log' },
-      { processorName: 'onException', path: 'onException' },
-      { processorName: 'onCompletion', path: 'onCompletion' },
-      { processorName: 'intercept', path: 'intercept' },
-      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
-    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity }, path: 'route' },
+      { primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity }, path: 'from' },
+      { primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern }, path: 'to' },
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern }, path: 'log' },
+      { primaryNodeId: { name: 'onException', catalogKind: CatalogKind.Entity }, path: 'onException' },
+      { primaryNodeId: { name: 'onCompletion', catalogKind: CatalogKind.Entity }, path: 'onCompletion' },
+      { primaryNodeId: { name: 'intercept', catalogKind: CatalogKind.Entity }, path: 'intercept' },
+      {
+        primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity },
+        path: 'interceptSendToEndpoint',
+      },
+    ])(`should return the correct interaction for the '%s' processor`, (data) => {
       const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
         interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
       });
 
       const result = interceptSendToEndpointVisualEntity.getNodeInteraction({
         ...data,
-        name: data.processorName,
         isPlaceholder: false,
         isGroup: false,
         title: '',

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -8,7 +8,6 @@ import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInter
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 export class CamelInterceptSendToEndpointVisualEntity
   extends AbstractCamelVisualEntity<{ interceptSendToEndpoint: InterceptSendToEndpoint }>
@@ -79,16 +78,18 @@ export class CamelInterceptSendToEndpointVisualEntity
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptSendToEndpointVisualEntity.ROOT_PATH;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
+    );
 
     return {
       canHavePreviousStep,

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -58,22 +58,24 @@ describe('CamelInterceptVisualEntity', () => {
 
   describe('getNodeInteraction', () => {
     it.each([
-      { processorName: 'route', path: 'route' },
-      { processorName: 'from', path: 'from' },
-      { processorName: 'to', path: 'to' },
-      { processorName: 'log', path: 'log' },
-      { processorName: 'onException', path: 'onException' },
-      { processorName: 'onCompletion', path: 'onCompletion' },
-      { processorName: 'intercept', path: 'intercept' },
-      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
-    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity }, path: 'route' },
+      { primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity }, path: 'from' },
+      { primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern }, path: 'to' },
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern }, path: 'log' },
+      { primaryNodeId: { name: 'onException', catalogKind: CatalogKind.Entity }, path: 'onException' },
+      { primaryNodeId: { name: 'onCompletion', catalogKind: CatalogKind.Entity }, path: 'onCompletion' },
+      { primaryNodeId: { name: 'intercept', catalogKind: CatalogKind.Entity }, path: 'intercept' },
+      {
+        primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity },
+        path: 'interceptSendToEndpoint',
+      },
+    ])(`should return the correct interaction for the '%s' processor`, (data) => {
       const interceptVisualEntity = new CamelInterceptVisualEntity({
         intercept: { id: 'id', disabled: false },
       });
 
       const result = interceptVisualEntity.getNodeInteraction({
         ...data,
-        name: data.processorName,
         isPlaceholder: false,
         isGroup: false,
         title: '',

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -8,7 +8,6 @@ import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInter
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 export class CamelInterceptVisualEntity
   extends AbstractCamelVisualEntity<{ intercept: Intercept }>
@@ -50,16 +49,18 @@ export class CamelInterceptVisualEntity
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelInterceptVisualEntity.ROOT_PATH;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
+    );
 
     return {
       canHavePreviousStep,

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -62,22 +62,24 @@ describe('CamelOnCompletionVisualEntity', () => {
 
   describe('getNodeInteraction', () => {
     it.each([
-      { processorName: 'route', path: 'route' },
-      { processorName: 'from', path: 'from' },
-      { processorName: 'to', path: 'to' },
-      { processorName: 'log', path: 'log' },
-      { processorName: 'onException', path: 'onException' },
-      { processorName: 'onCompletion', path: 'onCompletion' },
-      { processorName: 'intercept', path: 'intercept' },
-      { processorName: 'interceptSendToEndpoint', path: 'interceptSendToEndpoint' },
-    ] as const)(`should return the correct interaction for the '%s' processor`, (data) => {
+      { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity }, path: 'route' },
+      { primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity }, path: 'from' },
+      { primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern }, path: 'to' },
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern }, path: 'log' },
+      { primaryNodeId: { name: 'onException', catalogKind: CatalogKind.Entity }, path: 'onException' },
+      { primaryNodeId: { name: 'onCompletion', catalogKind: CatalogKind.Entity }, path: 'onCompletion' },
+      { primaryNodeId: { name: 'intercept', catalogKind: CatalogKind.Entity }, path: 'intercept' },
+      {
+        primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity },
+        path: 'interceptSendToEndpoint',
+      },
+    ])(`should return the correct interaction for the '%s' processor`, (data) => {
       const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
         onCompletion: { id: 'id', mode: 'AfterConsumer' },
       });
 
       const result = onCompletionVisualEntity.getNodeInteraction({
         ...data,
-        name: data.processorName,
         isPlaceholder: false,
         isGroup: false,
         iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -8,7 +8,6 @@ import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInter
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 export class CamelOnCompletionVisualEntity
   extends AbstractCamelVisualEntity<{ onCompletion: OnCompletion }>
@@ -52,16 +51,18 @@ export class CamelOnCompletionVisualEntity
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelOnCompletionVisualEntity.ROOT_PATH;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
+    );
 
     return {
       canHavePreviousStep,

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
@@ -3,6 +3,7 @@ import { OnException } from '@kaoto/camel-catalog/types';
 import { mockRandomValues } from '../../../stubs';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
+import { IVisualizationNodeData } from '../base-visual-entity';
 import { CamelOnExceptionVisualEntity } from './camel-on-exception-visual-entity';
 
 describe('CamelOnExceptionVisualEntity', () => {
@@ -42,30 +43,28 @@ describe('CamelOnExceptionVisualEntity', () => {
 
   describe('getNodeInteraction', () => {
     it.each([
-      { processorName: 'route', catalogKind: CatalogKind.Entity },
-      { processorName: 'from', catalogKind: CatalogKind.Entity },
-      { processorName: 'to', catalogKind: CatalogKind.Processor },
-      { processorName: 'log', catalogKind: CatalogKind.Processor },
-      { processorName: 'onException', catalogKind: CatalogKind.Entity },
-      { processorName: 'onCompletion', catalogKind: CatalogKind.Entity },
-      { processorName: 'intercept', catalogKind: CatalogKind.Entity },
-      { processorName: 'interceptFrom', catalogKind: CatalogKind.Entity },
-      { processorName: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity },
-    ])(`should return the correct interaction for the '%s' processor`, ({ processorName, catalogKind }) => {
+      { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern } },
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } },
+      { primaryNodeId: { name: 'onException', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'onCompletion', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'intercept', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'interceptFrom', catalogKind: CatalogKind.Entity } },
+      { primaryNodeId: { name: 'interceptSendToEndpoint', catalogKind: CatalogKind.Entity } },
+    ])(`should return the correct interaction for the '%s' processor`, ({ primaryNodeId }) => {
       const onExceptionDef = { onException: {} as OnException };
       const entity = new CamelOnExceptionVisualEntity(onExceptionDef);
 
       const result = entity.getNodeInteraction({
-        processorName,
-        catalogKind,
-        name: processorName,
+        primaryNodeId,
         isPlaceholder: false,
         isGroup: false,
         iconUrl: '',
         title: '',
         description: '',
         processorIconTooltip: '',
-      });
+      } as IVisualizationNodeData);
       expect(result).toMatchSnapshot();
     });
   });

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -9,7 +9,6 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from './support/camel-component-types';
 
 export class CamelOnExceptionVisualEntity
   extends AbstractCamelVisualEntity<{ onException: OnException }>
@@ -53,16 +52,18 @@ export class CamelOnExceptionVisualEntity
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName as keyof ProcessorDefinition,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.find((property) => property.type === 'branch') !== undefined;
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
     const canReplaceStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
     const canRemoveStep = data.path !== CamelOnExceptionVisualEntity.ROOT_PATH;
-    const canBeDisabled = CamelComponentSchemaService.canBeDisabled((data as CamelRouteVisualEntityData).processorName);
+    const canBeDisabled = CamelComponentSchemaService.canBeDisabled(
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
+    );
 
     return {
       canHavePreviousStep,


### PR DESCRIPTION
### Title
`refactor: replace CamelRouteVisualEntityData casts with primaryNodeId across visual entities`

### Description
**What changed:**

All `getNodeInteraction()` implementations across the route-configuration visual entities (and `AbstractCamelVisualEntity`) were casting `data` to `CamelRouteVisualEntityData` to access `processorName`. This was an unsafe cast that assumed a specific data shape not guaranteed by the `IVisualizationNodeData` interface.

The changes replace every such cast with `data.primaryNodeId?.name as keyof ProcessorDefinition`, using the canonical identifier already stored on the node data.

Files affected:
- `abstract-camel-visual-entity.ts` — also fixes the `canRemoveStep` guard: it now short-circuits on `canRemoveFlow` first, preventing removal of the root node even when `DISABLED_REMOVE_STEPS` doesn't cover it.
- `camel-intercept-visual-entity.ts`
- `camel-intercept-from-visual-entity.ts`
- `camel-intercept-send-to-endpoint-visual-entity.ts`
- `camel-on-completion-visual-entity.ts`
- `camel-on-exception-visual-entity.ts`

The `CamelRouteVisualEntityData` import is removed from all six files as it is no longer needed.

fix: https://github.com/KaotoIO/kaoto/issues/3646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved flow node interaction handling by consistently identifying nodes through their primary identity.
  - Prevented accidental removal of the root flow.
  - Preserved restrictions that prevent removal of disabled steps.
  - Improved handling of processor and pattern-based nodes across interception and completion actions.

- **Tests**
  - Updated interaction coverage to reflect the latest node identification and catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->