### PR TITLE
chore(dynamic_catalog): cleanup of the getNodeSchema()

### DIFF
--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -39,7 +39,6 @@ describe('ComponentMode', () => {
       description: '',
       iconUrl: '',
     });
-    vi.spyOn(node, 'getNodeSchema').mockReturnValue(undefined);
     vi.spyOn(node, 'getNodeDefinition').mockReturnValue({});
     vi.spyOn(node, 'updateModel').mockImplementation(vi.fn());
     return node;

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -13,7 +13,6 @@ import {
   ICamelProcessorDefinition,
   IKameletDefinition,
   KameletVisualEntity,
-  KaotoSchemaDefinition,
 } from '../../../../models';
 import { EntityType } from '../../../../models/entities';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
@@ -87,7 +86,6 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    vi.spyOn(noSchemaVizNode, 'getNodeSchema').mockReturnValue(undefined);
     vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(undefined);
 
     const { Provider } = await TestProvidersWrapper();
@@ -115,7 +113,6 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    vi.spyOn(noSchemaVizNode, 'getNodeSchema').mockReturnValue(null as unknown as KaotoSchemaDefinition['schema']);
     vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(null);
 
     const { Provider } = await TestProvidersWrapper();

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -107,7 +107,6 @@ describe('usePasteStep', () => {
   it('should call pasteBaseEntityStep() and updateEntitiesFromCamelResource()', async () => {
     vi.spyOn(navigator.permissions, 'query').mockResolvedValue({ state: 'granted' } as PermissionStatus);
     const mockVizNode = {
-      getNodeSchema: vi.fn(),
       getNodeDefinition: vi.fn(),
       pasteBaseEntityStep: vi.fn(),
     } as unknown as IVisualizationNode;

--- a/packages/ui/src/components/registers/datamapper.activationfn.test.ts
+++ b/packages/ui/src/components/registers/datamapper.activationfn.test.ts
@@ -1,6 +1,6 @@
 import { Step } from '@kaoto/camel-catalog/types';
 
-import { IVisualizationNode, KaotoSchemaDefinition } from '../../models';
+import { IVisualizationNode } from '../../models';
 import { datamapperRouteDefinitionStub } from '../../stubs/datamapper/data-mapper';
 import { datamapperActivationFn } from './datamapper.activationfn';
 
@@ -13,7 +13,6 @@ describe('datamapperActivationFn', () => {
 
   it('should return false if stepDefinition is undefined', () => {
     const result = datamapperActivationFn({
-      getNodeSchema: () => ({}) as KaotoSchemaDefinition['schema'],
       getNodeDefinition: () => undefined,
     } as unknown as IVisualizationNode);
 
@@ -22,7 +21,6 @@ describe('datamapperActivationFn', () => {
 
   it('should return `true` if stepDefinition is a DataMapper node', () => {
     const result = datamapperActivationFn({
-      getNodeSchema: () => ({}) as KaotoSchemaDefinition['schema'],
       getNodeDefinition: () => datamapperRouteDefinitionStub.from.steps[0].step as Step,
     } as unknown as IVisualizationNode);
 

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -26,15 +26,12 @@ export interface BaseVisualEntity extends BaseEntity {
   /** Given a path, get the component label */
   getNodeLabel: (path?: string, labelType?: NodeLabelType, ids?: IVisualizationNodeIds) => string;
 
-  /** Given a path, returns the node's associated schema used for the configuration form */
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined;
-
   /**
    * Async, ID-based schema resolution using the Dynamic Catalog.
    * Accepts the three node identifiers and returns the fully resolved schema.
    * DSL-specific logic is owned by each concrete BaseVisualEntity implementation.
    */
-  fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined>;
+  fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined>;
 
   /** Given a path, returns the node's underlying definition in JSON format */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -80,7 +77,7 @@ export interface BaseVisualEntity extends BaseEntity {
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction;
 
   /** Given a path, retrieve the Node validation status */
-  getNodeValidationText(path?: string): string | undefined;
+  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined;
 
   /** Generates a IVisualizationNode from the underlying Camel entity */
   toVizNode: () => Promise<IVisualizationNode>;
@@ -130,9 +127,6 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
   canDropOnNode(): boolean;
 
   getNodeInteraction(): NodeInteraction;
-
-  /** This method returns the node's associated schema used for the configuration form */
-  getNodeSchema(): KaotoSchemaDefinition['schema'] | undefined;
 
   /** This method returns the node's associated schema asynchronously from the catalog */
   fetchSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined>;

--- a/packages/ui/src/models/visualization/flows/__snapshots__/camel-error-handler-visual-entity.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/__snapshots__/camel-error-handler-visual-entity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CamelErrorHandlerVisualEntity > should return schema from store 1`] = `
+exports[`CamelErrorHandlerVisualEntity > should return schema from catalog 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -148,29 +148,18 @@ describe('AbstractCamelVisualEntity', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const missingParametersModel = cloneDeep(camelRouteJson.route);
       missingParametersModel.from.uri = '';
       abstractVisualEntity = new CamelRouteVisualEntity(missingParametersModel);
 
-      const result = abstractVisualEntity.getNodeValidationText('route.from');
+      const schema = await abstractVisualEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+        secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+      });
+      const result = abstractVisualEntity.getNodeValidationText('route.from', schema);
 
-      expect(result).toBe('1 required parameter is not yet configured: [ uri ]');
-    });
-  });
-
-  describe('getNodeSchema', () => {
-    it('should return undefined if path is not provided', () => {
-      const result = abstractVisualEntity.getNodeSchema();
-      expect(result).toBeUndefined();
-    });
-
-    it('should return schema when path is valid', () => {
-      const path = 'route.from.steps.1.choice';
-
-      const result = abstractVisualEntity.getNodeSchema(path);
-
-      expect(result).toMatchObject({ type: 'object', title: 'Choice' });
+      expect(result).toBe('2 required parameters are not yet configured: [ uri,timerName ]');
     });
   });
 
@@ -579,6 +568,19 @@ describe('AbstractCamelVisualEntity', () => {
   });
 
   describe('fetchNodeSchema', () => {
+    it('should return undefined if primaryNodeId is not provided', async () => {
+      const result = await abstractVisualEntity.fetchNodeSchema({});
+      expect(result).toBeUndefined();
+    });
+
+    it('should return schema when primaryNodeId is valid', async () => {
+      const result = await abstractVisualEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern },
+      });
+
+      expect(result).toMatchObject({ type: 'object', title: 'Choice' });
+    });
+
     it('should return the route Entity schema for the route group node', async () => {
       const routeNode = await abstractVisualEntity.toVizNode();
       const ids = routeNode.data;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -565,6 +565,14 @@ describe('AbstractCamelVisualEntity', () => {
         catalogKind: CatalogKind.Entity,
       });
     });
+
+    it('should enrich child nodes with schema after the visualization tree is linked', async () => {
+      const routeNode = await abstractVisualEntity.toVizNode();
+      const fromNode = routeNode.getChildren()?.[0];
+
+      expect(fromNode?.data.schema).toBeDefined();
+      expect(fromNode?.data.iconUrl).not.toBe('');
+    });
   });
 
   describe('fetchNodeSchema', () => {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -57,16 +57,8 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     return this.getNodeLabelFromIds(ids, definition, labelType);
   }
 
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
-    if (!path) return undefined;
-
-    const definition = getValue(this.entityDef, path);
-    const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup(path, definition);
-    return CamelComponentSchemaService.getSchema(camelElementLookup);
-  }
-
-  async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    if (!ids.primaryNodeId) {
+  async fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
       return;
     }
 
@@ -290,8 +282,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
-    const schema = this.getNodeSchema(path);
+  getNodeValidationText(path?: string | undefined, schema?: KaotoSchemaDefinition['schema']): string | undefined {
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -305,9 +305,6 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
       primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    // Enrich route group node with catalog properties (icon, title, description, etc.)
-    await NodeEnrichmentService.enrichNodeFromCatalog(routeGroupNode, CatalogKind.Entity);
-
     const fromNode = await NodeMapperService.getVizNode(
       `${this.getRootPath()}.from`,
       {
@@ -352,6 +349,8 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     };
 
     normalizeGroups(routeGroupNode);
+
+    await NodeEnrichmentService.enrichVisualizationTree(routeGroupNode);
 
     return routeGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -89,10 +89,14 @@ describe('CamelErrorHandlerVisualEntity', () => {
     expect(entity.getNodeDefinition()).toEqual(errorHandlerDef.errorHandler);
   });
 
-  it('should return schema from store', () => {
+  it('should return schema from catalog', async () => {
     const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
 
-    expect(entity.getNodeSchema()).toMatchSnapshot();
+    const result = await entity.fetchNodeSchema({
+      primaryNodeId: { name: 'errorHandler', catalogKind: CatalogKind.Entity },
+    });
+
+    expect(result).toMatchSnapshot();
   });
 
   describe('updateModel', () => {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -17,7 +17,6 @@ import {
 import { IClipboardContent } from '../clipboard';
 import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 
 export class CamelErrorHandlerVisualEntity implements BaseVisualEntity {
@@ -112,17 +111,15 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualEntity {
     return;
   }
 
-  getNodeSchema(): KaotoSchemaDefinition['schema'] {
-    const schema = CamelCatalogService.getComponent(CatalogKind.Entity, 'errorHandler');
-    return schema?.propertiesSchema ?? {};
-  }
-
-  async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    const { primaryNodeId } = ids;
-    if (!primaryNodeId) {
-      return undefined;
+  async fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
+      return;
     }
-    const definition = await DynamicCatalogRegistry.get().getEntity(primaryNodeId.catalogKind, primaryNodeId.name);
+
+    const definition = await DynamicCatalogRegistry.get().getEntity(
+      ids.primaryNodeId.catalogKind,
+      ids.primaryNodeId.name,
+    );
     return definition?.propertiesSchema;
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -173,8 +173,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualEntity {
       primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    // Enrich as Entity (not Processor) to get proper title formatting
-    await NodeEnrichmentService.enrichNodeFromCatalog(errorHandlerGroupNode, CatalogKind.Entity);
+    await NodeEnrichmentService.enrichVisualizationTree(errorHandlerGroupNode);
 
     return errorHandlerGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -99,7 +99,7 @@ describe('CamelInterceptFromVisualEntity', () => {
     const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
       interceptFrom: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptFromVisualEntity.getNodeValidationText('interceptFrom');
+    interceptFromVisualEntity.getNodeValidationText('interceptFrom', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -6,6 +6,7 @@ import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
@@ -102,6 +103,8 @@ export class CamelInterceptFromVisualEntity
     interceptFromGroupNode.data.catalogKind = CatalogKind.Entity;
     interceptFromGroupNode.data.name = this.type;
     interceptFromGroupNode.data.primaryNodeId = { name: this.type, catalogKind: CatalogKind.Entity };
+
+    await NodeEnrichmentService.enrichVisualizationTree(interceptFromGroupNode);
 
     return interceptFromGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -98,7 +98,10 @@ describe('CamelInterceptSendToEndpointVisualEntity', () => {
     const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
       interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint');
+    interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint', {
+      type: 'object',
+      properties: {},
+    });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -6,6 +6,7 @@ import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
@@ -114,6 +115,8 @@ export class CamelInterceptSendToEndpointVisualEntity
     interceptSendToEndpointGroupNode.data.catalogKind = CatalogKind.Entity;
     interceptSendToEndpointGroupNode.data.name = this.type;
     interceptSendToEndpointGroupNode.data.primaryNodeId = { name: this.type, catalogKind: CatalogKind.Entity };
+
+    await NodeEnrichmentService.enrichVisualizationTree(interceptSendToEndpointGroupNode);
 
     return interceptSendToEndpointGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -92,7 +92,7 @@ describe('CamelInterceptVisualEntity', () => {
     const interceptVisualEntity = new CamelInterceptVisualEntity({
       intercept: { id: 'id', disabled: false },
     });
-    interceptVisualEntity.getNodeValidationText('intercept');
+    interceptVisualEntity.getNodeValidationText('intercept', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -6,6 +6,7 @@ import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
@@ -85,6 +86,8 @@ export class CamelInterceptVisualEntity
     interceptGroupNode.data.catalogKind = CatalogKind.Entity;
     interceptGroupNode.data.name = this.type;
     interceptGroupNode.data.primaryNodeId = { name: this.type, catalogKind: CatalogKind.Entity };
+
+    await NodeEnrichmentService.enrichVisualizationTree(interceptGroupNode);
 
     return interceptGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -97,7 +97,7 @@ describe('CamelOnCompletionVisualEntity', () => {
     const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
       onCompletion: { id: 'id', mode: 'AfterConsumer' },
     });
-    onCompletionVisualEntity.getNodeValidationText('onCompletion');
+    onCompletionVisualEntity.getNodeValidationText('onCompletion', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -6,6 +6,7 @@ import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
@@ -87,6 +88,8 @@ export class CamelOnCompletionVisualEntity
     onCompletionGroupNode.data.catalogKind = CatalogKind.Entity;
     onCompletionGroupNode.data.name = this.type;
     onCompletionGroupNode.data.primaryNodeId = { name: this.type, catalogKind: CatalogKind.Entity };
+
+    await NodeEnrichmentService.enrichVisualizationTree(onCompletionGroupNode);
 
     return onCompletionGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -88,8 +88,8 @@ export class CamelOnExceptionVisualEntity
     onExceptionGroupNode.data.catalogKind = CatalogKind.Entity;
     onExceptionGroupNode.data.name = this.type;
     onExceptionGroupNode.data.primaryNodeId = { name: this.type, catalogKind: CatalogKind.Entity };
-    // Re-enrich node with correct catalogKind to get proper icons
-    await NodeEnrichmentService.enrichNodeFromCatalog(onExceptionGroupNode, CatalogKind.Entity);
+
+    await NodeEnrichmentService.enrichVisualizationTree(onExceptionGroupNode);
 
     return onExceptionGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -77,10 +77,14 @@ describe('CamelRestConfigurationVisualEntity', () => {
     expect(entity.getNodeDefinition()).toEqual(restConfigurationDef.restConfiguration);
   });
 
-  it('should return schema from store', () => {
+  it('should return schema from catalog', async () => {
     const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
 
-    expect(entity.getNodeSchema()).toEqual(restConfigurationSchema);
+    const result = await entity.fetchNodeSchema({
+      primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
+    });
+
+    expect(result).toEqual(restConfigurationSchema);
   });
 
   describe('updateModel', () => {
@@ -128,7 +132,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRestConfigurationVisualEntity({
         restConfiguration: {
           ...restConfigurationDef.restConfiguration,
@@ -143,19 +147,26 @@ describe('CamelRestConfigurationVisualEntity', () => {
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      const schema = await entity.fetchNodeSchema({
+        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
+      });
+
+      expect(entity.getNodeValidationText(undefined, schema)).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRestConfigurationDef: RestConfiguration = { ...restConfigurationDef.restConfiguration };
       const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
+      const schema = await entity.fetchNodeSchema({
+        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
+      });
 
-      entity.getNodeValidationText();
+      entity.getNodeValidationText(undefined, schema);
 
       expect(restConfigurationDef.restConfiguration).toEqual(originalRestConfigurationDef);
     });
 
-    it('should return errors when there is an invalid property', () => {
+    it('should return errors when there is an invalid property', async () => {
       const invalidRestConfigurationDef: RestConfiguration = {
         ...restConfigurationDef.restConfiguration,
         useXForwardHeaders: 'true' as unknown as RestConfiguration['useXForwardHeaders'],
@@ -168,8 +179,11 @@ describe('CamelRestConfigurationVisualEntity', () => {
         inlineRoutes: 'true' as unknown as RestConfiguration['inlineRoutes'],
       };
       const entity = new CamelRestConfigurationVisualEntity({ restConfiguration: invalidRestConfigurationDef });
+      const schema = await entity.fetchNodeSchema({
+        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
+      });
 
-      expect(entity.getNodeValidationText()).toBe(`'/useXForwardHeaders' must be boolean,
+      expect(entity.getNodeValidationText(undefined, schema)).toBe(`'/useXForwardHeaders' must be boolean,
 '/apiVendorExtension' must be boolean,
 '/skipBindingOnErrorCode' must be boolean,
 '/clientRequestValidation' must be boolean,

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -159,8 +159,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
       primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    // Enrich as Entity (not Processor) to get proper title formatting
-    await NodeEnrichmentService.enrichNodeFromCatalog(restConfigurationGroupNode, CatalogKind.Entity);
+    await NodeEnrichmentService.enrichVisualizationTree(restConfigurationGroupNode);
 
     return restConfigurationGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -17,7 +17,6 @@ import {
 import { IClipboardContent } from '../clipboard';
 import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 
 export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
@@ -92,17 +91,15 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     return;
   }
 
-  getNodeSchema(): KaotoSchemaDefinition['schema'] | undefined {
-    const schema = CamelCatalogService.getComponent(CatalogKind.Entity, 'restConfiguration');
-    return schema?.propertiesSchema ?? {};
-  }
-
-  async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    const { primaryNodeId } = ids;
-    if (!primaryNodeId) {
-      return undefined;
+  async fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
+      return;
     }
-    const definition = await DynamicCatalogRegistry.get().getEntity(primaryNodeId.catalogKind, primaryNodeId.name);
+
+    const definition = await DynamicCatalogRegistry.get().getEntity(
+      ids.primaryNodeId.catalogKind,
+      ids.primaryNodeId.name,
+    );
     return definition?.propertiesSchema;
   }
 
@@ -137,8 +134,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(): string | undefined {
-    const schema = this.getNodeSchema();
+  getNodeValidationText(_path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
     if (!schema) return undefined;
 
     this.schemaValidator ??= getValidator<RestConfiguration>(schema, { useDefaults: 'empty' });

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -141,10 +141,14 @@ describe('CamelRestVisualEntity', () => {
     });
   });
 
-  it('should return schema from store', () => {
+  it('should return schema from catalog', async () => {
     const entity = new CamelRestVisualEntity(restDef);
 
-    expect(entity.getNodeSchema(CamelRestVisualEntity.ROOT_PATH)).toEqual(restSchema);
+    const result = await entity.fetchNodeSchema({
+      primaryNodeId: { name: EntityType.Rest, catalogKind: CatalogKind.Entity },
+    });
+
+    expect(result).toEqual(restSchema);
   });
 
   describe('removeStep', () => {
@@ -163,42 +167,35 @@ describe('CamelRestVisualEntity', () => {
     });
   });
 
-  describe('getNodeSchema', () => {
-    it('should return REST method schema for REST DSL methods', () => {
+  describe('fetchNodeSchema', () => {
+    it('should return REST method schema for GET method', async () => {
       const entity = new CamelRestVisualEntity(restDef);
-      const getComponentSpy = vi.spyOn(CamelCatalogService, 'getComponent');
 
-      entity.getNodeSchema('rest.get.0');
+      const result = await entity.fetchNodeSchema({
+        primaryNodeId: { name: 'get', catalogKind: CatalogKind.Pattern },
+      });
 
-      expect(getComponentSpy).toHaveBeenCalledWith(CatalogKind.Pattern, 'get');
+      const getEntry = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Pattern, 'get');
+      expect(result).toEqual(getEntry?.propertiesSchema);
     });
 
-    it('should return REST method schema for POST method', () => {
+    it('should return REST method schema for POST method', async () => {
       const entity = new CamelRestVisualEntity(restDef);
-      const getComponentSpy = vi.spyOn(CamelCatalogService, 'getComponent');
 
-      entity.getNodeSchema('rest.post.0');
+      const result = await entity.fetchNodeSchema({
+        primaryNodeId: { name: 'post', catalogKind: CatalogKind.Pattern },
+      });
 
-      expect(getComponentSpy).toHaveBeenCalledWith(CatalogKind.Pattern, 'post');
+      const postEntry = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Pattern, 'post');
+      expect(result).toEqual(postEntry?.propertiesSchema);
     });
 
-    it('should delegate to super for non-REST method paths', () => {
+    it('should return undefined when primaryNodeId is missing', async () => {
       const entity = new CamelRestVisualEntity(restDef);
-      const superGetNodeSchemaSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'getNodeSchema');
 
-      // Use a path where method is NOT in REST_DSL_METHODS
-      entity.getNodeSchema('rest.unknown.0');
+      const result = await entity.fetchNodeSchema({});
 
-      expect(superGetNodeSchemaSpy).toHaveBeenCalledWith('rest.unknown.0');
-    });
-
-    it('should handle undefined path by delegating to super', () => {
-      const entity = new CamelRestVisualEntity(restDef);
-      const superGetNodeSchemaSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'getNodeSchema');
-
-      entity.getNodeSchema();
-
-      expect(superGetNodeSchemaSpy).toHaveBeenCalledWith(undefined);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
@@ -158,8 +158,7 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
       primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    // Enrich as Entity (not Processor) to get proper title formatting
-    await NodeEnrichmentService.enrichNodeFromCatalog(restGroupNode, CatalogKind.Entity);
+    await NodeEnrichmentService.enrichVisualizationTree(restGroupNode);
 
     return restGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
@@ -2,6 +2,7 @@ import { Rest } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getValue, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
 import { CatalogKind } from '../../catalog-kind';
@@ -25,7 +26,6 @@ import {
 import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 
 export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Rest }> implements BaseVisualEntity {
@@ -76,19 +76,16 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
     this.id = id;
   }
 
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
-    if (path === CamelRestVisualEntity.ROOT_PATH) {
-      return CamelCatalogService.getComponent(CatalogKind.Entity, REST_ELEMENT_NAME)?.propertiesSchema ?? {};
+  async fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
+      return;
     }
 
-    /** If we're targetting a Rest method, the path would be `rest.get.0` */
-    const pathSegments = path?.split('.') ?? [];
-    const method = (pathSegments[1] ?? '') as RestMethods;
-    if (pathSegments.length === 3 && REST_DSL_VERBS.includes(method)) {
-      return CamelCatalogService.getComponent(CatalogKind.Pattern, method)?.propertiesSchema ?? {};
-    }
-
-    return super.getNodeSchema(path);
+    const definition = await DynamicCatalogRegistry.get().getEntity(
+      ids.primaryNodeId.catalogKind,
+      ids.primaryNodeId.name,
+    );
+    return definition?.propertiesSchema;
   }
 
   getNodeDefinition(path?: string): unknown {

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
@@ -92,13 +92,18 @@ describe('CamelRouteConfigurationVisualEntity', () => {
     );
   });
 
-  it('should return schema from store', () => {
-    const catalogServiceSpy = vi.spyOn(CamelCatalogService, 'getComponent');
-
+  it('should return schema from catalog', async () => {
     const entity = new CamelRouteConfigurationVisualEntity(routeConfigurationDef);
-    entity.getNodeSchema(CamelRouteConfigurationVisualEntity.ROOT_PATH);
 
-    expect(catalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Entity, 'routeConfiguration');
+    const result = await entity.fetchNodeSchema({
+      primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity },
+    });
+
+    const routeConfigurationEntry = await DynamicCatalogRegistry.get().getEntity(
+      CatalogKind.Entity,
+      'routeConfiguration',
+    );
+    expect(result).toEqual(routeConfigurationEntry?.propertiesSchema);
   });
 
   describe('removeStep', () => {

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -2,6 +2,7 @@ import { ProcessorDefinition, RouteConfigurationDefinition } from '@kaoto/camel-
 import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getValue, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
 import { CatalogKind } from '../../catalog-kind';
@@ -18,7 +19,6 @@ import {
   NodeInteraction,
 } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 
 export class CamelRouteConfigurationVisualEntity
@@ -97,13 +97,20 @@ export class CamelRouteConfigurationVisualEntity
     }
   }
 
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
-    if (path === this.getRootPath()) {
-      const schema = CamelCatalogService.getComponent(CatalogKind.Entity, 'routeConfiguration');
-      return schema?.propertiesSchema ?? {};
+  async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
+      return;
     }
 
-    return super.getNodeSchema(path);
+    if (ids.primaryNodeId.catalogKind === CatalogKind.Entity && ids.primaryNodeId.name === 'routeConfiguration') {
+      const definition = await DynamicCatalogRegistry.get().getEntity(
+        ids.primaryNodeId.catalogKind,
+        ids.primaryNodeId.name,
+      );
+      return definition?.propertiesSchema;
+    }
+
+    return await super.fetchNodeSchema(ids);
   }
 
   getNodeDefinition(path?: string): unknown {

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -19,6 +19,7 @@ import {
   NodeInteraction,
 } from '../base-visual-entity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
+import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 
 export class CamelRouteConfigurationVisualEntity
@@ -177,6 +178,8 @@ export class CamelRouteConfigurationVisualEntity
       catalogKind: CatalogKind.Entity,
       name: 'routeConfiguration',
     };
+
+    await NodeEnrichmentService.enrichVisualizationTree(routeConfigurationGroupNode);
 
     return routeConfigurationGroupNode;
   }

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -1,8 +1,11 @@
-import { RouteDefinition } from '@kaoto/camel-catalog/types';
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
 
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { mockRandomValues } from '../../../stubs';
 import { camelRouteJson } from '../../../stubs/camel-route';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { EntityType } from '../../entities/base-entity';
 import { NodeLabelType } from '../../settings/settings.model';
 import { IVisualizationNode } from '../base-visual-entity';
@@ -11,6 +14,15 @@ import { CamelComponentSchemaService } from './support/camel-component-schema.se
 
 describe('Camel Route', () => {
   let camelEntity: CamelRouteVisualEntity;
+
+  beforeAll(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    setupDynamicCatalogRegistry(catalogsMap);
+  });
+
+  afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
 
   beforeEach(() => {
     camelEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
@@ -56,24 +68,17 @@ describe('Camel Route', () => {
     });
   });
 
-  describe('getNodeSchema', () => {
-    it('should return undefined if no path is provided', () => {
-      expect(camelEntity.getNodeSchema()).toBeUndefined();
+  describe('fetchNodeSchema', () => {
+    it('should return undefined if no primaryNodeId is provided', async () => {
+      expect(await camelEntity.fetchNodeSchema({})).toBeUndefined();
     });
 
-    it('should return empty object if no component model is found', () => {
-      const result = camelEntity.getNodeSchema('test');
+    it('should return schema for the from node with component merge', async () => {
+      const routeNode = await camelEntity.toVizNode();
+      const fromNode = routeNode.getChildren()?.[0];
+      const result = await camelEntity.fetchNodeSchema(fromNode!.data);
 
-      expect(result).toEqual({});
-    });
-
-    it('should return the component schema', () => {
-      const spy = vi.spyOn(CamelComponentSchemaService, 'getSchema');
-      spy.mockReturnValueOnce({ type: 'string' });
-
-      camelEntity.getNodeSchema('route.from');
-
-      expect(spy).toHaveBeenCalledWith({ processorName: 'from', componentName: 'timer' });
+      expect(result?.properties?.parameters?.['x-component-name']).toBe('timer');
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -165,18 +165,20 @@ describe('CitrusTestVisualEntity', () => {
     });
   });
 
-  describe('getNodeSchema', () => {
-    it('should return undefined if no path is provided', () => {
-      expect(citrusTestEntity.getNodeSchema()).toBeUndefined();
+  describe('fetchNodeSchema', () => {
+    it('should return undefined if no primaryNodeId is provided', async () => {
+      expect(await citrusTestEntity.fetchNodeSchema({})).toBeUndefined();
     });
 
-    it('should return empty schema if no component model is found', () => {
-      const result = citrusTestEntity.getNodeSchema('unknown');
+    it('should return empty schema if action is not found', async () => {
+      const result = await citrusTestEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'unknown', catalogKind: CatalogKind.TestAction },
+      });
 
       expect(result).toEqual({});
     });
 
-    it('should return root test schema from the catalog', () => {
+    it('should return root test schema from the catalog', async () => {
       CamelCatalogService.setCatalogKey(CatalogKind.Entity, {
         [CITRUS_TEST_ROOT_ENTITY_NAME]: {
           propertiesSchema: {
@@ -186,7 +188,9 @@ describe('CitrusTestVisualEntity', () => {
           },
         } as unknown as ICamelProcessorDefinition,
       });
-      const result = citrusTestEntity.getNodeSchema(CitrusTestVisualEntity.ROOT_PATH);
+      const result = await citrusTestEntity.fetchNodeSchema({
+        primaryNodeId: { name: CITRUS_TEST_ROOT_ENTITY_NAME, catalogKind: CatalogKind.Entity },
+      });
 
       expect(result).toHaveProperty('name');
       expect(result).toHaveProperty('description');
@@ -197,13 +201,12 @@ describe('CitrusTestVisualEntity', () => {
       expect(result?.properties?.finally).toEqual({});
     });
 
-    it('should return the component schema', () => {
-      const spy = vi.spyOn(CitrusTestSchemaService, 'extractTestActionName');
-      spy.mockReturnValueOnce('print');
+    it('should return the component schema for a test action', async () => {
+      const result = await citrusTestEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'print', catalogKind: CatalogKind.TestAction },
+      });
 
-      citrusTestEntity.getNodeSchema('actions.0.print');
-
-      expect(spy).toHaveBeenCalledWith('actions.0.print');
+      expect(result).toBeDefined();
     });
   });
 
@@ -904,13 +907,10 @@ describe('CitrusTestVisualEntity', () => {
       const invalidModel = cloneDeep(citrusTestJson);
       setValue(invalidModel, 'actions[0].print.message', undefined);
       const entity = new CitrusTestVisualEntity(invalidModel);
+      const schema = CitrusTestSchemaService.getNodeSchema('print');
 
-      const spy = vi.spyOn(CitrusTestSchemaService, 'extractTestActionName');
-      spy.mockReturnValueOnce('print');
+      const result = entity.getNodeValidationText('actions.0.print', schema);
 
-      const result = entity.getNodeValidationText('actions.0.print');
-
-      expect(spy).toHaveBeenCalledWith('actions.0.print');
       expect(result).toBe('1 required parameter is not yet configured: [ message ]');
     });
   });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -171,29 +171,18 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     return name;
   }
 
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
-    if (!path) return undefined;
-    if (path === this.getRootPath()) {
-      return this.getRootTestSchema();
-    }
-
-    const actionName = CitrusTestSchemaService.extractTestActionName(path);
-    return CitrusTestSchemaService.getNodeSchema(actionName);
-  }
-
   async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    const { primaryNodeId } = ids;
-    if (!primaryNodeId) {
-      return undefined;
+    if (!ids?.primaryNodeId) {
+      return;
     }
 
-    if (primaryNodeId.catalogKind === CatalogKind.Entity) {
+    if (ids.primaryNodeId.catalogKind === CatalogKind.Entity) {
       // Root test group node — use the static catalog (same as getNodeSchema at root path)
       return this.getRootTestSchema();
     }
 
     // Test action / container nodes — use CitrusTestSchemaService (static catalog)
-    return CitrusTestSchemaService.getNodeSchema(primaryNodeId.name);
+    return CitrusTestSchemaService.getNodeSchema(ids.primaryNodeId.name);
   }
 
   getNodeDefinition(path?: string): unknown {
@@ -357,8 +346,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
-    const schema = this.getNodeSchema(path);
+  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
@@ -455,7 +443,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
   }
 
   private async getVizNodeFromStep(action: TestActions, path: string): Promise<IVisualizationNode> {
-    const actionName = CitrusTestSchemaService.getTestActionName(action);
+    const actionName = await CitrusTestSchemaService.getTestActionName(action);
     const data: IVisualizationNodeData = {
       name: actionName,
       path,
@@ -495,7 +483,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const vizNodes: IVisualizationNode[] = [];
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index];
-      const actionName = CitrusTestSchemaService.getTestActionName(action);
+      const actionName = await CitrusTestSchemaService.getTestActionName(action);
       const vizNode = await this.getVizNodeFromStep(action, `${actionsPath}.${index}.${actionName}`);
 
       if (index > 0) {
@@ -585,7 +573,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       return [placeholderNode];
     }
 
-    const actionName = CitrusTestSchemaService.getTestActionName(action);
+    const actionName = await CitrusTestSchemaService.getTestActionName(action);
     const stepVizNode = await this.getVizNodeFromStep(action, `${path}.${actionName}`);
     return [stepVizNode];
   }
@@ -601,7 +589,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const children: IVisualizationNode[] = [];
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index];
-      const actionName = CitrusTestSchemaService.getTestActionName(action);
+      const actionName = await CitrusTestSchemaService.getTestActionName(action);
       const vizNode = await this.getVizNodeFromStep(action, `${path}.${index}.${actionName}`);
       children.push(vizNode);
     }
@@ -664,6 +652,10 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
    * Properties that belong to the test action group are removed from the test action model.
    */
   private updateTestGroupModel(actions: TestActions[]): void {
+    if (!Array.isArray(actions)) {
+      return;
+    }
+
     for (const action of actions) {
       const actionName = CitrusTestSchemaService.getTestActionName(action);
       const actionDefinition = CitrusTestSchemaService.getTestActionDefinition(actionName);

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -443,7 +443,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
   }
 
   private async getVizNodeFromStep(action: TestActions, path: string): Promise<IVisualizationNode> {
-    const actionName = await CitrusTestSchemaService.getTestActionName(action);
+    const actionName = CitrusTestSchemaService.getTestActionName(action);
     const data: IVisualizationNodeData = {
       name: actionName,
       path,
@@ -483,7 +483,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const vizNodes: IVisualizationNode[] = [];
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index];
-      const actionName = await CitrusTestSchemaService.getTestActionName(action);
+      const actionName = CitrusTestSchemaService.getTestActionName(action);
       const vizNode = await this.getVizNodeFromStep(action, `${actionsPath}.${index}.${actionName}`);
 
       if (index > 0) {
@@ -573,7 +573,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       return [placeholderNode];
     }
 
-    const actionName = await CitrusTestSchemaService.getTestActionName(action);
+    const actionName = CitrusTestSchemaService.getTestActionName(action);
     const stepVizNode = await this.getVizNodeFromStep(action, `${path}.${actionName}`);
     return [stepVizNode];
   }
@@ -589,7 +589,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     const children: IVisualizationNode[] = [];
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index];
-      const actionName = await CitrusTestSchemaService.getTestActionName(action);
+      const actionName = CitrusTestSchemaService.getTestActionName(action);
       const vizNode = await this.getVizNodeFromStep(action, `${path}.${index}.${actionName}`);
       children.push(vizNode);
     }

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -371,12 +371,13 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
       primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(testGroupNode, CatalogKind.TestAction);
-
     const actionNodes = await this.getVizNodesFromSteps(this.test.actions, this.getRootPath());
     actionNodes.forEach((actionNode) => {
       testGroupNode.addChild(actionNode);
     });
+
+    await NodeEnrichmentService.enrichVisualizationTree(testGroupNode);
+
     return testGroupNode;
   }
 
@@ -458,7 +459,6 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.TestAction);
 
     const containerSettings = CitrusTestSchemaService.getTestContainerSettings(actionName);
     if (containerSettings) {

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -1,15 +1,15 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { mockRandomValues } from '../../../stubs';
 import { camelFromJson } from '../../../stubs/camel-from';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { SourceSchemaType } from '../../camel';
 import { IKameletDefinition, IKameletMetadata, IKameletSpecProperty } from '../../camel/kamelets-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { NodeLabelType } from '../../settings';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-import { CamelCatalogService } from './camel-catalog.service';
 import { KameletVisualEntity } from './kamelet-visual-entity';
 
 describe('KameletVisualEntity', () => {
@@ -112,26 +112,30 @@ describe('KameletVisualEntity', () => {
     });
   });
 
-  it('should return the kamelet root schema when querying the ROOT_PATH', async () => {
+  it('should return the kamelet root schema when querying with KameletConfiguration primaryNodeId', async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    const entityCatalogMap = catalogsMap.entitiesCatalog;
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, entityCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
     const kamelet = new KameletVisualEntity(kameletDef);
 
-    expect(kamelet.getNodeSchema(KameletVisualEntity.ROOT_PATH)).toEqual(
-      entityCatalogMap.KameletConfiguration.propertiesSchema,
-    );
+    const result = await kamelet.fetchNodeSchema({
+      primaryNodeId: { name: 'KameletConfiguration', catalogKind: CatalogKind.Entity },
+    });
 
-    CamelCatalogService.clearCatalogs();
+    const kameletConfigEntry = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, 'KameletConfiguration');
+    expect(result).toEqual(kameletConfigEntry?.propertiesSchema);
   });
 
-  it('getNodeSchema should return the component schema from the underlying AbstractCamelVisualEntity', () => {
-    const getNodeSchemaSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'getNodeSchema');
+  it('fetchNodeSchema should delegate to the underlying AbstractCamelVisualEntity for nested nodes', async () => {
+    const fetchNodeSchemaSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'fetchNodeSchema');
 
     const kamelet = new KameletVisualEntity(kameletDef);
-    kamelet.getNodeSchema('test-path');
+    const ids = {
+      primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+      secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+    };
+    await kamelet.fetchNodeSchema(ids);
 
-    expect(getNodeSchemaSpy).toHaveBeenCalledWith('test-path');
+    expect(fetchNodeSchemaSpy).toHaveBeenCalledWith(ids);
   });
 
   it('should return the root uri', () => {

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -2,6 +2,7 @@ import { FromDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getCustomSchemaFromKamelet, setValue, updateKameletFromCustomSchema } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
 import { IKameletDefinition, IKameletSpec } from '../../camel/kamelets-catalog';
@@ -12,7 +13,6 @@ import { NodeLabelType } from '../../settings';
 import { AddStepMode, IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../base-visual-entity';
 import { IClipboardContent } from '../clipboard';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-import { CamelCatalogService } from './camel-catalog.service';
 import { CamelComponentDefaultService } from './support/camel-component-default.service';
 
 export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string; template: { from: FromDefinition } }> {
@@ -75,12 +75,16 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     return { from: this.entityDef.template.from };
   }
 
-  getNodeSchema(path?: string | undefined): KaotoSchemaDefinition['schema'] | undefined {
-    if (path === this.getRootPath()) {
-      return this.getRootKameletSchema();
+  async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    if (!ids?.primaryNodeId) {
+      return;
     }
 
-    return super.getNodeSchema(path);
+    if (ids.primaryNodeId.catalogKind === CatalogKind.Entity && ids.primaryNodeId.name === 'KameletConfiguration') {
+      return await this.getRootKameletSchema();
+    }
+
+    return await super.fetchNodeSchema(ids);
   }
 
   getNodeDefinition(path?: string): unknown {
@@ -165,8 +169,11 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     return this.kamelet.spec.template.from?.uri;
   }
 
-  private getRootKameletSchema(): KaotoSchemaDefinition['schema'] {
-    const rootKameletDefinition = CamelCatalogService.getComponent(CatalogKind.Entity, 'KameletConfiguration');
+  private async getRootKameletSchema(): Promise<KaotoSchemaDefinition['schema']> {
+    const rootKameletDefinition = await DynamicCatalogRegistry.get().getEntity(
+      CatalogKind.Entity,
+      'KameletConfiguration',
+    );
 
     if (rootKameletDefinition === undefined) return {} as unknown as KaotoSchemaDefinition['schema'];
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
@@ -13,7 +13,6 @@ import {
   CamelRouteVisualEntityData,
   ICamelElementLookupResult,
 } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { INodeMapper } from '../node-mapper';
 
 export class BaseNodeMapper implements INodeMapper {
@@ -24,18 +23,14 @@ export class BaseNodeMapper implements INodeMapper {
     componentLookup: ICamelElementLookupResult,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
-    let catalogKind: CatalogKind;
     let name: string;
     if (componentLookup.componentName?.startsWith('kamelet:')) {
-      catalogKind = CatalogKind.Kamelet;
       // For Kamelets, remove the 'kamelet:' prefix from the name
       // The resolvers will use the clean name to look up in the catalog
       name = componentLookup.componentName.replace('kamelet:', '');
     } else if (componentLookup.componentName) {
-      catalogKind = CatalogKind.Component;
       name = componentLookup.componentName;
     } else {
-      catalogKind = CatalogKind.Pattern;
       name = componentLookup.processorName;
     }
     const primaryNodeId: NodeIdentity = {
@@ -80,9 +75,6 @@ export class BaseNodeMapper implements INodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-
-    // Resolve catalog-derived properties
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, catalogKind);
 
     const childrenStepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
       componentLookup.processorName,

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class ChoiceNodeMapper extends BaseNodeMapper {
@@ -29,9 +28,6 @@ export class ChoiceNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-
-    /** Enrich the node*/
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const whenNodes = await this.getChildrenFromArrayClause(`${path}.when`, entityDefinition);
     whenNodes.forEach((whenNode) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class CircuitBreakerNodeMapper extends BaseNodeMapper {
@@ -29,7 +28,6 @@ export class CircuitBreakerNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
@@ -6,7 +6,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class DataMapperNodeMapper extends BaseNodeMapper {
@@ -30,7 +29,6 @@ export class DataMapperNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path + ':' + processorName, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
     return vizNode;
   }
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
@@ -237,11 +237,9 @@ describe('FromNodeMapper', () => {
     expect(vizNode.data.name).toBe('direct');
   });
 
-  it('should enrich node from catalog', () => {
-    // iconUrl must be non-empty: the mapper resolves the 'direct' component icon
-    expect(vizNode.data.iconUrl).toBeTruthy();
-    // title resolves to the component name ('direct') when the catalog has no entry in the test environment
-    expect(vizNode.data.title).toBe('direct');
+  it('should defer catalog enrichment until the visualization tree is built', () => {
+    expect(vizNode.data.iconUrl).toBe('');
+    expect(vizNode.data.title).toBe('');
   });
 
   it('should create linked list of step nodes', () => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.ts
@@ -8,7 +8,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class FromNodeMapper extends BaseNodeMapper {
@@ -53,9 +52,6 @@ export class FromNodeMapper extends BaseNodeMapper {
     if (kameletName) {
       vizNode.data.tertiaryNodeId = { catalogKind: CatalogKind.Kamelet, name: kameletName };
     }
-
-    /** Enrich the node*/
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
 
     const stepNodes = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     stepNodes.forEach((stepNode) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class OnFallbackNodeMapper extends BaseNodeMapper {
@@ -29,7 +28,6 @@ export class OnFallbackNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class OtherwiseNodeMapper extends BaseNodeMapper {
@@ -29,7 +28,6 @@ export class OtherwiseNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export abstract class ParallelProcessorBaseNodeMapper extends BaseNodeMapper {
@@ -31,7 +30,6 @@ export abstract class ParallelProcessorBaseNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {
       vizNode.addChild(child);

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.ts
@@ -6,7 +6,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class RouteConfigurationNodeMapper extends BaseNodeMapper {
@@ -30,8 +29,6 @@ export class RouteConfigurationNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
 
     for (const property of SPECIAL_PROCESSORS_PARENTS_MAP.routeConfiguration) {
       const configNodes = await this.getChildrenFromArrayClause(`${path}.${property}`, entityDefinition);

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.ts
@@ -6,7 +6,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 import { DataMapperNodeMapper } from './datamapper-node-mapper';
 
@@ -42,7 +41,6 @@ export class StepNodeMapper extends BaseNodeMapper {
     }
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.ts
@@ -5,7 +5,6 @@ import { IVisualizationNode } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
-import { NodeEnrichmentService } from '../node-enrichment.service';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class WhenNodeMapper extends BaseNodeMapper {
@@ -29,7 +28,6 @@ export class WhenNodeMapper extends BaseNodeMapper {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
 
     const children = await this.getChildrenFromBranch(`${path}.steps`, entityDefinition);
     children.forEach((child) => {

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
@@ -1,6 +1,7 @@
 import type { MockInstance } from 'vitest';
 
 import { CatalogKind } from '../../../catalog-kind';
+import { EntityType } from '../../../entities';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { BaseVisualEntity, IVisualizationNode } from '../../base-visual-entity';
 import { createVisualizationNode } from '../../visualization-node';
@@ -324,5 +325,109 @@ describe('NodeEnrichmentService', () => {
 
     expect(vizNode.fetchSchema).toHaveBeenCalled();
     expect(vizNode.data.schema).toBe(standardSchema);
+  });
+
+  describe('deriveCatalogKind', () => {
+    it('should derive Kamelet when a tertiary kamelet identity is present', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'to' };
+      vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'kamelet' };
+      vizNode.data.tertiaryNodeId = { catalogKind: CatalogKind.Kamelet, name: 'my-kamelet' };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.Kamelet);
+    });
+
+    it('should derive Entity for entity nodes such as from and route', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Entity, name: 'from' };
+      vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'timer' };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.Entity);
+    });
+
+    it('should derive Component for endpoint steps with a secondary component identity', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'to' };
+      vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'github' };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.Component);
+    });
+
+    it('should derive Pattern for processor-only steps', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'log' };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.Pattern);
+    });
+
+    it('should derive TestAction for citrus action nodes', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.TestAction, name: 'print' };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.TestAction);
+    });
+
+    it('should derive TestAction for the citrus test root node', () => {
+      const vizNode = createMockVizNode();
+      vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Entity, name: EntityType.Test };
+
+      expect(NodeEnrichmentService.deriveCatalogKind(vizNode)).toBe(CatalogKind.TestAction);
+    });
+  });
+
+  describe('enrichVisualizationTree', () => {
+    it('should enrich linked child nodes and skip placeholders', async () => {
+      const mockSchema: KaotoSchemaDefinition['schema'] = { type: 'object' as const };
+      mockGetIconRequest.mockResolvedValue({ icon: 'log-icon.svg', alt: 'Log icon' });
+      mockGetTooltipRequest.mockResolvedValue('Logs messages');
+      mockGetProcessorIconTooltipRequest.mockResolvedValue('Log processor');
+      mockGetTitleRequest.mockResolvedValue('Log');
+
+      const root = createVisualizationNode('route', {
+        name: 'route',
+        path: 'route',
+        entity: {} as BaseVisualEntity,
+        isPlaceholder: false,
+        isGroup: true,
+        iconUrl: '',
+        title: '',
+        description: '',
+        primaryNodeId: { catalogKind: CatalogKind.Entity, name: 'route' },
+      } as unknown as CamelRouteVisualEntityData);
+
+      const child = createVisualizationNode('route.from.steps.0.log', {
+        name: 'log',
+        path: 'route.from.steps.0.log',
+        isPlaceholder: false,
+        isGroup: false,
+        iconUrl: '',
+        title: '',
+        description: '',
+        primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'log' },
+      } as unknown as CamelRouteVisualEntityData);
+      child.fetchSchema = vi.fn(async () => mockSchema);
+
+      const placeholder = createVisualizationNode('route.from.steps.1.placeholder', {
+        name: 'placeholder',
+        path: 'route.from.steps.1.placeholder',
+        isPlaceholder: true,
+        isGroup: false,
+        iconUrl: '',
+        title: '',
+        description: '',
+        primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'placeholder' },
+      } as unknown as CamelRouteVisualEntityData);
+
+      root.addChild(child);
+      root.addChild(placeholder);
+      child.setPreviousNode(root);
+      root.setNextNode(child);
+
+      await NodeEnrichmentService.enrichVisualizationTree(root);
+
+      expect(root.data.title).toBe('Log');
+      expect(child.data.schema).toBe(mockSchema);
+      expect(placeholder.data.iconUrl).toBe('');
+    });
   });
 });

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
@@ -1,4 +1,5 @@
 import { CatalogKind } from '../../../catalog-kind';
+import { EntityType } from '../../../entities';
 import { IVisualizationNode } from '../../base-visual-entity';
 import { getIconRequest } from './resolvers/icon-resolver/getIconRequest';
 import { getTitleRequest } from './resolvers/title-resolver/getTitleRequest';
@@ -10,6 +11,74 @@ import { getTooltipRequest } from './resolvers/tooltip-resolver/getTooltipReques
  * This includes resolving icons, titles, and descriptions from the catalog.
  */
 export class NodeEnrichmentService {
+  /**
+   * Derives the catalog kind used for enrichment from the node's identity fields.
+   * Mirrors the catalog-kind selection previously done in node mappers.
+   */
+  static deriveCatalogKind(vizNode: IVisualizationNode): CatalogKind {
+    const { primaryNodeId, secondaryNodeId, tertiaryNodeId } = vizNode.data;
+
+    if (tertiaryNodeId?.catalogKind === CatalogKind.Kamelet) {
+      return CatalogKind.Kamelet;
+    }
+
+    // Citrus test root uses Entity on primaryNodeId but was always enriched with TestAction.
+    if (primaryNodeId?.catalogKind === CatalogKind.Entity && primaryNodeId.name === EntityType.Test) {
+      return CatalogKind.TestAction;
+    }
+
+    if (primaryNodeId?.catalogKind === CatalogKind.Entity) {
+      return CatalogKind.Entity;
+    }
+
+    // Citrus action nodes always store TestAction on primaryNodeId and use TestAction for enrichment.
+    if (primaryNodeId?.catalogKind === CatalogKind.TestAction) {
+      return CatalogKind.TestAction;
+    }
+
+    if (primaryNodeId?.catalogKind === CatalogKind.Kamelet) {
+      return CatalogKind.Kamelet;
+    }
+
+    if (secondaryNodeId?.catalogKind === CatalogKind.Component) {
+      return CatalogKind.Component;
+    }
+
+    if (primaryNodeId?.catalogKind === CatalogKind.Pattern) {
+      return CatalogKind.Pattern;
+    }
+
+    if (primaryNodeId?.catalogKind === CatalogKind.Processor) {
+      return CatalogKind.Processor;
+    }
+
+    return primaryNodeId?.catalogKind ?? CatalogKind.Pattern;
+  }
+
+  /**
+   * Enriches every non-placeholder node in the visualization tree after the structure is linked.
+   */
+  static async enrichVisualizationTree(root: IVisualizationNode): Promise<void> {
+    const visited = new Set<string>();
+
+    const visit = async (node: IVisualizationNode): Promise<void> => {
+      if (visited.has(node.id)) {
+        return;
+      }
+      visited.add(node.id);
+
+      if (!node.data.isPlaceholder) {
+        await NodeEnrichmentService.enrichNodeFromCatalog(node, NodeEnrichmentService.deriveCatalogKind(node));
+      }
+
+      for (const child of node.getChildren() ?? []) {
+        await visit(child);
+      }
+    };
+
+    await visit(root);
+  }
+
   /**
    * Enriches a visualization node with catalog properties (icon, title, description).
    * @param vizNode - The visualization node to enrich

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -168,27 +168,37 @@ describe('Pipe', () => {
     });
   });
 
-  describe('getNodeSchema', () => {
-    it('should return undefined if no path is provided', () => {
-      expect(pipeVisualEntity.getNodeSchema()).toBeUndefined();
+  describe('fetchNodeSchema', () => {
+    it('should return undefined if no primaryNodeId is provided', async () => {
+      expect(await pipeVisualEntity.fetchNodeSchema({})).toBeUndefined();
     });
 
-    it('should return {} when using an invalid path', () => {
-      const result = pipeVisualEntity.getNodeSchema('test');
+    it('should return the root pipe schema when primaryNodeId is PipeConfiguration', async () => {
+      (DynamicCatalogRegistry.get as Mock).mockReturnValue({
+        getEntity: vi.fn((kind: CatalogKind, name: string) => {
+          if (kind === CatalogKind.Entity && name === 'PipeConfiguration') {
+            return Promise.resolve({ propertiesSchema: { type: 'object', title: 'Pipe' } });
+          }
+          if (kind === CatalogKind.Kamelet) {
+            return Promise.resolve(kameletCatalogMap[name]);
+          }
+          return Promise.resolve(undefined);
+        }),
+      });
 
-      expect(result).toEqual({});
+      const result = await pipeVisualEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'PipeConfiguration', catalogKind: CatalogKind.Entity },
+      });
+
+      expect(result).toMatchObject({ type: 'object', title: 'Pipe' });
     });
 
-    it('should return the root pipe schema when path is root path', () => {
-      const result = pipeVisualEntity.getNodeSchema('pipe');
-      expect(result).toBeDefined();
-    });
+    it('should return the kamelet schema for a step primaryNodeId', async () => {
+      const result = await pipeVisualEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'delay-action', catalogKind: CatalogKind.Kamelet },
+      });
 
-    it('should return the node schema', () => {
-      const spy = vi.spyOn(KameletSchemaService, 'getKameletCatalogEntry');
-
-      pipeVisualEntity.getNodeSchema('source');
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(kameletCatalogMap['delay-action'].propertiesSchema);
     });
   });
 
@@ -520,12 +530,15 @@ describe('Pipe', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const missingParametersModel = cloneDeep(pipeJson);
       missingParametersModel.spec!.steps![0].properties = {};
       pipeVisualEntity = new PipeVisualEntity(missingParametersModel);
 
-      const result = pipeVisualEntity.getNodeValidationText('steps.0');
+      const schema = await pipeVisualEntity.fetchNodeSchema({
+        primaryNodeId: { name: 'delay-action', catalogKind: CatalogKind.Kamelet },
+      });
+      const result = pipeVisualEntity.getNodeValidationText('steps.0', schema);
 
       expect(result).toBe('1 required parameter is not yet configured: [ milliseconds ]');
     });

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -241,8 +241,6 @@ export class PipeVisualEntity implements BaseVisualEntity {
       primaryNodeId: { name: 'PipeConfiguration', catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     });
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(pipeGroupNode, CatalogKind.Entity);
-
     const sourceNode = await this.getVizNodeFromStep(this.pipe.spec!.source, 'source', true);
     const stepNodes = await this.getVizNodesFromSteps(this.pipe.spec!.steps);
     const sinkNode = await this.getVizNodeFromStep(this.pipe.spec!.sink, 'sink');
@@ -257,6 +255,7 @@ export class PipeVisualEntity implements BaseVisualEntity {
     if (stepNodes.length === 0) {
       sourceNode.setNextNode(sinkNode);
       sinkNode.setPreviousNode(sourceNode);
+      await NodeEnrichmentService.enrichVisualizationTree(pipeGroupNode);
       return pipeGroupNode;
     }
 
@@ -273,6 +272,8 @@ export class PipeVisualEntity implements BaseVisualEntity {
       lastStepNode.setNextNode(sinkNode);
       sinkNode.setPreviousNode(lastStepNode);
     }
+
+    await NodeEnrichmentService.enrichVisualizationTree(pipeGroupNode);
 
     return pipeGroupNode;
   }
@@ -319,7 +320,6 @@ export class PipeVisualEntity implements BaseVisualEntity {
     };
 
     const vizNode = createVisualizationNode(path, data);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Kamelet);
     return vizNode;
   }
 

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -27,7 +27,6 @@ import {
 import { IClipboardContent } from '../clipboard';
 import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { KameletSchemaService } from './support/kamelet-schema.service';
 import { ModelValidationService } from './support/validators/model-validation.service';
@@ -74,25 +73,19 @@ export class PipeVisualEntity implements BaseVisualEntity {
     return KameletSchemaService.getNodeLabel(stepModel, path);
   }
 
-  getNodeSchema(path?: string): KaotoSchemaDefinition['schema'] | undefined {
-    if (!path) return undefined;
-    if (path === this.getRootPath()) {
-      return this.getRootPipeSchema();
-    }
-
-    const stepModel: PipeStep = getValue(this.pipe.spec, path);
-    return (
-      KameletSchemaService.getKameletCatalogEntry(stepModel)?.propertiesSchema ??
-      ({} as KaotoSchemaDefinition['schema'])
-    );
-  }
-
   async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
-    const { primaryNodeId } = ids;
-    if (!primaryNodeId) {
-      return undefined;
+    if (!ids?.primaryNodeId) {
+      return;
     }
-    const definition = await DynamicCatalogRegistry.get().getEntity(primaryNodeId.catalogKind, primaryNodeId.name);
+
+    if (ids.primaryNodeId.catalogKind === CatalogKind.Entity && ids.primaryNodeId.name === 'PipeConfiguration') {
+      return await this.getRootPipeSchema();
+    }
+
+    const definition = await DynamicCatalogRegistry.get().getEntity(
+      ids.primaryNodeId.catalogKind,
+      ids.primaryNodeId.name,
+    );
     return definition?.propertiesSchema;
   }
 
@@ -227,8 +220,7 @@ export class PipeVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string | undefined): string | undefined {
-    const schema = this.getNodeSchema(path);
+  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
@@ -349,8 +341,8 @@ export class PipeVisualEntity implements BaseVisualEntity {
     return vizNodes;
   }
 
-  private getRootPipeSchema(): KaotoSchemaDefinition['schema'] {
-    const rootPipeDefinition = CamelCatalogService.getComponent(CatalogKind.Entity, 'PipeConfiguration');
+  private async getRootPipeSchema(): Promise<KaotoSchemaDefinition['schema']> {
+    const rootPipeDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, 'PipeConfiguration');
 
     if (rootPipeDefinition === undefined) return {} as unknown as KaotoSchemaDefinition['schema'];
 

--- a/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
@@ -28,10 +28,10 @@ describe('CitrusTestSchemaService', () => {
       ['iterate', CatalogKind.TestContainer],
       ['kubernetes-createService', CatalogKind.TestAction],
       ['camel-jbang-run', CatalogKind.TestAction],
-    ])('should leverage the CamelCatalogService.getComponent method', async (actionName, catalogKind) => {
+    ])('should leverage the CamelCatalogService.getComponent method', (actionName, catalogKind) => {
       const getComponentSpy = vi.spyOn(CamelCatalogService, 'getComponent');
 
-      await CitrusTestSchemaService.getNodeSchema(actionName);
+      CitrusTestSchemaService.getNodeSchema(actionName);
 
       expect(getComponentSpy).toHaveBeenCalledWith(catalogKind, actionName);
     });

--- a/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/citrus-test-schema.service.test.ts
@@ -28,10 +28,10 @@ describe('CitrusTestSchemaService', () => {
       ['iterate', CatalogKind.TestContainer],
       ['kubernetes-createService', CatalogKind.TestAction],
       ['camel-jbang-run', CatalogKind.TestAction],
-    ])('should leverage the CamelCatalogService.getComponent method', (actionName, catalogKind) => {
+    ])('should leverage the CamelCatalogService.getComponent method', async (actionName, catalogKind) => {
       const getComponentSpy = vi.spyOn(CamelCatalogService, 'getComponent');
 
-      CitrusTestSchemaService.getNodeSchema(actionName);
+      await CitrusTestSchemaService.getNodeSchema(actionName);
 
       expect(getComponentSpy).toHaveBeenCalledWith(catalogKind, actionName);
     });

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -80,27 +80,6 @@ describe('VisualizationNode', () => {
     expect(node.getId()).toBe('route-8888');
   });
 
-  it('should return the node schema from the underlying BaseVisualCamelEntity', () => {
-    const getNodeSchemaSpy = vi.fn();
-    const visualEntity = {
-      getNodeSchema: getNodeSchemaSpy,
-    } as unknown as BaseVisualEntity;
-
-    node = createVisualizationNode('test', {
-      name: 'log',
-      path: 'test-path',
-      entity: visualEntity,
-      isPlaceholder: false,
-      isGroup: false,
-      title: '',
-      description: '',
-      iconUrl: '',
-    });
-    node.getNodeSchema();
-
-    expect(getNodeSchemaSpy).toHaveBeenCalledWith(node.data.path);
-  });
-
   it('should return the node definition from the underlying BaseVisualCamelEntity', () => {
     const getNodeDefinitionSpy = vi.fn();
     const visualEntity = {
@@ -183,32 +162,6 @@ describe('VisualizationNode', () => {
 
       expect(label).toEqual(node.id);
     });
-  });
-
-  it('should return the node schema from the root node', () => {
-    /** Arrange */
-    const getNodeSchemaSpy = vi.fn();
-    const visualEntity = {
-      getNodeSchema: getNodeSchemaSpy,
-    } as unknown as BaseVisualEntity;
-
-    const rootNode = createVisualizationNode('test', {
-      name: 'log',
-      path: 'test-path',
-      entity: visualEntity,
-      isPlaceholder: false,
-      isGroup: false,
-      title: '',
-      description: '',
-      iconUrl: '',
-    });
-    node.setParentNode(rootNode);
-
-    /** Act */
-    node.getNodeSchema();
-
-    /** Assert */
-    expect(getNodeSchemaSpy).toHaveBeenCalledWith(node.data.path);
   });
 
   it('should return the node definition from the root node', () => {
@@ -479,10 +432,11 @@ describe('VisualizationNode', () => {
         title: '',
         description: '',
         iconUrl: '',
+        schema: { type: 'object' },
       });
       const validationText = node.getNodeValidationText();
 
-      expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path);
+      expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path, node.data.schema);
       expect(validationText).toBe('test-validation-text');
     });
   });

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -104,10 +104,6 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     return this.getBaseEntity()?.getNodeInteraction(this.data) ?? this.DISABLED_NODE_INTERACTION;
   }
 
-  getNodeSchema(): KaotoSchemaDefinition['schema'] | undefined {
-    return this.getBaseEntity()?.getNodeSchema(this.data.path);
-  }
-
   async fetchSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
     const baseEntity = this.getBaseEntity();
     if (!baseEntity) {
@@ -183,7 +179,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   }
 
   getNodeValidationText(): string | undefined {
-    return this.getBaseEntity()?.getNodeValidationText(this.data.path);
+    return this.getBaseEntity()?.getNodeValidationText(this.data.path, this.data.schema);
   }
 
   /**

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.test.tsx
@@ -10,7 +10,7 @@ import { KaotoResource } from '../../models/kaoto-resource';
 import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
 import { TestProvidersWrapper } from '../../stubs';
-import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { RestDslEditorPage } from './RestDslEditorPage';
 import { clickToolbarActionUtil } from './test-utils';
 
@@ -73,6 +73,7 @@ describe('RestDslEditorPage', () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
     CamelCatalogService.setCatalogKey(CatalogKind.Pattern, catalogsMap.patternCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   afterEach(() => {

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -3,13 +3,15 @@ import './RestDslEditorPage.scss';
 import { CodeSnippet } from '@carbon/react';
 import { Rest } from '@kaoto/camel-catalog/types';
 import { CanvasFormTabsProvider, FilteredFieldProvider, getCamelRandomId, KaotoForm } from '@kaoto/forms';
-import { FunctionComponent, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Loading } from '../../components/Loading';
 import { ResizableSplitPanels } from '../../components/ResizableSplitPanels/ResizableSplitPanels';
 import { SuggestionRegistrar } from '../../components/Visualization/Canvas/Form/suggestions/SuggestionsProvider';
 import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext';
+import { CatalogKind } from '../../models/catalog-kind';
 import { EntityType } from '../../models/entities';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
 import { AddMethodFormModel } from './components/add-method-schema';
 import { AddMethodModal } from './components/AddMethodModal';
@@ -30,10 +32,39 @@ const DEFAULT_REST_METHOD_URI = 'direct';
 export const RestDslEditorPage: FunctionComponent = () => {
   const { entities, camelResource, updateEntitiesFromCamelResource, updateSourceCodeFromEntities } = useEntityContext();
   const [selectedElement, setSelectedElement] = useState<IRestTreeSelection | undefined>();
+  const [schema, setSchema] = useState<KaotoSchemaDefinition['schema'] | undefined>();
+  const [isSchemaLoading, setIsSchemaLoading] = useState(false);
   const restRelatedEntities = useMemo(() => getRestEntities(entities), [entities]);
 
   const selectedEntity = restRelatedEntities.find((entity) => entity.id === selectedElement?.entityId);
-  const schema = selectedEntity?.getNodeSchema(selectedElement?.modelPath);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchema(undefined);
+    if (!selectedEntity || !selectedElement?.ids) return;
+    setIsSchemaLoading(true);
+    selectedEntity
+      .fetchNodeSchema(selectedElement.ids)
+      .then((resolved) => {
+        if (!cancelled) setSchema(resolved);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch REST DSL schema:', err);
+      })
+      .finally(() => {
+        if (!cancelled) setIsSchemaLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    selectedEntity,
+    selectedElement?.entityId,
+    selectedElement?.modelPath,
+    selectedElement?.ids?.primaryNodeId?.name,
+  ]);
+
   const model = selectedEntity?.getNodeDefinition(selectedElement?.modelPath);
 
   const [treeVersion, setTreeVersion] = useState(0);
@@ -75,14 +106,22 @@ export const RestDslEditorPage: FunctionComponent = () => {
   const handleAddRestConfiguration = useCallback(() => {
     const newId = camelResource.addNewEntity(EntityType.RestConfiguration);
     updateEntitiesFromCamelResource();
-    setSelectedElement({ modelPath: 'restConfiguration', entityId: newId });
+    setSelectedElement({
+      modelPath: 'restConfiguration',
+      entityId: newId,
+      ids: { primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity } },
+    });
     setTreeVersion((version) => version + 1);
   }, [camelResource, updateEntitiesFromCamelResource]);
 
   /** Adds a new REST service entity to the resource */
   const handleAddRest = useCallback(() => {
     const newId = camelResource.addNewEntity(EntityType.Rest);
-    setSelectedElement({ modelPath: 'rest', entityId: newId });
+    setSelectedElement({
+      modelPath: 'rest',
+      entityId: newId,
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+    });
     updateEntitiesFromCamelResource();
     setTreeVersion((version) => version + 1);
   }, [camelResource, updateEntitiesFromCamelResource]);
@@ -109,7 +148,11 @@ export const RestDslEditorPage: FunctionComponent = () => {
       });
 
       updateEntitiesFromCamelResource();
-      setSelectedElement({ entityId: selectedEntity.id, modelPath: `rest.${model.method}.${methodsArray.length - 1}` });
+      setSelectedElement({
+        entityId: selectedEntity.id,
+        modelPath: `rest.${model.method}.${methodsArray.length - 1}`,
+        ids: { primaryNodeId: { name: model.method, catalogKind: CatalogKind.Pattern } },
+      });
       setTreeVersion((version) => version + 1);
     },
     [selectedEntity, updateEntitiesFromCamelResource],
@@ -171,7 +214,7 @@ export const RestDslEditorPage: FunctionComponent = () => {
                     </>
                   )}
                 </div>
-                {!schema || Object.keys(schema).length === 0 ? (
+                {isSchemaLoading || !schema || Object.keys(schema).length === 0 ? (
                   <Loading>Loading schemas...</Loading>
                 ) : (
                   <Suspense fallback={<Loading>Loading form...</Loading>}>

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
+import { CatalogKind } from '../../../models/catalog-kind';
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
 import { getRestEntities } from './get-rest-entities';
 import { RestTree } from './RestTree';
@@ -79,6 +80,7 @@ describe('RestTree', () => {
     expect(mockOnSelect).toHaveBeenCalledWith({
       entityId: 'rest-1234',
       modelPath: 'rest',
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
     });
 
     mockOnSelect.mockClear();
@@ -89,6 +91,7 @@ describe('RestTree', () => {
     expect(mockOnSelect).toHaveBeenCalledWith({
       entityId: 'rest-1234',
       modelPath: 'rest.get.0',
+      ids: { primaryNodeId: { name: 'get', catalogKind: CatalogKind.Pattern } },
     });
   });
 
@@ -112,6 +115,7 @@ describe('RestTree', () => {
     expect(mockOnSelect).toHaveBeenCalledWith({
       entityId: 'rest-1234',
       modelPath: 'rest.get.0',
+      ids: { primaryNodeId: { name: 'get', catalogKind: CatalogKind.Pattern } },
     });
     expect(await screen.findByRole('menu', { name: 'REST tree node actions' })).toBeInTheDocument();
     const deleteAction = screen.getByRole('menuitem', { name: /Delete/ });
@@ -149,7 +153,11 @@ describe('RestTree', () => {
         insetBlockStart: '230px',
       });
     });
-    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-2', modelPath: 'rest' });
+    expect(mockOnSelect).toHaveBeenLastCalledWith({
+      entityId: 'rest-2',
+      modelPath: 'rest',
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+    });
   });
 
   it('should open the same menu for configuration, service, and method badge targets', async () => {
@@ -176,13 +184,22 @@ describe('RestTree', () => {
     expect(mockOnSelect).toHaveBeenLastCalledWith({
       entityId: configuration.id,
       modelPath: 'restConfiguration',
+      ids: { primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity } },
     });
 
     fireEvent.contextMenu(screen.getByText('rest-1'));
-    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-1', modelPath: 'rest' });
+    expect(mockOnSelect).toHaveBeenLastCalledWith({
+      entityId: 'rest-1',
+      modelPath: 'rest',
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+    });
 
     fireEvent.contextMenu(screen.getByText('GET'));
-    expect(mockOnSelect).toHaveBeenLastCalledWith({ entityId: 'rest-1', modelPath: 'rest.get.0' });
+    expect(mockOnSelect).toHaveBeenLastCalledWith({
+      entityId: 'rest-1',
+      modelPath: 'rest.get.0',
+      ids: { primaryNodeId: { name: 'get', catalogKind: CatalogKind.Pattern } },
+    });
     expect(screen.getAllByRole('menu', { name: 'REST tree node actions' })).toHaveLength(1);
   });
 
@@ -197,7 +214,11 @@ describe('RestTree', () => {
     render(
       <RestTree
         entities={entities}
-        selected={{ entityId: 'rest-1', modelPath: 'rest' }}
+        selected={{
+          entityId: 'rest-1',
+          modelPath: 'rest',
+          ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+        }}
         onSelect={mockOnSelect}
         onDelete={mockOnDelete}
       />,
@@ -321,7 +342,11 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    const selected = { entityId: 'rest-1234', modelPath: 'rest' };
+    const selected = {
+      entityId: 'rest-1234',
+      modelPath: 'rest',
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+    };
 
     const { container } = render(
       <RestTree entities={entities} selected={selected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
@@ -355,7 +380,11 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    const selected = { entityId: 'rest-1234', modelPath: 'rest.post.0' };
+    const selected = {
+      entityId: 'rest-1234',
+      modelPath: 'rest.post.0',
+      ids: { primaryNodeId: { name: 'post', catalogKind: CatalogKind.Pattern } },
+    };
 
     const { container } = render(
       <RestTree entities={entities} selected={selected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
@@ -395,7 +424,11 @@ describe('RestTree', () => {
     await camelResource.initialize();
 
     const entities = getRestEntities(camelResource.getEntities());
-    const initialSelected = { entityId: 'rest-1234', modelPath: 'rest' };
+    const initialSelected = {
+      entityId: 'rest-1234',
+      modelPath: 'rest',
+      ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+    };
 
     const { container, rerender } = render(
       <RestTree entities={entities} selected={initialSelected} onSelect={mockOnSelect} onDelete={mockOnDelete} />,
@@ -405,7 +438,11 @@ describe('RestTree', () => {
     let activeNode = container.querySelector(`[id="${expectedActiveId}"]`);
     expect(activeNode).toBeInTheDocument();
 
-    const newSelected = { entityId: 'rest-1234', modelPath: 'rest.get.0' };
+    const newSelected = {
+      entityId: 'rest-1234',
+      modelPath: 'rest.get.0',
+      ids: { primaryNodeId: { name: 'get', catalogKind: CatalogKind.Pattern } },
+    };
     rerender(<RestTree entities={entities} selected={newSelected} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 
     expectedActiveId = 'rest-1234::rest.get.0';

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
@@ -4,12 +4,12 @@ import { TrashCan } from '@carbon/icons-react';
 import { Menu, MenuItem, TreeNode, TreeView, useContextMenu } from '@carbon/react';
 import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 
-import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
+import { BaseVisualEntity, IVisualizationNodeIds } from '../../../models/visualization/base-visual-entity';
 import { restToTree } from '../rest-to-tree';
 import { MethodBadge } from './MethodBadge';
 
 /** Represents a selected item in the REST tree */
-export type IRestTreeSelection = { entityId: string; modelPath: string };
+export type IRestTreeSelection = { entityId: string; modelPath: string; ids: IVisualizationNodeIds };
 
 /**
  * Props for the RestTree component.
@@ -57,11 +57,13 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
     selectionsByNodeId.set(getNodeId(node.entityId, node.modelPath), {
       entityId: node.entityId,
       modelPath: node.modelPath,
+      ids: { primaryNodeId: node.primaryNodeId },
     });
     node.children?.forEach((child) => {
       selectionsByNodeId.set(getNodeId(child.entityId, child.modelPath), {
         entityId: child.entityId,
         modelPath: child.modelPath,
+        ids: { primaryNodeId: child.primaryNodeId },
       });
     });
   });
@@ -108,7 +110,11 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
                 id={nodeId}
                 label={node.id}
                 onSelect={() => {
-                  onSelect({ entityId: node.entityId, modelPath: node.modelPath });
+                  onSelect({
+                    entityId: node.entityId,
+                    modelPath: node.modelPath,
+                    ids: { primaryNodeId: node.primaryNodeId },
+                  });
                 }}
               >
                 {node.children?.map((child) => {
@@ -127,7 +133,11 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
                       label={label}
                       renderIcon={() => <MethodBadge type={child.type} />}
                       onSelect={() => {
-                        onSelect({ entityId: child.entityId, modelPath: child.modelPath });
+                        onSelect({
+                          entityId: child.entityId,
+                          modelPath: child.modelPath,
+                          ids: { primaryNodeId: child.primaryNodeId },
+                        });
                       }}
                     />
                   );

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
+import { CatalogKind } from '../../../models/catalog-kind';
 import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
 import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { clickToolbarActionUtil } from '../test-utils';
@@ -193,7 +194,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: restConfigEntity.id, modelPath: 'restConfiguration' }}
+          selectedElement={{
+            entityId: restConfigEntity.id,
+            modelPath: 'restConfiguration',
+            ids: { primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -225,7 +230,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'rest-1234', modelPath: 'rest' }}
+          selectedElement={{
+            entityId: 'rest-1234',
+            modelPath: 'rest',
+            ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -257,7 +266,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'rest-1234', modelPath: 'rest.get.0' }}
+          selectedElement={{
+            entityId: 'rest-1234',
+            modelPath: 'rest.get.0',
+            ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Pattern } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -293,7 +306,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'route-1234', modelPath: 'route' }}
+          selectedElement={{
+            entityId: 'route-1234',
+            modelPath: 'route',
+            ids: { primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -320,7 +337,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'rest-1234', modelPath: 'rest' }}
+          selectedElement={{
+            entityId: 'rest-1234',
+            modelPath: 'rest',
+            ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -366,7 +387,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'rest-1234', modelPath: 'rest' }}
+          selectedElement={{
+            entityId: 'rest-1234',
+            modelPath: 'rest',
+            ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}
@@ -393,7 +418,11 @@ describe('RestTreeToolbar', () => {
       render(
         <RestTreeToolbar
           entities={entities}
-          selectedElement={{ entityId: 'rest-1234', modelPath: 'rest' }}
+          selectedElement={{
+            entityId: 'rest-1234',
+            modelPath: 'rest',
+            ids: { primaryNodeId: { name: 'rest', catalogKind: CatalogKind.Entity } },
+          }}
           onAddRestConfiguration={mockOnAddRestConfiguration}
           onAddRest={mockOnAddRest}
           onAddMethodClick={mockOnAddMethodClick}

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
@@ -1,4 +1,5 @@
 import { CamelResourceFactory } from '../../models/camel/camel-resource-factory';
+import { CatalogKind } from '../../models/catalog-kind';
 import { KaotoResource } from '../../models/kaoto-resource';
 import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
 import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
@@ -61,6 +62,10 @@ describe('restToTree', () => {
         type: 'restConfiguration',
         label: 'Rest configuration',
         modelPath: 'restConfiguration',
+        primaryNodeId: {
+          name: 'restConfiguration',
+          catalogKind: CatalogKind.Entity,
+        },
       },
       {
         id: 'rest-3496',
@@ -68,6 +73,10 @@ describe('restToTree', () => {
         type: 'rest',
         label: 'Rest',
         modelPath: 'rest',
+        primaryNodeId: {
+          name: 'rest',
+          catalogKind: CatalogKind.Entity,
+        },
         children: [
           {
             id: 'rest-1816',
@@ -75,6 +84,10 @@ describe('restToTree', () => {
             type: 'get',
             label: 'aaa',
             modelPath: 'rest.get.0',
+            primaryNodeId: {
+              name: 'get',
+              catalogKind: CatalogKind.Pattern,
+            },
           },
           {
             id: 'rest-1996',
@@ -82,6 +95,10 @@ describe('restToTree', () => {
             type: 'get',
             label: 'bbb',
             modelPath: 'rest.get.1',
+            primaryNodeId: {
+              name: 'get',
+              catalogKind: CatalogKind.Pattern,
+            },
           },
           {
             id: 'rest-3315',
@@ -89,6 +106,10 @@ describe('restToTree', () => {
             type: 'delete',
             label: 'ddd',
             modelPath: 'rest.delete.0',
+            primaryNodeId: {
+              name: 'delete',
+              catalogKind: CatalogKind.Pattern,
+            },
           },
           {
             id: 'rest-5678',
@@ -96,6 +117,10 @@ describe('restToTree', () => {
             type: 'delete',
             label: 'ddd',
             modelPath: 'rest.delete.1',
+            primaryNodeId: {
+              name: 'delete',
+              catalogKind: CatalogKind.Pattern,
+            },
           },
           {
             id: 'rest-1370',
@@ -103,6 +128,10 @@ describe('restToTree', () => {
             type: 'head',
             label: 'ssss',
             modelPath: 'rest.head.0',
+            primaryNodeId: {
+              name: 'head',
+              catalogKind: CatalogKind.Pattern,
+            },
           },
         ],
       },

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.ts
@@ -1,6 +1,6 @@
 import { Rest } from '@kaoto/camel-catalog/types';
 
-import { BaseVisualEntity } from '../../models';
+import { BaseVisualEntity, CatalogKind, IVisualizationNodeIds } from '../../models';
 import { REST_DSL_VERBS } from '../../models/special-processors.constants';
 import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
@@ -9,7 +9,7 @@ import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-re
  * Represents a node in the REST DSL tree structure.
  * Used to display REST configurations and REST services with their methods in a hierarchical tree view.
  */
-export interface RestTreeNode {
+export interface RestTreeNode extends IVisualizationNodeIds {
   id: string;
   entityId: string;
   type: 'restConfiguration' | 'rest' | 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head';
@@ -40,6 +40,10 @@ export const restToTree = (visualEntities: BaseVisualEntity[]): RestTreeNode[] =
       type: 'restConfiguration',
       label: 'Rest configuration',
       modelPath: entity.getRootPath(),
+      primaryNodeId: {
+        name: 'restConfiguration',
+        catalogKind: CatalogKind.Entity,
+      },
     };
   });
 
@@ -63,6 +67,10 @@ export const restToTree = (visualEntities: BaseVisualEntity[]): RestTreeNode[] =
           type: method,
           label: methodDef.path,
           modelPath: `rest.${method}.${index}`,
+          primaryNodeId: {
+            name: method,
+            catalogKind: CatalogKind.Pattern,
+          },
         });
       });
     });
@@ -74,6 +82,10 @@ export const restToTree = (visualEntities: BaseVisualEntity[]): RestTreeNode[] =
       label: 'Rest',
       modelPath: entity.getRootPath(),
       children: methodsTreeNodes,
+      primaryNodeId: {
+        name: 'rest',
+        catalogKind: CatalogKind.Entity,
+      },
     };
   });
 


### PR DESCRIPTION
This PR focuses on removing the deprecated `getNodeSchema()` and using `fetchNodeSchema()` instead. Some implementations of `fetchNodeSchema()` still call the synchronous `camelCatalogService` to retrieve catalogs, which should be addressed in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved schema loading for visualization nodes and REST DSL editing.
  * REST editor forms now display a loading state while schemas are retrieved.
  * Visualization trees now receive richer catalog metadata, including titles and icons.
  * Added support for identifying schemas across REST entities, methods, routes, Kamelets, pipes, and tests.

* **Bug Fixes**
  * Improved validation messaging and handling for missing or unavailable schemas.
  * Prevented incomplete or placeholder nodes from receiving incorrect catalog metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->