### PR TITLE
e2e(chore): forcePerformNodeAction removed

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepPaste.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepPaste.cy.ts
@@ -102,8 +102,7 @@ describe('Tests for Design page', { browser: '!firefox' }, () => {
     });
     cy.openDesignPage();
 
-    // workaround for https://github.com/KaotoIO/kaoto/issues/2885
-    cy.forcePerformNodeAction('marshal', 'paste-as-next-step');
+    cy.selectPasteNode('marshal', 'paste-as-next-step');
     cy.checkNodeExist('amqp', 1);
 
     cy.openSourceCode();
@@ -128,8 +127,7 @@ describe('Tests for Design page', { browser: '!firefox' }, () => {
     });
     cy.openDesignPage();
 
-    // workaround for https://github.com/KaotoIO/kaoto/issues/2885
-    cy.forcePerformNodeAction('marshal', 'paste-as-next-step');
+    cy.selectPasteNode('marshal', 'paste-as-next-step');
     cy.checkNodeExist('log', 2);
 
     cy.openSourceCode();

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -90,7 +90,6 @@ declare global {
       selectPrependNode(inputName: string, nodeIndex?: number): Chainable<JQuery<Element>>;
       selectRemoveGroup(groupName: string, nodeIndex?: number): Chainable<JQuery<Element>>;
       performNodeAction(nodeName: string, action: ActionType, nodeIndex?: number): Chainable<JQuery<Element>>;
-      forcePerformNodeAction(nodeName: string, action: ActionType, nodeIndex?: number): Chainable<JQuery<Element>>;
       checkNodeExist(inputName: string, nodesCount: number): Chainable<JQuery<Element>>;
       checkEdgeExists(scope: string, sourceName: string, targetName: string): Chainable<JQuery<Element>>;
       deleteBranch(branchIndex: number): Chainable<JQuery<Element>>;

--- a/packages/ui-tests/cypress/support/next-commands/design.ts
+++ b/packages/ui-tests/cypress/support/next-commands/design.ts
@@ -150,35 +150,6 @@ Cypress.Commands.add('performNodeAction', (nodeName: string, action: ActionType,
   cy.get(menuItemSelector).should('be.visible').click();
 });
 
-Cypress.Commands.add('forcePerformNodeAction', (nodeName: string, action: ActionType, nodeIndex = 0) => {
-  const nodeSelector = `foreignObject[data-nodelabel="${nodeName}"]`;
-  const menuItemSelector = `[data-testid="context-menu-item-${action}"]`;
-
-  // Get the node and ensure it's visible
-  cy.get(nodeSelector).eq(nodeIndex).should('be.visible');
-
-  // Wrap the retry logic
-  cy.wait(200).then(() => {
-    // Right-click the node (query fresh from DOM)
-    cy.get(nodeSelector).eq(nodeIndex).rightclick({ force: true });
-
-    // Check if menu appeared, if not, right-click again with retries
-    for (let i = 0; i < 10; i++) {
-      cy.get('body').then(($body) => {
-        if ($body.find(menuItemSelector).length === 0) {
-          cy.log('Context menu not visible, retrying right-click...');
-          cy.wait(500);
-          cy.get(nodeSelector).eq(nodeIndex).rightclick({ force: true });
-        } else {
-          return;
-        }
-      });
-    }
-  });
-  // Now the menu should be visible, click it
-  cy.get(menuItemSelector).should('be.visible').click();
-});
-
 Cypress.Commands.add('checkNodeExist', (inputName, nodesCount = 1) => {
   cy.get(`foreignObject[data-nodelabel="${inputName}"]`).should('have.length', nodesCount);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated designer paste tests to use the standard node-selection workflow.
  - Improved test reliability by removing a workaround for paste actions.

- **Refactor**
  - Removed the obsolete custom test command and its associated type declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->