### PR TITLE
replace processorName with primaryNodeId.name across visualization components

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -1,5 +1,6 @@
 import './CustomGroupExpanded.scss';
 
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { Icon } from '@patternfly/react-core';
 import { BanIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -31,7 +32,6 @@ import { FunctionComponent, useContext, useMemo, useRef } from 'react';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { useEntityContext } from '../../../../hooks/useEntityContext/useEntityContext';
 import { AddStepMode, IVisualizationNode, NodeToolbarTrigger } from '../../../../models';
-import { CamelRouteVisualEntityData } from '../../../../models/visualization/flows/support/camel-component-types';
 import { SettingsContext } from '../../../../providers';
 import { getProcessorIcon } from '../../../../utils/processor-icon';
 import { Anchors } from '../../../registers/anchors';
@@ -69,7 +69,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const catalogModalContext = useContext(CatalogModalContext);
     const nodeInteractionAddonContext = useContext(NodeInteractionAddonContext);
     const label = groupVizNode?.getNodeLabel(settingsAdapter.getSettings().nodeLabel);
-    const processorName = (groupVizNode?.data as CamelRouteVisualEntityData)?.processorName;
+    const processorName = groupVizNode?.data.primaryNodeId?.name as keyof ProcessorDefinition;
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = groupVizNode?.data?.processorIconTooltip ?? '';
     const isDisabled = !!groupVizNode?.getNodeDefinition()?.disabled;

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.test.tsx
@@ -41,7 +41,7 @@ describe('useDuplicateStep', () => {
     iconUrl: '',
     title: '',
     description: '',
-    primaryNodeId: { name: 'to', catalogKind: CatalogKind.Processor },
+    primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
   });
   const whenVizNode = createVisualizationNode('when', {
     name: 'when',
@@ -53,7 +53,7 @@ describe('useDuplicateStep', () => {
     iconUrl: '',
     title: '',
     description: '',
-    primaryNodeId: { name: 'when', catalogKind: CatalogKind.Processor },
+    primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern },
   });
   const choiceVizNode = createVisualizationNode('choice', {
     name: 'choice',
@@ -65,7 +65,7 @@ describe('useDuplicateStep', () => {
     iconUrl: '',
     title: '',
     description: '',
-    primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Processor },
+    primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern },
   });
 
   // Set parent of when node to choice node and vice versa
@@ -82,7 +82,7 @@ describe('useDuplicateStep', () => {
     iconUrl: '',
     title: '',
     description: '',
-    primaryNodeId: { name: 'route', catalogKind: CatalogKind.Processor },
+    primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity },
   });
   // Set parent of viznode to route node
   vizNode.setParentNode(routeVizNode);

--- a/packages/ui/src/components/Visualization/Topology/topology-endpoints.ts
+++ b/packages/ui/src/components/Visualization/Topology/topology-endpoints.ts
@@ -38,7 +38,7 @@ const appendMapValue = (map: Map<string, string[]>, key: string, value: string):
 };
 
 const recordTopologyStep = async (vizNode: IVisualizationNode, registry: TopologyEndpointRegistry): Promise<void> => {
-  const processorName = vizNode.data.processorName;
+  const processorName = vizNode.data.primaryNodeId?.name;
   const nodeDefinition = vizNode.getNodeDefinition();
   const uriString = CamelUriHelper.getUriString(nodeDefinition);
 

--- a/packages/ui/src/components/registers/component-mode.activationfn.test.ts
+++ b/packages/ui/src/components/registers/component-mode.activationfn.test.ts
@@ -1,4 +1,4 @@
-import { IVisualizationNode } from '../../models';
+import { CatalogKind, IVisualizationNode } from '../../models';
 import { componentModeActivationFn } from './component-mode.activationfn';
 
 describe('componentModeActivationFn', () => {
@@ -18,7 +18,7 @@ describe('componentModeActivationFn', () => {
   ];
   it.each(TEST_CASES)('should return "%s" for "%s"', (expectedResult, processorName) => {
     const result = componentModeActivationFn({
-      data: { processorName },
+      data: { primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } },
     } as unknown as IVisualizationNode);
 
     expect(result).toBe(expectedResult);

--- a/packages/ui/src/components/registers/component-mode.activationfn.ts
+++ b/packages/ui/src/components/registers/component-mode.activationfn.ts
@@ -6,9 +6,8 @@ export const componentModeActivationFn = (vizNode?: IVisualizationNode): boolean
   }
 
   return (
-    'processorName' in vizNode.data &&
-    (vizNode.data.processorName === 'to' ||
-      vizNode.data.processorName === 'toD' ||
-      vizNode.data.processorName === 'poll')
+    vizNode.data.primaryNodeId?.name === 'to' ||
+    vizNode.data.primaryNodeId?.name === 'toD' ||
+    vizNode.data.primaryNodeId?.name === 'poll'
   );
 };

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -96,7 +96,7 @@ describe('AbstractCamelVisualEntity', () => {
       const result = abstractVisualEntity.getNodeInteraction(
         createMockNodeData({
           name: 'from',
-          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Pattern },
+          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         }),
       );
       expect(result.canHavePreviousStep).toBe(false);
@@ -258,9 +258,9 @@ describe('AbstractCamelVisualEntity', () => {
       name: 'choice',
       path: 'route.from.steps.1.choice',
       iconUrl: '/src/assets/eip/choice.png',
-      processorName: 'choice',
       componentName: undefined,
       isGroup: true,
+      primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern },
     });
 
     it('should prepend a new step to the model', () => {
@@ -356,7 +356,7 @@ describe('AbstractCamelVisualEntity', () => {
           componentName: 'timer',
           iconUrl: '/src/assets/components/timer.svg',
           path: 'route.from',
-          processorName: 'from' as keyof ProcessorDefinition,
+          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         }),
       });
 
@@ -405,6 +405,7 @@ describe('AbstractCamelVisualEntity', () => {
       processorName: 'choice',
       componentName: undefined,
       isGroup: true,
+      primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern },
     });
 
     it('should append a new step to the model', () => {
@@ -427,7 +428,7 @@ describe('AbstractCamelVisualEntity', () => {
           componentName: 'timer',
           iconUrl: '/src/assets/components/timer.svg',
           path: 'route.from',
-          processorName: 'from' as keyof ProcessorDefinition,
+          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         }),
       });
 
@@ -518,7 +519,7 @@ describe('AbstractCamelVisualEntity', () => {
   describe('getCopiedContent', () => {
     it('should return the copied content for a step', () => {
       const copiedContent = abstractVisualEntity.getCopiedContent('route.from.steps.2.to', {
-        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Processor },
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
         secondaryNodeId: undefined,
         tertiaryNodeId: undefined,
       });
@@ -540,7 +541,7 @@ describe('AbstractCamelVisualEntity', () => {
 
     it('should return undefined node default value if the path is invalid', () => {
       const copiedContent = abstractVisualEntity.getCopiedContent('route.from.steps.999.to', {
-        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Processor },
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
         secondaryNodeId: undefined,
         tertiaryNodeId: undefined,
       });

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -25,7 +25,7 @@ import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentDefaultService } from './support/camel-component-default.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
-import { CamelProcessorStepsProperties, CamelRouteVisualEntityData } from './support/camel-component-types';
+import { CamelProcessorStepsProperties } from './support/camel-component-types';
 import { ModelValidationService } from './support/validators/model-validation.service';
 
 export abstract class AbstractCamelVisualEntity<T extends object> implements BaseVisualEntity {
@@ -374,7 +374,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   ) {
     if (data.path === undefined) return;
     const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      (data as CamelRouteVisualEntityData).processorName,
+      data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
 
     if (mode === AddStepMode.InsertChildStep || mode === AddStepMode.InsertSpecialChildStep) {

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -111,7 +111,7 @@ describe('CamelInterceptFromVisualEntity', () => {
     const vizNode = await interceptFromVisualEntity.toVizNode();
     await vizNode.fetchSchema();
 
-    expect(vizNode.data.processorName).toBe(CamelInterceptFromVisualEntity.ROOT_PATH);
+    expect(vizNode.data.primaryNodeId?.name).toBe(CamelInterceptFromVisualEntity.ROOT_PATH);
     expect(vizNode.data.entity).toBe(interceptFromVisualEntity);
     expect(vizNode.data.isGroup).toBeTruthy();
     expect(vizNode.data.primaryNodeId).toEqual({

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -110,7 +110,7 @@ describe('CamelInterceptSendToEndpointVisualEntity', () => {
     const vizNode = await interceptSendToEndpointVisualEntity.toVizNode();
     await vizNode.fetchSchema();
 
-    expect(vizNode.data.processorName).toBe(CamelInterceptSendToEndpointVisualEntity.ROOT_PATH);
+    expect(vizNode.data.primaryNodeId?.name).toBe(CamelInterceptSendToEndpointVisualEntity.ROOT_PATH);
     expect(vizNode.data.entity).toBe(interceptSendToEndpointVisualEntity);
     expect(vizNode.data.isGroup).toBeTruthy();
     expect(vizNode.data.primaryNodeId).toEqual({

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -104,7 +104,7 @@ describe('CamelInterceptVisualEntity', () => {
     const vizNode = await interceptVisualEntity.toVizNode();
     await vizNode.fetchSchema();
 
-    expect(vizNode.data.processorName).toBe(CamelInterceptVisualEntity.ROOT_PATH);
+    expect(vizNode.data.primaryNodeId?.name).toBe(CamelInterceptVisualEntity.ROOT_PATH);
     expect(vizNode.data.entity).toBe(interceptVisualEntity);
     expect(vizNode.data.isGroup).toBeTruthy();
     expect(vizNode.data.primaryNodeId).toEqual({ name: interceptVisualEntity.type, catalogKind: CatalogKind.Entity });

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -109,7 +109,7 @@ describe('CamelOnCompletionVisualEntity', () => {
     const vizNode = await onCompletionVisualEntity.toVizNode();
     await vizNode.fetchSchema();
 
-    expect(vizNode.data.processorName).toBe(CamelOnCompletionVisualEntity.ROOT_PATH);
+    expect(vizNode.data.primaryNodeId?.name).toBe(CamelOnCompletionVisualEntity.ROOT_PATH);
     expect(vizNode.data.entity).toBe(onCompletionVisualEntity);
     expect(vizNode.data.isGroup).toBeTruthy();
     expect(vizNode.data.primaryNodeId).toEqual({

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.test.ts
@@ -78,7 +78,7 @@ describe('CamelOnExceptionVisualEntity', () => {
 
       expect(vizNode).toBeDefined();
       expect(vizNode.id).toBeDefined();
-      expect(vizNode.data.processorName).toBe('onException');
+      expect(vizNode.data.primaryNodeId?.name).toBe('onException');
       expect(vizNode.data.entity).toBe(entity);
       expect(vizNode.data.isGroup).toBe(true);
       expect(vizNode.data.catalogKind).toBe(CatalogKind.Entity);

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
@@ -233,7 +233,7 @@ describe('FromNodeMapper', () => {
   });
 
   it('should set correct processor name', () => {
-    expect(vizNode.data.processorName).toBe('from');
+    expect(vizNode.data.primaryNodeId?.name).toBe('from');
     expect(vizNode.data.name).toBe('direct');
   });
 


### PR DESCRIPTION
**Description:**
Removes the `processorName` field from `CamelRouteVisualEntityData` and replaces all usages with the `primaryNodeId?.name` property from the shared node data structure.

**Changes:**
- `CustomGroupExpanded.tsx` – reads processor name via `data.primaryNodeId?.name` instead of the now-removed `processorName` field; swaps the `CamelRouteVisualEntityData` import for the `ProcessorDefinition` type
- `topology-endpoints.ts` – same accessor change for the topology step recorder
- `component-mode.activationfn.ts` – simplifies the activation check by removing the `'processorName' in vizNode.data` guard and reading from `primaryNodeId?.name` directly
- `abstract-camel-visual-entity.ts` – passes `primaryNodeId?.name` to `getProcessorStepsProperties` and removes the unused `CamelRouteVisualEntityData` import
- Test files and snapshots updated accordingly

fix: https://github.com/KaotoIO/kaoto/issues/3646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor identification across route visualizations and topology views.
  * Fixed component activation behavior for common routing processors.
  * Improved adding and pasting steps within visualized flows.
  * Ensured special route handlers, including completion, exception, interception, and endpoint flows, display and behave consistently.

* **Tests**
  * Updated visualization coverage to verify processor names and routing behavior across supported flow types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->