### PR TITLE
fix: use CatalogKind.Pattern for DataMapper node to resolve schema correctly

### DIFF
--- a/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.test.ts
@@ -34,10 +34,10 @@ describe('DataMapperNodeMapper', () => {
       expect(vizNode.getChildren()).toBeUndefined();
     });
 
-    it('should populate primaryNodeId', async () => {
+    it('should populate primaryNodeId with CatalogKind.Pattern so the schema is resolved from the patterns catalog', async () => {
       const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
 
-      expect(vizNode.data.primaryNodeId).toEqual({ name: DATAMAPPER_ID_PREFIX, catalogKind: CatalogKind.Processor });
+      expect(vizNode.data.primaryNodeId).toEqual({ name: DATAMAPPER_ID_PREFIX, catalogKind: CatalogKind.Pattern });
     });
 
     it('should assign an unique ID for each DataMapper steps', async () => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
@@ -26,11 +26,11 @@ export class DataMapperNodeMapper extends BaseNodeMapper {
       iconUrl: '',
       title: '',
       description: '',
-      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Processor } satisfies NodeIdentity,
+      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } satisfies NodeIdentity,
     };
 
     const vizNode = createVisualizationNode(path + ':' + processorName, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Processor);
+    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
     return vizNode;
   }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/KaotoIO/kaoto/issues/3658

The DataMapper step was showing the **"Unknown node type"** warning in the configuration form instead of the schema-driven fields, while the Configure button still worked correctly.

## Root Cause

`DataMapperNodeMapper` was assigning `CatalogKind.Processor` to both `primaryNodeId.catalogKind` and the `enrichNodeFromCatalog()` call. However, the `kaoto-datamapper` schema is registered in the **patterns** catalog (`camel-catalog-aggregate-patterns-*.json`), not in the models/processor catalog.

This caused `fetchNodeSchema()` (in `abstract-camel-visual-entity.ts`) to look up `kaoto-datamapper` in the wrong registry bucket — returning `undefined` — which made `CanvasFormBody` fall through to rendering `<UnknownNode>`.

## Fix

Two lines changed in `datamapper-node-mapper.ts` — both `CatalogKind.Processor` references replaced with `CatalogKind.Pattern`:

```ts
// Before
primaryNodeId: { name: processorName, catalogKind: CatalogKind.Processor }
await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Processor);

// After
primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern }
await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
```

This aligns with how every other EIP/Pattern node mapper works (e.g. `StepNodeMapper` uses `CatalogKind.Pattern`).

## Testing

- Updated the existing `DataMapperNodeMapper` test to assert `CatalogKind.Pattern` and renamed it to make the intent explicit
- All 483 test files pass (`yarn workspace @kaoto/kaoto test`), lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Data Mapper visualization catalog classification to use the Patterns catalog.
  * Improved schema resolution for Data Mapper nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->