### PR TITLE
fix(DataMapper): Fixed inconsistent cardinality

### DIFF
--- a/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
+++ b/packages/ui/src/components/Document/FieldNodePopover/FieldNodePopover.tsx
@@ -37,7 +37,7 @@ export const FieldNodePopover: FunctionComponent<FieldNodePopoverProps> = ({
     return null;
   }
 
-  const detailItems = prepareFieldDetails(field, namespaceMap);
+  const detailItems = prepareFieldDetails(field, namespaceMap, nodeData);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
@@ -1,16 +1,20 @@
 import { IField } from '../../../models/datamapper/document';
 import { FieldItem, MappingTree } from '../../../models/datamapper/mapping';
 import {
+  AbstractFieldNodeData,
   AddMappingNodeData,
+  ChoiceFieldNodeData,
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
+  TargetAbstractFieldNodeData,
+  TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
   TargetFieldNodeData,
 } from '../../../models/datamapper/visualization';
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { QName } from '../../../xml-schema-ts/QName';
-import { formatTypeQName, isFieldNode, prepareFieldDetails } from './field-details-utils';
+import { formatTypeQName, getEffectiveMaxOccurs, isFieldNode, prepareFieldDetails } from './field-details-utils';
 
 describe('field-details-utils', () => {
   afterEach(() => {
@@ -81,6 +85,112 @@ describe('field-details-utils', () => {
     it('should return formatted string with namespace when both are present', () => {
       const qname = new QName('http://www.w3.org/2001/XMLSchema', 'string');
       expect(formatTypeQName(qname)).toBe('string (http://www.w3.org/2001/XMLSchema)');
+    });
+  });
+
+  describe('getEffectiveMaxOccurs', () => {
+    it('should return field.maxOccurs when nodeData is undefined (case 1)', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const field = { ...shipOrderDoc.fields[0], maxOccurs: 5 } as unknown as IField;
+
+      expect(getEffectiveMaxOccurs(field, undefined)).toBe(5);
+    });
+
+    it('should return field.maxOccurs for a plain FieldNodeData', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const field = shipOrderDoc.fields[0];
+      const fieldNodeData = new FieldNodeData(documentNodeData, field);
+
+      expect(getEffectiveMaxOccurs(field, fieldNodeData)).toBe(field.maxOccurs);
+    });
+
+    it('should return wrapperField.maxOccurs for a FieldItemNodeData with wrapperField set (case 2)', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, targetDoc.definitionType);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const memberField = { ...targetDoc.fields[0], maxOccurs: 1 } as unknown as IField;
+      const wrapperField = {
+        ...targetDoc.fields[0],
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const targetFieldNodeData = new TargetFieldNodeData(targetDocNodeData, memberField);
+      const fieldItem = new FieldItem(mappingTree, memberField);
+      const fieldItemNodeData = new FieldItemNodeData(targetFieldNodeData, fieldItem, wrapperField);
+
+      expect(getEffectiveMaxOccurs(memberField, fieldItemNodeData)).toBe('unbounded');
+    });
+
+    it('should return choiceField.maxOccurs for a selected ChoiceFieldNodeData', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const memberField = { ...shipOrderDoc.fields[0], maxOccurs: 1 } as unknown as IField;
+      const wrapperField = {
+        ...shipOrderDoc.fields[0],
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const choiceNode = new ChoiceFieldNodeData(documentNodeData, memberField);
+      choiceNode.choiceField = wrapperField;
+
+      expect(getEffectiveMaxOccurs(memberField, choiceNode)).toBe('unbounded');
+    });
+
+    it('should fall back to parent TargetChoiceFieldNodeData.field.maxOccurs when wrapperField is absent', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, targetDoc.definitionType);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const wrapperField = {
+        ...targetDoc.fields[0],
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const memberField = { ...targetDoc.fields[0], maxOccurs: 1 } as unknown as IField;
+      const choiceParentNode = new TargetChoiceFieldNodeData(targetDocNodeData, wrapperField);
+      const fieldItem = new FieldItem(mappingTree, memberField);
+      // no wrapperField passed → simulates findWrapperFieldForFieldItem returning undefined
+      const fieldItemNodeData = new FieldItemNodeData(choiceParentNode, fieldItem);
+
+      expect(getEffectiveMaxOccurs(memberField, fieldItemNodeData)).toBe('unbounded');
+    });
+
+    it('should fall back to parent TargetAbstractFieldNodeData.field.maxOccurs when wrapperField is absent', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const mappingTree = new MappingTree(targetDoc.documentType, targetDoc.documentId, targetDoc.definitionType);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, mappingTree);
+      const wrapperField = { ...targetDoc.fields[0], maxOccurs: 3, wrapperKind: 'abstract' } as unknown as IField;
+      const memberField = { ...targetDoc.fields[0], maxOccurs: 1 } as unknown as IField;
+      const abstractParentNode = new TargetAbstractFieldNodeData(targetDocNodeData, wrapperField);
+      const fieldItem = new FieldItem(mappingTree, memberField);
+      const fieldItemNodeData = new FieldItemNodeData(abstractParentNode, fieldItem);
+
+      expect(getEffectiveMaxOccurs(memberField, fieldItemNodeData)).toBe(3);
+    });
+
+    it('should return abstractField.maxOccurs for a selected AbstractFieldNodeData (case 5)', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const memberField = { ...shipOrderDoc.fields[0], maxOccurs: 1 } as unknown as IField;
+      const wrapperField = { ...shipOrderDoc.fields[0], maxOccurs: 4, wrapperKind: 'abstract' } as unknown as IField;
+      const abstractNode = new AbstractFieldNodeData(documentNodeData, memberField);
+      abstractNode.abstractField = wrapperField;
+
+      expect(getEffectiveMaxOccurs(memberField, abstractNode)).toBe(4);
+    });
+
+    it('should return field.maxOccurs for an unselected ChoiceFieldNodeData (no choiceField set)', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const wrapperField = {
+        ...shipOrderDoc.fields[0],
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const choiceNode = new ChoiceFieldNodeData(documentNodeData, wrapperField);
+      // choiceNode.choiceField is undefined (unselected)
+
+      expect(getEffectiveMaxOccurs(wrapperField, choiceNode)).toBe('unbounded');
     });
   });
 
@@ -249,6 +359,30 @@ describe('field-details-utils', () => {
       const result = prepareFieldDetails(field);
 
       expect(result.find((item) => item.label === 'Max Occurs')).toBeUndefined();
+    });
+
+    it('should show inherited maxOccurs from choice wrapper for a selected collection choice member', () => {
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const memberField = createMockField({ maxOccurs: 1 });
+      const wrapperField = {
+        ...memberField,
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const choiceNode = new ChoiceFieldNodeData(documentNodeData, memberField);
+      choiceNode.choiceField = wrapperField;
+
+      const result = prepareFieldDetails(memberField, {}, choiceNode);
+
+      expect(result).toContainEqual({ label: 'Max Occurs', value: 'unbounded' });
+    });
+
+    it('should show field maxOccurs unchanged when nodeData is not provided', () => {
+      const field = createMockField({ maxOccurs: 1 });
+      const result = prepareFieldDetails(field);
+
+      expect(result).toContainEqual({ label: 'Max Occurs', value: '1' });
     });
 
     it('should handle null typeQName', () => {

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
@@ -4,7 +4,10 @@ import {
   FieldItemNodeData,
   FieldNodeData,
   NodeData,
+  TargetAbstractFieldNodeData,
+  TargetChoiceFieldNodeData,
 } from '../../../models/datamapper/visualization';
+import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
 import { QName } from '../../../xml-schema-ts/QName';
 import { getOverrideDisplayInfo } from '../actions/FieldOverride/override-util';
 
@@ -28,8 +31,76 @@ export const formatTypeQName = (typeQName: QName | null): string => {
   return namespaceURI ? `${localPart} (${namespaceURI})` : localPart;
 };
 
-export const prepareFieldDetails = (field: IField, namespaceMap: Record<string, string> = {}): LabelValuePair[] => {
+/**
+ * Returns the effective maxOccurs for display in the field details popover.
+ *
+ * A selected choice member (or abstract substitution member) inherits its
+ * collection cardinality from the parent wrapper. In that case the member
+ * field's own maxOccurs is always 1, while the wrapper's maxOccurs carries
+ * the actual repeating constraint.
+ *
+ * Resolution order:
+ *
+ * 1. **No `nodeData`** — returns `field.maxOccurs` directly.
+ *
+ * 2. **`FieldItemNodeData` with `wrapperField` set** — target-side collection
+ *    member whose wrapper was resolved at node-construction time; returns
+ *    `wrapperField.maxOccurs`.
+ *
+ * 3. **`FieldItemNodeData` without `wrapperField`, parent is `TargetChoiceFieldNodeData`
+ *    or `TargetAbstractFieldNodeData`** — fallback for the case where
+ *    `VisualizationService.findWrapperFieldForFieldItem` returned `undefined`
+ *    but the parent node itself carries the wrapper's `IField`; returns
+ *    `parent.field.maxOccurs`.
+ *
+ * 4. **`ChoiceFieldNodeData` / `TargetChoiceFieldNodeData` with `choiceField` set** —
+ *    source or target selected choice member; returns `choiceField.maxOccurs`.
+ *
+ * 5. **`AbstractFieldNodeData` / `TargetAbstractFieldNodeData` with `abstractField` set** —
+ *    source or target selected abstract substitution member; returns `abstractField.maxOccurs`.
+ *
+ * 6. **All other nodes** (plain `FieldNodeData`, `TargetFieldNodeData`, unselected
+ *    choice/abstract wrappers, `AddMappingNodeData`, etc.) — returns `field.maxOccurs`.
+ *
+ * @param field    - The `IField` associated with the popover node.
+ * @param nodeData - Optional visualization node; when absent the raw field value is used.
+ */
+export const getEffectiveMaxOccurs = (field: IField, nodeData?: NodeData): IField['maxOccurs'] => {
+  if (!nodeData) {
+    return field.maxOccurs;
+  }
+
+  if (nodeData instanceof FieldItemNodeData) {
+    if (nodeData.wrapperField) {
+      return nodeData.wrapperField.maxOccurs;
+    }
+
+    if (
+      nodeData.parent instanceof TargetChoiceFieldNodeData ||
+      nodeData.parent instanceof TargetAbstractFieldNodeData
+    ) {
+      return nodeData.parent.field.maxOccurs;
+    }
+  }
+
+  if (VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField) {
+    return nodeData.choiceField.maxOccurs;
+  }
+
+  if (VisualizationUtilService.isAbstractField(nodeData) && nodeData.abstractField) {
+    return nodeData.abstractField.maxOccurs;
+  }
+
+  return field.maxOccurs;
+};
+
+export const prepareFieldDetails = (
+  field: IField,
+  namespaceMap: Record<string, string> = {},
+  nodeData?: NodeData,
+): LabelValuePair[] => {
   const overrideDisplay = getOverrideDisplayInfo(field, namespaceMap);
+  const effectiveMaxOccurs = getEffectiveMaxOccurs(field, nodeData);
 
   const rows = [
     { label: 'Category', value: field.type },
@@ -40,7 +111,7 @@ export const prepareFieldDetails = (field: IField, namespaceMap: Record<string, 
     },
     {
       label: 'Max Occurs',
-      value: field.maxOccurs !== null && field.maxOccurs !== undefined ? String(field.maxOccurs) : null,
+      value: effectiveMaxOccurs !== null && effectiveMaxOccurs !== undefined ? String(effectiveMaxOccurs) : null,
     },
     { label: 'Namespace', value: field.namespaceURI },
     { label: 'Attribute', value: field.isAttribute ? 'yes' : null },


### PR DESCRIPTION
Resolves: [#3454](https://github.com/KaotoIO/kaoto/issues/3454)

<img width="714" height="288" alt="cardinality-1" src="https://github.com/user-attachments/assets/2c58a41b-0b19-4515-96e3-187c936abc26" />
<img width="697" height="259" alt="cardinality-2" src="https://github.com/user-attachments/assets/7ea4f300-2123-4cba-bfe8-f4bd715d8418" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected field detail popovers to display the effective maximum occurrence when fields inherit cardinality from choices or wrapper elements.
  * Preserved the field’s own cardinality when no applicable inherited value is available.
* **Tests**
  * Added coverage for regular fields, choices, abstract wrappers, selected and unselected options, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->